### PR TITLE
cache node id in the data dir

### DIFF
--- a/demo/vagrant/cloud-config.yml.in
+++ b/demo/vagrant/cloud-config.yml.in
@@ -26,7 +26,6 @@ coreos:
       KillMode=process
 
       Environment=ROOKD_ACI=quay.io/rook/rookd:latest
-      Environment=ROOKD_ID=%m
       Environment=ROOKD_PUBLIC_IPV4=$public_ipv4
       Environment=ROOKD_PRIVATE_IPV4=$private_ipv4
       Environment=ROOKD_DATA_DIR=/var/lib/rook


### PR DESCRIPTION
The order of precedence for the id is as follows: (edited)
1) Load the id from the dataDir
2) generate a random id (12 random hex chars)

After generated at first run, it will be persisted to `$datadir/node-id`.

Fixes https://github.com/rook/rook/issues/216 and https://github.com/rook/rook/issues/182