### PR TITLE
Mon failover retries the same pod instead of creating multiple

### DIFF
--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -22,6 +22,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - extensions
   resources:
@@ -34,6 +35,7 @@ rules:
   - list
   - watch
   - create
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -45,6 +47,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - storage.k8s.io
   resources:
@@ -53,6 +56,7 @@ rules:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - rook.io
   resources:


### PR DESCRIPTION
Pod failover does not handle well the case where the new mon actually fails to start. If that happens, yet another mon pod will be created at the next health check interval. If they continue to fail to start, the number of failed mon pods will grow. Fixes #607 as well as an RBAC issue that prevented the operator from deleting failed mon pods