### PR TITLE
load a local build into vagrant based on env var

### DIFF
--- a/demo/vagrant/Vagrantfile
+++ b/demo/vagrant/Vagrantfile
@@ -26,8 +26,21 @@ require 'open-uri'
 if File.exists?('.discovery-token')
   token = IO.readlines(".discovery-token")[0..-1].join
 else
-  token = open($new_discovery_url).read
+  discovery_token = open($new_discovery_url).read
   File.open(".discovery-token", 'w') { |file| file.write("#{token}") }
+end
+
+private_build = false
+if ENV["START_LOCAL_ROOKD"] == "1"
+  private_build = true
+end
+
+if private_build
+  aci_location = "/release/quay.io-rook-rookd-dev.aci"
+  aci_options = "--insecure-options=image"
+else
+  aci_location = "quay.io/rook/rookd:latest"
+  aci_options = ""
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -40,11 +53,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
       attach_volumes(node, $node_disks, $disk_size)
 
-      # enable if you want to run for locally build ACI files
-      #node.vm.synced_folder "../../release", "/release", id: "release", :nfs => true, :mount_options => ['nolock,vers=3,tcp']
+      if private_build
+        # run locally built ACI files
+        node.vm.synced_folder "../../release", "/release", id: "release", :nfs => true, :mount_options => ['nolock,vers=3,tcp']
+      end
 
       node.vm.provision :cloud_config, :template => "cloud-config.yml.in",
-        :subst => { "%%token%%" => "#{token}" }
+        :subst => { 
+            "%%discovery_token%%" => "#{discovery_token}", 
+            "%%aci_location%%" => "#{aci_location}",
+            "%%aci_options%%" => "#{aci_options}" 
+        }
     end
   end
 end

--- a/demo/vagrant/cloud-config.yml.in
+++ b/demo/vagrant/cloud-config.yml.in
@@ -7,13 +7,6 @@ coreos:
   - name: rookd.service
     enable: true
     command: start
-# enable if you want to run from locally built ACI files
-#    drop-ins:
-#      - name: 10-local-aci.conf
-#        content: |
-#          [Service]
-#          Environment=ROOKD_ACI=/release/quay.io-rook-rookd-dev.aci
-#          Environment=RKT_OPTIONS=--insecure-options=image
     content: |
       [Unit]
       Description=Rook Daemon - software defined storage
@@ -25,11 +18,12 @@ coreos:
       Restart=always
       KillMode=process
 
-      Environment=ROOKD_ACI=quay.io/rook/rookd:latest
+      Environment=RKT_OPTIONS=%%aci_options%%
+      Environment=ROOKD_ACI=%%aci_location%%
       Environment=ROOKD_PUBLIC_IPV4=$public_ipv4
       Environment=ROOKD_PRIVATE_IPV4=$private_ipv4
       Environment=ROOKD_DATA_DIR=/var/lib/rook
-      Environment=ROOKD_DISCOVERY_URL=%%token%%
+      Environment=ROOKD_DISCOVERY_URL=%%discovery_token%%
       Environment=ROOKD_DATA_DEVICES=sda,sdb,sdc,sdd
 
       ExecStartPre=/usr/bin/mkdir -p ${ROOKD_DATA_DIR}


### PR DESCRIPTION
The approach of uncommenting from the Vagrantfile and cloud config to launch a local aci does not work long term during development because you have to constantly keep track of the two additional files checked out, for which you never have the intention of committing. With this change, you can set an environment variable to indicate that a local build (ACI) should be launched instead of pulling from quay.

Launch a local ACI build from vagrant:
```
export START_LOCAL_ROOKD=1
vagrant up
```

To download from quay again:
```
export START_LOCAL_ROOKD=
vagrant up
```
