### PR TITLE
Operator artifacts all start in default namespace in the sample

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -81,7 +81,7 @@ To learn how to set up monitoring for your Rook cluster, you can follow the step
 ## Teardown
 To clean up all the artifacts created by the demo, **first cleanup the resources from the block, file, and object walkthroughs** (unmount volumes, delete volume claims, etc), then run the following:
 ```bash
-kubectl delete deployment rook-operator
+kubectl delete -f rook-operator.yaml
 kubectl delete -n rook cluster rook
 kubectl delete thirdpartyresources cluster.rook.io pool.rook.io
 kubectl delete secret rook-rook-user

--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -2,6 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
+  namespace: default
 rules:
 - apiGroups:
   - ""
@@ -57,6 +58,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -70,6 +72,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: rook-operator
+  namespace: default
 spec:
   replicas: 1
   template:


### PR DESCRIPTION
In case running in a different context, the operator artifacts should all be specified in the same namespace