### PR TITLE
Remove workspace wipe on build failure to facilitate debugging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,5 +37,5 @@ catch (Exception e) {
         deleteDir()
     }
 
-    exit 1
+    error 1
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,5 +37,5 @@ catch (Exception e) {
         deleteDir()
     }
 
-    error 1
+    exit 1
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,5 +37,5 @@ catch (Exception e) {
         deleteDir()
     }
 
-    exit 1
+    error "Build failure"
 }


### PR DESCRIPTION
This would be a temporary change until we get artifact collection or log shipping implemented to assist with diagnosing build failures