### PR TITLE
build: workaround for shared download dir

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -52,14 +52,18 @@ ifeq ($(CCACHE),1)
 endif
 
 # The working directory where build generated files are stored
-WORKDIR ?= .work
+WORKDIR ?= $(abspath .work)
 BUILDDIR= $(WORKDIR)/build
 
 # A directory to hold files that are downloaded
 # as part of the build process but are immutable and do not
 # vary across build runs. These are can be cleaned with
 # "make distclean"
-DOWNLOADDIR ?= .download
+DOWNLOADDIR ?= $(abspath .download)
+
+# workaround races with cmake by copying the download dirs
+# to a private directory
+PRIVATE_DOWNLOADDIR = $(WORKDIR)/download
 
 # The host platform
 HOST = $(shell gcc -dumpmachine)
@@ -69,14 +73,16 @@ HOST = $(shell gcc -dumpmachine)
 
 define build-platform
 build.$(1):
+	@mkdir -p $(PRIVATE_DOWNLOADDIR)/$(1)
 	@mkdir -p $(DOWNLOADDIR)
+	@cp -a $(DOWNLOADDIR)/. $(PRIVATE_DOWNLOADDIR)/$(1)
 	@cmake \
 		-H$(CURDIR) \
 		-B$(BUILDDIR)/$(1) \
 		-DALLOCATOR=$(ALLOCATOR) \
 		-DCEPH_BRANCH=$(CEPH_BRANCH) \
 		-DEXTERNAL_ALWAYS_BUILD=$(ALWAYS_BUILD) \
-		-DEXTERNAL_DOWNLOAD_DIR=$(DOWNLOADDIR)/$(1) \
+		-DEXTERNAL_DOWNLOAD_DIR=$(PRIVATE_DOWNLOADDIR)/$(1) \
 		-DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/toolchain/$(1).cmake \
 		-DEXTERNAL_LOGGING=$(EXTERNAL_LOGGING) \
 		-DEXTERNAL_CCACHE=$(EXTERNAL_CCACHE) \
@@ -84,6 +90,7 @@ build.$(1):
 		-DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
 	@+$(MAKE) -C $(BUILDDIR)/$(1)
+	@cp -na $(PRIVATE_DOWNLOADDIR)/$(1)/. $(DOWNLOADDIR)
 endef
 
 $(foreach p,$(PLATFORMS),$(eval $(call build-platform,$(p))))

--- a/external/packages/aio/CMakeLists.txt
+++ b/external/packages/aio/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See https://git.fedorahosted.org/cgit/libaio.git/
 set(Aio_VERSION 0.3.110)
 set(Aio_URL http://ftp.us.debian.org/debian/pool/main/liba/libaio/libaio_${Aio_VERSION}.orig.tar.gz)
+set(Aio_SHA256 e019028e631725729376250e32b473012f7cb68e1f7275bfc1bbcdd0f8745f7e)
 
 message(STATUS "External: Building libaio ${Aio_VERSION}")
 
@@ -22,11 +23,11 @@ message(STATUS "External: Building libaio ${Aio_VERSION}")
 # Build
 #
 
-
 ExternalProject_Add(aio
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Aio_URL}
+  URL_HASH SHA256=${Aio_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   BUILD_IN_SOURCE 1

--- a/external/packages/gperftools/CMakeLists.txt
+++ b/external/packages/gperftools/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See https://github.com/gperftools/gperftools
 set(Gperftools_VERSION 2.5)
 set(Gperftools_URL https://github.com/gperftools/gperftools/releases/download/gperftools-${Gperftools_VERSION}/gperftools-${Gperftools_VERSION}.tar.gz)
+set(Gperftools_SHA256 6fa2748f1acdf44d750253e160cf6e2e72571329b42e563b455bde09e9e85173)
 
 message(STATUS "External: Building gperftools ${Gperftools_VERSION}")
 
@@ -31,6 +32,7 @@ ExternalProject_Add(gperftools
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Gperftools_URL}
+  URL_HASH SHA256=${Gperftools_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   BUILD_IN_SOURCE 1

--- a/external/packages/jemalloc/CMakeLists.txt
+++ b/external/packages/jemalloc/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See https://github.com/google/snappy
 set(Jemalloc_VERSION 4.3.1)
 set(Jemalloc_URL https://github.com/jemalloc/jemalloc/releases/download/${Jemalloc_VERSION}/jemalloc-${Jemalloc_VERSION}.tar.bz2)
+set(Jemalloc_SHA256 f7bb183ad8056941791e0f075b802e8ff10bd6e2d904e682f87c8f6a510c278b)
 
 message(STATUS "External: Building jemalloc ${Jemalloc_VERSION}")
 
@@ -32,6 +33,7 @@ ExternalProject_Add(jemalloc
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Jemalloc_URL}
+  URL_HASH SHA256=${Jemalloc_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   BUILD_IN_SOURCE 1

--- a/external/packages/rocksdb/CMakeLists.txt
+++ b/external/packages/rocksdb/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 set(Rocksdb_HASH a0deec960f3a8190831c673e5ba998fe6fb7ea90)
 set(Rocksdb_URL https://github.com/facebook/rocksdb/archive/${Rocksdb_HASH}.zip)
-
+set(Rocksdb_SHA256 c6c0226ef75fa73ead5b6bd259599cd4653fcb89e1d4aa6f22432beae9fb08b5)
 
 message(STATUS "External: Building rocksdb ${Rocksdb_HASH}")
 
@@ -31,6 +31,7 @@ ExternalProject_Add(rocksdb
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Rocksdb_URL}
+  URL_HASH SHA256=${Rocksdb_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   DOWNLOAD_NAME rocksdb-${Rocksdb_HASH}.zip

--- a/external/packages/snappy/CMakeLists.txt
+++ b/external/packages/snappy/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See https://github.com/google/snappy
 set(Snappy_VERSION 1.1.4)
 set(Snappy_URL https://github.com/google/snappy/releases/download/${Snappy_VERSION}/snappy-${Snappy_VERSION}.tar.gz)
+set(Snappy_SHA256 134bfe122fd25599bb807bb8130e7ba6d9bdb851e0b16efcb83ac4f5d0b70057)
 
 message(STATUS "External: Building snappy ${Snappy_VERSION}")
 
@@ -31,6 +32,7 @@ ExternalProject_Add(snappy
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Snappy_URL}
+  URL_HASH SHA256=${Snappy_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   BUILD_IN_SOURCE 1

--- a/external/packages/zstd/CMakeLists.txt
+++ b/external/packages/zstd/CMakeLists.txt
@@ -15,6 +15,7 @@
 # See https://github.com/facebook/zstd
 set(Zstd_VERSION 1.1.3)
 set(Zstd_URL https://github.com/facebook/zstd/archive/v${Zstd_VERSION}.tar.gz)
+set(Zstd_SHA256 106c532ae840a6ee4aee5258f04f3acab7b3e09b9e9584ebe94e4fbfd899af0a)
 
 message(STATUS "External: Building zstd ${Zstd_VERSION}")
 
@@ -26,6 +27,7 @@ ExternalProject_Add(zstd
   PREFIX ${EXTERNAL_ROOT}
 
   URL ${Zstd_URL}
+  URL_HASH SHA256=${Zstd_SHA256}
 
   DOWNLOAD_DIR ${EXTERNAL_DOWNLOAD_DIR}
   BUILD_IN_SOURCE 1


### PR DESCRIPTION
Fixes #535. Copy the external packages to a private download directory
before building, and then copy them back to the shared directory.