### PR TITLE
remove unnecessary linux packages

### DIFF
--- a/build/release/containers.sh
+++ b/build/release/containers.sh
@@ -22,7 +22,7 @@ build() {
 
     cat <<EOF > $tmpdir/Dockerfile
 FROM alpine:3.4
-RUN apk add --no-cache gptfdisk util-linux kmod coreutils grep gawk e2fsprogs btrfs-progs sudo
+RUN apk add --no-cache gptfdisk util-linux coreutils
 COPY root /
 ENTRYPOINT ["/usr/bin/rookd"]
 EOF


### PR DESCRIPTION
We still require three packages: 
- gptfdisk for `sgdisk`
- util-linux for `lsblk`
- coreutils for `df`

See https://github.com/rook/rook/issues/73
