### PR TITLE
pass DOCKER_API_VERSION from host's docker into build container

### DIFF
--- a/build/run
+++ b/build/run
@@ -24,6 +24,16 @@ if [ ! -z $DOCKER_HOST ]; then
     return 1
 fi
 
+DOCKER_CLIENT_API=1.24   # keep in sync with container's version of docker
+set +e
+DOCKER_SERVER_API=$(docker version --format '{{.Client.APIVersion}}' 2>/dev/null)
+if [ $? -ne 0 ]; then
+    echo -e "\nFATAL: Failed to query the docker version running on the host - aborting.\n"
+    echo "Please make sure that docker is running and your user has permissions to run docker commands by issuing the command 'docker version' on the command line."
+    exit 1
+fi
+set -e
+
 # if the container does not exist the pull or build it
 if [[ ! $(docker images -q ${container_image}) ]]; then
     echo ==== Pulling ${container_image}
@@ -120,6 +130,11 @@ if [ -z "${DISABLE_NESTED_DOCKER}" ]; then
     -v ${HOME}/.docker/config.json:${BUILDER_HOME}/.docker/config.json \
     -v /var/run/docker.sock:/var/run/docker.sock"
 fi
+DOCKER_API=''
+
+if (( $(bc <<< "$DOCKER_SERVER_API < $DOCKER_CLIENT_API") )); then
+    DOCKER_API="-e DOCKER_API_VERSION=${DOCKER_SERVER_API}"
+fi
 
 docker run \
     --rm \
@@ -127,7 +142,7 @@ docker run \
     -e WORKDIR="${BUILDER_HOME}/go/.work" \
     -e GO_PKG_DIR="" \
     -e GITHUB_TOKEN \
-    -e VERSION \
+    -e VERSION $DOCKER_API \
     ${TTY_ARGS} \
     ${CCACHE_ARGS} \
     ${NETRC_ARGS} \


### PR DESCRIPTION
Hit this when trying to build rook on CentOS 7 which in its standard repos only has docker-1.10.3 which supports API version 1.22 but the docker in the container used to build uses docker-1.12 which supports API version 1.24.

release build dies over this:

```
rook@pxecastle:~/go/src/github.com/rook/rook$ make -j 8 release
[..]
github.com/rook/rook/cmd/rookd
creating tar release/rook-e0f680c-linux-amd64.tar.gz
building docker container rook/rookd:e0f680c
WARNING: Error loading config file:/home/rook/.docker/config.json - read /home/rook/.docker/config.json: is a directory
Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.22)
build/makelib/release.mk:67: recipe for target 'release.build.containers' failed
make[2]: *** [release.build.containers] Error 1
make[2]: *** Waiting for unfinished jobs....
creating tar release/rook-e0f680c-linux-arm64.tar.gz
creating zip /home/rook/go/src/github.com/rook/rook/release/rook-e0f680c-darwin-amd64.zip
creating zip /home/rook/go/src/github.com/rook/rook/release/rook-e0f680c-windows-amd64.zip
build/makelib/release.mk:74: recipe for target 'release.build' failed
make[1]: *** [release.build] Error 2
Makefile:197: recipe for target 'release' failed
make: *** [release] Error 2
rook@pxecastle:~/go/src/github.com/rook/rook$
```

This would force the user to upgrade their docker version on the host to whatever is in CoreOS - could be a deterrent from contributing.

The patch assumes that the CoreOS version is always the newest version - but will make things worse if close to release we don't keep up with CoreOS updates anymore and people use newer clients.

Maybe the logic should be more sophisticated and pass in the API version if it is lower than what is in CoreOS. We would need to keep track of the CoreOS version in a variable - something like:

```
DOCKER_CLIENT_API=1.24 # keep in sync with container docker
DOCKER_SERVER_API=$(docker version | grep 'API version' | tail -1 | awk '{print $3}')
(( $(bc <<< "$DOCKER_SERVER_API < $DOCKER_CLIENT_API") )) && echo "pass -e DOCKER_API_VERSION=${DOCKER_SERVER_API}"

e.g.:
[lars@pxecastle rook]$ DOCKER_CLIENT_API=1.24
[lars@pxecastle rook]$ DOCKER_SERVER_API=1.22
[lars@pxecastle rook]$ (( $(bc <<< "$DOCKER_SERVER_API < $DOCKER_CLIENT_API") )) && echo "pass -e DOCKER_API_VERSION=${DOCKER_SERVER_API}"
pass -e DOCKER_API_VERSION=1.22
[lars@pxecastle rook]$ DOCKER_SERVER_API=1.25
[lars@pxecastle rook]$ (( $(bc <<< "$DOCKER_SERVER_API < $DOCKER_CLIENT_API") )) && echo "pass -e DOCKER_API_VERSION=${DOCKER_SERVER_API}"
[lars@pxecastle rook]$ 
```
drawback: then the script depends on bc... (not sure if that is installed on all OSes - but probably still better)