### PR TITLE
Update rookd REST API service node port to worker node

### DIFF
--- a/demo/kubernetes/rook.yml
+++ b/demo/kubernetes/rook.yml
@@ -7,7 +7,7 @@ metadata:
     role: rest
 spec:
   type: NodePort
-  externalIPs: [ "172.17.4.101" ]
+  externalIPs: [ "172.17.4.201" ]
   ports:
   - port: 8124
   selector:


### PR DESCRIPTION
To match the quickstart docs at https://github.com/rook/rook/tree/master/demo/kubernetes#using-the-storage