### PR TITLE
docs: remove stale roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Rook also integrates into the Kubernetes API to expose a uniform surface area fo
 
 Rook is in **alpha** state. We're just getting started. Not all planned features are complete. The API
 and other user-facing objects are subject to change. Backward-compability is not supported for this
-release. See our [Roadmap](https://github.com/rook/rook/wiki/Roadmap) and [Issues](https://github.com/rook/rook/issues).
+release. See our [Issues](https://github.com/rook/rook/issues).
 Please help us by [Contributing](CONTRIBUTING.md) to the project.
 
 ## Quickstart Guides


### PR DESCRIPTION
Removing the broken roadmap link until #638 is merged

[skip ci]