### PR TITLE
Added a kubernetes demo

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,8 @@ const (
 var RootCmd = &cobra.Command{
 	Use:   "rook",
 	Short: "A command line client for working with a rook cluster",
-	Long:  `https://github.com/rook/rook`,
+	Long: `A command line client for working with a rook cluster.
+https://github.com/rook/rook`,
 }
 
 func init() {
@@ -48,6 +50,9 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&logLevelRaw, "log-level", "WARNING", "logging level for logging/tracing output (valid values: CRITICAL,ERROR,WARNING,NOTICE,INFO,DEBUG,TRACE)")
 
 	RootCmd.MarkFlagRequired("api-server-endpoint")
+
+	// load the environment variables
+	flags.SetFlagsFromEnv(RootCmd.PersistentFlags(), "ROOK")
 }
 
 func SetupLogging() {

--- a/cmd/rookd/main.go
+++ b/cmd/rookd/main.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/rook/rook/pkg/api"
 	"github.com/rook/rook/pkg/cephmgr"
@@ -35,14 +34,15 @@ import (
 	"github.com/rook/rook/pkg/cephmgr/mon"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/util"
-
 	"github.com/rook/rook/pkg/util/flags"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "rookd",
 	Short: "rookd tool for bootstrapping and running rook storage",
-	Long:  `https://github.com/rook/rook`,
+	Long: `
+Tool for bootstrapping and running the rook storage daemon.
+https://github.com/rook/rook`,
 }
 var cfg = newConfig()
 
@@ -77,7 +77,7 @@ func main() {
 
 // Initialize the configuration parameters. The precedence from lowest to highest is:
 //  1) default value (at compilation)
-//  2) environment variables (upper case, replace - with _, and rook prefix. For example, discovery-url is ROOK_DISCOVERY_URL)
+//  2) environment variables (upper case, replace - with _, and rook prefix. For example, discovery-url is ROOKD_DISCOVERY_URL)
 //  3) command line parameter
 func init() {
 	rootCmd.Flags().StringVar(&cfg.adminSecret, "admin-secret", "", "secret for the admin user (random if not specified)")
@@ -94,7 +94,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevelRaw, "log-level", "INFO", "logging level for logging/tracing output (valid values: CRITICAL,ERROR,WARNING,NOTICE,INFO,DEBUG,TRACE)")
 
 	// load the environment variables
-	setFlagsFromEnv(rootCmd.Flags())
+	flags.SetFlagsFromEnv(rootCmd.Flags(), "ROOKD")
 
 	rootCmd.RunE = startJoinCluster
 }
@@ -179,19 +179,6 @@ func joinCluster() error {
 	signal.Notify(ch, os.Interrupt)
 	<-ch
 	fmt.Println("terminating due to ctrl-c interrupt...")
-
-	return nil
-}
-
-func setFlagsFromEnv(flags *pflag.FlagSet) error {
-	flags.VisitAll(func(f *pflag.Flag) {
-		envVar := "ROOKD_" + strings.Replace(strings.ToUpper(f.Name), "-", "_", -1)
-		value := os.Getenv(envVar)
-		if value != "" {
-			// Set the environment variable. Will override default values, but be overridden by command line parameters.
-			flags.Set(f.Name, value)
-		}
-	})
 
 	return nil
 }

--- a/demo/kubernetes/README.md
+++ b/demo/kubernetes/README.md
@@ -1,0 +1,58 @@
+# Rook on Kubernetes
+
+A demo of persistent block storage from rook within a [Kubernetes](http://kubernetes.io/) cluster. We will use a mysql service in Kubernetes as an example of using block storage from rook.
+
+## Prerequisites
+
+A running Kubernetes cluster with at least 2 nodes is required. Since this demo will use the rbd volume type it will need access to modprobe on the kubernetes nodes (<https://github.com/kubernetes/kubernetes/issues/23924>). There is a fork of [coreos-kubernetes](https://github.com/coreos/coreos-kubernetes) that has a fix for this <https://github.com/rook/coreos-kubernetes/tree/rook-demo> (rook-demo branch).
+
+If you are using the rook-demo branch you can get a vagrant kubernetes cluster running like this (from the root of the repo):
+
+    $ cd multi-node/vagrant
+    $ vagrant up
+    $ export KUBECONFIG="${KUBECONFIG}:$(pwd)/kubeconfig"
+    $ kubectl config use-context vagrant-multi
+
+## Starting rook
+
+    $ export TOKEN=$(curl -w "\n" 'https://discovery.etcd.io/new?size=2')
+    $ kubectl create configmap rookd --from-literal=discovery-token=$TOKEN
+    $ kubectl create -f rook.yml
+
+This generates a discovery token so the nodes can find each other and then starts rook. `rookd` will start up on each node and form a cluster.
+
+**Note**: In environments other than the coreos-kubernetes vagrant cluster, to have external access via the rook cli, the `rook.yml` will need to be edited and the `externalIPs` array will need to be changed to an appropriate externally routable ip to one of the cluster nodes.
+
+## Using the storage
+
+First let's setup access to the rook cluster via the command line client.  You can download a pre-built from [github releases](https://github.com/rook/rook/releases) or [build from source](https://github.com/rook/rook/blob/master/build/README.md). (If you are not using coreos-kubernetes vagrant substitute the ip from above that you put in the `rook.yml` for `ROOK_API_SERVER_ENDPOINT`)
+
+    $ export ROOK_API_SERVER_ENDPOINT=172.17.4.101:8124
+    $ rook status
+
+It may take a moment for the rook cluster to come up and `rook status` to complete successfully.  Once it is successful we will want to fetch the rook secret that is used to mount rook block devices and store it in a Kubernetes secret. This only needs to be done once for a given cluster.
+
+    $ SECRET=$(curl $ROOK_API_SERVER_ENDPOINT/client | jq -r '.secretKey')
+    $ kubectl create secret generic rookd --from-literal=key=$SECRET --type kubernetes.io/rbd
+
+To use a block device in the kubernetes cluster you will first need to create a block image for that device.
+
+    $ rook block create --name demoblock --size 1073741824
+
+Then we must fetch the mon endpoints and substitute them in to the `mysql.yml` for the example mysql service and pipe it into `kubectl` to create the pod:
+    
+    $ export MONS=$(curl $ROOK_API_SERVER_ENDPOINT/client | jq -c '.monAddresses')
+    $ sed 's#INSERT_HERE#'$MONS'#' mysql.yml | kubectl create -f -
+
+## Teardown demo
+
+    $ kubectl delete pod mysql
+    $ kubectl delete configmap rookd
+    $ kubectl delete secret rookd
+    $ kubectl delete -f rook.yml
+
+## Todo
+
+* Kubernetes volume plugin for rook that avoids the need for the mon endpoints being hard-coded into the pod spec
+* a better solution for the modprobe issue (<https://github.com/kubernetes/kubernetes/issues/23924>)
+* Figure out one node cluster scenario

--- a/demo/kubernetes/mysql.yml
+++ b/demo/kubernetes/mysql.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mysql
+  labels:
+    name: mysql
+spec:
+  containers:
+    - name: mysql
+      image: mysql
+      args:
+        - "--ignore-db-dir"
+        - "lost+found"
+      env:
+        - name: MYSQL_ROOT_PASSWORD
+          # change this
+          value: yourpassword
+      ports:
+        - containerPort: 3306
+          name: mysql
+      volumeMounts:
+        - name: mysql-persistent-storage
+          mountPath: /var/lib/mysql
+  volumes:
+    - name: mysql-persistent-storage
+      rbd:
+        monitors: INSERT_HERE
+        image: demoblock
+        user: admin
+        secretRef:
+            name: rookd
+        fsType: ext4
+        readOnly: false

--- a/demo/kubernetes/rook.yml
+++ b/demo/kubernetes/rook.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rest
+  labels:
+    app: rook
+    role: rest
+spec:
+  type: NodePort
+  externalIPs: [ "172.17.4.101" ]
+  ports:
+  - port: 8124
+  selector:
+    app: rook
+    role: rookd
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: rookd
+spec:
+  template:
+    metadata:
+      labels:
+        app: rook
+        role: rookd
+    spec:
+      containers:
+      - name: rookd
+        image: quay.io/rook/rookd
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        env:
+        - name: ROOKD_DISCOVERY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: rookd
+              key: discovery-token
+        - name: ROOKD_PRIVATE_IPV4
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ROOKD_PUBLIC_IPV4
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - mountPath: /var/lib/rook
+          name: rook-data-dir
+        - mountPath: /dev/disk
+          name: dev-disk
+      volumes:
+      - name: rook-data-dir
+        emptyDir: {}
+      - name: dev-disk
+        hostPath:
+          path: /dev/disk

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -17,9 +17,11 @@ package flags
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func VerifyRequiredFlags(cmd *cobra.Command, requiredFlags []string) error {
@@ -56,4 +58,17 @@ func createRequiredFlagError(name string, flags []string) error {
 	}
 
 	return fmt.Errorf("%s are required for %s", strings.Join(flags, ","), name)
+}
+
+func SetFlagsFromEnv(flags *pflag.FlagSet, prefix string) error {
+	flags.VisitAll(func(f *pflag.Flag) {
+		envVar := prefix + "_" + strings.Replace(strings.ToUpper(f.Name), "-", "_", -1)
+		value := os.Getenv(envVar)
+		if value != "" {
+			// Set the environment variable. Will override default values, but be overridden by command line parameters.
+			flags.Set(f.Name, value)
+		}
+	})
+
+	return nil
 }


### PR DESCRIPTION
This serves as a simple example of running rook in a kubernetes environment and shows how to consume a block device as a data dir for mysql.

Please see the following for changes need to coreos-kubernetes to run the demo: https://github.com/rook/coreos-kubernetes/commit/651dece8c62fef45d76889bd64247bd6eb51546a

Also added the ability to set global flags with environment variables in the rook cli.

Resolves #234 