### PR TITLE
enable file and object store smoke test and fix naming conventions

### DIFF
--- a/e2e/data/smoke/rgw_external.yaml
+++ b/e2e/data/smoke/rgw_external.yaml
@@ -12,6 +12,7 @@ spec:
     port: 53390
     protocol: TCP
     targetPort: 53390
+    nodePort: 30001
   selector:
     app: rgw
     rook_cluster: rook

--- a/e2e/framework/utils/rook_helper.go
+++ b/e2e/framework/utils/rook_helper.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -220,27 +219,4 @@ func (rh *RookHelper) ParserObjectBucketListData(rawdata string) map[string]Obje
 		}
 	}
 	return data
-}
-
-func (rh *RookHelper) GetRgwServiceNodePort(rawdata string) (string, error) {
-	lines := strings.Split(rawdata, "\n")
-	if len(lines) <= 1 {
-		return "NOT FOUND", fmt.Errorf("Port not found")
-	}
-	lines = lines[1 : len(lines)-1]
-	if len(lines) == 1 {
-		bktsrawdata := strings.Split(lines[0], "  ")
-		var r []string
-		for _, str := range bktsrawdata {
-			if str != "" {
-				r = append(r, strings.TrimSpace(str))
-			}
-		}
-		ports := strings.Split(r[3], ":")
-		port := strings.Replace(ports[1], "/TCP", "", -1)
-		return port, nil
-
-	} else {
-		return "NOT FOUND", fmt.Errorf("Port not found")
-	}
 }

--- a/e2e/tests/smoke/file_storage_smoke_test.go
+++ b/e2e/tests/smoke/file_storage_smoke_test.go
@@ -60,7 +60,6 @@ func (suite *FileSystemTestSuite) SetupTest() {
 
 func (suite *FileSystemTestSuite) TestFileStorage_SmokeTest() {
 
-	suite.T().Skip("Skipping test : existing issue https://github.com/rook/rook/issues/612")
 	suite.T().Log("File Storage Smoke Test - Create,Mount,write to, read from  and Unmount Filesystem")
 
 	defer fileSmokecleanUp(suite.helper)

--- a/e2e/tests/smoke/object_storage_smoke_test.go
+++ b/e2e/tests/smoke/object_storage_smoke_test.go
@@ -1,15 +1,15 @@
 package smoke
 
-//TODO - fix test, s3 library is having DNS issues resolving {bucketname}.{endpoint} since endpoint is not a regular amazon s3 endpoint
 import (
 	"errors"
+	"testing"
+
 	"github.com/rook/rook/e2e/framework/enums"
 	"github.com/rook/rook/e2e/framework/manager"
 	"github.com/rook/rook/e2e/framework/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 var (
@@ -30,9 +30,11 @@ type ObjectStorageTestSuite struct {
 	rookPlatform enums.RookPlatformType
 	k8sVersion   enums.K8sVersion
 	rookTag      string
+	helper       *SmokeTestHelper
 }
 
 func (suite *ObjectStorageTestSuite) SetupTest() {
+
 	var err error
 
 	suite.rookPlatform, err = enums.GetRookPlatFormTypeFromString(env.Platform)
@@ -47,15 +49,6 @@ func (suite *ObjectStorageTestSuite) SetupTest() {
 
 	require.NotEmpty(suite.T(), suite.rookTag, "RookTag parameter is required")
 
-	sc, _ := CreateSmokeTestClient(enums.Kubernetes)
-	sc.CreateObjectStore()
-}
-
-func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
-	//NOTE - fix test, s3 library is having intermittent DNS issues resolving {bucketname}.{endpoint} since endpoint is not a regular amazon s3 endpoint
-	suite.T().Skip("Skipping test : existing issue https://github.com/rook/rook/issues/612")
-	var err error
-
 	err, rookInfra := rook_test_infra.GetRookTestInfraManager(suite.rookPlatform, true, suite.k8sVersion)
 
 	require.Nil(suite.T(), err)
@@ -66,45 +59,44 @@ func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
 
 	require.Nil(suite.T(), err)
 
-	suite.T().Log("Object Storage Smoke Test")
-	sc, _ := CreateSmokeTestClient(rookInfra.GetRookPlatform())
-	defer objetTestcleanup()
+	suite.helper, err = CreateSmokeTestClient(rookInfra.GetRookPlatform())
+	require.Nil(suite.T(), err)
 
-	port, perr := sc.GetRGWPort()
-	assert.Nil(suite.T(), perr)
+}
+func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
+
+	suite.T().Log("Object Storage Smoke Test - Create Object Store, User,Bucket and read/write to bucket")
+
+	defer objectTestcleanup(suite.helper)
 
 	suite.T().Log("Step 0 : Create Object Store")
-	_, cobs_err := sc.CreateObjectStore()
+	_, cobs_err := suite.helper.CreateObjectStore()
 	assert.Nil(suite.T(), cobs_err)
 	suite.T().Log("Object store created successfully")
 
 	suite.T().Log("Step 1 : Create Object Store User")
-	initialUsers, _ := sc.GetObjectStoreUsers()
-	_, cosu_err := sc.CreateObjectStoreUser()
+	initialUsers, _ := suite.helper.GetObjectStoreUsers()
+	_, cosu_err := suite.helper.CreateObjectStoreUser()
 	assert.Nil(suite.T(), cosu_err)
-	usersAfterCrate, _ := sc.GetObjectStoreUsers()
+	usersAfterCrate, _ := suite.helper.GetObjectStoreUsers()
 	assert.Equal(suite.T(), len(initialUsers)+1, len(usersAfterCrate), "Make sure user list count is increaded by 1")
-	getuserData, gu_err := sc.GetObjectStoreUser(userid)
+	getuserData, gu_err := suite.helper.GetObjectStoreUser(userid)
 	assert.Nil(suite.T(), gu_err)
 	assert.Equal(suite.T(), userid, getuserData.UserId, "Check user id returned")
 	assert.Equal(suite.T(), userdisplayname, getuserData.DisplayName, "Check user name returned")
 	suite.T().Log("Object store user created successfully")
 
 	suite.T().Log("Step 2 : Get connection information")
-	conninfo, conninfo_error := sc.GetObjectStoreConnection(userid)
+	conninfo, conninfo_error := suite.helper.GetObjectStoreConnection(userid)
 	assert.Nil(suite.T(), conninfo_error)
 
-	//TODO - need to figure out how to expose rgw endpoint and get host ip
-	//If for rook infra its localhost, for rook on coreos-k8s its 172.17.4.101
-	s3endpoint := "localhost:" + port
+	s3endpoint, _ := suite.helper.GetRGWServiceUrl()
 	s3client := utils.CreateNewS3Helper(s3endpoint, conninfo.AwsAccessKey, conninfo.AwsSecretKey)
 
-	// Using s3 client
-
 	suite.T().Log("Step 3 : Create bucket")
-	initialBuckets, _ := sc.GetObjectStoreBucketList()
+	initialBuckets, _ := suite.helper.GetObjectStoreBucketList()
 	s3client.CreateBucket(bucketname)
-	BucketsAfterCreate, _ := sc.GetObjectStoreBucketList()
+	BucketsAfterCreate, _ := suite.helper.GetObjectStoreBucketList()
 	assert.Equal(suite.T(), len(initialBuckets)+1, len(BucketsAfterCreate), "Make sure new bucket is created")
 	bkt, _ := getBucket(bucketname, BucketsAfterCreate)
 	assert.Equal(suite.T(), bucketname, bkt.Name)
@@ -117,9 +109,9 @@ func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
 	assert.Equal(suite.T(), 0, initObjNum)
 	_, po_err := s3client.PutObjectInBucket(bucketname, objBody, objectKey, contentType)
 	assert.Nil(suite.T(), po_err)
-	BucketsAfterPut, _ := sc.GetObjectStoreBucketList()
+	BucketsAfterPut, _ := suite.helper.GetObjectStoreBucketList()
 	ObjSize, ObjNum, _ := getBucketSizeAndObjectes(bucketname, BucketsAfterPut)
-	assert.NotEmpty(suite.T(), 0, ObjSize)
+	assert.NotEmpty(suite.T(), ObjSize)
 	assert.Equal(suite.T(), 1, ObjNum)
 	suite.T().Log("Object Created on bucket successfully")
 
@@ -132,7 +124,7 @@ func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
 	suite.T().Log("Step 6 : Delete Object on bucket")
 	_, delobj_err := s3client.DeleteObjectInBucket(bucketname, objectKey)
 	assert.Nil(suite.T(), delobj_err)
-	BucketsAfterOjbDelete, _ := sc.GetObjectStoreBucketList()
+	BucketsAfterOjbDelete, _ := suite.helper.GetObjectStoreBucketList()
 	ObjSize1, ObjNum1, _ := getBucketSizeAndObjectes(bucketname, BucketsAfterOjbDelete)
 	assert.Equal(suite.T(), 0, ObjSize1)
 	assert.Equal(suite.T(), 0, ObjNum1)
@@ -141,30 +133,27 @@ func (suite *ObjectStorageTestSuite) TestObjectStorage_SmokeTest() {
 	suite.T().Log("Step 6 : Delete  bucket")
 	_, bkdel_err := s3client.DeleteBucket(bucketname)
 	assert.Nil(suite.T(), bkdel_err)
-	BucketsAfterDelete, _ := sc.GetObjectStoreBucketList()
+	BucketsAfterDelete, _ := suite.helper.GetObjectStoreBucketList()
 	assert.Equal(suite.T(), len(initialBuckets), len(BucketsAfterDelete), "Make sure new bucket is deleted")
 	suite.T().Log("Bucket  deleted successfully")
 
 	suite.T().Log("Step 7 : Delete  User")
-	usersBeforeDelete, _ := sc.GetObjectStoreUsers()
-	_, dosu_err := sc.DeleteObjectStoreUser()
+	usersBeforeDelete, _ := suite.helper.GetObjectStoreUsers()
+	_, dosu_err := suite.helper.DeleteObjectStoreUser()
 	assert.Nil(suite.T(), dosu_err)
-	usersAfterDelete, _ := sc.GetObjectStoreUsers()
+	usersAfterDelete, _ := suite.helper.GetObjectStoreUsers()
 	assert.Equal(suite.T(), len(usersBeforeDelete)-1, len(usersAfterDelete), "Make sure user list count is reducd by 1")
 	suite.T().Log("Object store user created successfully")
 
 }
 
-func objetTestcleanup() {
-	sc, _ := CreateSmokeTestClient(enums.Kubernetes)
-	conninfo, _ := sc.GetObjectStoreConnection(userid)
-	port, _ := sc.GetRGWPort()
-	//TODO - need to figure out how to expose rgw endpoint and get host ip.
-	s3endpoint := "http://172.17.4.101:" + port
+func objectTestcleanup(h *SmokeTestHelper) {
+	conninfo, _ := h.GetObjectStoreConnection(userid)
+	s3endpoint, _ := h.GetRGWServiceUrl()
 	s3client := utils.CreateNewS3Helper(s3endpoint, conninfo.AwsAccessKey, conninfo.AwsSecretKey)
 	s3client.DeleteObjectInBucket(bucketname, objectKey)
 	s3client.DeleteBucket(bucketname)
-	sc.DeleteObjectStoreUser()
+	h.DeleteObjectStoreUser()
 }
 
 func getBucket(bucketname string, bucketdict map[string]utils.ObjectBucketListData) (utils.ObjectBucketListData, error) {

--- a/e2e/tests/smoke/smoke_test_helper.go
+++ b/e2e/tests/smoke/smoke_test_helper.go
@@ -37,10 +37,10 @@ type objectUserData struct {
 }
 
 type objectConnectionData struct {
-	aws_endpoint          string
-	aws_host              string
-	aws_secret_key_id     string
-	aws_secret_access_key string
+	awsEndpoint       string
+	awsHost            string
+	awsSecretKeyId     string
+	awsSecretAccessKey string
 }
 
 func createObjectUserData(userid string, displayname string, emailid string) objectUserData {
@@ -408,14 +408,14 @@ func (h *SmokeTestHelper) DeleteObjectStoreUser() (string, error) {
 	return "USER DELETED ", nil
 }
 
-func (h *SmokeTestHelper) GetRGWPort() (string, error) {
+func (h *SmokeTestHelper) GetRGWServiceUrl() (string, error) {
 	switch h.platform {
 	case enums.Kubernetes:
-		rawdata, err := h.k8sHelp.GetService("rgw-external")
+		hostip, err := h.k8sHelp.GetPodHostId("rgw", "rook")
 		if err != nil {
-			return "port not found", err
+			panic(fmt.Errorf("RGW pods not found/object store possibly not started"))
 		}
-		return h.rookHelp.GetRgwServiceNodePort(rawdata)
+		return hostip + ":30001", err
 	case enums.StandAlone:
 		return "NEED TO IMPLEMENT", fmt.Errorf("NOT YET IMPLEMENTED")
 	default:


### PR DESCRIPTION
Enabling file system and object store smoke test. Also fixing variable names to follow go naming convention. 