### PR TITLE
Create a cluster role for the api service

### DIFF
--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -2,12 +2,12 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
-  namespace: default
 rules:
 - apiGroups:
   - ""
   resources:
   - namespaces
+  - serviceaccounts
   - secrets
   - pods
   - services
@@ -34,6 +34,17 @@ rules:
   - list
   - watch
   - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
The api service needs permission to execute kubernetes operations. These operations will not require as many privileges after TPRs are created for file and object, but this gets those service working for now with RBAC enabled. Fixes #612 and #635. 