### PR TITLE
build: publish binaries to s3 current and remove version from archive name

### DIFF
--- a/build/release/binaries.sh
+++ b/build/release/binaries.sh
@@ -18,9 +18,8 @@ get_archive_name() {
     local os=$1
     local arch=$2
     local suffix=$3
-    local version=${RELEASE_VERSION}
 
-    local file=rook-${version}-${os}-${arch}
+    local file=rook-${os}-${arch}
 
     if [[ -n ${suffix} ]]; then
         file=${file}-${suffix}

--- a/build/release/binaries.sh
+++ b/build/release/binaries.sh
@@ -70,18 +70,14 @@ publish() {
 
     s3_upload ${RELEASE_DIR}/$file
 
-    # we will always tag master builds as latest. i.e. auto-promote master
-    if [[ "${RELEASE_CHANNEL}" == "master" ]]; then
-        s3_promote_file $file
-    fi
-
     if [[ ${os} == "linux" ]]; then
         file=$(get_archive_name $os $arch "debug")
         s3_upload ${RELEASE_DIR}/$file
+    fi
 
-        if [[ "${RELEASE_CHANNEL}" == "master" ]]; then
-            s3_promote_file $file
-        fi
+    # we will always tag master builds as latest. i.e. auto-promote master
+    if [[ "${RELEASE_CHANNEL}" == "master" ]]; then
+        s3_promote_release
     fi
 }
 
@@ -90,7 +86,6 @@ promote() {
     local arch=$2
     local file=$(get_archive_name $os $arch)
 
-    s3_promote_file $file
     if [[ ! -e ${RELEASE_DIR}/$file ]]; then
         s3_download ${RELEASE_DIR}/$file
     fi
@@ -98,7 +93,6 @@ promote() {
 
     if [[ ${os} == "linux" ]]; then
         file=$(get_archive_name $os $arch "debug")
-        s3_promote_file $file
         if [[ ! -e ${RELEASE_DIR}/$file ]]; then
             s3_download ${RELEASE_DIR}/$file
         fi

--- a/build/release/common.sh
+++ b/build/release/common.sh
@@ -139,10 +139,6 @@ EOF
 
 publish_version_file() {
     s3_upload ${RELEASE_DIR}/version
-
-    if [[ "${RELEASE_CHANNEL}" == "master" ]]; then
-        s3_promote_file version
-    fi
 }
 
 # we assume that AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and possibly AWS_DEFAULT_REGION are already set
@@ -162,15 +158,6 @@ s3_download() {
 
     echo downloading ${filename} from S3 bucket ${RELEASE_S3_BUCKET}
     aws s3 cp --only-show-errors s3://${RELEASE_S3_BUCKET}/${RELEASE_CHANNEL}/${RELEASE_VERSION}/${filename} ${filepath}
-}
-
-s3_promote_file() {
-    local filename=$1
-
-    echo copying ${filename} from master to ${RELEASE_CHANNEL} in S3 bucket ${RELEASE_S3_BUCKET}
-    if [[ "${RELEASE_CHANNEL}" != "master" ]]; then
-        aws s3 cp --only-show-errors s3://${RELEASE_S3_BUCKET}/master/${RELEASE_VERSION}/${filename} s3://${RELEASE_S3_BUCKET}/${RELEASE_CHANNEL}/${RELEASE_VERSION}/${filename}
-    fi
 }
 
 s3_promote_release() {


### PR DESCRIPTION
Fix a regression introduced in 32cd0a1 where when publishing from master we were not updating the /current directory in s3. 

Fixes #652 and #651 