### PR TITLE
Standalone w/ Vagrant: Fix typos that stop rook01 and rook02 joining the cluster

### DIFF
--- a/demo/standalone/Vagrantfile
+++ b/demo/standalone/Vagrantfile
@@ -23,10 +23,10 @@ require_relative 'util.rb'
 require 'open-uri'
 
 if File.exists?('.discovery-token')
-  token = IO.readlines(".discovery-token")[0..-1].join
+  discovery_token = IO.readlines(".discovery-token")[0..-1].join
 else
   discovery_token = open($new_discovery_url).read
-  File.open(".discovery-token", 'w') { |file| file.write("#{token}") }
+  File.open(".discovery-token", 'w') { |file| file.write("#{discovery_token}") }
 end
 
 private_build = false


### PR DESCRIPTION
A couple of small typos meant that `vagrant up rook01` would only ever create another standalone single-node cluster (which you couldn't reach as only `rook00` has port-forwarding for the API).

Now both `rook00` and `rook01` are visible:

```
14:47 $ ./rook node ls
PUBLIC         PRIVATE        STATE     CLUSTER       SIZE        LOCATION       UPDATED
172.20.20.10   172.20.20.10   OK        rookcluster   33.46 GiB   root=default   0s ago    
172.20.20.11   172.20.20.11   OK        rookcluster   33.46 GiB   root=default   1s ago    
```
