### PR TITLE
Perform full ceph orchestration even if mons fail

### DIFF
--- a/pkg/cephmgr/cephleader.go
+++ b/pkg/cephmgr/cephleader.go
@@ -68,7 +68,6 @@ func (c *cephLeader) HandleRefresh(e *clusterd.RefreshEvent) {
 		err := c.configureCephMons(e.Context)
 		if err != nil {
 			log.Printf("FAILED TO CONFIGURE CEPH MONS. %v", err)
-			return
 		}
 	}
 
@@ -77,7 +76,6 @@ func (c *cephLeader) HandleRefresh(e *clusterd.RefreshEvent) {
 		err := configureOSDs(e.Context, osdsToRefresh.ToSlice())
 		if err != nil {
 			log.Printf("FAILED TO CONFIGURE CEPH OSDs. %v", err)
-			return
 		}
 	}
 


### PR DESCRIPTION
The orchestrator leader simply needs to continue with the orchestration instead of returning when the mons fail. If there are no mons, the behavior is that configuring an OSD is a no-op since no monitors are available. Once the mons are configured successfully, the osds would also get configured.