### PR TITLE
Update rook operator for missing `replicasets` permission

### DIFF
--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -28,6 +28,7 @@ rules:
   - thirdpartyresources
   - deployments
   - daemonsets
+  - replicasets
   verbs:
   - get
   - list


### PR DESCRIPTION
As discussed on Gitter, this is a missing RBAC permission for bringing up rook in a vanilla 1.6.1 kubeadm cluster.