### PR TITLE
build: extend the timeout to 2 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
     options {
         disableConcurrentBuilds()
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
         timestamps()
     }
 


### PR DESCRIPTION
new build agents could take 1 hour + 15 mins to build and test everything with empty caches.