### PR TITLE
Use existing TPR when exists

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -88,7 +88,7 @@ func (o *Operator) Run() error {
 		if err == nil {
 			break
 		}
-		logger.Errorf("failed to create tpr. %+v. retrying...", err)
+		logger.Errorf("failed to init resources. %+v. retrying...", err)
 		<-time.After(initRetryDelay)
 	}
 

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -59,7 +59,7 @@ func (o *Operator) createTPR() error {
 		}
 	}
 
-	return err
+	return nil
 }
 
 func (o *Operator) waitForTPRInit(restcli rest.Interface, maxRetries int, ns string) error {


### PR DESCRIPTION
This was a regression from #467. Fixes #473