### PR TITLE
Do not try to dump partition tables of RBD devices

### DIFF
--- a/pkg/clusterd/inventory/disk_test.go
+++ b/pkg/clusterd/inventory/disk_test.go
@@ -100,3 +100,19 @@ func TestDiscoverDevices(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(devices))
 }
+
+func TestIgnoreDevice(t *testing.T) {
+	cases := map[string]bool{
+		"rbd0":    true,
+		"rbd2":    true,
+		"rbd9913": true,
+		"rbd32p1": true,
+		"rbd0a2":  false,
+		"rbd":     false,
+		"arbd0":   false,
+		"rbd0x":   false,
+	}
+	for dev, expected := range cases {
+		assert.Equal(t, expected, ignoreDevice(dev), dev)
+	}
+}


### PR DESCRIPTION
If OSDs go down while RBD devices are mounted, you cannot get the OSDs back up since the startup sequence hangs when trying to access `rbd*` devices. This commit excludes rbd devices from initial scanning.

I tried building rook with that commit but failed doing so, so this PR is sadly untested. I'll open a separate issue for that.