### PR TITLE
adding new flag to skip rook set up

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,11 +22,61 @@ nodes can be identified by the following container names (kube-master, kube-node
 All tests with the name `SmokeSuite` in the method will execute and the results will be of a junit
 type output to the `e2e/results` directory.
 
+## Run Tests
+Rook Framework as several configuration options, that can be used to run install rook and run tests, or just run 
+tests against rook that is already installed.
+  
+#### Test parameters
+The following parameters are available while running tests
+
+ Parameter | Description | Possible values | Default
+ --- |--- | --- 
+rook_platform| platform rook needs to be installed on  | kubernetes | kubernetes
+k8s_version  | version of Kubernetes to be installed  | v1.6  | v1.6
+rook_version | rook version/tag to be installed | valid rook tag |master-latest 
+skip_install_rook | skips installing rook (if already installed) | true or false  | false
+
+if install_rook flag is set to false, then all the other flags are ignored,
+and tests are run without rook being installed and set up. Use this flag to run tests against
+a pre-installed/configured rook. 
+
+#### Test set up
+  Run ```glide install ``` on dir ```~e2e/```
+
+#### Install Rook and run Test
+To install rook and run tests use the command 
+```
+go test -run TestObjectStorageSmokeSuite github.com/rook/rook/e2e/tests/smoke
+```
+This uses the default  ```--skip_install_rook=false``` flag.  Then Based on other flags, rook is installed and tests
+are run. e.g.
+```
+go test -run TestObjectStorageSmokeSuite github.com/rook/rook/e2e/tests/smoke --rook_version=v3.0.1
+```
+
+#### Run Tests on pre-installed/exisitng Rook
+To run tests against a pre-installed rook set  ```--skip_install_rook=true``` . 
+Setting skip_install_rook to true will ignore all other flags and run tests without installing rook first.
+
+e.g.
+```
+go test -run TestFileStorageSmokeSuite github.com/rook/rook/e2e/tests/smoke --skip_install_rook=true
+```
+
+
+Prerequisites :
+* Go installed and GO_PATH set up
+* Glide installed 
+* when running tests locally, make sure Kubectl is accessible globally, test framework uses kubectl to do setup work. 
+* You can run tests using IDE of your choice, the the flags are configured in ```e2e/framework/objects/environment_manifest.go```
+file. Update the file to set default values as you see fit and then run tests from IDE directly. 
+
+
 ## Cleanup
 
 The Rook Test Framework normally cleans up all the containers it creates to setup the environment
 and to run the tests. If for some reason the cleanup of the Rook Test framework should fail, the easiest way to manually
 cleanup the environment is by doing the following
 
-1. Delete the docker container that uses an image named `quay.io/quantum/rook-test`
+1. Delete the docker container that uses an image named `quay.io/rook/rook-test`
 2. Run the script ```rook/e2e/framework/manager/scripts/rook-dind-cluster-v1.6.sh clean```

--- a/e2e/framework/manager/rook_test_infra.go
+++ b/e2e/framework/manager/rook_test_infra.go
@@ -201,8 +201,11 @@ func (r *rookTestInfraManager) copyImageToNode(containerId string, imageName str
 }
 
 //This method stands up a k8s cluster and pre-configures it for running tests
-func (r *rookTestInfraManager) ValidateAndSetupTestPlatform() {
+func (r *rookTestInfraManager) ValidateAndSetupTestPlatform(skipInstall bool) {
 
+	if skipInstall {
+		return
+	}
 	if r.isSetup {
 		return
 	}
@@ -354,7 +357,10 @@ func createk8sRookCluster(k8sHelper *utils.K8sHelper, tag string) error {
 	return nil
 }
 
-func (r *rookTestInfraManager) InstallRook(tag string) (err error) {
+func (r *rookTestInfraManager) InstallRook(tag string, skipInstall bool) (err error) {
+	if skipInstall {
+		return
+	}
 	if r.isRookInstalled {
 		return
 	}

--- a/e2e/framework/objects/environment_manifest.go
+++ b/e2e/framework/objects/environment_manifest.go
@@ -5,9 +5,10 @@ import (
 )
 
 type EnvironmentManifest struct {
-	K8sVersion string
-	Platform   string
-	RookTag    string
+	K8sVersion      string
+	Platform        string
+	RookTag         string
+	SkipInstallRook string
 }
 
 func NewManifest() EnvironmentManifest {
@@ -16,7 +17,7 @@ func NewManifest() EnvironmentManifest {
 	flag.StringVar(&e.K8sVersion, "k8s_version", "v1.6", "Version of kubernetes to test rook in; v1.5 | v1.6 are the only version of kubernetes currently supported")
 	flag.StringVar(&e.Platform, "rook_platform", "Kubernetes", "Platform to install rook on; Kubernetes is the only platform currently supported")
 	flag.StringVar(&e.RookTag, "rook_version", "master-latest", "Docker tag of the rook operator to install, must be in quay.io or local environment")
-
+	flag.StringVar(&e.SkipInstallRook, "skip_install_rook", "false", "Indicate if Rook need to installed - false if tests are being running at Rook that is pre-installed")
 	flag.Parse()
 
 	return e

--- a/e2e/images/README.md
+++ b/e2e/images/README.md
@@ -19,7 +19,7 @@ Execute the following command to start the environment.
         -d \
         --privileged \
         --security-opt=seccomp:unconfined \
-        quay.io/quantum/rook-test \
+        quay.io/rook/rook-test \
         /sbin/init
 
 ## Usage

--- a/e2e/scripts/smoke_test.sh
+++ b/e2e/scripts/smoke_test.sh
@@ -129,23 +129,9 @@ rook_infra::cleanup() {
 
 }
 
- if [ -z "$1" ]; then
-        tag_name="master-latest"
-    else
-        tag_name=$1
-    fi
-
-    if [ -z "$2" ]; then
-        rook_platform="Kubernetes"
-    else
-        rook_platform=$2
-    fi
-
-    if [ -z "$3" ]; then
-        k8s_version="v1.6"
-    else
-        k8s_version=$3
-    fi
+ tag_name=${1:-"master-latest"}
+ rook_platform=${2:-"Kubernetes"}
+ k8s_version=${3:-"v1.6"}
 
 { #try
 

--- a/e2e/tests/smoke/block_storage_smoke_test.go
+++ b/e2e/tests/smoke/block_storage_smoke_test.go
@@ -40,9 +40,11 @@ func (suite *BlockStorageTestSuite) SetupTest() {
 
 	require.Nil(suite.T(), err)
 
-	rookInfra.ValidateAndSetupTestPlatform()
+	skipRookInstall := env.SkipInstallRook == "true"
 
-	err = rookInfra.InstallRook(suite.rookTag)
+	rookInfra.ValidateAndSetupTestPlatform(skipRookInstall)
+
+	err = rookInfra.InstallRook(suite.rookTag, skipRookInstall)
 
 	require.Nil(suite.T(), err)
 

--- a/e2e/tests/smoke/file_storage_smoke_test.go
+++ b/e2e/tests/smoke/file_storage_smoke_test.go
@@ -47,9 +47,11 @@ func (suite *FileSystemTestSuite) SetupTest() {
 
 	require.Nil(suite.T(), err)
 
-	rookInfra.ValidateAndSetupTestPlatform()
+	skipRookInstall := env.SkipInstallRook == "true"
 
-	err = rookInfra.InstallRook(suite.rookTag)
+	rookInfra.ValidateAndSetupTestPlatform(skipRookInstall)
+
+	err = rookInfra.InstallRook(suite.rookTag, skipRookInstall)
 
 	require.Nil(suite.T(), err)
 

--- a/e2e/tests/smoke/object_storage_smoke_test.go
+++ b/e2e/tests/smoke/object_storage_smoke_test.go
@@ -53,9 +53,11 @@ func (suite *ObjectStorageTestSuite) SetupTest() {
 
 	require.Nil(suite.T(), err)
 
-	rookInfra.ValidateAndSetupTestPlatform()
+	skipRookInstall := env.SkipInstallRook == "true"
 
-	err = rookInfra.InstallRook(suite.rookTag)
+	rookInfra.ValidateAndSetupTestPlatform(skipRookInstall)
+
+	err = rookInfra.InstallRook(suite.rookTag, skipRookInstall)
 
 	require.Nil(suite.T(), err)
 


### PR DESCRIPTION
in case uses want to run tests against existing pre-installed version of rook.  #627 