### PR TITLE
Updating dependency to support K8S 1.6

### DIFF
--- a/cmd/rook/block/block_test.go
+++ b/cmd/rook/block/block_test.go
@@ -17,6 +17,7 @@ package block
 
 import (
 	"runtime"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,7 @@ func TestBlockCommand(t *testing.T) {
 	for _, command := range Cmd.Commands() {
 		commands = append(commands, command.Name())
 	}
+	sort.Strings(commands)
 
 	if runtime.GOOS == "linux" {
 		assert.Equal(t, []string{"create", "delete", "ls", "map", "unmap"}, commands)

--- a/glide.lock
+++ b/glide.lock
@@ -1,26 +1,19 @@
-hash: 23db89af71e3e11cfa7bb7722f8dd338f3285dd87270f8e6000898662e7def08
-updated: 2017-04-03T13:42:53.811824499-07:00
+hash: 6829e27eafddc4c5cbd00da491ddbcb8a6d330b7034bee743a3b9abec260f9f9
+updated: 2017-04-11T10:57:59.04811243-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: a547fc61f48d567d5b4ec6f8aee5573d8efce11d
   repo: https://github.com/quantum/goautoneg.git
-- name: cloud.google.com/go
-  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
-  subpackages:
-  - compute/metadata
-  - internal
 - name: github.com/bassam/cgosymbolizer
   version: a74b3c0ca249abdcb8b17014df253c0dcf3e4f7e
 - name: github.com/beorn7/perks
-  version: b965b613227fddccbfffe13eae360ed3fa822f8d
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/blang/semver
-  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/coreos/etcd
-  version: a6d22b96c3813b546494cdc72160c7cb407c3297
+  version: 288bccd28878d2750aa6e89a7c3dce305a580029
   subpackages:
   - alarm
   - auth
@@ -46,12 +39,14 @@ imports:
   - pkg/adt
   - pkg/contention
   - pkg/cors
+  - pkg/cpuutil
   - pkg/crc
   - pkg/fileutil
   - pkg/httputil
   - pkg/idutil
   - pkg/ioutil
   - pkg/logutil
+  - pkg/monotime
   - pkg/netutil
   - pkg/pathutil
   - pkg/pbutil
@@ -70,29 +65,22 @@ imports:
   - version
   - wal
   - wal/walpb
-- name: github.com/coreos/go-oidc
-  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
-  subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
 - name: github.com/coreos/go-semver
   version: 568e959cd89871e61434c1143528d9162da89ef2
   subpackages:
   - semver
 - name: github.com/coreos/go-systemd
-  version: bfdc81d0d7e0fb19447b08571f63b774495251ce
+  version: 1f9909e51b2dab2487c26d64c8f2e7e580e4c9f5
   subpackages:
   - journal
 - name: github.com/coreos/pkg
-  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
+  version: 099530d80109cc4876ac866c38dded19786731d0
   subpackages:
   - capnslog
-  - health
-  - httputil
-  - timeutil
+- name: github.com/cpuguy83/go-md2man
+  version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
+  subpackages:
+  - md2man
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -103,14 +91,14 @@ imports:
   - digest
   - reference
 - name: github.com/emicklei/go-restful
-  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
   - log
   - swagger
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -120,29 +108,29 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: e18d7aa8f8c624c915db340349aad4c49b10d173
+  version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 8616e8ee5e20a1704615e6c8d7afcdac06087a67
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - jsonpb
   - proto
 - name: github.com/google/btree
-  version: 7d79101e329e5a3adf994758c578dab82b90c017
+  version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/google/gofuzz
-  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/google/uuid
-  version: f3f4b54b2fabcf1f11dcc939025bb0c109b00ed8
+  version: 6a5e28554805e78ea6141142aba763936c4761c0
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 0a192a193177452756c362c20087ddafcf6829c4
+  version: 599cba5e7b6137d46ddf58fb1765f5d928e69604
 - name: github.com/grpc-ecosystem/grpc-gateway
-  version: f52d055dc48aec25854ed7d31862f78913cf17d1
+  version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
   - runtime
   - runtime/internal
@@ -160,39 +148,42 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
-- name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: ffe929a3f4c4faeaa10f2b9535c2b1be3ad15650
+  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
   subpackages:
   - expfmt
+  - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/russross/blackfriday
+  version: 5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
+- name: github.com/shurcooL/sanitized_anchor_name
+  version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
 - name: github.com/spf13/cobra
-  version: dbb7c2d02e284aa24423e3e6e105969dffe6e4d6
-  subpackages:
-  - cobra
+  version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - name: github.com/spf13/pflag
-  version: f676131e2660dc8cd88de99f7486d34aa8172635
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - name: github.com/ugorji/go
-  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: github.com/xiang90/probing
@@ -203,7 +194,7 @@ imports:
   - bcrypt
   - blowfish
 - name: golang.org/x/net
-  version: 6acef71eb69611914f7a30939ea9f6e194c78172
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - context/ctxhttp
@@ -211,16 +202,10 @@ imports:
   - http2/hpack
   - idna
   - internal/timeseries
+  - lex/httplex
   - trace
-- name: golang.org/x/oauth2
-  version: 3c3a985cb79f52a3190fbc056984415ca6763d01
-  subpackages:
-  - google
-  - internal
-  - jws
-  - jwt
 - name: golang.org/x/sys
-  version: 9c60d1c508f5134d1ca726b4641db998f2523357
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -236,20 +221,8 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
-- name: google.golang.org/appengine
-  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
-  subpackages:
-  - internal
-  - internal/app_identity
-  - internal/base
-  - internal/datastore
-  - internal/log
-  - internal/modules
-  - internal/remote_api
-  - internal/urlfetch
-  - urlfetch
 - name: google.golang.org/grpc
-  version: 231b4cfea0e79843053a33f5fe90bd4d84b23cd3
+  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
   subpackages:
   - codes
   - credentials
@@ -263,27 +236,75 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/apimachinery
+  version: 72e51762028fdf72f1a20e59bedceece02a425c6
+  subpackages:
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/openapi
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/types
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/net
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  version: fab6dd31b869138a964fa24b7e1e2139bd2ba3a0
   subpackages:
   - discovery
   - discovery/fake
   - kubernetes
   - kubernetes/fake
+  - kubernetes/scheme
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/apps/v1beta1/fake
+  - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1/fake
   - kubernetes/typed/authentication/v1beta1
   - kubernetes/typed/authentication/v1beta1/fake
+  - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1/fake
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/authorization/v1beta1/fake
   - kubernetes/typed/autoscaling/v1
   - kubernetes/typed/autoscaling/v1/fake
+  - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/autoscaling/v2alpha1/fake
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v1/fake
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/batch/v2alpha1/fake
-  - kubernetes/typed/certificates/v1alpha1
-  - kubernetes/typed/certificates/v1alpha1/fake
+  - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/certificates/v1beta1/fake
   - kubernetes/typed/core/v1
   - kubernetes/typed/core/v1/fake
   - kubernetes/typed/extensions/v1beta1
@@ -292,39 +313,39 @@ imports:
   - kubernetes/typed/policy/v1beta1/fake
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1alpha1/fake
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/rbac/v1beta1/fake
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/settings/v1alpha1/fake
+  - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1/fake
   - kubernetes/typed/storage/v1beta1
   - kubernetes/typed/storage/v1beta1/fake
   - pkg/api
-  - pkg/api/errors
   - pkg/api/install
-  - pkg/api/meta
-  - pkg/api/meta/metatypes
-  - pkg/api/resource
-  - pkg/api/unversioned
   - pkg/api/v1
-  - pkg/api/validation/path
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
   - pkg/apis/apps
   - pkg/apis/apps/install
   - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
   - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
   - pkg/apis/authentication/v1beta1
   - pkg/apis/authorization
   - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
   - pkg/apis/authorization/v1beta1
   - pkg/apis/autoscaling
   - pkg/apis/autoscaling/install
   - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
   - pkg/apis/batch
   - pkg/apis/batch/install
   - pkg/apis/batch/v1
   - pkg/apis/batch/v2alpha1
   - pkg/apis/certificates
   - pkg/apis/certificates/install
-  - pkg/apis/certificates/v1alpha1
+  - pkg/apis/certificates/v1beta1
   - pkg/apis/extensions
   - pkg/apis/extensions/install
   - pkg/apis/extensions/v1beta1
@@ -334,60 +355,33 @@ imports:
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
   - pkg/apis/storage
   - pkg/apis/storage/install
+  - pkg/apis/storage/v1
   - pkg/apis/storage/v1beta1
-  - pkg/auth/user
-  - pkg/conversion
-  - pkg/conversion/queryparams
-  - pkg/fields
-  - pkg/genericapiserver/openapi/common
-  - pkg/labels
-  - pkg/runtime
-  - pkg/runtime/serializer
-  - pkg/runtime/serializer/json
-  - pkg/runtime/serializer/protobuf
-  - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/streaming
-  - pkg/runtime/serializer/versioning
-  - pkg/selection
-  - pkg/third_party/forked/golang/reflect
-  - pkg/third_party/forked/golang/template
-  - pkg/types
   - pkg/util
-  - pkg/util/cert
-  - pkg/util/clock
-  - pkg/util/errors
-  - pkg/util/flowcontrol
-  - pkg/util/framer
-  - pkg/util/integer
-  - pkg/util/intstr
-  - pkg/util/json
-  - pkg/util/jsonpath
-  - pkg/util/labels
-  - pkg/util/net
   - pkg/util/parsers
-  - pkg/util/rand
-  - pkg/util/runtime
-  - pkg/util/sets
-  - pkg/util/uuid
-  - pkg/util/validation
-  - pkg/util/validation/field
-  - pkg/util/wait
-  - pkg/util/yaml
   - pkg/version
-  - pkg/watch
-  - pkg/watch/versioned
-  - plugin/pkg/client/auth
-  - plugin/pkg/client/auth/gcp
-  - plugin/pkg/client/auth/oidc
   - rest
+  - rest/watch
   - testing
   - tools/clientcmd/api
   - tools/metrics
   - transport
+  - util/cert
+  - util/clock
+  - util/flowcontrol
+  - util/integer
 testImports:
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
-  version: 9cc77fa25329013ce07362c7742952ff887361f2
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,14 +9,15 @@ excludeDirs:
 - scripts
 - toolbox
 import:
-- package: github.com/spf13/cobra
-  subpackages:
-  - cobra
 - package: github.com/coreos/etcd
+  version: release-3.1
   subpackages:
   - client
   - error
+- package: github.com/spf13/cobra
+  version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - package: github.com/spf13/pflag
+  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
 - package: github.com/google/uuid
 - package: github.com/go-ini/ini
 - package: github.com/ghodss/yaml
@@ -26,9 +27,11 @@ import:
   repo: https://github.com/quantum/goautoneg.git
 - package: github.com/coreos/pkg/capnslog
 - package: k8s.io/client-go
-  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  version: release-3.0
   subpackages:
   - kubernetes/typed/core/v1
+- package: k8s.io/apimachinery
+  version: release-1.6
 - package: github.com/bassam/cgosymbolizer
 - package: github.com/prometheus/client_golang
   version: v0.8.0

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/model"
 	k8smds "github.com/rook/rook/pkg/operator/mds"
 	k8srgw "github.com/rook/rook/pkg/operator/rgw"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -62,7 +63,7 @@ func (s *clusterHandler) RemoveObjectStore() error {
 
 func (s *clusterHandler) GetObjectStoreConnectionInfo() (*model.ObjectStoreConnectInfo, bool, error) {
 	logger.Infof("Getting the object store connection info")
-	service, err := s.clientset.Services(s.namespace).Get("rgw")
+	service, err := s.clientset.Services(s.namespace).Get("rgw", metav1.GetOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get rgw service. %+v", err)
 	}

--- a/pkg/api/k8s/node.go
+++ b/pkg/api/k8s/node.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 
 	"github.com/rook/rook/pkg/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 func getNodes(clientset *kubernetes.Clientset) ([]model.Node, error) {
 	nodes := []model.Node{}
-	options := v1.ListOptions{}
+	options := metav1.ListOptions{}
 	nl, err := clientset.Nodes().List(options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nodes. %+v", err)

--- a/pkg/cephmgr/osd/agent_test.go
+++ b/pkg/cephmgr/osd/agent_test.go
@@ -168,7 +168,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig StoreConfig) {
 	// wait for the async osds to complete
 	<-agent.osdsCompleted
 
-	assert.Equal(t, 0, agent.configCounter)
+	assert.Equal(t, int32(0), agent.configCounter)
 	assert.Equal(t, 2, outputExecCount)
 	assert.Equal(t, 2, startCount) // 2 OSD procs should be started
 	assert.Equal(t, 2, len(agent.osdProc), fmt.Sprintf("procs=%+v", agent.osdProc))
@@ -608,7 +608,7 @@ func createInventory() *inventory.Config {
 }
 
 func verifyPartitionEntry(t *testing.T, actual *PerfSchemePartitionDetails, expectedDevice string,
-	expectedSize int64, expectedOffset int64) {
+	expectedSize int, expectedOffset int) {
 
 	assert.Equal(t, expectedDevice, actual.Device)
 	assert.Equal(t, expectedSize, actual.SizeMB)

--- a/pkg/cephmgr/osd/scheme_test.go
+++ b/pkg/cephmgr/osd/scheme_test.go
@@ -108,7 +108,7 @@ func TestPopulateDistributedPerfSchemeEntry(t *testing.T) {
 	verifyMetadataDevicePartition(t, metadata, 1, entry.ID, entry.OsdUUID, DatabasePartitionType, 2, 2)
 }
 
-func verifyPartitionDetails(t *testing.T, entry *PerfSchemeEntry, partType PartitionType, device string, offset, size int64) {
+func verifyPartitionDetails(t *testing.T, entry *PerfSchemeEntry, partType PartitionType, device string, offset, size int) {
 	part, ok := entry.Partitions[partType]
 	assert.True(t, ok)
 	assert.NotNil(t, part)
@@ -118,7 +118,7 @@ func verifyPartitionDetails(t *testing.T, entry *PerfSchemeEntry, partType Parti
 }
 
 func verifyMetadataDevicePartition(t *testing.T, info *MetadataDeviceInfo, index int, osdID int, osdUUID uuid.UUID,
-	partType PartitionType, offset, size int64) {
+	partType PartitionType, offset, size int) {
 
 	part := info.Partitions[index]
 	assert.NotNil(t, part)

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -21,11 +21,12 @@ import (
 	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	opmon "github.com/rook/rook/pkg/operator/mon"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/pkg/util/intstr"
 )
 
 const (
@@ -80,7 +81,7 @@ func (c *Cluster) makeDeployment() *extensions.Deployment {
 	deployment.Namespace = c.Namespace
 
 	podSpec := v1.PodTemplateSpec{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        DeploymentName,
 			Labels:      c.getLabels(),
 			Annotations: map[string]string{},
@@ -126,7 +127,7 @@ func (c *Cluster) apiContainer() v1.Container {
 func (c *Cluster) startService() error {
 	labels := c.getLabels()
 	s := &v1.Service{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      DeploymentName,
 			Namespace: c.Namespace,
 			Labels:    labels,

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -24,6 +24,7 @@ import (
 	testop "github.com/rook/rook/pkg/operator/test"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -46,11 +47,11 @@ func TestStartAPI(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster) {
 
-	r, err := c.clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(DeploymentName)
+	r, err := c.clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(DeploymentName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, DeploymentName, r.Name)
 
-	s, err := c.clientset.CoreV1().Services(c.Namespace).Get(DeploymentName)
+	s, err := c.clientset.CoreV1().Services(c.Namespace).Get(DeploymentName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, DeploymentName, s.Name)
 }

--- a/pkg/operator/cluster.go
+++ b/pkg/operator/cluster.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rook/rook/pkg/operator/cluster"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	rookclient "github.com/rook/rook/pkg/rook/client"
-	kwatch "k8s.io/client-go/pkg/watch"
+	kwatch "k8s.io/apimachinery/pkg/watch"
 )
 
 type clusterManager struct {

--- a/pkg/operator/cluster/cluster_list.go
+++ b/pkg/operator/cluster/cluster_list.go
@@ -21,15 +21,15 @@ package cluster
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/pkg/api/unversioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterList is a list of rook clusters.
 type ClusterList struct {
-	unversioned.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	Metadata unversioned.ListMeta `json:"metadata,omitempty"`
+	Metadata metav1.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []Cluster `json:"items"`
 }

--- a/pkg/operator/cluster/cluster_test.go
+++ b/pkg/operator/cluster/cluster_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateSecrets(t *testing.T) {
@@ -50,7 +51,7 @@ func TestCreateSecrets(t *testing.T) {
 	assert.Nil(t, err)
 
 	secretName := fmt.Sprintf("%s-rbd-user", c.Namespace)
-	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName)
+	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, secretName, secret.Name)
 	assert.Equal(t, 1, len(secret.StringData))

--- a/pkg/operator/cluster/pool_list.go
+++ b/pkg/operator/cluster/pool_list.go
@@ -21,15 +21,15 @@ package cluster
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/pkg/api/unversioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // PoolList is a list of rook pools from the TPR.
 type PoolList struct {
-	unversioned.TypeMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	Metadata unversioned.ListMeta `json:"metadata,omitempty"`
+	Metadata metav1.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []Pool `json:"items"`
 }

--- a/pkg/operator/event.go
+++ b/pkg/operator/event.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/rook/rook/pkg/operator/cluster"
 
-	"k8s.io/client-go/pkg/api/unversioned"
-	kwatch "k8s.io/client-go/pkg/watch"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwatch "k8s.io/apimachinery/pkg/watch"
 )
 
 type clusterEvent struct {
@@ -44,7 +44,7 @@ type rawEvent struct {
 	Object json.RawMessage
 }
 
-func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *unversioned.Status, error) {
+func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *metav1.Status, error) {
 	re, status, err := pollEvent(decoder)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to poll cluster event. %+v", err)
@@ -65,7 +65,7 @@ func pollClusterEvent(decoder *json.Decoder) (*clusterEvent, *unversioned.Status
 	return ev, status, nil
 }
 
-func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *unversioned.Status, error) {
+func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *metav1.Status, error) {
 	re, status, err := pollEvent(decoder)
 	if err != nil {
 		return nil, status, fmt.Errorf("failed to poll pool event. %+v", err)
@@ -86,7 +86,7 @@ func pollPoolEvent(decoder *json.Decoder) (*poolEvent, *unversioned.Status, erro
 	return ev, nil, nil
 }
 
-func pollEvent(decoder *json.Decoder) (*rawEvent, *unversioned.Status, error) {
+func pollEvent(decoder *json.Decoder) (*rawEvent, *metav1.Status, error) {
 	re := &rawEvent{}
 	err := decoder.Decode(re)
 	if err != nil {
@@ -97,10 +97,10 @@ func pollEvent(decoder *json.Decoder) (*rawEvent, *unversioned.Status, error) {
 	}
 
 	if re.Type == kwatch.Error {
-		status := &unversioned.Status{}
+		status := &metav1.Status{}
 		err = json.Unmarshal(re.Object, status)
 		if err != nil {
-			return nil, nil, fmt.Errorf("fail to decode (%s) into unversioned.Status (%v)", re.Object, err)
+			return nil, nil, fmt.Errorf("fail to decode (%s) into metav1.Status (%v)", re.Object, err)
 		}
 		logger.Infof("returning pollEvent status %+v", status)
 		return nil, status, nil

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"os"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api"
-	unversionedAPI "k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -76,7 +76,7 @@ func PodWithAntiAffinity(pod *v1.Pod, attribute, value string) {
 		PodAntiAffinity: &v1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 				{
-					LabelSelector: &unversionedAPI.LabelSelector{
+					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							attribute: value,
 						},

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -24,8 +24,9 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	opmon "github.com/rook/rook/pkg/operator/mon"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/errors"
 	"k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
@@ -93,7 +94,7 @@ func (c *Cluster) Start(clientset kubernetes.Interface, cluster *mon.ClusterInfo
 }
 
 func (c *Cluster) createKeyring(clientset kubernetes.Interface, context *clusterd.DaemonContext, cluster *mon.ClusterInfo, conn client.Connection, id string) error {
-	_, err := clientset.CoreV1().Secrets(c.Namespace).Get(appName)
+	_, err := clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
 	if err == nil {
 		logger.Infof("the mds keyring was already generated")
 		return nil
@@ -113,7 +114,7 @@ func (c *Cluster) createKeyring(clientset kubernetes.Interface, context *cluster
 		keyringName: keyring,
 	}
 	secret := &v1.Secret{
-		ObjectMeta: v1.ObjectMeta{Name: appName, Namespace: c.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: c.Namespace},
 		StringData: secrets,
 		Type:       k8sutil.RookType,
 	}
@@ -131,7 +132,7 @@ func (c *Cluster) makeDeployment(id string) *extensions.Deployment {
 	deployment.Namespace = c.Namespace
 
 	podSpec := v1.PodTemplateSpec{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        appName,
 			Labels:      c.getLabels(),
 			Annotations: map[string]string{},

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -24,8 +24,8 @@ import (
 	testceph "github.com/rook/rook/pkg/cephmgr/client/test"
 	testclient "github.com/rook/rook/pkg/cephmgr/client/test"
 	testop "github.com/rook/rook/pkg/operator/test"
-
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 )
@@ -60,7 +60,7 @@ func TestStartMDS(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 
-	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get("mds")
+	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get("mds", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mds", r.Name)
 }

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -18,13 +18,12 @@ package mon
 import (
 	"testing"
 
-	"k8s.io/client-go/pkg/api/v1"
+	"os"
 
 	"github.com/rook/rook/pkg/cephmgr/client"
 	testclient "github.com/rook/rook/pkg/cephmgr/client/test"
 	"github.com/rook/rook/pkg/operator/test"
-
-	"os"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -53,20 +52,20 @@ func TestStartMonPods(t *testing.T) {
 }
 
 func validateStart(t *testing.T, c *Cluster) {
-	s, err := c.clientset.CoreV1().Secrets(c.Namespace).Get("rook-admin")
+	s, err := c.clientset.CoreV1().Secrets(c.Namespace).Get("rook-admin", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(s.StringData))
 
-	s, err = c.clientset.CoreV1().Secrets(c.Namespace).Get("mon")
+	s, err = c.clientset.CoreV1().Secrets(c.Namespace).Get("mon", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(s.StringData))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start
-	p, err := c.clientset.CoreV1().Pods(c.Namespace).Get("mon0")
+	p, err := c.clientset.CoreV1().Pods(c.Namespace).Get("mon0", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mon0", p.Name)
 
-	pods, err := c.clientset.CoreV1().Pods(c.Namespace).List(v1.ListOptions{})
+	pods, err := c.clientset.CoreV1().Pods(c.Namespace).List(metav1.ListOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(pods.Items))
 
@@ -86,7 +85,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	err := c.saveMonConfig()
 	assert.Nil(t, err)
 
-	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
+	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data["endpoints"])
 
@@ -95,7 +94,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	err = c.saveMonConfig()
 	assert.Nil(t, err)
 
-	cm, err = c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
+	cm, err = c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data["endpoints"])
 }
@@ -120,7 +119,7 @@ func TestCheckHealth(t *testing.T) {
 	err = c.failoverMon(conn, "mon1")
 	assert.Nil(t, err)
 
-	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config")
+	cm, err := c.clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mon11=:6790", cm.Data["endpoints"])
 }

--- a/pkg/operator/mon/pod.go
+++ b/pkg/operator/mon/pod.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/labels"
 )
 
 func ClusterNameEnvVar(name string) v1.EnvVar {
@@ -58,7 +59,7 @@ func (c *Cluster) makeMonPod(config *MonConfig, antiAffinity bool) *v1.Pod {
 	}
 
 	pod := &v1.Pod{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:        config.Name,
 			Namespace:   c.Namespace,
 			Labels:      c.getLabels(),
@@ -139,8 +140,8 @@ func (c *Cluster) pollPods() ([]*v1.Pod, []*v1.Pod, error) {
 	return running, pending, nil
 }
 
-func (c *Cluster) listOptions() v1.ListOptions {
-	return v1.ListOptions{
+func (c *Cluster) listOptions() metav1.ListOptions {
+	return metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
 			monClusterAttr:  c.Namespace,
 			k8sutil.AppAttr: appName,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,10 +28,10 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/rook/rook/pkg/cephmgr/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/runtime"
-	"k8s.io/client-go/pkg/runtime/serializer"
 )
 
 const (
@@ -114,7 +114,7 @@ func newHttpClient() (*rest.RESTClient, error) {
 		return nil, err
 	}
 
-	config.GroupVersion = &unversioned.GroupVersion{
+	config.GroupVersion = &schema.GroupVersion{
 		Group:   tprGroup,
 		Version: tprVersion,
 	}

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -18,10 +18,9 @@ package operator
 import (
 	"testing"
 
-	"k8s.io/client-go/pkg/api/v1"
-
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateCluster(t *testing.T) {

--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	opmon "github.com/rook/rook/pkg/operator/mon"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
 	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
@@ -113,7 +113,7 @@ func (c *Cluster) makeReplicaSet(nodeName string, devices []Device, directories 
 	rs.Namespace = c.Namespace
 
 	podSpec := c.podTemplateSpec(devices, directories, selection, config)
-	podSpec.Spec.NodeSelector = map[string]string{unversioned.LabelHostname: nodeName}
+	podSpec.Spec.NodeSelector = map[string]string{metav1.LabelHostname: nodeName}
 
 	replicaCount := int32(1)
 
@@ -149,7 +149,7 @@ func (c *Cluster) podTemplateSpec(devices []Device, directories []Directory, sel
 	}
 
 	return v1.PodTemplateSpec{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: appName,
 			Labels: map[string]string{
 				k8sutil.AppAttr:     appName,

--- a/pkg/operator/osd/osd_test.go
+++ b/pkg/operator/osd/osd_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/pkg/api/unversioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cephosd "github.com/rook/rook/pkg/cephmgr/osd"
 )
@@ -64,7 +64,7 @@ func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool)
 	assert.Equal(t, "osd-node1", replicaSet.Name)
 	assert.Equal(t, c.Namespace, replicaSet.Namespace)
 	assert.Equal(t, int32(1), *(replicaSet.Spec.Replicas))
-	assert.Equal(t, "node1", replicaSet.Spec.Template.Spec.NodeSelector[unversioned.LabelHostname])
+	assert.Equal(t, "node1", replicaSet.Spec.Template.Spec.NodeSelector[metav1.LabelHostname])
 	assert.Equal(t, v1.RestartPolicyAlways, replicaSet.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, 2, len(replicaSet.Spec.Template.Spec.Volumes))
 	assert.Equal(t, "rook-data", replicaSet.Spec.Template.Spec.Volumes[0].Name)

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -28,7 +28,7 @@ import (
 	"github.com/rook/rook/pkg/operator/cluster"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	rookclient "github.com/rook/rook/pkg/rook/client"
-	kwatch "k8s.io/client-go/pkg/watch"
+	kwatch "k8s.io/apimachinery/pkg/watch"
 )
 
 const (

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -25,8 +25,8 @@ import (
 	testclient "github.com/rook/rook/pkg/cephmgr/client/test"
 	cephrgw "github.com/rook/rook/pkg/cephmgr/rgw"
 	testop "github.com/rook/rook/pkg/operator/test"
-
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 )
@@ -60,15 +60,15 @@ func TestStartRGW(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 
-	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get("rgw")
+	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get("rgw", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "rgw", r.Name)
 
-	s, err := clientset.CoreV1().Services(c.Namespace).Get("rgw")
+	s, err := clientset.CoreV1().Services(c.Namespace).Get("rgw", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "rgw", s.Name)
 
-	secret, err := clientset.CoreV1().Secrets(c.Namespace).Get("rgw")
+	secret, err := clientset.CoreV1().Secrets(c.Namespace).Get("rgw", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "rgw", secret.Name)
 	assert.Equal(t, 1, len(secret.StringData))

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -26,10 +26,9 @@ import (
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
@@ -76,7 +75,7 @@ func createTPRs(context *context, tprs []tprScheme) error {
 func createTPR(context *context, tpr tprScheme) error {
 	logger.Infof("creating %s TPR", tpr.Name())
 	r := &v1beta1.ThirdPartyResource{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: qualifiedName(tpr),
 		},
 		Versions: []v1beta1.APIVersion{
@@ -146,7 +145,7 @@ func getRawList(clientset kubernetes.Interface, name string) ([]byte, error) {
 	return restcli.Get().RequestURI(tprURI(name)).DoRaw()
 }
 
-func handlePollEventResult(status *unversioned.Status, errIn error, checkStaleCache func() (bool, error), errCh chan error) (done bool, err error) {
+func handlePollEventResult(status *metav1.Status, errIn error, checkStaleCache func() (bool, error), errCh chan error) (done bool, err error) {
 	if errIn != nil {
 		if errIn == io.EOF { // apiserver will close stream periodically
 			logger.Debug("apiserver closed stream")

--- a/pkg/util/proc/monitoredproc_test.go
+++ b/pkg/util/proc/monitoredproc_test.go
@@ -29,44 +29,44 @@ func TestRestartDelay(t *testing.T) {
 	var zeroTime time.Time
 
 	// test cases for when last retry check time is not available
-	assert.Equal(t, 0, calcRetryDelay(0, 0, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 0, calcRetryDelay(0, 2, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 1, calcRetryDelay(2, 0, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 2, calcRetryDelay(2, 1, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 4, calcRetryDelay(2, 2, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 30, calcRetryDelay(2, 5, zeroTime, zeroTime, zeroTime))
-	assert.Equal(t, 30, calcRetryDelay(2, 100, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(0), calcRetryDelay(0, 0, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(0), calcRetryDelay(0, 2, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(1), calcRetryDelay(2, 0, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(2), calcRetryDelay(2, 1, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(4), calcRetryDelay(2, 2, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(30), calcRetryDelay(2, 5, zeroTime, zeroTime, zeroTime))
+	assert.Equal(t, float64(30), calcRetryDelay(2, 100, zeroTime, zeroTime, zeroTime))
 
 	// test cases for when last retry check is available and retry count is 0 and the process hasn't been
 	// running long at all. the time delay should be 2^(number of secs since last retry), with a max limit of 30.
 	now := time.Now()
 	lastStartTime := now
 	lastRetryCheck := now
-	assert.Equal(t, 1, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(1), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	lastRetryCheck = now.Add(-1 * time.Second)
-	assert.Equal(t, 2, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(2), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	lastRetryCheck = now.Add(-2 * time.Second)
-	assert.Equal(t, 4, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(4), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	lastRetryCheck = now.Add(-4 * time.Second)
-	assert.Equal(t, 16, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(16), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	lastRetryCheck = now.Add(-5 * time.Second)
-	assert.Equal(t, 30, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(30), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	lastRetryCheck = now.Add(-999999999 * time.Second)
-	assert.Equal(t, 30, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(30), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	// test case for when the process has been running for quite awhile.  we should not delay for very long since we
 	// are clearly not in a rapid retry loop.
 	lastStartTime = now.Add(-100 * time.Second)
-	assert.Equal(t, 1, calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(1), calcRetryDelay(2, 0, now, lastStartTime, lastRetryCheck))
 
 	// test cases for when both retry count and last retry check are available, retry count should be favored
 	lastRetryCheck = now.Add(-4 * time.Second)
-	assert.Equal(t, 2, calcRetryDelay(2, 1, now, lastStartTime, lastRetryCheck))
+	assert.Equal(t, float64(2), calcRetryDelay(2, 1, now, lastStartTime, lastRetryCheck))
 }
 
 func TestMonitoredRestart(t *testing.T) {


### PR DESCRIPTION
Updating package dependencies for Rook.
These is needed for the external volume provisioner work.
Partially fixes https://github.com/rook/rook/issues/538