### PR TITLE
allow ceph config file override with --ceph-config-override (or ROOKD…

### DIFF
--- a/cmd/rookd/main.go
+++ b/cmd/rookd/main.go
@@ -51,17 +51,18 @@ var logLevelRaw string
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "rookd")
 
 type config struct {
-	nodeID       string
-	discoveryURL string
-	etcdMembers  string
-	publicIPv4   string
-	privateIPv4  string
-	devices      string
-	dataDir      string
-	adminSecret  string
-	forceFormat  bool
-	location     string
-	logLevel     capnslog.LogLevel
+	nodeID             string
+	discoveryURL       string
+	etcdMembers        string
+	publicIPv4         string
+	privateIPv4        string
+	devices            string
+	dataDir            string
+	adminSecret        string
+	forceFormat        bool
+	location           string
+	logLevel           capnslog.LogLevel
+	cephConfigOverride string
 }
 
 func newConfig() *config {
@@ -93,9 +94,11 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.location, "location", "", "location of this node for CRUSH placement")
 
 	rootCmd.PersistentFlags().StringVar(&logLevelRaw, "log-level", "INFO", "logging level for logging/tracing output (valid values: CRITICAL,ERROR,WARNING,NOTICE,INFO,DEBUG,TRACE)")
+	rootCmd.PersistentFlags().StringVar(&cfg.cephConfigOverride, "ceph-config-override", "", "optional path to a ceph config file that will be appended to the config files that rook generates")
 
 	// load the environment variables
 	flags.SetFlagsFromEnv(rootCmd.Flags(), "ROOKD")
+	flags.SetFlagsFromEnv(rootCmd.PersistentFlags(), "ROOKD")
 
 	rootCmd.RunE = startJoinCluster
 }
@@ -162,7 +165,7 @@ func joinCluster() error {
 
 	// start the cluster orchestration services
 	context, err := clusterd.StartJoinCluster(services, cfg.dataDir, cfg.nodeID, cfg.discoveryURL,
-		cfg.etcdMembers, cfg.publicIPv4, cfg.privateIPv4, cfg.logLevel)
+		cfg.etcdMembers, cfg.publicIPv4, cfg.privateIPv4, cfg.cephConfigOverride, cfg.logLevel)
 	if err != nil {
 		return err
 	}

--- a/pkg/cephmgr/mon/config.go
+++ b/pkg/cephmgr/mon/config.go
@@ -148,6 +148,15 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 		return "", fmt.Errorf("failed to add initial monitor config sections, %+v", err)
 	}
 
+	// if there's a config file override path given, process the given config file
+	if context.ConfigFileOverride != "" {
+		err := configFile.Append(context.ConfigFileOverride)
+		if err != nil {
+			// log the config file override failure as a warning, but proceed without it
+			logger.Warningf("failed to add config file override from '%s': %+v", context.ConfigFileOverride, err)
+		}
+	}
+
 	// write the entire config to disk
 	filePath := GetConfFilePath(pathRoot, cluster.Name)
 	logger.Debugf("writing config file %s", filePath)

--- a/pkg/clusterd/clusterservice.go
+++ b/pkg/clusterd/clusterservice.go
@@ -82,18 +82,22 @@ type Context struct {
 
 	// A value indicating the desired logging/tracing level
 	LogLevel capnslog.LogLevel
+
+	// The full path to a config file that can be used to override generated settings
+	ConfigFileOverride string
 }
 
 func copyContext(c *Context) *Context {
 	return &Context{
-		Services:   c.Services,
-		NodeID:     c.NodeID,
-		EtcdClient: c.EtcdClient,
-		Executor:   c.Executor,
-		ProcMan:    c.ProcMan,
-		Inventory:  c.Inventory,
-		ConfigDir:  c.ConfigDir,
-		LogLevel:   c.LogLevel,
+		Services:           c.Services,
+		NodeID:             c.NodeID,
+		EtcdClient:         c.EtcdClient,
+		Executor:           c.Executor,
+		ProcMan:            c.ProcMan,
+		Inventory:          c.Inventory,
+		ConfigDir:          c.ConfigDir,
+		LogLevel:           c.LogLevel,
+		ConfigFileOverride: c.ConfigFileOverride,
 	}
 }
 

--- a/pkg/clusterd/join.go
+++ b/pkg/clusterd/join.go
@@ -29,10 +29,10 @@ import (
 
 // StartJoinCluster initializes the cluster services to enable joining the cluster and listening for orchestration.
 func StartJoinCluster(services []*ClusterService, configDir, nodeID, discoveryURL,
-	etcdMembers, publicIPv4, privateIPv4 string, logLevel capnslog.LogLevel) (*Context, error) {
+	etcdMembers, publicIPv4, privateIPv4, configFileOverride string, logLevel capnslog.LogLevel) (*Context, error) {
 
-	logger.Infof("Starting cluster. configDir=%s, nodeID=%s, url=%s, members=%s, publicIPv4=%s, privateIPv4=%s, logLevel=%s",
-		configDir, nodeID, discoveryURL, etcdMembers, publicIPv4, privateIPv4, logLevel)
+	logger.Infof("Starting cluster. configDir=%s, nodeID=%s, url=%s, members=%s, publicIPv4=%s, privateIPv4=%s, configFileOverride=%s, logLevel=%s",
+		configDir, nodeID, discoveryURL, etcdMembers, publicIPv4, privateIPv4, configFileOverride, logLevel)
 
 	etcdClients := []string{}
 	if etcdMembers != "" {
@@ -70,14 +70,15 @@ func StartJoinCluster(services []*ClusterService, configDir, nodeID, discoveryUR
 
 	executor := &exec.CommandExecutor{}
 	context := &Context{
-		EtcdClient: etcdClient,
-		Executor:   executor,
-		NodeID:     nodeID,
-		Services:   services,
-		ProcMan:    proc.New(executor),
-		ConfigDir:  configDir,
-		LogLevel:   logLevel,
-		Inventory:  &inventory.Config{},
+		EtcdClient:         etcdClient,
+		Executor:           executor,
+		NodeID:             nodeID,
+		Services:           services,
+		ProcMan:            proc.New(executor),
+		ConfigDir:          configDir,
+		LogLevel:           logLevel,
+		ConfigFileOverride: configFileOverride,
+		Inventory:          &inventory.Config{},
 	}
 
 	// initialize the device inventory


### PR DESCRIPTION
…_CEPH_CONFIG_OVERRIDE env var)

Addresses #326 and #292 