### PR TITLE
Add patch to clusterrole

### DIFF
--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -20,6 +20,7 @@ rules:
   - get
   - list
   - watch
+  - patch
   - create
   - update
   - delete


### PR DESCRIPTION
Rook complained that it is not allowed to patch in the default namespace. I added it to the clusterrole.