### PR TITLE
execute all child processes with logging and same executor

### DIFF
--- a/pkg/clusterd/join.go
+++ b/pkg/clusterd/join.go
@@ -13,7 +13,7 @@ import (
 )
 
 // StartJoinCluster initializes the cluster services to enable joining the cluster and listening for orchestration.
-func StartJoinCluster(services []*ClusterService, procMan *proc.ProcManager, configDir, nodeID, discoveryURL,
+func StartJoinCluster(services []*ClusterService, configDir, nodeID, discoveryURL,
 	etcdMembers, publicIPv4, privateIPv4 string, debug bool) (*Context, error) {
 
 	log.Printf("Starting cluster. configDir=%s, nodeID=%s, url=%s, members=%s, publicIPv4=%s, privateIPv4=%s, debug=%t",
@@ -53,12 +53,13 @@ func StartJoinCluster(services []*ClusterService, procMan *proc.ProcManager, con
 		return nil, fmt.Errorf("failed to initialize lease manager: %+v", err)
 	}
 
+	executor := &exec.CommandExecutor{}
 	context := &Context{
 		EtcdClient: etcdClient,
-		Executor:   &exec.CommandExecutor{},
+		Executor:   executor,
 		NodeID:     nodeID,
 		Services:   services,
-		ProcMan:    procMan,
+		ProcMan:    proc.New(executor),
 		ConfigDir:  configDir,
 		Debug:      debug,
 	}

--- a/pkg/util/exec/error.go
+++ b/pkg/util/exec/error.go
@@ -1,0 +1,32 @@
+package exec
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+type CommandError struct {
+	ActionName string
+	Err        error
+}
+
+func (e *CommandError) Error() string {
+	return fmt.Sprintf("Failed to complete %s: %+v", e.ActionName, e.Err)
+}
+
+func (e *CommandError) ExitStatus() int {
+	exitStatus := -1
+	exitErr, ok := e.Err.(*exec.ExitError)
+	if ok {
+		waitStatus, ok := exitErr.ProcessState.Sys().(syscall.WaitStatus)
+		if ok {
+			exitStatus = waitStatus.ExitStatus()
+		}
+	}
+	return exitStatus
+}
+
+func createCommandError(err error, actionName string) error {
+	return &CommandError{ActionName: actionName, Err: err}
+}

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -2,16 +2,14 @@ package exec
 
 import (
 	"bufio"
-	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os/exec"
 	"strings"
-	"syscall"
 )
 
 type Executor interface {
+	StartExecuteCommand(actionName string, command string, arg ...string) (*exec.Cmd, error)
 	ExecuteCommand(actionName string, command string, arg ...string) error
 	ExecuteCommandPipeline(actionName string, command string) (string, error)
 	ExecuteCommandWithOutput(actionName string, command string, arg ...string) (string, error)
@@ -20,23 +18,26 @@ type Executor interface {
 type CommandExecutor struct {
 }
 
+// Start a process and return immediately
+func (*CommandExecutor) StartExecuteCommand(actionName string, command string, arg ...string) (*exec.Cmd, error) {
+	cmd, stdout, stderr, err := startCommand(command, arg...)
+	if err != nil {
+		return cmd, createCommandError(err, actionName)
+	}
+
+	go logOutput(stdout, stderr)
+
+	return cmd, nil
+}
+
+// Start a process and wait for its completion
 func (*CommandExecutor) ExecuteCommand(actionName string, command string, arg ...string) error {
-	cmd := exec.Command(command, arg...)
-	stdout, _ := cmd.StdoutPipe()
-	stderr, _ := cmd.StderrPipe()
-
-	logCommand(command, arg...)
-	if err := cmd.Start(); err != nil {
-		return errors.New(fmt.Sprintf("Failed to start action '%s': %+v", actionName, err))
+	cmd, stdout, stderr, err := startCommand(command, arg...)
+	if err != nil {
+		return createCommandError(err, actionName)
 	}
 
-	// read command's stdout line by line and write it to the log
-	in := bufio.NewScanner(io.MultiReader(stdout, stderr))
-	lastLine := ""
-	for in.Scan() {
-		lastLine = in.Text()
-		log.Printf(lastLine)
-	}
+	logOutput(stdout, stderr)
 
 	if err := cmd.Wait(); err != nil {
 		return createCommandError(err, actionName)
@@ -46,16 +47,42 @@ func (*CommandExecutor) ExecuteCommand(actionName string, command string, arg ..
 }
 
 func (*CommandExecutor) ExecuteCommandWithOutput(actionName string, command string, arg ...string) (string, error) {
-	cmd := exec.Command(command, arg...)
 	logCommand(command, arg...)
+	cmd := exec.Command(command, arg...)
 	return runCommandWithOutput(actionName, cmd)
 }
 
 func (*CommandExecutor) ExecuteCommandPipeline(actionName string, command string) (string, error) {
-	cmd := exec.Command("bash", "-c", command)
-
 	logCommand(command)
+	cmd := exec.Command("bash", "-c", command)
 	return runCommandWithOutput(actionName, cmd)
+}
+
+func startCommand(command string, arg ...string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	logCommand(command, arg...)
+
+	cmd := exec.Command(command, arg...)
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+
+	err := cmd.Start()
+
+	return cmd, stdout, stderr, err
+}
+
+func logOutput(stdout, stderr io.ReadCloser) {
+	if stdout == nil || stderr == nil {
+		log.Printf("failed to collect stdout and stderr")
+		return
+	}
+
+	// read command's stdout line by line and write it to the log
+	in := bufio.NewScanner(io.MultiReader(stdout, stderr))
+	lastLine := ""
+	for in.Scan() {
+		lastLine = in.Text()
+		log.Printf(lastLine)
+	}
 }
 
 func runCommandWithOutput(actionName string, cmd *exec.Cmd) (string, error) {
@@ -69,29 +96,4 @@ func runCommandWithOutput(actionName string, cmd *exec.Cmd) (string, error) {
 
 func logCommand(command string, arg ...string) {
 	log.Printf("Running command: %s %s", command, strings.Join(arg, " "))
-}
-
-type CommandError struct {
-	ActionName string
-	Err        error
-}
-
-func (e *CommandError) Error() string {
-	return fmt.Sprintf("Failed to complete %s: %+v", e.ActionName, e.Err)
-}
-
-func (e *CommandError) ExitStatus() int {
-	exitStatus := -1
-	exitErr, ok := e.Err.(*exec.ExitError)
-	if ok {
-		waitStatus, ok := exitErr.ProcessState.Sys().(syscall.WaitStatus)
-		if ok {
-			exitStatus = waitStatus.ExitStatus()
-		}
-	}
-	return exitStatus
-}
-
-func createCommandError(err error, actionName string) error {
-	return &CommandError{ActionName: actionName, Err: err}
 }

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -1,8 +1,11 @@
 package test
 
+import "os/exec"
+
 // ******************** MockExecutor ********************
 type MockExecutor struct {
 	MockExecuteCommand           func(actionName string, command string, arg ...string) error
+	MockStartExecuteCommand      func(actionName string, command string, arg ...string) (*exec.Cmd, error)
 	MockExecuteCommandPipeline   func(actionName string, command string) (string, error)
 	MockExecuteCommandWithOutput func(actionName string, command string, arg ...string) (string, error)
 }
@@ -13,6 +16,14 @@ func (e *MockExecutor) ExecuteCommand(actionName string, command string, arg ...
 	}
 
 	return nil
+}
+
+func (e *MockExecutor) StartExecuteCommand(actionName string, command string, arg ...string) (*exec.Cmd, error) {
+	if e.MockStartExecuteCommand != nil {
+		return e.MockStartExecuteCommand(actionName, command, arg...)
+	}
+
+	return &exec.Cmd{}, nil
 }
 
 func (e *MockExecutor) ExecuteCommandPipeline(actionName string, command string) (string, error) {


### PR DESCRIPTION
This will capture the output of all child processes in the log. This works around the parenting issue in rkt, at least for logging. It also is a cleans up the implementation of a single place where processes are launched, instead of two places.
