### PR TITLE
Write child process log entries with a very specific id

### DIFF
--- a/pkg/cephmgr/mon/agent.go
+++ b/pkg/cephmgr/mon/agent.go
@@ -146,6 +146,7 @@ func (a *agent) makeMonitorFileSystem(context *clusterd.Context, cluster *Cluste
 
 	// call mon --mkfs in a child process
 	err = context.ProcMan.Run(
+		fmt.Sprintf("mkfs-%s", monName),
 		"mon",
 		"--mkfs",
 		fmt.Sprintf("--cluster=%s", cluster.Name),
@@ -170,6 +171,7 @@ func (a *agent) runMonitor(context *clusterd.Context, cluster *ClusterInfo, moni
 	logger.Infof("starting monitor %s", monitor.Name)
 	monNameArg := fmt.Sprintf("--name=mon.%s", monitor.Name)
 	monProc, err := context.ProcMan.Start(
+		monitor.Name,
 		"mon",
 		regexp.QuoteMeta(monNameArg),
 		proc.ReuseExisting,

--- a/pkg/cephmgr/osd/agent.go
+++ b/pkg/cephmgr/osd/agent.go
@@ -476,6 +476,7 @@ func (a *osdAgent) runOSD(context *clusterd.Context, clusterName string, config 
 	}
 
 	process, err := context.ProcMan.Start(
+		fmt.Sprintf("osd%d", config.id),
 		"osd",
 		regexp.QuoteMeta(osdUUIDArg),
 		proc.ReuseExisting,

--- a/pkg/cephmgr/osd/device.go
+++ b/pkg/cephmgr/osd/device.go
@@ -318,6 +318,7 @@ func createOSDFileSystem(context *clusterd.Context, clusterName string, config *
 
 	// create the OSD file system and journal
 	err := context.ProcMan.Run(
+		fmt.Sprintf("mkfs-osd%d", config.id),
 		"osd",
 		options...)
 

--- a/pkg/util/proc/monitoredproc.go
+++ b/pkg/util/proc/monitoredproc.go
@@ -42,7 +42,7 @@ func newMonitoredProc(p *ProcManager, cmd *exec.Cmd) *MonitoredProc {
 	return m
 }
 
-func (p *MonitoredProc) Monitor() {
+func (p *MonitoredProc) Monitor(logName string) {
 	p.monitor = true
 	var err error
 
@@ -64,7 +64,7 @@ func (p *MonitoredProc) Monitor() {
 		<-time.After(time.Second * time.Duration(delaySeconds))
 
 		// start the process
-		p.cmd, err = p.parent.executor.StartExecuteCommand("restart", p.cmd.Args[0], p.cmd.Args[1:]...)
+		p.cmd, err = p.parent.executor.StartExecuteCommand(logName, p.cmd.Args[0], p.cmd.Args[1:]...)
 		if err != nil {
 			logger.Warningf("retry %d (total %d): process %v failed to restart. %v", p.retries, p.totalRetries, p.cmd.Args, err)
 			p.retries++

--- a/pkg/util/proc/monitoredproc_test.go
+++ b/pkg/util/proc/monitoredproc_test.go
@@ -70,7 +70,7 @@ func TestMonitoredRestart(t *testing.T) {
 		iter++
 	}
 
-	proc.Monitor()
+	proc.Monitor("testproc")
 	assert.False(t, proc.monitor)
 	assert.Equal(t, proc.retries, 0)
 	assert.Equal(t, proc.totalRetries, 2)


### PR DESCRIPTION
Issue https://github.com/rook/rook/issues/221. Now we will know which mon, osd, or other subprocess is logging.