### PR TITLE
Mons bind to the pod IP and advertise the service IP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,8 @@ def RunIntegrationTest(k, v) {
                         sh '''#!/bin/bash
                         set -o pipefail
                         export KUBECONFIG=$HOME/admin.conf
+                        kubectl config view
+                        kubectl create clusterrolebinding anon-user-access --clusterrole cluster-admin --user system:anonymous
                         _output/tests/linux_amd64/smoke -test.v -test.timeout 1200s 2>&1 | tee _output/tests/integrationTests.log'''
                     }
                     finally{

--- a/cmd/rook/api.go
+++ b/cmd/rook/api.go
@@ -50,7 +50,8 @@ func init() {
 }
 
 func startAPI(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(apiCmd, []string{"repo-prefix", "namespace", "config-dir", "cluster-name", "mon-endpoints", "mon-secret", "admin-secret"}); err != nil {
+	required := []string{"repo-prefix", "namespace", "config-dir", "cluster-name", "mon-endpoints", "mon-secret", "admin-secret", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(apiCmd, required); err != nil {
 		return err
 	}
 	if apiPort == 0 {

--- a/cmd/rook/main.go
+++ b/cmd/rook/main.go
@@ -240,5 +240,6 @@ func createContext() *clusterd.Context {
 		ConfigDir:          cfg.dataDir,
 		ConfigFileOverride: cfg.cephConfigOverride,
 		LogLevel:           cfg.logLevel,
+		NetworkInfo:        cfg.networkInfo,
 	}
 }

--- a/cmd/rook/mds.go
+++ b/cmd/rook/mds.go
@@ -47,7 +47,8 @@ func init() {
 }
 
 func startMDS(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(mdsCmd, []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "mds-id", "mds-keyring"}); err != nil {
+	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "mds-id", "mds-keyring", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(mdsCmd, required); err != nil {
 		return err
 	}
 

--- a/cmd/rook/mgr.go
+++ b/cmd/rook/mgr.go
@@ -47,7 +47,8 @@ func init() {
 }
 
 func startMgr(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(mgrCmd, []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret"}); err != nil {
+	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(mgrCmd, required); err != nil {
 		return err
 	}
 

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -58,7 +58,8 @@ func init() {
 }
 
 func startMon(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(monCmd, []string{"name", "fsid", "mon-secret", "admin-secret", "config-dir", "cluster-name", "public-ipv4", "private-ipv4"}); err != nil {
+	required := []string{"name", "fsid", "mon-secret", "admin-secret", "config-dir", "cluster-name", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(monCmd, required); err != nil {
 		return err
 	}
 
@@ -73,9 +74,7 @@ func startMon(cmd *cobra.Command, args []string) error {
 	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddrIPv4)
 
 	monCfg := &mon.Config{Name: monName, Cluster: &clusterInfo}
-	context := createContext()
-	context.NetworkInfo = cfg.networkInfo
-	err := mon.Run(context, monCfg)
+	err := mon.Run(createContext(), monCfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func startMon(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(monCmd, []string{"name", "fsid", "mon-secret", "admin-secret", "config-dir", "cluster-name", "private-ipv4"}); err != nil {
+	if err := flags.VerifyRequiredFlags(monCmd, []string{"name", "fsid", "mon-secret", "admin-secret", "config-dir", "cluster-name", "public-ipv4", "private-ipv4"}); err != nil {
 		return err
 	}
 
@@ -70,10 +70,12 @@ func startMon(cmd *cobra.Command, args []string) error {
 
 	// at first start the local monitor needs to be added to the list of mons
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.ClusterAddrIPv4)
+	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddrIPv4)
 
 	monCfg := &mon.Config{Name: monName, Cluster: &clusterInfo}
-	err := mon.Run(createContext(), monCfg)
+	context := createContext()
+	context.NetworkInfo = cfg.networkInfo
+	err := mon.Run(context, monCfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/flags"
@@ -53,6 +54,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 
 	logger.Infof("starting operator")
 	context := createContext()
+	context.NetworkInfo = clusterd.NetworkInfo{}
 	context.ConfigDir = k8sutil.DataDir
 	context.Clientset = clientset
 	context.APIExtensionClientset = apiExtClientset

--- a/cmd/rook/osd.go
+++ b/cmd/rook/osd.go
@@ -61,7 +61,8 @@ func init() {
 }
 
 func startOSD(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(osdCmd, []string{"cluster-name", "mon-endpoints", "mon-secret", "admin-secret", "node-name"}); err != nil {
+	required := []string{"cluster-name", "mon-endpoints", "mon-secret", "admin-secret", "node-name", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(osdCmd, required); err != nil {
 		return err
 	}
 

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -49,7 +49,8 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	if err := flags.VerifyRequiredFlags(rgwCmd, []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "rgw-host", "rgw-keyring"}); err != nil {
+	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}
 

--- a/cmd/rookctl/status/status.go
+++ b/cmd/rookctl/status/status.go
@@ -120,6 +120,9 @@ func getStatus(c client.RookRestClient) (string, error) {
 	for state, count := range statusDetails.PGs.StateCounts {
 		fmt.Fprintf(w, "%s\t%d\n", state, count)
 	}
+	if statusDetails.PGs.Total == 0 {
+		fmt.Fprintf(w, "none\n")
+	}
 	w.Flush()
 
 	w.Flush()

--- a/cmd/rookctl/status/status_test.go
+++ b/cmd/rookctl/status/status_test.go
@@ -114,6 +114,7 @@ func TestGetStatusEmptyResponse(t *testing.T) {
 		"TOTAL     UP        IN        FULL      NEAR FULL\n" +
 		"0         0         0         false     false\n\n" +
 		"PLACEMENT GROUPS (0 total):\n" +
-		"STATE     COUNT\n"
+		"STATE     COUNT\n" +
+		"none\n"
 	assert.Equal(t, expectedOut, out)
 }

--- a/images/ceph/CMakeLists.txt
+++ b/images/ceph/CMakeLists.txt
@@ -19,6 +19,7 @@ add_custom_target(rook DEPENDS
   cephfs
   cls_rbd
   crushtool
+  monmaptool
   rados
   radosgw
   radosgw-admin

--- a/pkg/ceph/client/auth.go
+++ b/pkg/ceph/client/auth.go
@@ -40,7 +40,6 @@ func AuthGetOrCreateKey(context *clusterd.Context, clusterName, name string, cap
 		return "", fmt.Errorf("failed get-or-create-key %s: %+v", name, err)
 	}
 
-	logger.Infof("Parsing key: %v", string(buf))
 	return parseAuthKey(buf)
 }
 

--- a/pkg/ceph/mon/agent_test.go
+++ b/pkg/ceph/mon/agent_test.go
@@ -40,6 +40,9 @@ func TestMonAgent(t *testing.T) {
 		logger.Infof("RUN %d. %s %+v", runCommands, command, args)
 		switch {
 		case runCommands == 0:
+			assert.Equal(t, "monmaptool", command)
+		case runCommands == 1:
+			assert.Equal(t, "ceph-mon", command)
 			assert.Equal(t, "--mkfs", args[0])
 		default:
 			assert.Fail(t, fmt.Sprintf("unexpected case %d", runCommands))
@@ -55,7 +58,7 @@ func TestMonAgent(t *testing.T) {
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 		assert.Equal(t, "--cluster=rookcluster", args[1])
 		assert.Equal(t, "--name=mon.mon0", args[2])
-		assert.Equal(t, fmt.Sprintf("--mon-data=%s/mon0/mon.mon0", context.ConfigDir), args[3])
+		assert.Equal(t, fmt.Sprintf("--mon-data=%s/mon0/data", context.ConfigDir), args[3])
 		assert.Equal(t, fmt.Sprintf("--conf=%s/mon0/rookcluster.config", context.ConfigDir), args[4])
 		switch {
 		case startCommands == 0:
@@ -90,7 +93,7 @@ func TestMonAgent(t *testing.T) {
 	// now the monitor will be configured
 	err = agent.ConfigureLocalService(context)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, runCommands)
+	assert.Equal(t, 2, runCommands)
 	assert.Equal(t, 1, startCommands)
 	assert.NotNil(t, agent.monProc)
 
@@ -98,7 +101,7 @@ func TestMonAgent(t *testing.T) {
 	etcdClient.DeleteDir(key)
 	err = agent.ConfigureLocalService(context)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, runCommands)
+	assert.Equal(t, 2, runCommands)
 	assert.Equal(t, 1, startCommands)
 	assert.Nil(t, agent.monProc)
 }

--- a/pkg/ceph/mon/config.go
+++ b/pkg/ceph/mon/config.go
@@ -43,6 +43,7 @@ type GlobalConfig struct {
 	FSID                     string `ini:"fsid,omitempty"`
 	RunDir                   string `ini:"run dir,omitempty"`
 	MonMembers               string `ini:"mon initial members,omitempty"`
+	MonHost                  string `ini:"mon host"`
 	LogFile                  string `ini:"log file,omitempty"`
 	MonClusterLogFile        string `ini:"mon cluster log file,omitempty"`
 	PublicAddr               string `ini:"public addr,omitempty"`
@@ -154,10 +155,6 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 		return "", fmt.Errorf("failed to add admin client config section, %+v", err)
 	}
 
-	if err := addInitialMonitorsConfigFileSections(configFile, cluster); err != nil {
-		return "", fmt.Errorf("failed to add initial monitor config sections, %+v", err)
-	}
-
 	// if there's a config file override path given, process the given config file
 	if context.ConfigFileOverride != "" {
 		err := configFile.Append(context.ConfigFileOverride)
@@ -236,9 +233,11 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 	// extract a list of just the monitor names, which will populate the "mon initial members"
 	// global config field
 	monMembers := make([]string, len(cluster.Monitors))
+	monHosts := make([]string, len(cluster.Monitors))
 	i := 0
 	for _, monitor := range cluster.Monitors {
 		monMembers[i] = monitor.Name
+		monHosts[i] = monitor.Endpoint
 		i++
 	}
 
@@ -257,6 +256,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 			FSID:                   cluster.FSID,
 			RunDir:                 runDir,
 			MonMembers:             strings.Join(monMembers, " "),
+			MonHost:                strings.Join(monHosts, ","),
 			LogFile:                "/dev/stdout",
 			MonClusterLogFile:      "/dev/stdout",
 			PublicAddr:             context.NetworkInfo.PublicAddrIPv4,
@@ -316,27 +316,6 @@ func addClientConfigFileSection(configFile *ini.File, clientName, keyringPath st
 	for key, val := range settings {
 		if _, err := s.NewKey(key, val); err != nil {
 			return fmt.Errorf("failed to add key %s. %v", key, err)
-		}
-	}
-
-	return nil
-}
-
-func addInitialMonitorsConfigFileSections(configFile *ini.File, cluster *ClusterInfo) error {
-	// write the config for each individual monitor member of the cluster to the content buffer
-	for _, mon := range cluster.Monitors {
-
-		s, err := configFile.NewSection(fmt.Sprintf("mon.%s", mon.Name))
-		if err != nil {
-			return err
-		}
-
-		if _, err := s.NewKey("name", mon.Name); err != nil {
-			return err
-		}
-
-		if _, err := s.NewKey("mon addr", mon.Endpoint); err != nil {
-			return err
 		}
 	}
 

--- a/pkg/ceph/mon/config.go
+++ b/pkg/ceph/mon/config.go
@@ -84,7 +84,7 @@ func getMonKeyringPath(configDir, monName string) string {
 
 // get the path of a given monitor's data dir
 func getMonDataDirPath(configDir, monName string) string {
-	return filepath.Join(getMonRunDirPath(configDir, monName), fmt.Sprintf("mon.%s", monName))
+	return filepath.Join(getMonRunDirPath(configDir, monName), "data")
 }
 
 // get the path of a given monitor's config file

--- a/pkg/ceph/mon/config_test.go
+++ b/pkg/ceph/mon/config_test.go
@@ -116,7 +116,6 @@ debug bluestore = 1234`
 	actualConf, err := ini.Load(configFilePath)
 	assert.Nil(t, err)
 	verifyConfigValue(t, actualConf, "global", "fsid", clusterInfo.FSID)
-	verifyConfigValue(t, actualConf, "mon.mon0", "mon addr", "10.0.0.1:6790")
 
 	// verify the content of the config file override successfully overwrote the default generated config
 	verifyConfigValue(t, actualConf, "global", "debug bluestore", "1234")

--- a/pkg/ceph/mon/daemon.go
+++ b/pkg/ceph/mon/daemon.go
@@ -116,9 +116,15 @@ func startMon(context *clusterd.Context, config *Config, confFilePath, monDataDi
 	// call mon --mkfs in a child process
 	logger.Infof("initializing mon")
 
+	// generate the monmap
+	monmapPath, err := generateMonMap(context, config.Cluster, getMonRunDirPath(context.ConfigDir, config.Name))
+	if err != nil {
+		return err
+	}
+
 	monNameArg := fmt.Sprintf("--name=mon.%s", config.Name)
 	keyringPath := getMonKeyringPath(context.ConfigDir, config.Name)
-	err := context.ProcMan.Run(
+	err = context.ProcMan.Run(
 		fmt.Sprintf("mkfs-%s", config.Name),
 		"ceph-mon",
 		"--mkfs",
@@ -126,7 +132,8 @@ func startMon(context *clusterd.Context, config *Config, confFilePath, monDataDi
 		fmt.Sprintf("--cluster=%s", config.Cluster.Name),
 		fmt.Sprintf("--mon-data=%s", monDataDir),
 		fmt.Sprintf("--conf=%s", confFilePath),
-		fmt.Sprintf("--keyring=%s", keyringPath))
+		fmt.Sprintf("--keyring=%s", keyringPath),
+		fmt.Sprintf("--monmap=%s", monmapPath))
 	if err != nil {
 		return fmt.Errorf("failed mon %s --mkfs: %+v", config.Name, err)
 	}

--- a/pkg/ceph/mon/daemon.go
+++ b/pkg/ceph/mon/daemon.go
@@ -143,6 +143,8 @@ func startMon(context *clusterd.Context, config *Config, confFilePath, monDataDi
 		fmt.Sprintf("--mon-data=%s", monDataDir),
 		fmt.Sprintf("--conf=%s", confFilePath),
 		fmt.Sprintf("--keyring=%s", keyringPath),
+		fmt.Sprintf("--public-addr=%s:%d", context.NetworkInfo.PublicAddrIPv4, Port),
+		fmt.Sprintf("--public-bind-addr=%s:%d", context.NetworkInfo.ClusterAddrIPv4, Port),
 	}
 	err = context.ProcMan.Run(config.Name, "ceph-mon", args...)
 	if err != nil {

--- a/pkg/ceph/mon/leader.go
+++ b/pkg/ceph/mon/leader.go
@@ -262,13 +262,12 @@ func chooseMonitorNodes(context *clusterd.Context) (map[string]*CephMonitorConfi
 		}
 
 		// Store the monitor id and connection info
-		port := "6790"
 		monitorID := fmt.Sprintf("mon%d", nextMonID)
 		settings[path.Join(nodeID, "id")] = monitorID
 		settings[path.Join(nodeID, "ipaddress")] = node.PublicIP
-		settings[path.Join(nodeID, "port")] = port
+		settings[path.Join(nodeID, "port")] = strconv.Itoa(Port)
 
-		monitor := &CephMonitorConfig{Name: monitorID, Endpoint: fmt.Sprintf("%s:%s", node.PublicIP, port)}
+		monitor := &CephMonitorConfig{Name: monitorID, Endpoint: fmt.Sprintf("%s:%d", node.PublicIP, Port)}
 		monitors[nodeID] = monitor
 
 		nextMonID++

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -69,6 +69,11 @@ func ConfigOverrideEnvVar() v1.EnvVar {
 	return v1.EnvVar{Name: "ROOKD_CEPH_CONFIG_OVERRIDE", Value: path.Join(configMountDir, overrideFilename)}
 }
 
+// PodIPEnvVar private ip env var
+func PodIPEnvVar(property string) v1.EnvVar {
+	return v1.EnvVar{Name: property, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}}
+}
+
 // NamespaceEnvVar namespace env var
 func NamespaceEnvVar() v1.EnvVar {
 	return v1.EnvVar{Name: "ROOKD_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -35,8 +35,11 @@ const (
 	ClusterAttr = "rook_cluster"
 	// VersionAttr version label
 	VersionAttr = "rook_version"
-	// PodIPEnvVar pod IP env var
-	PodIPEnvVar = "ROOKD_PRIVATE_IPV4"
+	// PublicIPEnvVar public IP env var
+	PublicIPEnvVar = "ROOKD_PUBLIC_IPV4"
+	// PrivateIPEnvVar pod IP env var
+	PrivateIPEnvVar = "ROOKD_PRIVATE_IPV4"
+
 	// DefaultRepoPrefix repo prefix
 	DefaultRepoPrefix = "rook"
 	// ConfigOverrideName config override name

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -169,6 +169,8 @@ func (c *Cluster) mdsContainer(id string) v1.Container {
 			opmon.ClusterNameEnvVar(c.Namespace),
 			opmon.EndpointEnvVar(),
 			opmon.SecretEnvVar(),
+			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 			opmon.AdminSecretEnvVar(),
 			k8sutil.ConfigOverrideEnvVar(),
 		},

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -82,7 +82,6 @@ func TestPodSpecs(t *testing.T) {
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
-	assert.Equal(t, 6, len(cont.Env))
 
 	assert.Equal(t, "mds", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])

--- a/pkg/operator/mgr/mgr.go
+++ b/pkg/operator/mgr/mgr.go
@@ -127,6 +127,8 @@ func (c *Cluster) mgrContainer(name string) v1.Container {
 		Env: []v1.EnvVar{
 			{Name: "ROOKD_MGR_NAME", Value: name},
 			{Name: "ROOKD_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
+			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 			opmon.ClusterNameEnvVar(c.Namespace),
 			opmon.EndpointEnvVar(),
 			opmon.SecretEnvVar(),

--- a/pkg/operator/mgr/mgr_test.go
+++ b/pkg/operator/mgr/mgr_test.go
@@ -84,7 +84,6 @@ func TestPodSpec(t *testing.T) {
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
-	assert.Equal(t, 7, len(cont.Env))
 
 	assert.Equal(t, "mgr", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -105,12 +105,29 @@ func (c *Cluster) failoverMon(name string) error {
 	logger.Infof("Failing over monitor %s", name)
 
 	// Start a new monitor
-	mons := []*monConfig{{Name: fmt.Sprintf("%s%d", appName, c.maxMonID+1), Port: int32(mon.Port)}}
-	logger.Infof("starting new mon %s", mons[0].Name)
-	err := c.startPods(mons)
+	m := &monConfig{Name: fmt.Sprintf("%s%d", appName, c.maxMonID+1), Port: int32(mon.Port)}
+	logger.Infof("starting new mon %s", m.Name)
+
+	// Create the service endpoint
+	serviceIP, err := c.createService(m)
 	if err != nil {
-		return fmt.Errorf("failed to start new mon %s. %+v", mons[0].Name, err)
+		return fmt.Errorf("failed to create mon service. %+v", err)
 	}
+	m.PublicIP = serviceIP
+	c.clusterInfo.Monitors[m.Name] = mon.ToCephMon(m.Name, m.PublicIP)
+
+	// Save the mon config
+	err = c.saveMonConfig()
+	if err != nil {
+		return fmt.Errorf("failed to save mons. %+v", err)
+	}
+
+	// Start the pod
+	err = c.startPods([]*monConfig{m})
+	if err != nil {
+		return fmt.Errorf("failed to start new mon %s. %+v", m.Name, err)
+	}
+
 	// Only increment the max mon id if the new pod started successfully
 	c.maxMonID++
 
@@ -139,9 +156,20 @@ func (c *Cluster) removeMon(name string) error {
 		return fmt.Errorf("failed to remove mon %s from quorum. %+v", name, err)
 	}
 	delete(c.clusterInfo.Monitors, name)
+
+	// Remove the service endpoint
+	err = c.context.Clientset.CoreV1().Services(c.Namespace).Delete(name, options)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Infof("dead mon service %s was already gone", name)
+		} else {
+			return fmt.Errorf("failed to remove dead mon pod %s. %+v", name, err)
+		}
+	}
+
 	err = c.saveMonConfig()
 	if err != nil {
-		return fmt.Errorf("failed to save mon config after failing mon %s. %+v", name, err)
+		return fmt.Errorf("failed to save mon config after failing over mon %s. %+v", name, err)
 	}
 
 	return nil

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/ceph/client"
@@ -33,7 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+<<<<<<< HEAD
 	"k8s.io/apimachinery/pkg/util/wait"
+=======
+	"k8s.io/apimachinery/pkg/util/intstr"
+>>>>>>> operator: mons based on service ip instead of pod ip
 	helper "k8s.io/kubernetes/pkg/api/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 )
@@ -79,8 +82,9 @@ type Cluster struct {
 
 // monConfig for a single monitor
 type monConfig struct {
-	Name string
-	Port int32
+	Name     string
+	PublicIP string
+	Port     int32
 }
 
 // New creates an instance of a mon cluster
@@ -110,7 +114,11 @@ func (c *Cluster) Start() (*mon.ClusterInfo, error) {
 
 	if len(c.clusterInfo.Monitors) == 0 {
 		// Start the initial monitors at startup
-		mons := c.getExpectedMonConfig()
+		mons, err := c.initMonServices()
+		if err != nil {
+			return nil, fmt.Errorf("failed to init mons. %+v", err)
+		}
+
 		err = c.startPods(mons)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start mon pods. %+v", err)
@@ -173,7 +181,7 @@ func (c *Cluster) initClusterInfo() error {
 	return nil
 }
 
-func (c *Cluster) getExpectedMonConfig() []*monConfig {
+func (c *Cluster) initMonServices() ([]*monConfig, error) {
 	mons := []*monConfig{}
 
 	// initialize the mon pod info for mons that have been previously created
@@ -187,15 +195,30 @@ func (c *Cluster) getExpectedMonConfig() []*monConfig {
 		mons = append(mons, &monConfig{Name: fmt.Sprintf("%s%d", appName, c.maxMonID), Port: int32(mon.Port)})
 	}
 
-	return mons
+	for _, m := range mons {
+		serviceIP, err := c.createService(m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mon service. %+v", err)
+		}
+		m.PublicIP = serviceIP
+		c.clusterInfo.Monitors[m.Name] = mon.ToCephMon(m.Name, m.PublicIP)
+	}
+
+	// save the mon config
+	err := c.saveMonConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to save mons. %+v", err)
+	}
+
+	return mons, nil
 }
 
 // get the ID of a monitor from its name
 func getMonID(name string) (int, error) {
-	if strings.Index(name, "mon") != 0 || len(name) < 4 {
+	if strings.Index(name, appName) != 0 || len(name) < len(appName) {
 		return -1, fmt.Errorf("unexpected mon name")
 	}
-	id, err := strconv.Atoi(name[3:])
+	id, err := strconv.Atoi(name[len(appName):])
 	if err != nil {
 		return -1, err
 	}
@@ -249,6 +272,41 @@ func (c *Cluster) createMonSecretsAndSave() error {
 	return nil
 }
 
+func (c *Cluster) createService(mon *monConfig) (string, error) {
+	labels := c.getLabels(mon.Name)
+	s := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   mon.Name,
+			Labels: labels,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:       mon.Name,
+					Port:       mon.Port,
+					TargetPort: intstr.FromInt(int(mon.Port)),
+					Protocol:   v1.ProtocolTCP,
+				},
+			},
+			Selector: labels,
+		},
+	}
+
+	s, err := c.context.Clientset.CoreV1().Services(c.Namespace).Create(s)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return "", fmt.Errorf("failed to create mon service. %+v", err)
+		}
+	}
+
+	if s == nil {
+		logger.Warningf("service ip not found for mon %s. this better be a test", mon.Name)
+		return "", nil
+	}
+	logger.Infof("mon %s running at %s:%d", mon.Name, s.Spec.ClusterIP, mon.Port)
+	return s.Spec.ClusterIP, nil
+}
+
 func (c *Cluster) startPods(mons []*monConfig) error {
 	// schedule the mons on different nodes if we have enough nodes to be unique
 	availableNodes, err := c.getAvailableMonNodes()
@@ -256,35 +314,20 @@ func (c *Cluster) startPods(mons []*monConfig) error {
 		return fmt.Errorf("failed to get available nodes for mons. %+v", err)
 	}
 
-	preexisted := len(c.clusterInfo.Monitors)
 	nodeIndex := 0
 	for _, m := range mons {
 		// pick one of the available nodes where the mon will be assigned
 		node := availableNodes[nodeIndex%len(availableNodes)]
 		nodeIndex++
 
-		// start the mon
-		err := c.startMon(m, node.Name)
+		// start the mon replicaset/pod
+		err = c.startMon(m, node.Name)
 		if err != nil {
 			return fmt.Errorf("failed to create pod %s. %+v", m.Name, err)
 		}
-
-		// wait for the mon to start
-		podIP, err := c.waitForPodToStart(m.Name)
-		if err != nil {
-			return fmt.Errorf("failed to start pod %s. %+v", m.Name, err)
-		}
-		c.clusterInfo.Monitors[m.Name] = mon.ToCephMon(m.Name, podIP)
-
-		// save the mon config
-		err = c.saveMonConfig()
-		if err != nil {
-			return fmt.Errorf("failed to save endpoints after starting mon %s. %+v", m.Name, err)
-		}
 	}
 
-	logger.Infof("mons created: %d, preexisted: %d", len(mons), preexisted)
-
+	logger.Infof("mons created: %d", len(mons))
 	return c.waitForMonsToJoin(mons)
 }
 
@@ -305,42 +348,6 @@ func (c *Cluster) waitForMonsToJoin(mons []*monConfig) error {
 	}
 
 	return nil
-}
-
-func (c *Cluster) waitForPodToStart(name string) (string, error) {
-	if !c.waitForStart {
-		return "", nil
-	}
-
-	// Poll the status of the pods to see if they are ready
-	options := metav1.ListOptions{LabelSelector: fmt.Sprintf("mon=%s", name)}
-	status := string(v1.PodUnknown)
-	var pod v1.Pod
-	err := wait.Poll(c.monPodRetryInterval, c.monPodTimeout, func() (bool, error) {
-		logger.Infof("waiting for mon %s to start. status=%s", name, status)
-		pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(options)
-		if err != nil {
-			return false, fmt.Errorf("failed to get mon %s pod. %+v", name, err)
-		}
-		if len(pods.Items) == 0 {
-			logger.Infof("%s pod not yet created", name)
-			return false, nil
-		}
-		if len(pods.Items) > 1 {
-			logger.Warningf("more than one mon pod found for %s", name)
-		}
-		pod = pods.Items[0]
-		if pod.Status.Phase == v1.PodRunning {
-			logger.Infof("pod %s started", pod.Name)
-			return true, nil
-		}
-		status = string(pod.Status.Phase)
-		return false, nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("timed out waiting for pod %s to start", name)
-	}
-	return pod.Status.PodIP, nil
 }
 
 func (c *Cluster) saveMonConfig() error {
@@ -434,7 +441,7 @@ func (c *Cluster) getAvailableMonNodes() ([]v1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("there are %d nodes available for mons (existing mons=%d)", len(nodes.Items), len(c.clusterInfo.Monitors))
+	logger.Infof("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
 
 	// get the nodes that have mons assigned
 	nodesInUse, err := c.getNodesWithMons()

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/ceph/client"
@@ -32,11 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-<<<<<<< HEAD
-	"k8s.io/apimachinery/pkg/util/wait"
-=======
 	"k8s.io/apimachinery/pkg/util/intstr"
->>>>>>> operator: mons based on service ip instead of pod ip
 	helper "k8s.io/kubernetes/pkg/api/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 )

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -61,23 +61,22 @@ func TestStartMonPods(t *testing.T) {
 		Version:             "myversion",
 		Size:                3,
 		maxMonID:            -1,
-		waitForStart:        true,
+		waitForStart:        false,
 		monPodRetryInterval: 10 * time.Millisecond,
 		monPodTimeout:       1 * time.Second,
 	}
 
 	// start a basic cluster
-	// an error is expected since mocking always creates pods that are not running
 	info, err := c.Start()
-	assert.NotNil(t, err)
-	assert.Nil(t, info)
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
 
 	validateStart(t, c)
 
 	// starting again should be a no-op, but still results in an error
 	info, err = c.Start()
-	assert.NotNil(t, err)
-	assert.Nil(t, info)
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
 
 	validateStart(t, c)
 }
@@ -177,15 +176,15 @@ func TestMonID(t *testing.T) {
 	id, err = getMonID("mon")
 	assert.NotNil(t, err)
 	assert.Equal(t, -1, id)
-	id, err = getMonID("monitor0")
+	id, err = getMonID("rook-ceph-monitor0")
 	assert.NotNil(t, err)
 	assert.Equal(t, -1, id)
 
 	// valid
-	id, err = getMonID("mon0")
+	id, err = getMonID("rook-ceph-mon0")
 	assert.Nil(t, err)
 	assert.Equal(t, 0, id)
-	id, err = getMonID("mon123")
+	id, err = getMonID("rook-ceph-mon123")
 	assert.Nil(t, err)
 	assert.Equal(t, 123, id)
 }

--- a/pkg/operator/mon/spec.go
+++ b/pkg/operator/mon/spec.go
@@ -27,11 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
-// PrivateIPEnvVar is the private cluster ip env var for monitors
-func PrivateIPEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: k8sutil.PrivateIPEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}}
-}
-
 // PublicIPEnvVar is the public ip env var for monitors
 func PublicIPEnvVar(publicIP string) v1.EnvVar {
 	return v1.EnvVar{Name: k8sutil.PublicIPEnvVar, Value: publicIP}
@@ -141,7 +136,7 @@ func (c *Cluster) monContainer(config *monConfig, fsid string) v1.Container {
 			k8sutil.ConfigOverrideMount(),
 		},
 		Env: []v1.EnvVar{
-			PrivateIPEnvVar(),
+			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 			PublicIPEnvVar(config.PublicIP),
 			ClusterNameEnvVar(c.Namespace),
 			EndpointEnvVar(),

--- a/pkg/operator/mon/spec.go
+++ b/pkg/operator/mon/spec.go
@@ -27,6 +27,16 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
+// PrivateIPEnvVar is the private cluster ip env var for monitors
+func PrivateIPEnvVar() v1.EnvVar {
+	return v1.EnvVar{Name: k8sutil.PrivateIPEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}}
+}
+
+// PublicIPEnvVar is the public ip env var for monitors
+func PublicIPEnvVar(publicIP string) v1.EnvVar {
+	return v1.EnvVar{Name: k8sutil.PublicIPEnvVar, Value: publicIP}
+}
+
 // ClusterNameEnvVar is the cluster name environment var
 func ClusterNameEnvVar(name string) v1.EnvVar {
 	return v1.EnvVar{Name: "ROOKD_CLUSTER_NAME", Value: name}
@@ -59,7 +69,6 @@ func (c *Cluster) getLabels(name string) map[string]string {
 }
 
 func (c *Cluster) makeReplicaSet(config *monConfig, nodeName string) *extensions.ReplicaSet {
-
 	rs := &extensions.ReplicaSet{}
 	rs.Name = config.Name
 	rs.Namespace = c.Namespace
@@ -110,7 +119,6 @@ func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
 }
 
 func (c *Cluster) monContainer(config *monConfig, fsid string) v1.Container {
-
 	return v1.Container{
 		Args: []string{
 			"mon",
@@ -133,7 +141,8 @@ func (c *Cluster) monContainer(config *monConfig, fsid string) v1.Container {
 			k8sutil.ConfigOverrideMount(),
 		},
 		Env: []v1.EnvVar{
-			{Name: k8sutil.PodIPEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "status.podIP"}}},
+			PrivateIPEnvVar(),
+			PublicIPEnvVar(config.PublicIP),
 			ClusterNameEnvVar(c.Namespace),
 			EndpointEnvVar(),
 			SecretEnvVar(),

--- a/pkg/operator/mon/spec_test.go
+++ b/pkg/operator/mon/spec_test.go
@@ -62,7 +62,7 @@ func testPodSpec(t *testing.T, dataDir string) {
 	cont := pod.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
-	assert.Equal(t, 6, len(cont.Env))
+	assert.Equal(t, 7, len(cont.Env))
 
 	logger.Infof("Command : %+v", cont.Command)
 	assert.Equal(t, "mon", cont.Args[0])

--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -182,6 +182,8 @@ func (c *Cluster) osdContainer(devices []Device, directories []Directory, select
 
 	envVars := []v1.EnvVar{
 		nodeNameEnvVar(),
+		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 		opmon.ClusterNameEnvVar(c.Namespace),
 		opmon.EndpointEnvVar(),
 		opmon.SecretEnvVar(),

--- a/pkg/operator/osd/osd_test.go
+++ b/pkg/operator/osd/osd_test.go
@@ -48,7 +48,6 @@ func TestPodContainer(t *testing.T) {
 	assert.NotNil(t, c)
 	assert.Equal(t, 1, len(c.Spec.Containers))
 	container := c.Spec.Containers[0]
-	assert.Equal(t, 7, len(container.Env))
 	assert.Equal(t, "osd", container.Args[0])
 }
 

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -169,6 +169,8 @@ func (c *Cluster) rgwContainer() v1.Container {
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOKD_RGW_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: appName}, Key: keyringName}}},
+			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 			opmon.ClusterNameEnvVar(c.Namespace),
 			opmon.EndpointEnvVar(),
 			opmon.SecretEnvVar(),

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -93,7 +93,6 @@ func TestPodSpecs(t *testing.T) {
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
-	assert.Equal(t, 6, len(cont.Env))
 
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -281,14 +281,14 @@ func (k8sh *K8sHelper) GetResource(args []string) (string, error) {
 //GetMonitorServices returns all ceph mon pod names
 func (k8sh *K8sHelper) GetMonitorServices() (map[string]string, error) {
 
-	cmdArgs := []string{"-n", "rook", "get", "svc", "-l", "app=rook-ceph-mon", "--no-headers=true"}
-	stdout, _, status := ExecuteCmd("kubectl", cmdArgs)
-	if status != 0 {
-		return nil, fmt.Errorf("Failed to find mon services. %d", status)
+	args := []string{"-n", "rook", "get", "svc", "-l", "app=rook-ceph-mon", "--no-headers=true"}
+	result, err := k8sh.Kubectl(args...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to find mon services. %v", err)
 	}
 
 	// Get the IP address from the 2nd position in the line
-	mons, err := parseMonEndpoints(stdout)
+	mons, err := parseMonEndpoints(result)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/smoke/file_test.go
+++ b/tests/smoke/file_test.go
@@ -18,6 +18,7 @@ package smoke
 
 import (
 	"fmt"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,21 +83,11 @@ func (suite *SmokeSuite) fileTestDataCleanUp() {
 }
 
 func (suite *SmokeSuite) podWithFileSystem(action string) error {
-	mons, err := suite.k8sh.GetMonitorPods()
-	if err != nil {
-		return err
-	}
-	ip1, _ := suite.k8sh.GetMonIP(mons[0])
-	ip2, _ := suite.k8sh.GetMonIP(mons[1])
-	ip3, _ := suite.k8sh.GetMonIP(mons[2])
+	mons, err := suite.k8sh.GetMonitorServices()
+	require.Nil(suite.T(), err)
 
-	config := map[string]string{
-		"mon0": ip1,
-		"mon1": ip2,
-		"mon2": ip3,
-	}
 	logger.Infof("mountFileStorage: Mons: %+v", mons)
-	_, err = suite.k8sh.ResourceOperationFromTemplate(action, getFileSystemTestPod(), config)
+	_, err = suite.k8sh.ResourceOperationFromTemplate(action, getFileSystemTestPod(), mons)
 	if err != nil {
 		return fmt.Errorf("failed to %s pod -- %s. %+v", action, getFileSystemTestPod(), err)
 	}

--- a/tests/smoke/mon_test.go
+++ b/tests/smoke/mon_test.go
@@ -30,8 +30,9 @@ import (
 func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Mon Failover Smoke Test")
 
+	namespace := "rook"
 	opts := metav1.ListOptions{LabelSelector: "app=rook-ceph-mon"}
-	monReplicas, err := suite.helper.Clientset.ReplicaSets(suite.helper.namespace).List(opts)
+	monReplicas, err := suite.k8sh.Clientset.ReplicaSets(namespace).List(opts)
 	require.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 3, len(monReplicas.Items))
 
@@ -39,12 +40,12 @@ func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Killing mon %s", monToKill)
 	propagation := metav1.DeletePropagationForeground
 	delOptions := &metav1.DeleteOptions{PropagationPolicy: &propagation}
-	err = suite.helper.Clientset.ReplicaSets(suite.helper.namespace).Delete(monToKill, delOptions)
+	err = suite.k8sh.Clientset.ReplicaSets(namespace).Delete(monToKill, delOptions)
 	require.Nil(suite.T(), err)
 
 	// Wait for the health check to start a new monitor
 	for i := 0; i < 10; i++ {
-		monReplicas, err := suite.helper.Clientset.ReplicaSets(suite.helper.namespace).List(opts)
+		monReplicas, err := suite.k8sh.Clientset.ReplicaSets(namespace).List(opts)
 		require.Nil(suite.T(), err)
 
 		// Make sure the old mon is not still alive

--- a/tests/smoke/mon_test.go
+++ b/tests/smoke/mon_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smoke
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
+//Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,Delete Bucket and
+//Delete user
+func (suite *SmokeSuite) TestMonFailover() {
+	logger.Infof("Mon Failover Smoke Test")
+
+	opts := metav1.ListOptions{LabelSelector: "app=rook-ceph-mon"}
+	monReplicas, err := suite.helper.Clientset.ReplicaSets(suite.helper.namespace).List(opts)
+	require.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 3, len(monReplicas.Items))
+
+	monToKill := monReplicas.Items[0].Name
+	logger.Infof("Killing mon %s", monToKill)
+	propagation := metav1.DeletePropagationForeground
+	delOptions := &metav1.DeleteOptions{PropagationPolicy: &propagation}
+	err = suite.helper.Clientset.ReplicaSets(suite.helper.namespace).Delete(monToKill, delOptions)
+	require.Nil(suite.T(), err)
+
+	// Wait for the health check to start a new monitor
+	for i := 0; i < 10; i++ {
+		monReplicas, err := suite.helper.Clientset.ReplicaSets(suite.helper.namespace).List(opts)
+		require.Nil(suite.T(), err)
+
+		// Make sure the old mon is not still alive
+		foundOldMon := false
+		for _, mon := range monReplicas.Items {
+			if mon.Name == monToKill {
+				foundOldMon = true
+			}
+		}
+
+		// Check if we have three monitors
+		if !foundOldMon {
+			if len(monReplicas.Items) == 3 {
+				var newMons []string
+				for _, mon := range monReplicas.Items {
+					newMons = append(newMons, mon.Name)
+				}
+				logger.Infof("Found a new monitor! monitors=%v", newMons)
+				return
+			}
+
+			assert.Equal(suite.T(), 2, len(monReplicas.Items))
+		}
+
+		logger.Infof("Waiting for a new monitor to start")
+		time.Sleep(8 * time.Second)
+	}
+
+	require.Fail(suite.T(), "giving up waiting for a new monitor")
+}


### PR DESCRIPTION
Monitors require a stable identity. In Kubernetes a stable IP is specified with a service. The mon startup sequence is now:
- Create a K8s service for each mon
- Set the expected mon endpoints in a configmap
- Start the monitor pods
- The mons will generate the monmap with all expected monitors

Fixes #586 to survive reboots. Also included is to fix the PID 1 issue and launch with tini, which means processes now will respond to properly shutdown the pod. 

A side effect of the monmap generation is that initial startup is on the order of a few seconds to form mon quorum instead of 30-60 seconds.

Still need to add functional tests.