### PR TITLE
build: run glide update when glide.yaml changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ fmt:
 vendor: go.vendor
 
 clean:
-	@rm -fr $(OUTPUT_DIR)
 	@$(MAKE) -C images clean
+	@rm -fr $(OUTPUT_DIR) $(WORK_DIR)
 
 distclean: go.distclean clean
 	@rm -fr $(CACHE_DIR)
@@ -175,11 +175,3 @@ help:
 	@echo '    VERSION      The version information compiled into binaries.'
 	@echo '                 The default is obtained from git.'
 	@echo '    V            Set to 1 enable verbose build. Default is 0.'
-	@echo ''
-	@echo 'Advanced Options:'
-	@echo '    CACHE_DIR    A directory where downloaded files and other'
-	@echo '                 files used during the build are cached. These'
-	@echo '                 files help speedup the build by avoiding network'
-	@echo '                 transfers. Its safe to use these files across builds.'
-	@echo '    WORK_DIR     The working directory where most build files'
-	@echo '                 are stored. The default is .work'

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -62,28 +62,33 @@ ifeq ($(origin VERSION), undefined)
 VERSION := $(shell git describe --dirty --always --tags)
 endif
 
-# a registry that is scoped to the current build tree on this host
-ifeq ($(origin BUILD_REGISTRY), undefined)
-HOSTNAME := $(shell hostname)
-SELFDIR := $(dir $(lastword $(MAKEFILE_LIST)))
-ROOTDIR := $(shell cd $(SELFDIR)/../.. && pwd -P)
-BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOTDIR) | shasum -a 256 | cut -c1-8)
-endif
-
 # include the common make file
 COMMON_SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ifeq ($(origin ROOT_DIR),undefined)
+ROOT_DIR := $(abspath $(shell cd $(COMMON_SELF_DIR)/../.. && pwd -P))
+endif
 ifeq ($(origin OUTPUT_DIR),undefined)
-OUTPUT_DIR := $(abspath $(COMMON_SELF_DIR)/../../_output)
+OUTPUT_DIR := $(ROOT_DIR)/_output
 endif
 ifeq ($(origin WORK_DIR), undefined)
-WORK_DIR := $(abspath $(COMMON_SELF_DIR)/../../.work)
+WORK_DIR := $(ROOT_DIR)/.work
 endif
 ifeq ($(origin CACHE_DIR), undefined)
-CACHE_DIR := $(abspath $(COMMON_SELF_DIR)/../../.cache)
+CACHE_DIR := $(ROOT_DIR)/.cache
 endif
+
 TOOLS_DIR := $(CACHE_DIR)/tools
 TOOLS_HOST_DIR := $(TOOLS_DIR)/$(HOST_PLATFORM)
+
+ifeq ($(origin HOSTNAME), undefined)
+HOSTNAME := $(shell hostname)
+endif
+
+# a registry that is scoped to the current build tree on this host
+ifeq ($(origin BUILD_REGISTRY), undefined)
+BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | shasum -a 256 | cut -c1-8)
+endif
 
 COMMA := ,
 SPACE :=

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 87157469836148176d50b8368601122106cba44d7992b8fb6f2478da1a371ae3
-updated: 2017-06-11T21:49:37.68482446-07:00
+hash: 3c45cd12cedd08e1708ea0a32038900a785d28d62830a027283b9e20c9be3745
+updated: 2017-07-07T12:34:32.725119263-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: a547fc61f48d567d5b4ec6f8aee5573d8efce11d
@@ -30,10 +30,9 @@ imports:
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
   - private/waiter
+  - service/efs
   - service/s3
   - service/sts
-- name: github.com/bassam/cgosymbolizer
-  version: a74b3c0ca249abdcb8b17014df253c0dcf3e4f7e
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
@@ -98,9 +97,11 @@ imports:
   subpackages:
   - semver
 - name: github.com/coreos/go-systemd
-  version: 1f9909e51b2dab2487c26d64c8f2e7e580e4c9f5
+  version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
+  - daemon
   - journal
+  - util
 - name: github.com/coreos/pkg
   version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
   subpackages:
@@ -108,7 +109,7 @@ imports:
 - name: github.com/corpix/uarand
   version: 1d58d0383c4d7a4697f63d1097d466864c9ab6d3
 - name: github.com/cpuguy83/go-md2man
-  version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
+  version: 23709d0847197db6021a51fdb193e66e9222d4e7
   subpackages:
   - md2man
 - name: github.com/davecgh/go-spew
@@ -128,7 +129,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
+  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -138,7 +139,7 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/go-sql-driver/mysql
-  version: a825be04c652d01442384e9dcdf2cdc3f1eda67f
+  version: a0583e0143b1624142adab07e0e97fe106d99561
 - name: github.com/gogo/protobuf
   version: 909568be09de550ed094403c2bf8a261b5bb730a
   subpackages:
@@ -164,7 +165,7 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 599cba5e7b6137d46ddf58fb1765f5d928e69604
+  version: ac112f7d75a0714af1bd86ab17749b31f7809640
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
@@ -176,7 +177,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
 - name: github.com/jmoiron/jsonq
   version: e874b168d07ecc7808bc950a17998a8aa3141d82
 - name: github.com/jonboulle/clockwork
@@ -211,13 +212,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: 3e6a7635bac6573d43f49f97b47eb9bda195dba8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -225,9 +226,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/russross/blackfriday
-  version: b253417e1cb644d645a0a3bb1fa5034c8030127c
-- name: github.com/shurcooL/sanitized_anchor_name
-  version: 10ef21a441db47d8b13ebcc5fd2310f636973c77
+  version: 067529f716f4c3f5e37c8c95ddd59df1007290ae
 - name: github.com/spf13/cobra
   version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - name: github.com/spf13/pflag
@@ -445,7 +444,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,7 +39,7 @@ import:
   - prometheus/promhttp
 testImport:
 - package: github.com/aws/aws-sdk-go
-  version: ^1.8.13
+  version: v1.7.3
   subpackages:
   - aws
   - aws/credentials
@@ -47,7 +47,6 @@ testImport:
   - service/s3
 - package: github.com/jmoiron/jsonq
 - package: github.com/go-sql-driver/mysql
-  version: ^1.3.0
 - package: github.com/icrowley/fake
 - package: github.com/stretchr/testify
   version: ^1.1.4


### PR DESCRIPTION
this will ensure that we do not have broken dependencies. Expected behavior:


Completely clean tree -- i.e. no vendor subdir
```
make -j4
== glide install runs
```

glide.yaml is updated and more recent than glide.lock
```
make -j4
== glide update runs
== glide install runs (not needed but really quick)
```

also addresses #789.

@kokhang this should probably be merged before #787 