### PR TITLE
detect all available devices for bluestore by default

### DIFF
--- a/demo/kubernetes/rook.yml
+++ b/demo/kubernetes/rook.yml
@@ -46,7 +46,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: ROOKD_DATA_DEVICES
-          value: sdb,sdc
+          value: all
         volumeMounts:
         - mountPath: /var/lib/rook
           name: rook-data-dir

--- a/demo/vagrant/cloud-config.yml.in
+++ b/demo/vagrant/cloud-config.yml.in
@@ -30,7 +30,7 @@ coreos:
       Environment=ROOKD_PRIVATE_IPV4=$private_ipv4
       Environment=ROOKD_DATA_DIR=/var/lib/rook
       Environment=ROOKD_DISCOVERY_URL=%%token%%
-      Environment=ROOKD_DATA_DEVICES=sda,sdb,sdc,sdd
+      Environment=ROOKD_DATA_DEVICES=all
 
       ExecStartPre=/usr/bin/mkdir -p ${ROOKD_DATA_DIR}
 

--- a/demo/vagrant/cloud-config.yml.in
+++ b/demo/vagrant/cloud-config.yml.in
@@ -30,6 +30,7 @@ coreos:
       Environment=ROOKD_PRIVATE_IPV4=$private_ipv4
       Environment=ROOKD_DATA_DIR=/var/lib/rook
       Environment=ROOKD_DISCOVERY_URL=%%token%%
+      Environment=ROOKD_REALLY_FORMAT_ALL_DEVICES=true
       Environment=ROOKD_DATA_DEVICES=all
 
       ExecStartPre=/usr/bin/mkdir -p ${ROOKD_DATA_DIR}

--- a/pkg/cephmgr/osd/agent.go
+++ b/pkg/cephmgr/osd/agent.go
@@ -45,7 +45,7 @@ const (
 	osdAgentName    = "osd"
 	deviceKey       = "device"
 	dirKey          = "dir"
-	allDevices      = "all"
+	AllDevices      = "all"
 	unassignedOSDID = -1
 )
 
@@ -75,7 +75,7 @@ func (a *osdAgent) Initialize(context *clusterd.Context) error {
 	deviceCount := 0
 	if len(a.devices) > 0 {
 		var devices []string
-		if strings.EqualFold(a.devices, allDevices) {
+		if strings.EqualFold(a.devices, AllDevices) {
 			var err error
 			devices, err = inventory.GetAvailableDevices(context.NodeID, context.EtcdClient)
 			if err != nil {

--- a/pkg/clusterd/inventory/disk_test.go
+++ b/pkg/clusterd/inventory/disk_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package inventory
+
+import (
+	"path"
+	"testing"
+
+	etcd "github.com/coreos/etcd/client"
+	ctx "golang.org/x/net/context"
+
+	"github.com/rook/rook/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSimpleDiskPropertiesFromSerial(t *testing.T) {
+	nodeID := "df1c87e8266843f2ab822c0d72f584d3"
+	etcdClient := &util.MockEtcdClient{}
+	hardwareKey := path.Join(NodesConfigKey, nodeID)
+	etcdClient.Set(ctx.Background(), hardwareKey, "", &etcd.SetOptions{Dir: true})
+	TestSetDiskInfo(etcdClient, hardwareKey, "sda", "abcd4869-29ee-4bfd-bf21-dfd597bd222e",
+		10737418240, true, false, "btrfs", "/mnt/abc", Disk, "", true)
+
+	diskNode, _ := etcdClient.Get(ctx.Background(), path.Join(hardwareKey, "disks", "sda"), nil)
+	disk, err := getDiskInfo(diskNode.Node)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "sda", disk.Name)
+	assert.Equal(t, "abcd4869-29ee-4bfd-bf21-dfd597bd222e", disk.UUID)
+}
+
+func TestAvailableDisks(t *testing.T) {
+	nodeID := "a"
+	etcdClient := &util.MockEtcdClient{}
+	hardwareKey := path.Join(NodesConfigKey, nodeID)
+
+	// no disks discovered for a node is an error
+	disks, err := GetAvailableDevices(nodeID, etcdClient)
+	assert.Equal(t, 0, len(disks))
+	assert.NotNil(t, err)
+
+	// no available disks because of the formatting
+	TestSetDiskInfo(etcdClient, hardwareKey, "sda", "myuuid1", 123, true, false, "btrfs", "/mnt/abc", Disk, "", true)
+	disks, err = GetAvailableDevices(nodeID, etcdClient)
+	assert.Equal(t, 0, len(disks))
+	assert.Nil(t, err)
+
+	// multiple available disks
+	TestSetDiskInfo(etcdClient, hardwareKey, "sdb", "myuuid2", 123, true, false, "", "", Disk, "", true)
+	TestSetDiskInfo(etcdClient, hardwareKey, "sdc", "myuuid3", 123, true, false, "", "", Disk, "", true)
+	disks, err = GetAvailableDevices(nodeID, etcdClient)
+	assert.Equal(t, 2, len(disks))
+	assert.Nil(t, err)
+
+	// partitions don't result in more available devices
+	TestSetDiskInfo(etcdClient, hardwareKey, "sdb1", "myuuid4", 123, true, false, "", "", Part, "sdb", true)
+	TestSetDiskInfo(etcdClient, hardwareKey, "sdb2", "myuuid5", 123, true, false, "", "", Part, "sdb", true)
+	disks, err = GetAvailableDevices(nodeID, etcdClient)
+	assert.Equal(t, 2, len(disks))
+	assert.Nil(t, err)
+}

--- a/pkg/clusterd/inventory/hardware.go
+++ b/pkg/clusterd/inventory/hardware.go
@@ -20,18 +20,19 @@ import "time"
 type DiskType int
 
 const (
-	MemoryTotalSizeKey             = "total"
-	NetworkIPv4AddressKey          = "ipv4"
-	NetworkIPv6AddressKey          = "ipv6"
-	NetworkSpeedKey                = "speed"
-	ProcPhysicalIDKey              = "physical-id"
-	ProcSiblingsKey                = "siblings"
-	ProcCoreIDKey                  = "core-id"
-	ProcNumCoresKey                = "cores"
-	ProcSpeedKey                   = "speed"
-	ProcBitsKey                    = "arch"
-	Disk                  DiskType = iota
-	Part
+	MemoryTotalSizeKey    = "total"
+	NetworkIPv4AddressKey = "ipv4"
+	NetworkIPv6AddressKey = "ipv6"
+	NetworkSpeedKey       = "speed"
+	ProcPhysicalIDKey     = "physical-id"
+	ProcSiblingsKey       = "siblings"
+	ProcCoreIDKey         = "core-id"
+	ProcNumCoresKey       = "cores"
+	ProcSpeedKey          = "speed"
+	ProcBitsKey           = "arch"
+	Disk                  = "disk"
+	SSD                   = "ssd"
+	Part                  = "part"
 )
 
 type Config struct {
@@ -50,16 +51,16 @@ type NodeConfig struct {
 }
 
 type DiskConfig struct {
-	Name        string   `json:"name"`
-	UUID        string   `json:"uuid"`
-	Size        uint64   `json:"size"`
-	Rotational  bool     `json:"rotational"`
-	Readonly    bool     `json:"readonly"`
-	FileSystem  string   `json:"fileSystem"`
-	MountPoint  string   `json:"mountPoint"`
-	Type        DiskType `json:"type"`
-	Parent      string   `json:"parent"`
-	HasChildren bool     `json:"hasChildren"`
+	Name        string `json:"name"`
+	UUID        string `json:"uuid"`
+	Size        uint64 `json:"size"`
+	Rotational  bool   `json:"rotational"`
+	Readonly    bool   `json:"readonly"`
+	FileSystem  string `json:"fileSystem"`
+	MountPoint  string `json:"mountPoint"`
+	Type        string `json:"type"`
+	Parent      string `json:"parent"`
+	HasChildren bool   `json:"hasChildren"`
 }
 
 type MemoryConfig struct {

--- a/pkg/clusterd/inventory/node_test.go
+++ b/pkg/clusterd/inventory/node_test.go
@@ -220,19 +220,3 @@ func verifyNetworkConfig(t *testing.T, nodeConfig *NodeConfig, expectedNetsConfi
 		assert.Equal(t, expectedNet, matchingActual)
 	}
 }
-
-func TestGetSimpleDiskPropertiesFromSerial(t *testing.T) {
-	nodeID := "df1c87e8266843f2ab822c0d72f584d3"
-	etcdClient := &util.MockEtcdClient{}
-	hardwareKey := path.Join(NodesConfigKey, nodeID)
-	etcdClient.Set(ctx.Background(), hardwareKey, "", &etcd.SetOptions{Dir: true})
-	TestSetDiskInfo(etcdClient, hardwareKey, "sda", "abcd4869-29ee-4bfd-bf21-dfd597bd222e",
-		10737418240, true, false, "btrfs", "/mnt/abc", Disk, "", true)
-
-	diskNode, _ := etcdClient.Get(ctx.Background(), path.Join(hardwareKey, "disks", "sda"), nil)
-	disk, err := getDiskInfo(diskNode.Node)
-	assert.Nil(t, err)
-
-	assert.Equal(t, "sda", disk.Name)
-	assert.Equal(t, "abcd4869-29ee-4bfd-bf21-dfd597bd222e", disk.UUID)
-}


### PR DESCRIPTION
If `ROOKD_DATA_DEVICES=all`, configure all devices for bluestore that meet the following criteria:
- Do not have a file system (such as a system partition
- Is of type Disk
- Has no parent device

If no devices are found, a filestore directory will be created