### PR TITLE
Added volume provisioner to Rook

### DIFF
--- a/Documentation/k8s-block.md
+++ b/Documentation/k8s-block.md
@@ -7,17 +7,11 @@ Block storage allows you to mount storage to a single pod.
 This guide assumes you have created a Rook cluster as explained in the main [Kubernetes guide](kubernetes.md)
 
 ### Provision Storage
-Before Rook can start provisioning storage, a StorageClass and its storage pool need to be created. This is needed for Kubernetes to interoperate with Rook for provisioning persistent volumes. The rook-storageclass.yaml sample will create the storage pool automatically. For more options on pools, see the documentation on [creating storage pools](pool-tpr.md).
-
-Rook already creates a default admin and rbd user, whose secrets are specified in the sample [rook-storageclass.yaml](/demo/kubernetes/rook-storageclass.yaml). Now we just need to specify the Ceph monitor endpoints (requires `jq`):
+Before Rook can start provisioning storage, a StorageClass and its storage pool need to be created. This is needed for Kubernetes to interoperate with Rook for provisioning persistent volumes. The [rook-storageclass.yaml](/demo/kubernetes/rook-storageclass.yaml) sample will create the storage pool automatically. For more options on pools, see the documentation on [creating storage pools](pool-tpr.md).
 
 ```bash
-cd demo/kubernetes
-export MONS=$(kubectl -n rook get pod mon0 mon1 mon2 -o json|jq ".items[].status.podIP"|tr -d "\""|sed -e 's/$/:6790/'|paste -s -d, -)
-sed 's#INSERT_HERE#'$MONS'#' rook-storageclass.yaml | kubectl create -f -
-``` 
-
-**NOTE:** We are working on streamlining the experience and removing the need for this step. See [#355](https://github.com/rook/rook/issues/355).
+kubectl create -f rook-storageclass.yaml
+```
 
 ### Consume the storage
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -82,7 +82,7 @@ To clean up all the artifacts created by the demo, **first cleanup the resources
 kubectl delete deployment rook-operator
 kubectl delete -n rook rookcluster rook
 kubectl delete thirdpartyresources rookcluster.rook.io rookpool.rook.io
-kubectl delete secret rook-rbd-user
+kubectl delete secret rook-rook-user
 kubectl delete namespace rook
 ```
 If you modified the demo settings, additional cleanup is up to you for devices, host paths, etc.

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -183,7 +183,7 @@ go.validate: go.vet go.fmt
 .PHONY: go.vendor
 go.vendor $(GO_VENDOR_DIR)/vendor.stamp: $(GLIDE)
 	@mkdir -p $(GLIDE_HOME)
-	@$(GLIDE) install
+	@$(GLIDE) install --strip-vendor
 	@touch $(GO_VENDOR_DIR)/vendor.stamp
 
 $(GLIDE):

--- a/demo/kubernetes/rook-storageclass.yaml
+++ b/demo/kubernetes/rook-storageclass.yaml
@@ -17,12 +17,9 @@ kind: StorageClass
 metadata:
    name: rook-block
    namespace: rook
-provisioner: kubernetes.io/rbd
+provisioner: rook.io/block
 parameters:
-    monitors: INSERT_HERE
-    adminId: admin
-    adminSecretName: rook-admin
-    adminSecretNamespace: rook
     pool: replicapool
-    userId: rook-rbd-user
-    userSecretName: rook-rbd-user
+    # Specify the Rook cluster from which to create volumes. If not specified, it will use `rook` as the namespace and name of the cluster.
+    # clusterName: rook
+    # clusterNamespace: rook

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6829e27eafddc4c5cbd00da491ddbcb8a6d330b7034bee743a3b9abec260f9f9
-updated: 2017-04-11T10:57:59.04811243-07:00
+hash: 791fe92e4f8d196d1f28a3e4400108969dd94ddd2de0283916fa7c00646aa7a8
+updated: 2017-04-14T12:56:26.659073101-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: a547fc61f48d567d5b4ec6f8aee5573d8efce11d
@@ -13,7 +13,7 @@ imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/coreos/etcd
-  version: 288bccd28878d2750aa6e89a7c3dce305a580029
+  version: 9f7bb0df3a038b20c5b2cd0ce3ed48da8b5e3503
   subpackages:
   - alarm
   - auth
@@ -74,7 +74,7 @@ imports:
   subpackages:
   - journal
 - name: github.com/coreos/pkg
-  version: 099530d80109cc4876ac866c38dded19786731d0
+  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
   - capnslog
 - name: github.com/cpuguy83/go-md2man
@@ -114,6 +114,10 @@ imports:
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
@@ -141,6 +145,12 @@ imports:
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/kubernetes-incubator/external-storage
+  version: df6c4aaa84a6b255479404353f8480978bc3caf4
+  subpackages:
+  - lib/controller
+  - lib/leaderelection
+  - lib/leaderelection/resourcelock
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -151,6 +161,8 @@ imports:
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -175,9 +187,9 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/russross/blackfriday
-  version: 5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
+  version: b253417e1cb644d645a0a3bb1fa5034c8030127c
 - name: github.com/shurcooL/sanitized_anchor_name
-  version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
+  version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
 - name: github.com/spf13/cobra
   version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - name: github.com/spf13/pflag
@@ -262,20 +274,25 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/mergepatch
   - pkg/util/net
   - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
+  - pkg/util/strategicpatch
+  - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
+  - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: fab6dd31b869138a964fa24b7e1e2139bd2ba3a0
@@ -369,13 +386,21 @@ imports:
   - rest
   - rest/watch
   - testing
+  - tools/cache
   - tools/clientcmd/api
   - tools/metrics
+  - tools/record
   - transport
   - util/cert
   - util/clock
   - util/flowcontrol
   - util/integer
+- name: k8s.io/kubernetes
+  version: fff5156092b56e6bd60fff75aad4dc9de6b6ef37
+  subpackages:
+  - pkg/util/goroutinemap
+  - pkg/util/goroutinemap/exponentialbackoff
+  - pkg/util/version
 testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,7 @@ import:
 - package: github.com/google/uuid
 - package: github.com/go-ini/ini
 - package: github.com/ghodss/yaml
+- package: github.com/kubernetes-incubator/external-storage
 - package: github.com/gorilla/mux
 - package: bitbucket.org/ww/goautoneg
   version: a547fc61f48d567d5b4ec6f8aee5573d8efce11d

--- a/pkg/operator/cluster/cluster.go
+++ b/pkg/operator/cluster/cluster.go
@@ -129,7 +129,7 @@ func (c *Cluster) createClientAccess(clusterInfo *cephmon.ClusterInfo) error {
 	defer conn.Shutdown()
 
 	// create a user for rbd clients
-	name := fmt.Sprintf("%s-rbd-user", c.Name)
+	name := fmt.Sprintf("%s-rook-user", c.Name)
 	username := fmt.Sprintf("client.%s", name)
 	access := []string{"osd", "allow rwx", "mon", "allow r"}
 

--- a/pkg/operator/cluster/cluster_test.go
+++ b/pkg/operator/cluster/cluster_test.go
@@ -50,7 +50,7 @@ func TestCreateSecrets(t *testing.T) {
 	err := c.createClientAccess(info)
 	assert.Nil(t, err)
 
-	secretName := fmt.Sprintf("%s-rbd-user", c.Name)
+	secretName := fmt.Sprintf("%s-rook-user", c.Name)
 	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, secretName, secret.Name)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -92,7 +92,7 @@ func PodWithAntiAffinity(pod *v1.Pod, attribute, value string) {
 		panic("failed to marshal affinty struct")
 	}
 
-	pod.Annotations[api.AffinityAnnotationKey] = string(affinityb)
+	pod.Annotations[v1.AffinityAnnotationKey] = string(affinityb)
 }
 
 func SetPodVersion(pod *v1.Pod, key, version string) {

--- a/pkg/operator/provisioner.go
+++ b/pkg/operator/provisioner.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package operator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/rook/rook/pkg/model"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	rookclient "github.com/rook/rook/pkg/rook/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+type rookVolumeProvisioner struct {
+	clusterManager *clusterManager
+
+	// Configuration of rook volume provisioner
+	provConfig provisionerConfig
+}
+
+type provisionerConfig struct {
+	// Required:  the pool name to provision volumes from.
+	pool string
+
+	// Optional: Namespace of the cluster. Default is `rook`
+	clusterNamespace string
+
+	// Optional: Name of the cluster. Default is `rook`
+	clusterName string
+}
+
+func newRookVolumeProvisioner(clusterManager *clusterManager) controller.Provisioner {
+	return &rookVolumeProvisioner{
+		clusterManager: clusterManager,
+	}
+}
+
+// Provision creates a storage asset and returns a PV object representing it.
+func (p *rookVolumeProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+
+	var err error
+	if options.PVC.Spec.Selector != nil {
+		return nil, fmt.Errorf("claim Selector is not supported")
+	}
+
+	logger.Infof("VolumeOptions %v", options)
+
+	cfg, err := parseClassParameters(options.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	p.provConfig = *cfg
+
+	logger.Infof("creating volume with configuration %+v", p.provConfig)
+
+	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	requestBytes := capacity.Value()
+
+	imageName := fmt.Sprintf("kubernetes-dynamic-%s-%s", options.PVName, uuid.NewUUID())
+
+	rookClient, err := p.clusterManager.getRookClient(p.provConfig.clusterNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get rook client: %v", err)
+	}
+
+	res, err := createVolume(imageName, p.provConfig.pool, requestBytes, rookClient)
+	if err != nil {
+		return nil, err
+	}
+	logger.Infof("Rook block image created: %s", res)
+
+	rookClientInfo, err := rookClient.GetClientAccessInfo()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get rook client information: %v", err)
+	}
+	monitors := processMonAddresses(rookClientInfo.MonAddresses)
+	radosUser := fmt.Sprintf("%s-rook-user", p.provConfig.clusterName)
+	secretRef := new(v1.LocalObjectReference)
+	secretRef.Name = fmt.Sprintf("%s-rook-user", p.provConfig.clusterName)
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options.PVName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   options.PVC.Spec.AccessModes,
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): capacity,
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				RBD: &v1.RBDVolumeSource{
+					RBDImage:     imageName,
+					RBDPool:      p.provConfig.pool,
+					CephMonitors: monitors,
+					RadosUser:    radosUser,
+					SecretRef:    secretRef,
+					FSType:       "ext4",
+					ReadOnly:     false,
+				},
+			},
+		},
+	}
+	logger.Infof("successfully created Rook Block volume %+v", pv.Spec.PersistentVolumeSource.RBD)
+	return pv, nil
+}
+
+// createVolume creates a rook block volume.
+func createVolume(image, pool string, size int64, client rookclient.RookRestClient) (string, error) {
+	newImage := model.BlockImage{
+		Name:     image,
+		PoolName: pool,
+		Size:     uint64(size),
+	}
+
+	res, err := client.CreateBlockImage(newImage)
+	if err != nil {
+		return "", fmt.Errorf("Failed to create rook block image %s/%s: %v", pool, image, err)
+	}
+
+	return res, nil
+}
+
+// Delete removes the storage asset that was created by Provision represented
+// by the given PV.
+func (p *rookVolumeProvisioner) Delete(volume *v1.PersistentVolume) error {
+	rookClient, err := p.clusterManager.getRookClient(p.provConfig.clusterNamespace)
+	if err != nil {
+		return fmt.Errorf("Failed to get rook client: %v", err)
+	}
+
+	image := model.BlockImage{
+		Name:     volume.Spec.PersistentVolumeSource.RBD.RBDImage,
+		PoolName: p.provConfig.pool,
+	}
+
+	_, err = rookClient.DeleteBlockImage(image)
+	if err != nil {
+		return fmt.Errorf("Failed to delete rook block image %s/%s: %v", p.provConfig.pool, volume.Name, err)
+	}
+	return nil
+}
+
+func parseClassParameters(params map[string]string) (*provisionerConfig, error) {
+	var cfg provisionerConfig
+
+	// Namespace and cluster name have the same default name
+	defaultCluster := k8sutil.Namespace
+
+	for k, v := range params {
+		switch strings.ToLower(k) {
+		case "pool":
+			cfg.pool = v
+		case "clusternamespace":
+			cfg.clusterNamespace = v
+		case "clustername":
+			cfg.clusterName = v
+		default:
+			return nil, fmt.Errorf("invalid option %q for volume plugin %s", k, "rookVolumeProvisioner")
+		}
+	}
+
+	if len(cfg.pool) == 0 {
+		return nil, fmt.Errorf("StorageClass for provisioner %s must contain 'pool' parameter", "rookVolumeProvisioner")
+	}
+
+	if len(cfg.clusterNamespace) == 0 {
+		cfg.clusterNamespace = defaultCluster
+	}
+
+	if len(cfg.clusterName) == 0 {
+		cfg.clusterName = defaultCluster
+	}
+
+	return &cfg, nil
+}
+
+func processMonAddresses(monAddresses []string) []string {
+	monAddrs := make([]string, len(monAddresses))
+	for i, addr := range monAddresses {
+		mon := strings.Split(addr, "/")
+		monAddrs[i] = mon[0]
+	}
+	return monAddrs
+}

--- a/pkg/operator/provisioner_test.go
+++ b/pkg/operator/provisioner_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessMonAddresses(t *testing.T) {
+	unformattedMons := []string{"10.0.0.1:8124/0", "10.0.0.2:8125", "10.0.0.3/24"}
+	formattedMons := processMonAddresses(unformattedMons)
+
+	assert.Equal(t, "10.0.0.1:8124", formattedMons[0])
+	assert.Equal(t, "10.0.0.2:8125", formattedMons[1])
+	assert.Equal(t, "10.0.0.3", formattedMons[2])
+}
+
+func TestParseClassParameters(t *testing.T) {
+	cfg := make(map[string]string)
+	cfg["pool"] = "testPool"
+	cfg["clusterNamespace"] = "mynamespace"
+	cfg["clustername"] = "myname"
+
+	provConfig, err := parseClassParameters(cfg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "testPool", provConfig.pool)
+	assert.Equal(t, "mynamespace", provConfig.clusterNamespace)
+	assert.Equal(t, "myname", provConfig.clusterName)
+}
+
+func TestParseClassParametersDefault(t *testing.T) {
+	cfg := make(map[string]string)
+	cfg["pool"] = "testPool"
+
+	provConfig, err := parseClassParameters(cfg)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "testPool", provConfig.pool)
+	assert.Equal(t, "rook", provConfig.clusterNamespace)
+	assert.Equal(t, "rook", provConfig.clusterName)
+}
+
+func TestParseClassParametersNoPool(t *testing.T) {
+	cfg := make(map[string]string)
+	cfg["clusterNamespace"] = "mynamespace"
+	cfg["clustername"] = "myname"
+
+	_, err := parseClassParameters(cfg)
+	assert.EqualError(t, err, "StorageClass for provisioner rookVolumeProvisioner must contain 'pool' parameter")
+
+}
+
+func TestParseClassParametersInvalidOption(t *testing.T) {
+	cfg := make(map[string]string)
+	cfg["pool"] = "testPool"
+	cfg["foo"] = "bar"
+
+	_, err := parseClassParameters(cfg)
+	assert.EqualError(t, err, "invalid option \"foo\" for volume plugin rookVolumeProvisioner")
+}

--- a/pkg/operator/tpr.go
+++ b/pkg/operator/tpr.go
@@ -123,13 +123,13 @@ func watchTPR(context *k8sutil.Context, name, resourceVersion string) (*http.Res
 func tprURINamespaced(name, namespace string) string {
 	// creates a uri that is for retrieving or watching a tpr in a specific namespace. For example:
 	//   /apis/rook.io/v1alpha1/namespaces/rook/rookclusters
-	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/%ss", tprGroup, tprVersion, namespace, name)
+	return fmt.Sprintf("apis/%s/%s/namespaces/%s/%ss", tprGroup, tprVersion, namespace, name)
 }
 
 func tprURI(name string) string {
 	// creates a uri that is for retrieving or watching a tpr in all namespaces. For example:
 	//   /apis/rook.io/v1alpha1/rookclusters
-	return fmt.Sprintf("/apis/%s/%s/%ss", tprGroup, tprVersion, name)
+	return fmt.Sprintf("apis/%s/%s/%ss", tprGroup, tprVersion, name)
 }
 
 func getRawListNamespaced(clientset kubernetes.Interface, name, namespace string) ([]byte, error) {


### PR DESCRIPTION
- The provisioner is a Kubernetes external volume provisioner
- It calls the Rook API to create and delete volumes on behalf
  of Kubernetes
- It automatically discover Ceph monitor endpoints
- It locates RBD ceph user keys based on the Rook cluster location
- It uses the in-tree RBD volume plugin to do the map/unmap
- Also modified the documentation to reflect the changes on the
  storageclass
Fixes  https://github.com/rook/rook/issues/538