### PR TITLE
fine tuning

### DIFF
--- a/demo/helm/rook-operator/README.md
+++ b/demo/helm/rook-operator/README.md
@@ -15,7 +15,7 @@ Alternatively, to deploy from a local checkout of the rook codebase (until the r
 
 ```console
 $ cd demo/helm/rook-operator
-$ helm install --name rook-operator --namespace rook-operator .
+$ helm install --name rook-operator --namespace rook .
 ```
 
 Introduction
@@ -66,7 +66,7 @@ Uninstalling the Chart
 To uninstall/delete the `rook-operator` deployment:
 
 ```console
-$ helm delete rook-operator
+$ helm delete --purge rook-operator
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.


### PR DESCRIPTION
Great addition!
Few suggestions:
i. namespace used till now for operator was: rook (not rook-operator).
ii. `helm delete --purge` (note the --purge), so one can retry again later with the same name.
With regards to charts.rook.io -> why not in the https://github.com/kubernetes/charts/tree/master/incubator , so you won't need to deploy a helmet yourself?