### PR TITLE
Internal etcd working consistently

### DIFF
--- a/pkg/etcdmgr/bootstrap/etcd.go
+++ b/pkg/etcdmgr/bootstrap/etcd.go
@@ -84,7 +84,7 @@ func (ee *EmbeddedEtcd) InitializeListeners() error {
 		if err != nil {
 			return err
 		}
-		ee.peerListeners = append(ee.clientListeners, l)
+		ee.peerListeners = append(ee.peerListeners, l)
 	}
 
 	return nil


### PR DESCRIPTION
Keep the client and peer etcd listeners straight. The peer listener routes were replacing the routes for the client listener. Since they were started in go routines, on occasion the client routes would actually get initialized as expected, but the majority of the time would not.