### PR TITLE
operator: remove provisioner dependence on rest api

### DIFF
--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -107,18 +107,18 @@ func TestSaveMonEndpoints(t *testing.T) {
 	err := c.saveMonConfig()
 	assert.Nil(t, err)
 
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data["endpoints"])
+	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
 
 	// update the config map
 	c.clusterInfo.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
 	err = c.saveMonConfig()
 	assert.Nil(t, err)
 
-	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
+	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data["endpoints"])
+	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data[EndpointDataKey])
 }
 
 func TestCheckHealth(t *testing.T) {
@@ -147,9 +147,9 @@ func TestCheckHealth(t *testing.T) {
 	err = c.failoverMon("mon1")
 	assert.Nil(t, err)
 
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data["endpoints"])
+	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
 }
 
 func TestMonInQuourm(t *testing.T) {

--- a/pkg/operator/mon/spec.go
+++ b/pkg/operator/mon/spec.go
@@ -34,7 +34,7 @@ func ClusterNameEnvVar(name string) v1.EnvVar {
 
 // EndpointEnvVar is the mon endpoint environment var
 func EndpointEnvVar() v1.EnvVar {
-	ref := &v1.ConfigMapKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: monConfigMapName}, Key: monEndpointKey}
+	ref := &v1.ConfigMapKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: EndpointConfigMapName}, Key: EndpointDataKey}
 	return v1.EnvVar{Name: "ROOKD_MON_ENDPOINTS", ValueFrom: &v1.EnvVarSource{ConfigMapKeyRef: ref}}
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -65,7 +65,7 @@ func New(context *clusterd.Context) *Operator {
 		logger.Errorf("failed to create Operator. %+v.", err)
 		return nil
 	}
-	volumeProvisioner := provisioner.New(context.Clientset)
+	volumeProvisioner := provisioner.New(context)
 
 	schemes := []kit.CustomResource{cluster.ClusterResource, pool.PoolResource}
 	return &Operator{


### PR DESCRIPTION
Remove the provisioner's dependence on the Rook REST api. The image can be created directly by the operator and the mon endpoints retrieved from the configmap directly.