### PR TITLE
build: support concurrent runs of build/run

### DIFF
--- a/build/clean
+++ b/build/clean
@@ -17,13 +17,14 @@
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${scriptdir}/common.sh"
 
-if [[ $(docker ps -f name=${container_name} | grep -w ${container_name}) ]]; then
-    docker stop ${container_name}
-    docker rm ${container_name}
-fi
+# this should only clean up leaked containers during rsync
+for c in $(docker ps -a -q --filter=ancestor=${container_image}); do
+    echo removing container ${c}
+    docker stop ${c}
+    docker rm ${c}
+done
 
 if [[ $(docker volume ls | grep ${container_volume}) ]]; then
+    echo removing volume ${container_volume}
     docker volume rm ${container_volume}
 fi
-
-echo SUCCESS

--- a/build/run
+++ b/build/run
@@ -35,11 +35,6 @@ fi
 USER_ARGS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g )"
 BUILDER_HOME=/home/rook
 
-cleanup() {
-    docker stop ${container_name} &> /dev/null || true
-    docker rm ${container_name} &> /dev/null || true
-}
-
 # mount arguments
 MOUNT_OPTS="\
     -v ${scriptdir}/../bin:${BUILDER_HOME}/go/src/${source_repo}/bin \
@@ -67,17 +62,15 @@ if [ "`uname -s`" != "Linux" ]; then
     #       /src/github.com/rook/rook (rsync'd from host <source>)
     #
 
-    # create a new volume to hold our go workspace
+    # create a new volume to hold our go workspace. NOTE: while concurrent
+    # runs of the build container are supported they will share the same volume
+    # and we will be rsyncing to it at different times. This could lead to
+    # undefined behavior but this should be a rare case on non-linux envs.
     if [[ ! $(docker volume ls | grep ${container_volume}) ]]; then
-        echo ==== Syncing sources for first time. This could take a few seconds.
+        echo ==== Creating docker volume "${container_volume}" and syncing sources
+        echo ==== for first time. This could take a few seconds.
         docker volume create --name ${container_volume} &> /dev/null
     fi
-
-    trap "cleanup" EXIT
-    cleanup
-
-    # start rsyncd inside the container so that we can rsync files into it
-    start_and_wait_for_rsyncd
 
     # now copy the source tree to the container volume
     run_rsync ${scriptdir}/.. rsync://localhost:${rsync_port}/volume/src/${source_repo}
@@ -128,12 +121,8 @@ if [ -z "${DISABLE_NESTED_DOCKER}" ]; then
     -v /var/run/docker.sock:/var/run/docker.sock"
 fi
 
-trap "cleanup" EXIT
-cleanup
-
 docker run \
     --rm \
-    --name "${container_name}" \
     -e GOPATH="${BUILDER_HOME}/go" \
     -e WORKDIR="${BUILDER_HOME}/go/.work" \
     -e GO_PKG_DIR="" \
@@ -154,10 +143,6 @@ docker run \
 # copy some folders back to the source. We avoid a bind mount here
 # due to https://github.com/rook/rook/issues/93
 if [ "`uname -s`" != "Linux" ]; then
-
-    start_and_wait_for_rsyncd
-
     run_rsync rsync://localhost:${rsync_port}/volume/src/${source_repo}/vendor ${scriptdir}/..
     run_rsync rsync://localhost:${rsync_port}/volume/src/${source_repo}/tools ${scriptdir}/..
-
 fi


### PR DESCRIPTION
concurrent runs of build/run are now supported. This is mostly
to benefit jenkins scenarios. removed the need to name containers
and also refactored the rsync path.

Fixes #202