### PR TITLE
Rename tpr version to alpha

### DIFF
--- a/demo/kubernetes/rook-cluster.yaml
+++ b/demo/kubernetes/rook-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: rook.io/v1beta1
+apiVersion: rook.io/v1alpha1
 kind: Rookcluster
 metadata:
   name: rook

--- a/demo/kubernetes/rook-pool.yaml
+++ b/demo/kubernetes/rook-pool.yaml
@@ -1,4 +1,4 @@
-apiVersion: rook.io/v1beta1
+apiVersion: rook.io/v1alpha1
 kind: Rookpool
 metadata:
   name: rook-replicapool

--- a/demo/kubernetes/rook-storageclass.yaml
+++ b/demo/kubernetes/rook-storageclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: rook.io/v1beta1
+apiVersion: rook.io/v1alpha1
 kind: Rookpool
 metadata:
   name: rook-replicapool

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	tprGroup   = "rook.io"
-	tprVersion = "v1beta1"
+	tprVersion = "v1alpha1"
 )
 
 type TPR interface {


### PR DESCRIPTION
Rook is not in beta yet, so the tpr version should be alpha