### PR TITLE
Cleanup test infra after e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,30 +1,32 @@
 # Rook Test Framework
  
 The Rook Test Framework is a Go project that that uses a Docker container with Kubernetes
-tools and Docker pre-installed to quickly create a 3 node Kubernetes cluster using Docker in 
+tools and Docker pre-installed to quickly create a three node Kubernetes cluster using Docker in 
 Docker (DinD) techniques, installs Rook and then runs automation tests to verify its functionality.
  
-##Requirements
+## Requirements
+
 1. Docker version => 1.2 && < 17.0
 2. Ubuntu Host 16 (currently the framework has only been tested on this version)
  
-##Instructions 
+## Instructions 
+
 On your Ubuntu box do the following;
 1.   Be sure to allocate a minimum of 4 processors to your vm
-2.   Navigate to the root directory of the repo and run the following:;
+2.   Navigate to the root directory of the repo and run the following:
          ```e2e/scripts/smoke_test.sh```
 
-At this point a Docker container with the base image of "quay.io/quantum/rook-test" is created, a
-Kubernetes 3 node cluster is created using Kubeadm, that is visible from the Docker host. The 
+At this point a Docker container with the base image of ```quay.io/quantum/rook-test``` is created, a
+Kubernetes three node cluster is created using Kubeadm, that is visible from the Docker host. The 
 nodes can be identified by the following container names (kube-master, kube-node1 and kube-node2).
-All tests with the name 'SmokeSuite' in the method will execute and the results will be of a junit
-type output to the e2e/results directory.
+All tests with the name `SmokeSuite` in the method will execute and the results will be of a junit
+type output to the `e2e/results` directory.
 
+## Cleanup
 
-### Cleanup
 The Rook Test Framework normally cleans up all the containers it creates to setup the environment
 and to run the tests. If for some reason the cleanup of the Rook Test framework should fail, the easiest way to manually
-cleanup the environment is by doing the following;
+cleanup the environment is by doing the following
 
-1. Delete the docker container that uses an image named "quay.io/quantum/rook-test"
-2. Run the script rook/e2e/framework/manager/scripts/rook-dind-cluster-v1.6.sh clean
+1. Delete the docker container that uses an image named `quay.io/quantum/rook-test`
+2. Run the script ```rook/e2e/framework/manager/scripts/rook-dind-cluster-v1.6.sh clean```

--- a/e2e/framework/objects/environment_manifest.go
+++ b/e2e/framework/objects/environment_manifest.go
@@ -15,7 +15,7 @@ func NewManifest() EnvironmentManifest {
 
 	flag.StringVar(&e.K8sVersion, "k8s_version", "v1.6", "Version of kubernetes to test rook in; v1.5 | v1.6 are the only version of kubernetes currently supported")
 	flag.StringVar(&e.Platform, "rook_platform", "Kubernetes", "Platform to install rook on; Kubernetes is the only platform currently supported")
-	flag.StringVar(&e.RookTag, "rook_version", "quay.io/rook/rookd:master-latest", "Docker tag of the rook operator to install, must be in quay.io or local environment")
+	flag.StringVar(&e.RookTag, "rook_version", "master-latest", "Docker tag of the rook operator to install, must be in quay.io or local environment")
 
 	flag.Parse()
 

--- a/e2e/tests/cleanup_test_infra_test.go
+++ b/e2e/tests/cleanup_test_infra_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/rook/rook/e2e/framework/enums"
+	"github.com/rook/rook/e2e/framework/manager"
+	"github.com/rook/rook/e2e/framework/objects"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+var env objects.EnvironmentManifest
+
+func init() {
+	env = objects.NewManifest()
+}
+
+func TestRookInfraCleanUp(t *testing.T) {
+	suite.Run(t, new(CleanUpTestSuite))
+}
+
+type CleanUpTestSuite struct {
+	suite.Suite
+	rookPlatform enums.RookPlatformType
+	k8sVersion   enums.K8sVersion
+	rookTag      string
+}
+
+func (suite *CleanUpTestSuite) TestRookInfraCleanUpTest() {
+	var err error
+
+	suite.rookPlatform, err = enums.GetRookPlatFormTypeFromString(env.Platform)
+
+	require.Nil(suite.T(), err)
+
+	suite.k8sVersion, err = enums.GetK8sVersionFromString(env.K8sVersion)
+
+	require.Nil(suite.T(), err)
+
+	suite.rookTag = env.RookTag
+
+	require.NotEmpty(suite.T(), suite.rookTag, "RookTag parameter is required")
+
+	fmt.Println(suite.rookPlatform)
+	fmt.Println(suite.k8sVersion)
+	fmt.Println(suite.rookTag)
+
+	err, rookInfra := rook_test_infra.GetRookTestInfraManager(suite.rookPlatform, true, suite.k8sVersion)
+
+	require.Nil(suite.T(), err)
+
+	rookInfra.TearDownInfrastructureCreatedEnvironment()
+}

--- a/e2e/tests/smoke/block_storage_smoke_test.go
+++ b/e2e/tests/smoke/block_storage_smoke_test.go
@@ -17,14 +17,7 @@ type BlockStorageTestSuite struct {
 	rookPlatform enums.RookPlatformType
 	k8sVersion   enums.K8sVersion
 	rookTag      string
-}
-
-func (suite *BlockStorageTestSuite) TearDownSuite() {
-	err, rookInfra := rook_test_infra.GetRookTestInfraManager(suite.rookPlatform, true, suite.k8sVersion)
-
-	require.Nil(suite.T(), err)
-
-	rookInfra.TearDownInfrastructureCreatedEnvironment()
+	helper       *SmokeTestHelper
 }
 
 func (suite *BlockStorageTestSuite) SetupTest() {
@@ -41,10 +34,6 @@ func (suite *BlockStorageTestSuite) SetupTest() {
 	suite.rookTag = env.RookTag
 
 	require.NotEmpty(suite.T(), suite.rookTag, "RookTag parameter is required")
-}
-
-func (suite *BlockStorageTestSuite) TestBlockStorage_SmokeTest() {
-	var err error
 
 	err, rookInfra := rook_test_infra.GetRookTestInfraManager(suite.rookPlatform, true, suite.k8sVersion)
 
@@ -56,17 +45,23 @@ func (suite *BlockStorageTestSuite) TestBlockStorage_SmokeTest() {
 
 	require.Nil(suite.T(), err)
 
+	suite.helper, err = CreateSmokeTestClient(rookInfra.GetRookPlatform())
+	require.Nil(suite.T(), err)
+}
+
+func (suite *BlockStorageTestSuite) TestBlockStorage_SmokeTest() {
+
 	suite.T().Log("Block Storage Smoke Test - Create,Mount,write to, read from  and Unmount Block")
-	sc, _ := CreateSmokeTestClient(rookInfra.GetRookPlatform())
-	defer blockTestcleanup()
-	rh := sc.rookHelp
-	rbc := sc.GetBlockClient()
+
+	defer blockTestcleanup(suite.helper)
+	rh := suite.helper.rookHelp
+	rbc := suite.helper.GetBlockClient()
 	suite.T().Log("Step 0 : Get Initial List Block")
 	rawlistInit, _ := rbc.BlockList()
 	initblocklistMap := rh.ParseBlockListData(rawlistInit)
 
 	suite.T().Log("step 1: Create block storage")
-	_, cb_err := sc.CreateBlockStorage()
+	_, cb_err := suite.helper.CreateBlockStorage()
 	require.Nil(suite.T(), cb_err)
 	rawlistAfterCreate, _ := rbc.BlockList()
 	blocklistMapAfterBlockCreate := rh.ParseBlockListData(rawlistAfterCreate)
@@ -74,41 +69,40 @@ func (suite *BlockStorageTestSuite) TestBlockStorage_SmokeTest() {
 	suite.T().Log("Block Storage created successfully")
 
 	suite.T().Log("step 2: Mount block storage")
-	_, mt_err := sc.MountBlockStorage()
+	_, mt_err := suite.helper.MountBlockStorage()
 	require.Nil(suite.T(), mt_err)
 	suite.T().Log("Block Storage Mounted successfully")
 
 	suite.T().Log("step 3: Write to block storage")
-	_, wt_err := sc.WriteToBlockStorage("Test Data", "testFile1")
+	_, wt_err := suite.helper.WriteToBlockStorage("Test Data", "testFile1")
 	require.Nil(suite.T(), wt_err)
 	suite.T().Log("Write to Block storage successfully")
 
 	suite.T().Log("step 4: Read from  block storage")
-	read, r_err := sc.ReadFromBlockStorage("testFile1")
+	read, r_err := suite.helper.ReadFromBlockStorage("testFile1")
 	require.Nil(suite.T(), r_err)
 	require.Contains(suite.T(), read, "Test Data", "make sure content of the files is unchanged")
 	suite.T().Log("Read from  Block storage successfully")
 
 	suite.T().Log("step 5: Unmount block storage")
-	_, unmt_err := sc.UnMountBlockStorage()
+	_, unmt_err := suite.helper.UnMountBlockStorage()
 	require.Nil(suite.T(), unmt_err)
 	suite.T().Log("Block Storage unmounted successfully")
 
 	suite.T().Log("step 6: Deleting block storage")
-	_, db_err := sc.DeleteBlockStorage()
+	_, db_err := suite.helper.DeleteBlockStorage()
 	require.Nil(suite.T(), db_err)
 	rawlistAfterDelete, _ := rbc.BlockList()
 	blocklistMapAfterBlockDelete := rh.ParseBlockListData(rawlistAfterDelete)
 	//This is a stop gap, block storage is not deleted when pods are deleted
-	sc.CleanUpDymanicBlockStorge()
+	suite.helper.CleanUpDymanicBlockStorge()
 	require.Empty(suite.T(), len(initblocklistMap), len(blocklistMapAfterBlockDelete), "Make sure a new block is created")
 	suite.T().Log("Block Storage deleted successfully")
 
 }
 
-func blockTestcleanup() {
-	sc, _ := CreateSmokeTestClient(enums.Kubernetes)
-	sc.UnMountBlockStorage()
-	sc.DeleteBlockStorage()
-	sc.CleanUpDymanicBlockStorge()
+func blockTestcleanup(h *SmokeTestHelper) {
+	h.UnMountBlockStorage()
+	h.DeleteBlockStorage()
+	h.CleanUpDymanicBlockStorge()
 }

--- a/e2e/tests/smoke/file_storage_smoke_test.go
+++ b/e2e/tests/smoke/file_storage_smoke_test.go
@@ -20,6 +20,7 @@ type FileSystemTestSuite struct {
 	rookPlatform enums.RookPlatformType
 	k8sVersion   enums.K8sVersion
 	rookTag      string
+	helper       *SmokeTestHelper
 }
 
 func TestFileSystemSmokeSuite(t *testing.T) {
@@ -42,12 +43,6 @@ func (suite *FileSystemTestSuite) SetupTest() {
 
 	require.NotEmpty(suite.T(), suite.rookTag, "RookTag parameter is required")
 
-}
-
-func (suite *FileSystemTestSuite) TestFileStorage_SmokeTest() {
-	suite.T().Skip("Skipping test : existing issue https://github.com/rook/rook/issues/612")
-	var err error
-
 	err, rookInfra := rook_test_infra.GetRookTestInfraManager(suite.rookPlatform, true, suite.k8sVersion)
 
 	require.Nil(suite.T(), err)
@@ -58,14 +53,22 @@ func (suite *FileSystemTestSuite) TestFileStorage_SmokeTest() {
 
 	require.Nil(suite.T(), err)
 
+	suite.helper, err = CreateSmokeTestClient(rookInfra.GetRookPlatform())
+	require.Nil(suite.T(), err)
+
+}
+
+func (suite *FileSystemTestSuite) TestFileStorage_SmokeTest() {
+
+	suite.T().Skip("Skipping test : existing issue https://github.com/rook/rook/issues/612")
 	suite.T().Log("File Storage Smoke Test - Create,Mount,write to, read from  and Unmount Filesystem")
-	sc, _ := CreateSmokeTestClient(rookInfra.GetRookPlatform())
-	defer fileSmokecleanUp()
-	rh := sc.rookHelp
-	rfc := sc.GetFileSystemClient()
+
+	defer fileSmokecleanUp(suite.helper)
+	rh := suite.helper.rookHelp
+	rfc := suite.helper.GetFileSystemClient()
 
 	suite.T().Log("Step 1: Create file System")
-	_, fsc_err := sc.CreateFileStorage()
+	_, fsc_err := suite.helper.CreateFileStorage()
 	require.Nil(suite.T(), fsc_err)
 	rawlist, _ := rfc.FSList()
 	filesystemData := rh.ParseFileSystemData(rawlist)
@@ -73,35 +76,35 @@ func (suite *FileSystemTestSuite) TestFileStorage_SmokeTest() {
 	suite.T().Log("File system created")
 
 	suite.T().Log("Step 2: Mount file System")
-	_, mtfs_err := sc.MountFileStorage()
+	_, mtfs_err := suite.helper.MountFileStorage()
 	require.Nil(suite.T(), mtfs_err)
 	suite.T().Log("File system mounted successfully")
 
 	suite.T().Log("Step 3: Write to file system")
-	_, wfs_err := sc.WriteToFileStorage("Test data for file", "fsFile1")
+	_, wfs_err := suite.helper.WriteToFileStorage("Test data for file", "fsFile1")
 	require.Nil(suite.T(), wfs_err)
 	suite.T().Log("Write to file system successful")
 
 	suite.T().Log("Step 4: Read from file system")
-	read, rd_err := sc.ReadFromFileStorage("fsFile1")
+	read, rd_err := suite.helper.ReadFromFileStorage("fsFile1")
 	require.Nil(suite.T(), rd_err)
 	require.Contains(suite.T(), read, "Test data for file", "make sure content of the files is unchanged")
 	suite.T().Log("Read from file system successful")
 
 	suite.T().Log("Step 5: Mount file System")
-	_, umtfs_err := sc.UnmountFileStorage()
+	_, umtfs_err := suite.helper.UnmountFileStorage()
 	require.Nil(suite.T(), umtfs_err)
 	suite.T().Log("File system mounted successfully")
 
 	suite.T().Log("Step 6: Deleting file storage")
-	_, fsd_err := sc.DeleteFileStorage()
+	_, fsd_err := suite.helper.DeleteFileStorage()
 	require.Nil(suite.T(), fsd_err)
 	//Delete is not actually deleting filesystem
 	suite.T().Log("File system deleted")
 }
 
-func fileSmokecleanUp() {
-	sc, _ := CreateSmokeTestClient(enums.Kubernetes)
-	sc.UnmountFileStorage()
-	sc.DeleteFileStorage()
+func fileSmokecleanUp(h *SmokeTestHelper) {
+	//suite.helper, _ := CreateSmokeTestClient(enums.Kubernetes)
+	h.UnmountFileStorage()
+	h.DeleteFileStorage()
 }


### PR DESCRIPTION
fix for 629 and 640
We are calling clean up before starting a new test suite run so any residue of test infra from older runs are removed.
Also cleaning up test images and adding file system test. 