### PR TITLE
Added PATCH /api/v1/events RBAC privilege

### DIFF
--- a/demo/kubernetes/rook-operator.yaml
+++ b/demo/kubernetes/rook-operator.yaml
@@ -23,6 +23,12 @@ rules:
   - create
   - update
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - patch
+- apiGroups:
   - extensions
   resources:
   - thirdpartyresources


### PR DESCRIPTION
Without this patch, rook at v0.4.0 is broken if RBAC is enabled