### PR TITLE
Detect unhealthy monitors and start new monitors in their place

### DIFF
--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -47,8 +47,8 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 
 func (s *clusterHandler) EnableObjectStore() error {
 	logger.Infof("Starting the Object store")
-	r := k8srgw.New(s.namespace, s.version, s.factory)
-	err := r.Start(s.clientset, s.clusterInfo)
+	r := k8srgw.New(s.clientset, s.factory, s.namespace, s.version)
+	err := r.Start(s.clusterInfo)
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
 	}

--- a/pkg/api/k8s/node.go
+++ b/pkg/api/k8s/node.go
@@ -35,7 +35,7 @@ func getNodes(clientset *kubernetes.Clientset) ([]model.Node, error) {
 		node := model.Node{
 			NodeID:      n.Status.NodeInfo.SystemUUID,
 			PublicIP:    n.Spec.ExternalID,
-			ClusterName: "rookcluster",
+			ClusterName: n.Namespace,
 		}
 		nodes = append(nodes, node)
 	}

--- a/pkg/cephmgr/mon/config.go
+++ b/pkg/cephmgr/mon/config.go
@@ -251,7 +251,7 @@ func ConnectToCluster(context *clusterd.Context, factory client.ConnectionFactor
 		return nil, fmt.Errorf("failed to connect to cluster %s: %+v", cluster.Name, err)
 	}
 
-	logger.Infof("successfully connected to cluster %s", cluster.Name)
+	logger.Infof("successfully connected to cluster %s with user %s", cluster.Name, user)
 	return conn, nil
 }
 

--- a/pkg/cephmgr/mon/config.go
+++ b/pkg/cephmgr/mon/config.go
@@ -251,6 +251,7 @@ func ConnectToCluster(context *clusterd.Context, factory client.ConnectionFactor
 		return nil, fmt.Errorf("failed to connect to cluster %s: %+v", cluster.Name, err)
 	}
 
+	logger.Infof("successfully connected to cluster %s", cluster.Name)
 	return conn, nil
 }
 

--- a/pkg/cephmgr/mon/info.go
+++ b/pkg/cephmgr/mon/info.go
@@ -77,6 +77,11 @@ func createOrGetClusterInfo(factory client.ConnectionFactory, etcdClient etcd.Ke
 
 // create new cluster info (FSID, shared keys)
 func CreateClusterInfo(factory client.ConnectionFactory, adminSecret string) (*ClusterInfo, error) {
+	return CreateNamedClusterInfo(factory, adminSecret, "rookcluster")
+}
+
+// create new cluster info (FSID, shared keys)
+func CreateNamedClusterInfo(factory client.ConnectionFactory, adminSecret, clusterName string) (*ClusterInfo, error) {
 	fsid, err := factory.NewFsid()
 	if err != nil {
 		return nil, err
@@ -99,7 +104,7 @@ func CreateClusterInfo(factory client.ConnectionFactory, adminSecret string) (*C
 		FSID:          fsid,
 		MonitorSecret: monSecret,
 		AdminSecret:   adminSecret,
-		Name:          "rookcluster",
+		Name:          clusterName,
 	}, nil
 }
 

--- a/pkg/cephmgr/mon/leader.go
+++ b/pkg/cephmgr/mon/leader.go
@@ -42,7 +42,7 @@ type Leader struct {
 }
 
 func NewLeader() *Leader {
-	return &Leader{waitForQuorum: waitForQuorum}
+	return &Leader{waitForQuorum: WaitForQuorum}
 }
 
 // Apply the desired state to the cluster. The context provides all the information needed to make changes to the service.
@@ -356,7 +356,8 @@ func calculateMonitorCount(nodeCount int) int {
 	}
 }
 
-func waitForQuorum(factory client.ConnectionFactory, context *clusterd.Context, cluster *ClusterInfo) error {
+func WaitForQuorum(factory client.ConnectionFactory, context *clusterd.Context, cluster *ClusterInfo) error {
+	logger.Infof("waiting for mon quorum...")
 
 	// open an admin connection to the cluster
 	adminConn, err := ConnectToClusterAsAdmin(context, factory, cluster)

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -75,7 +75,9 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "quay.io/rook/rook-operator:myversion", cont.Image)
 	assert.Equal(t, 1, len(cont.VolumeMounts))
 	assert.Equal(t, 5, len(cont.Env))
-
+	for _, v := range cont.Env {
+		assert.True(t, strings.HasPrefix(v.Name, "ROOK_OPERATOR_"))
+	}
 	expectedCommand := fmt.Sprintf("/usr/bin/rook-operator api --data-dir=/var/lib/rook --api-port=%d --container-version=%s",
 		model.Port, c.Version)
 

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -24,41 +24,41 @@ import (
 	testop "github.com/rook/rook/pkg/operator/test"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestStartAPI(t *testing.T) {
 	clientset := testop.New(3)
 	info := testop.CreateClusterInfo(1)
-	c := New("ns", "myversion")
+	c := New(clientset, "ns", "myversion")
 
 	// start a basic cluster
-	err := c.Start(clientset, info)
+	err := c.Start(info)
 	assert.Nil(t, err)
 
-	validateStart(t, c, clientset)
+	validateStart(t, c)
 
 	// starting again should be a no-op
-	err = c.Start(clientset, info)
+	err = c.Start(info)
 	assert.Nil(t, err)
 
-	validateStart(t, c, clientset)
+	validateStart(t, c)
 }
 
-func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
+func validateStart(t *testing.T, c *Cluster) {
 
-	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(deploymentName)
+	r, err := c.clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(deploymentName)
 	assert.Nil(t, err)
 	assert.Equal(t, deploymentName, r.Name)
 
-	s, err := clientset.CoreV1().Services(c.Namespace).Get(deploymentName)
+	s, err := c.clientset.CoreV1().Services(c.Namespace).Get(deploymentName)
 	assert.Nil(t, err)
 	assert.Equal(t, deploymentName, s.Name)
 }
 
 func TestPodSpecs(t *testing.T) {
-	c := New("ns", "myversion")
+	clientset := testop.New(1)
+	c := New(clientset, "ns", "myversion")
 	info := testop.CreateClusterInfo(0)
 
 	d := c.makeDeployment(info)

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -92,14 +92,14 @@ func (c *Cluster) CreateInstance() error {
 	}
 
 	a := api.New(c.clientset, c.Spec.Namespace, c.Spec.Version)
-	err = a.Start(cluster)
+	err = a.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the REST api. %+v", err)
 	}
 
 	// Start the OSDs
 	osds := osd.New(c.clientset, c.Spec.Namespace, c.Spec.Version, c.Spec.DeviceFilter, c.Spec.DataDirHostPath, c.Spec.UseAllDevices)
-	err = osds.Start(cluster)
+	err = osds.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the osds. %+v", err)
 	}

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -85,21 +85,21 @@ func (c *Cluster) CreateInstance() error {
 	}
 
 	// Start the mon pods
-	m := mon.New(c.Spec.Namespace, c.factory, c.Spec.DataDirHostPath, c.Spec.Version)
-	cluster, err := m.Start(c.clientset)
+	m := mon.New(c.clientset, c.factory, c.Spec.Namespace, c.Spec.DataDirHostPath, c.Spec.Version)
+	cluster, err := m.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the mons. %+v", err)
 	}
 
-	a := api.New(c.Spec.Namespace, c.Spec.Version)
-	err = a.Start(c.clientset, cluster)
+	a := api.New(c.clientset, c.Spec.Namespace, c.Spec.Version)
+	err = a.Start(cluster)
 	if err != nil {
 		return fmt.Errorf("failed to start the REST api. %+v", err)
 	}
 
 	// Start the OSDs
-	osds := osd.New(c.Spec.Namespace, c.Spec.Version, c.Spec.DeviceFilter, c.Spec.DataDirHostPath, c.Spec.UseAllDevices)
-	err = osds.Start(c.clientset, cluster)
+	osds := osd.New(c.clientset, c.Spec.Namespace, c.Spec.Version, c.Spec.DeviceFilter, c.Spec.DataDirHostPath, c.Spec.UseAllDevices)
+	err = osds.Start(cluster)
 	if err != nil {
 		return fmt.Errorf("failed to start the osds. %+v", err)
 	}

--- a/pkg/operator/cluster/cluster.go
+++ b/pkg/operator/cluster/cluster.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	healthCheckInterval = 8 * time.Second
+	healthCheckInterval = 10 * time.Second
 	logger              = capnslog.NewPackageLogger("github.com/rook/rook-operator", "op-cluster")
 )
 
@@ -115,7 +115,7 @@ func (c *Cluster) Monitor(stopCh <-chan struct{}) {
 			return
 
 		case <-time.After(healthCheckInterval):
-			logger.Infof("checking health of mons")
+			logger.Debugf("checking health of mons")
 			err := c.mons.CheckHealth()
 			if err != nil {
 				logger.Infof("failed to check mon health. %+v", err)

--- a/pkg/operator/cluster/cluster_list.go
+++ b/pkg/operator/cluster/cluster_list.go
@@ -16,7 +16,7 @@ limitations under the License.
 Some of the code below came from https://github.com/coreos/etcd-operator
 which also has the apache 2.0 license.
 */
-package operator
+package cluster
 
 import (
 	"encoding/json"

--- a/pkg/operator/cluster/cluster_test.go
+++ b/pkg/operator/cluster/cluster_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 Some of the code below came from https://github.com/coreos/etcd-operator
 which also has the apache 2.0 license.
 */
-package operator
+package cluster
 
 import (
 	"fmt"
@@ -39,8 +39,8 @@ func TestCreateSecrets(t *testing.T) {
 		response := "{\"key\":\"mysecurekey\"}"
 		return []byte(response), "", nil
 	}
-	spec := ClusterSpec{Namespace: "ns", Version: "myversion"}
-	c := newCluster(spec, factory, clientset)
+	spec := Spec{Namespace: "ns", Version: "myversion"}
+	c := New(spec, factory, clientset)
 	c.dataDir = "/tmp/testdir"
 	defer os.RemoveAll(c.dataDir)
 

--- a/pkg/operator/cluster/spec.go
+++ b/pkg/operator/cluster/spec.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package cluster
+
+type Spec struct {
+	// The namespace where the the rook resources will all be created.
+	Namespace string `json:"namespace"`
+
+	// Version is the expected version of the rook container to run in the cluster.
+	// The rook-operator will eventually make the rook cluster version
+	// equal to the expected version.
+	Version string `json:"version"`
+
+	// Paused is to pause the control of the operator for the rook cluster.
+	Paused bool `json:"paused,omitempty"`
+
+	// Whether to consume all the storage devices found on a machine
+	UseAllDevices bool `json:"useAllDevices"`
+
+	// A regular expression to allow more fine-grained selection of devices on nodes across the cluster
+	DeviceFilter string `json:"deviceFilter"`
+
+	// The path on the host where config and data can be persisted.
+	DataDirHostPath string `json:"dataDirHostPath"`
+}

--- a/pkg/operator/event.go
+++ b/pkg/operator/event.go
@@ -23,13 +23,15 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/rook/rook/pkg/operator/cluster"
+
 	"k8s.io/client-go/pkg/api/unversioned"
 	kwatch "k8s.io/client-go/pkg/watch"
 )
 
 type Event struct {
 	Type   kwatch.EventType
-	Object *Cluster
+	Object *cluster.Cluster
 }
 
 type rawEvent struct {
@@ -58,7 +60,7 @@ func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
 
 	ev := &Event{
 		Type:   re.Type,
-		Object: &Cluster{},
+		Object: &cluster.Cluster{},
 	}
 	err = json.Unmarshal(re.Object, ev.Object)
 	if err != nil {

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rook/rook/pkg/cephmgr/mon"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	k8smon "github.com/rook/rook/pkg/operator/mon"
+	opmon "github.com/rook/rook/pkg/operator/mon"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
@@ -76,7 +76,7 @@ func (c *Cluster) Start(clientset kubernetes.Interface, cluster *mon.ClusterInfo
 	}
 
 	// start the deployment
-	deployment := c.makeDeployment(cluster, id)
+	deployment := c.makeDeployment(id)
 	_, err = clientset.ExtensionsV1beta1().Deployments(c.Namespace).Create(deployment)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -123,7 +123,7 @@ func (c *Cluster) createKeyring(clientset kubernetes.Interface, context *cluster
 	return nil
 }
 
-func (c *Cluster) makeDeployment(cluster *mon.ClusterInfo, id string) *extensions.Deployment {
+func (c *Cluster) makeDeployment(id string) *extensions.Deployment {
 	deployment := &extensions.Deployment{}
 	deployment.Name = appName
 	deployment.Namespace = c.Namespace
@@ -131,11 +131,11 @@ func (c *Cluster) makeDeployment(cluster *mon.ClusterInfo, id string) *extension
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        appName,
-			Labels:      getLabels(cluster.Name),
+			Labels:      c.getLabels(),
 			Annotations: map[string]string{},
 		},
 		Spec: v1.PodSpec{
-			Containers:    []v1.Container{c.mdsContainer(cluster, id)},
+			Containers:    []v1.Container{c.mdsContainer(id)},
 			RestartPolicy: v1.RestartPolicyAlways,
 			Volumes: []v1.Volume{
 				{Name: k8sutil.DataDirVolume, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
@@ -148,10 +148,10 @@ func (c *Cluster) makeDeployment(cluster *mon.ClusterInfo, id string) *extension
 	return deployment
 }
 
-func (c *Cluster) mdsContainer(cluster *mon.ClusterInfo, id string) v1.Container {
+func (c *Cluster) mdsContainer(id string) v1.Container {
 
-	command := fmt.Sprintf("/usr/bin/rookd mds --data-dir=%s --mon-endpoints=%s --cluster-name=%s --mds-id=%s ",
-		k8sutil.DataDir, mon.FlattenMonEndpoints(cluster.Monitors), cluster.Name, id)
+	command := fmt.Sprintf("/usr/bin/rookd mds --data-dir=%s --mds-id=%s ",
+		k8sutil.DataDir, id)
 	return v1.Container{
 		// TODO: fix "sleep 5".
 		// Without waiting some time, there is highly probable flakes in network setup.
@@ -163,15 +163,17 @@ func (c *Cluster) mdsContainer(cluster *mon.ClusterInfo, id string) v1.Container
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOKD_MDS_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: keyringName}}},
-			k8smon.MonSecretEnvVar(),
-			k8smon.AdminSecretEnvVar(),
+			opmon.ClusterNameEnvVar(),
+			opmon.MonEndpointEnvVar(),
+			opmon.MonSecretEnvVar(),
+			opmon.AdminSecretEnvVar(),
 		},
 	}
 }
 
-func getLabels(clusterName string) map[string]string {
+func (c *Cluster) getLabels() map[string]string {
 	return map[string]string{
 		k8sutil.AppAttr:     appName,
-		k8sutil.ClusterAttr: clusterName,
+		k8sutil.ClusterAttr: c.Namespace,
 	}
 }

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -67,10 +67,9 @@ func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 
 func TestPodSpecs(t *testing.T) {
 	c := New("ns", "myversion", nil)
-	info := testop.CreateClusterInfo(0)
 	mdsID := "mds1"
 
-	d := c.makeDeployment(info, mdsID)
+	d := c.makeDeployment(mdsID)
 	assert.NotNil(t, d)
 	assert.Equal(t, "mds", d.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, d.Spec.Template.Spec.RestartPolicy)
@@ -79,16 +78,16 @@ func TestPodSpecs(t *testing.T) {
 
 	assert.Equal(t, "mds", d.ObjectMeta.Name)
 	assert.Equal(t, "mds", d.Spec.Template.ObjectMeta.Labels["app"])
-	assert.Equal(t, info.Name, d.Spec.Template.ObjectMeta.Labels["rook_cluster"])
+	assert.Equal(t, c.Namespace, d.Spec.Template.ObjectMeta.Labels["rook_cluster"])
 	assert.Equal(t, 0, len(d.ObjectMeta.Annotations))
 
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "quay.io/rook/rookd:myversion", cont.Image)
 	assert.Equal(t, 1, len(cont.VolumeMounts))
-	assert.Equal(t, 3, len(cont.Env))
+	assert.Equal(t, 5, len(cont.Env))
 
-	expectedCommand := fmt.Sprintf("/usr/bin/rookd mds --data-dir=/var/lib/rook --mon-endpoints= --cluster-name=%s --mds-id=%s ",
-		info.Name, mdsID)
+	expectedCommand := fmt.Sprintf("/usr/bin/rookd mds --data-dir=/var/lib/rook --mds-id=%s ",
+		mdsID)
 
 	assert.NotEqual(t, -1, strings.Index(cont.Command[2], expectedCommand), cont.Command[2])
 }

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -17,6 +17,8 @@ package mon
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rook/rook/pkg/cephmgr/client"
@@ -39,6 +41,7 @@ const (
 	clusterSecretName = "cluster-name"
 	monConfigMapName  = "mon-config"
 	monEndpointKey    = "endpoints"
+	maxMonIDKey       = "maxMonId"
 )
 
 type Cluster struct {
@@ -54,7 +57,11 @@ type Cluster struct {
 	clientset       kubernetes.Interface
 	factory         client.ConnectionFactory
 	retryDelay      int
+	maxRetries      int
 	clusterInfo     *mon.ClusterInfo
+	maxMonID        int
+	configDir       string
+	waitForStart    bool
 	dataDirHostPath string
 }
 
@@ -73,6 +80,10 @@ func New(clientset kubernetes.Interface, factory client.ConnectionFactory, names
 		Size:            3,
 		AntiAffinity:    true,
 		retryDelay:      6,
+		maxRetries:      15,
+		maxMonID:        -1,
+		configDir:       k8sutil.DataDir,
+		waitForStart:    true,
 	}
 }
 
@@ -83,33 +94,48 @@ func (c *Cluster) Start() (*mon.ClusterInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize ceph cluster info. %+v", err)
 	}
-	mons := []*MonConfig{}
-	for i := 0; i < c.Size; i++ {
-		mons = append(mons, &MonConfig{Name: fmt.Sprintf("mon%d", i), Port: int32(mon.Port)})
-	}
 
-	err = c.startPods(mons)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start mon pods. %+v", err)
-	}
-
-	context := &clusterd.Context{ConfigDir: k8sutil.DataDir}
-	err = mon.WaitForQuorum(c.factory, context, c.clusterInfo)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for mon quorum. %+v", err)
+	if len(c.clusterInfo.Monitors) == 0 {
+		// Start the initial monitors at startup
+		mons := c.getExpectedMonConfig()
+		err = c.startPods(nil, mons)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start mon pods. %+v", err)
+		}
+	} else {
+		// Check the health of a previously started cluster
+		err = c.CheckHealth()
+		if err != nil {
+			logger.Warningf("failed to check mon health %+v. %+v", c.clusterInfo.Monitors, err)
+		}
 	}
 
 	return c.clusterInfo, nil
 }
 
 func (c *Cluster) CheckHealth() error {
-	context := &clusterd.Context{ConfigDir: k8sutil.DataDir}
+	// update the config map if the pod ips changed
+	// must retry since during startup of pods they might take some time to initialize
+	k8sutil.Retry(time.Duration(c.retryDelay)*time.Second, c.maxRetries, func() (bool, error) {
+		// TODO: There is more work to get the reboot functional. The mons are not
+		// happy if their ip address changes. They expect a constant id.
+		err := c.updateConfigMapIfPodIPsChanged()
+		if err != nil {
+			logger.Infof("unable to check on mon pods. %+v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// connect to the mons
+	context := &clusterd.Context{ConfigDir: c.configDir}
 	conn, err := mon.ConnectToClusterAsAdmin(context, c.factory, c.clusterInfo)
 	if err != nil {
 		return fmt.Errorf("cannot connect to cluster. %+v", err)
 	}
 	defer conn.Shutdown()
 
+	// get the status and check for quorum
 	status, err := client.GetMonStatus(conn)
 	if err != nil {
 		return fmt.Errorf("failed to get mon status. %+v", err)
@@ -118,26 +144,56 @@ func (c *Cluster) CheckHealth() error {
 	for _, monitor := range status.MonMap.Mons {
 		inQuorum := monInQuorum(monitor, status.Quorum)
 		if inQuorum {
-			logger.Infof("mon %s found in quorum", monitor.Name)
+			logger.Debugf("mon %s found in quorum", monitor.Name)
 		} else {
-			logger.Infof("mon %s NOT found in quroum. %+v", monitor.Name, status.Quorum)
-		}
+			logger.Warningf("mon %s NOT found in quroum. %+v", monitor.Name, status.Quorum)
 
-		pod, err := c.clientset.CoreV1().Pods(c.Namespace).Get(monitor.Name)
-		if err != nil {
-			logger.Infof("Get mon %s pod failed. %+v", monitor.Name, err)
-		} else {
-			logger.Infof("mon %s pod status: %+v", monitor.Name, pod.Status.Phase)
-		}
-
-		if !inQuorum {
-			err = c.failoverMon(monitor.Name)
+			err = c.failoverMon(conn, monitor.Name)
 			if err != nil {
 				logger.Errorf("failed to failover mon %s. %+v", monitor.Name, err)
 			}
 		}
 	}
 
+	return nil
+}
+
+func (c *Cluster) updateConfigMapIfPodIPsChanged() error {
+	pods, err := c.getPods()
+	if err != nil {
+		return fmt.Errorf("failed to check if pod ips changed. %+v", err)
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("where are the mon pods?")
+	}
+
+	logger.Debugf("there are %d mon pods. checking the podIPs.", len(pods.Items))
+	updated := false
+	for _, pod := range pods.Items {
+		if pod.Status.PodIP == "" {
+			return fmt.Errorf("no podIP for mon %s", pod.Name)
+		}
+		if pod.Status.Phase != v1.PodRunning {
+			return fmt.Errorf("pod %s is not running. phase=%v", pod.Name, pod.Status.Phase)
+		}
+		m := mon.ToCephMon(pod.Name, pod.Status.PodIP)
+		existing, ok := c.clusterInfo.Monitors[pod.Name]
+		if !ok || existing.Endpoint == m.Endpoint {
+			// the endpoint does not need to be updated
+			logger.Debugf("Did not need to update pod %s with endpoint %+v. ok=%t, m=%+v", pod.Name, pod.Status.PodIP, ok, m)
+			continue
+		}
+
+		logger.Infof("updating mon %s endpoint from %s to %s", pod.Name, existing.Endpoint, m.Endpoint)
+		c.clusterInfo.Monitors[pod.Name] = m
+		updated = true
+	}
+
+	if updated {
+		return c.saveMonConfig()
+	}
+
+	logger.Debugf("no update to mon pod ips")
 	return nil
 }
 
@@ -150,32 +206,103 @@ func monInQuorum(monitor client.MonMapEntry, quorum []int) bool {
 	return false
 }
 
-func (c *Cluster) failoverMon(name string) error {
-	//logger.Infof("Failing over monitor %s", name)
+func (c *Cluster) failoverMon(conn client.Connection, name string) error {
+	logger.Infof("Failing over monitor %s", name)
+
+	// Start a new monitor
+	c.maxMonID++
+	mons := []*MonConfig{&MonConfig{Name: fmt.Sprintf("mon%d", c.maxMonID), Port: int32(mon.Port)}}
+	logger.Infof("starting new mon %s", mons[0].Name)
+	err := c.startPods(conn, mons)
+	if err != nil {
+		return fmt.Errorf("failed to start new mon %s. %+v", mons[0].Name, err)
+	}
+
+	// Remove the mon pod if it is still there
+	var gracePeriod int64
+	options := &v1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	err = c.clientset.CoreV1().Pods(c.Namespace).Delete(name, options)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Infof("dead mon pod %s was already gone", name)
+		} else {
+			return fmt.Errorf("failed to remove dead mon pod %s. %+v", name, err)
+		}
+	}
+
+	// Remove the bad monitor from quorum
+	err = mon.RemoveMonitorFromQuorum(conn, name)
+	if err != nil {
+		return fmt.Errorf("failed to remove mon %s from quorum. %+v", name, err)
+	}
+	delete(c.clusterInfo.Monitors, name)
+	err = c.saveMonConfig()
+	if err != nil {
+		return fmt.Errorf("failed to save mon config after failing mon %s. %+v", name, err)
+	}
+
 	return nil
 }
 
 // Retrieve the ceph cluster info if it already exists.
 // If a new cluster create new keys.
 func (c *Cluster) initClusterInfo() error {
+	// get the cluster secrets
 	secrets, err := c.clientset.CoreV1().Secrets(c.Namespace).Get(appName)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to get mon secrets. %+v", err)
 		}
 
-		return c.createMonSecretsAndSave()
+		err = c.createMonSecretsAndSave()
+		if err != nil {
+			return err
+		}
+	} else {
+		c.clusterInfo = &mon.ClusterInfo{
+			Name:          string(secrets.Data[clusterSecretName]),
+			FSID:          string(secrets.Data[fsidSecretName]),
+			MonitorSecret: string(secrets.Data[monSecretName]),
+			AdminSecret:   string(secrets.Data[adminSecretName]),
+		}
+		logger.Debugf("found existing monitor secrets for cluster %s", c.clusterInfo.Name)
 	}
 
-	c.clusterInfo = &mon.ClusterInfo{
-		Name:          string(secrets.Data[clusterSecretName]),
-		FSID:          string(secrets.Data[fsidSecretName]),
-		MonitorSecret: string(secrets.Data[monSecretName]),
-		AdminSecret:   string(secrets.Data[adminSecretName]),
-		Monitors:      map[string]*mon.CephMonitorConfig{},
+	// get the existing monitor config
+	err = c.loadMonConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get mon config. %+v", err)
 	}
-	logger.Infof("found existing monitor secrets for cluster %s", c.clusterInfo.Name)
 	return nil
+}
+
+func (c *Cluster) getExpectedMonConfig() []*MonConfig {
+	mons := []*MonConfig{}
+
+	// initialize the mon pod info for mons that have been previously created
+	for _, monitor := range c.clusterInfo.Monitors {
+		mons = append(mons, &MonConfig{Name: monitor.Name, Port: int32(mon.Port)})
+	}
+
+	// initialize mon info if we don't have enough mons (at first startup)
+	for i := len(c.clusterInfo.Monitors); i < c.Size; i++ {
+		c.maxMonID++
+		mons = append(mons, &MonConfig{Name: fmt.Sprintf("mon%d", c.maxMonID), Port: int32(mon.Port)})
+	}
+
+	return mons
+}
+
+// get the ID of a monitor from its name
+func getMonID(name string) (int, error) {
+	if strings.Index(name, "mon") != 0 || len(name) < 4 {
+		return -1, fmt.Errorf("unexpected mon name")
+	}
+	id, err := strconv.Atoi(name[3:])
+	if err != nil {
+		return -1, err
+	}
+	return id, nil
 }
 
 func (c *Cluster) createMonSecretsAndSave() error {
@@ -225,40 +352,20 @@ func (c *Cluster) createMonSecretsAndSave() error {
 	return nil
 }
 
-func (c *Cluster) startPods(mons []*MonConfig) error {
+func (c *Cluster) startPods(conn client.Connection, mons []*MonConfig) error {
 	// schedule the mons on different nodes if we have enough nodes to be unique
 	antiAffinity, err := c.getAntiAffinity()
 	if err != nil {
 		return fmt.Errorf("failed to get antiaffinity. %+v", err)
 	}
 
-	running, pending, err := c.pollPods()
-	if err != nil {
-		return fmt.Errorf("failed to get mon pods. %+v", err)
-	}
-	logger.Infof("%d running, %d pending pods", len(running), len(pending))
-
-	c.clusterInfo.Monitors = map[string]*mon.CephMonitorConfig{}
-	for _, m := range running {
-		c.clusterInfo.Monitors[m.Name] = mon.ToCephMon(m.Name, m.Status.PodIP)
-	}
-
-	err = c.saveMonEndpoints()
-	if err != nil {
-		return fmt.Errorf("failed to save endpoints for %d running mons. %+v", len(c.clusterInfo.Monitors), err)
-	}
-
-	if len(running) == c.Size {
-		logger.Infof("pods are already running")
-		return nil
-	}
-
-	started := 0
+	preexisted := len(c.clusterInfo.Monitors)
+	created := 0
 	alreadyRunning := 0
 	for _, m := range mons {
 		monPod := c.makeMonPod(m, antiAffinity)
-		name := monPod.Name
 		logger.Debugf("Starting pod: %+v", monPod)
+		name := monPod.Name
 		_, err = c.clientset.CoreV1().Pods(c.Namespace).Create(monPod)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
@@ -267,7 +374,7 @@ func (c *Cluster) startPods(mons []*MonConfig) error {
 			logger.Infof("pod %s already exists", name)
 			alreadyRunning++
 		} else {
-			started++
+			created++
 		}
 
 		podIP, err := c.waitForPodToStart(name)
@@ -276,21 +383,55 @@ func (c *Cluster) startPods(mons []*MonConfig) error {
 		}
 		c.clusterInfo.Monitors[m.Name] = mon.ToCephMon(m.Name, podIP)
 
-		err = c.saveMonEndpoints()
+		err = c.saveMonConfig()
 		if err != nil {
 			return fmt.Errorf("failed to save endpoints after starting mon %s. %+v", m.Name, err)
 		}
 	}
 
-	logger.Infof("started %d/%d mons (%d already running)", (started + alreadyRunning), c.Size, alreadyRunning)
+	logger.Infof("mons created: %d, alreadyRunning: %d, preexisted: %d", created, alreadyRunning, preexisted)
+
+	return c.waitForMonsToJoin(conn, mons)
+}
+
+func (c *Cluster) waitForMonsToJoin(conn client.Connection, mons []*MonConfig) error {
+	if !c.waitForStart {
+		return nil
+	}
+
+	// initialize a connection if it is not already connected
+	if conn == nil {
+		context := &clusterd.Context{ConfigDir: k8sutil.DataDir}
+		var err error
+		conn, err = mon.ConnectToClusterAsAdmin(context, c.factory, c.clusterInfo)
+		if err != nil {
+			return fmt.Errorf("cannot connect to cluster. %+v", err)
+		}
+		defer conn.Shutdown()
+	}
+
+	starting := []string{}
+	for _, m := range mons {
+		starting = append(starting, m.Name)
+	}
+
+	// wait for the monitors to join quorum
+	err := mon.WaitForQuorumWithConnection(conn, starting)
+	if err != nil {
+		return fmt.Errorf("failed to wait for mon quorum. %+v", err)
+	}
+
 	return nil
 }
 
 func (c *Cluster) waitForPodToStart(name string) (string, error) {
+	if !c.waitForStart {
+		return "", nil
+	}
 
 	// Poll the status of the pods to see if they are ready
 	status := ""
-	for i := 0; i < 15; i++ {
+	for i := 0; i < c.maxRetries; i++ {
 		// wait and try again
 		logger.Infof("waiting %ds for pod %s to start. status=%s", c.retryDelay, name, status)
 		<-time.After(time.Duration(c.retryDelay) * time.Second)
@@ -310,7 +451,7 @@ func (c *Cluster) waitForPodToStart(name string) (string, error) {
 	return "", fmt.Errorf("timed out waiting for pod %s to start", name)
 }
 
-func (c *Cluster) saveMonEndpoints() error {
+func (c *Cluster) saveMonConfig() error {
 	configMap := &v1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        monConfigMapName,
@@ -320,6 +461,7 @@ func (c *Cluster) saveMonEndpoints() error {
 	}
 	configMap.Data = map[string]string{
 		monEndpointKey: mon.FlattenMonEndpoints(c.clusterInfo.Monitors),
+		maxMonIDKey:    strconv.Itoa(c.maxMonID),
 	}
 
 	_, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap)
@@ -335,6 +477,45 @@ func (c *Cluster) saveMonEndpoints() error {
 	}
 
 	logger.Infof("saved mon endpoints to config map %s", configMap.Name)
+	return nil
+}
+
+func (c *Cluster) loadMonConfig() error {
+	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get(monConfigMapName)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		// If the config map was not found, initialize the empty set of monitors
+		c.maxMonID = -1
+		c.clusterInfo.Monitors = map[string]*mon.CephMonitorConfig{}
+		return c.saveMonConfig()
+	}
+
+	// Parse the monitor List
+	if info, ok := cm.Data[monEndpointKey]; ok {
+		c.clusterInfo.Monitors = mon.ParseMonEndpoints(info)
+	} else {
+		c.clusterInfo.Monitors = map[string]*mon.CephMonitorConfig{}
+	}
+
+	// Parse the max monitor id
+	if id, ok := cm.Data[maxMonIDKey]; ok {
+		c.maxMonID, err = strconv.Atoi(id)
+		if err != nil {
+			logger.Errorf("invalid max mon id %s. %+v", id, err)
+		}
+	}
+
+	// Make sure the max id is consistent with the current monitors
+	for _, m := range c.clusterInfo.Monitors {
+		id, _ := getMonID(m.Name)
+		if c.maxMonID < id {
+			c.maxMonID = id
+		}
+	}
+
+	logger.Infof("loaded: maxMonID=%d, mons=%+v", c.maxMonID, c.clusterInfo.Monitors)
 	return nil
 }
 

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -72,3 +72,27 @@ func validateStart(t *testing.T, c *Cluster) {
 	assert.Equal(t, 0, len(running))
 	assert.Equal(t, 0, len(pending))
 }
+
+func TestSaveMonEndpoints(t *testing.T) {
+	clientset := test.New(1)
+	c := New(clientset, nil, "ns", "myversion")
+	info := test.CreateClusterInfo(1)
+
+	// create the initial config map
+	err := c.saveMonEndpoints(info)
+	assert.Nil(t, err)
+
+	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
+	assert.Nil(t, err)
+	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data["endpoints"])
+
+	// update the config map
+	info.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
+	err = c.saveMonEndpoints(info)
+	assert.Nil(t, err)
+
+	cm, err = c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
+	assert.Nil(t, err)
+	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data["endpoints"])
+
+}

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -67,7 +67,7 @@ func validateStart(t *testing.T, c *Cluster) {
 	assert.Equal(t, 1, len(pods.Items))
 
 	// no pods are running or pending
-	running, pending, err := c.pollPods(c.ClusterName)
+	running, pending, err := c.pollPods()
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(running))
 	assert.Equal(t, 0, len(pending))
@@ -76,10 +76,10 @@ func validateStart(t *testing.T, c *Cluster) {
 func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(1)
 	c := New(clientset, nil, "ns", "myversion")
-	info := test.CreateClusterInfo(1)
+	c.clusterInfo = test.CreateClusterInfo(1)
 
 	// create the initial config map
-	err := c.saveMonEndpoints(info)
+	err := c.saveMonConfig()
 	assert.Nil(t, err)
 
 	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
@@ -87,8 +87,8 @@ func TestSaveMonEndpoints(t *testing.T) {
 	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data["endpoints"])
 
 	// update the config map
-	info.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
-	err = c.saveMonEndpoints(info)
+	c.clusterInfo.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
+	err = c.saveMonConfig()
 	assert.Nil(t, err)
 
 	cm, err = c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -113,8 +113,8 @@ func (c *Cluster) monContainer(config *MonConfig, fsid string) v1.Container {
 	}
 }
 
-func (c *Cluster) pollPods(clusterName string) ([]*v1.Pod, []*v1.Pod, error) {
-	podList, err := c.clientset.CoreV1().Pods(c.Namespace).List(listOptions(clusterName))
+func (c *Cluster) pollPods() ([]*v1.Pod, []*v1.Pod, error) {
+	podList, err := c.clientset.CoreV1().Pods(c.Namespace).List(c.listOptions())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list running pods: %v", err)
 	}
@@ -137,10 +137,10 @@ func (c *Cluster) pollPods(clusterName string) ([]*v1.Pod, []*v1.Pod, error) {
 	return running, pending, nil
 }
 
-func listOptions(clusterName string) v1.ListOptions {
+func (c *Cluster) listOptions() v1.ListOptions {
 	return v1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
-			monClusterAttr:  clusterName,
+			monClusterAttr:  c.Namespace,
 			k8sutil.AppAttr: appName,
 		}).String(),
 	}

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -18,7 +18,6 @@ package mon
 import (
 	"fmt"
 
-	"github.com/rook/rook/pkg/cephmgr/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/labels"
@@ -51,7 +50,7 @@ func (c *Cluster) getLabels() map[string]string {
 	}
 }
 
-func (c *Cluster) makeMonPod(config *MonConfig, clusterInfo *mon.ClusterInfo, antiAffinity bool) *v1.Pod {
+func (c *Cluster) makeMonPod(config *MonConfig, antiAffinity bool) *v1.Pod {
 
 	container := c.monContainer(config, clusterInfo.FSID)
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
@@ -78,7 +77,7 @@ func (c *Cluster) makeMonPod(config *MonConfig, clusterInfo *mon.ClusterInfo, an
 	k8sutil.SetPodVersion(pod, k8sutil.VersionAttr, c.Version)
 
 	if antiAffinity {
-		k8sutil.PodWithAntiAffinity(pod, monClusterAttr, clusterInfo.Name)
+		k8sutil.PodWithAntiAffinity(pod, monClusterAttr, c.clusterInfo.Name)
 	}
 	return pod
 }

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -52,7 +52,7 @@ func (c *Cluster) getLabels() map[string]string {
 
 func (c *Cluster) makeMonPod(config *MonConfig, antiAffinity bool) *v1.Pod {
 
-	container := c.monContainer(config, clusterInfo.FSID)
+	container := c.monContainer(config, c.clusterInfo.FSID)
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if c.dataDirHostPath != "" {
 		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: c.dataDirHostPath}}
@@ -112,8 +112,12 @@ func (c *Cluster) monContainer(config *MonConfig, fsid string) v1.Container {
 	}
 }
 
+func (c *Cluster) getPods() (*v1.PodList, error) {
+	return c.clientset.CoreV1().Pods(c.Namespace).List(c.listOptions())
+}
+
 func (c *Cluster) pollPods() ([]*v1.Pod, []*v1.Pod, error) {
-	podList, err := c.clientset.CoreV1().Pods(c.Namespace).List(c.listOptions())
+	podList, err := c.getPods()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list running pods: %v", err)
 	}

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/rook/rook/pkg/cephmgr/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/labels"
 )
@@ -100,8 +99,8 @@ func (c *Cluster) monContainer(config *MonConfig, clusterInfo *mon.ClusterInfo) 
 	}
 }
 
-func (c *Cluster) pollPods(clientset kubernetes.Interface, clusterName string) ([]*v1.Pod, []*v1.Pod, error) {
-	podList, err := clientset.CoreV1().Pods(c.Namespace).List(listOptions(clusterName))
+func (c *Cluster) pollPods(clusterName string) ([]*v1.Pod, []*v1.Pod, error) {
+	podList, err := c.clientset.CoreV1().Pods(c.Namespace).List(listOptions(clusterName))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list running pods: %v", err)
 	}

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -24,24 +24,36 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
+func ClusterNameEnvVar() v1.EnvVar {
+	ref := &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}
+	return v1.EnvVar{Name: "ROOKD_CLUSTER_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: ref}}
+}
+
+func MonEndpointEnvVar() v1.EnvVar {
+	ref := &v1.ConfigMapKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: monConfigMapName}, Key: monEndpointKey}
+	return v1.EnvVar{Name: "ROOKD_MON_ENDPOINTS", ValueFrom: &v1.EnvVarSource{ConfigMapKeyRef: ref}}
+}
+
 func MonSecretEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: "ROOKD_MON_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: monSecretName}}}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: monSecretName}
+	return v1.EnvVar{Name: "ROOKD_MON_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
 
 func AdminSecretEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: "ROOKD_ADMIN_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: adminSecretName}}}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: adminSecretName}
+	return v1.EnvVar{Name: "ROOKD_ADMIN_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }
 
-func getLabels(clusterName string) map[string]string {
+func (c *Cluster) getLabels() map[string]string {
 	return map[string]string{
 		k8sutil.AppAttr: appName,
-		monClusterAttr:  clusterName,
+		monClusterAttr:  c.Namespace,
 	}
 }
 
 func (c *Cluster) makeMonPod(config *MonConfig, clusterInfo *mon.ClusterInfo, antiAffinity bool) *v1.Pod {
 
-	container := c.monContainer(config, clusterInfo)
+	container := c.monContainer(config, clusterInfo.FSID)
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if c.dataDirHostPath != "" {
 		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: c.dataDirHostPath}}
@@ -51,7 +63,7 @@ func (c *Cluster) makeMonPod(config *MonConfig, clusterInfo *mon.ClusterInfo, an
 		ObjectMeta: v1.ObjectMeta{
 			Name:        config.Name,
 			Namespace:   c.Namespace,
-			Labels:      getLabels(clusterInfo.Name),
+			Labels:      c.getLabels(),
 			Annotations: map[string]string{},
 		},
 		Spec: v1.PodSpec{
@@ -71,9 +83,9 @@ func (c *Cluster) makeMonPod(config *MonConfig, clusterInfo *mon.ClusterInfo, an
 	return pod
 }
 
-func (c *Cluster) monContainer(config *MonConfig, clusterInfo *mon.ClusterInfo) v1.Container {
-	command := fmt.Sprintf("/usr/bin/rookd mon --data-dir=%s --name=%s --mon-endpoints=%s --port=%d --fsid=%s --cluster-name=%s",
-		k8sutil.DataDir, config.Name, mon.FlattenMonEndpoints(clusterInfo.Monitors), config.Port, clusterInfo.FSID, clusterInfo.Name)
+func (c *Cluster) monContainer(config *MonConfig, fsid string) v1.Container {
+	command := fmt.Sprintf("/usr/bin/rookd mon --data-dir=%s --name=%s --port=%d --fsid=%s",
+		k8sutil.DataDir, config.Name, config.Port, fsid)
 
 	return v1.Container{
 		// TODO: fix "sleep 5".
@@ -93,6 +105,8 @@ func (c *Cluster) monContainer(config *MonConfig, clusterInfo *mon.ClusterInfo) 
 		},
 		Env: []v1.EnvVar{
 			{Name: k8sutil.PodIPEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}},
+			ClusterNameEnvVar(),
+			MonEndpointEnvVar(),
 			MonSecretEnvVar(),
 			AdminSecretEnvVar(),
 		},

--- a/pkg/operator/mon/pod_test.go
+++ b/pkg/operator/mon/pod_test.go
@@ -32,7 +32,8 @@ func TestPodSpecs(t *testing.T) {
 }
 
 func testPodSpec(t *testing.T, dataDir string) {
-	c := New("ns", nil, dataDir, "myversion")
+	clientset := testop.New(1)
+	c := New(clientset, nil, "ns", dataDir, "myversion")
 	config := &MonConfig{Name: "mon0", Port: 6790}
 	info := testop.CreateClusterInfo(0)
 

--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -18,9 +18,8 @@ package osd
 import (
 	"fmt"
 
-	"github.com/rook/rook/pkg/cephmgr/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	k8smon "github.com/rook/rook/pkg/operator/mon"
+	opmon "github.com/rook/rook/pkg/operator/mon"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
@@ -52,14 +51,10 @@ func New(clientset kubernetes.Interface, namespace, version, deviceFilter, dataD
 	}
 }
 
-func (c *Cluster) Start(cluster *mon.ClusterInfo) error {
+func (c *Cluster) Start() error {
 	logger.Infof("start running osds")
 
-	if cluster == nil || len(cluster.Monitors) == 0 {
-		return fmt.Errorf("missing mons to start osds")
-	}
-
-	ds, err := c.makeDaemonSet(cluster)
+	ds, err := c.makeDaemonSet()
 	_, err = c.clientset.Extensions().DaemonSets(c.Namespace).Create(ds)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -73,7 +68,7 @@ func (c *Cluster) Start(cluster *mon.ClusterInfo) error {
 	return nil
 }
 
-func (c *Cluster) makeDaemonSet(cluster *mon.ClusterInfo) (*extensions.DaemonSet, error) {
+func (c *Cluster) makeDaemonSet() (*extensions.DaemonSet, error) {
 	ds := &extensions.DaemonSet{}
 	ds.Name = appName
 	ds.Namespace = c.Namespace
@@ -88,12 +83,12 @@ func (c *Cluster) makeDaemonSet(cluster *mon.ClusterInfo) (*extensions.DaemonSet
 			Name: appName,
 			Labels: map[string]string{
 				k8sutil.AppAttr:     appName,
-				k8sutil.ClusterAttr: cluster.Name,
+				k8sutil.ClusterAttr: c.Namespace,
 			},
 			Annotations: map[string]string{},
 		},
 		Spec: v1.PodSpec{
-			Containers:    []v1.Container{c.osdContainer(cluster)},
+			Containers:    []v1.Container{c.osdContainer()},
 			RestartPolicy: v1.RestartPolicyAlways,
 			Volumes: []v1.Volume{
 				{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
@@ -107,10 +102,9 @@ func (c *Cluster) makeDaemonSet(cluster *mon.ClusterInfo) (*extensions.DaemonSet
 	return ds, nil
 }
 
-func (c *Cluster) osdContainer(cluster *mon.ClusterInfo) v1.Container {
+func (c *Cluster) osdContainer() v1.Container {
 
-	command := fmt.Sprintf("/usr/bin/rookd osd --data-dir=%s --mon-endpoints=%s --cluster-name=%s ",
-		k8sutil.DataDir, mon.FlattenMonEndpoints(cluster.Monitors), cluster.Name)
+	command := fmt.Sprintf("/usr/bin/rookd osd --data-dir=%s ", k8sutil.DataDir)
 	if c.deviceFilter != "" {
 		command += fmt.Sprintf("--data-devices=%s ", c.deviceFilter)
 	} else if c.useAllDevices {
@@ -129,8 +123,10 @@ func (c *Cluster) osdContainer(cluster *mon.ClusterInfo) v1.Container {
 			{Name: "devices", MountPath: "/dev"},
 		},
 		Env: []v1.EnvVar{
-			k8smon.MonSecretEnvVar(),
-			k8smon.AdminSecretEnvVar(),
+			opmon.ClusterNameEnvVar(),
+			opmon.MonEndpointEnvVar(),
+			opmon.MonSecretEnvVar(),
+			opmon.AdminSecretEnvVar(),
 		},
 		SecurityContext: &v1.SecurityContext{Privileged: &privileged},
 	}

--- a/pkg/operator/osd/osd_test.go
+++ b/pkg/operator/osd/osd_test.go
@@ -27,22 +27,21 @@ import (
 )
 
 func TestStartDaemonset(t *testing.T) {
-	c := New("ns", "myversion", "", "", false)
-
 	clientset := fake.NewSimpleClientset()
+	c := New(clientset, "ns", "myversion", "", "", false)
 
 	// Cannot start the cluster with zero mons
 	info := testop.CreateClusterInfo(0)
-	err := c.Start(clientset, info)
+	err := c.Start(info)
 	assert.NotNil(t, err)
 
 	// Can start with one mon
 	info = testop.CreateClusterInfo(1)
-	err = c.Start(clientset, info)
+	err = c.Start(info)
 	assert.Nil(t, err)
 
 	// Should not fail if it already exists
-	err = c.Start(clientset, info)
+	err = c.Start(info)
 	assert.Nil(t, err)
 }
 
@@ -52,7 +51,8 @@ func TestDaemonset(t *testing.T) {
 }
 
 func testPodDevices(t *testing.T, dataDir string, useDevices bool) {
-	c := New("ns", "myversion", "", dataDir, useDevices)
+	clientset := fake.NewSimpleClientset()
+	c := New(clientset, "ns", "myversion", "", dataDir, useDevices)
 	info := testop.CreateClusterInfo(1)
 	daemonSet, err := c.makeDaemonSet(info)
 	assert.Nil(t, err)


### PR DESCRIPTION
The operator will monitor the cluster for health of the monitors.
- Every 10s query the monitor health
- If a monitor is not in quorum, start a new monitor
- Wait for the new monitor to join quorum
- Remove the dead monitor from quorum
- Update a configmap with the set of mon endpoints in quorum

The mon/osd/rgw/mds/api pods all pick up the mon endpoints from the configmap, which will pass the latest to the pods each time the pod is started