### PR TITLE
Expose metrics for Rook with Prometheus

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 292ac02d911bbb2a5dc4885762c5984039de5144201f9c49907faf7b8c43f192
-updated: 2017-03-07T20:04:18.141713365-08:00
+hash: 81178d6bc6321564bed3985f0746ccd7357067d5c9eaecfdccdbd86cfd897387
+updated: 2017-03-08T10:56:46.619273095-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: a547fc61f48d567d5b4ec6f8aee5573d8efce11d
@@ -166,9 +166,10 @@ imports:
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
-  version: e51041b3fa41cece0dca035740ba6411905be473
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,3 +29,8 @@ import:
   subpackages:
   - kubernetes/typed/core/v1
 - package: github.com/bassam/cgosymbolizer
+- package: github.com/prometheus/client_golang
+  version: v0.8.0
+  subpackages:
+  - prometheus
+  - prometheus/promhttp

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package api
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+	"github.com/rook/rook/pkg/cephmgr/collectors"
+)
+
+// CephExporter wraps all the ceph collectors and provides a single global
+// exporter to extracts metrics out of. It also ensures that the collection
+// is done in a thread-safe manner, the necessary requirement stated by
+// prometheus. It also implements a prometheus.Collector interface in order
+// to register it correctly.
+type CephExporter struct {
+	mu         sync.Mutex
+	collectors []prometheus.Collector
+	handler    *Handler
+	conn       ceph.Connection
+}
+
+// Verify that the exporter implements the interface correctly.
+var _ prometheus.Collector = &CephExporter{}
+
+// NewCephExporter creates an instance to CephExporter and returns a reference
+// to it. We can choose to enable a collector to extract stats out of by adding
+// it to the list of collectors.
+func NewCephExporter(handler *Handler, conn ceph.Connection) *CephExporter {
+	return &CephExporter{
+		handler:    handler,
+		conn:       conn,
+		collectors: createCollectors(conn),
+	}
+}
+
+// Describe sends all the descriptors of the collectors included to
+// the provided channel.
+func (c *CephExporter) Describe(ch chan<- *prometheus.Desc) {
+	for _, cc := range c.collectors {
+		cc.Describe(ch)
+	}
+}
+
+// Collect sends the collected metrics from each of the collectors to
+// prometheus. Collect could be called several times concurrently
+// and thus its run is protected by a single mutex.
+func (c *CephExporter) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// test the ceph connection to make sure it's still active/alive
+	_, err := ceph.Status(c.conn)
+	if err != nil {
+		// the ceph connection doesn't appear to be alive, close the old one and create a new one then recreate the collectors
+		logger.Noticef("metrics ceph connection appears down, will try to restart it: %+v", err)
+		c.conn.Shutdown()
+
+		newConn, err := c.handler.connectToCeph()
+		if err != nil {
+			logger.Errorf("metrics ceph connection cannot be restarted: %+v", err)
+			return
+		}
+
+		logger.Noticef("metrics ceph connection was reconnected")
+		c.conn = newConn
+		c.collectors = createCollectors(c.conn)
+	}
+
+	// collect metrics from all of our collectors
+	for _, cc := range c.collectors {
+		cc.Collect(ch)
+	}
+}
+
+func createCollectors(conn ceph.Connection) []prometheus.Collector {
+	return []prometheus.Collector{
+		collectors.NewClusterUsageCollector(conn),
+		collectors.NewClusterHealthCollector(conn),
+		collectors.NewMonitorCollector(conn),
+		collectors.NewOSDCollector(conn),
+		collectors.NewPoolUsageCollector(conn),
+	}
+}

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+	testceph "github.com/rook/rook/pkg/cephmgr/client/test"
+	"github.com/rook/rook/pkg/cephmgr/test"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsCollectFailureRetry(t *testing.T) {
+	context := &clusterd.Context{}
+	cephFactory := &testceph.MockConnectionFactory{Fsid: "myfsid", SecretKey: "mykey"}
+	connFactory := &test.MockConnectionFactory{}
+
+	connectCount := 0
+	connFactory.MockConnectAsAdmin = func(context *clusterd.Context, cephFactory ceph.ConnectionFactory) (ceph.Connection, error) {
+		connectCount++
+		return cephFactory.NewConnWithClusterAndUser("mycluster", "admin")
+	}
+
+	// mock it so the first status mon command attempt will fail (even though the initial connection was established OK)
+	attempt := 0
+	cephFactory.Conn = &testceph.MockConnection{
+		MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+			attempt++
+			switch {
+			case strings.Index(string(args), "status") != -1:
+				if attempt <= 1 {
+					// first attempt for status mon command should fail
+					return nil, "", fmt.Errorf("mock mon command failure")
+				}
+				// subsequent attempts return a good response
+				return []byte(CephStatusResponseRaw), "info", nil
+			}
+
+			// mock fail all other mon commands (each collector will make several, but we don't care about their results)
+			return nil, "", fmt.Errorf("mock mon command failure for '%s'", string(args))
+		},
+	}
+
+	// create the handler and connect to ceph
+	h := newTestHandler(context, connFactory, cephFactory)
+	conn, err := h.connectToCeph()
+	assert.Nil(t, err)
+	assert.NotNil(t, conn)
+
+	// create a ceph metrics exporter that will use the ceph connection
+	cephExporter := NewCephExporter(h, conn)
+	assert.NotNil(t, cephExporter)
+
+	// try to collect ceph metrics, this will fail at first due to the mock failed mon command above, but
+	// then it should reestablish the connection successfully and complete the collection process
+	ch := make(chan prometheus.Metric)
+	go func() {
+		// in a goroutine, read from the metrics channel (but discard the results) so that the collection process can complete
+		for _ = range ch {
+		}
+	}()
+	cephExporter.Collect(ch)
+
+	// there should have been 2 connection attempts: initial and the retry after the failed mon command
+	assert.Equal(t, 2, connectCount)
+}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -15,6 +15,12 @@ limitations under the License.
 */
 package api
 
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
 func (h *Handler) GetRoutes() []Route {
 	return []Route{
 		{
@@ -148,6 +154,12 @@ func (h *Handler) GetRoutes() []Route {
 			"POST",
 			"/log",
 			h.SetLogLevel,
+		},
+		{
+			"GetMetrics",
+			"GET",
+			"/metrics",
+			promhttp.Handler().(http.HandlerFunc),
 		},
 	}
 }

--- a/pkg/cephmgr/client/osd.go
+++ b/pkg/cephmgr/client/osd.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type OSDUsage struct {
+	OSDNodes []struct {
+		Name        string      `json:"name"`
+		CrushWeight json.Number `json:"crush_weight"`
+		Depth       json.Number `json:"depth"`
+		Reweight    json.Number `json:"reweight"`
+		KB          json.Number `json:"kb"`
+		UsedKB      json.Number `json:"kb_used"`
+		AvailKB     json.Number `json:"kb_avail"`
+		Utilization json.Number `json:"utilization"`
+		Variance    json.Number `json:"var"`
+		Pgs         json.Number `json:"pgs"`
+	} `json:"nodes"`
+
+	Summary struct {
+		TotalKB      json.Number `json:"total_kb"`
+		TotalUsedKB  json.Number `json:"total_kb_used"`
+		TotalAvailKB json.Number `json:"total_kb_avail"`
+		AverageUtil  json.Number `json:"average_utilization"`
+	} `json:"summary"`
+}
+
+type OSDPerfStats struct {
+	PerfInfo []struct {
+		ID    json.Number `json:"id"`
+		Stats struct {
+			CommitLatency json.Number `json:"commit_latency_ms"`
+			ApplyLatency  json.Number `json:"apply_latency_ms"`
+		} `json:"perf_stats"`
+	} `json:"osd_perf_infos"`
+}
+
+type OSDDump struct {
+	OSDs []struct {
+		OSD json.Number `json:"osd"`
+		Up  json.Number `json:"up"`
+		In  json.Number `json:"in"`
+	} `json:"osds"`
+}
+
+func GetOSDUsage(conn Connection) (*OSDUsage, error) {
+	cmd := map[string]interface{}{"prefix": "osd df"}
+	buf, err := ExecuteMonCommand(conn, cmd, "osd df")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get osd df: %+v", err)
+	}
+
+	var osdUsage OSDUsage
+	if err := json.Unmarshal(buf, &osdUsage); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal osd df response: %+v", err)
+	}
+
+	return &osdUsage, nil
+}
+
+func GetOSDPerfStats(conn Connection) (*OSDPerfStats, error) {
+	cmd := map[string]interface{}{"prefix": "osd perf"}
+	buf, err := ExecuteMonCommand(conn, cmd, "osd perf")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get osd perf: %+v", err)
+	}
+
+	var osdPerfStats OSDPerfStats
+	if err := json.Unmarshal(buf, &osdPerfStats); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal osd perf response: %+v", err)
+	}
+
+	return &osdPerfStats, nil
+}
+
+func GetOSDDump(conn Connection) (*OSDDump, error) {
+	cmd := map[string]interface{}{"prefix": "osd dump"}
+	buf, err := ExecuteMonCommand(conn, cmd, "osd dump")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get osd dump: %+v", err)
+	}
+
+	var osdDump OSDDump
+	if err := json.Unmarshal(buf, &osdDump); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal osd dump response: %+v", err)
+	}
+
+	return &osdDump, nil
+}

--- a/pkg/cephmgr/client/usage.go
+++ b/pkg/cephmgr/client/usage.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type CephUsage struct {
+	Stats struct {
+		TotalBytes      json.Number `json:"total_bytes"`
+		TotalUsedBytes  json.Number `json:"total_used_bytes"`
+		TotalAvailBytes json.Number `json:"total_avail_bytes"`
+		TotalObjects    json.Number `json:"total_objects"`
+	} `json:"stats"`
+}
+
+func Usage(conn Connection) (*CephUsage, error) {
+	cmd := map[string]interface{}{"prefix": "df", "detail": "detail"}
+	buf, err := ExecuteMonCommand(conn, cmd, "df")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get usage: %+v", err)
+	}
+
+	var usage CephUsage
+	if err := json.Unmarshal(buf, &usage); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal usage response: %+v", err)
+	}
+
+	return &usage, nil
+}

--- a/pkg/cephmgr/collectors/health.go
+++ b/pkg/cephmgr/collectors/health.go
@@ -1,0 +1,786 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+
+package collectors
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+)
+
+var (
+	recoveryIORateRegex    = regexp.MustCompile(`(\d+) (\w{2})/s`)
+	recoveryIOKeysRegex    = regexp.MustCompile(`(\d+) keys/s`)
+	recoveryIOObjectsRegex = regexp.MustCompile(`(\d+) objects/s`)
+	clientIOReadRegex      = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s rd`)
+	clientIOWriteRegex     = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s wr`)
+	clientIOReadOpsRegex   = regexp.MustCompile(`(\d+) op/s rd`)
+	clientIOWriteOpsRegex  = regexp.MustCompile(`(\d+) op/s wr`)
+	cacheFlushRateRegex    = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s flush`)
+	cacheEvictRateRegex    = regexp.MustCompile(`(\d+) ([kKmMgG][bB])/s evict`)
+	cachePromoteOpsRegex   = regexp.MustCompile(`(\d+) op/s promote`)
+
+	// Older versions of Ceph, hammer (v0.94) and below, support this format.
+	clientIOOpsRegex = regexp.MustCompile(`(\d+) op/s[^ \w]*$`)
+)
+
+// ClusterHealthCollector collects information about the health of an overall cluster.
+// It surfaces changes in the ceph parameters unlike data usage that ClusterUsageCollector
+// does.
+type ClusterHealthCollector struct {
+	// conn holds connection to the Ceph cluster
+	conn ceph.Connection
+
+	// HealthStatus shows the overall health status of a given cluster.
+	HealthStatus prometheus.Gauge
+
+	// TotalPGs shows the total no. of PGs the cluster constitutes of.
+	TotalPGs prometheus.Gauge
+
+	// DegradedPGs shows the no. of PGs that have some of the replicas
+	// missing.
+	DegradedPGs prometheus.Gauge
+
+	// StuckDegradedPGs shows the no. of PGs that have some of the replicas
+	// missing, and are stuck in that state.
+	StuckDegradedPGs prometheus.Gauge
+
+	// UncleanPGs shows the no. of PGs that do not have all objects in the PG
+	// that are supposed to be in it.
+	UncleanPGs prometheus.Gauge
+
+	// StuckUncleanPGs shows the no. of PGs that do not have all objects in the PG
+	// that are supposed to be in it, and are stuck in that state.
+	StuckUncleanPGs prometheus.Gauge
+
+	// UndersizedPGs depicts the no. of PGs that have fewer copies than configured
+	// replication level.
+	UndersizedPGs prometheus.Gauge
+
+	// StuckUndersizedPGs depicts the no. of PGs that have fewer copies than configured
+	// replication level, and are stuck in that state.
+	StuckUndersizedPGs prometheus.Gauge
+
+	// StalePGs depicts no. of PGs that are in an unknown state i.e. monitors do not know
+	// anything about their latest state since their pg mapping was modified.
+	StalePGs prometheus.Gauge
+
+	// StuckStalePGs depicts no. of PGs that are in an unknown state i.e. monitors do not know
+	// anything about their latest state since their pg mapping was modified, and are stuck
+	// in that state.
+	StuckStalePGs prometheus.Gauge
+
+	// DegradedObjectsCount gives the no. of RADOS objects are constitute the degraded PGs.
+	// This includes object replicas in its count.
+	DegradedObjectsCount prometheus.Gauge
+
+	// MisplacedObjectsCount gives the no. of RADOS objects that constitute the misplaced PGs.
+	// Misplaced PGs usually represent the PGs that are not in the storage locations that
+	// they should be in. This is different than degraded PGs which means a PG has fewer copies
+	// that it should.
+	// This includes object replicas in its count.
+	MisplacedObjectsCount prometheus.Gauge
+
+	// OSDsDown show the no. of OSDs that are in the DOWN state.
+	OSDsDown prometheus.Gauge
+
+	// OSDsUp show the no. of OSDs that are in the UP state and are able to serve requests.
+	OSDsUp prometheus.Gauge
+
+	// OSDsIn shows the no. of OSDs that are marked as IN in the cluster.
+	OSDsIn prometheus.Gauge
+
+	// OSDsNum shows the no. of total OSDs the cluster has.
+	OSDsNum prometheus.Gauge
+
+	// RemappedPGs show the no. of PGs that are currently remapped and needs to be moved
+	// to newer OSDs.
+	RemappedPGs prometheus.Gauge
+
+	// RecoveryIORate shows the i/o rate at which the cluster is performing its ongoing
+	// recovery at.
+	RecoveryIORate prometheus.Gauge
+
+	// RecoveryIOKeys shows the rate of rados keys recovery.
+	RecoveryIOKeys prometheus.Gauge
+
+	// RecoveryIOObjects shows the rate of rados objects being recovered.
+	RecoveryIOObjects prometheus.Gauge
+
+	// ClientIORead shows the total client read i/o on the cluster.
+	ClientIORead prometheus.Gauge
+
+	// ClientIOWrite shows the total client write i/o on the cluster.
+	ClientIOWrite prometheus.Gauge
+
+	// ClientIOOps shows the rate of total operations conducted by all clients on the cluster.
+	ClientIOOps prometheus.Gauge
+
+	// ClientIOReadOps shows the rate of total read operations conducted by all clients on the cluster.
+	ClientIOReadOps prometheus.Gauge
+
+	// ClientIOWriteOps shows the rate of total write operations conducted by all clients on the cluster.
+	ClientIOWriteOps prometheus.Gauge
+
+	// CacheFlushIORate shows the i/o rate at which data is being flushed from the cache pool.
+	CacheFlushIORate prometheus.Gauge
+
+	// CacheEvictIORate shows the i/o rate at which data is being flushed from the cache pool.
+	CacheEvictIORate prometheus.Gauge
+
+	// CachePromoteIOOps shows the rate of operations promoting objects to the cache pool.
+	CachePromoteIOOps prometheus.Gauge
+}
+
+// NewClusterHealthCollector creates a new instance of ClusterHealthCollector to collect health
+// metrics on.
+func NewClusterHealthCollector(conn ceph.Connection) *ClusterHealthCollector {
+	return &ClusterHealthCollector{
+		conn: conn,
+
+		HealthStatus: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "health_status",
+				Help:      "Health status of Cluster, can vary only between 3 states (err:2, warn:1, ok:0)",
+			},
+		),
+		TotalPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "total_pgs",
+				Help:      "Total no. of PGs in the cluster",
+			},
+		),
+		DegradedPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "degraded_pgs",
+				Help:      "No. of PGs in a degraded state",
+			},
+		),
+		StuckDegradedPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "stuck_degraded_pgs",
+				Help:      "No. of PGs stuck in a degraded state",
+			},
+		),
+		UncleanPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "unclean_pgs",
+				Help:      "No. of PGs in an unclean state",
+			},
+		),
+		StuckUncleanPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "stuck_unclean_pgs",
+				Help:      "No. of PGs stuck in an unclean state",
+			},
+		),
+		UndersizedPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "undersized_pgs",
+				Help:      "No. of undersized PGs in the cluster",
+			},
+		),
+		StuckUndersizedPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "stuck_undersized_pgs",
+				Help:      "No. of stuck undersized PGs in the cluster",
+			},
+		),
+		StalePGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "stale_pgs",
+				Help:      "No. of stale PGs in the cluster",
+			},
+		),
+		StuckStalePGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "stuck_stale_pgs",
+				Help:      "No. of stuck stale PGs in the cluster",
+			},
+		),
+		DegradedObjectsCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "degraded_objects",
+				Help:      "No. of degraded objects across all PGs, includes replicas",
+			},
+		),
+		MisplacedObjectsCount: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "misplaced_objects",
+				Help:      "No. of misplaced objects across all PGs, includes replicas",
+			},
+		),
+		OSDsDown: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osds_down",
+				Help:      "Count of OSDs that are in DOWN state",
+			},
+		),
+		OSDsUp: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osds_up",
+				Help:      "Count of OSDs that are in UP state",
+			},
+		),
+		OSDsIn: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osds_in",
+				Help:      "Count of OSDs that are in IN state and available to serve requests",
+			},
+		),
+		OSDsNum: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osds",
+				Help:      "Count of total OSDs in the cluster",
+			},
+		),
+		RemappedPGs: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "pgs_remapped",
+				Help:      "No. of PGs that are remapped and incurring cluster-wide movement",
+			},
+		),
+		RecoveryIORate: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "recovery_io_bytes",
+				Help:      "Rate of bytes being recovered in cluster per second",
+			},
+		),
+		RecoveryIOKeys: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "recovery_io_keys",
+				Help:      "Rate of keys being recovered in cluster per second",
+			},
+		),
+		RecoveryIOObjects: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "recovery_io_objects",
+				Help:      "Rate of objects being recovered in cluster per second",
+			},
+		),
+		ClientIORead: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "client_io_read_bytes",
+				Help:      "Rate of bytes being read by all clients per second",
+			},
+		),
+		ClientIOWrite: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "client_io_write_bytes",
+				Help:      "Rate of bytes being written by all clients per second",
+			},
+		),
+		ClientIOOps: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "client_io_ops",
+				Help:      "Total client ops on the cluster measured per second",
+			},
+		),
+		ClientIOReadOps: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "client_io_read_ops",
+				Help:      "Total client read I/O ops on the cluster measured per second",
+			},
+		),
+		ClientIOWriteOps: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "client_io_write_ops",
+				Help:      "Total client write I/O ops on the cluster measured per second",
+			},
+		),
+		CacheFlushIORate: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "cache_flush_io_bytes",
+				Help:      "Rate of bytes being flushed from the cache pool per second",
+			},
+		),
+		CacheEvictIORate: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "cache_evict_io_bytes",
+				Help:      "Rate of bytes being evicted from the cache pool per second",
+			},
+		),
+		CachePromoteIOOps: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "cache_promote_io_ops",
+				Help:      "Total cache promote operations measured per second",
+			},
+		),
+	}
+}
+
+func (c *ClusterHealthCollector) metricsList() []prometheus.Metric {
+	return []prometheus.Metric{
+		c.HealthStatus,
+		c.TotalPGs,
+		c.DegradedPGs,
+		c.StuckDegradedPGs,
+		c.UncleanPGs,
+		c.StuckUncleanPGs,
+		c.UndersizedPGs,
+		c.StuckUndersizedPGs,
+		c.StalePGs,
+		c.StuckStalePGs,
+		c.DegradedObjectsCount,
+		c.MisplacedObjectsCount,
+		c.OSDsDown,
+		c.OSDsUp,
+		c.OSDsIn,
+		c.OSDsNum,
+		c.RemappedPGs,
+		c.RecoveryIORate,
+		c.RecoveryIOKeys,
+		c.RecoveryIOObjects,
+		c.ClientIORead,
+		c.ClientIOWrite,
+		c.ClientIOOps,
+		c.ClientIOReadOps,
+		c.ClientIOWriteOps,
+		c.CacheFlushIORate,
+		c.CacheEvictIORate,
+		c.CachePromoteIOOps,
+	}
+}
+
+func (c *ClusterHealthCollector) collect() error {
+	stats, err := ceph.Status(c.conn)
+	if err != nil {
+		return err
+	}
+
+	for _, metric := range c.metricsList() {
+		if gauge, ok := metric.(prometheus.Gauge); ok {
+			gauge.Set(0)
+		}
+	}
+
+	switch stats.Health.OverallStatus {
+	case ceph.CephHealthOK:
+		c.HealthStatus.Set(0)
+	case ceph.CephHealthWarn:
+		c.HealthStatus.Set(1)
+	case ceph.CephHealthErr:
+		c.HealthStatus.Set(2)
+	default:
+		c.HealthStatus.Set(2)
+	}
+
+	var (
+		degradedRegex         = regexp.MustCompile(`([\d]+) pgs degraded`)
+		stuckDegradedRegex    = regexp.MustCompile(`([\d]+) pgs stuck degraded`)
+		uncleanRegex          = regexp.MustCompile(`([\d]+) pgs unclean`)
+		stuckUncleanRegex     = regexp.MustCompile(`([\d]+) pgs stuck unclean`)
+		undersizedRegex       = regexp.MustCompile(`([\d]+) pgs undersized`)
+		stuckUndersizedRegex  = regexp.MustCompile(`([\d]+) pgs stuck undersized`)
+		staleRegex            = regexp.MustCompile(`([\d]+) pgs stale`)
+		stuckStaleRegex       = regexp.MustCompile(`([\d]+) pgs stuck stale`)
+		degradedObjectsRegex  = regexp.MustCompile(`recovery ([\d]+)/([\d]+) objects degraded`)
+		misplacedObjectsRegex = regexp.MustCompile(`recovery ([\d]+)/([\d]+) objects misplaced`)
+	)
+
+	for _, s := range stats.Health.Summary {
+		matched := degradedRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.DegradedPGs.Set(float64(v))
+		}
+
+		matched = stuckDegradedRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.StuckDegradedPGs.Set(float64(v))
+		}
+
+		matched = uncleanRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.UncleanPGs.Set(float64(v))
+		}
+
+		matched = stuckUncleanRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.StuckUncleanPGs.Set(float64(v))
+		}
+
+		matched = undersizedRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.UndersizedPGs.Set(float64(v))
+		}
+
+		matched = stuckUndersizedRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.StuckUndersizedPGs.Set(float64(v))
+		}
+
+		matched = staleRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.StalePGs.Set(float64(v))
+		}
+
+		matched = stuckStaleRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 2 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.StuckStalePGs.Set(float64(v))
+		}
+
+		matched = degradedObjectsRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 3 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.DegradedObjectsCount.Set(float64(v))
+		}
+
+		matched = misplacedObjectsRegex.FindStringSubmatch(s.Summary)
+		if len(matched) == 3 {
+			v, err := strconv.Atoi(matched[1])
+			if err != nil {
+				return err
+			}
+			c.MisplacedObjectsCount.Set(float64(v))
+		}
+	}
+
+	osdsUp := float64(stats.OsdMap.OsdMap.NumUpOsd)
+	c.OSDsUp.Set(osdsUp)
+
+	osdsIn := float64(stats.OsdMap.OsdMap.NumInOsd)
+	c.OSDsIn.Set(osdsIn)
+
+	osdsNum := float64(stats.OsdMap.OsdMap.NumOsd)
+	c.OSDsNum.Set(osdsNum)
+
+	// Ceph (until v10.2.3) doesn't expose the value of down OSDs
+	// from its status, which is why we have to compute it ourselves.
+	c.OSDsDown.Set(osdsNum - osdsUp)
+
+	remappedPGs := float64(stats.OsdMap.OsdMap.NumRemappedPgs)
+	c.RemappedPGs.Set(remappedPGs)
+
+	totalPGs := float64(stats.PgMap.NumPgs)
+	c.TotalPGs.Set(totalPGs)
+
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectRecoveryClientIO() error {
+	buf, err := ceph.StatusPlain(c.conn)
+	if err != nil {
+		return err
+	}
+
+	sc := bufio.NewScanner(bytes.NewReader(buf))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+
+		switch {
+		case strings.HasPrefix(line, "recovery io"):
+			if err := c.collectRecoveryIO(line); err != nil {
+				return err
+			}
+		case strings.HasPrefix(line, "client io"):
+			if err := c.collectClientIO(line); err != nil {
+				return err
+			}
+		case strings.HasPrefix(line, "cache io"):
+			if err := c.collectCacheIO(line); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectClientIO(clientStr string) error {
+	matched := clientIOReadRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.ClientIORead.Set(float64(v))
+	}
+
+	matched = clientIOWriteRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.ClientIOWrite.Set(float64(v))
+	}
+
+	var clientIOOps float64
+	matched = clientIOOpsRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		clientIOOps = float64(v)
+	}
+
+	var clientIOReadOps, clientIOWriteOps float64
+	matched = clientIOReadOpsRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		clientIOReadOps = float64(v)
+		c.ClientIOReadOps.Set(clientIOReadOps)
+	}
+
+	matched = clientIOWriteOpsRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		clientIOWriteOps = float64(v)
+		c.ClientIOWriteOps.Set(clientIOWriteOps)
+	}
+
+	// In versions older than Jewel, we directly get access to total
+	// client I/O. But in Jewel and newer the format is changed to
+	// separately display read and write IOPs. In such a case, we
+	// compute and set the total IOPs ourselves.
+	if clientIOOps == 0 {
+		clientIOOps = clientIOReadOps + clientIOWriteOps
+	}
+
+	c.ClientIOOps.Set(clientIOOps)
+
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectRecoveryIO(recoveryStr string) error {
+	matched := recoveryIORateRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.RecoveryIORate.Set(float64(v))
+	}
+
+	matched = recoveryIOKeysRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.RecoveryIOKeys.Set(float64(v))
+	}
+
+	matched = recoveryIOObjectsRegex.FindStringSubmatch(recoveryStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.RecoveryIOObjects.Set(float64(v))
+	}
+	return nil
+}
+
+func (c *ClusterHealthCollector) collectCacheIO(clientStr string) error {
+	matched := cacheFlushRateRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.CacheFlushIORate.Set(float64(v))
+	}
+
+	matched = cacheEvictRateRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 3 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		switch strings.ToLower(matched[2]) {
+		case "gb":
+			v = v * 1e9
+		case "mb":
+			v = v * 1e6
+		case "kb":
+			v = v * 1e3
+		default:
+			return fmt.Errorf("can't parse units %q", matched[2])
+		}
+
+		c.CacheEvictIORate.Set(float64(v))
+	}
+
+	matched = cachePromoteOpsRegex.FindStringSubmatch(clientStr)
+	if len(matched) == 2 {
+		v, err := strconv.Atoi(matched[1])
+		if err != nil {
+			return err
+		}
+
+		c.CachePromoteIOOps.Set(float64(v))
+	}
+	return nil
+}
+
+// Describe sends all the descriptions of individual metrics of ClusterHealthCollector
+// to the provided prometheus channel.
+func (c *ClusterHealthCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range c.metricsList() {
+		ch <- metric.Desc()
+	}
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+// It requires the caller to handle synchronization.
+func (c *ClusterHealthCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(); err != nil {
+		logger.Errorf("failed collecting cluster health metrics: %+v", err)
+	}
+
+	if err := c.collectRecoveryClientIO(); err != nil {
+		logger.Errorf("failed collecting cluster recovery/client io: %+v", err)
+	}
+
+	for _, metric := range c.metricsList() {
+		ch <- metric
+	}
+}

--- a/pkg/cephmgr/collectors/health_test.go
+++ b/pkg/cephmgr/collectors/health_test.go
@@ -1,0 +1,383 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rook/rook/pkg/cephmgr/client/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterHealthCollector(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		regexes []*regexp.Regexp
+	}{
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "5 pgs degraded"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`degraded_pgs 5`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "15 pgs stuck degraded"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stuck_degraded_pgs 15`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "6 pgs unclean"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`unclean_pgs 6`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "16 pgs stuck unclean"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stuck_unclean_pgs 16`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`undersized_pgs 7`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "17 pgs stuck undersized"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stuck_undersized_pgs 17`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "8 pgs stale"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stale_pgs 8`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "18 pgs stuck stale"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`stuck_stale_pgs 18`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "recovery 10/20 objects degraded"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`degraded_objects 10`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "recovery 20/40 objects misplaced"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`misplaced_objects 20`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 20,
+			"num_up_osds": 10,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`osds_down 10`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 1200,
+			"num_up_osds": 1200,
+			"num_in_osds": 1190,
+			"num_remapped_pgs": 10
+		}
+	},
+	"health": {"summary": []}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`osds 1200`),
+				regexp.MustCompile(`osds_up 1200`),
+				regexp.MustCompile(`osds_in 1190`),
+				regexp.MustCompile(`pgs_remapped 10`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 1200,
+			"num_up_osds": 1200,
+			"num_in_osds": 1190,
+			"num_remapped_pgs": 10
+		}
+	},
+	"health": { "overall_status": "HEALTH_OK" } }`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`health_status 0`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 1200,
+			"num_up_osds": 1200,
+			"num_in_osds": 1190,
+			"num_remapped_pgs": 10
+		}
+	},
+	"health": { "overall_status": "HEALTH_WARN" } }`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`health_status 1`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 1200,
+			"num_up_osds": 1200,
+			"num_in_osds": 1190,
+			"num_remapped_pgs": 10
+		}
+	},
+	"health": { "overall_status": "HEALTH_ERR" } }`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`health_status 2`),
+			},
+		},
+		{
+			input: `
+$ sudo ceph -s
+    cluster eff51be8-938a-4afa-b0d1-7a580b4ceb37
+     health HEALTH_OK
+     monmap e3: 3 mons at {mon01,mon02,mon03}
+  recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
+  client io 4273 kB/s rd, 2740 MB/s wr, 2863 op/s
+`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`recovery_io_bytes 5.779e`),
+				regexp.MustCompile(`recovery_io_keys 4`),
+				regexp.MustCompile(`recovery_io_objects 1522`),
+				regexp.MustCompile(`client_io_ops 2863`),
+				regexp.MustCompile(`client_io_read_bytes 4.273e`),
+				regexp.MustCompile(`client_io_write_bytes 2.74e`),
+			},
+		},
+		{
+			input: `
+$ sudo ceph -s
+    cluster eff51be8-938a-4afa-b0d1-7a580b4ceb37
+     health HEALTH_OK
+     monmap e3: 3 mons at {mon01,mon02,mon03}
+  recovery io 5779 MB/s, 4 keys/s, 1522 objects/s
+  client io 2863 op/s rd, 5847 op/s wr
+  cache io 251 MB/s flush, 6646 kB/s evict, 55 op/s promote
+`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`recovery_io_bytes 5.779e`),
+				regexp.MustCompile(`recovery_io_keys 4`),
+				regexp.MustCompile(`recovery_io_objects 1522`),
+				regexp.MustCompile(`client_io_ops 8710`),
+				regexp.MustCompile(`client_io_read_ops 2863`),
+				regexp.MustCompile(`client_io_write_ops 5847`),
+				regexp.MustCompile(`cache_flush_io_bytes 2.51e`),
+				regexp.MustCompile(`cache_evict_io_bytes 6.646e`),
+				regexp.MustCompile(`cache_promote_io_ops 55`),
+			},
+		},
+		{
+			input: `
+{
+	"osdmap": {
+		"osdmap": {
+			"num_osds": 0,
+			"num_up_osds": 0,
+			"num_in_osds": 0,
+			"num_remapped_pgs": 0
+		}
+	},
+	"pgmap": { "num_pgs": 52000 },
+	"health": {"summary": [{"severity": "HEALTH_WARN", "summary": "7 pgs undersized"}]}
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`total_pgs 52000`),
+			},
+		},
+	} {
+		func() {
+			mockConn := &test.MockConnection{
+				MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+					return []byte(tt.input), "info", nil
+				},
+			}
+			collector := NewClusterHealthCollector(mockConn)
+			if err := prometheus.Register(collector); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(collector)
+
+			server := httptest.NewServer(prometheus.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.regexes {
+				assert.True(t, re.Match(buf), fmt.Sprintf("failed matching: %q", re))
+			}
+		}()
+	}
+}

--- a/pkg/cephmgr/collectors/log.go
+++ b/pkg/cephmgr/collectors/log.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package collectors
+
+import "github.com/coreos/pkg/capnslog"
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephcollectors")

--- a/pkg/cephmgr/collectors/mon.go
+++ b/pkg/cephmgr/collectors/mon.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+)
+
+// MonitorCollector is used to extract stats related to monitors
+// running within Ceph cluster. As we extract information pertaining
+// to each monitor instance, there are various vector metrics we
+// need to use.
+type MonitorCollector struct {
+	conn ceph.Connection
+
+	// TotalKBs display the total storage a given monitor node has.
+	TotalKBs *prometheus.GaugeVec
+
+	// UsedKBs depict how much of the total storage our monitor process
+	// has utilized.
+	UsedKBs *prometheus.GaugeVec
+
+	// AvailKBs shows the space left unused.
+	AvailKBs *prometheus.GaugeVec
+
+	// PercentAvail shows the amount of unused space as a percentage of total
+	// space.
+	PercentAvail *prometheus.GaugeVec
+
+	// Store exposes information about internal backing store.
+	Store Store
+
+	// ClockSkew shows how far the monitor clocks have skewed from each other. This
+	// is an important metric because the functioning of Ceph's paxos depends on
+	// the clocks being aligned as close to each other as possible.
+	ClockSkew *prometheus.GaugeVec
+
+	// Latency displays the time the monitors take to communicate between themselves.
+	Latency *prometheus.GaugeVec
+
+	// NodesinQuorum show the size of the working monitor quorum. Any change in this
+	// metric can imply a significant issue in the cluster if it is not manually changed.
+	NodesinQuorum prometheus.Gauge
+}
+
+// Store displays information about Monitor's FileStore. It is responsible for
+// storing all the meta information about the cluster, including monmaps, osdmaps,
+// pgmaps, etc. along with logs and other data.
+type Store struct {
+	// TotalBytes displays the current size of the FileStore.
+	TotalBytes *prometheus.GaugeVec
+
+	// SSTBytes shows the amount used by LevelDB's sorted-string tables.
+	SSTBytes *prometheus.GaugeVec
+
+	// LogBytes shows the amount used by logs.
+	LogBytes *prometheus.GaugeVec
+
+	// MiscBytes shows the amount used by miscellaneous information.
+	MiscBytes *prometheus.GaugeVec
+}
+
+// NewMonitorCollector creates an instance of the MonitorCollector and instantiates
+// the individual metrics that show information about the monitor processes.
+func NewMonitorCollector(conn ceph.Connection) *MonitorCollector {
+	return &MonitorCollector{
+		conn: conn,
+
+		TotalKBs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_capacity_bytes",
+				Help:      "Total storage capacity of the monitor node",
+			},
+			[]string{"monitor"},
+		),
+		UsedKBs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_used_bytes",
+				Help:      "Storage of the monitor node that is currently allocated for use",
+			},
+			[]string{"monitor"},
+		),
+		AvailKBs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_avail_bytes",
+				Help:      "Total unused storage capacity that the monitor node has left",
+			},
+			[]string{"monitor"},
+		),
+		PercentAvail: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_avail_percent",
+				Help:      "Percentage of total unused storage capacity that the monitor node has left",
+			},
+			[]string{"monitor"},
+		),
+		Store: Store{
+			TotalBytes: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: cephNamespace,
+					Name:      "monitor_store_capacity_bytes",
+					Help:      "Total capacity of the FileStore backing the monitor daemon",
+				},
+				[]string{"monitor"},
+			),
+			SSTBytes: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: cephNamespace,
+					Name:      "monitor_store_sst_bytes",
+					Help:      "Capacity of the FileStore used only for raw SSTs",
+				},
+				[]string{"monitor"},
+			),
+			LogBytes: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: cephNamespace,
+					Name:      "monitor_store_log_bytes",
+					Help:      "Capacity of the FileStore used only for logging",
+				},
+				[]string{"monitor"},
+			),
+			MiscBytes: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Namespace: cephNamespace,
+					Name:      "monitor_store_misc_bytes",
+					Help:      "Capacity of the FileStore used only for storing miscellaneous information",
+				},
+				[]string{"monitor"},
+			),
+		},
+		ClockSkew: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_clock_skew_seconds",
+				Help:      "Clock skew the monitor node is incurring",
+			},
+			[]string{"monitor"},
+		),
+		Latency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_latency_seconds",
+				Help:      "Latency the monitor node is incurring",
+			},
+			[]string{"monitor"},
+		),
+		NodesinQuorum: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "monitor_quorum_count",
+				Help:      "The total size of the monitor quorum",
+			},
+		),
+	}
+}
+
+func (m *MonitorCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.TotalKBs,
+		m.UsedKBs,
+		m.AvailKBs,
+		m.PercentAvail,
+
+		m.Store.TotalBytes,
+		m.Store.SSTBytes,
+		m.Store.LogBytes,
+		m.Store.MiscBytes,
+
+		m.ClockSkew,
+		m.Latency,
+	}
+}
+
+func (m *MonitorCollector) metricsList() []prometheus.Metric {
+	return []prometheus.Metric{
+		m.NodesinQuorum,
+	}
+}
+
+func (m *MonitorCollector) collect() error {
+	stats, err := ceph.GetMonStats(m.conn)
+	if err != nil {
+		return err
+	}
+
+	for _, healthService := range stats.Health.Health.HealthServices {
+		for _, monstat := range healthService.Mons {
+			kbTotal, err := monstat.KBTotal.Float64()
+			if err != nil {
+				return err
+			}
+			m.TotalKBs.WithLabelValues(monstat.Name).Set(kbTotal * 1e3)
+
+			kbUsed, err := monstat.KBUsed.Float64()
+			if err != nil {
+				return err
+			}
+			m.UsedKBs.WithLabelValues(monstat.Name).Set(kbUsed * 1e3)
+
+			kbAvail, err := monstat.KBAvail.Float64()
+			if err != nil {
+				return err
+			}
+			m.AvailKBs.WithLabelValues(monstat.Name).Set(kbAvail * 1e3)
+
+			percentAvail, err := monstat.AvailPercent.Float64()
+			if err != nil {
+				return err
+			}
+			m.PercentAvail.WithLabelValues(monstat.Name).Set(percentAvail)
+
+			storeBytes, err := monstat.StoreStats.BytesTotal.Float64()
+			if err != nil {
+				return err
+			}
+			m.Store.TotalBytes.WithLabelValues(monstat.Name).Set(storeBytes)
+
+			sstBytes, err := monstat.StoreStats.BytesSST.Float64()
+			if err != nil {
+				return err
+			}
+			m.Store.SSTBytes.WithLabelValues(monstat.Name).Set(sstBytes)
+
+			logBytes, err := monstat.StoreStats.BytesLog.Float64()
+			if err != nil {
+				return err
+			}
+			m.Store.LogBytes.WithLabelValues(monstat.Name).Set(logBytes)
+
+			miscBytes, err := monstat.StoreStats.BytesMisc.Float64()
+			if err != nil {
+				return err
+			}
+			m.Store.MiscBytes.WithLabelValues(monstat.Name).Set(miscBytes)
+		}
+	}
+
+	for _, monstat := range stats.Health.TimeChecks.Mons {
+		skew, err := monstat.Skew.Float64()
+		if err != nil {
+			return err
+		}
+		m.ClockSkew.WithLabelValues(monstat.Name).Set(skew)
+
+		latency, err := monstat.Latency.Float64()
+		if err != nil {
+			return err
+		}
+		m.Latency.WithLabelValues(monstat.Name).Set(latency)
+	}
+
+	m.NodesinQuorum.Set(float64(len(stats.Quorum)))
+
+	return nil
+}
+
+// Describe sends the descriptors of each Monitor related metric we have defined
+// to the channel provided.
+func (m *MonitorCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range m.collectorList() {
+		metric.Describe(ch)
+	}
+
+	for _, metric := range m.metricsList() {
+		ch <- metric.Desc()
+	}
+}
+
+// Collect extracts the given metrics from the Monitors and sends it to the prometheus
+// channel.
+func (m *MonitorCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := m.collect(); err != nil {
+		logger.Errorf("failed collecting monitor metrics: %+v", err)
+		return
+	}
+
+	for _, metric := range m.collectorList() {
+		metric.Collect(ch)
+	}
+
+	for _, metric := range m.metricsList() {
+		ch <- metric
+	}
+}

--- a/pkg/cephmgr/collectors/mon_test.go
+++ b/pkg/cephmgr/collectors/mon_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rook/rook/pkg/cephmgr/client/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitorCollector(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		regexes []*regexp.Regexp
+	}{
+		{
+			`
+{
+    "health": {
+        "health": {
+            "health_services": [
+                {
+                    "mons": [
+                        {
+                            "name": "test-mon01",
+                            "kb_total": 412718256,
+                            "kb_used": 1812852,
+                            "kb_avail": 389917500,
+                            "avail_percent": 94,
+                            "last_updated": "2015-12-28 15:54:03.763348",
+                            "store_stats": {
+                                "bytes_total": 1781282079,
+                                "bytes_sst": 1,
+                                "bytes_log": 609694,
+                                "bytes_misc": 1780672385,
+                                "last_updated": "0.000000"
+                            },
+                            "health": "HEALTH_OK"
+                        },
+                        {
+                            "name": "test-mon02",
+                            "kb_total": 412718256,
+                            "kb_used": 1875304,
+                            "kb_avail": 389855048,
+                            "avail_percent": 94,
+                            "last_updated": "2015-12-28 15:53:53.808657",
+                            "store_stats": {
+                                "bytes_total": 1844348214,
+                                "bytes_sst": 2,
+                                "bytes_log": 871605,
+                                "bytes_misc": 1843476609,
+                                "last_updated": "0.000000"
+                            },
+                            "health": "HEALTH_OK"
+                        },
+                        {
+                            "name": "test-mon03",
+                            "kb_total": 412718256,
+                            "kb_used": 2095356,
+                            "kb_avail": 389634996,
+                            "avail_percent": 94,
+                            "last_updated": "2015-12-28 15:53:06.292749",
+                            "store_stats": {
+                                "bytes_total": 2069468587,
+                                "bytes_sst": 3,
+                                "bytes_log": 871605,
+                                "bytes_misc": 2068596982,
+                                "last_updated": "0.000000"
+                            },
+                            "health": "HEALTH_OK"
+                        },
+                        {
+                            "name": "test-mon04",
+                            "kb_total": 412718256,
+                            "kb_used": 1726276,
+                            "kb_avail": 390004076,
+                            "avail_percent": 94,
+                            "last_updated": "2015-12-28 15:53:10.770775",
+                            "store_stats": {
+                                "bytes_total": 1691972147,
+                                "bytes_sst": 4,
+                                "bytes_log": 871605,
+                                "bytes_misc": 1691100542,
+                                "last_updated": "0.000000"
+                            },
+                            "health": "HEALTH_OK"
+                        },
+                        {
+                            "name": "test-mon05",
+                            "kb_total": 412718256,
+                            "kb_used": 1883228,
+                            "kb_avail": 389847124,
+                            "avail_percent": 94,
+                            "last_updated": "2015-12-28 15:53:11.407033",
+                            "store_stats": {
+                                "bytes_total": 1852485942,
+                                "bytes_sst": 5,
+                                "bytes_log": 871605,
+                                "bytes_misc": 1851614337,
+                                "last_updated": "0.000000"
+                            },
+                            "health": "HEALTH_OK"
+                        }
+                    ]
+                }
+            ]
+        },
+        "timechecks": {
+            "epoch": 70,
+            "round": 3362,
+            "round_status": "finished",
+            "mons": [
+                {
+                    "name": "test-mon01",
+                    "skew": 0.000000,
+                    "latency": 0.000000,
+                    "health": "HEALTH_OK"
+                },
+                {
+                    "name": "test-mon02",
+                    "skew": -0.000002,
+                    "latency": 0.000815,
+                    "health": "HEALTH_OK"
+                },
+                {
+                    "name": "test-mon03",
+                    "skew": -0.000002,
+                    "latency": 0.000829,
+                    "health": "HEALTH_OK"
+                },
+                {
+                    "name": "test-mon04",
+                    "skew": -0.000019,
+                    "latency": 0.000609,
+                    "health": "HEALTH_OK"
+                },
+                {
+                    "name": "test-mon05",
+                    "skew": -0.000628,
+                    "latency": 0.000659,
+                    "health": "HEALTH_OK"
+                }
+            ]
+        },
+        "summary": [],
+        "overall_status": "HEALTH_OK",
+        "detail": []
+    },
+    "fsid": "6C9BF03E-044E-4EEB-9C5F-145A54ECF7DB",
+    "election_epoch": 70,
+    "quorum": [
+        0,
+        1,
+        2,
+        3,
+        4
+    ],
+    "monmap": {
+        "epoch": 12,
+        "fsid": "6C9BF03E-044E-4EEB-9C5F-145A54ECF7DB",
+        "modified": "2015-11-25 07:58:56.388352",
+        "created": "0.000000",
+        "mons": [
+            {
+                "rank": 0,
+                "name": "test-mon01",
+                "addr": "10.123.1.25:6789\/0"
+            },
+            {
+                "rank": 1,
+                "name": "test-mon02",
+                "addr": "10.123.1.26:6789\/0"
+            },
+            {
+                "rank": 2,
+                "name": "test-mon03",
+                "addr": "10.123.2.25:6789\/0"
+            },
+            {
+                "rank": 3,
+                "name": "test-mon04",
+                "addr": "10.123.2.26:6789\/0"
+            },
+            {
+                "rank": 4,
+                "name": "test-mon05",
+                "addr": "10.123.2.27:6789\/0"
+            }
+        ]
+    }
+}
+`,
+			[]*regexp.Regexp{
+				regexp.MustCompile(`ceph_monitor_avail_bytes{monitor="test-mon01"} 3.899175e`),
+				regexp.MustCompile(`ceph_monitor_avail_bytes{monitor="test-mon02"} 3.89855048e`),
+				regexp.MustCompile(`ceph_monitor_avail_bytes{monitor="test-mon03"} 3.89634996e`),
+				regexp.MustCompile(`ceph_monitor_avail_bytes{monitor="test-mon04"} 3.90004076e`),
+				regexp.MustCompile(`ceph_monitor_avail_bytes{monitor="test-mon05"} 3.89847124e`),
+				regexp.MustCompile(`ceph_monitor_avail_percent{monitor="test-mon01"} 94`),
+				regexp.MustCompile(`ceph_monitor_avail_percent{monitor="test-mon02"} 94`),
+				regexp.MustCompile(`ceph_monitor_avail_percent{monitor="test-mon03"} 94`),
+				regexp.MustCompile(`ceph_monitor_avail_percent{monitor="test-mon04"} 94`),
+				regexp.MustCompile(`ceph_monitor_avail_percent{monitor="test-mon05"} 94`),
+				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{monitor="test-mon01"} 0`),
+				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{monitor="test-mon02"} -2e-06`),
+				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{monitor="test-mon03"} -2e-06`),
+				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{monitor="test-mon04"} -1.9e-05`),
+				regexp.MustCompile(`ceph_monitor_clock_skew_seconds{monitor="test-mon05"} -0.000628`),
+				regexp.MustCompile(`ceph_monitor_latency_seconds{monitor="test-mon01"} 0`),
+				regexp.MustCompile(`ceph_monitor_latency_seconds{monitor="test-mon02"} 0.000815`),
+				regexp.MustCompile(`ceph_monitor_latency_seconds{monitor="test-mon03"} 0.000829`),
+				regexp.MustCompile(`ceph_monitor_latency_seconds{monitor="test-mon04"} 0.000609`),
+				regexp.MustCompile(`ceph_monitor_latency_seconds{monitor="test-mon05"} 0.000659`),
+				regexp.MustCompile(`ceph_monitor_quorum_count 5`),
+				regexp.MustCompile(`ceph_monitor_store_log_bytes{monitor="test-mon01"} 609694`),
+				regexp.MustCompile(`ceph_monitor_store_log_bytes{monitor="test-mon02"} 871605`),
+				regexp.MustCompile(`ceph_monitor_store_log_bytes{monitor="test-mon03"} 871605`),
+				regexp.MustCompile(`ceph_monitor_store_log_bytes{monitor="test-mon04"} 871605`),
+				regexp.MustCompile(`ceph_monitor_store_log_bytes{monitor="test-mon05"} 871605`),
+				regexp.MustCompile(`ceph_monitor_store_misc_bytes{monitor="test-mon01"} 1.780672385e`),
+				regexp.MustCompile(`ceph_monitor_store_misc_bytes{monitor="test-mon02"} 1.843476609e`),
+				regexp.MustCompile(`ceph_monitor_store_misc_bytes{monitor="test-mon03"} 2.068596982e`),
+				regexp.MustCompile(`ceph_monitor_store_misc_bytes{monitor="test-mon04"} 1.691100542e`),
+				regexp.MustCompile(`ceph_monitor_store_misc_bytes{monitor="test-mon05"} 1.851614337e`),
+				regexp.MustCompile(`ceph_monitor_store_sst_bytes{monitor="test-mon01"} 1`),
+				regexp.MustCompile(`ceph_monitor_store_sst_bytes{monitor="test-mon02"} 2`),
+				regexp.MustCompile(`ceph_monitor_store_sst_bytes{monitor="test-mon03"} 3`),
+				regexp.MustCompile(`ceph_monitor_store_sst_bytes{monitor="test-mon04"} 4`),
+				regexp.MustCompile(`ceph_monitor_store_sst_bytes{monitor="test-mon05"} 5`),
+				regexp.MustCompile(`ceph_monitor_store_capacity_bytes{monitor="test-mon01"} 1.781282079e`),
+				regexp.MustCompile(`ceph_monitor_store_capacity_bytes{monitor="test-mon02"} 1.844348214e`),
+				regexp.MustCompile(`ceph_monitor_store_capacity_bytes{monitor="test-mon03"} 2.069468587e`),
+				regexp.MustCompile(`ceph_monitor_store_capacity_bytes{monitor="test-mon04"} 1.691972147e`),
+				regexp.MustCompile(`ceph_monitor_store_capacity_bytes{monitor="test-mon05"} 1.852485942e`),
+				regexp.MustCompile(`ceph_monitor_capacity_bytes{monitor="test-mon01"} 4.12718256e`),
+				regexp.MustCompile(`ceph_monitor_capacity_bytes{monitor="test-mon02"} 4.12718256e`),
+				regexp.MustCompile(`ceph_monitor_capacity_bytes{monitor="test-mon03"} 4.12718256e`),
+				regexp.MustCompile(`ceph_monitor_capacity_bytes{monitor="test-mon04"} 4.12718256e`),
+				regexp.MustCompile(`ceph_monitor_capacity_bytes{monitor="test-mon05"} 4.12718256e`),
+				regexp.MustCompile(`ceph_monitor_used_bytes{monitor="test-mon01"} 1.812852e`),
+				regexp.MustCompile(`ceph_monitor_used_bytes{monitor="test-mon02"} 1.875304e`),
+				regexp.MustCompile(`ceph_monitor_used_bytes{monitor="test-mon03"} 2.095356e`),
+				regexp.MustCompile(`ceph_monitor_used_bytes{monitor="test-mon04"} 1.726276e`),
+				regexp.MustCompile(`ceph_monitor_used_bytes{monitor="test-mon05"} 1.883228e`),
+			},
+		},
+	} {
+		func() {
+			mockConn := &test.MockConnection{
+				MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+					return []byte(tt.input), "info", nil
+				},
+			}
+			collector := NewMonitorCollector(mockConn)
+			if err := prometheus.Register(collector); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(collector)
+
+			server := httptest.NewServer(prometheus.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.regexes {
+				assert.True(t, re.Match(buf), fmt.Sprintf("failed matching: %q", re))
+			}
+		}()
+	}
+}

--- a/pkg/cephmgr/collectors/osd.go
+++ b/pkg/cephmgr/collectors/osd.go
@@ -1,0 +1,465 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+
+package collectors
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+)
+
+// OSDCollector displays statistics about OSD in the ceph cluster.
+// An important aspect of monitoring OSDs is to ensure that when the cluster is up and
+// running that all OSDs that are in the cluster are up and running, too
+type OSDCollector struct {
+	conn ceph.Connection
+
+	// CrushWeight is a persistent setting, and it affects how CRUSH assigns data to OSDs.
+	// It displays the CRUSH weight for the OSD
+	CrushWeight *prometheus.GaugeVec
+
+	// Depth displays the OSD's level of hierarchy in the CRUSH map
+	Depth *prometheus.GaugeVec
+
+	// Reweight sets an override weight on the OSD.
+	// It displays value within 0 to 1.
+	Reweight *prometheus.GaugeVec
+
+	// Bytes displays the total bytes available in the OSD
+	Bytes *prometheus.GaugeVec
+
+	// UsedBytes displays the total used bytes in the OSD
+	UsedBytes *prometheus.GaugeVec
+
+	// AvailBytes displays the total available bytes in the OSD
+	AvailBytes *prometheus.GaugeVec
+
+	// Utilization displays current utilization of the OSD
+	Utilization *prometheus.GaugeVec
+
+	// Variance displays current variance of the OSD from the standard utilization
+	Variance *prometheus.GaugeVec
+
+	// Pgs displays total no. of placement groups in the OSD.
+	// Available in Ceph Jewel version.
+	Pgs *prometheus.GaugeVec
+
+	// CommitLatency displays in seconds how long it takes for an operation to be applied to disk
+	CommitLatency *prometheus.GaugeVec
+
+	// ApplyLatency displays in seconds how long it takes to get applied to the backing filesystem
+	ApplyLatency *prometheus.GaugeVec
+
+	// OSDIn displays the In state of the OSD
+	OSDIn *prometheus.GaugeVec
+
+	// OSDUp displays the Up state of the OSD
+	OSDUp *prometheus.GaugeVec
+
+	// TotalBytes displays total bytes in all OSDs
+	TotalBytes prometheus.Gauge
+
+	// TotalUsedBytes displays total used bytes in all OSDs
+	TotalUsedBytes prometheus.Gauge
+
+	// TotalAvailBytes displays total available bytes in all OSDs
+	TotalAvailBytes prometheus.Gauge
+
+	// AverageUtil displays average utilization in all OSDs
+	AverageUtil prometheus.Gauge
+}
+
+//NewOSDCollector creates an instance of the OSDCollector and instantiates
+// the individual metrics that show information about the OSD.
+func NewOSDCollector(conn ceph.Connection) *OSDCollector {
+	return &OSDCollector{
+		conn: conn,
+
+		CrushWeight: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_crush_weight",
+				Help:      "OSD Crush Weight",
+			},
+			[]string{"osd"},
+		),
+
+		Depth: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_depth",
+				Help:      "OSD Depth",
+			},
+			[]string{"osd"},
+		),
+
+		Reweight: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_reweight",
+				Help:      "OSD Reweight",
+			},
+			[]string{"osd"},
+		),
+
+		Bytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_bytes",
+				Help:      "OSD Total Bytes",
+			},
+			[]string{"osd"},
+		),
+
+		UsedBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_used_bytes",
+				Help:      "OSD Used Storage in Bytes",
+			},
+			[]string{"osd"},
+		),
+
+		AvailBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_avail_bytes",
+				Help:      "OSD Available Storage in Bytes",
+			},
+			[]string{"osd"},
+		),
+
+		Utilization: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_utilization",
+				Help:      "OSD Utilization",
+			},
+			[]string{"osd"},
+		),
+
+		Variance: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_variance",
+				Help:      "OSD Variance",
+			},
+			[]string{"osd"},
+		),
+
+		Pgs: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_pgs",
+				Help:      "OSD Placement Group Count",
+			},
+			[]string{"osd"},
+		),
+
+		TotalBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_total_bytes",
+				Help:      "OSD Total Storage Bytes",
+			},
+		),
+		TotalUsedBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_total_used_bytes",
+				Help:      "OSD Total Used Storage Bytes",
+			},
+		),
+
+		TotalAvailBytes: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_total_avail_bytes",
+				Help:      "OSD Total Available Storage Bytes ",
+			},
+		),
+
+		AverageUtil: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_average_utilization",
+				Help:      "OSD Average Utilization",
+			},
+		),
+
+		CommitLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_perf_commit_latency_seconds",
+				Help:      "OSD Perf Commit Latency",
+			},
+			[]string{"osd"},
+		),
+
+		ApplyLatency: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_perf_apply_latency_seconds",
+				Help:      "OSD Perf Apply Latency",
+			},
+			[]string{"osd"},
+		),
+
+		OSDIn: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_in",
+				Help:      "OSD In Status",
+			},
+			[]string{"osd"},
+		),
+
+		OSDUp: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Name:      "osd_up",
+				Help:      "OSD Up Status",
+			},
+			[]string{"osd"},
+		),
+	}
+}
+
+func (o *OSDCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		o.CrushWeight,
+		o.Depth,
+		o.Reweight,
+		o.Bytes,
+		o.UsedBytes,
+		o.AvailBytes,
+		o.Utilization,
+		o.Variance,
+		o.Pgs,
+		o.TotalBytes,
+		o.TotalUsedBytes,
+		o.TotalAvailBytes,
+		o.AverageUtil,
+		o.CommitLatency,
+		o.ApplyLatency,
+		o.OSDIn,
+		o.OSDUp,
+	}
+}
+
+func (o *OSDCollector) collect() error {
+	osdDF, err := ceph.GetOSDUsage(o.conn)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range osdDF.OSDNodes {
+
+		crushWeight, err := node.CrushWeight.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.CrushWeight.WithLabelValues(node.Name).Set(crushWeight)
+
+		depth, err := node.Depth.Float64()
+		if err != nil {
+
+			return err
+		}
+
+		o.Depth.WithLabelValues(node.Name).Set(depth)
+
+		reweight, err := node.Reweight.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.Reweight.WithLabelValues(node.Name).Set(reweight)
+
+		osdKB, err := node.KB.Float64()
+		if err != nil {
+			return nil
+		}
+
+		o.Bytes.WithLabelValues(node.Name).Set(osdKB * 1e3)
+
+		usedKB, err := node.UsedKB.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.UsedBytes.WithLabelValues(node.Name).Set(usedKB * 1e3)
+
+		availKB, err := node.AvailKB.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.AvailBytes.WithLabelValues(node.Name).Set(availKB * 1e3)
+
+		util, err := node.Utilization.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.Utilization.WithLabelValues(node.Name).Set(util)
+
+		variance, err := node.Variance.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.Variance.WithLabelValues(node.Name).Set(variance)
+
+		pgs, err := node.Pgs.Float64()
+		if err != nil {
+			continue
+		}
+
+		o.Pgs.WithLabelValues(node.Name).Set(pgs)
+
+	}
+
+	totalKB, err := osdDF.Summary.TotalKB.Float64()
+	if err != nil {
+		return err
+	}
+
+	o.TotalBytes.Set(totalKB * 1e3)
+
+	totalUsedKB, err := osdDF.Summary.TotalUsedKB.Float64()
+	if err != nil {
+		return err
+	}
+
+	o.TotalUsedBytes.Set(totalUsedKB * 1e3)
+
+	totalAvailKB, err := osdDF.Summary.TotalAvailKB.Float64()
+	if err != nil {
+		return err
+	}
+
+	o.TotalAvailBytes.Set(totalAvailKB * 1e3)
+
+	averageUtil, err := osdDF.Summary.AverageUtil.Float64()
+	if err != nil {
+		return err
+	}
+
+	o.AverageUtil.Set(averageUtil)
+
+	return nil
+
+}
+
+func (o *OSDCollector) collectOSDPerf() error {
+	osdPerf, err := ceph.GetOSDPerfStats(o.conn)
+	if err != nil {
+		return err
+	}
+
+	for _, perfStat := range osdPerf.PerfInfo {
+		osdID, err := perfStat.ID.Int64()
+		if err != nil {
+			return err
+		}
+		osdName := fmt.Sprintf("osd.%v", osdID)
+
+		commitLatency, err := perfStat.Stats.CommitLatency.Float64()
+		if err != nil {
+			return err
+		}
+		o.CommitLatency.WithLabelValues(osdName).Set(commitLatency / 1e3)
+
+		applyLatency, err := perfStat.Stats.ApplyLatency.Float64()
+		if err != nil {
+			return err
+		}
+		o.ApplyLatency.WithLabelValues(osdName).Set(applyLatency / 1e3)
+	}
+
+	return nil
+}
+
+func (o *OSDCollector) collectOSDDump() error {
+	osdDump, err := ceph.GetOSDDump(o.conn)
+	if err != nil {
+		return err
+	}
+
+	for _, dumpInfo := range osdDump.OSDs {
+		osdID, err := dumpInfo.OSD.Int64()
+		if err != nil {
+			return err
+		}
+		osdName := fmt.Sprintf("osd.%v", osdID)
+
+		in, err := dumpInfo.In.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.OSDIn.WithLabelValues(osdName).Set(in)
+
+		up, err := dumpInfo.Up.Float64()
+		if err != nil {
+			return err
+		}
+
+		o.OSDUp.WithLabelValues(osdName).Set(up)
+	}
+
+	return nil
+
+}
+
+// Describe sends the descriptors of each OSDCollector related metrics we have defined
+// to the provided prometheus channel.
+func (o *OSDCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range o.collectorList() {
+		metric.Describe(ch)
+	}
+
+}
+
+// Collect sends all the collected metrics to the provided prometheus channel.
+// It requires the caller to handle synchronization.
+func (o *OSDCollector) Collect(ch chan<- prometheus.Metric) {
+
+	if err := o.collectOSDPerf(); err != nil {
+		logger.Errorf("failed collecting osd perf stats: %+v", err)
+	}
+
+	if err := o.collectOSDDump(); err != nil {
+		logger.Errorf("failed collecting osd dump: %+v", err)
+	}
+
+	if err := o.collect(); err != nil {
+		logger.Errorf("failed collecting osd metrics: %+v", err)
+	}
+
+	for _, metric := range o.collectorList() {
+		metric.Collect(ch)
+	}
+
+}

--- a/pkg/cephmgr/collectors/osd_test.go
+++ b/pkg/cephmgr/collectors/osd_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rook/rook/pkg/cephmgr/client/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOSDCollector(t *testing.T) {
+	for _, tt := range []struct {
+		input   string
+		regexes []*regexp.Regexp
+	}{
+		{
+			input: `
+{
+    "nodes": [
+        {
+            "id": 0,
+            "name": "osd.0",
+            "type": "osd",
+            "type_id": 0,
+            "crush_weight": 0.010391,
+            "depth": 2,
+            "reweight": 1.000000,
+            "kb": 11150316,
+            "kb_used": 40772,
+            "kb_avail": 11109544,
+            "utilization": 0.365658,
+            "var": 1.053676,
+            "pgs": 283
+        },
+        {
+            "id": 2,
+            "name": "osd.2",
+            "type": "osd",
+            "type_id": 0,
+            "crush_weight": 0.010391,
+            "depth": 2,
+            "reweight": 1.000000,
+            "kb": 11150316,
+            "kb_used": 36712,
+            "kb_avail": 11113604,
+            "utilization": 0.329246,
+            "var": 0.948753,
+            "pgs": 162
+        },
+        {
+            "id": 1,
+            "name": "osd.1",
+            "type": "osd",
+            "type_id": 0,
+            "crush_weight": 0.010391,
+            "depth": 2,
+            "reweight": 1.000000,
+            "kb": 11150316,
+            "kb_used": 40512,
+            "kb_avail": 11109804,
+            "utilization": 0.363326,
+            "var": 1.046957,
+            "pgs": 279
+        },
+        {
+            "id": 3,
+            "name": "osd.3",
+            "type": "osd",
+            "type_id": 0,
+            "crush_weight": 0.010391,
+            "depth": 2,
+            "reweight": 1.000000,
+            "kb": 11150316,
+            "kb_used": 36784,
+            "kb_avail": 11113532,
+            "utilization": 0.329892,
+            "var": 0.950614,
+            "pgs": 164
+        }
+    ],
+    "stray": [],
+    "summary": {
+        "total_kb": 44601264,
+        "total_kb_used": 154780,
+        "total_kb_avail": 44446484,
+        "average_utilization": 0.347031,
+        "min_var": 0.948753,
+        "max_var": 1.053676,
+        "dev": 0.017482
+    }
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_osd_crush_weight{osd="osd.0"} 0.010391`),
+				regexp.MustCompile(`ceph_osd_crush_weight{osd="osd.1"} 0.010391`),
+				regexp.MustCompile(`ceph_osd_crush_weight{osd="osd.2"} 0.010391`),
+				regexp.MustCompile(`ceph_osd_crush_weight{osd="osd.3"} 0.010391`),
+				regexp.MustCompile(`ceph_osd_depth{osd="osd.0"} 2`),
+				regexp.MustCompile(`ceph_osd_depth{osd="osd.1"} 2`),
+				regexp.MustCompile(`ceph_osd_depth{osd="osd.2"} 2`),
+				regexp.MustCompile(`ceph_osd_depth{osd="osd.3"} 2`),
+				regexp.MustCompile(`ceph_osd_reweight{osd="osd.0"} 1`),
+				regexp.MustCompile(`ceph_osd_reweight{osd="osd.1"} 1`),
+				regexp.MustCompile(`ceph_osd_reweight{osd="osd.2"} 1`),
+				regexp.MustCompile(`ceph_osd_reweight{osd="osd.3"} 1`),
+				regexp.MustCompile(`ceph_osd_bytes{osd="osd.0"} 1.1150316e`),
+				regexp.MustCompile(`ceph_osd_bytes{osd="osd.1"} 1.1150316e`),
+				regexp.MustCompile(`ceph_osd_bytes{osd="osd.2"} 1.1150316e`),
+				regexp.MustCompile(`ceph_osd_bytes{osd="osd.3"} 1.1150316e`),
+				regexp.MustCompile(`ceph_osd_used_bytes{osd="osd.0"} 4.0772e`),
+				regexp.MustCompile(`ceph_osd_used_bytes{osd="osd.1"} 4.0512e`),
+				regexp.MustCompile(`ceph_osd_used_bytes{osd="osd.2"} 3.6712e`),
+				regexp.MustCompile(`ceph_osd_used_bytes{osd="osd.3"} 3.6784e`),
+				regexp.MustCompile(`ceph_osd_avail_bytes{osd="osd.0"} 1.1109544e`),
+				regexp.MustCompile(`ceph_osd_avail_bytes{osd="osd.1"} 1.1109804e`),
+				regexp.MustCompile(`ceph_osd_avail_bytes{osd="osd.2"} 1.1113604e`),
+				regexp.MustCompile(`ceph_osd_avail_bytes{osd="osd.3"} 1.1113532e`),
+				regexp.MustCompile(`ceph_osd_utilization{osd="osd.0"} 0.365658`),
+				regexp.MustCompile(`ceph_osd_utilization{osd="osd.1"} 0.363326`),
+				regexp.MustCompile(`ceph_osd_utilization{osd="osd.2"} 0.329246`),
+				regexp.MustCompile(`ceph_osd_utilization{osd="osd.3"} 0.329892`),
+				regexp.MustCompile(`ceph_osd_variance{osd="osd.0"} 1.053676`),
+				regexp.MustCompile(`ceph_osd_variance{osd="osd.1"} 1.046957`),
+				regexp.MustCompile(`ceph_osd_variance{osd="osd.2"} 0.948753`),
+				regexp.MustCompile(`ceph_osd_variance{osd="osd.3"} 0.950614`),
+				regexp.MustCompile(`ceph_osd_pgs{osd="osd.0"} 283`),
+				regexp.MustCompile(`ceph_osd_pgs{osd="osd.1"} 279`),
+				regexp.MustCompile(`ceph_osd_pgs{osd="osd.2"} 162`),
+				regexp.MustCompile(`ceph_osd_pgs{osd="osd.3"} 164`),
+				regexp.MustCompile(`ceph_osd_total_bytes 4.4601264e`),
+				regexp.MustCompile(`ceph_osd_total_used_bytes 1.5478e`),
+				regexp.MustCompile(`ceph_osd_total_avail_bytes 4.4446484e`),
+				regexp.MustCompile(`ceph_osd_average_utilization 0.347031`),
+			},
+		},
+		{
+			input: `
+{
+    "osd_perf_infos": [
+        {
+            "id": 3,
+            "perf_stats": {
+                "commit_latency_ms": 1,
+                "apply_latency_ms": 64
+            }
+        },
+        {
+            "id": 2,
+            "perf_stats": {
+                "commit_latency_ms": 2,
+                "apply_latency_ms": 79
+            }
+        },
+        {
+            "id": 1,
+            "perf_stats": {
+                "commit_latency_ms": 2,
+                "apply_latency_ms": 39
+            }
+        },
+        {
+            "id": 0,
+            "perf_stats": {
+                "commit_latency_ms": 2,
+                "apply_latency_ms": 31
+            }
+        }
+    ]
+}`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{osd="osd.0"} 0.002`),
+				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{osd="osd.1"} 0.002`),
+				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{osd="osd.2"} 0.002`),
+				regexp.MustCompile(`ceph_osd_perf_commit_latency_seconds{osd="osd.3"} 0.001`),
+				regexp.MustCompile(`ceph_osd_perf_apply_latency_seconds{osd="osd.0"} 0.031`),
+				regexp.MustCompile(`ceph_osd_perf_apply_latency_seconds{osd="osd.1"} 0.039`),
+				regexp.MustCompile(`ceph_osd_perf_apply_latency_seconds{osd="osd.2"} 0.079`),
+				regexp.MustCompile(`ceph_osd_perf_apply_latency_seconds{osd="osd.3"} 0.064`),
+			},
+		},
+		{
+			input: `
+{
+    "osds": [
+        {
+            "osd": 0,
+            "uuid": "135b53c3",
+            "up": 1,
+            "in": 1
+        },
+        {
+            "osd": 1,
+            "uuid": "370a33f2",
+            "up": 1,
+            "in": 1
+        },
+        {
+            "osd": 2,
+            "uuid": "ca9ab3de",
+            "up": 1,
+            "in": 1
+        },
+        {
+            "osd": 3,
+            "uuid": "bef98b10",
+            "up": 1,
+            "in": 1
+        }
+    ]
+}
+`,
+			regexes: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_osd_in{osd="osd.0"} 1`),
+				regexp.MustCompile(`ceph_osd_in{osd="osd.1"} 1`),
+				regexp.MustCompile(`ceph_osd_in{osd="osd.2"} 1`),
+				regexp.MustCompile(`ceph_osd_in{osd="osd.3"} 1`),
+				regexp.MustCompile(`ceph_osd_up{osd="osd.0"} 1`),
+				regexp.MustCompile(`ceph_osd_up{osd="osd.1"} 1`),
+				regexp.MustCompile(`ceph_osd_up{osd="osd.2"} 1`),
+				regexp.MustCompile(`ceph_osd_up{osd="osd.3"} 1`),
+			},
+		},
+	} {
+		func() {
+			mockConn := &test.MockConnection{
+				MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+					return []byte(tt.input), "info", nil
+				},
+			}
+			collector := NewOSDCollector(mockConn)
+			if err := prometheus.Register(collector); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(collector)
+
+			server := httptest.NewServer(prometheus.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.regexes {
+				assert.True(t, re.Match(buf), fmt.Sprintf("failed matching: %q", re))
+			}
+		}()
+
+	}
+}

--- a/pkg/cephmgr/collectors/pool.go
+++ b/pkg/cephmgr/collectors/pool.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+
+package collectors
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+)
+
+// PoolUsageCollector displays statistics about each pool we have created
+// in the ceph cluster.
+type PoolUsageCollector struct {
+	conn ceph.Connection
+
+	// UsedBytes tracks the amount of bytes currently allocated for the pool. This
+	// does not factor in the overcommitment made for individual images.
+	UsedBytes *prometheus.GaugeVec
+
+	// RawUsedBytes tracks the amount of raw bytes currently used for the pool. This
+	// factors in the replication factor (size) of the pool.
+	RawUsedBytes *prometheus.GaugeVec
+
+	// MaxAvail tracks the amount of bytes currently free for the pool,
+	// which depends on the replication settings for the pool in question.
+	MaxAvail *prometheus.GaugeVec
+
+	// Objects shows the no. of RADOS objects created within the pool.
+	Objects *prometheus.GaugeVec
+
+	// DirtyObjects shows the no. of RADOS dirty objects in a cache-tier pool,
+	// this doesn't make sense in a regular pool, see:
+	// http://lists.ceph.com/pipermail/ceph-users-ceph.com/2015-April/000557.html
+	DirtyObjects *prometheus.GaugeVec
+
+	// ReadIO tracks the read IO calls made for the images within each pool.
+	ReadIO *prometheus.GaugeVec
+
+	// Readbytes tracks the read throughput made for the images within each pool.
+	ReadBytes *prometheus.GaugeVec
+
+	// WriteIO tracks the write IO calls made for the images within each pool.
+	WriteIO *prometheus.GaugeVec
+
+	// WriteBytes tracks the write throughput made for the images within each pool.
+	WriteBytes *prometheus.GaugeVec
+}
+
+// NewPoolUsageCollector creates a new instance of PoolUsageCollector and returns
+// its reference.
+func NewPoolUsageCollector(conn ceph.Connection) *PoolUsageCollector {
+	var (
+		subSystem = "pool"
+		poolLabel = []string{"pool"}
+	)
+	return &PoolUsageCollector{
+		conn: conn,
+
+		UsedBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "used_bytes",
+				Help:      "Capacity of the pool that is currently under use",
+			},
+			poolLabel,
+		),
+		RawUsedBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "raw_used_bytes",
+				Help:      "Raw capacity of the pool that is currently under use, this factors in the size",
+			},
+			poolLabel,
+		),
+		MaxAvail: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "available_bytes",
+				Help:      "Free space for this ceph pool",
+			},
+			poolLabel,
+		),
+		Objects: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "objects_total",
+				Help:      "Total no. of objects allocated within the pool",
+			},
+			poolLabel,
+		),
+		DirtyObjects: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "dirty_objects_total",
+				Help:      "Total no. of dirty objects in a cache-tier pool",
+			},
+			poolLabel,
+		),
+		ReadIO: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "read_total",
+				Help:      "Total read i/o calls for the pool",
+			},
+			poolLabel,
+		),
+		ReadBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "read_bytes_total",
+				Help:      "Total read throughput for the pool",
+			},
+			poolLabel,
+		),
+		WriteIO: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "write_total",
+				Help:      "Total write i/o calls for the pool",
+			},
+			poolLabel,
+		),
+		WriteBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: cephNamespace,
+				Subsystem: subSystem,
+				Name:      "write_bytes_total",
+				Help:      "Total write throughput for the pool",
+			},
+			poolLabel,
+		),
+	}
+}
+
+func (p *PoolUsageCollector) collectorList() []prometheus.Collector {
+	return []prometheus.Collector{
+		p.UsedBytes,
+		p.RawUsedBytes,
+		p.MaxAvail,
+		p.Objects,
+		p.DirtyObjects,
+		p.ReadIO,
+		p.ReadBytes,
+		p.WriteIO,
+		p.WriteBytes,
+	}
+}
+
+func (p *PoolUsageCollector) collect() error {
+	stats, err := ceph.GetPoolStats(p.conn)
+	if err != nil {
+		return err
+	}
+
+	if len(stats.Pools) < 1 {
+		return errors.New("no pools found in the cluster to report stats on")
+	}
+
+	for _, pool := range stats.Pools {
+		p.UsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.BytesUsed)
+		p.RawUsedBytes.WithLabelValues(pool.Name).Set(pool.Stats.RawBytesUsed)
+		p.MaxAvail.WithLabelValues(pool.Name).Set(pool.Stats.MaxAvail)
+		p.Objects.WithLabelValues(pool.Name).Set(pool.Stats.Objects)
+		p.DirtyObjects.WithLabelValues(pool.Name).Set(pool.Stats.DirtyObjects)
+		p.ReadIO.WithLabelValues(pool.Name).Set(pool.Stats.ReadIO)
+		p.ReadBytes.WithLabelValues(pool.Name).Set(pool.Stats.ReadBytes)
+		p.WriteIO.WithLabelValues(pool.Name).Set(pool.Stats.WriteIO)
+		p.WriteBytes.WithLabelValues(pool.Name).Set(pool.Stats.WriteBytes)
+	}
+
+	return nil
+}
+
+// Describe fulfills the prometheus.Collector's interface and sends the descriptors
+// of pool's metrics to the given channel.
+func (p *PoolUsageCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range p.collectorList() {
+		metric.Describe(ch)
+	}
+}
+
+// Collect extracts the current values of all the metrics and sends them to the
+// prometheus channel.
+func (p *PoolUsageCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := p.collect(); err != nil {
+		logger.Errorf("failed collecting pool usage metrics: %+v", err)
+		return
+	}
+
+	for _, metric := range p.collectorList() {
+		metric.Collect(ch)
+	}
+}

--- a/pkg/cephmgr/collectors/pool_test.go
+++ b/pkg/cephmgr/collectors/pool_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rook/rook/pkg/cephmgr/client/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoolUsageCollector(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	for _, tt := range []struct {
+		input              string
+		reMatch, reUnmatch []*regexp.Regexp
+	}{
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 20`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 5`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 4`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 6`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 0`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 5`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 4`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 6`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 20`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 0`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 4`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 6`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "objects": 5, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 20`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 5`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 0`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 6`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "objects": 5, "rd": 4}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 20`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 5`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 4`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 0`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+    {{{{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{},
+			reUnmatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes`),
+				regexp.MustCompile(`pool_objects_total`),
+				regexp.MustCompile(`pool_read_total`),
+				regexp.MustCompile(`pool_write_total`),
+			},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "rbd", "id": 11, "stats": {"bytes_used": 20, "objects": 5, "rd": 4, "wr": 6}},
+	{"name": "rbd-new", "id": 12, "stats": {"bytes_used": 50, "objects": 20, "rd": 10, "wr": 30}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_used_bytes{pool="rbd"} 20`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd"} 5`),
+				regexp.MustCompile(`pool_read_total{pool="rbd"} 4`),
+				regexp.MustCompile(`pool_write_total{pool="rbd"} 6`),
+				regexp.MustCompile(`pool_used_bytes{pool="rbd-new"} 50`),
+				regexp.MustCompile(`pool_objects_total{pool="rbd-new"} 20`),
+				regexp.MustCompile(`pool_read_total{pool="rbd-new"} 10`),
+				regexp.MustCompile(`pool_write_total{pool="rbd-new"} 30`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{"pools": [
+	{"name": "ssd", "id": 11, "stats": {"max_avail": 4618201748262, "objects": 5, "rd": 4, "wr": 6}}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`pool_available_bytes{pool="ssd"} 4.618201748262e\+12`),
+			},
+		},
+		{
+			input: `
+{"pools": [
+	{"id": 32, "name": "cinder_sas", "stats": { "bytes_used": 71525351713, "dirty": 17124, "kb_used": 69848977, "max_avail": 6038098673664, "objects": 17124, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 214576054272, "rd": 348986643, "rd_bytes": 3288983853056, "wr": 45792703, "wr_bytes": 272268791808 }},
+	{"id": 33, "name": "cinder_ssd", "stats": { "bytes_used": 68865564849, "dirty": 16461, "kb_used": 67251529, "max_avail": 186205372416, "objects": 16461, "quota_bytes": 0, "quota_objects": 0, "raw_bytes_used": 206596702208, "rd": 347, "rd_bytes": 12899328, "wr": 26721, "wr_bytes": 68882356224 }}
+]}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_pool_available_bytes{pool="cinder_sas"} 6.038098673664e\+12`),
+				regexp.MustCompile(`ceph_pool_dirty_objects_total{pool="cinder_sas"} 17124`),
+				regexp.MustCompile(`ceph_pool_objects_total{pool="cinder_sas"} 17124`),
+				regexp.MustCompile(`ceph_pool_raw_used_bytes{pool="cinder_sas"} 2.14576054272e\+11`),
+				regexp.MustCompile(`ceph_pool_read_bytes_total{pool="cinder_sas"} 3.288983853056e\+12`),
+				regexp.MustCompile(`ceph_pool_read_total{pool="cinder_sas"} 3.48986643e\+08`),
+				regexp.MustCompile(`ceph_pool_used_bytes{pool="cinder_sas"} 7.1525351713e\+10`),
+				regexp.MustCompile(`ceph_pool_write_bytes_total{pool="cinder_sas"} 2.72268791808e\+11`),
+				regexp.MustCompile(`ceph_pool_write_total{pool="cinder_sas"} 4.5792703e\+07`),
+				regexp.MustCompile(`ceph_pool_available_bytes{pool="cinder_ssd"} 1.86205372416e\+11`),
+				regexp.MustCompile(`ceph_pool_dirty_objects_total{pool="cinder_ssd"} 16461`),
+				regexp.MustCompile(`ceph_pool_objects_total{pool="cinder_ssd"} 16461`),
+				regexp.MustCompile(`ceph_pool_raw_used_bytes{pool="cinder_ssd"} 2.06596702208e\+11`),
+				regexp.MustCompile(`ceph_pool_read_bytes_total{pool="cinder_ssd"} 1.2899328e\+07`),
+				regexp.MustCompile(`ceph_pool_read_total{pool="cinder_ssd"} 347`),
+				regexp.MustCompile(`ceph_pool_used_bytes{pool="cinder_ssd"} 6.8865564849e\+10`),
+				regexp.MustCompile(`ceph_pool_write_bytes_total{pool="cinder_ssd"} 6.8882356224e\+10`),
+				regexp.MustCompile(`ceph_pool_write_total{pool="cinder_ssd"} 26721`),
+			},
+		},
+	} {
+		func() {
+			mockConn := &test.MockConnection{
+				MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+					return []byte(tt.input), "info", nil
+				},
+			}
+			collector := NewPoolUsageCollector(mockConn)
+			if err := prometheus.Register(collector); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(collector)
+
+			server := httptest.NewServer(prometheus.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.reMatch {
+				assert.True(t, re.Match(buf), fmt.Sprintf("failed matching: %q", re))
+			}
+
+			for _, re := range tt.reUnmatch {
+				assert.False(t, re.Match(buf), fmt.Sprintf("should not have matched: %q", re))
+			}
+		}()
+	}
+}

--- a/pkg/cephmgr/collectors/usage.go
+++ b/pkg/cephmgr/collectors/usage.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+
+package collectors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	ceph "github.com/rook/rook/pkg/cephmgr/client"
+)
+
+const (
+	cephNamespace = "ceph"
+)
+
+// A ClusterUsageCollector is used to gather all the global stats about a given
+// ceph cluster. It is sometimes essential to know how fast the cluster is growing
+// or shrinking as a whole in order to zero in on the cause. The pool specific
+// stats are provided separately.
+type ClusterUsageCollector struct {
+	conn ceph.Connection
+
+	// GlobalCapacity displays the total storage capacity of the cluster. This
+	// information is based on the actual no. of objects that are allocated. It
+	// does not take overcommitment into consideration.
+	GlobalCapacity prometheus.Gauge
+
+	// UsedCapacity shows the storage under use.
+	UsedCapacity prometheus.Gauge
+
+	// AvailableCapacity shows the remaining capacity of the cluster that is left unallocated.
+	AvailableCapacity prometheus.Gauge
+
+	// Objects show the total no. of RADOS objects that are currently allocated.
+	Objects prometheus.Gauge
+}
+
+// NewClusterUsageCollector creates and returns the reference to ClusterUsageCollector
+// and internally defines each metric that display cluster stats.
+func NewClusterUsageCollector(conn ceph.Connection) *ClusterUsageCollector {
+	return &ClusterUsageCollector{
+		conn: conn,
+
+		GlobalCapacity: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cephNamespace,
+			Name:      "cluster_capacity_bytes",
+			Help:      "Total capacity of the cluster",
+		}),
+		UsedCapacity: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cephNamespace,
+			Name:      "cluster_used_bytes",
+			Help:      "Capacity of the cluster currently in use",
+		}),
+		AvailableCapacity: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cephNamespace,
+			Name:      "cluster_available_bytes",
+			Help:      "Available space within the cluster",
+		}),
+		Objects: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: cephNamespace,
+			Name:      "cluster_objects",
+			Help:      "No. of rados objects within the cluster",
+		}),
+	}
+}
+
+func (c *ClusterUsageCollector) metricsList() []prometheus.Metric {
+	return []prometheus.Metric{
+		c.GlobalCapacity,
+		c.UsedCapacity,
+		c.AvailableCapacity,
+		c.Objects,
+	}
+}
+
+func (c *ClusterUsageCollector) collect() error {
+	stats, err := ceph.Usage(c.conn)
+	if err != nil {
+		return err
+	}
+
+	var totBytes, usedBytes, availBytes, totObjects float64
+
+	totBytes, err = stats.Stats.TotalBytes.Float64()
+	if err != nil {
+		logger.Errorf("cannot extract total bytes: %+v", err)
+	}
+
+	usedBytes, err = stats.Stats.TotalUsedBytes.Float64()
+	if err != nil {
+		logger.Errorf("cannot extract used bytes: %+v", err)
+	}
+
+	availBytes, err = stats.Stats.TotalAvailBytes.Float64()
+	if err != nil {
+		logger.Errorf("cannot extract available bytes: %+v", err)
+	}
+
+	totObjects, err = stats.Stats.TotalObjects.Float64()
+	if err != nil {
+		logger.Errorf("cannot extract total objects: %+v", err)
+	}
+
+	c.GlobalCapacity.Set(totBytes)
+	c.UsedCapacity.Set(usedBytes)
+	c.AvailableCapacity.Set(availBytes)
+	c.Objects.Set(totObjects)
+
+	return nil
+}
+
+// Describe sends the descriptors of each metric over to the provided channel.
+// The corresponding metric values are sent separately.
+func (c *ClusterUsageCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range c.metricsList() {
+		ch <- metric.Desc()
+	}
+}
+
+// Collect sends the metric values for each metric pertaining to the global
+// cluster usage over to the provided prometheus Metric channel.
+func (c *ClusterUsageCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := c.collect(); err != nil {
+		logger.Errorf("failed collecting cluster usage metrics: %+v", err)
+		return
+	}
+
+	for _, metric := range c.metricsList() {
+		ch <- metric
+	}
+}

--- a/pkg/cephmgr/collectors/usage_test.go
+++ b/pkg/cephmgr/collectors/usage_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package collectors
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rook/rook/pkg/cephmgr/client/test"
+)
+
+func TestClusterUsage(t *testing.T) {
+	for _, tt := range []struct {
+		input              string
+		reMatch, reUnmatch []*regexp.Regexp
+	}{
+		{
+			input: `
+{
+	"stats": {
+		"total_bytes": 10,
+		"total_used_bytes": 6,
+		"total_avail_bytes": 4,
+		"total_objects": 1
+	}
+}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes 10`),
+				regexp.MustCompile(`ceph_cluster_used_bytes 6`),
+				regexp.MustCompile(`ceph_cluster_available_bytes 4`),
+				regexp.MustCompile(`ceph_cluster_objects 1`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{
+	"stats": {
+		"total_used_bytes": 6,
+		"total_avail_bytes": 4,
+		"total_objects": 1
+	}
+}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes 0`),
+				regexp.MustCompile(`ceph_cluster_used_bytes 6`),
+				regexp.MustCompile(`ceph_cluster_available_bytes 4`),
+				regexp.MustCompile(`ceph_cluster_objects 1`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{
+	"stats": {
+		"total_bytes": 10,
+		"total_avail_bytes": 4,
+		"total_objects": 1
+	}
+}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes 10`),
+				regexp.MustCompile(`ceph_cluster_used_bytes 0`),
+				regexp.MustCompile(`ceph_cluster_available_bytes 4`),
+				regexp.MustCompile(`ceph_cluster_objects 1`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{
+	"stats": {
+		"total_bytes": 10,
+		"total_used_bytes": 6,
+		"total_objects": 1
+	}
+}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes 10`),
+				regexp.MustCompile(`ceph_cluster_used_bytes 6`),
+				regexp.MustCompile(`ceph_cluster_available_bytes 0`),
+				regexp.MustCompile(`ceph_cluster_objects 1`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{
+	"stats": {
+		"total_bytes": 10,
+		"total_used_bytes": 6,
+		"total_avail_bytes": 4
+	}
+}`,
+			reMatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes 10`),
+				regexp.MustCompile(`ceph_cluster_used_bytes 6`),
+				regexp.MustCompile(`ceph_cluster_available_bytes 4`),
+				regexp.MustCompile(`ceph_cluster_objects 0`),
+			},
+			reUnmatch: []*regexp.Regexp{},
+		},
+		{
+			input: `
+{
+	"stats": {{{
+		"total_bytes": 10,
+		"total_used_bytes": 6,
+		"total_avail_bytes": 4,
+		"total_objects": 1
+	}
+}`,
+			reMatch: []*regexp.Regexp{},
+			reUnmatch: []*regexp.Regexp{
+				regexp.MustCompile(`ceph_cluster_capacity_bytes`),
+				regexp.MustCompile(`ceph_cluster_used_bytes`),
+				regexp.MustCompile(`ceph_cluster_available_bytes`),
+				regexp.MustCompile(`ceph_cluster_objects`),
+			},
+		},
+	} {
+		func() {
+			mockConn := &test.MockConnection{
+				MockMonCommand: func(args []byte) (buffer []byte, info string, err error) {
+					return []byte(tt.input), "info", nil
+				},
+			}
+			collector := NewClusterUsageCollector(mockConn)
+			if err := prometheus.Register(collector); err != nil {
+				t.Fatalf("collector failed to register: %s", err)
+			}
+			defer prometheus.Unregister(collector)
+
+			server := httptest.NewServer(prometheus.Handler())
+			defer server.Close()
+
+			resp, err := http.Get(server.URL)
+			if err != nil {
+				t.Fatalf("unexpected failed response from prometheus: %s", err)
+			}
+			defer resp.Body.Close()
+
+			buf, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("failed reading server response: %s", err)
+			}
+
+			for _, re := range tt.reMatch {
+				assert.True(t, re.Match(buf), fmt.Sprintf("failed matching: %q", re))
+			}
+			for _, re := range tt.reUnmatch {
+				assert.False(t, re.Match(buf), fmt.Sprintf("should not have matched: %q", re))
+			}
+		}()
+	}
+}

--- a/pkg/cephmgr/mon/conn.go
+++ b/pkg/cephmgr/mon/conn.go
@@ -16,6 +16,8 @@ limitations under the License.
 package mon
 
 import (
+	"fmt"
+
 	"github.com/rook/rook/pkg/cephmgr/client"
 	"github.com/rook/rook/pkg/clusterd"
 )
@@ -45,6 +47,10 @@ func (c *lookupConnFactory) ConnectAsAdmin(context *clusterd.Context, cephFactor
 	clusterInfo, err := LoadClusterInfo(context.EtcdClient)
 	if err != nil {
 		return nil, err
+	}
+
+	if clusterInfo == nil {
+		return nil, fmt.Errorf("cluster info does not exist")
 	}
 
 	// open an admin connection to the cluster


### PR DESCRIPTION
First commit is all the new work that should be reviewed thoroughly.  The second commit is all the Prometheus collectors that were adapted from https://github.com/digitalocean/ceph_exporter, so those can be less rigorously reviewed.

Addresses #426 

Note updated user guide/docs will be addressed by #471 (completed in https://github.com/jbw976/rook/tree/metrics-docs but waiting to open PR until a release with this PR is published)