### PR TITLE
setting proper exit code on stage failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,9 +44,11 @@ try {
 }
 catch (Exception e) {
     echo 'Failure encountered'
-} finally {
+
     node("ec2-stateful") {
         echo 'Cleaning up workspace'
         deleteDir()
     }
+
+    exit 1
 }


### PR DESCRIPTION
currently the builds are always exiting 0 even when there are failures because the error handling mechanism is overriding the final exit code passed back up to jenkins