### PR TITLE
logs: stop writing the frequent health check

### DIFF
--- a/cmd/rookctl/block/list_test.go
+++ b/cmd/rookctl/block/list_test.go
@@ -40,7 +40,7 @@ func TestListBlockImages(t *testing.T) {
 		},
 	}
 	e := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			if strings.Contains(command, "mount") {
 				return "/dev/rbd5 on /tmp/mymount1", nil
 			}

--- a/cmd/rookctl/block/map_test.go
+++ b/cmd/rookctl/block/map_test.go
@@ -41,7 +41,7 @@ func TestMountBlock(t *testing.T) {
 		},
 	}
 	e := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			switch {
 			case strings.HasPrefix(command, "modinfo"):
 				return "single_major:Use a single major number for all rbd devices (default: false) (bool)", nil

--- a/cmd/rookctl/block/unmap_test.go
+++ b/cmd/rookctl/block/unmap_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestUnmountBlock(t *testing.T) {
 	e := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			switch {
 			case strings.HasPrefix(command, "modinfo"):
 				return "single_major:Use a single major number for all rbd devices (default: false) (bool)", nil
@@ -64,7 +64,7 @@ func TestUnmountBlock(t *testing.T) {
 
 func TestUnmountBlockFailure(t *testing.T) {
 	e := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			switch {
 			case strings.HasPrefix(command, "modinfo"):
 				return "single_major:Use a single major number for all rbd devices (default: false) (bool)", nil

--- a/cmd/rookctl/filesystem/mount_test.go
+++ b/cmd/rookctl/filesystem/mount_test.go
@@ -37,7 +37,7 @@ func TestMountFilesystem(t *testing.T) {
 		},
 	}
 	e := &exectest.MockExecutor{
-		MockExecuteCommand: func(actionName string, command string, arg ...string) error {
+		MockExecuteCommand: func(debug bool, actionName string, command string, arg ...string) error {
 			assert.Equal(t, "mount", command)
 			expectedArgs := []string{"-t", "ceph", "-o", "name=admin,secret=AQBsCv1X5oD9GhAARHVU9N+kFRWDjyLA1dqzIg==",
 				"10.37.129.214:6790:/", "/tmp/myfs1mount"}

--- a/cmd/rookctl/filesystem/unmount_test.go
+++ b/cmd/rookctl/filesystem/unmount_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestUnmountFilesystem(t *testing.T) {
 	e := &exectest.MockExecutor{
-		MockExecuteCommand: func(actionName string, command string, arg ...string) error {
+		MockExecuteCommand: func(debug bool, actionName string, command string, arg ...string) error {
 			assert.Equal(t, "umount", command)
 			expectedArgs := []string{"/tmp/myfs1mount"}
 			assert.Equal(t, expectedArgs, arg)
@@ -41,7 +41,7 @@ func TestUnmountFilesystem(t *testing.T) {
 
 func TestUnmountFilesystemError(t *testing.T) {
 	e := &exectest.MockExecutor{
-		MockExecuteCommand: func(actionName string, command string, arg ...string) error {
+		MockExecuteCommand: func(debug bool, actionName string, command string, arg ...string) error {
 			return fmt.Errorf("mock unmount failure")
 		},
 	}

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -29,7 +29,7 @@ func (h *Handler) GetClientAccessInfo(w http.ResponseWriter, r *http.Request) {
 	// TODO: auth is extremely important here because we are returning cephx credentials
 	// https://github.com/rook/rook/issues/209
 
-	monStatus, err := ceph.GetMonStatus(h.context, h.config.ClusterInfo.Name)
+	monStatus, err := ceph.GetMonStatus(h.context, h.config.ClusterInfo.Name, false)
 	if err != nil {
 		logger.Errorf("failed to get monitor status, err: %+v", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/api/filesystem_test.go
+++ b/pkg/api/filesystem_test.go
@@ -50,7 +50,7 @@ func TestGetFileSystemsHandler(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mon0"})
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			logger.Infof("OUTPUT: %s %v", command, args)
 			if args[0] == "fs" && args[1] == "ls" {
 				return cephFilesystemListResponseRaw, nil

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -113,7 +113,7 @@ func (h *Handler) GetMonitors(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get the monitor status
-	monStatusResp, err := ceph.GetMonStatus(h.context, h.config.ClusterInfo.Name)
+	monStatusResp, err := ceph.GetMonStatus(h.context, h.config.ClusterInfo.Name, false)
 	if err != nil {
 		logger.Errorf("failed to get mon_status, err: %+v", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -145,7 +145,7 @@ func TestGetMonsHandler(t *testing.T) {
 	etcdClient.SetValue(path.Join(key, "ipaddress"), "1.2.3.4")
 	etcdClient.SetValue(path.Join(key, "port"), "8765")
 
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		if args[0] == "mon_status" {
 			return cephclienttest.MonInQuorumResponse(), nil
 		}
@@ -170,7 +170,7 @@ func TestGetPoolsHandler(t *testing.T) {
 	}
 
 	// first return no storage pools
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "osd" && args[1] == "lspools":
 			return `[]`, nil
@@ -187,7 +187,7 @@ func TestGetPoolsHandler(t *testing.T) {
 
 	// now return some storage pools from the ceph connection
 	w = httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "osd" && args[1] == "lspools":
 			return `[{"poolnum":0,"poolname":"rbd"},{"poolnum":1,"poolname":"ecPool1"}]`, nil
@@ -246,7 +246,7 @@ func TestCreatePoolHandler(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[1] == "erasure-code-profile" && args[2] == "get":
 			if args[3] == "default" {
@@ -279,7 +279,7 @@ func TestCreatePoolHandlerFailure(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	context.Executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "", fmt.Errorf("mock failure to create pool1")
 		},
 	}
@@ -301,7 +301,7 @@ func TestGetClientAccessInfo(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "mon_status":
 			response := "{\"name\":\"mon0\",\"rank\":0,\"state\":\"leader\",\"election_epoch\":3,\"quorum\":[0],\"monmap\":{\"epoch\":1," +

--- a/pkg/api/image_test.go
+++ b/pkg/api/image_test.go
@@ -37,10 +37,10 @@ func TestGetImagesHandler(t *testing.T) {
 
 	// first return no storage pools, which means no images will be returned either
 	w := httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		return `[]`, nil
 	}
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		return `[]`, nil
 	}
 
@@ -52,7 +52,7 @@ func TestGetImagesHandler(t *testing.T) {
 
 	// now return some storage pools and images from the ceph connection
 	w = httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case command == "ceph" && args[0] == "osd" && args[1] == "lspools":
 			return `[{"poolnum":0,"poolname":"pool0"},{"poolnum":1,"poolname":"pool1"}]`, nil
@@ -60,7 +60,7 @@ func TestGetImagesHandler(t *testing.T) {
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
 
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
 			poolName := args[2]
@@ -85,7 +85,7 @@ func TestGetImagesHandlerFailure(t *testing.T) {
 		logger.Fatal(err)
 	}
 
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		return "mock error", fmt.Errorf("mock error for list pools")
 	}
 
@@ -141,7 +141,7 @@ func TestCreateImageHandler(t *testing.T) {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
 			return "", nil
@@ -167,7 +167,7 @@ func TestCreateImageHandlerFailure(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		return "mock failure", fmt.Errorf("mock failure to create image")
 	}
 
@@ -222,7 +222,7 @@ func TestDeleteImageHandler(t *testing.T) {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "rm":
 			return "", nil
@@ -246,7 +246,7 @@ func TestDeleteImageHandlerFailure(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "rm":
 			return "mock failure", fmt.Errorf("mock failure to remove image")

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -126,7 +126,9 @@ func TestListUsers(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, path.Join(configDir, "rookcluster"), []string{"mymon"})
 
 	runTest := func(runner func(args ...string) (string, error)) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) { return runner(args...) }}
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
+			return runner(args...)
+		}}
 		context := &clusterd.Context{
 			DirectContext: clusterd.DirectContext{EtcdClient: etcdClient},
 			Executor:      executor,
@@ -224,7 +226,7 @@ func TestGetUser(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(s string, e error, expectedArgs ...string) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) {
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 			assert.Equal(t, expectedArgs, args)
 			return s, e
 		}}
@@ -292,7 +294,7 @@ func TestCreateUser(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(body string, s string, e error, expectedArgs ...string) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) {
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 			assert.Equal(t, expectedArgs, args)
 			return s, e
 		}}
@@ -372,7 +374,7 @@ func TestUpdateUser(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(body string, s string, e error, expectedArgs ...string) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) {
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 			assert.Equal(t, expectedArgs, args)
 			return s, e
 		}}
@@ -456,7 +458,7 @@ func TestDeleteUser(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(s string, e error, expectedArgs ...string) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) {
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 			assert.Equal(t, expectedArgs, args)
 			return s, e
 		}}
@@ -509,7 +511,9 @@ func TestListBuckets(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(runner func(args ...string) (string, error)) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) { return runner(args...) }}
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
+			return runner(args...)
+		}}
 		context := &clusterd.Context{
 			DirectContext: clusterd.DirectContext{EtcdClient: etcdClient},
 			ConfigDir:     configDir,
@@ -652,7 +656,9 @@ func TestGetBucket(t *testing.T) {
 	cephtest.CreateClusterInfo(etcdClient, configDir, []string{"mymon"})
 
 	runTest := func(runner func(args ...string) (string, error)) *httptest.ResponseRecorder {
-		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) { return runner(args...) }}
+		executor := &testexec.MockExecutor{MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
+			return runner(args...)
+		}}
 		context := &clusterd.Context{
 			DirectContext: clusterd.DirectContext{EtcdClient: etcdClient},
 			ConfigDir:     configDir,
@@ -766,7 +772,7 @@ func TestBucketDelete(t *testing.T) {
 
 	runTest := func(s string, e error, expectedArgs ...string) *httptest.ResponseRecorder {
 		executor := &testexec.MockExecutor{
-			MockExecuteCommandWithCombinedOutput: func(command string, subcommand string, args ...string) (string, error) {
+			MockExecuteCommandWithCombinedOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 				assert.Equal(t, expectedArgs, args)
 				return s, e
 			},

--- a/pkg/api/status_test.go
+++ b/pkg/api/status_test.go
@@ -44,7 +44,7 @@ func TestGetStatusDetailsHandler(t *testing.T) {
 		logger.Fatal(err)
 	}
 
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "status":
 			return cephStatusResponseRaw, nil
@@ -100,7 +100,7 @@ func TestGetStatusDetailsEmptyResponseFromCeph(t *testing.T) {
 		logger.Fatal(err)
 	}
 
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "status":
 			return "{}", nil

--- a/pkg/ceph/client/crush.go
+++ b/pkg/ceph/client/crush.go
@@ -135,7 +135,7 @@ func CreateDefaultCrushMap(context *clusterd.Context, clusterName string) (strin
 
 	// compile the crush map to an output file
 	args := []string{"-c", decompiledMap.Name(), "-o", compiledMap.Name()}
-	output, err = context.Executor.ExecuteCommandWithOutput("", CrushTool, args...)
+	output, err = context.Executor.ExecuteCommandWithOutput(false, "", CrushTool, args...)
 	if err != nil {
 		return output, fmt.Errorf("failed to compile crushmap from %s: %+v", decompiledMap.Name(), err)
 	}

--- a/pkg/ceph/client/image_test.go
+++ b/pkg/ceph/client/image_test.go
@@ -32,7 +32,7 @@ func TestCreateImage(t *testing.T) {
 
 	// mock an error during the create image call.  rbd tool returns error information to the output stream,
 	// separate from the error object, so verify that information also makes it back to us (because it is useful).
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
 			return "mocked detailed ceph error output stream", fmt.Errorf("some mocked error")
@@ -47,7 +47,7 @@ func TestCreateImage(t *testing.T) {
 	// (except for 0, that's OK)
 	createCalled := false
 	expectedSizeArg := ""
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
 			createCalled = true

--- a/pkg/ceph/client/mon.go
+++ b/pkg/ceph/client/mon.go
@@ -74,13 +74,17 @@ func AppendAdminConnectionArgs(args []string, configDir, clusterName string) []s
 func ExecuteCephCommandPlain(context *clusterd.Context, clusterName string, args []string) ([]byte, error) {
 	args = AppendAdminConnectionArgs(args, context.ConfigDir, clusterName)
 	args = append(args, "--format", "plain")
-	return executeCommandWithOutputFile(context, CephTool, args)
+	return executeCommandWithOutputFile(context, false, CephTool, args)
 }
 
 func ExecuteCephCommand(context *clusterd.Context, clusterName string, args []string) ([]byte, error) {
+	return executeCephCommandWithOutputFile(context, clusterName, false, args)
+}
+
+func executeCephCommandWithOutputFile(context *clusterd.Context, clusterName string, debug bool, args []string) ([]byte, error) {
 	args = AppendAdminConnectionArgs(args, context.ConfigDir, clusterName)
 	args = append(args, "--format", "json")
-	return executeCommandWithOutputFile(context, CephTool, args)
+	return executeCommandWithOutputFile(context, debug, CephTool, args)
 }
 
 func ExecuteRBDCommand(context *clusterd.Context, clusterName string, args []string) ([]byte, error) {
@@ -95,19 +99,19 @@ func ExecuteRBDCommandNoFormat(context *clusterd.Context, clusterName string, ar
 }
 
 func executeCommand(context *clusterd.Context, tool string, args []string) ([]byte, error) {
-	output, err := context.Executor.ExecuteCommandWithOutput("", tool, args...)
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", tool, args...)
 	return []byte(output), err
 }
 
-func executeCommandWithOutputFile(context *clusterd.Context, tool string, args []string) ([]byte, error) {
-	output, err := context.Executor.ExecuteCommandWithOutputFile("", tool, "--out-file", args...)
+func executeCommandWithOutputFile(context *clusterd.Context, debug bool, tool string, args []string) ([]byte, error) {
+	output, err := context.Executor.ExecuteCommandWithOutputFile(debug, "", tool, "--out-file", args...)
 	return []byte(output), err
 }
 
 // calls mon_status mon_command
-func GetMonStatus(context *clusterd.Context, clusterName string) (MonStatusResponse, error) {
+func GetMonStatus(context *clusterd.Context, clusterName string, debug bool) (MonStatusResponse, error) {
 	args := []string{"mon_status"}
-	buf, err := ExecuteCephCommand(context, clusterName, args)
+	buf, err := executeCephCommandWithOutputFile(context, clusterName, debug, args)
 	if err != nil {
 		return MonStatusResponse{}, fmt.Errorf("mon status failed. %+v", err)
 	}

--- a/pkg/ceph/collectors/health_test.go
+++ b/pkg/ceph/collectors/health_test.go
@@ -351,7 +351,7 @@ $ sudo ceph -s
 	} {
 		func() {
 			executor := &exectest.MockExecutor{
-				MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+				MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 					return tt.input, nil
 				},
 			}

--- a/pkg/ceph/collectors/mon_test.go
+++ b/pkg/ceph/collectors/mon_test.go
@@ -187,7 +187,7 @@ func TestMonitorCollector(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			if args[0] == "time-sync-status" {
 				return timeStatusInput, nil
 			} else {

--- a/pkg/ceph/collectors/osd_test.go
+++ b/pkg/ceph/collectors/osd_test.go
@@ -247,7 +247,7 @@ func TestOSDCollector(t *testing.T) {
 	} {
 		func() {
 			executor := &exectest.MockExecutor{
-				MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+				MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 					return tt.input, nil
 				},
 			}

--- a/pkg/ceph/collectors/pool_test.go
+++ b/pkg/ceph/collectors/pool_test.go
@@ -176,7 +176,7 @@ func TestPoolUsageCollector(t *testing.T) {
 	} {
 		func() {
 			executor := &exectest.MockExecutor{
-				MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+				MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 					return tt.input, nil
 				},
 			}

--- a/pkg/ceph/collectors/usage_test.go
+++ b/pkg/ceph/collectors/usage_test.go
@@ -145,7 +145,7 @@ func TestClusterUsage(t *testing.T) {
 	} {
 		func() {
 			executor := &exectest.MockExecutor{
-				MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+				MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 					return tt.input, nil
 				},
 			}

--- a/pkg/ceph/leader_test.go
+++ b/pkg/ceph/leader_test.go
@@ -175,7 +175,7 @@ func testContext() *clusterd.Context {
 
 	configDir, _ := ioutil.TempDir("", "")
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			logger.Infof("OUTPUT: %s %v", command, args)
 			if command == "ceph-authtool" {
 				cephtest.CreateClusterInfo(nil, path.Join(configDir, "rookcluster"), []string{"a"})
@@ -183,7 +183,7 @@ func testContext() *clusterd.Context {
 			}
 			return "", fmt.Errorf("unrecognized command: %s %+v", command, args)
 		},
-		MockExecuteCommandWithOutputFile: func(actionName, command, outfileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName, command, outfileArg string, args ...string) (string, error) {
 			if command == "ceph" && args[0] == "mon_status" {
 				return clienttest.MonInQuorumResponse(), nil
 			}

--- a/pkg/ceph/mds/agent_test.go
+++ b/pkg/ceph/mds/agent_test.go
@@ -46,7 +46,7 @@ func TestGetSetMDSID(t *testing.T) {
 func TestStartMDS(t *testing.T) {
 	etcdClient := util.NewMockEtcdClient()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/ceph/mds/leader_test.go
+++ b/pkg/ceph/mds/leader_test.go
@@ -153,7 +153,7 @@ func TestAddRemoveFileSystem(t *testing.T) {
 	// MockMonCommand to pass back mocked ceph data and verify the calls we are making.
 	monCmdCount := 0
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			logger.Infof("RUN %s %+v", command, args)
 			result := ""
 			switch monCmdCount {

--- a/pkg/ceph/mon/agent.go
+++ b/pkg/ceph/mon/agent.go
@@ -222,7 +222,7 @@ func generateMonMap(context *clusterd.Context, cluster *ClusterInfo, folder stri
 		args = append(args, "--add", mon.Name, mon.Endpoint)
 	}
 
-	err := context.Executor.ExecuteCommand("", "monmaptool", args...)
+	err := context.Executor.ExecuteCommand(false, "", "monmaptool", args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate monmap. %+v", err)
 	}

--- a/pkg/ceph/mon/agent_test.go
+++ b/pkg/ceph/mon/agent_test.go
@@ -36,7 +36,7 @@ func TestMonAgent(t *testing.T) {
 	defer os.RemoveAll(context.ConfigDir)
 
 	runCommands := 0
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		logger.Infof("RUN %d. %s %+v", runCommands, command, args)
 		switch {
 		case runCommands == 0:
@@ -53,7 +53,7 @@ func TestMonAgent(t *testing.T) {
 	}
 
 	startCommands := 0
-	executor.MockStartExecuteCommand = func(name string, command string, args ...string) (*exec.Cmd, error) {
+	executor.MockStartExecuteCommand = func(debug bool, name string, command string, args ...string) (*exec.Cmd, error) {
 		logger.Infof("START %d. %s %+v", startCommands, command, args)
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 		assert.Equal(t, "--cluster=rookcluster", args[1])
@@ -111,7 +111,7 @@ func testContext() (*clusterd.Context, *util.MockEtcdClient, *exectest.MockExecu
 
 	configDir, _ := ioutil.TempDir("", "")
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			logger.Infof("OUTPUT: %s %v", command, args)
 			if command == "ceph-authtool" {
 				cephtest.CreateClusterInfo(nil, path.Join(configDir, "rookcluster"), []string{"a"})

--- a/pkg/ceph/mon/info.go
+++ b/pkg/ceph/mon/info.go
@@ -130,7 +130,7 @@ func genSecret(executor exec.Executor, configDir, name string, args []string) (s
 		"-n", name,
 	}
 	args = append(base, args...)
-	_, err := executor.ExecuteCommandWithOutput("gen secret", "ceph-authtool", args...)
+	_, err := executor.ExecuteCommandWithOutput(false, "gen secret", "ceph-authtool", args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to gen secret. %+v", err)
 	}

--- a/pkg/ceph/mon/leader.go
+++ b/pkg/ceph/mon/leader.go
@@ -392,7 +392,7 @@ func WaitForQuorumWithMons(context *clusterd.Context, clusterName string, mons [
 
 		// get the mon_status response that contains info about all monitors in the mon map and
 		// their quorum status
-		monStatusResp, err := client.GetMonStatus(context, clusterName)
+		monStatusResp, err := client.GetMonStatus(context, clusterName, false)
 		if err != nil {
 			logger.Debugf("failed to get mon_status, err: %+v", err)
 			continue

--- a/pkg/ceph/mon/leader_test.go
+++ b/pkg/ceph/mon/leader_test.go
@@ -124,7 +124,7 @@ func TestMoveUnhealthyMonitor(t *testing.T) {
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			logger.Infof("OUTPUT: %s %v", command, args)
 			if command == "ceph-authtool" {
 				cephtest.CreateClusterInfo(etcdClient, path.Join(configDir, "rookcluster"), []string{"a", "b", "c"})
@@ -302,7 +302,7 @@ func TestCreateInitialCrushMap(t *testing.T) {
 	assert.Equal(t, "1", etcdClient.GetValue("/rook/services/ceph/crushMapInitialized"))
 
 	// now call again, since we've already done it once we should not try to create the crushmap again
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		return "", fmt.Errorf("crushmap was already created, we shouldn't be calling this again")
 	}
 	err = createInitialCrushMap(context, clusterInfo)

--- a/pkg/ceph/osd/agent_test.go
+++ b/pkg/ceph/osd/agent_test.go
@@ -57,7 +57,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig StoreConfig) {
 	etcdClient, agent, executor := createTestAgent(t, nodeID, "sdx,sdy", configDir, &storeConfig)
 
 	startCount := 0
-	executor.MockStartExecuteCommand = func(name string, command string, args ...string) (*exec.Cmd, error) {
+	executor.MockStartExecuteCommand = func(debug bool, name string, command string, args ...string) (*exec.Cmd, error) {
 		logger.Infof("START %d for %s. %s %+v", startCount, name, command, args)
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 
@@ -72,7 +72,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig StoreConfig) {
 	}
 
 	execCount := 0
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		logger.Infof("RUN %d for %s. %s %+v", execCount, name, command, args)
 		parts := strings.Split(name, " ")
 		nameSuffix := parts[0]
@@ -146,7 +146,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig StoreConfig) {
 	}
 
 	outputExecCount := 0
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, actionName, command, args)
 		outputExecCount++
 		if args[0] == "auth" && args[1] == "get-or-create-key" {
@@ -157,7 +157,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig StoreConfig) {
 		}
 		return "", nil
 	}
-	executor.MockExecuteCommandWithOutput = func(actionName string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, actionName, command, args)
 		outputExecCount++
 		if strings.HasPrefix(actionName, "lsblk /dev/disk/by-partuuid") {
@@ -233,7 +233,7 @@ func TestOSDAgentNoDevices(t *testing.T) {
 
 	startCount := 0
 	executor := &exectest.MockExecutor{}
-	executor.MockStartExecuteCommand = func(name string, command string, args ...string) (*exec.Cmd, error) {
+	executor.MockStartExecuteCommand = func(debug bool, name string, command string, args ...string) (*exec.Cmd, error) {
 		startCount++
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 		return cmd, nil
@@ -241,7 +241,7 @@ func TestOSDAgentNoDevices(t *testing.T) {
 
 	// should be no executeCommand calls
 	runCount := 0
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		runCount++
 		createTestKeyring(t, configDir, args)
 		return nil
@@ -249,7 +249,7 @@ func TestOSDAgentNoDevices(t *testing.T) {
 
 	// should be no executeCommandWithOutput calls
 	outputExecCount := 0
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, actionName, command, args)
 		outputExecCount++
 		return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
@@ -360,7 +360,7 @@ func createTestAgent(t *testing.T, nodeID, devices, configDir string, storeConfi
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
 		},
 	}
@@ -508,7 +508,7 @@ func TestGetPartitionPerfScheme(t *testing.T) {
 	// mock monitor command to return an osd ID when the client registers/creates an osd
 	currOsdID := 10
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			switch {
 			case args[0] == "osd" && args[1] == "create":
 				currOsdID++

--- a/pkg/ceph/osd/crushmap_test.go
+++ b/pkg/ceph/osd/crushmap_test.go
@@ -33,7 +33,7 @@ func TestCrushMap(t *testing.T) {
 func testCrushMapHelper(t *testing.T, storeConfig *StoreConfig) {
 	etcdClient := util.NewMockEtcdClient()
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(name string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		logger.Infof("OUTPUT for %s. %s %+v", name, command, args)
 		if strings.HasPrefix(name, "lsblk /dev/disk/by-partuuid") {
 			// this is a call to get device properties so we figure out CRUSH weight, which should only be done for Bluestore

--- a/pkg/ceph/osd/daemon_test.go
+++ b/pkg/ceph/osd/daemon_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestSetNodeName(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		assert.Equal(t, "hostname", command)
 		assert.Equal(t, args[0], "myhost")
 		return nil
@@ -100,7 +100,7 @@ func TestStoreOSDDirMap(t *testing.T) {
 func TestAvailableDevices(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithOutput = func(name string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		logger.Infof("OUTPUT for %s. %s %+v", name, command, args)
 
 		if command == "lsblk" {

--- a/pkg/ceph/osd/device_test.go
+++ b/pkg/ceph/osd/device_test.go
@@ -67,7 +67,7 @@ func TestOSDBootstrap(t *testing.T) {
 	defer os.Remove(targetPath)
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
@@ -98,7 +98,7 @@ func TestOverwriteRookOwnedPartitions(t *testing.T) {
 	// set up mock execute so we can verify the partitioning happens on sda
 	execCount := 0
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		logger.Infof("RUN %d for '%s'. %s %+v", execCount, name, command, args)
 		assert.Equal(t, "sgdisk", command)
 		switch execCount {
@@ -119,7 +119,7 @@ func TestOverwriteRookOwnedPartitions(t *testing.T) {
 
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
 	outputExecCount := 0
-	executor.MockExecuteCommandWithOutput = func(name string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, name, command, args)
 		var output string
 		switch outputExecCount {
@@ -188,7 +188,7 @@ func TestPartitionBluestoreMetadata(t *testing.T) {
 
 	execCount := 0
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		logger.Infof("RUN %d for '%s'. %s %+v", execCount, name, command, args)
 		assert.Equal(t, "sgdisk", command)
 		switch execCount {
@@ -247,7 +247,7 @@ func TestPartitionBluestoreMetadataSafe(t *testing.T) {
 	nodeID := "node123"
 	etcdClient := util.NewMockEtcdClient()
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(name string, command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		if command == "df" {
 			// mock that the metadata device already has a filesytem, this should abort the partition effort
 			if strings.Index(name, "nvme01") != -1 {
@@ -294,7 +294,7 @@ func testPartitionOSDHelper(t *testing.T, storeConfig StoreConfig) {
 	// setup the mock executor to validate the calls to partition the device
 	execCount := 0
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		logger.Infof("RUN %d for '%s'. %s %+v", execCount, name, command, args)
 		if execCount <= 2 {
 			assert.Equal(t, "sgdisk", command)

--- a/pkg/ceph/rgw/admin.go
+++ b/pkg/ceph/rgw/admin.go
@@ -37,7 +37,7 @@ func RunAdminCommand(context *clusterd.Context, getClusterInfo func() (*mon.Clus
 	options = append(options, args...)
 
 	// start the rgw admin command
-	output, err := context.Executor.ExecuteCommandWithCombinedOutput("", "radosgw-admin", options...)
+	output, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "radosgw-admin", options...)
 	if err != nil {
 		return "", fmt.Errorf("failed to run radosgw-admin: %+v", err)
 	}

--- a/pkg/ceph/rgw/agent_test.go
+++ b/pkg/ceph/rgw/agent_test.go
@@ -32,7 +32,7 @@ import (
 func TestStartRGW(t *testing.T) {
 	etcdClient := util.NewMockEtcdClient()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/ceph/rgw/leader_test.go
+++ b/pkg/ceph/rgw/leader_test.go
@@ -43,7 +43,7 @@ func TestRGWConfig(t *testing.T) {
 		"b": {PublicIP: "2.3.4.5"},
 	}
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return `{"key":"mykey"}`, nil
 			}

--- a/pkg/clusterd/clusterMember_test.go
+++ b/pkg/clusterd/clusterMember_test.go
@@ -547,7 +547,7 @@ func TestHardwareDiscoveryLocking(t *testing.T) {
 	execCount := 0
 	executor := &util.MockExecutor{}
 	context.Executor = executor
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		// block until the loser discovery bails out
 		<-discoveryComplete
 		execCount++

--- a/pkg/clusterd/inventory/disk_test.go
+++ b/pkg/clusterd/inventory/disk_test.go
@@ -87,11 +87,11 @@ func TestAvailableDisks(t *testing.T) {
 
 func TestDiscoverDevices(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommand: func(actionName string, command string, arg ...string) error {
+		MockExecuteCommand: func(debug bool, actionName string, command string, arg ...string) error {
 			logger.Infof("mock execute. %s. %s", actionName, command)
 			return nil
 		},
-		MockExecuteCommandWithOutput: func(actionName string, command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, arg ...string) (string, error) {
 			logger.Infof("mock execute with output. %s. %s", actionName, command)
 			return "", nil
 		},

--- a/pkg/operator/cluster/controller_test.go
+++ b/pkg/operator/cluster/controller_test.go
@@ -36,7 +36,7 @@ func TestCreateSecrets(t *testing.T) {
 	clientset := testop.New(3)
 	info := testop.CreateClusterInfo(1)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
@@ -73,7 +73,7 @@ func TestCreateInitialCrushMap(t *testing.T) {
 	assert.Equal(t, "1", cm.Data[crushmapCreatedKey])
 
 	// the crushmap should NOT get created again
-	executor.MockExecuteCommandWithOutputFile = func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		return "", fmt.Errorf("crushmap was already created, we shouldn't be calling this again")
 	}
 	err = c.createInitialCrushMap()

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestStartMDS(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/operator/mgr/mgr_test.go
+++ b/pkg/operator/mgr/mgr_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestStartMGR(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -66,7 +66,7 @@ func (c *Cluster) checkHealth() error {
 
 	// connect to the mons
 	// get the status and check for quorum
-	status, err := client.GetMonStatus(c.context, c.clusterInfo.Name)
+	status, err := client.GetMonStatus(c.context, c.clusterInfo.Name, true)
 	if err != nil {
 		return fmt.Errorf("failed to get mon status. %+v", err)
 	}

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -43,7 +43,7 @@ func TestStartMonPods(t *testing.T) {
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
 				cephtest.CreateClusterInfo(nil, path.Join(configDir, namespace), nil)
 			}
@@ -122,7 +122,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 
 func TestCheckHealth(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return clienttest.MonInQuorumResponse(), nil
 		},
 	}

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -35,7 +35,7 @@ import (
 func TestStartRGW(t *testing.T) {
 	clientset := testop.New(3)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(actionName string, command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -22,50 +22,50 @@ import (
 
 // ******************** MockExecutor ********************
 type MockExecutor struct {
-	MockExecuteCommand                   func(actionName string, command string, arg ...string) error
-	MockStartExecuteCommand              func(actionName string, command string, arg ...string) (*exec.Cmd, error)
-	MockExecuteCommandWithOutput         func(actionName string, command string, arg ...string) (string, error)
-	MockExecuteCommandWithCombinedOutput func(actionName string, command string, arg ...string) (string, error)
-	MockExecuteCommandWithOutputFile     func(actionName, command, outfileArg string, arg ...string) (string, error)
+	MockExecuteCommand                   func(debug bool, actionName string, command string, arg ...string) error
+	MockStartExecuteCommand              func(debug bool, actionName string, command string, arg ...string) (*exec.Cmd, error)
+	MockExecuteCommandWithOutput         func(debug bool, actionName string, command string, arg ...string) (string, error)
+	MockExecuteCommandWithCombinedOutput func(debug bool, actionName string, command string, arg ...string) (string, error)
+	MockExecuteCommandWithOutputFile     func(debug bool, actionName string, command, outfileArg string, arg ...string) (string, error)
 	MockExecuteStat                      func(name string) (os.FileInfo, error)
 }
 
-func (e *MockExecutor) ExecuteCommand(actionName string, command string, arg ...string) error {
+func (e *MockExecutor) ExecuteCommand(debug bool, actionName string, command string, arg ...string) error {
 	if e.MockExecuteCommand != nil {
-		return e.MockExecuteCommand(actionName, command, arg...)
+		return e.MockExecuteCommand(debug, actionName, command, arg...)
 	}
 
 	return nil
 }
 
-func (e *MockExecutor) StartExecuteCommand(actionName string, command string, arg ...string) (*exec.Cmd, error) {
+func (e *MockExecutor) StartExecuteCommand(debug bool, actionName string, command string, arg ...string) (*exec.Cmd, error) {
 	if e.MockStartExecuteCommand != nil {
-		return e.MockStartExecuteCommand(actionName, command, arg...)
+		return e.MockStartExecuteCommand(debug, actionName, command, arg...)
 	}
 
 	args := []string{command}
 	return &exec.Cmd{Args: append(args, arg...)}, nil
 }
 
-func (e *MockExecutor) ExecuteCommandWithOutput(actionName string, command string, arg ...string) (string, error) {
+func (e *MockExecutor) ExecuteCommandWithOutput(debug bool, actionName string, command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutput != nil {
-		return e.MockExecuteCommandWithOutput(actionName, command, arg...)
+		return e.MockExecuteCommandWithOutput(debug, actionName, command, arg...)
 	}
 
 	return "", nil
 }
 
-func (e *MockExecutor) ExecuteCommandWithCombinedOutput(actionName string, command string, arg ...string) (string, error) {
+func (e *MockExecutor) ExecuteCommandWithCombinedOutput(debug bool, actionName string, command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithCombinedOutput != nil {
-		return e.MockExecuteCommandWithCombinedOutput(actionName, command, arg...)
+		return e.MockExecuteCommandWithCombinedOutput(debug, actionName, command, arg...)
 	}
 
 	return "", nil
 }
 
-func (e *MockExecutor) ExecuteCommandWithOutputFile(actionName, command, outfileArg string, arg ...string) (string, error) {
+func (e *MockExecutor) ExecuteCommandWithOutputFile(debug bool, actionName string, command, outfileArg string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutputFile != nil {
-		return e.MockExecuteCommandWithOutputFile(actionName, command, outfileArg, arg...)
+		return e.MockExecuteCommandWithOutputFile(debug, actionName, command, outfileArg, arg...)
 	}
 
 	return "", nil

--- a/pkg/util/proc/monitoredproc.go
+++ b/pkg/util/proc/monitoredproc.go
@@ -76,7 +76,7 @@ func (p *MonitoredProc) Monitor(logName string) {
 		}
 
 		// start the process
-		p.cmd, err = p.parent.executor.StartExecuteCommand(logName, p.cmd.Args[0], p.cmd.Args[1:]...)
+		p.cmd, err = p.parent.executor.StartExecuteCommand(false, logName, p.cmd.Args[0], p.cmd.Args[1:]...)
 		if err != nil {
 			logger.Warningf("retry %d (total %d): process %v failed to restart. %v", p.retries, p.totalRetries, p.cmd.Args, err)
 			p.retries++

--- a/pkg/util/proc/monitoredproc_test.go
+++ b/pkg/util/proc/monitoredproc_test.go
@@ -77,7 +77,7 @@ func TestMonitoredRestart(t *testing.T) {
 	proc.retrySecondsExponentBase = 0.0
 
 	commands := 0
-	executor.MockStartExecuteCommand = func(name string, command string, args ...string) (*exec.Cmd, error) {
+	executor.MockStartExecuteCommand = func(debug bool, name string, command string, args ...string) (*exec.Cmd, error) {
 		commands++
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 		switch {

--- a/pkg/util/proc/procmanager.go
+++ b/pkg/util/proc/procmanager.go
@@ -53,7 +53,7 @@ func New(executor exec.Executor) *ProcManager {
 func (p *ProcManager) RunWithOutput(logName, command string, args ...string) (string, error) {
 
 	logger.Infof("Running process %s with args: %v", command, args)
-	output, err := p.executor.ExecuteCommandWithOutput(logName, command, args...)
+	output, err := p.executor.ExecuteCommandWithOutput(false, logName, command, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to run %s: %+v", command, err)
 	}
@@ -65,7 +65,7 @@ func (p *ProcManager) RunWithOutput(logName, command string, args ...string) (st
 func (p *ProcManager) RunWithCombinedOutput(logName, command string, args ...string) (string, error) {
 
 	logger.Infof("Running process %s with args: %v", command, args)
-	output, err := p.executor.ExecuteCommandWithCombinedOutput(logName, command, args...)
+	output, err := p.executor.ExecuteCommandWithCombinedOutput(false, logName, command, args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to run %s: %+v", command, err)
 	}
@@ -77,7 +77,7 @@ func (p *ProcManager) RunWithCombinedOutput(logName, command string, args ...str
 func (p *ProcManager) Run(logName, command string, args ...string) error {
 
 	logger.Infof("Running process %s with args: %v", command, args)
-	err := p.executor.ExecuteCommand(logName, command, args...)
+	err := p.executor.ExecuteCommand(false, logName, command, args...)
 	if err != nil {
 		return fmt.Errorf("failed to run %s: %+v", command, err)
 	}
@@ -102,7 +102,7 @@ func (p *ProcManager) Start(name, command, procSearchPattern string, policy Proc
 	}
 
 	logger.Infof("Starting process %s with args: %v", name, args)
-	cmd, err := p.executor.StartExecuteCommand(name, command, args...)
+	cmd, err := p.executor.StartExecuteCommand(false, name, command, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start process %s: %+v", name, err)
 	}

--- a/pkg/util/proc/procmanager_test.go
+++ b/pkg/util/proc/procmanager_test.go
@@ -70,7 +70,7 @@ func TestRunProcesses(t *testing.T) {
 	assert.Equal(t, "arg2", proc.cmd.Args[2])
 
 	run := false
-	executor.MockExecuteCommand = func(name string, command string, args ...string) error {
+	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
 		assert.Equal(t, "arg1", args[0])
 		assert.Equal(t, "arg2", args[1])
 		run = true

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -43,7 +43,7 @@ type Partition struct {
 
 func ListDevices(executor exec.Executor) ([]string, error) {
 	cmd := "lsblk all"
-	devices, err := executor.ExecuteCommandWithOutput(cmd, "lsblk", "--all", "--noheadings", "--list", "--output", "KNAME")
+	devices, err := executor.ExecuteCommandWithOutput(false, cmd, "lsblk", "--all", "--noheadings", "--list", "--output", "KNAME")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list all devices: %+v", err)
 	}
@@ -53,7 +53,7 @@ func ListDevices(executor exec.Executor) ([]string, error) {
 
 func GetDevicePartitions(device string, executor exec.Executor) (partitions []*Partition, unusedSpace uint64, err error) {
 	cmd := fmt.Sprintf("lsblk /dev/%s", device)
-	output, err := executor.ExecuteCommandWithOutput(cmd, "lsblk", fmt.Sprintf("/dev/%s", device),
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, "lsblk", fmt.Sprintf("/dev/%s", device),
 		"--bytes", "--pairs", "--output", "NAME,SIZE,TYPE,PKNAME")
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get device %s partitions. %+v", device, err)
@@ -102,7 +102,7 @@ func GetDeviceProperties(device string, executor exec.Executor) (map[string]stri
 
 func GetDevicePropertiesFromPath(devicePath string, executor exec.Executor) (map[string]string, error) {
 	cmd := fmt.Sprintf("lsblk %s", devicePath)
-	output, err := executor.ExecuteCommandWithOutput(cmd, "lsblk", devicePath,
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, "lsblk", devicePath,
 		"--bytes", "--nodeps", "--pairs", "--output", "SIZE,ROTA,RO,TYPE,PKNAME")
 	if err != nil {
 		// try to get more information about the command error
@@ -122,7 +122,7 @@ func GetDevicePropertiesFromPath(devicePath string, executor exec.Executor) (map
 // get the file systems availab
 func GetDeviceFilesystems(device string, executor exec.Executor) (string, error) {
 	cmd := fmt.Sprintf("get filesystem type for %s", device)
-	output, err := executor.ExecuteCommandWithOutput(cmd, "df", "--output=source,fstype")
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, "df", "--output=source,fstype")
 	if err != nil {
 		return "", fmt.Errorf("command %s failed: %+v", cmd, err)
 	}
@@ -132,13 +132,13 @@ func GetDeviceFilesystems(device string, executor exec.Executor) (string, error)
 
 func RemovePartitions(device string, executor exec.Executor) error {
 	cmd := fmt.Sprintf("zap %s", device)
-	err := executor.ExecuteCommand(cmd, sgdisk, "--zap-all", "/dev/"+device)
+	err := executor.ExecuteCommand(false, cmd, sgdisk, "--zap-all", "/dev/"+device)
 	if err != nil {
 		return fmt.Errorf("failed to zap partitions on /dev/%s: %+v", device, err)
 	}
 
 	cmd = fmt.Sprintf("clear %s", device)
-	err = executor.ExecuteCommand(cmd, sgdisk, "--clear", "--mbrtogpt", "/dev/"+device)
+	err = executor.ExecuteCommand(false, cmd, sgdisk, "--clear", "--mbrtogpt", "/dev/"+device)
 	if err != nil {
 		return fmt.Errorf("failed to clear partitions on /dev/%s: %+v", device, err)
 	}
@@ -148,12 +148,12 @@ func RemovePartitions(device string, executor exec.Executor) error {
 
 func CreatePartitions(device string, args []string, executor exec.Executor) error {
 	cmd := fmt.Sprintf("partition %s", device)
-	return executor.ExecuteCommand(cmd, sgdisk, args...)
+	return executor.ExecuteCommand(false, cmd, sgdisk, args...)
 }
 
 func FormatDevice(devicePath string, executor exec.Executor) error {
 	cmd := fmt.Sprintf("mkfs.ext4 %s", devicePath)
-	if err := executor.ExecuteCommand(cmd, "mkfs.ext4", devicePath); err != nil {
+	if err := executor.ExecuteCommand(false, cmd, "mkfs.ext4", devicePath); err != nil {
 		return fmt.Errorf("command %s failed: %+v", cmd, err)
 	}
 
@@ -163,7 +163,7 @@ func FormatDevice(devicePath string, executor exec.Executor) error {
 // look up the UUID for a disk.
 func GetDiskUUID(device string, executor exec.Executor) (string, error) {
 	cmd := fmt.Sprintf("get disk %s uuid", device)
-	output, err := executor.ExecuteCommandWithOutput(cmd,
+	output, err := executor.ExecuteCommandWithOutput(false, cmd,
 		sgdisk, "--print", fmt.Sprintf("/dev/%s", device))
 	if err != nil {
 		return "", err
@@ -177,7 +177,7 @@ func GetPartitionLabel(deviceName string, executor exec.Executor) (string, error
 	// not available in containers
 	devicePath := fmt.Sprintf("/dev/%s", deviceName)
 	cmd := fmt.Sprintf("blkid %s", devicePath)
-	output, err := executor.ExecuteCommandWithOutput(cmd, "blkid", devicePath, "-s", "PARTLABEL", "-o", "value")
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, "blkid", devicePath, "-s", "PARTLABEL", "-o", "value")
 	if err != nil {
 		return "", fmt.Errorf("failed to get partition label for device %s: %+v", deviceName, err)
 	}
@@ -188,7 +188,7 @@ func GetPartitionLabel(deviceName string, executor exec.Executor) (string, error
 // look up the mount point of the given device.  empty string returned if device is not mounted.
 func GetDeviceMountPoint(deviceName string, executor exec.Executor) (string, error) {
 	cmd := fmt.Sprintf("get mount point for %s", deviceName)
-	output, err := executor.ExecuteCommandWithOutput(cmd, mountCmd)
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, mountCmd)
 	if err != nil {
 		return "", fmt.Errorf("command %s failed: %+v", cmd, err)
 	}
@@ -201,7 +201,7 @@ func GetDeviceMountPoint(deviceName string, executor exec.Executor) (string, err
 func GetDeviceFromMountPoint(mountPoint string, executor exec.Executor) (string, error) {
 	mountPoint = filepath.Clean(mountPoint)
 	cmd := fmt.Sprintf("get device from mount point %s", mountPoint)
-	output, err := executor.ExecuteCommandWithOutput(cmd, mountCmd)
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, mountCmd)
 	if err != nil {
 		return "", fmt.Errorf("command %s failed: %+v", cmd, err)
 	}
@@ -232,7 +232,7 @@ func MountDeviceWithOptions(devicePath, mountPath, fstype, options string, execu
 
 	os.MkdirAll(mountPath, 0755)
 	cmd := fmt.Sprintf("mount %s", devicePath)
-	if err := executor.ExecuteCommand(cmd, mountCmd, args...); err != nil {
+	if err := executor.ExecuteCommand(false, cmd, mountCmd, args...); err != nil {
 		return fmt.Errorf("command %s failed: %+v", cmd, err)
 	}
 
@@ -241,7 +241,7 @@ func MountDeviceWithOptions(devicePath, mountPath, fstype, options string, execu
 
 func UnmountDevice(devicePath string, executor exec.Executor) error {
 	cmd := fmt.Sprintf("umount %s", devicePath)
-	if err := executor.ExecuteCommand(cmd, "umount", devicePath); err != nil {
+	if err := executor.ExecuteCommand(false, cmd, "umount", devicePath); err != nil {
 		cmdErr, ok := err.(*exec.CommandError)
 		if ok && cmdErr.ExitStatus() == 32 {
 			logger.Infof("ignoring exit status 32 from unmount of device %s, err:%+v", devicePath, cmdErr)
@@ -255,7 +255,7 @@ func UnmountDevice(devicePath string, executor exec.Executor) error {
 
 func DoesDeviceHaveChildren(device string, executor exec.Executor) (bool, error) {
 	cmd := fmt.Sprintf("check children for device %s", device)
-	output, err := executor.ExecuteCommandWithOutput(cmd, "lsblk --all -n -l --output PKNAME")
+	output, err := executor.ExecuteCommandWithOutput(false, cmd, "lsblk --all -n -l --output PKNAME")
 	if err != nil {
 		return false, fmt.Errorf("command %s failed: %+v", cmd, err)
 	}

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -62,7 +62,7 @@ sdc            tmpfs`
 func TestGetDeviceFromMountPoint(t *testing.T) {
 	const device = "/dev/rbd3"
 	e := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName, command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
 			switch {
 			case strings.HasPrefix(actionName, "get device from mount point"):
 				// verify that the mount path being searched for has been cleaned
@@ -92,7 +92,7 @@ func TestGetDeviceFromMountPoint(t *testing.T) {
 func TestMountDeviceWithOptions(t *testing.T) {
 	testCount := 0
 	e := &exectest.MockExecutor{
-		MockExecuteCommand: func(actionName string, command string, arg ...string) error {
+		MockExecuteCommand: func(debug bool, actionName string, command string, arg ...string) error {
 			switch testCount {
 			case 0:
 				assert.Equal(t, []string{"/dev/abc1", "/tmp/mount1"}, arg)
@@ -125,7 +125,7 @@ func TestMountDeviceWithOptions(t *testing.T) {
 func TestGetPartitions(t *testing.T) {
 	run := 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(actionName string, command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, arg ...string) (string, error) {
 			run++
 			switch {
 			case run == 1:

--- a/pkg/util/sys/kmod.go
+++ b/pkg/util/sys/kmod.go
@@ -28,7 +28,7 @@ func LoadKernelModule(name string, options []string, executor exec.Executor) err
 
 	args := append([]string{name}, options...)
 
-	if err := executor.ExecuteCommand(fmt.Sprintf("modprobe %s", name), "modprobe", args[:]...); err != nil {
+	if err := executor.ExecuteCommand(false, fmt.Sprintf("modprobe %s", name), "modprobe", args[:]...); err != nil {
 		return fmt.Errorf("failed to load kernel module %s: %+v", name, err)
 	}
 
@@ -36,7 +36,7 @@ func LoadKernelModule(name string, options []string, executor exec.Executor) err
 }
 
 func CheckKernelModuleParam(name, param string, executor exec.Executor) (bool, error) {
-	out, err := executor.ExecuteCommandWithOutput("check kmod param", "modinfo", "-F", "parm", name)
+	out, err := executor.ExecuteCommandWithOutput(false, "check kmod param", "modinfo", "-F", "parm", name)
 	if err != nil {
 		return false, fmt.Errorf("failed to check for %s module %s param: %+v", name, param, err)
 	}

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -72,7 +72,7 @@ func (k8sh *K8sHelper) GetK8sServerVersion() string {
 
 //Kubectl is wrapper for executing kubectl commands
 func (k8sh *K8sHelper) Kubectl(args ...string) (string, error) {
-	result, err := k8sh.executor.ExecuteCommandWithOutput("", "kubectl", args...)
+	result, err := k8sh.executor.ExecuteCommandWithOutput(false, "", "kubectl", args...)
 	if err != nil {
 		k8slogger.Errorf("Errors Encountered while executing kubectl command : %v", err)
 		return "", fmt.Errorf("Failed to run kubectl commands on args %v : %v", args, err)
@@ -102,7 +102,7 @@ func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, e
 }
 
 func getKubeConfig(executor exec.Executor) (*rest.Config, error) {
-	context, err := executor.ExecuteCommandWithOutput("", "kubectl", "config", "view", "-o", "json")
+	context, err := executor.ExecuteCommandWithOutput(false, "", "kubectl", "config", "view", "-o", "json")
 	if err != nil {
 		k8slogger.Errorf("Errors Encountered while executing kubectl command : %v", err)
 	}


### PR DESCRIPTION
A small change that touches a lot of files that allows us to suppress writing a command to the log. The health check every 10s fills up the logs. Finally opening this PR after having it locally for a while...