### PR TITLE
TPRs managed in the cluster namespace instead of the operator namespace

### DIFF
--- a/Documentation/cluster-tpr.md
+++ b/Documentation/cluster-tpr.md
@@ -5,9 +5,12 @@ available for a cluster.
 ## Settings
 Settings can be specified at the global level to apply to the cluster as a whole, while other settings can be specified at more fine-grained levels.  If any setting is unspecified, a suitable default will be used automatically.
 
+### Cluster metadata
+- `name`: The name that will be used internally for the Ceph cluster. Most commonly the name is the same as the namespace since multiple clusters are not supported in the same namespace.
+- `namespace`: The Kubernetes namespace that will be created for the Rook cluster. The services, pods, and other resources created by the operator will be added to this namespace. The common scenario is to create a single Rook cluster. If multiple clusters are created, they must not have conflicting devices or host paths.
+
 ### Cluster settings
-- `namespace`: The Kubernetes namespace that will be created for the Rook cluster. The services, pods, and other resources created by the operator will be added to this namespace. Each cluster must have a unique namespace. The common scenario is to create a single Rook cluster. If multiple clusters are created, they must not have conflicting devices or host paths.
-- `version`: The version (tag) of the `quay.io/rook/rookd` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
+- `versionTag`: The version (tag) of the `quay.io/rook/rookd` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
 - `dataDirHostPath`: The host path where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.  Therefore, for test scenarios, the path must be deleted if you are going to delete a cluster and start a new cluster on the same hosts.  More details can be found in the Kubernetes [host path docs](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).  
 If this value is empty, each pod will get an ephemeral directory to store their config files that is tied to the lifetime of the pod running on that node. More details can be found in the Kubernetes [empty dir docs](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
 - `storage`: Storage selection and configuration that will be used across the cluster.  Note that these settings can be overridden for specific nodes.

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -119,6 +119,8 @@ To clean up all the artifacts created by the demo, run the following:
 kubectl delete -f wordpress.yaml
 kubectl delete -f mysql.yaml
 kubectl delete deployment rook-operator
+kubectl delete -n rook rookcluster rook
+kubectl delete -n rook rookpool replicapool
 kubectl delete thirdpartyresources rookcluster.rook.io rookpool.rook.io
 kubectl delete storageclass rook-block
 kubectl delete secret rook-rbd-user

--- a/Documentation/pool-tpr.md
+++ b/Documentation/pool-tpr.md
@@ -7,12 +7,11 @@ for pools.
 apiVersion: rook.io/v1alpha1
 kind: Rookpool
 metadata:
-  name: rook-ecpool
-spec:
   name: ecpool
   namespace: rook
+spec:
   replication:
-  #  count: 3
+  #  size: 3
   erasureCode:
     codingChunks: 2
     dataChunks: 2
@@ -21,14 +20,12 @@ spec:
 ## Pool Settings
 
 ### Metadata
-- `name`: The name of the kubernetes resource. Must be unique across all Rook clusters. The naming convention is `clusterName-poolName`.
-- `namespace`: The namespace where the Rook operator is running.
+- `name`: The name of the pool to create.
+- `namespace`: The namespace of the Rook cluster where the pool is created.
 
 ### Spec
-- `name`: The name of the pool to create in the cluster.
-- `namespace`: The namespace where the Rook cluster is running to create the pool.
 - `replication`: Settings for a replicated pool. If specified, `erasureCode` settings must not be specified.
-  - `count`: The number of copies of the data in the pool.
+  - `size`: The number of copies of the data in the pool.
 - `erasureCode`: Settings for an erasure-coded pool. If specified, `replication` settings must not be specified.
   - `codingChunks`: Number of coding chunks per object in an erasure coded storage pool
   - `dataChunks`: Number of data chunks per object in an erasure coded storage pool

--- a/cmd/rookd/api.go
+++ b/cmd/rookd/api.go
@@ -40,11 +40,11 @@ var repoPrefix string
 func init() {
 	apiCmd.Flags().IntVar(&apiPort, "port", 0, "port on which the api is listening")
 	apiCmd.Flags().StringVar(&repoPrefix, "repo-prefix", "quay.io/rook", "the repo from which to pull images")
-	apiCmd.Flags().StringVar(&cfg.containerVersion, "container-version", "latest", "version of the rook container to launch")
+	apiCmd.Flags().StringVar(&cfg.versionTag, "version-tag", "latest", "version of the rook container to launch")
 	apiCmd.Flags().StringVar(&cfg.namespace, "namespace", "", "the namespace in which the api service is running")
 	addCephFlags(apiCmd)
 
-	flags.SetFlagsFromEnv(rootCmd.Flags(), "ROOKD")
+	flags.SetFlagsFromEnv(apiCmd.Flags(), "ROOKD")
 
 	apiCmd.RunE = startAPI
 }
@@ -72,7 +72,7 @@ func startAPI(cmd *cobra.Command, args []string) error {
 		ConnFactory:    mon.NewConnectionFactoryWithClusterInfo(&clusterInfo),
 		CephFactory:    factory,
 		Port:           apiPort,
-		ClusterHandler: apik8s.New(clientset, context, &clusterInfo, factory, cfg.namespace, cfg.containerVersion),
+		ClusterHandler: apik8s.New(clientset, context, &clusterInfo, factory, cfg.namespace, cfg.versionTag),
 	}
 
 	return api.Run(context, apiCfg)

--- a/cmd/rookd/api.go
+++ b/cmd/rookd/api.go
@@ -30,18 +30,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var apiCmd = &cobra.Command{
-	Use:   "api",
-	Short: "Runs the Rook API service",
-}
-var apiPort int
-var repoPrefix string
+var (
+	apiCmd = &cobra.Command{
+		Use:   "api",
+		Short: "Runs the Rook API service",
+	}
+	apiPort    int
+	repoPrefix string
+	namespace  string
+	versionTag string
+)
 
 func init() {
 	apiCmd.Flags().IntVar(&apiPort, "port", 0, "port on which the api is listening")
 	apiCmd.Flags().StringVar(&repoPrefix, "repo-prefix", "quay.io/rook", "the repo from which to pull images")
-	apiCmd.Flags().StringVar(&cfg.versionTag, "version-tag", "latest", "version of the rook container to launch")
-	apiCmd.Flags().StringVar(&cfg.namespace, "namespace", "", "the namespace in which the api service is running")
+	apiCmd.Flags().StringVar(&versionTag, "version-tag", "latest", "version of the rook container to launch")
+	apiCmd.Flags().StringVar(&namespace, "namespace", "", "the namespace in which the api service is running")
 	addCephFlags(apiCmd)
 
 	flags.SetFlagsFromEnv(apiCmd.Flags(), "ROOKD")
@@ -72,7 +76,7 @@ func startAPI(cmd *cobra.Command, args []string) error {
 		ConnFactory:    mon.NewConnectionFactoryWithClusterInfo(&clusterInfo),
 		CephFactory:    factory,
 		Port:           apiPort,
-		ClusterHandler: apik8s.New(clientset, context, &clusterInfo, factory, cfg.namespace, cfg.versionTag),
+		ClusterHandler: apik8s.New(clientset, context, &clusterInfo, factory, namespace, versionTag),
 	}
 
 	return api.Run(context, apiCfg)

--- a/cmd/rookd/daemon.go
+++ b/cmd/rookd/daemon.go
@@ -39,6 +39,7 @@ var daemonCmd = &cobra.Command{
 func init() {
 	daemonCmd.Flags().StringVar(&daemonType, "type", "", "type of daemon [mon|osd|mds|rgw]")
 	daemonCmd.MarkFlagRequired("type")
+	flags.SetFlagsFromEnv(daemonCmd.Flags(), "ROOKD")
 
 	daemonCmd.RunE = runDaemon
 }

--- a/cmd/rookd/main.go
+++ b/cmd/rookd/main.go
@@ -72,8 +72,6 @@ type config struct {
 	storeConfig        osd.StoreConfig
 	networkInfo        clusterd.NetworkInfo
 	monEndpoints       string
-	namespace          string
-	versionTag         string
 }
 
 func main() {

--- a/cmd/rookd/main.go
+++ b/cmd/rookd/main.go
@@ -73,7 +73,7 @@ type config struct {
 	networkInfo        clusterd.NetworkInfo
 	monEndpoints       string
 	namespace          string
-	containerVersion   string
+	versionTag         string
 }
 
 func main() {

--- a/cmd/rookd/operator.go
+++ b/cmd/rookd/operator.go
@@ -35,7 +35,6 @@ https://github.com/rook/rook`,
 }
 
 func init() {
-	operatorCmd.Flags().StringVar(&cfg.containerVersion, "container-version", "latest", "version of the rook container to launch")
 	operatorCmd.Flags().StringVar(&cfg.namespace, "namespace", "", "the namespace in which the operator is running")
 
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), "ROOKD")

--- a/cmd/rookd/operator.go
+++ b/cmd/rookd/operator.go
@@ -35,18 +35,12 @@ https://github.com/rook/rook`,
 }
 
 func init() {
-	operatorCmd.Flags().StringVar(&cfg.namespace, "namespace", "", "the namespace in which the operator is running")
-
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), "ROOKD")
 
 	operatorCmd.RunE = startOperator
 }
 
 func startOperator(cmd *cobra.Command, args []string) error {
-	// verify required flags
-	if err := flags.VerifyRequiredFlags(cmd, []string{"namespace"}); err != nil {
-		return err
-	}
 
 	setLogLevel()
 
@@ -56,8 +50,8 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	logger.Infof("starting operator in namespace %s", cfg.namespace)
-	op := operator.New(host, cfg.namespace, cephd.New(), clientset)
+	logger.Infof("starting operator")
+	op := operator.New(host, cephd.New(), clientset)
 	err = op.Run()
 	if err != nil {
 		fmt.Printf("failed to run operator. %+v\n", err)

--- a/demo/kubernetes/rook-cluster.yaml
+++ b/demo/kubernetes/rook-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rook
 spec:
   namespace: rook
-  version: master-latest
+  versionTag: master-latest
   dataDirHostPath:
   storage:                # cluster level storage configuration and selection
     useAllNodes: true

--- a/demo/kubernetes/rook-cluster.yaml
+++ b/demo/kubernetes/rook-cluster.yaml
@@ -2,8 +2,8 @@ apiVersion: rook.io/v1alpha1
 kind: Rookcluster
 metadata:
   name: rook
-spec:
   namespace: rook
+spec:
   versionTag: master-latest
   dataDirHostPath:
   storage:                # cluster level storage configuration and selection

--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -14,10 +14,6 @@ spec:
         image: quay.io/rook/rookd:master-latest
         args: ["operator"]
         env:
-        - name: ROOKD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: ROOKD_REPO_PREFIX
           value: quay.io/rook
 

--- a/demo/kubernetes/rook-pool.yaml
+++ b/demo/kubernetes/rook-pool.yaml
@@ -12,3 +12,4 @@ spec:
   #erasureCode:
   #  codingChunks: 2
   #  dataChunks: 2
+  

--- a/demo/kubernetes/rook-pool.yaml
+++ b/demo/kubernetes/rook-pool.yaml
@@ -4,10 +4,11 @@ metadata:
   name: replicapool
   namespace: rook
 spec:
+  # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replication:
-    count: 1
-  # For an erasure-coded pool, comment out the replication count above and uncomment the following settings.
-  # Make sure you have enough OSDs to support the replica count or erasure code chunks.
+    size: 1
+  # For an erasure-coded pool, comment out the replication size above and uncomment the following settings.
+  # Make sure you have enough OSDs to support the replica size or sum of the erasure coding and data chunks.
   #erasureCode:
   #  codingChunks: 2
   #  dataChunks: 2

--- a/demo/kubernetes/rook-pool.yaml
+++ b/demo/kubernetes/rook-pool.yaml
@@ -1,10 +1,9 @@
 apiVersion: rook.io/v1alpha1
 kind: Rookpool
 metadata:
-  name: rook-replicapool
-spec:
   name: replicapool
   namespace: rook
+spec:
   replication:
     count: 1
   # For an erasure-coded pool, comment out the replication count above and uncomment the following settings.

--- a/demo/kubernetes/rook-storageclass.yaml
+++ b/demo/kubernetes/rook-storageclass.yaml
@@ -1,12 +1,11 @@
 apiVersion: rook.io/v1alpha1
 kind: Rookpool
 metadata:
-  name: rook-replicapool
-spec:
   name: replicapool
   namespace: rook
+spec:
   replication:
-    count: 1
+    size: 1
   # For an erasure-coded pool, comment out the replication count above and uncomment the following settings.
   # Make sure you have enough OSDs to support the replica count or erasure code chunks.
   #erasureCode:

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -34,11 +34,11 @@ type clusterHandler struct {
 	clusterInfo *mon.ClusterInfo
 	factory     client.ConnectionFactory
 	namespace   string
-	version     string
+	tag         string
 }
 
-func New(clientset *kubernetes.Clientset, context *clusterd.DaemonContext, clusterInfo *mon.ClusterInfo, factory client.ConnectionFactory, namespace, containerVersion string) *clusterHandler {
-	return &clusterHandler{clientset: clientset, context: context, clusterInfo: clusterInfo, factory: factory, namespace: namespace, version: containerVersion}
+func New(clientset *kubernetes.Clientset, context *clusterd.DaemonContext, clusterInfo *mon.ClusterInfo, factory client.ConnectionFactory, namespace, versionTag string) *clusterHandler {
+	return &clusterHandler{clientset: clientset, context: context, clusterInfo: clusterInfo, factory: factory, namespace: namespace, tag: versionTag}
 }
 
 func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
@@ -47,7 +47,7 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 
 func (s *clusterHandler) EnableObjectStore() error {
 	logger.Infof("Starting the Object store")
-	r := k8srgw.New(s.clientset, s.factory, s.namespace, s.version)
+	r := k8srgw.New(s.clientset, s.factory, s.namespace, s.tag)
 	err := r.Start(s.clusterInfo)
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
@@ -77,7 +77,7 @@ func (s *clusterHandler) GetObjectStoreConnectionInfo() (*model.ObjectStoreConne
 
 func (s *clusterHandler) StartFileSystem(fs *model.FilesystemRequest) error {
 	logger.Infof("Starting the MDS")
-	c := k8smds.New(s.namespace, s.version, s.factory)
+	c := k8smds.New(s.namespace, s.tag, s.factory)
 	return c.Start(s.clientset, s.clusterInfo)
 }
 

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -34,11 +34,11 @@ type clusterHandler struct {
 	clusterInfo *mon.ClusterInfo
 	factory     client.ConnectionFactory
 	namespace   string
-	tag         string
+	versionTag  string
 }
 
 func New(clientset *kubernetes.Clientset, context *clusterd.DaemonContext, clusterInfo *mon.ClusterInfo, factory client.ConnectionFactory, namespace, versionTag string) *clusterHandler {
-	return &clusterHandler{clientset: clientset, context: context, clusterInfo: clusterInfo, factory: factory, namespace: namespace, tag: versionTag}
+	return &clusterHandler{clientset: clientset, context: context, clusterInfo: clusterInfo, factory: factory, namespace: namespace, versionTag: versionTag}
 }
 
 func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
@@ -47,7 +47,7 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 
 func (s *clusterHandler) EnableObjectStore() error {
 	logger.Infof("Starting the Object store")
-	r := k8srgw.New(s.clientset, s.factory, s.namespace, s.tag)
+	r := k8srgw.New(s.clientset, s.factory, s.clusterInfo.Name, s.namespace, s.versionTag)
 	err := r.Start(s.clusterInfo)
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
@@ -77,7 +77,7 @@ func (s *clusterHandler) GetObjectStoreConnectionInfo() (*model.ObjectStoreConne
 
 func (s *clusterHandler) StartFileSystem(fs *model.FilesystemRequest) error {
 	logger.Infof("Starting the MDS")
-	c := k8smds.New(s.namespace, s.tag, s.factory)
+	c := k8smds.New(s.clusterInfo.Name, s.namespace, s.versionTag, s.factory)
 	return c.Start(s.clientset, s.clusterInfo)
 }
 

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -99,7 +99,7 @@ func (c *Cluster) makeDeployment() *extensions.Deployment {
 
 func (c *Cluster) apiContainer() v1.Container {
 
-	command := fmt.Sprintf("/usr/bin/rookd api --config-dir=%s --port=%d --container-version=%s", k8sutil.DataDir, model.Port, c.Version)
+	command := fmt.Sprintf("/usr/bin/rookd api --config-dir=%s --port=%d --version-tag=%s", k8sutil.DataDir, model.Port, c.Version)
 	return v1.Container{
 		// TODO: fix "sleep 5".
 		// Without waiting some time, there is highly probable flakes in network setup.

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestStartAPI(t *testing.T) {
 	clientset := testop.New(3)
-	c := New(clientset, "ns", "myversion")
+	c := New(clientset, "myname", "ns", "myversion")
 
 	// start a basic cluster
 	err := c.Start()
@@ -57,7 +57,7 @@ func validateStart(t *testing.T, c *Cluster) {
 
 func TestPodSpecs(t *testing.T) {
 	clientset := testop.New(1)
-	c := New(clientset, "ns", "myversion")
+	c := New(clientset, "myname", "ns", "myversion")
 
 	d := c.makeDeployment()
 	assert.NotNil(t, d)
@@ -74,12 +74,12 @@ func TestPodSpecs(t *testing.T) {
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "quay.io/rook/rookd:myversion", cont.Image)
 	assert.Equal(t, 1, len(cont.VolumeMounts))
-	assert.Equal(t, 6, len(cont.Env))
+	assert.Equal(t, 7, len(cont.Env))
 	for _, v := range cont.Env {
 		assert.True(t, strings.HasPrefix(v.Name, "ROOKD_"))
 	}
 
-	expectedCommand := fmt.Sprintf("/usr/bin/rookd api --config-dir=/var/lib/rook --port=%d --version-tag=%s", model.Port, c.Version)
+	expectedCommand := fmt.Sprintf("/usr/bin/rookd api --config-dir=/var/lib/rook --port=%d", model.Port)
 
 	assert.NotEqual(t, -1, strings.Index(cont.Command[2], expectedCommand), cont.Command[2])
 }

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -79,7 +79,7 @@ func TestPodSpecs(t *testing.T) {
 		assert.True(t, strings.HasPrefix(v.Name, "ROOKD_"))
 	}
 
-	expectedCommand := fmt.Sprintf("/usr/bin/rookd api --config-dir=/var/lib/rook --port=%d --container-version=%s", model.Port, c.Version)
+	expectedCommand := fmt.Sprintf("/usr/bin/rookd api --config-dir=/var/lib/rook --port=%d --version-tag=%s", model.Port, c.Version)
 
 	assert.NotEqual(t, -1, strings.Index(cont.Command[2], expectedCommand), cont.Command[2])
 }

--- a/pkg/operator/cluster/cluster.go
+++ b/pkg/operator/cluster/cluster.go
@@ -46,53 +46,50 @@ var (
 )
 
 type Cluster struct {
-	factory   client.ConnectionFactory
-	clientset kubernetes.Interface
-	Metadata  v1.ObjectMeta `json:"metadata,omitempty"`
-	Spec      `json:"spec"`
-	dataDir   string
-	mons      *mon.Cluster
-	osds      *osd.Cluster
-	apis      *api.Cluster
-	rgws      *rgw.Cluster
-	rclient   rookclient.RookRestClient
+	factory       client.ConnectionFactory
+	clientset     kubernetes.Interface
+	v1.ObjectMeta `json:"metadata,omitempty"`
+	Spec          `json:"spec"`
+	dataDir       string
+	mons          *mon.Cluster
+	osds          *osd.Cluster
+	apis          *api.Cluster
+	rgws          *rgw.Cluster
+	rclient       rookclient.RookRestClient
 }
 
-func New(spec Spec, factory client.ConnectionFactory, clientset kubernetes.Interface) *Cluster {
-	return &Cluster{
-		Spec:      spec,
-		factory:   factory,
-		clientset: clientset,
-		dataDir:   k8sutil.DataDir,
-	}
+func (c *Cluster) Init(factory client.ConnectionFactory, clientset kubernetes.Interface) {
+	c.factory = factory
+	c.clientset = clientset
+	c.dataDir = k8sutil.DataDir
 }
 
 func (c *Cluster) CreateInstance() error {
 
 	// Create the namespace if not already created
-	ns := &v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: c.Spec.Namespace}}
+	ns := &v1.Namespace{ObjectMeta: v1.ObjectMeta{Name: c.Name}}
 	_, err := c.clientset.CoreV1().Namespaces().Create(ns)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create namespace %s. %+v", c.Spec.Namespace, err)
+			return fmt.Errorf("failed to create namespace %s. %+v", c.Name, err)
 		}
 	}
 
 	// Start the mon pods
-	c.mons = mon.New(c.clientset, c.factory, c.Spec.Namespace, c.Spec.DataDirHostPath, c.Spec.Version)
+	c.mons = mon.New(c.clientset, c.factory, c.Name, c.Spec.DataDirHostPath, c.Spec.VersionTag)
 	clusterInfo, err := c.mons.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the mons. %+v", err)
 	}
 
-	c.apis = api.New(c.clientset, c.Spec.Namespace, c.Spec.Version)
+	c.apis = api.New(c.clientset, c.Name, c.Spec.VersionTag)
 	err = c.apis.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the REST api. %+v", err)
 	}
 
 	// Start the OSDs
-	c.osds = osd.New(c.clientset, c.Spec.Namespace, c.Spec.Version, c.Spec.Storage, c.Spec.DataDirHostPath)
+	c.osds = osd.New(c.clientset, c.Name, c.Spec.VersionTag, c.Spec.Storage, c.Spec.DataDirHostPath)
 	err = c.osds.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the osds. %+v", err)
@@ -103,7 +100,7 @@ func (c *Cluster) CreateInstance() error {
 		return fmt.Errorf("failed to create client access. %+v", err)
 	}
 
-	logger.Infof("Done creating rook instance in namespace %s", c.Spec.Namespace)
+	logger.Infof("Done creating rook instance in namespace %s", c.Name)
 	return nil
 }
 
@@ -111,7 +108,7 @@ func (c *Cluster) Monitor(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			logger.Infof("Stopping monitoring of cluster %s", c.Spec.Namespace)
+			logger.Infof("Stopping monitoring of cluster %s", c.Name)
 			return
 
 		case <-time.After(healthCheckInterval):
@@ -133,7 +130,8 @@ func (c *Cluster) createClientAccess(clusterInfo *cephmon.ClusterInfo) error {
 	defer conn.Shutdown()
 
 	// create a user for rbd clients
-	username := "client.rook-rbd-user"
+	name := fmt.Sprintf("%s-rbd-user", c.Name)
+	username := fmt.Sprintf("client.%s", name)
 	access := []string{"osd", "allow rwx", "mon", "allow r"}
 
 	// get-or-create-key for the user account
@@ -143,7 +141,6 @@ func (c *Cluster) createClientAccess(clusterInfo *cephmon.ClusterInfo) error {
 	}
 
 	// store the secret for the rbd user in the default namespace
-	name := fmt.Sprintf("%s-rbd-user", c.Spec.Namespace)
 	secrets := map[string]string{
 		"key": rbdKey,
 	}
@@ -177,8 +174,8 @@ func (c *Cluster) GetRookClient() (rookclient.RookRestClient, error) {
 	}
 
 	// Look up the api service for the given namespace
-	logger.Infof("retrieving rook api endpoint for namespace %s", c.Namespace)
-	svc, err := c.clientset.CoreV1().Services(c.Namespace).Get(api.DeploymentName)
+	logger.Infof("retrieving rook api endpoint for namespace %s", c.Name)
+	svc, err := c.clientset.CoreV1().Services(c.Name).Get(api.DeploymentName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find the api service. %+v", err)
 	}
@@ -187,6 +184,6 @@ func (c *Cluster) GetRookClient() (rookclient.RookRestClient, error) {
 	httpClient.Timeout = clientTimeout
 	endpoint := fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port)
 	c.rclient = rookclient.NewRookNetworkRestClient(rookclient.GetRestURL(endpoint), httpClient)
-	logger.Infof("rook api endpoint %s for namespace %s", endpoint, c.Namespace)
+	logger.Infof("rook api endpoint %s for namespace %s", endpoint, c.Name)
 	return c.rclient, nil
 }

--- a/pkg/operator/cluster/cluster_test.go
+++ b/pkg/operator/cluster/cluster_test.go
@@ -39,15 +39,16 @@ func TestCreateSecrets(t *testing.T) {
 		response := "{\"key\":\"mysecurekey\"}"
 		return []byte(response), "", nil
 	}
-	spec := Spec{Namespace: "ns", Version: "myversion"}
-	c := New(spec, factory, clientset)
+	c := &Cluster{Spec: Spec{VersionTag: "myversion"}}
+	c.Name = "myrook"
+	c.Init(factory, clientset)
 	c.dataDir = "/tmp/testdir"
 	defer os.RemoveAll(c.dataDir)
 
 	err := c.createClientAccess(info)
 	assert.Nil(t, err)
 
-	secretName := fmt.Sprintf("%s-rbd-user", spec.Namespace)
+	secretName := fmt.Sprintf("%s-rbd-user", c.Name)
 	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName)
 	assert.Nil(t, err)
 	assert.Equal(t, secretName, secret.Name)

--- a/pkg/operator/cluster/cluster_test.go
+++ b/pkg/operator/cluster/cluster_test.go
@@ -41,6 +41,7 @@ func TestCreateSecrets(t *testing.T) {
 	}
 	c := &Cluster{Spec: Spec{VersionTag: "myversion"}}
 	c.Name = "myrook"
+	c.Namespace = "myns"
 	c.Init(factory, clientset)
 	c.dataDir = "/tmp/testdir"
 	defer os.RemoveAll(c.dataDir)
@@ -48,7 +49,7 @@ func TestCreateSecrets(t *testing.T) {
 	err := c.createClientAccess(info)
 	assert.Nil(t, err)
 
-	secretName := fmt.Sprintf("%s-rbd-user", c.Name)
+	secretName := fmt.Sprintf("%s-rbd-user", c.Namespace)
 	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName)
 	assert.Nil(t, err)
 	assert.Equal(t, secretName, secret.Name)

--- a/pkg/operator/cluster/pool.go
+++ b/pkg/operator/cluster/pool.go
@@ -33,8 +33,8 @@ const (
 )
 
 type Pool struct {
-	Metadata v1.ObjectMeta `json:"metadata,omitempty"`
-	PoolSpec `json:"spec"`
+	v1.ObjectMeta `json:"metadata,omitempty"`
+	PoolSpec      `json:"spec"`
 }
 
 // Instantiate a new pool
@@ -46,26 +46,26 @@ func NewPool(spec PoolSpec) *Pool {
 func (p *Pool) Create(rclient rookclient.RookRestClient) error {
 	// validate the pool settings
 	if err := p.validate(); err != nil {
-		return fmt.Errorf("invalid pool %s arguments. %+v", p.PoolSpec.Name, err)
+		return fmt.Errorf("invalid pool %s arguments. %+v", p.Name, err)
 	}
 
 	// check if the pool already exists
 	exists, err := p.exists(rclient)
 	if err == nil && exists {
-		logger.Infof("pool %s already exists in namespace %s", p.PoolSpec.Name, p.PoolSpec.Namespace)
+		logger.Infof("pool %s already exists in namespace %s", p.Name, p.Namespace)
 		return nil
 	}
 
 	// create the pool
-	pool := model.Pool{Name: p.PoolSpec.Name}
+	pool := model.Pool{Name: p.Name}
 	r := p.replication()
 	if r != nil {
-		logger.Infof("creating pool %s in namespace %s with replicas %d", p.PoolSpec.Name, p.Namespace, r.Count)
+		logger.Infof("creating pool %s in namespace %s with replicas %d", p.Name, p.Namespace, r.Count)
 		pool.ReplicationConfig.Size = r.Count
 		pool.Type = model.Replicated
 	} else {
 		ec := p.erasureCode()
-		logger.Infof("creating pool %s in namespace %s. coding chunks = %d, data chunks = %d", p.PoolSpec.Name, p.Namespace, ec.CodingChunks, ec.DataChunks)
+		logger.Infof("creating pool %s in namespace %s. coding chunks = %d, data chunks = %d", p.Name, p.Namespace, ec.CodingChunks, ec.DataChunks)
 		pool.ErasureCodedConfig.CodingChunkCount = ec.CodingChunks
 		pool.ErasureCodedConfig.DataChunkCount = ec.DataChunks
 		pool.Type = model.ErasureCoded
@@ -73,10 +73,10 @@ func (p *Pool) Create(rclient rookclient.RookRestClient) error {
 
 	info, err := rclient.CreatePool(pool)
 	if err != nil {
-		return fmt.Errorf("failed to create pool %s. %+v", p.PoolSpec.Name, err)
+		return fmt.Errorf("failed to create pool %s. %+v", p.Name, err)
 	}
 
-	logger.Infof("created pool %s. %s", p.PoolSpec.Name, info)
+	logger.Infof("created pool %s. %s", p.Name, info)
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (p *Pool) Delete(rclient rookclient.RookRestClient) error {
 		return nil
 	}
 
-	logger.Infof("TODO: delete pool %s from namespace %s", p.PoolSpec.Name, p.PoolSpec.Namespace)
+	logger.Infof("TODO: delete pool %s from namespace %s", p.Name, p.Namespace)
 	//return p.client.DeletePool(p.PoolSpec.Name)
 	return nil
 }
@@ -100,7 +100,7 @@ func (p *Pool) exists(rclient rookclient.RookRestClient) (bool, error) {
 		return false, err
 	}
 	for _, pool := range pools {
-		if pool.Name == p.PoolSpec.Name {
+		if pool.Name == p.Name {
 			return true, nil
 		}
 	}
@@ -109,10 +109,10 @@ func (p *Pool) exists(rclient rookclient.RookRestClient) (bool, error) {
 
 // Validate the pool arguments
 func (p *Pool) validate() error {
-	if p.PoolSpec.Name == "" {
+	if p.Name == "" {
 		return fmt.Errorf("missing name")
 	}
-	if p.PoolSpec.Namespace == "" {
+	if p.Namespace == "" {
 		return fmt.Errorf("missing namespace")
 	}
 	if p.replication() != nil && p.erasureCode() != nil {

--- a/pkg/operator/cluster/pool.go
+++ b/pkg/operator/cluster/pool.go
@@ -52,16 +52,17 @@ func (p *Pool) Create(rclient rookclient.RookRestClient) error {
 	// check if the pool already exists
 	exists, err := p.exists(rclient)
 	if err == nil && exists {
-		logger.Infof("pool %s already exists in namespace %s", p.Name, p.Namespace)
+		logger.Infof("pool %s already exists in namespace %s ", p.Name, p.Namespace)
 		return nil
 	}
 
 	// create the pool
 	pool := model.Pool{Name: p.Name}
+
 	r := p.replication()
 	if r != nil {
-		logger.Infof("creating pool %s in namespace %s with replicas %d", p.Name, p.Namespace, r.Count)
-		pool.ReplicationConfig.Size = r.Count
+		logger.Infof("creating pool %s in namespace %s with replicas %d", p.Name, p.Namespace, r.Size)
+		pool.ReplicationConfig.Size = r.Size
 		pool.Type = model.Replicated
 	} else {
 		ec := p.erasureCode()
@@ -125,7 +126,7 @@ func (p *Pool) validate() error {
 }
 
 func (p *Pool) replication() *ReplicationSpec {
-	if p.PoolSpec.Replication.Count > 0 {
+	if p.PoolSpec.Replication.Size > 0 {
 		return &p.PoolSpec.Replication
 	}
 	return nil

--- a/pkg/operator/cluster/pool_test.go
+++ b/pkg/operator/cluster/pool_test.go
@@ -46,7 +46,7 @@ func TestValidatePool(t *testing.T) {
 
 	// must not specify both replication and EC settings
 	p = Pool{ObjectMeta: v1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
-	p.Replication.Count = 1
+	p.Replication.Size = 1
 	p.ErasureCoding.CodingChunks = 2
 	p.ErasureCoding.DataChunks = 3
 	err = p.validate()
@@ -54,7 +54,7 @@ func TestValidatePool(t *testing.T) {
 
 	// succeed with replication settings
 	p = Pool{ObjectMeta: v1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
-	p.Replication.Count = 1
+	p.Replication.Size = 1
 	err = p.validate()
 	assert.Nil(t, err)
 
@@ -69,7 +69,7 @@ func TestValidatePool(t *testing.T) {
 func TestCreatePool(t *testing.T) {
 	rclient := &test.MockRookRestClient{}
 	p := Pool{ObjectMeta: v1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
-	p.Replication.Count = 1
+	p.Replication.Size = 1
 
 	exists, err := p.exists(rclient)
 	assert.False(t, exists)
@@ -83,7 +83,7 @@ func TestCreatePool(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// succeed with EC
-	p.Replication.Count = 0
+	p.Replication.Size = 0
 	err = p.Create(rclient)
 	assert.Nil(t, err)
 }

--- a/pkg/operator/cluster/spec.go
+++ b/pkg/operator/cluster/spec.go
@@ -40,13 +40,6 @@ type Spec struct {
 }
 
 type PoolSpec struct {
-	// The name of the pool. Defined in the spec since the object metadata name must be unique across all namespaces,
-	// while you could have the same pool name created in multiple instances of rook.
-	Name string `json:"name"`
-
-	// The namespace where the pool will be created (required). A Rook cluster must be running in this namespace.
-	Namespace string `json:"namespace"`
-
 	// The replication settings
 	Replication ReplicationSpec `json:"replication"`
 

--- a/pkg/operator/cluster/spec.go
+++ b/pkg/operator/cluster/spec.go
@@ -21,13 +21,10 @@ package cluster
 import "github.com/rook/rook/pkg/operator/osd"
 
 type Spec struct {
-	// The namespace where the the rook resources will all be created.
-	Namespace string `json:"namespace"`
-
-	// Version is the expected version of the rook container to run in the cluster.
+	// VersionTag is the expected version of the rook container to run in the cluster.
 	// The operator will eventually make the rook cluster version
 	// equal to the expected version.
-	Version string `json:"version"`
+	VersionTag string `json:"versionTag"`
 
 	// Paused is to pause the control of the operator for the rook cluster.
 	Paused bool `json:"paused,omitempty"`
@@ -49,7 +46,7 @@ type PoolSpec struct {
 
 type ReplicationSpec struct {
 	// Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-	Count uint `json:"count"`
+	Size uint `json:"size"`
 }
 
 type ErasureCodeSpec struct {

--- a/pkg/operator/cluster_test.go
+++ b/pkg/operator/cluster_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package operator
+
+import (
+	"testing"
+
+	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrackCluster(t *testing.T) {
+	context := &context{}
+	mgr := newClusterManager(context, []inclusterInitiator{})
+
+	c1 := &cluster.Cluster{}
+	c1.Name = "myname"
+	c1.Namespace = "myns"
+	c1.ResourceVersion = "23"
+
+	// not tracked yet
+	checkClusterTracked(t, mgr, c1, false, false)
+
+	// track the cluster
+	err := mgr.startTrack(c1)
+	assert.Nil(t, err)
+	checkClusterTracked(t, mgr, c1, true, true)
+
+	// do not support muliple clusters in the same namespace
+	c2 := &cluster.Cluster{}
+	c2.Name = "myothername"
+	c2.Namespace = "myns"
+	c2.ResourceVersion = "24"
+	err = mgr.startTrack(c2)
+	assert.NotNil(t, err)
+	checkClusterTracked(t, mgr, c2, false, true)
+
+	// stop tracking the cluster
+	mgr.stopTrack(c1)
+	checkClusterTracked(t, mgr, c1, false, false)
+}
+
+func checkClusterTracked(t *testing.T, mgr *clusterManager, c *cluster.Cluster, nameTracked, namespaceTracked bool) {
+	trackedCluster, clusterOK := mgr.clusters[c.Namespace]
+	version, trackerOK := mgr.tracker.clusterRVs[c.Namespace]
+	assert.Equal(t, namespaceTracked, clusterOK)
+	assert.Equal(t, namespaceTracked, trackerOK)
+	if nameTracked {
+		assert.Equal(t, c.Name, trackedCluster.Name)
+		assert.Equal(t, c.ResourceVersion, version)
+	}
+	if namespaceTracked && !nameTracked {
+		assert.NotEqual(t, c.Name, trackedCluster.Name)
+		assert.NotEqual(t, c.ResourceVersion, version)
+	}
+}

--- a/pkg/operator/event.go
+++ b/pkg/operator/event.go
@@ -50,6 +50,10 @@ func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *unversioned.Status
 		return nil, nil, fmt.Errorf("failed to poll cluster event. %+v", err)
 	}
 
+	if status != nil {
+		return nil, status, nil
+	}
+
 	ev := &clusterEvent{
 		Type:   re.Type,
 		Object: &cluster.Cluster{},
@@ -65,6 +69,10 @@ func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *unversioned.Status, erro
 	re, status, err := pollEvent(decoder)
 	if err != nil {
 		return nil, status, fmt.Errorf("failed to poll pool event. %+v", err)
+	}
+
+	if status != nil {
+		return nil, status, nil
 	}
 
 	ev := &poolEvent{
@@ -94,6 +102,7 @@ func pollEvent(decoder *json.Decoder) (*rawEvent, *unversioned.Status, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("fail to decode (%s) into unversioned.Status (%v)", re.Object, err)
 		}
+		logger.Infof("returning pollEvent status %+v", status)
 		return nil, status, nil
 	}
 

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -38,6 +38,7 @@ const (
 )
 
 type Cluster struct {
+	Name      string
 	Namespace string
 	Version   string
 	Replicas  int32
@@ -45,8 +46,9 @@ type Cluster struct {
 	dataDir   string
 }
 
-func New(namespace, version string, factory client.ConnectionFactory) *Cluster {
+func New(name, namespace, version string, factory client.ConnectionFactory) *Cluster {
 	return &Cluster{
+		Name:      name,
 		Namespace: namespace,
 		Version:   version,
 		Replicas:  1,
@@ -163,7 +165,7 @@ func (c *Cluster) mdsContainer(id string) v1.Container {
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOKD_MDS_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: keyringName}}},
-			opmon.ClusterNameEnvVar(),
+			opmon.ClusterNameEnvVar(c.Name),
 			opmon.MonEndpointEnvVar(),
 			opmon.MonSecretEnvVar(),
 			opmon.AdminSecretEnvVar(),

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -39,7 +39,7 @@ func TestStartMDS(t *testing.T) {
 		return []byte(response), "", nil
 	}
 
-	c := New("ns", "myversion", factory)
+	c := New("myname", "ns", "myversion", factory)
 	c.dataDir = "/tmp/mdstest"
 	defer os.RemoveAll(c.dataDir)
 
@@ -66,7 +66,7 @@ func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 }
 
 func TestPodSpecs(t *testing.T) {
-	c := New("ns", "myversion", nil)
+	c := New("myname", "ns", "myversion", nil)
 	mdsID := "mds1"
 
 	d := c.makeDeployment(mdsID)

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -45,9 +45,9 @@ const (
 )
 
 type Cluster struct {
+	Name            string
 	Namespace       string
 	Keyring         string
-	ClusterName     string
 	Version         string
 	MasterHost      string
 	Size            int
@@ -70,11 +70,12 @@ type MonConfig struct {
 	Port int32
 }
 
-func New(clientset kubernetes.Interface, factory client.ConnectionFactory, namespace, dataDirHostPath, version string) *Cluster {
+func New(clientset kubernetes.Interface, factory client.ConnectionFactory, name, namespace, dataDirHostPath, version string) *Cluster {
 	return &Cluster{
 		clientset:       clientset,
 		factory:         factory,
 		dataDirHostPath: dataDirHostPath,
+		Name:            name,
 		Namespace:       namespace,
 		Version:         version,
 		Size:            3,

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -32,7 +32,7 @@ import (
 func TestStartMonPods(t *testing.T) {
 	clientset := test.New(3)
 	factory := &testclient.MockConnectionFactory{Fsid: "fsid", SecretKey: "mysecret"}
-	c := New(clientset, factory, "ns", "", "myversion")
+	c := New(clientset, factory, "myname", "ns", "", "myversion")
 	c.maxRetries = 1
 	c.retryDelay = 0
 
@@ -79,7 +79,7 @@ func validateStart(t *testing.T, c *Cluster) {
 
 func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(1)
-	c := New(clientset, nil, "ns", "", "myversion")
+	c := New(clientset, nil, "myname", "ns", "", "myversion")
 	c.clusterInfo = test.CreateClusterInfo(1)
 
 	// create the initial config map
@@ -103,7 +103,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 func TestCheckHealth(t *testing.T) {
 	clientset := test.New(1)
 	factory := &testclient.MockConnectionFactory{Fsid: "fsid", SecretKey: "mysecret"}
-	c := New(clientset, factory, "ns", "", "myversion")
+	c := New(clientset, factory, "myname", "ns", "", "myversion")
 	c.retryDelay = 1
 	c.maxRetries = 1
 	c.clusterInfo = test.CreateClusterInfo(1)

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -23,9 +23,8 @@ import (
 	"k8s.io/client-go/pkg/labels"
 )
 
-func ClusterNameEnvVar() v1.EnvVar {
-	ref := &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}
-	return v1.EnvVar{Name: "ROOKD_CLUSTER_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: ref}}
+func ClusterNameEnvVar(name string) v1.EnvVar {
+	return v1.EnvVar{Name: "ROOKD_CLUSTER_NAME", Value: name}
 }
 
 func MonEndpointEnvVar() v1.EnvVar {
@@ -104,7 +103,7 @@ func (c *Cluster) monContainer(config *MonConfig, fsid string) v1.Container {
 		},
 		Env: []v1.EnvVar{
 			{Name: k8sutil.PodIPEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}},
-			ClusterNameEnvVar(),
+			ClusterNameEnvVar(c.Name),
 			MonEndpointEnvVar(),
 			MonSecretEnvVar(),
 			AdminSecretEnvVar(),

--- a/pkg/operator/mon/pod_test.go
+++ b/pkg/operator/mon/pod_test.go
@@ -33,7 +33,7 @@ func TestPodSpecs(t *testing.T) {
 
 func testPodSpec(t *testing.T, dataDir string) {
 	clientset := testop.New(1)
-	c := New(clientset, nil, "ns", dataDir, "myversion")
+	c := New(clientset, nil, "myname", "ns", dataDir, "myversion")
 	c.clusterInfo = testop.CreateClusterInfo(0)
 	config := &MonConfig{Name: "mon0", Port: 6790}
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -44,7 +44,6 @@ var (
 
 type context struct {
 	clientset   kubernetes.Interface
-	namespace   string
 	retryDelay  int
 	maxRetries  int
 	masterHost  string
@@ -60,9 +59,8 @@ type Operator struct {
 	clusterMgr *clusterManager
 }
 
-func New(host, namespace string, factory client.ConnectionFactory, clientset kubernetes.Interface) *Operator {
+func New(host string, factory client.ConnectionFactory, clientset kubernetes.Interface) *Operator {
 	context := &context{
-		namespace:  namespace,
 		masterHost: host,
 		factory:    factory,
 		clientset:  clientset,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -80,6 +80,7 @@ func New(host, namespace string, factory client.ConnectionFactory, clientset kub
 }
 
 func (o *Operator) Run() error {
+
 	for {
 		err := o.initResources()
 		if err == nil {
@@ -90,7 +91,8 @@ func (o *Operator) Run() error {
 	}
 
 	// watch for changes to the rook clusters
-	return o.clusterMgr.BeginWatch()
+	o.clusterMgr.Manage()
+	return nil
 }
 
 func (o *Operator) initResources() error {
@@ -103,10 +105,6 @@ func (o *Operator) initResources() error {
 	err = createTPRs(o.context, o.tprSchemes)
 	if err != nil {
 		return fmt.Errorf("failed to create TPR. %+v", err)
-	}
-
-	if err := o.clusterMgr.Load(); err != nil {
-		return fmt.Errorf("failed to load cluster. %+v", err)
 	}
 
 	return nil

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestCreateCluster(t *testing.T) {
 	clientset := test.New(3)
-	o := New("foo", "rook", nil, clientset)
+	o := New("foo", nil, clientset)
 	o.context.retryDelay = 1
 
 	// fail to init k8s client since we're not actually inside k8s

--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -38,6 +38,7 @@ const (
 
 type Cluster struct {
 	clientset       kubernetes.Interface
+	Name            string
 	Namespace       string
 	Keyring         string
 	Version         string
@@ -45,9 +46,10 @@ type Cluster struct {
 	dataDirHostPath string
 }
 
-func New(clientset kubernetes.Interface, namespace, version string, storageSpec StorageSpec, dataDirHostPath string) *Cluster {
+func New(clientset kubernetes.Interface, name, namespace, version string, storageSpec StorageSpec, dataDirHostPath string) *Cluster {
 	return &Cluster{
 		clientset:       clientset,
+		Name:            name,
 		Namespace:       namespace,
 		Version:         version,
 		Storage:         storageSpec,
@@ -168,7 +170,7 @@ func (c *Cluster) osdContainer(devices []Device, directories []Directory, select
 	command := "/usr/bin/rookd osd"
 
 	envVars := []v1.EnvVar{
-		opmon.ClusterNameEnvVar(),
+		opmon.ClusterNameEnvVar(c.Name),
 		opmon.MonEndpointEnvVar(),
 		opmon.MonSecretEnvVar(),
 		opmon.AdminSecretEnvVar(),

--- a/pkg/operator/osd/osd_test.go
+++ b/pkg/operator/osd/osd_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestStartDaemonset(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	c := New(clientset, "ns", "myversion", StorageSpec{}, "")
+	c := New(clientset, "myname", "ns", "myversion", StorageSpec{}, "")
 
 	// Start the first time
 	err := c.Start()
@@ -56,7 +56,7 @@ func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool)
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(clientset, "ns", "myversion", storageSpec, dataDir)
+	c := New(clientset, "myname", "ns", "myversion", storageSpec, dataDir)
 
 	n := c.Storage.resolveNode(storageSpec.Nodes[0].Name)
 	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Directories, n.Selection, n.Config)
@@ -131,7 +131,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(clientset, "ns", "myversion", storageSpec, "")
+	c := New(clientset, "myname", "ns", "myversion", storageSpec, "")
 
 	n := c.Storage.resolveNode(storageSpec.Nodes[0].Name)
 	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Directories, n.Selection, n.Config)
@@ -173,7 +173,7 @@ func TestStorageSpecConfig(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(clientset, "ns", "myversion", storageSpec, "")
+	c := New(clientset, "myname", "ns", "myversion", storageSpec, "")
 
 	n := c.Storage.resolveNode(storageSpec.Nodes[0].Name)
 	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Directories, n.Selection, n.Config)

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -37,6 +37,7 @@ const (
 )
 
 type Cluster struct {
+	Name      string
 	Namespace string
 	Version   string
 	Replicas  int32
@@ -45,10 +46,11 @@ type Cluster struct {
 	clientset kubernetes.Interface
 }
 
-func New(clientset kubernetes.Interface, factory client.ConnectionFactory, namespace, version string) *Cluster {
+func New(clientset kubernetes.Interface, factory client.ConnectionFactory, name, namespace, version string) *Cluster {
 	return &Cluster{
 		clientset: clientset,
 		factory:   factory,
+		Name:      name,
 		Namespace: namespace,
 		Version:   version,
 		Replicas:  2,
@@ -171,7 +173,7 @@ func (c *Cluster) rgwContainer() v1.Container {
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOKD_RGW_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: keyringName}}},
-			opmon.ClusterNameEnvVar(),
+			opmon.ClusterNameEnvVar(c.Name),
 			opmon.MonEndpointEnvVar(),
 			opmon.MonSecretEnvVar(),
 			opmon.AdminSecretEnvVar(),

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -41,7 +41,7 @@ func TestStartRGW(t *testing.T) {
 		return []byte(response), "", nil
 	}
 
-	c := New(clientset, factory, "ns", "version")
+	c := New(clientset, factory, "myname", "ns", "version")
 	c.dataDir = "/tmp/rgwtest"
 	defer os.RemoveAll(c.dataDir)
 
@@ -76,7 +76,7 @@ func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 }
 
 func TestPodSpecs(t *testing.T) {
-	c := New(nil, nil, "ns", "myversion")
+	c := New(nil, nil, "myname", "ns", "myversion")
 
 	d := c.makeDeployment()
 	assert.NotNil(t, d)

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -49,8 +49,8 @@ type inclusterInitiator interface {
 
 type tprManager interface {
 	Load() error
-	BeginWatch() error
-	EndWatch() error
+	Watch() error
+	Manage()
 }
 
 func qualifiedName(tpr tprScheme) string {

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
@@ -37,18 +38,26 @@ const (
 	tprVersion = "v1alpha1"
 )
 
-type TPR interface {
+type tprScheme interface {
 	Name() string
 	Description() string
-	Load() error
-	Watch() error
 }
 
-func qualifiedName(tpr TPR) string {
+type inclusterInitiator interface {
+	Create(clusterMgr *clusterManager, namespace string) (tprManager, error)
+}
+
+type tprManager interface {
+	Load() error
+	BeginWatch() error
+	EndWatch() error
+}
+
+func qualifiedName(tpr tprScheme) string {
 	return fmt.Sprintf("%s.%s", tpr.Name(), tprGroup)
 }
 
-func createTPRs(context *context, tprs []TPR) error {
+func createTPRs(context *context, tprs []tprScheme) error {
 	for _, tpr := range tprs {
 		if err := createTPR(context, tpr); err != nil {
 			return fmt.Errorf("failed to init tpr %s. %+v", tpr.Name(), err)
@@ -64,7 +73,7 @@ func createTPRs(context *context, tprs []TPR) error {
 	return nil
 }
 
-func createTPR(context *context, tpr TPR) error {
+func createTPR(context *context, tpr tprScheme) error {
 	logger.Infof("creating %s TPR", tpr.Name())
 	r := &v1beta1.ThirdPartyResource{
 		ObjectMeta: v1.ObjectMeta{
@@ -85,9 +94,9 @@ func createTPR(context *context, tpr TPR) error {
 	return nil
 }
 
-func waitForTPRInit(context *context, tpr TPR) error {
+func waitForTPRInit(context *context, tpr tprScheme) error {
 	restcli := context.clientset.CoreV1().RESTClient()
-	uri := tprURI(context, tpr.Name())
+	uri := tprURI(tpr.Name(), context.namespace)
 	return k8sutil.Retry(time.Duration(context.retryDelay)*time.Second, context.maxRetries, func() (bool, error) {
 		_, err := restcli.Get().RequestURI(uri).DoRaw()
 		if err != nil {
@@ -101,18 +110,18 @@ func waitForTPRInit(context *context, tpr TPR) error {
 	})
 }
 
-func watchTPR(context *context, name string, resourceVersion string) (*http.Response, error) {
+func watchTPR(context *context, name, namespace, resourceVersion string) (*http.Response, error) {
 	return context.kubeHttpCli.Get(fmt.Sprintf("%s/%s?watch=true&resourceVersion=%s",
-		context.masterHost, tprURI(context, name), resourceVersion))
+		context.masterHost, tprURI(name, namespace), resourceVersion))
 }
 
-func tprURI(context *context, name string) string {
-	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%ss", tprGroup, tprVersion, context.namespace, name)
+func tprURI(name, namespace string) string {
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%ss", tprGroup, tprVersion, namespace, name)
 }
 
-func getRawList(context *context, tpr TPR) ([]byte, error) {
-	restcli := context.clientset.CoreV1().RESTClient()
-	return restcli.Get().RequestURI(tprURI(context, tpr.Name())).DoRaw()
+func getRawList(clientset kubernetes.Interface, name, namespace string) ([]byte, error) {
+	restcli := clientset.CoreV1().RESTClient()
+	return restcli.Get().RequestURI(tprURI(name, namespace)).DoRaw()
 }
 
 func handlePollEventResult(status *unversioned.Status, errIn error, checkStaleCache func() (bool, error), errCh chan error) (done bool, err error) {

--- a/pkg/operator/tracker.go
+++ b/pkg/operator/tracker.go
@@ -34,8 +34,19 @@ func newTPRTracker() *tprTracker {
 }
 
 func (t *tprTracker) add(name, version string) {
-	t.stopChMap[name] = make(chan struct{})
 	t.clusterRVs[name] = version
+	if _, ok := t.stopChMap[name]; !ok {
+		t.stopChMap[name] = make(chan struct{})
+	}
+}
+
+func (t *tprTracker) remove(name string) {
+	delete(t.clusterRVs, name)
+
+	if stopCh, ok := t.stopChMap[name]; ok {
+		close(stopCh)
+	}
+	delete(t.stopChMap, name)
 }
 
 func (t *tprTracker) stop() {


### PR DESCRIPTION
- The pool tpr name and namespace are now used from the metadata instead of the spec. 
- The cluster tpr name now is used from the metadata, which name will be the namespace that is created for the cluster.

Fixes #492, #522, and #526