### PR TITLE
Mons started as a replicaset instead of directly as a pod

### DIFF
--- a/e2e/framework/clients/rest_client.go
+++ b/e2e/framework/clients/rest_client.go
@@ -27,7 +27,7 @@ func CreateRestAPIClient(platform enums.RookPlatformType) *RestAPIClient {
 		}
 		apiIp, err := rkh.GetPodHostId("rook-api", "rook")
 		if err != nil {
-			panic(fmt.Errorf("Host Ip for Rook-api service not found"))
+			panic(fmt.Errorf("Host Ip for Rook-api service not found. %+v", err))
 		}
 		endpoint = "http://" + apiIp + ":30002"
 	case platform == enums.StandAlone:

--- a/e2e/framework/manager/rook_test_infra.go
+++ b/e2e/framework/manager/rook_test_infra.go
@@ -401,7 +401,6 @@ func (r *rookTestInfraManager) InstallRook(tag string, skipInstall bool) (err er
 	k8sHelp := utils.CreatK8sHelper()
 
 	err = createK8sRookOperator(k8sHelp, rookOperatorTag)
-
 	if err != nil {
 		panic(err)
 	}
@@ -410,7 +409,6 @@ func (r *rookTestInfraManager) InstallRook(tag string, skipInstall bool) (err er
 
 	//Create rook cluster
 	err = createk8sRookCluster(k8sHelp, tag)
-
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/framework/utils/k8s_helper.go
+++ b/e2e/framework/utils/k8s_helper.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jmoiron/jsonq"
 	"html/template"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jmoiron/jsonq"
 )
 
 type K8sHelper struct {
@@ -271,6 +272,10 @@ func (k8sh *K8sHelper) GetPodHostId(podNamePattern string, namespace string) (st
 		if str != "" {
 			r = append(r, strings.TrimSpace(str))
 		}
+	}
+
+	if len(r) == 0 {
+		return "", fmt.Errorf("pod not found for pattern %s", podNamePattern)
 	}
 
 	//get host Ip of the pod

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mon
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/cephmgr/client"
+	"github.com/rook/rook/pkg/cephmgr/mon"
+	"github.com/rook/rook/pkg/clusterd"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *Cluster) CheckHealth() error {
+	logger.Debugf("Checking health for mons. %+v", c.clusterInfo)
+
+	// connect to the mons
+	ctx := &clusterd.Context{ConfigDir: c.configDir}
+	conn, err := mon.ConnectToClusterAsAdmin(ctx, c.context.Factory, c.clusterInfo)
+	if err != nil {
+		return fmt.Errorf("cannot connect to cluster. %+v", err)
+	}
+	defer conn.Shutdown()
+
+	// get the status and check for quorum
+	status, err := client.GetMonStatus(conn)
+	if err != nil {
+		return fmt.Errorf("failed to get mon status. %+v", err)
+	}
+	logger.Debugf("Mon status: %+v", status)
+
+	// failover the unhealthy mons
+	for _, mon := range status.MonMap.Mons {
+		inQuorum := monInQuorum(mon, status.Quorum)
+		if inQuorum {
+			logger.Debugf("mon %s found in quorum", mon.Name)
+		} else {
+			logger.Warningf("mon %s NOT found in quorum. %+v", mon.Name, status)
+
+			if len(status.MonMap.Mons) > c.Size {
+				// no need to create a new mon since we have an extra
+				err = c.removeMon(conn, mon.Name)
+				if err != nil {
+					logger.Errorf("failed to remove mon %s. %+v", mon.Name, err)
+				}
+			} else {
+				// bring up a new mon to replace the unhealthy mon
+				err = c.failoverMon(conn, mon.Name)
+				if err != nil {
+					logger.Errorf("failed to failover mon %s. %+v", mon.Name, err)
+				}
+			}
+			// only deal with one unhealthy mon per health check
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) failoverMon(conn client.Connection, name string) error {
+	logger.Infof("Failing over monitor %s", name)
+
+	// Start a new monitor
+	mons := []*MonConfig{&MonConfig{Name: fmt.Sprintf("mon%d", c.maxMonID+1), Port: int32(mon.Port)}}
+	logger.Infof("starting new mon %s", mons[0].Name)
+	err := c.startPods(conn, mons)
+	if err != nil {
+		return fmt.Errorf("failed to start new mon %s. %+v", mons[0].Name, err)
+	}
+	// Only increment the max mon id if the new pod started successfully
+	c.maxMonID++
+
+	return c.removeMon(conn, name)
+}
+
+func (c *Cluster) removeMon(conn client.Connection, name string) error {
+	logger.Infof("ensuring removal of unhealthy monitor %s", name)
+
+	// Remove the mon pod if it is still there
+	var gracePeriod int64
+	propagation := metav1.DeletePropagationForeground
+	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
+	err := c.context.Clientset.Extensions().ReplicaSets(c.Namespace).Delete(name, options)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Infof("dead mon %s was already gone", name)
+		} else {
+			return fmt.Errorf("failed to remove dead mon pod %s. %+v", name, err)
+		}
+	}
+
+	// Remove the bad monitor from quorum
+	err = mon.RemoveMonitorFromQuorum(conn, name)
+	if err != nil {
+		return fmt.Errorf("failed to remove mon %s from quorum. %+v", name, err)
+	}
+	delete(c.clusterInfo.Monitors, name)
+	err = c.saveMonConfig()
+	if err != nil {
+		return fmt.Errorf("failed to save mon config after failing mon %s. %+v", name, err)
+	}
+
+	return nil
+}

--- a/pkg/operator/mon/spec_test.go
+++ b/pkg/operator/mon/spec_test.go
@@ -38,7 +38,7 @@ func testPodSpec(t *testing.T, dataDir string) {
 	c.clusterInfo = testop.CreateClusterInfo(0)
 	config := &MonConfig{Name: "mon0", Port: 6790}
 
-	pod := c.makeMonPod(config, false)
+	pod := c.makeMonPod(config, "foo")
 	assert.NotNil(t, pod)
 	assert.Equal(t, "mon0", pod.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, pod.Spec.RestartPolicy)

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -25,7 +25,8 @@ import (
 func New(nodes int) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 	for i := 0; i < nodes; i++ {
-		n := &v1.Node{}
+		ready := v1.NodeCondition{Type: v1.NodeReady}
+		n := &v1.Node{Status: v1.NodeStatus{Conditions: []v1.NodeCondition{ready}}}
 		n.Name = fmt.Sprintf("node%d", i)
 		clientset.CoreV1().Nodes().Create(n)
 	}


### PR DESCRIPTION
One replicaset is created for each mon, with a replica count of 1. The mons are assigned to a node, which is critical for recovery of the mon. When a new pod is started, the same metadata dir will be available on the same node as long as a hostDir was specified. If no hostDir was specified then quorum is required to restore that monitor. Bringing up a new mon to replace a bad pod is dependent on #586. Until that is fixed, if the replicaset replaces a mon pod, it will just be killed off by the operator's health check and a new mon will be created altogether.
Fixes #579