### PR TITLE
Start and resume clusters asynchronously

### DIFF
--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -54,7 +54,9 @@ func (o *Operator) createTPR() error {
 	}
 	_, err := o.clientset.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
 	if err != nil {
-		return fmt.Errorf("failed to create rook third party resources. %+v", err)
+		if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
+			return fmt.Errorf("failed to create rook third party resources. %+v", err)
+		}
 	}
 
 	return o.waitForTPRInit(o.clientset.CoreV1().RESTClient(), 3*time.Second, 90*time.Second, o.Namespace)


### PR DESCRIPTION
For the operator to avoid the timeout when initializing a cluster, a Rook cluster can be created in a goroutine. 

Fixes #438 

