### PR TITLE
Add lint pipeline

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -163,7 +163,7 @@ go.vet:
 go.fmt:
 	@gofmt_out=$$(gofmt -d -e $(GO_SUBDIRS) $(GO_INTEGRATION_TESTS_SUBDIRS) 2>&1) && [ -z "$${gofmt_out}" ] || (echo "$${gofmt_out}" 1>&2; exit 1)
 
-go.validate: go.vet go.fmt
+go.validate: go.vet go.fmt go.lint
 
 $(GLIDE_LOCK): $(GLIDE) $(GLIDE_YAML)
 	@echo === updating vendor dependencies


### PR DESCRIPTION
This PR adds and enables the lint check to our current Jenkins pipeline. This check will fail until all the errors have been resolved. Once resolved, we could merge this. 

I will run the check for this PR periodically until we have no errors.