### PR TITLE
mon: using appName as monitor name on failover

### DIFF
--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -105,7 +105,7 @@ func (c *Cluster) failoverMon(name string) error {
 	logger.Infof("Failing over monitor %s", name)
 
 	// Start a new monitor
-	mons := []*monConfig{{Name: fmt.Sprintf("mon%d", c.maxMonID+1), Port: int32(mon.Port)}}
+	mons := []*monConfig{{Name: fmt.Sprintf("%s%d", appName, c.maxMonID+1), Port: int32(mon.Port)}}
 	logger.Infof("starting new mon %s", mons[0].Name)
 	err := c.startPods(mons)
 	if err != nil {

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -149,7 +149,7 @@ func TestCheckHealth(t *testing.T) {
 
 	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get("mon-config", metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "mon11=:6790", cm.Data["endpoints"])
+	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data["endpoints"])
 }
 
 func TestMonInQuourm(t *testing.T) {


### PR DESCRIPTION
Fixes #854 