### PR TITLE
build: add a script to check ceph submodule

### DIFF
--- a/build/ceph-submodule-check
+++ b/build/ceph-submodule-check
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+# Copyright 2016 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+commits=$(git log --pretty=oneline --raw --no-abbrev --submodule=log ceph | grep '^:' | cut -d' ' -f4)
+for c in ${commits}; do
+    # ignore the first commit we used to branch the submodule
+    if [[ "$c" == "c4da56d0cbfcd75e37be29dd4853b23487a3526f" ]]; then
+        continue
+    fi
+    if $(cd ceph; git show $c > /dev/null 2>&1); then
+        b=$(cd ceph; git branch --contains $c | tr -d "* ")
+        if [[ $b != "" ]]; then
+            echo ceph submodule reference $c is in branches $b
+        else
+            echo ceph submodule reference $c exists but not part of a branch
+        fi
+    else
+        echo ceph submodule reference $c is MISSING
+    fi
+done


### PR DESCRIPTION
helper script to check submodule references are valid. see https://github.com/rook/rook/wiki/Ceph-submodule for details.