### PR TITLE
set kill mode to mixed for castled unit

### DIFF
--- a/demo/vagrant/cloud-config.yml.in
+++ b/demo/vagrant/cloud-config.yml.in
@@ -21,7 +21,7 @@ coreos:
       [Service]
       Slice=machine.slice
       Restart=always
-      KillMode=process
+      KillMode=mixed
 
       Environment=CASTLED_ACI=quay.io/quantum/castled:latest
       Environment=CASTLED_ID=%m


### PR DESCRIPTION
KillMode=process was causing the child processes of castled to be orphaned when the unit stopped.
