### PR TITLE
Improve stability of internal etcd at startup

### DIFF
--- a/pkg/etcdmgr/bootstrap/client.go
+++ b/pkg/etcdmgr/bootstrap/client.go
@@ -15,19 +15,15 @@ limitations under the License.
 */
 package bootstrap
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
 // GetEtcdClients bootstraps an embedded etcd instance and returns a list of
 // current etcd cluster's client URLs. (entrypoint, when it's used as a library)
 func GetEtcdClients(configDir, token, ipAddr, nodeID string) ([]string, error) {
 
-	full, err, currentNodes := isQuorumFull(token)
-	//currentNodes, err := GetCurrentNodesFromDiscovery(token)
+	full, currentNodes, err := isQuorumFull(token)
 	if err != nil {
-		return []string{}, errors.New("error querying discovery service")
+		return nil, fmt.Errorf("error querying discovery service. %+v", err)
 	}
 	logger.Infof("current etcd cluster nodes: %+v", currentNodes)
 
@@ -58,7 +54,7 @@ func GetEtcdClients(configDir, token, ipAddr, nodeID string) ([]string, error) {
 	factory := EmbeddedEtcdFactory{}
 	ee, err := factory.NewEmbeddedEtcd(token, conf, true)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to start embedded etcd. %+v", err)
 	}
 
 	return ee.Server.Cluster().ClientURLs(), nil

--- a/pkg/etcdmgr/bootstrap/context.go
+++ b/pkg/etcdmgr/bootstrap/context.go
@@ -74,7 +74,13 @@ func (e *Context) KeysAPI() (client.KeysAPI, error) {
 func (e *Context) Members() ([]string, types.URLsMap, error) {
 	urlsMap := types.URLsMap{}
 	var nodes []string
-	initialNodes, err := GetCurrentNodesFromDiscovery(e.ClusterToken)
+
+	size, err := getClusterSize(e.ClusterToken)
+	if err != nil {
+		return nodes, urlsMap, err
+	}
+
+	initialNodes, err := GetCurrentNodesFromDiscovery(e.ClusterToken, size)
 	if err != nil {
 		logger.Errorf("error in GetCurrentNodesFromDiscovery: %+v", err)
 		return nodes, urlsMap, err

--- a/pkg/etcdmgr/bootstrap/discovery_test.go
+++ b/pkg/etcdmgr/bootstrap/discovery_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package bootstrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectDiscoveredNodes(t *testing.T) {
+	var ignored []string
+	nodeMap := map[uint64][]string{}
+	upperIndex := uint64(0)
+	size := 1
+
+	// the first entry will be added because it's below size 1
+	index5 := uint64(5)
+	endpoints5 := []string{"http://10.1.1.5:5000"}
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints5, size, index5, upperIndex, ignored)
+	assert.Equal(t, index5, upperIndex)
+	assert.Equal(t, 1, len(nodeMap))
+	assert.Equal(t, endpoints5, nodeMap[index5])
+	assert.Equal(t, 0, len(ignored))
+
+	// the second entry is ignored since size is full and the index is higher
+	index6 := uint64(6)
+	endpoints6 := []string{"http://10.1.1.6:5000"}
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints6, size, index6, upperIndex, ignored)
+	assert.Equal(t, index5, upperIndex)
+	assert.Equal(t, 1, len(nodeMap))
+	assert.Equal(t, endpoints5, nodeMap[index5])
+	assert.Equal(t, 1, len(ignored))
+	assert.Equal(t, endpoints6[0], ignored[0])
+
+	// the third entry replaces the first since its index is lower
+	index4 := uint64(4)
+	endpoints4 := []string{"http://1.1.1.4:5000"}
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints4, size, index4, upperIndex, ignored)
+	assert.Equal(t, index4, upperIndex)
+	assert.Equal(t, 1, len(nodeMap))
+	assert.Equal(t, endpoints4, nodeMap[index4])
+	assert.Equal(t, 2, len(ignored))
+	assert.Equal(t, endpoints6[0], ignored[0])
+	assert.Equal(t, endpoints5[0], ignored[1])
+
+	// increase size to 3
+	ignored = []string{}
+	size = 3
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints6, size, index6, upperIndex, ignored)
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints5, size, index5, upperIndex, ignored)
+	assert.Equal(t, index6, upperIndex)
+	assert.Equal(t, 3, len(nodeMap))
+	assert.Equal(t, 0, len(ignored))
+	assert.Equal(t, index6, upperIndex)
+
+	// replace a node with a lower index
+	index3 := uint64(3)
+	endpoints3 := []string{"http://1.1.1.3:5000"}
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints3, size, index3, upperIndex, ignored)
+	assert.Equal(t, index5, upperIndex)
+	assert.Equal(t, 3, len(nodeMap))
+	assert.Equal(t, endpoints6[0], ignored[0])
+
+	// replace another node
+	index2 := uint64(2)
+	endpoints2 := []string{"http://1.1.1.2:5000"}
+	upperIndex, ignored = addNodeToMap(nodeMap, endpoints2, size, index2, upperIndex, ignored)
+	assert.Equal(t, index4, upperIndex)
+	assert.Equal(t, 3, len(nodeMap))
+	assert.Equal(t, 2, len(ignored))
+}

--- a/pkg/etcdmgr/bootstrap/etcd.go
+++ b/pkg/etcdmgr/bootstrap/etcd.go
@@ -55,7 +55,7 @@ func (e *EmbeddedEtcdFactory) NewEmbeddedEtcd(token string, conf *Config, newClu
 
 	instance.Server, err = etcdserver.NewServer(serverConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error in creating etcd server. %+v", err)
+		return nil, err
 	}
 
 	instance.Server.Start()


### PR DESCRIPTION
Two improvements in this change:
1. Retry requests to the etcd discovery service in case the network is unstable. Retry up to 10 times, backing off another half second each time. If it still fails after that, the daemon that launched rook should restart it (ie. the k8s pod will restart)
2. When etcd members are starting concurrently the first time, there is a race condition that allows more servers to register with the etcd discovery service than the size specifies. If this were external etcd, the extra servers could simply fall back to be proxies. But in rook we would rather ignore the extra registered servers. The servers that registered first, up to the cluster size, will be returned.