### PR TITLE
increase timeout for actions waiting for object store init

### DIFF
--- a/cmd/rook/object/connection.go
+++ b/cmd/rook/object/connection.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/rook/client"
@@ -69,7 +70,7 @@ func getConnectionInfoEntry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c := rook.NewRookNetworkRestClient()
+	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
 	out, err := getConnectionInfo(c, args[0], connOutputFormat)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/rook/object/user.go
+++ b/cmd/rook/object/user.go
@@ -20,12 +20,17 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/rook/client"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
+)
+
+const (
+	initObjectStoreTimeout = 60
 )
 
 var (
@@ -68,7 +73,7 @@ func listUsersEntry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c := rook.NewRookNetworkRestClient()
+	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
 	out, err := listUsers(c)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -231,7 +236,7 @@ func createUserEntry(cmd *cobra.Command, args []string) error {
 		user.Email = &emailFlag
 	}
 
-	c := rook.NewRookNetworkRestClient()
+	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
 	out, err := createUser(c, user)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Helps fix #523, although even with a timeout of 60s it still may not be enough time to wait for the object store to init