### PR TITLE
API: Log errors encountered when getting nodes

### DIFF
--- a/pkg/api/filesystem.go
+++ b/pkg/api/filesystem.go
@@ -36,7 +36,7 @@ func (h *Handler) GetFileSystems(w http.ResponseWriter, r *http.Request) {
 
 	filesystems, err := ceph.ListFilesystems(adminConn)
 	if err != nil {
-		logger.Errorf("failed to list pools: %+v", err)
+		logger.Errorf("failed to list file systems: %+v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/api/node.go
+++ b/pkg/api/node.go
@@ -23,6 +23,7 @@ import "net/http"
 func (h *Handler) GetNodes(w http.ResponseWriter, r *http.Request) {
 	nodes, err := h.config.ClusterHandler.GetNodes()
 	if err != nil {
+		logger.Errorf("failed to list nodes: %+v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
From a discussion on gitter: https://gitter.im/rook/rook?at=58e955297ea420cc424fbe67

I did a full audit of the API service and this is the only error condition not getting logged.