### PR TITLE
usage of public and private ip addresses

### DIFF
--- a/cmd/rook/node-list.go
+++ b/cmd/rook/node-list.go
@@ -45,11 +45,11 @@ func listNodes(c client.RookRestClient) (string, error) {
 	w := NewTableWriter(&buffer)
 
 	// write header columns
-	fmt.Fprintln(w, "ADDRESS\tSTATE\tCLUSTER\tSIZE\tLOCATION\tUPDATED\t")
+	fmt.Fprintln(w, "PUBLIC\tPRIVATE\tSTATE\tCLUSTER\tSIZE\tLOCATION\tUPDATED\t")
 
 	// print a row for each node
 	for _, n := range nodes {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s ago\t\n", n.IPAddress, model.NodeStateToString(n.State), n.ClusterName,
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s ago\t\n", n.PublicIP, n.PrivateIP, model.NodeStateToString(n.State), n.ClusterName,
 			display.BytesToString(n.Storage), n.Location, n.LastUpdated.String())
 	}
 

--- a/cmd/rook/node-list_test.go
+++ b/cmd/rook/node-list_test.go
@@ -18,7 +18,8 @@ func TestListNodes(t *testing.T) {
 				{
 					NodeID:      "node1",
 					ClusterName: "cluster1",
-					IPAddress:   "10.0.0.100",
+					PublicIP:    "187.1.2.3",
+					PrivateIP:   "10.0.0.100",
 					Storage:     100,
 					LastUpdated: time.Duration(1) * time.Second,
 					State:       model.Healthy,
@@ -31,7 +32,7 @@ func TestListNodes(t *testing.T) {
 
 	out, err := listNodes(c)
 	assert.Nil(t, err)
-	assert.Equal(t, "ADDRESS      STATE     CLUSTER    SIZE      LOCATION                      UPDATED   \n10.0.0.100   OK        cluster1   100 B     root=default,dc=datacenter5   1s ago    \n", out)
+	assert.Equal(t, "PUBLIC      PRIVATE      STATE     CLUSTER    SIZE      LOCATION                      UPDATED   \n187.1.2.3   10.0.0.100   OK        cluster1   100 B     root=default,dc=datacenter5   1s ago    \n", out)
 }
 
 func TestListNodesError(t *testing.T) {

--- a/cmd/rookd/main.go
+++ b/cmd/rookd/main.go
@@ -63,13 +63,16 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.nodeID, "id", "", "unique identifier in the cluster for this machine. defaults to /etc/machine-id if found.")
 	rootCmd.Flags().StringVar(&cfg.discoveryURL, "discovery-url", "", "etcd discovery URL. Example: http://discovery.rook.com/26bd83c92e7145e6b103f623263f61df")
 	rootCmd.Flags().StringVar(&cfg.etcdMembers, "etcd-members", "", "etcd members to connect to. Overrides the discovery URL. Example: http://10.23.45.56:2379")
-	rootCmd.Flags().StringVar(&cfg.publicIPv4, "public-ipv4", "", "public IPv4 address for this machine")
-	rootCmd.Flags().StringVar(&cfg.privateIPv4, "private-ipv4", "127.0.0.1", "private IPv4 address for this machine")
+	rootCmd.Flags().StringVar(&cfg.publicIPv4, "public-ipv4", "", "public IPv4 address for this machine (required)")
+	rootCmd.Flags().StringVar(&cfg.privateIPv4, "private-ipv4", "", "private IPv4 address for this machine (required)")
 	rootCmd.Flags().StringVar(&cfg.devices, "data-devices", "", "comma separated list of devices to use for storage")
 	rootCmd.Flags().StringVar(&cfg.dataDir, "data-dir", "/var/lib/rook", "directory for storing configuration")
 	rootCmd.Flags().BoolVar(&cfg.forceFormat, "force-format", false,
 		"true to force the format of any specified devices, even if they already have a filesystem.  BE CAREFUL!")
 	rootCmd.Flags().StringVar(&cfg.location, "location", "", "location of this node for CRUSH placement")
+
+	rootCmd.MarkFlagRequired("private-ipv4")
+	rootCmd.MarkFlagRequired("public-ipv4")
 
 	// load the environment variables
 	setFlagsFromEnv(rootCmd.Flags())
@@ -84,7 +87,7 @@ func addCommands() {
 
 func startJoinCluster(cmd *cobra.Command, args []string) error {
 	// verify required flags
-	if err := flags.VerifyRequiredFlags(cmd, []string{}); err != nil {
+	if err := flags.VerifyRequiredFlags(cmd, []string{"private-ipv4", "public-ipv4"}); err != nil {
 		return err
 	}
 

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -89,7 +89,7 @@ func TestGetNodesHandler(t *testing.T) {
 	assert.Equal(t, `[]`, w.Body.String())
 
 	// set up a discovered node in etcd
-	inventory.SetIPAddress(etcdClient, "node1", "10.0.0.11")
+	inventory.SetIPAddress(etcdClient, "node1", "1.2.3.4", "10.0.0.11")
 	inventory.SetLocation(etcdClient, "node1", "root=default,dc=datacenter1")
 	nodeConfigKey := path.Join(inventory.NodesConfigKey, "node1")
 	etcdClient.CreateDir(nodeConfigKey)
@@ -106,7 +106,7 @@ func TestGetNodesHandler(t *testing.T) {
 	h.GetNodes(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"nodeId\":\"node1\",\"clusterName\":\"cluster5\",\"ipAddr\":\"10.0.0.11\",\"storage\":150,\"lastUpdated\":31536000000000000,\"state\":1,\"location\":\"root=default,dc=datacenter1\"}]",
+	assert.Equal(t, "[{\"nodeId\":\"node1\",\"clusterName\":\"cluster5\",\"publicIp\":\"1.2.3.4\",\"privateIp\":\"10.0.0.11\",\"storage\":150,\"lastUpdated\":31536000000000000,\"state\":1,\"location\":\"root=default,dc=datacenter1\"}]",
 		w.Body.String())
 }
 

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -61,7 +61,8 @@ func (h *Handler) GetNodes(w http.ResponseWriter, r *http.Request) {
 		nodes[i] = model.Node{
 			NodeID:      nodeID,
 			ClusterName: clusterName,
-			IPAddress:   n.IPAddress,
+			PublicIP:    n.PublicIP,
+			PrivateIP:   n.PrivateIP,
 			Storage:     storage,
 			LastUpdated: n.HeartbeatAge,
 			State:       state,

--- a/pkg/cephmgr/cephleader_test.go
+++ b/pkg/cephmgr/cephleader_test.go
@@ -33,7 +33,7 @@ func TestCephLeaders(t *testing.T) {
 
 	nodes := make(map[string]*inventory.NodeConfig)
 	inv := &inventory.Config{Nodes: nodes}
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
+	nodes["a"] = &inventory.NodeConfig{PublicIP: "1.2.3.4"}
 
 	etcdClient := util.NewMockEtcdClient()
 	context := &clusterd.Context{
@@ -61,7 +61,7 @@ func TestCephLeaders(t *testing.T) {
 	assert.Equal(t, "6790", etcdClient.GetValue("/rook/services/ceph/monitor/desired/a/port"))
 
 	// trigger an add node event
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.3.4.5"}
+	nodes["b"] = &inventory.NodeConfig{PublicIP: "2.3.4.5"}
 	addNode := clusterd.NewAddNodeEvent(context, "b")
 	leader.Events() <- addNode
 
@@ -83,9 +83,9 @@ func TestMoveUnhealthyMonitor(t *testing.T) {
 
 	nodes := make(map[string]*inventory.NodeConfig)
 	inv := &inventory.Config{Nodes: nodes}
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.3.4.5"}
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.4.5.6"}
+	nodes["a"] = &inventory.NodeConfig{PublicIP: "1.2.3.4"}
+	nodes["b"] = &inventory.NodeConfig{PublicIP: "2.3.4.5"}
+	nodes["c"] = &inventory.NodeConfig{PublicIP: "3.4.5.6"}
 
 	context := &clusterd.Context{
 		EtcdClient: etcdClient,
@@ -105,7 +105,7 @@ func TestMoveUnhealthyMonitor(t *testing.T) {
 
 	// add a new node and mark node a as unhealthy
 	nodes["a"].HeartbeatAge = (unhealthyMonHeatbeatAgeSeconds + 1) * time.Second
-	nodes["d"] = &inventory.NodeConfig{IPAddress: "4.5.6.7"}
+	nodes["d"] = &inventory.NodeConfig{PublicIP: "4.5.6.7"}
 	etcdClient.WatcherResponses["/rook/_notify/d/monitor/status"] = "succeeded"
 
 	err = leader.configureCephMons(context)
@@ -119,16 +119,16 @@ func TestMoveUnhealthyMonitor(t *testing.T) {
 	mon2 := false
 	mon3 := false
 	for _, mon := range cluster.Monitors {
-		if strings.Contains(mon.Endpoint, nodes["a"].IPAddress) {
+		if strings.Contains(mon.Endpoint, nodes["a"].PublicIP) {
 			assert.Fail(t, "mon a was not removed")
 		}
-		if strings.Contains(mon.Endpoint, nodes["b"].IPAddress) {
+		if strings.Contains(mon.Endpoint, nodes["b"].PublicIP) {
 			mon1 = true
 		}
-		if strings.Contains(mon.Endpoint, nodes["c"].IPAddress) {
+		if strings.Contains(mon.Endpoint, nodes["c"].PublicIP) {
 			mon2 = true
 		}
-		if strings.Contains(mon.Endpoint, nodes["d"].IPAddress) {
+		if strings.Contains(mon.Endpoint, nodes["d"].PublicIP) {
 			mon3 = true
 		}
 	}

--- a/pkg/cephmgr/monleader.go
+++ b/pkg/cephmgr/monleader.go
@@ -221,7 +221,7 @@ func chooseMonitorNodes(context *clusterd.Context) (map[string]*CephMonitorConfi
 		}
 
 		node, ok := context.Inventory.Nodes[nodeID]
-		if !ok || node.IPAddress == "" {
+		if !ok || node.PublicIP == "" {
 			log.Printf("failed to discover desired ip address for node %s. %v", nodeID, err)
 			return nil, nil, err
 		}
@@ -234,10 +234,10 @@ func chooseMonitorNodes(context *clusterd.Context) (map[string]*CephMonitorConfi
 		port := "6790"
 		monitorID := fmt.Sprintf("mon%d", nextMonID)
 		settings[path.Join(nodeID, "id")] = monitorID
-		settings[path.Join(nodeID, "ipaddress")] = node.IPAddress
+		settings[path.Join(nodeID, "ipaddress")] = node.PublicIP
 		settings[path.Join(nodeID, "port")] = port
 
-		monitor := &CephMonitorConfig{Name: monitorID, Endpoint: fmt.Sprintf("%s:%s", node.IPAddress, port)}
+		monitor := &CephMonitorConfig{Name: monitorID, Endpoint: fmt.Sprintf("%s:%s", node.PublicIP, port)}
 		monitors[nodeID] = monitor
 
 		nextMonID++

--- a/pkg/cephmgr/monleader_test.go
+++ b/pkg/cephmgr/monleader_test.go
@@ -16,7 +16,7 @@ func TestMonSelection(t *testing.T) {
 	etcdClient := util.NewMockEtcdClient()
 	nodes := make(map[string]*inventory.NodeConfig)
 	inv := &inventory.Config{Nodes: nodes}
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
+	nodes["a"] = &inventory.NodeConfig{PublicIP: "1.2.3.4"}
 	context := &clusterd.Context{
 		EtcdClient: etcdClient,
 		Inventory:  inv,
@@ -30,7 +30,7 @@ func TestMonSelection(t *testing.T) {
 	assert.Equal(t, 0, len(bad))
 
 	// no new monitors when we have 2 nodes
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.2.3.4"}
+	nodes["b"] = &inventory.NodeConfig{PublicIP: "2.2.3.4"}
 	chosen, bad, err = chooseMonitorNodes(context)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(chosen))
@@ -38,7 +38,7 @@ func TestMonSelection(t *testing.T) {
 	assert.Equal(t, "mon0", chosen["a"].Name)
 
 	// add two more monitors when we hit the threshold of 3 nodes
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.2.3.4"}
+	nodes["c"] = &inventory.NodeConfig{PublicIP: "3.2.3.4"}
 	chosen, bad, err = chooseMonitorNodes(context)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(chosen))
@@ -50,8 +50,8 @@ func TestMonSelection(t *testing.T) {
 
 	// remove a node, then check that with four nodes we only go to three monitors
 	etcdClient.DeleteDir("/rook/services/ceph/monitor/desired/c")
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "4.2.3.4"}
-	nodes["d"] = &inventory.NodeConfig{IPAddress: "5.2.3.4"}
+	nodes["c"] = &inventory.NodeConfig{PublicIP: "4.2.3.4"}
+	nodes["d"] = &inventory.NodeConfig{PublicIP: "5.2.3.4"}
 	chosen, bad, err = chooseMonitorNodes(context)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(bad))
@@ -132,10 +132,10 @@ func TestUnhealthyMon(t *testing.T) {
 	etcdClient := util.NewMockEtcdClient()
 	nodes := make(map[string]*inventory.NodeConfig)
 	inv := &inventory.Config{Nodes: nodes}
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4", HeartbeatAge: unhealthyMonHeatbeatAgeSeconds * time.Second}
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.2.3.4"}
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.2.3.4"}
-	nodes["d"] = &inventory.NodeConfig{IPAddress: "4.2.3.4"}
+	nodes["a"] = &inventory.NodeConfig{PublicIP: "1.2.3.4", HeartbeatAge: unhealthyMonHeatbeatAgeSeconds * time.Second}
+	nodes["b"] = &inventory.NodeConfig{PublicIP: "2.2.3.4"}
+	nodes["c"] = &inventory.NodeConfig{PublicIP: "3.2.3.4"}
+	nodes["d"] = &inventory.NodeConfig{PublicIP: "4.2.3.4"}
 	context := &clusterd.Context{
 		EtcdClient: etcdClient,
 		Inventory:  inv,

--- a/pkg/cephmgr/osdagent_test.go
+++ b/pkg/cephmgr/osdagent_test.go
@@ -65,7 +65,7 @@ func TestOSDAgentWithDevices(t *testing.T) {
 	}
 
 	// prep the etcd keys that would have been discovered by inventory
-	disksKey := path.Join(inventory.GetNodeConfigKey(context.NodeID), inventory.DisksKey)
+	disksKey := path.Join(inventory.GetNodeConfigKey(context.NodeID), "disks")
 	etcdClient.SetValue(path.Join(disksKey, "sdx", "uuid"), "12345")
 	etcdClient.SetValue(path.Join(disksKey, "sdy", "uuid"), "54321")
 	etcdClient.SetValue(path.Join(disksKey, "sdx", "size"), "1234567890")

--- a/pkg/clusterd/clusterMember_test.go
+++ b/pkg/clusterd/clusterMember_test.go
@@ -386,7 +386,8 @@ func TestSimpleMembershipChangeWatching(t *testing.T) {
 	}
 
 	machineIds := []string{context.NodeID}
-	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, context.NodeID, "ipaddress"), "5.1.2.3")
+	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, context.NodeID, "publicIp"), "5.1.2.3")
+	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, context.NodeID, "privateIp"), "10.2.2.3")
 	setupGetMachineIds(etcdClient, machineIds)
 
 	// set up a mock watcher that the cluster leader will use
@@ -397,7 +398,8 @@ func TestSimpleMembershipChangeWatching(t *testing.T) {
 			// to caller of the watcher simulating the new machine has joined the cluster
 			newMemberId := <-newMemberChannel
 			key := path.Join(inventory.NodesConfigKey, newMemberId)
-			etcdClient.SetValue(path.Join(key, "ipaddress"), "10.1.2.3")
+			etcdClient.SetValue(path.Join(key, "publicIp"), "1.1.2.3")
+			etcdClient.SetValue(path.Join(key, "privateIp"), "10.1.2.3")
 			return &etcd.Response{Action: store.Create, Node: &etcd.Node{Key: key}}, nil
 		},
 	}

--- a/pkg/clusterd/inventory/hardware.go
+++ b/pkg/clusterd/inventory/hardware.go
@@ -28,7 +28,8 @@ type NodeConfig struct {
 	Processors      []ProcessorConfig `json:"processors"`
 	Memory          MemoryConfig      `json:"memory"`
 	NetworkAdapters []NetworkConfig   `json:"networkAdapters"`
-	IPAddress       string            `json:"ipAddr"`
+	PublicIP        string            `json:"publicIp"`
+	PrivateIP       string            `json:"privateIp"`
 	HeartbeatAge    time.Duration     `json:"heartbeatAge"`
 	Location        string            `json:"location"`
 }

--- a/pkg/clusterd/join.go
+++ b/pkg/clusterd/join.go
@@ -41,7 +41,7 @@ func StartJoinCluster(services []*ClusterService, procMan *proc.ProcManager, con
 	if err := util.CreateEtcdDir(etcdClient, key); err != nil {
 		return nil, err
 	}
-	if err := inventory.SetIPAddress(etcdClient, nodeID, privateIPv4); err != nil {
+	if err := inventory.SetIPAddress(etcdClient, nodeID, publicIPv4, privateIPv4); err != nil {
 		return nil, err
 	}
 

--- a/pkg/clusterd/servicesleader_test.go
+++ b/pkg/clusterd/servicesleader_test.go
@@ -29,7 +29,8 @@ func TestLoadDiscoveredNodes(t *testing.T) {
 	mockHandler.StartWatchEvents()
 	defer mockHandler.Close()
 
-	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, "23", "ipaddress"), "1.2.3.4")
+	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, "23", "publicIp"), "1.2.3.4")
+	etcdClient.SetValue(path.Join(inventory.NodesConfigKey, "23", "privateIp"), "10.2.3.4")
 
 	// one unhealthy nodes to discover
 	err := leader.discoverUnhealthyNodes()

--- a/pkg/etcdmgr/leader.go
+++ b/pkg/etcdmgr/leader.go
@@ -144,7 +144,7 @@ func (e *etcdMgrLeader) growEtcdQuorum(context *clusterd.Context, candidates []s
 		// add target node to the current etcd cluster
 		var targetIP string
 		if node, ok := context.Inventory.Nodes[candidate]; ok {
-			targetIP = node.IPAddress
+			targetIP = node.PrivateIP
 		} else {
 			return errors.New("candidate ip not found in the inventory")
 		}
@@ -172,7 +172,7 @@ func (e *etcdMgrLeader) shrinkEtcdQuorum(context *clusterd.Context, candidates [
 		// remove target node from the current etcd cluster
 		var targetEndpoint string
 		if node, ok := context.Inventory.Nodes[candidate]; ok {
-			targetEndpoint = getPeerEndpointFromIP(node.IPAddress)
+			targetEndpoint = getPeerEndpointFromIP(node.PrivateIP)
 		} else {
 			return errors.New("candidate endpoint not found in the inventory")
 		}
@@ -213,7 +213,7 @@ func getNodeIDs(nodeURLs []string, Nodes map[string]*inventory.NodeConfig) ([]st
 		ip, _, _ := net.SplitHostPort(uu.Host)
 		for nodeID, config := range Nodes {
 			log.Println("nodeID: ", nodeID)
-			if config.IPAddress == ip {
+			if config.PrivateIP == ip {
 				log.Printf("matched, ip: %v | nodeID: %v\n", ip, nodeID)
 				nodeIDs = append(nodeIDs, nodeID)
 			}

--- a/pkg/etcdmgr/leader_test.go
+++ b/pkg/etcdmgr/leader_test.go
@@ -18,14 +18,14 @@ func TestEtcdMgrLeaderGrow(t *testing.T) {
 	inv := &inventory.Config{Nodes: nodes}
 
 	// adding 1.2.3.4 as the first/existing cluster member
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
+	nodes["a"] = &inventory.NodeConfig{PrivateIP: "1.2.3.4"}
 	mockContext.AddMembers([]string{"http://1.2.3.4:53379"})
 	etcdmgrService := etcdMgrLeader{context: &mockContext}
 	etcdmgrService.StartWatchEvents()
 	defer etcdmgrService.Close()
 
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.3.4.5"}
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.4.5.6"}
+	nodes["b"] = &inventory.NodeConfig{PrivateIP: "2.3.4.5"}
+	nodes["c"] = &inventory.NodeConfig{PrivateIP: "3.4.5.6"}
 
 	etcdClient := util.NewMockEtcdClient()
 	context := &clusterd.Context{
@@ -55,19 +55,19 @@ func TestEtcdMgrLeaderShrink(t *testing.T) {
 	inv := &inventory.Config{Nodes: nodes}
 
 	// adding 1.2.3.4 as the first/existing cluster member
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
+	nodes["a"] = &inventory.NodeConfig{PrivateIP: "1.2.3.4"}
 	mockContext.AddMembers([]string{"http://1.2.3.4:53379"})
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.3.4.5"}
+	nodes["b"] = &inventory.NodeConfig{PrivateIP: "2.3.4.5"}
 	mockContext.AddMembers([]string{"http://2.3.4.5:53379"})
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.4.5.6"}
+	nodes["c"] = &inventory.NodeConfig{PrivateIP: "3.4.5.6"}
 	mockContext.AddMembers([]string{"http://3.4.5.6:53379"})
 	etcdmgrService := etcdMgrLeader{context: &mockContext}
 	etcdmgrService.StartWatchEvents()
 	defer etcdmgrService.Close()
 
-	nodes["a"] = &inventory.NodeConfig{IPAddress: "1.2.3.4"}
-	nodes["b"] = &inventory.NodeConfig{IPAddress: "2.3.4.5"}
-	nodes["c"] = &inventory.NodeConfig{IPAddress: "3.4.5.6"}
+	nodes["a"] = &inventory.NodeConfig{PrivateIP: "1.2.3.4"}
+	nodes["b"] = &inventory.NodeConfig{PrivateIP: "2.3.4.5"}
+	nodes["c"] = &inventory.NodeConfig{PrivateIP: "3.4.5.6"}
 
 	etcdClient := util.NewMockEtcdClient()
 	context := &clusterd.Context{

--- a/pkg/model/node.go
+++ b/pkg/model/node.go
@@ -12,7 +12,8 @@ const (
 type Node struct {
 	NodeID      string        `json:"nodeId"`
 	ClusterName string        `json:"clusterName"`
-	IPAddress   string        `json:"ipAddr"`
+	PublicIP    string        `json:"publicIp"`
+	PrivateIP   string        `json:"privateIp"`
 	Storage     uint64        `json:"storage"`
 	LastUpdated time.Duration `json:"lastUpdated"`
 	State       NodeState     `json:"state"`

--- a/pkg/rook/client/client_test.go
+++ b/pkg/rook/client/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	SuccessGetNodesContent             = `[{"nodeID": "node1","ipAddr": "10.0.0.100","storage": 100},{"nodeID": "node2","ipAddr": "10.0.0.101","storage": 200}]`
+	SuccessGetNodesContent             = `[{"nodeID": "node1","publicIp": "1.2.3.100","privateIp": "10.0.0.100","storage": 100},{"nodeID": "node2","ipAddr": "10.0.0.101","storage": 200}]`
 	SuccessGetPoolsContent             = "[{\"poolName\":\"rbd\",\"poolNum\":0,\"type\":0,\"replicationConfig\":{\"size\":1},\"erasureCodedConfig\":{\"dataChunkCount\":0,\"codingChunkCount\":0,\"algorithm\":\"\"}},{\"poolName\":\"ecPool1\",\"poolNum\":1,\"type\":1,\"replicationConfig\":{\"size\":0},\"erasureCodedConfig\":{\"dataChunkCount\":2,\"codingChunkCount\":1,\"algorithm\":\"jerasure::reed_sol_van\"}}]"
 	SuccessCreatePoolContent           = `pool 'ecPool1' created`
 	SuccessGetBlockImagesContent       = `[{"imageName":"myimage1","poolName":"rbd","size":10485760,"device":"","mountPoint":""},{"imageName":"myimage2","poolName":"rbd2","size":10485761,"device":"","mountPoint":""}]`
@@ -51,7 +51,8 @@ func TestGetNodes(t *testing.T) {
 	}
 
 	assert.NotNil(t, testNode)
-	assert.Equal(t, "10.0.0.100", testNode.IPAddress)
+	assert.Equal(t, "1.2.3.100", testNode.PublicIP)
+	assert.Equal(t, "10.0.0.100", testNode.PrivateIP)
 	assert.Equal(t, uint64(100), testNode.Storage)
 }
 

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -7,36 +7,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func SplitList(list string) []string {
-	if list == "" {
-		return nil
-	}
-
-	return strings.Split(list, ",")
-}
-
 func VerifyRequiredFlags(cmd *cobra.Command, requiredFlags []string) error {
+	var missingFlags []string
 	for _, reqFlag := range requiredFlags {
 		val, err := cmd.Flags().GetString(reqFlag)
 		if err != nil || val == "" {
-			return createRequiredFlagError(cmd, reqFlag)
+			missingFlags = append(missingFlags, reqFlag)
 		}
 	}
 
-	return nil
+	return createRequiredFlagError(cmd.Name(), missingFlags)
 }
 
 func VerifyRequiredUint64Flags(cmd *cobra.Command, requiredFlags []string) error {
+	var missingFlags []string
 	for _, reqFlag := range requiredFlags {
 		val, err := cmd.Flags().GetUint64(reqFlag)
 		if err != nil || val == 0 {
-			return createRequiredFlagError(cmd, reqFlag)
+			missingFlags = append(missingFlags, reqFlag)
 		}
 	}
 
-	return nil
+	return createRequiredFlagError(cmd.Name(), missingFlags)
 }
 
-func createRequiredFlagError(cmd *cobra.Command, flagName string) error {
-	return fmt.Errorf("%s is required for %s", flagName, cmd.Name())
+func createRequiredFlagError(name string, flags []string) error {
+	if len(flags) == 0 {
+		return nil
+	}
+
+	if len(flags) == 1 {
+		return fmt.Errorf("%s is required for %s", flags[0], name)
+	}
+
+	return fmt.Errorf("%s are required for %s", strings.Join(flags, ","), name)
 }

--- a/pkg/util/flags/flags_test.go
+++ b/pkg/util/flags/flags_test.go
@@ -1,0 +1,60 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Creates a test arg",
+	}
+
+	var arg1 string
+	var arg2 string
+	cmd.Flags().StringVar(&arg1, "foo", "", "test 1")
+	cmd.Flags().StringVar(&arg2, "bar", "", "test 2")
+
+	// both arguments are missing
+	err := VerifyRequiredFlags(cmd, []string{"foo", "bar"})
+	assert.Equal(t, "foo,bar are required for test", err.Error())
+
+	// one argument is missing
+	cmd.Flags().Set("foo", "fooval")
+	err = VerifyRequiredFlags(cmd, []string{"foo", "bar"})
+	assert.Equal(t, "bar is required for test", err.Error())
+
+	// no arguments are missing
+	cmd.Flags().Set("bar", "barval")
+	err = VerifyRequiredFlags(cmd, []string{"foo", "bar"})
+	assert.Nil(t, err)
+}
+
+func TestUintFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Creates a test arg",
+	}
+
+	var arg1 uint64
+	var arg2 uint64
+	cmd.Flags().Uint64Var(&arg1, "foo", 0, "test 1")
+	cmd.Flags().Uint64Var(&arg2, "bar", 0, "test 2")
+
+	// both arguments are missing
+	err := VerifyRequiredUint64Flags(cmd, []string{"foo", "bar"})
+	assert.Equal(t, "foo,bar are required for test", err.Error())
+
+	// one argument is missing
+	cmd.Flags().Set("foo", "1234")
+	err = VerifyRequiredUint64Flags(cmd, []string{"foo", "bar"})
+	assert.Equal(t, "bar is required for test", err.Error())
+
+	// no arguments are missing
+	cmd.Flags().Set("bar", "5432")
+	err = VerifyRequiredUint64Flags(cmd, []string{"foo", "bar"})
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
The public and private ip addresses are now required parameters to castled.
- The public ip is used by ceph mons
- The private ip is used by internal etcd

`rook node ls` will show both the public and private ip, though we may want to change that.
