### PR TITLE
support customize repository prefix of image through environment

### DIFF
--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -113,7 +113,7 @@ func (c *Cluster) apiContainer(cluster *mon.ClusterInfo) v1.Container {
 		// Without waiting some time, there is highly probable flakes in network setup.
 		Command: []string{"/bin/sh", "-c", fmt.Sprintf("sleep 5; %s", command)},
 		Name:    deploymentName,
-		Image:   fmt.Sprintf("quay.io/rook/rook-operator:%v", c.Version),
+		Image:   k8sutil.MakeRookOperatorImage(c.Version),
 		VolumeMounts: []v1.VolumeMount{
 			{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
 		},

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -21,6 +21,7 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"k8s.io/client-go/1.5/pkg/api"
 	unversionedAPI "k8s.io/client-go/1.5/pkg/api/unversioned"
@@ -28,14 +29,38 @@ import (
 )
 
 const (
-	AppAttr     = "app"
-	ClusterAttr = "rook_cluster"
-	VersionAttr = "rook_version"
-	PodIPEnvVar = "ROOKD_PRIVATE_IPV4"
+	AppAttr           = "app"
+	ClusterAttr       = "rook_cluster"
+	VersionAttr       = "rook_version"
+	PodIPEnvVar       = "ROOKD_PRIVATE_IPV4"
+	DefaultRepoPrefix = "quay.io/rook"
+	repoPrefixEnvVar  = "ROOK_OPERATOR_REPO_PREFIX"
+	defaultVersion    = "latest"
 )
 
+func RepoPrefix() string {
+	var repoPrefix string
+	if repoPrefix = os.Getenv(repoPrefixEnvVar); repoPrefix == "" {
+		repoPrefix = DefaultRepoPrefix
+	}
+
+	return repoPrefix
+}
+
+func getVersion(version string) string {
+	if version == "" {
+		version = defaultVersion
+	}
+
+	return version
+}
+
 func MakeRookImage(version string) string {
-	return fmt.Sprintf("quay.io/rook/rookd:%v", version)
+	return fmt.Sprintf("%s/rookd:%v", RepoPrefix(), getVersion(version))
+}
+
+func MakeRookOperatorImage(version string) string {
+	return fmt.Sprintf("%s/rook-operator:%v", RepoPrefix(), getVersion(version))
 }
 
 func PodWithAntiAffinity(pod *v1.Pod, attribute, value string) {

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package k8sutil
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeRookImage(t *testing.T) {
+	assert.Equal(t, "quay.io/rook/rookd:v1", MakeRookImage("v1"))
+}
+
+func TestMakeRookImageWithEnv(t *testing.T) {
+	os.Setenv(repoPrefixEnvVar, "myrepo.io/rook")
+	assert.Equal(t, "myrepo.io/rook/rookd:v1", MakeRookImage("v1"))
+	os.Setenv(repoPrefixEnvVar, "")
+}
+
+func TestMakeRookOperatorImage(t *testing.T) {
+	assert.Equal(t, "quay.io/rook/rook-operator:v1", MakeRookOperatorImage("v1"))
+}
+
+func TestMakeRookOperatorImageWithEnv(t *testing.T) {
+	os.Setenv(repoPrefixEnvVar, "myrepo.io/rook")
+	assert.Equal(t, "myrepo.io/rook/rook-operator:v1", MakeRookOperatorImage("v1"))
+	os.Setenv(repoPrefixEnvVar, "")
+}
+
+func TestDefaultVersion(t *testing.T) {
+	assert.Equal(t, fmt.Sprintf("quay.io/rook/rook-operator:%s", defaultVersion), MakeRookOperatorImage(""))
+}


### PR DESCRIPTION
rook-operator does not support customize repository prefix of image quay.io/rook/rookd:TAG.
This prevent us from using our own image repository to deploy rook-operator.

fix #415 

I cannot squash all these commits right for #415 , so i open this new pr. closing #415.

@travisn 

Related to #418 