### PR TITLE
docs: Fix a dead link in client.md

### DIFF
--- a/Documentation/client.md
+++ b/Documentation/client.md
@@ -1,7 +1,7 @@
 # Using Rook
 The `rookctl` client tool can be used to manage your Rook cluster once it is running as well as manage block, file and object storage.  See the sections below for details on how to configure each type of storage.  
 
-If you don't yet have a Rook cluster running, refer to our [Quickstart Guides](README.md). 
+If you don't yet have a Rook cluster running, refer to our [Quickstart Guides](../README.md#quickstart-guides). 
 
 `rookctl` can be accessed in the following ways:
 - Kubernetes: Start the [toolbox](toolbox.md) pod


### PR DESCRIPTION
Hi,

I came across a dead link while browsing the documentation. This pull request would fix that, assuming this is where the link was meant to go.

For reference, the dead link is the first link on this page: https://github.com/rook/rook/blob/master/Documentation/client.md

Take care