### PR TITLE
rook: remove block mount and unmount on mac

### DIFF
--- a/cmd/rook/block-list.go
+++ b/cmd/rook/block-list.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/rook/rook/pkg/rook/client"
@@ -66,20 +67,22 @@ func listBlocks(rbdSysBusPath string, c client.RookRestClient, executor exec.Exe
 		return "", nil
 	}
 
-	// for each image returned from the client API call, look up local details
-	for i := range images {
-		image := &(images[i])
+	if runtime.GOOS == "linux" {
+		// for each image returned from the client API call, look up local details
+		for i := range images {
+			image := &(images[i])
 
-		// look up local device and mount point, ignoring errors
-		devPath, _ := findDevicePath(image.Name, image.PoolName, rbdSysBusPath)
-		dev := strings.TrimPrefix(devPath, devicePathPrefix)
-		var mountPoint string
-		if dev != "" {
-			mountPoint, _ = sys.GetDeviceMountPoint(dev, executor)
+			// look up local device and mount point, ignoring errors
+			devPath, _ := findDevicePath(image.Name, image.PoolName, rbdSysBusPath)
+			dev := strings.TrimPrefix(devPath, devicePathPrefix)
+			var mountPoint string
+			if dev != "" {
+				mountPoint, _ = sys.GetDeviceMountPoint(dev, executor)
+			}
+
+			image.Device = dev
+			image.MountPoint = mountPoint
 		}
-
-		image.Device = dev
-		image.MountPoint = mountPoint
 	}
 
 	var buffer bytes.Buffer

--- a/cmd/rook/block-list_test.go
+++ b/cmd/rook/block-list_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -58,8 +59,12 @@ func TestListBlockImages(t *testing.T) {
 	out, err := listBlocks(mockRBDSysBusPath, c, e)
 	assert.Nil(t, err)
 
-	expectedOut := "NAME       POOL      SIZE       DEVICE    MOUNT\n" +
-		"myimage1   mypool1   1.00 KiB   rbd5      /tmp/mymount1\n"
+	expectedOut := "NAME       POOL      SIZE       DEVICE    MOUNT\n"
+	if runtime.GOOS == "linux" {
+		expectedOut += "myimage1   mypool1   1.00 KiB   rbd5      /tmp/mymount1\n"
+	} else {
+		expectedOut += "myimage1   mypool1   1.00 KiB             \n"
+	}
 	assert.Equal(t, expectedOut, out)
 }
 

--- a/cmd/rook/block_test.go
+++ b/cmd/rook/block_test.go
@@ -17,21 +17,22 @@ package rook
 
 import (
 	"runtime"
+	"testing"
 
-	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 )
 
-var blockCmd = &cobra.Command{
-	Use:   "block",
-	Short: "Performs commands and operations on block devices and images in the cluster",
-}
+func TestBlockCommand(t *testing.T) {
+	assert.Equal(t, "block", blockCmd.Use)
 
-func init() {
-	blockCmd.AddCommand(blockListCmd)
-	blockCmd.AddCommand(blockCreateCmd)
+	commands := []string{}
+	for _, command := range blockCmd.Commands() {
+		commands = append(commands, command.Name())
+	}
 
 	if runtime.GOOS == "linux" {
-		blockCmd.AddCommand(blockMountCmd)
-		blockCmd.AddCommand(blockUnmountCmd)
+		assert.Equal(t, []string{"create", "ls", "mount", "unmount"}, commands)
+	} else {
+		assert.Equal(t, []string{"create", "ls"}, commands)
 	}
 }


### PR DESCRIPTION
Block mount and unmount is not supported and will error so I've removed it from the rook client (only on mac) for now.

fixes #185 