### PR TITLE
Create storage pools through a TPR

### DIFF
--- a/Documentation/cluster-tpr.md
+++ b/Documentation/cluster-tpr.md
@@ -1,16 +1,17 @@
-# Rook TPRs
+# Creating Rook Clusters
 Rook allows creation and customization of storage clusters through the third party resources (TPRs). The following settings are available
 for a cluster.
 
 ## Sample
 ```
 apiVersion: rook.io/v1beta1
-kind: Cluster
+kind: Rookcluster
 metadata:
-  name: my-rook
+  name: rook
 spec:
   namespace: rook
   version: latest
+  hostPath: /var/lib/rook
   useAllDevices: false
   deviceFilter: ^sd.
 ```
@@ -19,6 +20,7 @@ spec:
 Settings can be specified at the global level to apply to the cluster as a whole, while other settings can be specified at more fine-grained levels.
 
 ### Global settings
+- `hostPath`: The host path where config and data should be stored for each of the services. If the directory does not exist, it will be created. In test scenarios, the path must be deleted if you are going to delete a cluster and start a new cluster on the same hosts.
 - `namespace`: The Kubernetes namespace that will be created for the Rook cluster. The services, pods, and other resources created by the operator will be added to this namespace. Each cluster must have a unique namespace. The common scenario is to create a single Rook cluster. If multiple clusters are created, they must not have conflicting devices or host paths.
 - `version`: The version of the `quay.io/rook/rookd` and `quay.io/rook/rook-operator` containers that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
 - `useAllDevices`: `true` or `false`, indicating whether all devices found on nodes in the cluster should be automatically consumed by OSDs. **Not recommended** unless you have a very controlled environment where you will not risk formatting of devices with existing data. When `true`, all devices will be used except those with partitions created or a local filesystem. Is overridden by `deviceFilter` if specified.

--- a/Documentation/pool-tpr.md
+++ b/Documentation/pool-tpr.md
@@ -1,0 +1,34 @@
+# Creating Rook Storage Pools
+Rook allows creation and customization of storage pools through the third party resources (TPRs). The following settings are available
+for pools.
+
+## Sample
+```
+apiVersion: rook.io/v1beta1
+kind: Rookpool
+metadata:
+  name: rook-ecpool
+spec:
+  name: ecpool
+  namespace: rook
+  replication:
+  #  count: 3
+  erasureCode:
+    codingChunks: 2
+    dataChunks: 2
+```
+
+## Pool Settings
+
+### Metadata
+- `name`: The name of the kubernetes resource. Must be unique across all Rook clusters. The naming convention is `clusterName-poolName`.
+- `namespace`: The namespace where the Rook operator is running.
+
+### Spec
+- `name`: The name of the pool to create in the cluster.
+- `namespace`: The namespace where the Rook cluster is running to create the pool.
+- `replication`: Settings for a replicated pool. If specified, `erasureCode` settings must not be specified.
+  - `count`: The number of copies of the data in the pool.
+- `erasureCode`: Settings for an erasure-coded pool. If specified, `replication` settings must not be specified.
+  - `codingChunks`: Number of coding chunks per object in an erasure coded storage pool
+  - `dataChunks`: Number of data chunks per object in an erasure coded storage pool

--- a/demo/kubernetes/rook-cluster.yaml
+++ b/demo/kubernetes/rook-cluster.yaml
@@ -1,8 +1,10 @@
 apiVersion: rook.io/v1beta1
-kind: Cluster
+kind: Rookcluster
 metadata:
-  name: my-rook
+  name: rook
 spec:
   namespace: rook
   version: latest
+  dataDirHostPath: 
   useAllDevices: false
+  deviceFilter:

--- a/demo/kubernetes/rook-operator-with-repo.yaml
+++ b/demo/kubernetes/rook-operator-with-repo.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: rook-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: rook-operator
+    spec:
+      containers:
+      - name: rook-operator
+        image: quay.io/myrepo/rook-operator:mytag
+        env:
+        - name: ROOK_OPERATOR_REPO_PREFIX
+          value: quay.io/myrepo
+        - name: ROOK_OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/demo/kubernetes/rook-pool.yaml
+++ b/demo/kubernetes/rook-pool.yaml
@@ -1,0 +1,14 @@
+apiVersion: rook.io/v1beta1
+kind: Rookpool
+metadata:
+  name: rook-replicapool
+spec:
+  name: replicapool
+  namespace: rook
+  replication:
+    count: 1
+  # For an erasure-coded pool, comment out the replication count above and uncomment the following settings.
+  # Make sure you have enough OSDs to support the replica count or erasure code chunks.
+  #erasureCode:
+  #  codingChunks: 2
+  #  dataChunks: 2

--- a/demo/kubernetes/rook-storageclass.yaml
+++ b/demo/kubernetes/rook-storageclass.yaml
@@ -9,6 +9,6 @@ parameters:
     adminId: admin
     adminSecretName: rook-admin
     adminSecretNamespace: rook
-    pool: rook
+    pool: replicapool
     userId: rook-rbd-user
     userSecretName: rook-rbd-user

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package operator
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	kwatch "k8s.io/client-go/pkg/watch"
+
+	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+)
+
+type clusterTPR struct {
+	context      *context
+	watchVersion string
+	devicesInUse bool
+	clusters     map[string]*cluster.Cluster
+	tracker      *tprTracker
+}
+
+func newClusterTPR(context *context) *clusterTPR {
+	return &clusterTPR{
+		context:  context,
+		clusters: make(map[string]*cluster.Cluster),
+		tracker:  newTPRTracker(),
+	}
+}
+
+func (t *clusterTPR) Name() string {
+	return "cluster"
+}
+
+func (t *clusterTPR) Description() string {
+	return "Managed Rook clusters"
+}
+
+func (t *clusterTPR) Load() error {
+
+	// Check if there is an existing cluster to recover
+	err := t.findAllClusters()
+	if err != nil {
+		return fmt.Errorf("failed to find clusters. %+v", err)
+	}
+	return nil
+}
+
+func (t *clusterTPR) findAllClusters() error {
+	logger.Info("finding existing clusters...")
+	clusterList, err := t.getClusterList()
+	if err != nil {
+		return err
+	}
+	logger.Infof("found %d clusters", len(clusterList.Items))
+	for i := range clusterList.Items {
+		c := clusterList.Items[i]
+
+		ns := c.Spec.Namespace
+		existingCluster := cluster.New(c.Spec, t.context.factory, t.context.clientset)
+		t.tracker.add(ns, c.Metadata.ResourceVersion)
+		t.clusters[ns] = existingCluster
+
+		logger.Infof("resuming cluster %s in namespace %s", c.Metadata.Name, ns)
+		t.startCluster(existingCluster)
+	}
+
+	t.watchVersion = clusterList.Metadata.ResourceVersion
+	return nil
+}
+
+func (t *clusterTPR) startCluster(c *cluster.Cluster) {
+	if t.devicesInUse && c.Spec.UseAllDevices {
+		logger.Warningf("devices in more than one namespace not supported. ignoring devices in namespace %s", c.Spec.Namespace)
+		c.Spec.UseAllDevices = false
+	}
+
+	if c.Spec.UseAllDevices {
+		t.devicesInUse = true
+	}
+
+	go func() {
+		err := c.CreateInstance()
+		if err != nil {
+			logger.Errorf("failed to create cluster in namespace %s. %+v", c.Spec.Namespace, err)
+			return
+		}
+		c.Monitor(t.tracker.stopChMap[c.Spec.Namespace])
+	}()
+}
+
+func (t *clusterTPR) isClustersCacheStale(currentClusters []cluster.Cluster) bool {
+	if len(t.tracker.clusterRVs) != len(currentClusters) {
+		return true
+	}
+
+	for _, cc := range currentClusters {
+		rv, ok := t.tracker.clusterRVs[cc.Metadata.Name]
+		if !ok || rv != cc.Metadata.ResourceVersion {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *clusterTPR) getClusterList() (*cluster.ClusterList, error) {
+	b, err := getRawList(t.context, t)
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := &cluster.ClusterList{}
+	if err := json.Unmarshal(b, clusters); err != nil {
+		return nil, err
+	}
+	return clusters, nil
+}
+
+func (t *clusterTPR) Watch() error {
+	logger.Infof("start watching %s tpr: %s", t.Name(), t.watchVersion)
+	defer t.tracker.stop()
+
+	eventCh, errCh := t.watch()
+
+	go func() {
+		timer := k8sutil.NewPanicTimer(
+			time.Minute,
+			fmt.Sprintf("unexpected long blocking (> 1 Minute) when handling %s event", t.Name()))
+
+		for event := range eventCh {
+			timer.Start()
+
+			c := event.Object
+
+			switch event.Type {
+			case kwatch.Added:
+				ns := c.Spec.Namespace
+				if ns == "" {
+					logger.Errorf("missing namespace attribute in rook spec")
+					continue
+				}
+
+				newCluster := cluster.New(c.Spec, t.context.factory, t.context.clientset)
+				t.tracker.add(ns, c.Metadata.ResourceVersion)
+				t.clusters[ns] = newCluster
+
+				logger.Infof("starting new cluster %s in namespace %s", c.Metadata.Name, ns)
+				t.startCluster(newCluster)
+
+			case kwatch.Modified:
+				logger.Infof("modifying a cluster not implemented")
+
+			case kwatch.Deleted:
+				logger.Infof("deleting a cluster not implemented")
+			}
+
+			timer.Stop()
+		}
+	}()
+	return <-errCh
+
+}
+
+// watch creates a go routine, and watches the cluster.rook kind resources from
+// the given watch version. It emits events on the resources through the returned
+// event chan. Errors will be reported through the returned error chan. The go routine
+// exits on any error.
+func (t *clusterTPR) watch() (<-chan *clusterEvent, <-chan error) {
+	eventCh := make(chan *clusterEvent)
+	// On unexpected error case, the operator should exit
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(eventCh)
+
+		for {
+			cancel, err := t.watchOuterTPR(eventCh)
+			if err != nil {
+				logger.Errorf("failed to watch cluster tpr. %+v", err)
+			}
+			if cancel {
+				logger.Warningf("cancelling cluster tpr watch")
+				return
+			}
+		}
+	}()
+
+	return eventCh, errCh
+}
+
+func (t *clusterTPR) watchOuterTPR(eventCh chan *clusterEvent) (bool, error) {
+	resp, err := watchTPR(t.context, t.Name(), t.watchVersion)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return false, errors.New("invalid status code: " + resp.Status)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		ev, st, err := pollClusterEvent(decoder)
+		done, cancel, err := handlePollEventResult(st, err, t.checkStaleCache)
+		if err != nil {
+			return false, err
+		}
+		if done {
+			return false, nil
+		}
+		if cancel {
+			return true, nil
+		}
+		logger.Debugf("rook cluster event: %+v", ev)
+
+		t.watchVersion = ev.Object.Metadata.ResourceVersion
+		eventCh <- ev
+	}
+}
+
+func (t *clusterTPR) checkStaleCache() (bool, error) {
+	clusterList, err := t.getClusterList()
+	if err == nil && !t.isClustersCacheStale(clusterList.Items) {
+		t.watchVersion = clusterList.Metadata.ResourceVersion
+		return false, nil
+	}
+
+	return true, err
+}

--- a/pkg/operator/cluster/pool.go
+++ b/pkg/operator/cluster/pool.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package cluster
+
+import (
+	"fmt"
+
+	rookclient "github.com/rook/rook/pkg/rook/client"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/rook/rook/pkg/model"
+)
+
+const (
+	replicatedType  = "replicated"
+	erasureCodeType = "erasure-coded"
+)
+
+type Pool struct {
+	Metadata v1.ObjectMeta `json:"metadata,omitempty"`
+	PoolSpec `json:"spec"`
+}
+
+// Instantiate a new pool
+func NewPool(spec PoolSpec) *Pool {
+	return &Pool{PoolSpec: spec}
+}
+
+// Create the pool
+func (p *Pool) Create(rclient rookclient.RookRestClient) error {
+	// validate the pool settings
+	if err := p.validate(); err != nil {
+		return fmt.Errorf("invalid pool %s arguments. %+v", p.PoolSpec.Name, err)
+	}
+
+	// check if the pool already exists
+	exists, err := p.exists(rclient)
+	if err == nil && exists {
+		logger.Infof("pool %s already exists in namespace %s", p.PoolSpec.Name, p.PoolSpec.Namespace)
+		return nil
+	}
+
+	// create the pool
+	pool := model.Pool{Name: p.PoolSpec.Name}
+	r := p.replication()
+	if r != nil {
+		logger.Infof("creating pool %s in namespace %s with replicas %d", p.PoolSpec.Name, p.Namespace, r.Count)
+		pool.ReplicationConfig.Size = r.Count
+		pool.Type = model.Replicated
+	} else {
+		ec := p.erasureCode()
+		logger.Infof("creating pool %s in namespace %s. coding chunks = %d, data chunks = %d", p.PoolSpec.Name, p.Namespace, ec.CodingChunks, ec.DataChunks)
+		pool.ErasureCodedConfig.CodingChunkCount = ec.CodingChunks
+		pool.ErasureCodedConfig.DataChunkCount = ec.DataChunks
+		pool.Type = model.ErasureCoded
+	}
+
+	info, err := rclient.CreatePool(pool)
+	if err != nil {
+		return fmt.Errorf("failed to create pool %s. %+v", p.PoolSpec.Name, err)
+	}
+
+	logger.Infof("created pool %s. %s", p.PoolSpec.Name, info)
+	return nil
+}
+
+// Delete the pool
+func (p *Pool) Delete(rclient rookclient.RookRestClient) error {
+	// check if the pool  exists
+	exists, err := p.exists(rclient)
+	if err == nil && !exists {
+		return nil
+	}
+
+	logger.Infof("TODO: delete pool %s from namespace %s", p.PoolSpec.Name, p.PoolSpec.Namespace)
+	//return p.client.DeletePool(p.PoolSpec.Name)
+	return nil
+}
+
+// Check if the pool exists
+func (p *Pool) exists(rclient rookclient.RookRestClient) (bool, error) {
+	pools, err := rclient.GetPools()
+	if err != nil {
+		return false, err
+	}
+	for _, pool := range pools {
+		if pool.Name == p.PoolSpec.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Validate the pool arguments
+func (p *Pool) validate() error {
+	if p.PoolSpec.Name == "" {
+		return fmt.Errorf("missing name")
+	}
+	if p.PoolSpec.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if p.replication() != nil && p.erasureCode() != nil {
+		return fmt.Errorf("both replication and erasure code settings cannot be specified")
+	}
+	if p.replication() == nil && p.erasureCode() == nil {
+		return fmt.Errorf("neither replication nor erasure code settings were specified")
+	}
+	return nil
+}
+
+func (p *Pool) replication() *ReplicationSpec {
+	if p.PoolSpec.Replication.Count > 0 {
+		return &p.PoolSpec.Replication
+	}
+	return nil
+}
+
+func (p *Pool) erasureCode() *ErasureCodeSpec {
+	ec := &p.PoolSpec.ErasureCoding
+	if ec.CodingChunks > 0 || ec.DataChunks > 0 {
+		return ec
+	}
+	return nil
+}

--- a/pkg/operator/cluster/pool_list.go
+++ b/pkg/operator/cluster/pool_list.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package cluster
+
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/pkg/api/unversioned"
+)
+
+// PoolList is a list of rook pools from the TPR.
+type PoolList struct {
+	unversioned.TypeMeta `json:",inline"`
+	// Standard list metadata
+	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
+	Metadata unversioned.ListMeta `json:"metadata,omitempty"`
+	// Items is a list of third party objects
+	Items []Pool `json:"items"`
+}
+
+// There is known issue with TPR in client-go:
+//   https://github.com/kubernetes/client-go/issues/8
+// Workarounds:
+// - We include `Metadata` field in object explicitly.
+// - we have the code below to work around a known problem with third-party resources and ugorji.
+
+type PoolListCopy PoolList
+type PoolCopy Pool
+
+func (p *Pool) UnmarshalJSON(data []byte) error {
+	tmp := PoolCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := Pool(tmp)
+	*p = tmp2
+	return nil
+}
+
+func (pl *PoolList) UnmarshalJSON(data []byte) error {
+	tmp := PoolListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := PoolList(tmp)
+	*pl = tmp2
+	return nil
+}

--- a/pkg/operator/cluster/pool_test.go
+++ b/pkg/operator/cluster/pool_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package cluster
+
+import (
+	"testing"
+
+	"github.com/rook/rook/pkg/model"
+	"github.com/rook/rook/pkg/rook/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePool(t *testing.T) {
+	// must specify some replication or EC settings
+	spec := PoolSpec{Name: "mypool", Namespace: "myns"}
+	err := NewPool(spec).validate()
+	assert.NotNil(t, err)
+
+	// must specify name
+	spec = PoolSpec{Namespace: "myns"}
+	err = NewPool(spec).validate()
+	assert.NotNil(t, err)
+
+	// must specify namespace
+	spec = PoolSpec{Name: "mypool"}
+	err = NewPool(spec).validate()
+	assert.NotNil(t, err)
+
+	// must not specify both replication and EC settings
+	spec = PoolSpec{Name: "mypool", Namespace: "myns"}
+	spec.Replication.Count = 1
+	spec.ErasureCoding.CodingChunks = 2
+	spec.ErasureCoding.DataChunks = 3
+	err = NewPool(spec).validate()
+	assert.NotNil(t, err)
+
+	// succeed with replication settings
+	spec = PoolSpec{Name: "mypool", Namespace: "myns"}
+	spec.Replication.Count = 1
+	err = NewPool(spec).validate()
+	assert.Nil(t, err)
+
+	// succeed with ec settings
+	spec = PoolSpec{Name: "mypool", Namespace: "myns"}
+	spec.ErasureCoding.CodingChunks = 1
+	spec.ErasureCoding.DataChunks = 2
+	err = NewPool(spec).validate()
+	assert.Nil(t, err)
+}
+
+func TestCreatePool(t *testing.T) {
+	rclient := &test.MockRookRestClient{}
+	spec := PoolSpec{Name: "mypool", Namespace: "myns"}
+	spec.Replication.Count = 1
+	p := NewPool(spec)
+
+	exists, err := p.exists(rclient)
+	assert.False(t, exists)
+	err = p.Create(rclient)
+	assert.Nil(t, err)
+
+	// fail if both replication and EC are specified
+	spec.ErasureCoding.CodingChunks = 2
+	spec.ErasureCoding.DataChunks = 2
+	p.PoolSpec = spec
+	err = p.Create(rclient)
+	assert.NotNil(t, err)
+
+	// succeed with EC
+	spec.Replication.Count = 0
+	p.PoolSpec = spec
+	err = p.Create(rclient)
+	assert.Nil(t, err)
+}
+
+func TestDeletePool(t *testing.T) {
+	rclient := &test.MockRookRestClient{
+		MockGetPools: func() ([]model.Pool, error) {
+			pools := []model.Pool{
+				model.Pool{Name: "mypool"},
+			}
+			return pools, nil
+		},
+	}
+
+	// delete a pool that exists
+	spec := PoolSpec{Name: "mypool", Namespace: "myns"}
+	p := NewPool(spec)
+	exists, err := p.exists(rclient)
+	assert.Nil(t, err)
+	assert.True(t, exists)
+	err = p.Delete(rclient)
+	assert.Nil(t, err)
+
+	// succeed even if the pool doesn't exist
+	spec = PoolSpec{Name: "otherpool", Namespace: "myns"}
+	p = NewPool(spec)
+	exists, err = p.exists(rclient)
+	assert.Nil(t, err)
+	assert.False(t, exists)
+	err = p.Delete(rclient)
+	assert.Nil(t, err)
+}

--- a/pkg/operator/cluster/spec.go
+++ b/pkg/operator/cluster/spec.go
@@ -39,3 +39,20 @@ type Spec struct {
 	// The path on the host where config and data can be persisted.
 	DataDirHostPath string `json:"dataDirHostPath"`
 }
+
+type PoolSpec struct {
+	// The namespace where the pool will be created (required). A Rook cluster must be running in this namespace.
+	Namespace string `json:"namespace"`
+
+	// Type of storage pool, 'replicated' or 'erasure-coded' (required) (default "replicated")
+	Type string `json:"type"`
+
+	// Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+	ReplicaCount int `json:"replicaCount"`
+
+	// Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
+	ECCodingChunks int `json:"ecCodingChunks"`
+
+	// Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
+	ECDataChunks int `json:"ecDataChunks"`
+}

--- a/pkg/operator/cluster/spec.go
+++ b/pkg/operator/cluster/spec.go
@@ -41,18 +41,29 @@ type Spec struct {
 }
 
 type PoolSpec struct {
+	// The name of the pool. Defined in the spec since the object metadata name must be unique across all namespaces,
+	// while you could have the same pool name created in multiple instances of rook.
+	Name string `json:"name"`
+
 	// The namespace where the pool will be created (required). A Rook cluster must be running in this namespace.
 	Namespace string `json:"namespace"`
 
-	// Type of storage pool, 'replicated' or 'erasure-coded' (required) (default "replicated")
-	Type string `json:"type"`
+	// The replication settings
+	Replication ReplicationSpec `json:"replication"`
 
+	// The erasure code setteings
+	ErasureCoding ErasureCodeSpec `json:"erasureCode"`
+}
+
+type ReplicationSpec struct {
 	// Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-	ReplicaCount int `json:"replicaCount"`
+	Count uint `json:"count"`
+}
 
+type ErasureCodeSpec struct {
 	// Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-	ECCodingChunks int `json:"ecCodingChunks"`
+	CodingChunks uint `json:"codingChunks"`
 
 	// Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-	ECDataChunks int `json:"ecDataChunks"`
+	DataChunks uint `json:"dataChunks"`
 }

--- a/pkg/operator/event.go
+++ b/pkg/operator/event.go
@@ -36,7 +36,7 @@ type clusterEvent struct {
 
 type poolEvent struct {
 	Type   kwatch.EventType
-	Object *cluster.PoolSpec
+	Object *cluster.Pool
 }
 
 type rawEvent struct {
@@ -64,16 +64,16 @@ func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *unversioned.Status
 func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *unversioned.Status, error) {
 	re, status, err := pollEvent(decoder)
 	if err != nil {
-		return nil, status, fmt.Errorf("failed to poll cluster event. %+v", err)
+		return nil, status, fmt.Errorf("failed to poll pool event. %+v", err)
 	}
 
 	ev := &poolEvent{
 		Type:   re.Type,
-		Object: &cluster.PoolSpec{},
+		Object: &cluster.Pool{},
 	}
 	err = json.Unmarshal(re.Object, ev.Object)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
+		return nil, nil, fmt.Errorf("fail to unmarshal Pool object from data (%s): %v", re.Object, err)
 	}
 	return ev, nil, nil
 }

--- a/pkg/operator/event.go
+++ b/pkg/operator/event.go
@@ -29,9 +29,14 @@ import (
 	kwatch "k8s.io/client-go/pkg/watch"
 )
 
-type Event struct {
+type clusterEvent struct {
 	Type   kwatch.EventType
 	Object *cluster.Cluster
+}
+
+type poolEvent struct {
+	Type   kwatch.EventType
+	Object *cluster.PoolSpec
 }
 
 type rawEvent struct {
@@ -39,7 +44,41 @@ type rawEvent struct {
 	Object json.RawMessage
 }
 
-func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
+func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *unversioned.Status, error) {
+	re, status, err := pollEvent(decoder)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to poll cluster event. %+v", err)
+	}
+
+	ev := &clusterEvent{
+		Type:   re.Type,
+		Object: &cluster.Cluster{},
+	}
+	err = json.Unmarshal(re.Object, ev.Object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
+	}
+	return ev, status, nil
+}
+
+func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *unversioned.Status, error) {
+	re, status, err := pollEvent(decoder)
+	if err != nil {
+		return nil, status, fmt.Errorf("failed to poll cluster event. %+v", err)
+	}
+
+	ev := &poolEvent{
+		Type:   re.Type,
+		Object: &cluster.PoolSpec{},
+	}
+	err = json.Unmarshal(re.Object, ev.Object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
+	}
+	return ev, nil, nil
+}
+
+func pollEvent(decoder *json.Decoder) (*rawEvent, *unversioned.Status, error) {
 	re := &rawEvent{}
 	err := decoder.Decode(re)
 	if err != nil {
@@ -58,13 +97,5 @@ func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
 		return nil, status, nil
 	}
 
-	ev := &Event{
-		Type:   re.Type,
-		Object: &cluster.Cluster{},
-	}
-	err = json.Unmarshal(re.Object, ev.Object)
-	if err != nil {
-		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
-	}
-	return ev, nil, nil
+	return re, nil, nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -19,12 +19,9 @@ which also has the apache 2.0 license.
 package operator
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -32,13 +29,10 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/rook/rook/pkg/cephmgr/client"
-	"github.com/rook/rook/pkg/operator/cluster"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/pkg/runtime/serializer"
-	kwatch "k8s.io/client-go/pkg/watch"
 )
 
 const (
@@ -49,39 +43,39 @@ var (
 	ErrVersionOutdated = errors.New("requested version is outdated in apiserver")
 )
 
+type context struct {
+	clientset   kubernetes.Interface
+	namespace   string
+	retryDelay  int
+	maxRetries  int
+	masterHost  string
+	kubeHttpCli *http.Client
+	factory     client.ConnectionFactory
+}
+
 type Operator struct {
-	Namespace    string
-	MasterHost   string
-	devicesInUse bool
-	retryDelay   int
-	clientset    kubernetes.Interface
-	waitCluster  sync.WaitGroup
-	factory      client.ConnectionFactory
-	stopChMap    map[string]chan struct{}
-	clusters     map[string]*cluster.Cluster
-	kubeHttpCli  *http.Client
-	// Kubernetes resource version of the clusters
-	clusterRVs map[string]string
+	context *context
+	tprs    []TPR
 }
 
 func New(host, namespace string, factory client.ConnectionFactory, clientset kubernetes.Interface) *Operator {
-	return &Operator{
-		Namespace:  namespace,
-		MasterHost: host,
+	context := &context{
+		namespace:  namespace,
+		masterHost: host,
 		factory:    factory,
 		clientset:  clientset,
-		clusters:   make(map[string]*cluster.Cluster),
-		clusterRVs: make(map[string]string),
-		stopChMap:  map[string]chan struct{}{},
 		retryDelay: 3,
+		maxRetries: 30,
+	}
+	return &Operator{
+		context: context,
+		tprs:    []TPR{newClusterTPR(context), newPoolTPR(context)},
 	}
 }
 
 func (o *Operator) Run() error {
-	var watchVersion string
-	var err error
 	for {
-		watchVersion, err = o.initResources()
+		err := o.initResources()
 		if err == nil {
 			break
 		}
@@ -90,235 +84,34 @@ func (o *Operator) Run() error {
 	}
 
 	// watch for changes to the rook clusters
-	return o.watchTPR(watchVersion)
+	for _, tpr := range o.tprs {
+		if err := tpr.Watch(); err != nil {
+			return fmt.Errorf("failed to watch tpr %s. %+v", tpr.Name(), err)
+		}
+	}
+
+	return nil
 }
 
-func (o *Operator) initResources() (string, error) {
+func (o *Operator) initResources() error {
 	httpCli, err := newHttpClient()
 	if err != nil {
-		return "", fmt.Errorf("failed to get tpr client. %+v", err)
+		return fmt.Errorf("failed to get tpr client. %+v", err)
 	}
-	o.kubeHttpCli = httpCli.Client
+	o.context.kubeHttpCli = httpCli.Client
 
-	err = o.createTPR()
+	err = createTPRs(o.context, o.tprs)
 	if err != nil {
-		return "", fmt.Errorf("failed to create TPR. %+v", err)
-	}
-	err = o.waitForTPRInit(o.clientset.CoreV1().RESTClient(), 30, o.Namespace)
-	if err != nil {
-		return "", fmt.Errorf("failed to wait for TPR. %+v", err)
+		return fmt.Errorf("failed to create TPR. %+v", err)
 	}
 
-	// Check if there is an existing cluster to recover
-	watchVersion, err := o.findAllClusters()
-	if err != nil {
-		return "", fmt.Errorf("failed to find clusters. %+v", err)
-	}
-	return watchVersion, nil
-}
-
-func (o *Operator) watchTPR(watchVersion string) error {
-	logger.Infof("start watching rook tpr: %s", watchVersion)
-	defer func() {
-		for _, stop := range o.stopChMap {
-			close(stop)
-		}
-		o.waitCluster.Wait()
-	}()
-
-	eventCh, errCh := o.watch(watchVersion)
-
-	go func() {
-		pt := k8sutil.NewPanicTimer(time.Minute, "unexpected long blocking (> 1 Minute) when handling cluster event")
-
-		for event := range eventCh {
-			pt.Start()
-
-			c := event.Object
-
-			switch event.Type {
-			case kwatch.Added:
-				ns := c.Spec.Namespace
-				if ns == "" {
-					logger.Errorf("missing namespace attribute in rook spec")
-					continue
-				}
-
-				newCluster := cluster.New(c.Spec, o.factory, o.clientset)
-				stopCh := make(chan struct{})
-				o.stopChMap[ns] = stopCh
-				o.clusters[ns] = newCluster
-				o.clusterRVs[ns] = c.Metadata.ResourceVersion
-
-				logger.Infof("starting new cluster %s in namespace %s", c.Metadata.Name, ns)
-				o.startCluster(newCluster)
-
-			case kwatch.Modified:
-				logger.Infof("modifying a cluster not implemented")
-
-			case kwatch.Deleted:
-				logger.Infof("deleting a cluster not implemented")
-			}
-
-			pt.Stop()
-		}
-	}()
-	return <-errCh
-
-}
-
-func (o *Operator) startCluster(c *cluster.Cluster) {
-	if o.devicesInUse && c.Spec.UseAllDevices {
-		logger.Warningf("devices in more than one namespace not supported. ignoring devices in namespace %s", c.Spec.Namespace)
-		c.Spec.UseAllDevices = false
-	}
-
-	if c.Spec.UseAllDevices {
-		o.devicesInUse = true
-	}
-
-	go func() {
-		err := c.CreateInstance()
-		if err != nil {
-			logger.Errorf("failed to create cluster in namespace %s. %+v", c.Spec.Namespace, err)
-			return
-		}
-		c.Monitor(o.stopChMap[c.Spec.Namespace])
-	}()
-}
-
-func (o *Operator) findAllClusters() (string, error) {
-	logger.Info("finding existing clusters...")
-	clusterList, err := getClusterList(o.clientset.CoreV1().RESTClient(), o.Namespace)
-	if err != nil {
-		return "", err
-	}
-	logger.Infof("found %d clusters", len(clusterList.Items))
-	for i := range clusterList.Items {
-		c := clusterList.Items[i]
-
-		stopCh := make(chan struct{})
-		ns := c.Spec.Namespace
-		existingCluster := cluster.New(c.Spec, o.factory, o.clientset)
-		o.stopChMap[ns] = stopCh
-		o.clusters[ns] = existingCluster
-		o.clusterRVs[ns] = c.Metadata.ResourceVersion
-
-		logger.Infof("resuming cluster %s in namespace %s", c.Metadata.Name, ns)
-		o.startCluster(existingCluster)
-	}
-
-	return clusterList.Metadata.ResourceVersion, nil
-}
-
-// watch creates a go routine, and watches the cluster.rook kind resources from
-// the given watch version. It emits events on the resources through the returned
-// event chan. Errors will be reported through the returned error chan. The go routine
-// exits on any error.
-func (o *Operator) watch(watchVersion string) (<-chan *Event, <-chan error) {
-	eventCh := make(chan *Event)
-	// On unexpected error case, the operator should exit
-	errCh := make(chan error, 1)
-
-	go func() {
-		defer close(eventCh)
-
-		for {
-			resp, err := watchClusters(o.MasterHost, o.Namespace, o.kubeHttpCli, watchVersion)
-			if err != nil {
-				errCh <- err
-				return
-			}
-			if resp.StatusCode != http.StatusOK {
-				resp.Body.Close()
-				errCh <- errors.New("invalid status code: " + resp.Status)
-				return
-			}
-
-			decoder := json.NewDecoder(resp.Body)
-			for {
-				ev, st, err := pollEvent(decoder)
-				if err != nil {
-					if err == io.EOF { // apiserver will close stream periodically
-						logger.Debug("apiserver closed stream")
-						break
-					}
-
-					logger.Errorf("received invalid event from API server: %v", err)
-					errCh <- err
-					return
-				}
-
-				if st != nil {
-					resp.Body.Close()
-
-					if st.Code == http.StatusGone {
-						// event history is outdated.
-						// if nothing has changed, we can go back to watch again.
-						clusterList, err := getClusterList(o.clientset.CoreV1().RESTClient(), o.Namespace)
-						if err == nil && !o.isClustersCacheStale(clusterList.Items) {
-							watchVersion = clusterList.Metadata.ResourceVersion
-							break
-						}
-
-						// if anything has changed (or error on relist), we have to rebuild the state.
-						// go to recovery path
-						errCh <- ErrVersionOutdated
-						return
-					}
-
-					logger.Errorf("unexpected status response from API server: %v", st.Message)
-					break
-				}
-
-				logger.Debugf("rook cluster event: %+v", ev)
-
-				watchVersion = ev.Object.Metadata.ResourceVersion
-				eventCh <- ev
-			}
-
-			resp.Body.Close()
-		}
-	}()
-
-	return eventCh, errCh
-}
-
-func (o *Operator) isClustersCacheStale(currentClusters []cluster.Cluster) bool {
-	if len(o.clusterRVs) != len(currentClusters) {
-		return true
-	}
-
-	for _, cc := range currentClusters {
-		rv, ok := o.clusterRVs[cc.Metadata.Name]
-		if !ok || rv != cc.Metadata.ResourceVersion {
-			return true
+	for _, tpr := range o.tprs {
+		if err := tpr.Load(); err != nil {
+			return fmt.Errorf("failed to load tpr %s. %+v", tpr.Name(), err)
 		}
 	}
 
-	return false
-}
-
-func watchClusters(host, ns string, httpClient *http.Client, resourceVersion string) (*http.Response, error) {
-	return httpClient.Get(fmt.Sprintf("%s/apis/%s/%s/namespaces/%s/clusters?watch=true&resourceVersion=%s",
-		host, tprGroup, tprVersion, ns, resourceVersion))
-}
-
-func getClusterList(restcli rest.Interface, ns string) (*cluster.ClusterList, error) {
-	b, err := restcli.Get().RequestURI(listClustersURI(ns)).DoRaw()
-	if err != nil {
-		return nil, err
-	}
-
-	clusters := &cluster.ClusterList{}
-	if err := json.Unmarshal(b, clusters); err != nil {
-		return nil, err
-	}
-	return clusters, nil
-}
-
-func listClustersURI(ns string) string {
-	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", tprGroup, tprVersion, ns)
+	return nil
 }
 
 func newHttpClient() (*rest.RESTClient, error) {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -27,20 +27,37 @@ import (
 func TestCreateCluster(t *testing.T) {
 	clientset := test.New(3)
 	o := New("foo", "rook", nil, clientset)
-	o.retryDelay = 0
+	o.context.retryDelay = 1
 
 	// fail to init k8s client since we're not actually inside k8s
-	_, err := o.initResources()
+	err := o.initResources()
 	assert.NotNil(t, err)
 
 	// create the tpr
-	err = o.createTPR()
+	test := &testTPR{}
+	err = createTPR(o.context, test)
 	assert.Nil(t, err)
 	tpr, err := clientset.ExtensionsV1beta1().ThirdPartyResources().List(v1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(tpr.Items))
-	assert.Equal(t, "cluster.rook.io", tpr.Items[0].Name)
-	assert.Equal(t, tprDescription, tpr.Items[0].Description)
+	assert.Equal(t, "test.rook.io", tpr.Items[0].Name)
+	assert.Equal(t, test.Description(), tpr.Items[0].Description)
 
 	// TODO: Watch for a new Rook cluster and create it. Need a mocked http client to be working
+}
+
+type testTPR struct {
+}
+
+func (t *testTPR) Name() string {
+	return "test"
+}
+func (t *testTPR) Description() string {
+	return "test description"
+}
+func (t *testTPR) Load() error {
+	return nil
+}
+func (t *testTPR) Watch() error {
+	return nil
 }

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package operator
+
+type poolTPR struct {
+	context *context
+}
+
+func newPoolTPR(context *context) *poolTPR {
+	return &poolTPR{context: context}
+}
+
+func (t *poolTPR) Name() string {
+	return "pool"
+}
+
+func (t *poolTPR) Description() string {
+	return "Managed Rook pools"
+}
+
+func (t *poolTPR) Load() error {
+	return nil
+}
+func (t *poolTPR) Watch() error {
+	return nil
+}

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -18,16 +18,31 @@ which also has the apache 2.0 license.
 */
 package operator
 
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	kwatch "k8s.io/client-go/pkg/watch"
+
+	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+)
+
 type poolTPR struct {
-	context *context
+	context      *context
+	watchVersion string
+	cluster      *clusterTPR
 }
 
-func newPoolTPR(context *context) *poolTPR {
-	return &poolTPR{context: context}
+func newPoolTPR(context *context, cluster *clusterTPR) *poolTPR {
+	return &poolTPR{context: context, cluster: cluster}
 }
 
 func (t *poolTPR) Name() string {
-	return "pool"
+	return "rookpool"
 }
 
 func (t *poolTPR) Description() string {
@@ -35,8 +50,144 @@ func (t *poolTPR) Description() string {
 }
 
 func (t *poolTPR) Load() error {
+	// Check if pools have all been created
+	logger.Info("finding existing pools...")
+	poolList, err := t.getPoolList()
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("found %d pools. ensuring they exist.", len(poolList.Items))
+	for i := range poolList.Items {
+		// ensure the pool exists
+		p := poolList.Items[i]
+		rclient, err := t.cluster.getRookClient(p.Namespace)
+		if err != nil {
+			return fmt.Errorf("failed to get rook client for namespace %s. %+v", p.Namespace, err)
+		}
+		if err := p.Create(rclient); err != nil {
+			logger.Warningf("failed to check that pool %s exists in namespace %s. %+v", p.PoolSpec.Name, p.PoolSpec.Namespace, err)
+		}
+	}
+
+	t.watchVersion = poolList.Metadata.ResourceVersion
 	return nil
 }
+
+func (t *poolTPR) getPoolList() (*cluster.PoolList, error) {
+	b, err := getRawList(t.context, t)
+	if err != nil {
+		return nil, err
+	}
+
+	pools := &cluster.PoolList{}
+	if err := json.Unmarshal(b, pools); err != nil {
+		return nil, err
+	}
+	return pools, nil
+}
+
 func (t *poolTPR) Watch() error {
-	return nil
+	logger.Infof("start watching %s tpr: %s", t.Name(), t.watchVersion)
+
+	eventCh, errCh := t.watch()
+
+	go func() {
+		timer := k8sutil.NewPanicTimer(
+			time.Minute,
+			fmt.Sprintf("unexpected long blocking (> 1 Minute) when handling %s event", t.Name()))
+
+		for event := range eventCh {
+			timer.Start()
+
+			pool := event.Object
+			rclient, err := t.cluster.getRookClient(pool.PoolSpec.Namespace)
+			if err != nil {
+				logger.Errorf("failed %v pool %s. %+v", event.Type, pool.Name, err)
+				break
+			}
+
+			switch event.Type {
+			case kwatch.Added:
+				p := cluster.NewPool(pool.PoolSpec)
+				if err := p.Create(rclient); err != nil {
+					logger.Errorf("failed to create pool %s. %+v", pool.PoolSpec.Name, err)
+					break
+				}
+
+			case kwatch.Modified:
+				// if the pool is modified, allow the pool to be created if it wasn't already
+				p := cluster.NewPool(pool.PoolSpec)
+				if err := p.Create(rclient); err != nil {
+					logger.Errorf("failed to create (modify) pool %s. %+v", pool.PoolSpec.Name, err)
+					break
+				}
+
+			case kwatch.Deleted:
+				oldPool := cluster.NewPool(pool.PoolSpec)
+				err := oldPool.Delete(rclient)
+				if err != nil {
+					logger.Errorf("failed to delete pool %s. %+v", pool.PoolSpec.Name, err)
+					break
+				}
+			}
+
+			timer.Stop()
+		}
+	}()
+	return <-errCh
+
+}
+
+// watch creates a go routine, and watches the pool.rook.io kind resources from
+// the given watch version. It emits events on the resources through the returned
+// event chan. Errors will be reported through the returned error chan. The go routine
+// exits on any error.
+func (t *poolTPR) watch() (<-chan *poolEvent, <-chan error) {
+	eventCh := make(chan *poolEvent)
+	// On unexpected error case, the operator should exit
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(eventCh)
+
+		for {
+			err := t.watchOuterTPR(eventCh, errCh)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to watch pool tpr. %+v", err)
+				return
+			}
+		}
+	}()
+
+	return eventCh, errCh
+}
+
+func (t *poolTPR) watchOuterTPR(eventCh chan *poolEvent, errCh chan error) error {
+	resp, err := watchTPR(t.context, t.Name(), t.watchVersion)
+	if err != nil {
+		errCh <- err
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("invalid status code: " + resp.Status)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	for {
+		ev, st, err := pollPoolEvent(decoder)
+		done, err := handlePollEventResult(st, err, func() (bool, error) { return false, nil }, errCh)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+		logger.Debugf("rook pool event: %+v", ev)
+
+		t.watchVersion = ev.Object.Metadata.ResourceVersion
+		eventCh <- ev
+	}
 }

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -20,53 +20,78 @@ package operator
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"time"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/rest"
 )
 
 const (
-	tprKind        = "cluster"
-	tprGroup       = "rook.io"
-	tprVersion     = "v1beta1"
-	tprDescription = "Managed rook clusters"
+	tprGroup   = "rook.io"
+	tprVersion = "v1beta1"
 )
 
-func tprName() string {
-	return fmt.Sprintf("%s.%s", tprKind, tprGroup)
+type TPR interface {
+	Name() string
+	Description() string
+	Load() error
+	Watch() error
 }
 
-func (o *Operator) createTPR() error {
-	logger.Info("creating rook TPR")
-	tpr := &v1beta1.ThirdPartyResource{
-		ObjectMeta: v1.ObjectMeta{
-			Name: tprName(),
-		},
-		Versions: []v1beta1.APIVersion{
-			{Name: tprVersion},
-		},
-		Description: tprDescription,
+func qualifiedName(tpr TPR) string {
+	return fmt.Sprintf("%s.%s", tpr.Name(), tprGroup)
+}
+
+func createTPRs(context *context, tprs []TPR) error {
+	for _, tpr := range tprs {
+		if err := createTPR(context, tpr); err != nil {
+			return fmt.Errorf("failed to init tpr %s. %+v", tpr.Name(), err)
+		}
 	}
-	_, err := o.clientset.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create rook third party resources. %+v", err)
+
+	for _, tpr := range tprs {
+		if err := waitForTPRInit(context, tpr); err != nil {
+			return fmt.Errorf("failed to complete init %s. %+v", tpr.Name(), err)
 		}
 	}
 
 	return nil
 }
 
-func (o *Operator) waitForTPRInit(restcli rest.Interface, maxRetries int, ns string) error {
-	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", tprGroup, tprVersion, ns)
-	return k8sutil.Retry(time.Duration(o.retryDelay)*time.Second, maxRetries, func() (bool, error) {
+func createTPR(context *context, tpr TPR) error {
+	logger.Infof("creating %s TPR", tpr.Name())
+	r := &v1beta1.ThirdPartyResource{
+		ObjectMeta: v1.ObjectMeta{
+			Name: qualifiedName(tpr),
+		},
+		Versions: []v1beta1.APIVersion{
+			{Name: tprVersion},
+		},
+		Description: tpr.Description(),
+	}
+	_, err := context.clientset.ExtensionsV1beta1().ThirdPartyResources().Create(r)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s TPR. %+v", tpr.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func waitForTPRInit(context *context, tpr TPR) error {
+	restcli := context.clientset.CoreV1().RESTClient()
+	uri := tprURI(context, tpr.Name())
+	return k8sutil.Retry(time.Duration(context.retryDelay)*time.Second, context.maxRetries, func() (bool, error) {
 		_, err := restcli.Get().RequestURI(uri).DoRaw()
 		if err != nil {
+			logger.Infof("failed to query for tpr %s. %+v", tpr.Name(), err)
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
@@ -74,4 +99,58 @@ func (o *Operator) waitForTPRInit(restcli rest.Interface, maxRetries int, ns str
 		}
 		return true, nil
 	})
+}
+
+func watchTPR(context *context, name string, resourceVersion string) (*http.Response, error) {
+	return context.kubeHttpCli.Get(fmt.Sprintf("%s/%s?watch=true&resourceVersion=%s",
+		context.masterHost, tprURI(context, name), resourceVersion))
+}
+
+func tprURI(context *context, name string) string {
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%ss", tprGroup, tprVersion, context.namespace, name)
+}
+
+func getRawList(context *context, tpr TPR) ([]byte, error) {
+	restcli := context.clientset.CoreV1().RESTClient()
+	return restcli.Get().RequestURI(tprURI(context, tpr.Name())).DoRaw()
+}
+
+func handlePollEventResult(status *unversioned.Status, errIn error, checkStaleCache func() (bool, error)) (done, cancel bool, err error) {
+	if errIn != nil {
+		if errIn == io.EOF { // apiserver will close stream periodically
+			logger.Debug("apiserver closed stream")
+			done = true
+			return
+		}
+
+		logger.Errorf("received invalid event from API server: %v", err)
+		err = errIn
+		cancel = true
+		return
+	}
+
+	if status != nil {
+
+		if status.Code == http.StatusGone {
+			// event history is outdated.
+			// if nothing has changed, we can go back to watch again.
+			var stale bool
+			stale, err = checkStaleCache()
+			if err == nil && !stale {
+				done = true
+				return
+			}
+
+			// if anything has changed (or error on relist), we have to rebuild the state.
+			// go to recovery path
+			err = ErrVersionOutdated
+			cancel = true
+			return
+		}
+
+		logger.Errorf("unexpected status response from API server: %v", status.Message)
+		done = true
+		return
+	}
+	return
 }

--- a/pkg/operator/tracker.go
+++ b/pkg/operator/tracker.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package operator
+
+import "sync"
+
+type tprTracker struct {
+	stopChMap   map[string]chan struct{}
+	clusterRVs  map[string]string
+	waitCluster sync.WaitGroup
+}
+
+func newTPRTracker() *tprTracker {
+	return &tprTracker{
+		clusterRVs: make(map[string]string),
+		stopChMap:  map[string]chan struct{}{},
+	}
+}
+
+func (t *tprTracker) add(name, version string) {
+	t.stopChMap[name] = make(chan struct{})
+	t.clusterRVs[name] = version
+}
+
+func (t *tprTracker) stop() {
+	for _, stop := range t.stopChMap {
+		close(stop)
+	}
+	t.waitCluster.Wait()
+}


### PR DESCRIPTION
The `rookpool` TPR allows creating pools with replication or erasure coding. 

Take note that the `cluster` TPR is renamed to `rookcluster` for consistency of naming and to allow kubectl commands without fully qualifying the tpr name. For example:
```
kubectl get rookcluster
kubectl get rookpool
```