### PR TITLE
Configure bluestore devices asynchronously from orchestration

### DIFF
--- a/pkg/cephmgr/osdagent_test.go
+++ b/pkg/cephmgr/osdagent_test.go
@@ -96,6 +96,11 @@ func TestOSDAgentWithDevices(t *testing.T) {
 
 	err := agent.ConfigureLocalService(context)
 	assert.Nil(t, err)
+
+	// wait for the async osds to complete
+	<-agent.osdsCompleted
+
+	assert.Equal(t, 0, agent.configCounter)
 	assert.Equal(t, 6, execCount)
 	assert.Equal(t, 2, outputExecCount)
 	assert.Equal(t, 2, startCount)


### PR DESCRIPTION
Devices will be configured asynchronously with bluestore. The core orchestration will be unblocked  during osd configuration to proceed with other configuration. If another request for osd configuration is sent to a node, it will already be detected as in progress and the agent will return immediately.

Apps that need a confirmation that the storage is available (ie. osds are complete) will come as a separate change.