### PR TITLE
revert the etcdmgr changes to restore multi-node functionality

### DIFF
--- a/cmd/castled/castled.go
+++ b/cmd/castled/castled.go
@@ -17,7 +17,6 @@ import (
 	"github.com/quantum/castle/pkg/cephmgr"
 	"github.com/quantum/castle/pkg/cephmgr/cephd"
 	"github.com/quantum/castle/pkg/clusterd"
-	"github.com/quantum/castle/pkg/etcdmgr"
 	"github.com/quantum/castle/pkg/util"
 	"github.com/quantum/castle/pkg/util/flags"
 	"github.com/quantum/castle/pkg/util/proc"
@@ -95,7 +94,7 @@ func joinCluster(cmd *cobra.Command, args []string) error {
 
 	services := []*clusterd.ClusterService{
 		cephmgr.NewCephService(cephd.New(), cfg.devices, cfg.forceFormat, cfg.location),
-		etcdmgr.NewEtcdMgrService(cfg.discoveryURL),
+		//etcdmgr.NewEtcdMgrService(cfg.discoveryURL),
 	}
 	procMan := &proc.ProcManager{}
 	defer func() {


### PR DESCRIPTION
The multi-node etcd cluster is broken from https://github.com/quantum/castle/pull/41. Given that the change was not fully tested, this PR will revert to the previous behavior and disable the etcdmgr until further testing can be done.
