### PR TITLE
Rook flex volume

### DIFF
--- a/Documentation/k8s-block.md
+++ b/Documentation/k8s-block.md
@@ -42,14 +42,6 @@ Create the storage class.
 kubectl create -f rook-storageclass.yaml
 ```
 
-### Secrets
-The pod consuming storage will need access to a secret for the rbd plugin. The secret is automatically generated in the `default`
-namespace, but would need to be copied to other namespaces. In this example we are copying to the `kube-system` namespace.
-
-```bash
-kubectl get secret rook-rook-user -o json | jq '.metadata.namespace = "kube-system"' | kubectl apply -f -
-```
-
 ## Consume the storage
 
 We create a sample app to consume the block storage provisioned by Rook with the classic wordpress and mysql apps.

--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -6,6 +6,8 @@ indent: true
 
 # Prerequisites
 
+Rook can be installed on any existing Kubernetes clusters as long as it meets the minimum version and have the required priviledge to run in the cluster (see below for more information). If you dont have a Kubernetes cluster, you can quickly set one up using [Minikube](#minikube), [Kubeadm](#kubeadm) or [CoreOS/Vagrant](#new-local-kubernetes-cluster-with-vagrant).
+
 ## Minimum Version
 
 Kubernetes v1.6 or higher is targeted by Rook (while Rook is in alpha it will track the latest release to use the latest features).
@@ -20,14 +22,30 @@ Creating the Rook operator requires privileges for setting up RBAC. To launch th
 -subj "/CN=admin/O=system:masters"
 ```
 
+## Minikube
+
+To install `minikube`, refer to this [page](https://github.com/kubernetes/minikube/releases). Once you have `minikube` installed, start a cluster by doing the following:
+
+```console
+$ minikube start
+Starting local Kubernetes cluster...
+Starting VM...
+SSH-ing files into VM...
+Setting up certs...
+Starting cluster components...
+Connecting to cluster...
+Setting up kubeconfig...
+Kubectl is now configured to use the cluster.
+```
+
+After these steps, your minikube cluster is ready to install Rook on.
+
 ## Kubeadm
 
 You can easily spin up Rook on top of a `kubeadm` cluster.
 You can find the instructions on how to install kubeadm in the [`kubeadm` installation page](https://kubernetes.io/docs/getting-started-guides/kubeadm/).
 
 By using `kubeadm`, you can use Rook in just a few minutes!
-
-The only thing you might have to do is to install the `ceph-common` package on all nodes that are going to consume Rook PVs.
 
 ## New local Kubernetes cluster with Vagrant
 
@@ -49,86 +67,6 @@ kubectl cluster-info
 
 Once you see a url response, your cluster is [ready for use by Rook](kubernetes.md#deploy-rook).
 
-## Minikube
-
-If using `minikube`, you can deploy Rook to it with a small update, which modifies the minikube host to install the `rbd` command. This is needed by the Kubernetes `rbd` volume plugin. To install `minikube`, refer to this [page](https://github.com/kubernetes/minikube/releases).
-
-Once you have `minikube` installed, start a cluster by doing the following:
-
-```console
-$ minikube start
-Starting local Kubernetes cluster...
-Starting VM...
-SSH-ing files into VM...
-Setting up certs...
-Starting cluster components...
-Connecting to cluster...
-Setting up kubeconfig...
-Kubectl is now configured to use the cluster.
-```
-
-SSH into the minikube host and install `rbd`:
-
-```console
-$ minikube ssh
-$ cd /bin
-$ sudo curl -O https://raw.githubusercontent.com/ceph/ceph-docker/master/examples/kubernetes-coreos/rbd
-$ sudo chmod +x /bin/rbd
-$ rbd #run command to download ceph images.
-Unable to find image 'ceph/base:latest' locally
-latest: Pulling from ceph/base
-...
-$ exit
-```
-
-After these steps, your minikube cluster is ready to install Rook on.
-
-## Existing Kubernetes Cluster
-
-Alternatively, if you already have a running Kubernetes cluster, you can deploy Rook to it with a small update to modify the kubelet service to bind mount `/sbin/modprobe`, which allows access to `modprobe`.
-Access to modprobe is necessary for using the rbd volume plugin, which is being tracked in the Kubernetes code base with [#23924](https://github.com/kubernetes/kubernetes/issues/23924).
-
-If using RKT, you can enable `modprobe` by following this [guide](https://github.com/coreos/coreos-kubernetes/blob/master/Documentation/kubelet-wrapper.md#allow-pods-to-use-rbd-volumes). Instructions have been directly copied below for your convenience:
-
-Add the following options to the `RKT_OPTS` env before launching the kubelet via kubelet-wrapper:
-
-```ini
-[Service]
-Environment=KUBELET_VERSION=v1.5.3_coreos.0
-Environment="RKT_OPTS=--volume modprobe,kind=host,source=/usr/sbin/modprobe \
-  --mount volume=modprobe,target=/usr/sbin/modprobe \
-  --volume lib-modules,kind=host,source=/lib/modules \
-  --mount volume=lib-modules,target=/lib/modules \
-  --uuid-file-save=/var/run/kubelet-pod.uuid"
-...
-```
-
-Note that the kubelet also requires access to the userspace `rbd` tool that is included only in hyperkube images tagged `v1.3.6_coreos.0` or later. See next section on how to deploy `rbd`.
-
-## Ceph and RBD utilities installed on the nodes
-
-The Kubernetes kubelet shells out to system utilities to mount Rook volumes. This means that every Kubernetes host must have these utilities installed. This requirement extends to the control plane, since there may be interactions between kube-controller-manager and the Ceph cluster. Login to each Kubernetes host where Kubelet runs and execute the following:
-
-For Debian-based distros:
-
-```
-apt-get install ceph-fs-common ceph-common
-```
-
-For Redhat-based distros:
-
-```
-yum install ceph
-```
-
-For other Linux distros that don't have an explicit package manager, such as CoreOS, you can use a container with the ceph utilities. To deploy the containers on your hosts, do the following:
-
-```
-cd /bin
-sudo curl -O https://raw.githubusercontent.com/ceph/ceph-docker/master/examples/kubernetes-coreos/rbd
-sudo chmod +x /bin/rbd
-rbd #Command to download ceph images.
-```
 
 ## Using Rook in Kubernetes
 

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -21,27 +21,36 @@ You will need to use the yaml files from the [1.5 folder](/cluster/examples/kube
 
 ### Prerequisites
 
-To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [follow these quick instructions](k8s-pre-reqs.md), including:
-- The `kubelet` requires access to `modprobe` and `rbd` on host
-
-Note that we are striving for even more smooth integration with Kubernetes in the future such that `Rook` will work out of the box with any Kubernetes cluster.
+To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [follow these quick instructions](k8s-pre-reqs.md).
 
 If you are using `dataDirHostPath` to persist rook data on kubernetes hosts, make sure your host has at least 5GB of space available on the specified path.
 
 ### Deploy Rook
 
-With your Kubernetes cluster running, Rook can be setup and deployed by simply creating the rook-operator deployment and creating a rook cluster. To customize the operator settings, see the [Operator Helm Chart](helm-operator.md).
+With your Kubernetes cluster running, Rook can be setup and deployed by simply creating the rook-operator deployment and creating a rook cluster. To customize the operator settings, see the [Rook Helm Chart](helm-operator.md).
 
 ```bash
 cd cluster/examples/kubernetes
 kubectl create -f rook-operator.yaml
 
-# verify the rook-operator pod is in the `Running` state before proceeding
-kubectl get pod
+# verify the rook-operator and rook-agents pods are in the `Running` state before proceeding
+kubectl -n rook-system get pod
 ```
+
+---
+**Restart Kubelet (K8S 1.7 and older)**
+
+For versions of Kubernetes prior to 1.8, the Kubelet process on all nodes will require a restart after the Rook operator and Rook agents have been deployed. As part of their initial setup, the Rook agents deploy and configure a Flexvolume plugin in order to integrate with Kubernetes' volume controller framework. In Kubernetes v1.8+, the [dynamic Flexvolume plugin discovery](https://github.com/kubernetes/community/pull/833) will find and initialize our plugin, but in older versions of Kubernetes a manual restart of the Kubelet will be required.
+
+**Disable Attacher-detacher controller (K8S 1.6.x only)**
+
+For Kubernetes 1.6, it is also necessary to pass the `--enable-controller-attach-detach=false` flag to Kubelet when you restart it.  This is a workaround for a [Kubernetes issue](https://github.com/kubernetes/kubernetes/issues/47109) that only affects 1.6.
+
+---
 
 Now that the rook-operator pod is running, we can create the Rook cluster. For the cluster to survive reboots, 
 make sure you set the `dataDirHostPath` property. For more settings, see the documentation on [configuring the cluster](cluster-crd.md). 
+
 
 Save the cluster spec as `rook-cluster.yaml`:
 
@@ -111,6 +120,7 @@ To clean up all the artifacts created by the demo, **first cleanup the resources
 
 ```bash
 kubectl delete -f rook-operator.yaml
+kubectl delete -n rook-system daemonset rook-agent
 kubectl delete -n rook cluster rook
 kubectl delete -n rook serviceaccount rook-api
 kubectl delete clusterrole rook-api
@@ -120,8 +130,8 @@ kubectl delete clusterrole rook-ceph-osd
 kubectl delete clusterrolebinding rook-ceph-osd
 kubectl delete thirdpartyresources cluster.rook.io pool.rook.io  # ignore errors if on K8s 1.7+
 kubectl delete crd clusters.rook.io pools.rook.io  # ignore errors if on K8s 1.5 and 1.6
-kubectl delete secret rook-rook-user
 kubectl delete namespace rook
+kubectl delete namespace rook-system
 ```
 If you modified the demo settings, additional cleanup is up to you for devices, host paths, etc.
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CLIENT_PLATFORMS := $(filter-out linux_%,$(PLATFORMS))
 CLIENT_PACKAGES = $(GO_PROJECT)/cmd/rookctl
 
 # server projects that we build on server platforms
-SERVER_PACKAGES = $(GO_PROJECT)/cmd/rook
+SERVER_PACKAGES = $(GO_PROJECT)/cmd/rook $(GO_PROJECT)/cmd/flexvolume
 
 # tests packages that will be compiled into binaries
 TEST_PACKAGES = $(GO_PROJECT)/tests/integration

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -27,6 +27,10 @@
 
 - Rook Standalone
   - Standalone mode has been disabled and is no longer supported. A Kubernetes environment is required to run Rook.
+- Rook-operator now deploys in `rook-system` namespace
+  - If using the example manifest of [rook-operator.yaml](/cluster/examples/kubernetes/rook-operator.yaml), the rook-operator deployment is now changed to deploy in the `rook-system` namespace.
+- Introduces a new flexvolume plugin that will handle all volume attachment requests. This will simplify the deployment by not requiring to have ceph-tools package installed.
+- For Kubernetes cluster 1.7.x and older, Kubelet will need to be restarted in order to load the new flexvolume. This has been resolve in K8S 1.8. For more information about the requirements, refer to this [doc](/Documentation/k8s-pre-reqs.md)
 - Pool CRD
   - `replication` renamed to `replicated`
   - `erasureCode` renamed to `erasureCoded`

--- a/cluster/charts/rook/templates/clusterrole.yaml
+++ b/cluster/charts/rook/templates/clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - pods
   - services
   - nodes
+  - nodes/proxy
   - configmaps
   - events
   - persistentvolumes

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -25,6 +25,23 @@ spec:
           value: {{ .Values.image.prefix }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ROOK_OPERATOR_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
 {{- if .Values.mon }}
 {{- if .Values.mon.healthCheckInterval }}
         - name: ROOK_MON_HEALTHCHECK_INTERVAL

--- a/cluster/examples/kubernetes/1.5/rook-operator.yaml
+++ b/cluster/examples/kubernetes/1.5/rook-operator.yaml
@@ -1,7 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-system
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: rook-operator
+  namespace: rook-system
 spec:
   replicas: 1
   template:
@@ -23,3 +29,11 @@ spec:
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT
           value: "300s"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName

--- a/cluster/examples/kubernetes/1.5/rook-storageclass.yaml
+++ b/cluster/examples/kubernetes/1.5/rook-storageclass.yaml
@@ -19,6 +19,9 @@ metadata:
 provisioner: rook.io/block
 parameters:
   pool: replicapool
-  # Specify the Rook cluster from which to create volumes. If not specified, it will use `rook` as the namespace and name of the cluster.
-  # clusterName: rook
-  # clusterNamespace: rook
+  # Specify the Rook cluster from which to create volumes.
+  # If not specified, it will use `rook` as the name of the cluster.
+  # This is also the namespace where the cluster will be
+  clusterName: rook
+  # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
+  # fstype: ext4

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-system
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -12,6 +17,7 @@ rules:
   - pods
   - services
   - nodes
+  - nodes/proxy
   - configmaps
   - events
   - persistentvolumes
@@ -79,13 +85,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-operator
-  namespace: default
+  namespace: rook-system
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
-  namespace: default
+  namespace: rook-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -93,13 +99,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-operator
-  namespace: default
+  namespace: rook-system
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: rook-operator
-  namespace: default
+  namespace: rook-system
 spec:
   replicas: 1
   template:
@@ -122,3 +128,19 @@ spec:
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT
           value: "300s"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ROOK_OPERATOR_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/cluster/examples/kubernetes/rook-storageclass.yaml
+++ b/cluster/examples/kubernetes/rook-storageclass.yaml
@@ -19,8 +19,9 @@ metadata:
 provisioner: rook.io/block
 parameters:
   pool: replicapool
-  # Specify the Rook cluster from which to create volumes. If not specified, it will use `rook` as the namespace and name of the cluster.
-  # clusterName: rook
-  # clusterNamespace: rook
+  # Specify the Rook cluster from which to create volumes.
+  # If not specified, it will use `rook` as the name of the cluster.
+  # This is also the namespace where the cluster will be
+  clusterName: rook
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
   # fstype: ext4

--- a/cmd/flexvolume/cmd/attach.go
+++ b/cmd/flexvolume/cmd/attach.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	attachCmd = &cobra.Command{
+		Use:   "attach",
+		Short: "attaches a volume",
+		RunE:  attach,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(attachCmd)
+}
+
+func attach(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/detach.go
+++ b/cmd/flexvolume/cmd/detach.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	detachCmd = &cobra.Command{
+		Use:   "detach",
+		Short: "Detach a volume",
+		RunE:  detach,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(detachCmd)
+}
+
+func detach(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/getvolumename.go
+++ b/cmd/flexvolume/cmd/getvolumename.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var getVolumeNameCmd = &cobra.Command{
+	Use:   "getvolumename",
+	Short: "Get the name of the volume",
+	RunE:  getVolumeName,
+}
+
+func init() {
+	RootCmd.AddCommand(getVolumeNameCmd)
+}
+
+func getVolumeName(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/init.go
+++ b/cmd/flexvolume/cmd/init.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/rook/rook/pkg/util/sys"
+	"github.com/spf13/cobra"
+)
+
+const (
+	moduleName = "rbd"
+)
+
+var (
+	initCmd = &cobra.Command{
+		Use:   "init",
+		Short: "Initialize the volume plugin",
+		RunE:  initPlugin,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(initCmd)
+}
+
+func initPlugin(cmd *cobra.Command, args []string) error {
+
+	hasSingleMajor := false
+	// check to see if the rbd kernel module has single_major support
+	out, err := exec.Command("modinfo", "-F", "parm", moduleName).Output()
+	if err == nil {
+		hasSingleMajor = sys.Grep(string(out), "^single_major") != ""
+	}
+
+	opts := []string{moduleName}
+	if hasSingleMajor {
+		opts = append(opts, "single_major=Y")
+	}
+
+	// load the rbd kernel module with options
+	// TODO: should this fail if modprobe fails?
+	exec.Command("modprobe", opts...).Run()
+
+	fmt.Println(`{"status":"Success", "capabilities": {"attach": false}}`)
+	os.Exit(0)
+	return nil
+}

--- a/cmd/flexvolume/cmd/isattached.go
+++ b/cmd/flexvolume/cmd/isattached.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	isAttachedCmd = &cobra.Command{
+		Use:   "isattached",
+		Short: "Checks if volume is attached",
+		RunE:  isAttached,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(isAttachedCmd)
+}
+
+func isAttached(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/mount.go
+++ b/cmd/flexvolume/cmd/mount.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rook/rook/pkg/agent/flexvolume"
+	"github.com/spf13/cobra"
+)
+
+var (
+	mountCmd = &cobra.Command{
+		Use:   "mount",
+		Short: "Mounts the volume to the pod volume",
+		RunE:  mount,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(mountCmd)
+}
+
+func mount(cmd *cobra.Command, args []string) error {
+
+	client, err := getRPCClient()
+	if err != nil {
+		return fmt.Errorf("Rook: Error getting RPC client: %v", err)
+	}
+
+	var opts = &flexvolume.AttachOptions{}
+	if err := json.Unmarshal([]byte(args[1]), opts); err != nil {
+		return fmt.Errorf("Rook: Could not parse options for mounting %s. Got %v", args[1], err)
+	}
+	opts.MountDir = args[0]
+
+	err = client.Call("FlexvolumeController.GetAttachInfoFromMountDir", opts.MountDir, &opts)
+	if err != nil {
+		log(client, fmt.Sprintf("Attach volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
+		return fmt.Errorf("Rook: Mount volume failed: %v", err)
+	}
+
+	// Attach volume to node
+	log(client, fmt.Sprintf("calling agent to attach volume %s/%s", opts.Pool, opts.Image), false)
+	var devicePath string
+	err = client.Call("FlexvolumeController.Attach", opts, &devicePath)
+	if err != nil {
+		log(client, fmt.Sprintf("Attach volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
+		return fmt.Errorf("Rook: Mount volume failed: %v", err)
+	}
+
+	mounter := getMounter()
+
+	// Mount the volume to a global volume path
+	var globalVolumeMountPath string
+	err = client.Call("FlexvolumeController.GetGlobalMountPath", opts.VolumeName, &globalVolumeMountPath)
+	if err != nil {
+		log(client, fmt.Sprintf("Attach volume %s/%s failed. Cannot get global volume mount path: %v", opts.Pool, opts.Image, err), true)
+		return fmt.Errorf("Rook: Mount volume failed. Cannot get global volume mount path: %v", err)
+	}
+	notMnt, err := mounter.Interface.IsLikelyNotMountPoint(globalVolumeMountPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(globalVolumeMountPath, 0750); err != nil {
+				return fmt.Errorf("Rook: Mount volume failed. Cannot create global volume mount path dir: %v", err)
+			}
+			notMnt = true
+		} else {
+			return fmt.Errorf("Rook: Mount volume failed. Error checking if %s is a mount point: %v", globalVolumeMountPath, err)
+		}
+	}
+	options := []string{opts.RW}
+	if notMnt {
+		err = redirectStdout(
+			client,
+			func() error {
+				if err = mounter.FormatAndMount(devicePath, globalVolumeMountPath, opts.FsType, options); err != nil {
+					return fmt.Errorf("failed to mount volume %s [%s] to %s, error %v", devicePath, opts.FsType, globalVolumeMountPath, err)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			log(client, fmt.Sprintf("mount volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
+			os.Remove(globalVolumeMountPath)
+			return err
+		}
+		log(client,
+			"Ignore error about Mount failed: exit status 32. Kubernetes does this to check whether the volume has been formatted. It will format and retry again. https://github.com/kubernetes/kubernetes/blob/release-1.7/pkg/util/mount/mount_linux.go#L360",
+			false)
+		log(client, fmt.Sprintf("formatting volume %v devicePath %v deviceMountPath %v fs %v with options %+v", opts.VolumeName, devicePath, globalVolumeMountPath, opts.FsType, options), false)
+	}
+
+	// Mount the global mount path to pod mount dir
+	log(client, fmt.Sprintf("mounting global mount path %s on %s", globalVolumeMountPath, opts.MountDir), false)
+	// Perform a bind mount to the full path to allow duplicate mounts of the same volume. This is only supported for RO attachments.
+	options = append(options, "bind")
+	err = redirectStdout(
+		client,
+		func() error {
+			err := mounter.Interface.Mount(globalVolumeMountPath, opts.MountDir, "", options)
+			if err != nil {
+				notMnt, mntErr := mounter.Interface.IsLikelyNotMountPoint(opts.MountDir)
+				if mntErr != nil {
+					return fmt.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
+				}
+				if !notMnt {
+					if mntErr = mounter.Interface.Unmount(opts.MountDir); mntErr != nil {
+						return fmt.Errorf("Failed to unmount: %v", mntErr)
+					}
+					notMnt, mntErr := mounter.Interface.IsLikelyNotMountPoint(opts.MountDir)
+					if mntErr != nil {
+						return fmt.Errorf("IsLikelyNotMountPoint check failed: %v", mntErr)
+					}
+					if !notMnt {
+						// This is very odd, we don't expect it.  We'll try again next sync loop.
+						return fmt.Errorf("%s is still mounted, despite call to unmount().  Will try again next sync loop", opts.MountDir)
+					}
+				}
+				os.Remove(opts.MountDir)
+				return fmt.Errorf("failed to mount volume %s to %s, error %v", globalVolumeMountPath, opts.MountDir, err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		log(client, fmt.Sprintf("mount volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
+		return err
+	}
+
+	log(client, fmt.Sprintf("volume %s/%s has been attached and mounted", opts.Pool, opts.Image), false)
+	return nil
+}

--- a/cmd/flexvolume/cmd/mountdevice.go
+++ b/cmd/flexvolume/cmd/mountdevice.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	mountDeviceCmd = &cobra.Command{
+		Use:   "mountdevice",
+		Short: "Mounts the attached device to a mount directory",
+		RunE:  mountDevice,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(mountDeviceCmd)
+}
+
+func mountDevice(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/root.go
+++ b/cmd/flexvolume/cmd/root.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"os"
+	"path"
+
+	"k8s.io/kubernetes/pkg/util/exec"
+	k8smount "k8s.io/kubernetes/pkg/util/mount"
+
+	"github.com/rook/rook/pkg/agent/flexvolume"
+	"github.com/spf13/cobra"
+)
+
+var RootCmd = &cobra.Command{
+	Use:           "rook",
+	Short:         "Rook Flex volume plugin",
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+type NotSupportedError struct{}
+
+func (e *NotSupportedError) Error() string {
+	return "Not supported"
+}
+
+func Execute() {
+	RootCmd.Execute()
+}
+
+func getRPCClient() (*rpc.Client, error) {
+
+	ex, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("error getting path of the Rook flexvolume driver: %v", err)
+	}
+	unixSocketFile := path.Join(path.Dir(ex), path.Join(flexvolume.UnixSocketName)) // /usr/libexec/kubernetes/plugin/volume/rook.io~rook/.rook.sock
+	conn, err := net.Dial("unix", unixSocketFile)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to socket %s: %+v", unixSocketFile, err)
+	}
+	return rpc.NewClient(conn), nil
+}
+
+func getMounter() *k8smount.SafeFormatAndMount {
+	return &k8smount.SafeFormatAndMount{
+		Interface: k8smount.New("" /* default mount path */),
+		Runner:    exec.New(),
+	}
+}
+
+func log(client *rpc.Client, message string, isError bool) {
+	var log = &flexvolume.LogMessage{
+		Message: message,
+		IsError: isError,
+	}
+	client.Call("FlexvolumeController.Log", log, nil)
+}
+
+// redirectStdout redirects the stdout for the fn function to the driver logger
+func redirectStdout(client *rpc.Client, fn func() error) error {
+	// keep backup of the real stdout and stderr
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+
+	// restoring the real stdout and stderr
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	err := fn()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	log(client, buf.String(), false)
+	return err
+}

--- a/cmd/flexvolume/cmd/unmount.go
+++ b/cmd/flexvolume/cmd/unmount.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/rook/rook/pkg/agent/flexvolume"
+	"github.com/spf13/cobra"
+	mountutil "k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume/util"
+)
+
+var (
+	unmountCmd = &cobra.Command{
+		Use:   "unmount",
+		Short: "Unmounts the pod volume",
+		RunE:  unmount,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(unmountCmd)
+}
+
+func unmount(cmd *cobra.Command, args []string) error {
+
+	client, err := getRPCClient()
+	if err != nil {
+		return fmt.Errorf("Rook: Error getting RPC client: %v", err)
+	}
+
+	var opts = &flexvolume.AttachOptions{
+		MountDir: args[0],
+	}
+
+	// unmounts the volume
+	log(client, fmt.Sprintf("unmounting mount dir: %s", opts.MountDir), false)
+
+	err = client.Call("FlexvolumeController.GetAttachInfoFromMountDir", opts.MountDir, &opts)
+	if err != nil {
+		log(client, fmt.Sprintf("Unmount volume at mount dir %s failed: %v", opts.MountDir, err), true)
+		return fmt.Errorf("Unmount volume at mount dir %s failed: %v", opts.MountDir, err)
+	}
+
+	mounter := getMounter()
+
+	var globalVolumeMountPath string
+	err = client.Call("FlexvolumeController.GetGlobalMountPath", opts.VolumeName, &globalVolumeMountPath)
+	if err != nil {
+		log(client, fmt.Sprintf("Detach volume %s/%s failed. Cannot get global volume mount path: %v", opts.Pool, opts.Image, err), true)
+		return fmt.Errorf("Rook: Unmount volume failed. Cannot get global volume mount path: %v", err)
+	}
+
+	var refs []string
+	err = redirectStdout(
+		client,
+		func() error {
+			refs, err = mountutil.GetMountRefs(mounter.Interface, opts.MountDir)
+			if err != nil {
+				glog.Errorf("failed to get reference mount %s", opts.MountDir)
+				return err
+			}
+
+			// Unmount pod mount dir
+			if err := util.UnmountPath(opts.MountDir, mounter.Interface); err != nil {
+				return fmt.Errorf("failed to unmount volume at %s: %+v", opts.MountDir, err)
+			}
+
+			// Remove attachment item from the CRD
+			err = client.Call("FlexvolumeController.RemoveAttachmentObject", opts, nil)
+			if err != nil {
+				log(client, fmt.Sprintf("Unmount volume %s failed: %v", opts.MountDir, err), true)
+				// Do not return error. Try detaching first. If error happens during detach, Kubernetes will retry.
+			}
+
+			// If len(refs) is 1, then all bind mounts have been removed, and the
+			// remaining reference is the global mount. It is safe to detach. Unmount global mount dir
+			if len(refs) == 1 {
+				if err := util.UnmountPath(globalVolumeMountPath, mounter.Interface); err != nil {
+					return fmt.Errorf("failed to unmount volume at %s: %+v", opts.MountDir, err)
+				}
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	if len(refs) == 1 {
+		// call detach
+		log(client, fmt.Sprintf("calling agent to detach mountDir: %s", opts.MountDir), false)
+		err = client.Call("FlexvolumeController.Detach", opts, nil)
+		if err != nil {
+			log(client, fmt.Sprintf("Detach volume from %s failed: %v", opts.MountDir, err), true)
+			return fmt.Errorf("Rook: Unmount volume failed: %v", err)
+		}
+		log(client, fmt.Sprintf("volume has been unmounted and detached from %s", opts.MountDir), false)
+	}
+	log(client, fmt.Sprintf("volume has been unmounted from %s", opts.MountDir), false)
+	return nil
+}

--- a/cmd/flexvolume/cmd/unmountdevice.go
+++ b/cmd/flexvolume/cmd/unmountdevice.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	unmountDeviceCmd = &cobra.Command{
+		Use:   "unmountdevice",
+		Short: "Unmount the attached device",
+		RunE:  unmountDevice,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(unmountDeviceCmd)
+}
+
+func unmountDevice(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/cmd/waitforattach.go
+++ b/cmd/flexvolume/cmd/waitforattach.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	waitForAttachTimeout time.Duration = 10 * time.Minute
+	checkSleepDuration                 = time.Second
+)
+
+var (
+	waitForAttachCmd = &cobra.Command{
+		Use:   "waitforattach",
+		Short: "Waits until volume is attached",
+		RunE:  waitForAttach,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(waitForAttachCmd)
+}
+
+func waitForAttach(cmd *cobra.Command, args []string) error {
+	return new(NotSupportedError)
+}

--- a/cmd/flexvolume/main.go
+++ b/cmd/flexvolume/main.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rook/rook/cmd/flexvolume/cmd"
+)
+
+type result struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+func main() {
+	var r result
+	if err := cmd.RootCmd.Execute(); err != nil {
+		if e, ok := err.(*cmd.NotSupportedError); ok {
+			r.Status = e.Error()
+		} else {
+			r.Status = "Failure"
+			r.Message = err.Error()
+		}
+	} else {
+		r.Status = "Success"
+	}
+	reply(r)
+}
+
+func reply(r result) {
+	code := 0
+	if r.Status == "Failure" {
+		code = 1
+	}
+	res, err := json.Marshal(r)
+	if err != nil {
+		fmt.Println(`{"status":"Failure","message":\"JSON error"}`)
+	} else {
+		fmt.Println(string(res))
+	}
+	os.Exit(code)
+}

--- a/cmd/rook/agent.go
+++ b/cmd/rook/agent.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/rook/rook/pkg/agent"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/flags"
+	"github.com/spf13/cobra"
+)
+
+var agentCmd = &cobra.Command{
+	Use:    "agent",
+	Short:  "Runs the rook agent",
+	Hidden: true,
+}
+
+func init() {
+	flags.SetFlagsFromEnv(agentCmd.Flags(), "ROOK")
+	agentCmd.RunE = startAgent
+}
+
+func startAgent(cmd *cobra.Command, args []string) error {
+
+	setLogLevel()
+
+	logStartupInfo(agentCmd.Flags())
+
+	clientset, apiExtClientset, err := getClientset()
+	if err != nil {
+		fmt.Printf("failed to get k8s client. %+v", err)
+		os.Exit(1)
+	}
+
+	logger.Info("starting rook agent")
+	context := createContext()
+	context.NetworkInfo = clusterd.NetworkInfo{}
+	context.ConfigDir = k8sutil.DataDir
+	context.Clientset = clientset
+	context.APIExtensionClientset = apiExtClientset
+
+	agent := agent.New(context)
+	err = agent.Run()
+	if err != nil {
+		fmt.Printf("failed to run rook agent. %+v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -25,9 +25,6 @@ import (
 	"github.com/rook/rook/pkg/operator/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var operatorCmd = &cobra.Command{
@@ -76,22 +73,4 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func getClientset() (kubernetes.Interface, apiextensionsclient.Interface, error) {
-	// create the k8s client
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get k8s config. %+v", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create k8s clientset. %+v", err)
-	}
-	apiExtClientset, err := apiextensionsclient.NewForConfig(config)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create k8s API extension clientset. %+v", err)
-	}
-	return clientset, apiExtClientset, nil
 }

--- a/cmd/rookctl/block/list.go
+++ b/cmd/rookctl/block/list.go
@@ -50,7 +50,7 @@ func listBlocksEntry(cmd *cobra.Command, args []string) error {
 
 	c := rook.NewRookNetworkRestClient()
 	e := &exec.CommandExecutor{}
-	out, err := listBlocks(rbdSysBusPathDefault, c, e)
+	out, err := listBlocks(sys.RBDSysBusPathDefault, c, e)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -69,14 +69,14 @@ func listBlocks(rbdSysBusPath string, c client.RookRestClient, executor exec.Exe
 	if len(images) == 0 {
 		return "", nil
 	}
-
 	if runtime.GOOS == "linux" {
 		// for each image returned from the client API call, look up local details
 		for i := range images {
 			image := &(images[i])
 
 			// look up local device and mount point, ignoring errors
-			devPath, _ := findDevicePath(image.Name, image.PoolName, rbdSysBusPath)
+			imageFile, _ := sys.FindRBDMappedFile(image.Name, image.PoolName, rbdSysBusPath)
+			devPath := sys.RBDDevicePathPrefix + imageFile
 			dev := strings.TrimPrefix(devPath, devicePathPrefix)
 			var mountPoint string
 			if dev != "" {

--- a/cmd/rookctl/block/list_test.go
+++ b/cmd/rookctl/block/list_test.go
@@ -53,8 +53,9 @@ func TestListBlockImages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp rbd sys bus dir: %+v", err)
 	}
+	mockRBDDevicePath := filepath.Join(mockRBDSysBusPath, "dev", "rbd")
 	defer os.RemoveAll(mockRBDSysBusPath)
-	createMockRBD(mockRBDSysBusPath, "5", "myimage1", "mypool1")
+	createMockRBD(mockRBDSysBusPath, mockRBDDevicePath, "5", "myimage1", "mypool1")
 
 	out, err := listBlocks(mockRBDSysBusPath, c, e)
 	assert.Nil(t, err)
@@ -94,9 +95,11 @@ func TestListBlockImagesZeroImages(t *testing.T) {
 	assert.Equal(t, "", out)
 }
 
-func createMockRBD(mockRBDSysBusPath, deviceID, imageName, poolName string) {
+func createMockRBD(mockRBDSysBusPath, mockRBDDevicePath, deviceID, imageName, poolName string) {
 	dev0Path := filepath.Join(mockRBDSysBusPath, "devices", deviceID)
 	os.MkdirAll(dev0Path, 0777)
+	os.MkdirAll(mockRBDDevicePath, 0777)
 	ioutil.WriteFile(filepath.Join(dev0Path, "name"), []byte(imageName), 0777)
 	ioutil.WriteFile(filepath.Join(dev0Path, "pool"), []byte(poolName), 0777)
+	ioutil.WriteFile(filepath.Join(mockRBDDevicePath, "rbd"+deviceID), []byte(imageName), 0777)
 }

--- a/cmd/rookctl/block/map.go
+++ b/cmd/rookctl/block/map.go
@@ -17,7 +17,6 @@ package block
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,9 +34,6 @@ import (
 
 const (
 	rbdKernelModuleName      = "rbd"
-	rbdSysBusPathDefault     = "/sys/bus/rbd"
-	rbdDevicesDir            = "devices"
-	rbdDevicePathPrefix      = "/dev/rbd"
 	devicePathPrefix         = "/dev/"
 	rbdAddNode               = "add"
 	rbdAddSingleMajorNode    = "add_single_major"
@@ -76,7 +72,7 @@ func mapBlockEntry(cmd *cobra.Command, args []string) error {
 	}
 	c := rook.NewRookNetworkRestClient()
 	e := &exec.CommandExecutor{}
-	out, err := mapBlock(mapImageName, mapImagePoolName, mapImagePath, rbdSysBusPathDefault, mapFormatRequested, c, e)
+	out, err := mapBlock(mapImageName, mapImagePoolName, mapImagePath, sys.RBDSysBusPathDefault, sys.RBDDevicePathPrefix, mapFormatRequested, c, e)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -86,7 +82,7 @@ func mapBlockEntry(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func mapBlock(name, poolName, mountPoint, rbdSysBusPath string, formatRequested bool, c client.RookRestClient, executor exec.Executor) (string, error) {
+func mapBlock(name, poolName, mountPoint, rbdSysBusPath, rbdDevicePathPrefix string, formatRequested bool, c client.RookRestClient, executor exec.Executor) (string, error) {
 	clientAccessInfo, err := c.GetClientAccessInfo()
 	if err != nil {
 		return "", err
@@ -125,7 +121,7 @@ func mapBlock(name, poolName, mountPoint, rbdSysBusPath string, formatRequested 
 	}
 
 	// wait for the device to become available so we can find out its name/ID
-	devicePath, err := waitForDevicePath(name, poolName, rbdSysBusPath, 10, 1)
+	devicePath, err := waitForDevicePath(name, poolName, rbdSysBusPath, rbdDevicePathPrefix, 10, 1)
 	if err != nil {
 		return "", err
 	}
@@ -205,33 +201,19 @@ func openRBDFile(hasSingleMajor bool, singleMajorPath, path string) (*os.File, e
 	return fd, nil
 }
 
-func findDevicePath(imageName, poolName, rbdSysBusPath string) (string, error) {
-	rbdDevicesPath := filepath.Join(rbdSysBusPath, rbdDevicesDir)
-	files, err := ioutil.ReadDir(rbdDevicesPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read rbd device dir: %+v", err)
-	}
-
-	for _, idFile := range files {
-		nameContent, err := ioutil.ReadFile(filepath.Join(rbdDevicesPath, idFile.Name(), "name"))
-		if err == nil && imageName == strings.TrimSpace(string(nameContent)) {
-			// the image for the current rbd device matches, now try to match pool
-			poolContent, err := ioutil.ReadFile(filepath.Join(rbdDevicesPath, idFile.Name(), "pool"))
-			if err == nil && poolName == strings.TrimSpace(string(poolContent)) {
-				// match current device matches both image name and pool name, return the device
-				return rbdDevicePathPrefix + idFile.Name(), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("failed to find rbd device path for image '%s' in pool '%s'", imageName, poolName)
-}
-
-func waitForDevicePath(imageName, poolName, rbdSysBusPath string, maxRetries, sleepSecs int) (string, error) {
+func waitForDevicePath(imageName, poolName, rbdSysBusPath, rbdDevicePathPrefix string, maxRetries, sleepSecs int) (string, error) {
 	retryCount := 0
 	for {
-		devicePath, err := findDevicePath(imageName, poolName, rbdSysBusPath)
-		if err == nil {
+		mappedFile, err := sys.FindRBDMappedFile(imageName, poolName, rbdSysBusPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to find mapped image: %+v", err)
+		}
+
+		if mappedFile != "" {
+			devicePath := rbdDevicePathPrefix + mappedFile
+			if _, err := os.Lstat(devicePath); err != nil {
+				return "", fmt.Errorf("sysfs information for image '%s' in pool '%s' found but the rbd device path %s does not exist", imageName, poolName, devicePath)
+			}
 			return devicePath, nil
 		}
 

--- a/cmd/rookctl/block/unmap.go
+++ b/cmd/rookctl/block/unmap.go
@@ -53,7 +53,7 @@ func unmapBlockEntry(cmd *cobra.Command, args []string) error {
 	}
 
 	e := &exec.CommandExecutor{}
-	out, err := unmapBlock(unmapDeviceName, unmapPath, rbdSysBusPathDefault, e)
+	out, err := unmapBlock(unmapDeviceName, unmapPath, sys.RBDSysBusPathDefault, e)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -93,7 +93,7 @@ func unmapBlock(device, path, rbdSysBusPath string, executor exec.Executor) (str
 		return "", fmt.Errorf("failed to unmount rbd device %s: %+v", device, err)
 	}
 
-	rbdNum := strings.TrimPrefix(device, rbdDevicePathPrefix)
+	rbdNum := strings.TrimPrefix(device, sys.RBDDevicePathPrefix)
 	logger.Infof("removing rbd device %s (%s)", rbdNum, device)
 
 	// determine if the rbd kernel module supports single_major and open the

--- a/cmd/rookctl/block/unmap_test.go
+++ b/cmd/rookctl/block/unmap_test.go
@@ -46,10 +46,11 @@ func TestUnmountBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp rbd sys bus dir: %+v", err)
 	}
+	mockRBDDevicePath := filepath.Join(mockRBDSysBusPath, "dev", "rbd")
 	defer os.RemoveAll(mockRBDSysBusPath)
 	os.Create(filepath.Join(mockRBDSysBusPath, rbdRemoveSingleMajorNode))
 	os.Create(filepath.Join(mockRBDSysBusPath, rbdRemoveNode))
-	createMockRBD(mockRBDSysBusPath, "4", "myimage1", "mypool1")
+	createMockRBD(mockRBDSysBusPath, mockRBDDevicePath, "4", "myimage1", "mypool1")
 
 	// call unmountBlock and verify success and output
 	out, err := unmapBlock("", "/tmp/mymount1", mockRBDSysBusPath, e)

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: b1ae2ccb7faf8210c44626b044e695dd929e9ad04262670c2148304ce9f6cce5
-updated: 2017-08-10T14:00:48.392169515-07:00
+hash: 90eb2d9001e8cc062c5b410bad7168b9434f753631beef0d2097a5aa4e929fb3
+updated: 2017-09-20T18:50:39.018434283-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: d05c000e0b41647375a4093373eb1301e02c8a4e
+  version: 599f09b4d88b78336612acd62e94e6ae87334b4b
   subpackages:
   - aws
   - aws/awserr
@@ -27,7 +27,6 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
-  - service/efs
   - service/s3
   - service/sts
 - name: github.com/beorn7/perks
@@ -97,22 +96,29 @@ imports:
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - daemon
+  - dbus
   - journal
+  - unit
   - util
 - name: github.com/coreos/pkg
-  version: 3ac0863d7acf3bc44daf49afef8919af12f704ef
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
   - capnslog
 - name: github.com/corpix/uarand
-  version: bec9f4e76616d890ce207e1898e5998764435494
+  version: 2b8494104d86337cdd41d0a49cbed8e4583c0ab4
 - name: github.com/cpuguy83/go-md2man
-  version: 23709d0847197db6021a51fdb193e66e9222d4e7
+  version: 1d903dcb749992f3741d744c0f8376b4bd7eb3e1
   subpackages:
   - md2man
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  subpackages:
+  - digest
+  - reference
 - name: github.com/emicklei/go-restful
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
@@ -122,7 +128,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
+  version: c787282c39ac1fc618827141a1f762240def08a3
 - name: github.com/go-openapi/analysis
   version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/jsonpointer
@@ -136,12 +142,35 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/go-sql-driver/mysql
-  version: 3955978caca48c1658a4bb7a9c6a0f084e326af3
+  version: be22b3051b3467094e9908389d900e74f72cf08f
 - name: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
+  - gogoproto
+  - plugin/compare
+  - plugin/defaultcheck
+  - plugin/description
+  - plugin/embedcheck
+  - plugin/enumstringer
+  - plugin/equal
+  - plugin/face
+  - plugin/gostring
+  - plugin/marshalto
+  - plugin/oneofcheck
+  - plugin/populate
+  - plugin/size
+  - plugin/stringer
+  - plugin/testgen
+  - plugin/union
+  - plugin/unmarshal
   - proto
+  - protoc-gen-gogo/descriptor
+  - protoc-gen-gogo/generator
+  - protoc-gen-gogo/grpc
+  - protoc-gen-gogo/plugin
   - sortkeys
+  - vanity
+  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
@@ -153,16 +182,20 @@ imports:
   subpackages:
   - jsonpb
   - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/google/btree
-  version: 925471ac9e2131377a91e1595defec898166fe49
+  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/google/uuid
-  version: 1c6adf5cd133db09196c44ffae1f77ebf4da64aa
+  version: 7e072fc3a7be179aee6d3359e46015aa8c995314
 - name: github.com/gorilla/context
-  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+  version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
 - name: github.com/gorilla/mux
-  version: ac112f7d75a0714af1bd86ab17749b31f7809640
+  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
@@ -174,17 +207,15 @@ imports:
   subpackages:
   - simplelru
 - name: github.com/icrowley/fake
-  version: 9ebaa17f46192cb20228d501435ff944717ef907
+  version: e64cc2cf92049a299f359734c6ea76073f2a8b2c
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jbw976/go-ps
   version: 82859aed1b5dafbbe6ad4f3dac5404d2a742cf18
 - name: github.com/jmespath/go-jmespath
   version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
-- name: github.com/jmoiron/jsonq
-  version: e874b168d07ecc7808bc950a17998a8aa3141d82
 - name: github.com/jonboulle/clockwork
-  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/kubernetes-incubator/external-storage
@@ -206,7 +237,7 @@ imports:
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
   - prometheus
   - prometheus/promhttp
@@ -235,38 +266,59 @@ imports:
 - name: github.com/spf13/cobra
   version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
+  - codec/codecgen
 - name: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - bcrypt
   - blowfish
+  - curve25519
+  - ed25519
+  - ed25519/internal/edwards25519
+  - nacl/secretbox
+  - pkcs12
+  - pkcs12/internal/rc2
+  - poly1305
+  - salsa20/salsa
+  - ssh
+  - ssh/terminal
 - name: golang.org/x/net
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
   - context/ctxhttp
+  - html
+  - html/atom
   - http2
   - http2/hpack
   - idna
   - internal/timeseries
   - lex/httplex
+  - proxy
   - trace
+  - websocket
 - name: golang.org/x/sys
   version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 2910a502d2bf9e43193af9d68ca516529614eed3
   subpackages:
   - cases
+  - encoding
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/unicode
   - internal/tag
+  - internal/utf8internal
   - language
   - runes
   - secure/bidirule
@@ -306,6 +358,7 @@ imports:
   - certificates/v1beta1
   - core/v1
   - extensions/v1beta1
+  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1alpha1
@@ -361,6 +414,7 @@ imports:
   - pkg/util/json
   - pkg/util/mergepatch
   - pkg/util/net
+  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/strategicpatch
@@ -373,6 +427,82 @@ imports:
   - pkg/watch
   - third_party/forked/golang/json
   - third_party/forked/golang/reflect
+- name: k8s.io/apiserver
+  version: e739ac20f4d03d8612c80b8bc00260c093593345
+  subpackages:
+  - pkg/admission
+  - pkg/admission/initializer
+  - pkg/admission/plugin/namespace/lifecycle
+  - pkg/apis/apiserver
+  - pkg/apis/apiserver/install
+  - pkg/apis/apiserver/v1alpha1
+  - pkg/apis/audit
+  - pkg/apis/audit/install
+  - pkg/apis/audit/v1alpha1
+  - pkg/apis/audit/validation
+  - pkg/audit
+  - pkg/audit/policy
+  - pkg/authentication/authenticator
+  - pkg/authentication/authenticatorfactory
+  - pkg/authentication/group
+  - pkg/authentication/request/anonymous
+  - pkg/authentication/request/bearertoken
+  - pkg/authentication/request/headerrequest
+  - pkg/authentication/request/union
+  - pkg/authentication/request/websocket
+  - pkg/authentication/request/x509
+  - pkg/authentication/serviceaccount
+  - pkg/authentication/token/tokenfile
+  - pkg/authentication/user
+  - pkg/authorization/authorizer
+  - pkg/authorization/authorizerfactory
+  - pkg/authorization/union
+  - pkg/endpoints
+  - pkg/endpoints/discovery
+  - pkg/endpoints/filters
+  - pkg/endpoints/handlers
+  - pkg/endpoints/handlers/negotiation
+  - pkg/endpoints/handlers/responsewriters
+  - pkg/endpoints/metrics
+  - pkg/endpoints/openapi
+  - pkg/endpoints/request
+  - pkg/features
+  - pkg/registry/generic
+  - pkg/registry/generic/registry
+  - pkg/registry/rest
+  - pkg/server
+  - pkg/server/filters
+  - pkg/server/healthz
+  - pkg/server/httplog
+  - pkg/server/mux
+  - pkg/server/openapi
+  - pkg/server/options
+  - pkg/server/routes
+  - pkg/server/routes/data/swagger
+  - pkg/server/storage
+  - pkg/storage
+  - pkg/storage/errors
+  - pkg/storage/etcd
+  - pkg/storage/etcd/metrics
+  - pkg/storage/etcd/util
+  - pkg/storage/etcd3
+  - pkg/storage/names
+  - pkg/storage/storagebackend
+  - pkg/storage/storagebackend/factory
+  - pkg/storage/value
+  - pkg/util/feature
+  - pkg/util/flag
+  - pkg/util/flushwriter
+  - pkg/util/logs
+  - pkg/util/proxy
+  - pkg/util/trace
+  - pkg/util/trie
+  - pkg/util/webhook
+  - pkg/util/wsstream
+  - plugin/pkg/audit/log
+  - plugin/pkg/audit/webhook
+  - plugin/pkg/authenticator/token/webhook
+  - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
   version: 42a124578af9e61f5c6902fa7b6b2cb6538f17d2
   subpackages:
@@ -424,6 +554,7 @@ imports:
   - pkg/api/v1/ref
   - pkg/version
   - rest
+  - rest/fake
   - rest/watch
   - testing
   - tools/cache
@@ -437,14 +568,108 @@ imports:
 - name: k8s.io/kubernetes
   version: df7f4b3526a580ef122aaeef61ab52842a60a88b
   subpackages:
+  - federation/apis/federation
+  - federation/apis/federation/install
+  - federation/apis/federation/v1beta1
   - pkg/api
   - pkg/api/helper
+  - pkg/api/install
+  - pkg/api/testapi
+  - pkg/api/v1
   - pkg/api/v1/helper
+  - pkg/api/v1/helper/qos
+  - pkg/api/v1/ref
+  - pkg/apis/admission
+  - pkg/apis/admission/install
+  - pkg/apis/admission/v1alpha1
+  - pkg/apis/admissionregistration
+  - pkg/apis/admissionregistration/install
+  - pkg/apis/admissionregistration/v1alpha1
+  - pkg/apis/apps
+  - pkg/apis/apps/install
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/install
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/install
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/install
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch
+  - pkg/apis/batch/install
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/install
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/componentconfig
+  - pkg/apis/componentconfig/install
+  - pkg/apis/componentconfig/v1alpha1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/imagepolicy
+  - pkg/apis/imagepolicy/install
+  - pkg/apis/imagepolicy/v1alpha1
+  - pkg/apis/networking
+  - pkg/apis/networking/install
+  - pkg/apis/networking/v1
+  - pkg/apis/policy
+  - pkg/apis/policy/install
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/install
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/install
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/install
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
+  - pkg/client/clientset_generated/clientset
+  - pkg/client/clientset_generated/clientset/scheme
+  - pkg/client/clientset_generated/clientset/typed/admissionregistration/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/apps/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1
+  - pkg/client/clientset_generated/clientset/typed/authentication/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1
+  - pkg/client/clientset_generated/clientset/typed/authorization/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v1
+  - pkg/client/clientset_generated/clientset/typed/autoscaling/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/batch/v1
+  - pkg/client/clientset_generated/clientset/typed/batch/v2alpha1
+  - pkg/client/clientset_generated/clientset/typed/certificates/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/core/v1
+  - pkg/client/clientset_generated/clientset/typed/extensions/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/networking/v1
+  - pkg/client/clientset_generated/clientset/typed/policy/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/rbac/v1beta1
+  - pkg/client/clientset_generated/clientset/typed/settings/v1alpha1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1
+  - pkg/client/clientset_generated/clientset/typed/storage/v1beta1
   - pkg/kubelet/apis
+  - pkg/kubelet/qos
+  - pkg/kubelet/types
+  - pkg/master/ports
+  - pkg/util
+  - pkg/util/exec
   - pkg/util/goroutinemap
   - pkg/util/goroutinemap/exponentialbackoff
+  - pkg/util/mount
+  - pkg/util/parsers
   - pkg/util/version
+  - pkg/volume/util
 testImports:
+- name: github.com/jmoiron/jsonq
+  version: e874b168d07ecc7808bc950a17998a8aa3141d82
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,10 +15,12 @@ import:
   subpackages:
   - client
   - error
+- package: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
 - package: github.com/spf13/cobra
   version: 1c44ec8d3f1552cac48999f9306da23c4d8a288b
 - package: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - package: github.com/google/uuid
 - package: github.com/go-ini/ini
 - package: github.com/gorilla/mux
@@ -34,15 +36,12 @@ import:
 - package: k8s.io/apiextensions-apiserver
   version: 3eb4c5fefbe7ad866747f78c7e4994cb555170c6
 - package: github.com/prometheus/client_golang
-  version: v0.8.0
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
   - prometheus
   - prometheus/promhttp
 - package: github.com/jbw976/go-ps
   version: 82859aed1b5dafbbe6ad4f3dac5404d2a742cf18
-testImport:
-- package: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - package: github.com/aws/aws-sdk-go
   version: ^1.7.3
   subpackages:
@@ -50,6 +49,9 @@ testImport:
   - aws/credentials
   - aws/session
   - service/s3
+testImport:
+- package: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - package: github.com/jmoiron/jsonq
 - package: github.com/go-sql-driver/mysql
 - package: github.com/icrowley/fake

--- a/images/rook/Dockerfile
+++ b/images/rook/Dockerfile
@@ -15,6 +15,7 @@
 FROM BASEIMAGE
 
 ADD rook /usr/local/bin/
+COPY flexvolume /
 
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
 CMD [""]

--- a/images/rook/Makefile
+++ b/images/rook/Makefile
@@ -73,6 +73,7 @@ do.build: rook-base-image
 	@echo === docker build $(ROOK_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
+	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/flexvolume $(TEMP)
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(ROOK_BASE_IMAGE)|g' Dockerfile
 	@docker build $(BUILD_ARGS) -t $(ROOK_IMAGE) $(TEMP)
 	@[ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] && [ -n "$(OLD_IMAGE_ID)" ] && docker rmi $(OLD_IMAGE_ID) || true

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package agent to manage Kubernetes storage attach events.
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/agent/flexvolume"
+	"github.com/rook/rook/pkg/agent/flexvolume/crd"
+	"github.com/rook/rook/pkg/agent/flexvolume/manager/ceph"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/kit"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "rook-agent")
+
+// Agent represent all the references needed to manage a Rook agent
+type Agent struct {
+	context *clusterd.Context
+}
+
+// New creates an Agent instance
+func New(context *clusterd.Context) *Agent {
+	return &Agent{
+		context: context,
+	}
+}
+
+// Run the agent
+func (a *Agent) Run() error {
+
+	volumeAttachmentClient, _, err := kit.NewHTTPClient(k8sutil.CustomResourceGroup, k8sutil.V1Alpha1, crd.SchemeBuilder)
+	if err != nil {
+		return fmt.Errorf("failed to create Volumeattach CRD client: %+v", err)
+	}
+
+	flexvolumeServer, err := flexvolume.NewFlexvolumeServer(
+		a.context,
+		volumeAttachmentClient,
+		ceph.NewVolumeManager(a.context),
+	)
+	if err != nil {
+		return err
+	}
+
+	flexvolumeServer.Start()
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGTERM)
+	for {
+		select {
+		case <-sigc:
+			logger.Infof("shutdown signal received, exiting...")
+			flexvolumeServer.Stop()
+			return nil
+		}
+	}
+}

--- a/pkg/agent/flexvolume/controller.go
+++ b/pkg/agent/flexvolume/controller.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package flexvolume to manage Kubernetes storage attach events.
+package flexvolume
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/agent/flexvolume/crd"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/agent"
+	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/util/version"
+)
+
+const (
+	StorageClassKey       = "storageClass"
+	PoolKey               = "pool"
+	ImageKey              = "image"
+	kubeletDefaultRootDir = "/var/lib/kubelet"
+	serverVersionV170     = "v1.7.0"
+)
+
+var driverLogger = capnslog.NewPackageLogger("github.com/rook/rook", "rook-flexdriver")
+
+// FlexvolumeController handles all events from the Flexvolume driver
+type FlexvolumeController struct {
+	clientset                  kubernetes.Interface
+	volumeManager              VolumeManager
+	volumeAttachmentController crd.VolumeAttachmentController
+}
+
+func newFlexvolumeController(context *clusterd.Context, volumeAttachmentCRDClient rest.Interface, manager VolumeManager) (*FlexvolumeController, error) {
+
+	var controller crd.VolumeAttachmentController
+	// CRD is available on v1.7.0. TPR became deprecated on v1.7.0
+	// Remove this code when TPR is not longer supported
+	kubeVersion, err := k8sutil.GetK8SVersion(context.Clientset)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting server version: %v", err)
+	}
+	if kubeVersion.AtLeast(version.MustParseSemantic(serverVersionV170)) {
+		controller = crd.New(volumeAttachmentCRDClient)
+	} else {
+		controller = crd.NewTPR(context.Clientset)
+	}
+
+	return &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeManager:              manager,
+		volumeAttachmentController: controller,
+	}, nil
+}
+
+// Attach attaches rook volume to the node
+func (c *FlexvolumeController) Attach(attachOpts AttachOptions, devicePath *string) error {
+
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	node := os.Getenv(k8sutil.NodeNameEnvVar)
+
+	// Name of CRD is the PV name. This is done so that the CRD can be use for fencing
+	crdName := attachOpts.VolumeName
+
+	// Check if this volume has been attached
+	volumeattachObj, err := c.volumeAttachmentController.Get(namespace, crdName)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get volume CRD %s. %+v", crdName, err)
+		}
+		// No volumeattach CRD for this volume found. Create one
+		volumeattachObj = crd.NewVolumeAttachment(crdName, namespace, node, attachOpts.PodNamespace, attachOpts.Pod,
+			attachOpts.MountDir, strings.ToLower(attachOpts.RW) == ReadOnly)
+		logger.Infof("Creating Volume attach Resource %s/%s: %+v", volumeattachObj.Namespace, volumeattachObj.Name, attachOpts)
+		err = c.volumeAttachmentController.Create(volumeattachObj)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create volume CRD %s. %+v", crdName, err)
+			}
+			// Some other attacher beat us in this race. Kubernetes will retry again.
+			return fmt.Errorf("failed to attach volume %s. Volume is already attached by a different pod", crdName)
+		}
+	} else {
+		// Volume has already been attached.
+		// Check if there is already an attachment with RW.
+		index := getPodRWAttachmentObject(volumeattachObj)
+		if index != -1 {
+			// check if the RW attachment is orphaned.
+			attachment := &volumeattachObj.Attachments[index]
+			pod, err := c.clientset.Core().Pods(attachment.PodNamespace).Get(attachment.PodName, metav1.GetOptions{})
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					return fmt.Errorf("failed to get pod CRD %s/%s. %+v", attachment.PodNamespace, attachment.PodName, err)
+				}
+
+				// Attachment is orphaned. Update attachment record and proceed with attaching
+				attachment.Node = node
+				attachment.MountDir = attachOpts.MountDir
+				attachment.PodNamespace = attachOpts.PodNamespace
+				attachment.PodName = attachOpts.Pod
+				attachment.ReadOnly = attachOpts.RW == ReadOnly
+				err = c.volumeAttachmentController.Update(volumeattachObj)
+				if err != nil {
+					return fmt.Errorf("failed to update volume CRD %s. %+v", crdName, err)
+				}
+			} else {
+				// Attachment is not orphaned. Original pod still exists. Dont attach.
+				return fmt.Errorf("failed to attach volume %s. Volume is already attached by pod %s/%s. Status %+v", crdName, attachment.PodNamespace, attachment.PodName, pod.Status.Phase)
+			}
+		} else {
+			// No RW attachment found. Check if this is a RW attachment request.
+			// We only support RW once attachment. No mixing either with RO
+			if attachOpts.RW == "rw" && len(volumeattachObj.Attachments) > 0 {
+				return fmt.Errorf("failed to attach volume %s. Volume is already attached by one or more pods", crdName)
+			}
+
+		}
+
+		// find if the attachment object has been previously created
+		found := false
+		for _, a := range volumeattachObj.Attachments {
+			if a.MountDir == attachOpts.MountDir {
+				found = true
+			}
+		}
+
+		if !found {
+			// Create a new attachment record and proceed with attaching
+			newAttach := crd.Attachment{
+				Node:         node,
+				PodNamespace: attachOpts.PodNamespace,
+				PodName:      attachOpts.Pod,
+				MountDir:     attachOpts.MountDir,
+				ReadOnly:     attachOpts.RW == ReadOnly,
+			}
+			volumeattachObj.Attachments = append(volumeattachObj.Attachments, newAttach)
+			err = c.volumeAttachmentController.Update(volumeattachObj)
+			if err != nil {
+				return fmt.Errorf("failed to update volume CRD %s. %+v", crdName, err)
+			}
+		}
+	}
+	*devicePath, err = c.volumeManager.Attach(attachOpts.Image, attachOpts.Pool, attachOpts.ClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to attach volume %s/%s: %+v", attachOpts.Pool, attachOpts.Image, err)
+	}
+
+	return nil
+}
+
+// Detach detaches a rook volume to the node
+func (c *FlexvolumeController) Detach(detachOpts AttachOptions, _ *struct{} /* void reply */) error {
+
+	err := c.volumeManager.Detach(detachOpts.Image, detachOpts.Pool, detachOpts.ClusterName)
+	if err != nil {
+		return fmt.Errorf("Failed to detach volume %s/%s: %+v", detachOpts.Pool, detachOpts.Image, err)
+	}
+
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	crdName := detachOpts.VolumeName
+	volumeAttach, err := c.volumeAttachmentController.Get(namespace, crdName)
+	if len(volumeAttach.Attachments) == 0 {
+		logger.Infof("Deleting VolumeAttachment CRD %s/%s", namespace, crdName)
+		return c.volumeAttachmentController.Delete(namespace, crdName)
+	}
+	return nil
+}
+
+// RemoveAttachmentObject removes the attachment from the VolumeAttachment CRD
+func (c *FlexvolumeController) RemoveAttachmentObject(detachOpts AttachOptions, _ *struct{} /* void reply */) error {
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	crdName := detachOpts.VolumeName
+	logger.Infof("Deleting attachment for mountDir %s from Volume attach CRD %s/%s", detachOpts.MountDir, namespace, crdName)
+	volumeAttach, err := c.volumeAttachmentController.Get(namespace, crdName)
+	if err != nil {
+		return fmt.Errorf("failed to get Volume attach CRD %s/%s: %+v", namespace, crdName, err)
+	}
+	for i, v := range volumeAttach.Attachments {
+		if v.MountDir == detachOpts.MountDir {
+			// Deleting slice
+			volumeAttach.Attachments = append(volumeAttach.Attachments[:i], volumeAttach.Attachments[i+1:]...)
+
+			// Update CRD.
+			return c.volumeAttachmentController.Update(volumeAttach)
+		}
+	}
+	return fmt.Errorf("VolumeAttachment CRD %s found but attachment to the mountDir %s was not found", crdName, detachOpts.MountDir)
+}
+
+// Log logs messages from the driver
+func (c *FlexvolumeController) Log(message LogMessage, _ *struct{} /* void reply */) error {
+	if message.IsError {
+		driverLogger.Error(message.Message)
+	} else {
+		driverLogger.Info(message.Message)
+	}
+	return nil
+}
+
+func (c *FlexvolumeController) parseClusterName(storageClassName string) (string, error) {
+	sc, err := c.clientset.Storage().StorageClasses().Get(storageClassName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	clusterName, ok := sc.Parameters["clusterName"]
+	if !ok {
+		// Defaults to rook if not found
+		logger.Infof("clusterName not specified in the storage class %s. Defaulting to '%s'", storageClassName, cluster.DefaultClusterName)
+		return cluster.DefaultClusterName, nil
+	}
+	return clusterName, nil
+}
+
+// GetAttachInfoFromMountDir obtain pod and volume information from the mountDir. K8s does not provide
+// all necessary information to detach a volume (https://github.com/kubernetes/kubernetes/issues/52590).
+// So we are hacking a bit and by parsing it from mountDir
+func (c *FlexvolumeController) GetAttachInfoFromMountDir(mountDir string, attachOptions *AttachOptions) error {
+
+	if attachOptions.PodID == "" {
+		podID, pvName, err := getPodAndPVNameFromMountDir(mountDir)
+		if err != nil {
+			return err
+		}
+		attachOptions.PodID = podID
+		attachOptions.VolumeName = pvName
+	}
+
+	pv, err := c.clientset.CoreV1().PersistentVolumes().Get(attachOptions.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get persistent volume %s: %+v", attachOptions.VolumeName, err)
+	}
+
+	if attachOptions.PodNamespace == "" {
+		// pod namespace should be the same as the PVC namespace
+		attachOptions.PodNamespace = pv.Spec.ClaimRef.Namespace
+	}
+
+	node := os.Getenv(k8sutil.NodeNameEnvVar)
+	if attachOptions.Pod == "" {
+		// Find all pods scheduled to this node
+		opts := metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", node).String(),
+		}
+		pods, err := c.clientset.Core().Pods(attachOptions.PodNamespace).List(opts)
+		if err != nil {
+			return fmt.Errorf("failed to get pods in namespace %s: %+v", attachOptions.PodNamespace, err)
+		}
+
+		pod := findPodByID(pods, types.UID(attachOptions.PodID))
+		if pod != nil {
+			attachOptions.Pod = pod.GetName()
+		}
+	}
+
+	if attachOptions.Image == "" {
+		attachOptions.Image = pv.Spec.PersistentVolumeSource.FlexVolume.Options[ImageKey]
+	}
+	if attachOptions.Pool == "" {
+		attachOptions.Pool = pv.Spec.PersistentVolumeSource.FlexVolume.Options[PoolKey]
+	}
+	if attachOptions.StorageClass == "" {
+		attachOptions.StorageClass = pv.Spec.PersistentVolumeSource.FlexVolume.Options[StorageClassKey]
+	}
+	attachOptions.ClusterName, err = c.parseClusterName(attachOptions.StorageClass)
+	if err != nil {
+		return fmt.Errorf("Failed to parse clusterName from storageClass %s: %+v", attachOptions.StorageClass, err)
+	}
+	return nil
+}
+
+// GetGlobalMountPath generate the global mount path where the device path is mounted.
+// It is based on the kubelet root dir, which defaults to /var/lib/kubelet
+func (c *FlexvolumeController) GetGlobalMountPath(volumeName string, globalMountPath *string) error {
+	*globalMountPath = path.Join(c.getKubeletRootDir(), "plugins", FlexvolumeVendor, FlexvolumeDriver, "mounts", volumeName)
+	return nil
+}
+
+// getKubeletRootDir queries the kubelet configuration to find the kubelet root dir. Defaults to /var/lib/kubelet
+func (c *FlexvolumeController) getKubeletRootDir() string {
+	nodeConfigURI, err := k8sutil.NodeConfigURI()
+	if err != nil {
+		logger.Warningf(err.Error())
+		return kubeletDefaultRootDir
+	}
+
+	// determining where the path of the kubelet root dir and flexvolume dir on the node
+	nodeConfig, err := c.clientset.Core().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
+	if err != nil {
+		logger.Warningf("unable to query node configuration: %v", err)
+		return kubeletDefaultRootDir
+	}
+	configKubelet := agent.NodeConfigKubelet{}
+	if err := json.Unmarshal(nodeConfig, &configKubelet); err != nil {
+		logger.Warningf("unable to parse node config from Kubelet: %+v", err)
+		return kubeletDefaultRootDir
+	}
+
+	if configKubelet.ComponentConfig.RootDirectory == "" {
+		return kubeletDefaultRootDir
+	}
+	return configKubelet.ComponentConfig.RootDirectory
+}
+
+// getPodAndPVNameFromMountDir parses pod information from the mountDir
+func getPodAndPVNameFromMountDir(mountDir string) (string, string, error) {
+	// mountDir is in the form of <rootDir>/pods/<podID>/volumes/rook.io~rook/<pv name>
+	filepath.Clean(mountDir)
+	token := strings.Split(mountDir, string(filepath.Separator))
+	// token lenght should at least size 5
+	length := len(token)
+	if length < 5 {
+		return "", "", fmt.Errorf("failed to parse mountDir %s for CRD name and podID", mountDir)
+	}
+	return token[length-4], token[length-1], nil
+}
+
+func findPodByID(pods *v1.PodList, podUID types.UID) *v1.Pod {
+	for i := range pods.Items {
+		if pods.Items[i].GetUID() == podUID {
+			return &(pods.Items[i])
+		}
+	}
+	return nil
+}
+
+// getPodRWAttachmentObject loops through the list of attachments of the VolumeAttachment
+// resource and returns the index of the first RW attachment object
+func getPodRWAttachmentObject(volumeAttachmentObject crd.VolumeAttachment) int {
+	for i, a := range volumeAttachmentObject.Attachments {
+		if !a.ReadOnly {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/agent/flexvolume/controller_test.go
+++ b/pkg/agent/flexvolume/controller_test.go
@@ -1,0 +1,713 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package flexvolume to manage Kubernetes storage attach events.
+package flexvolume
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/rook/rook/pkg/agent/flexvolume/crd"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/fake"
+	fakerestclient "k8s.io/client-go/rest/fake"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+func TestAttach(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	scheme := crd.RegisterFakeAPI()
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)},
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/rook-system/volumeattachments/pvc-123" && m == "GET":
+				return &http.Response{StatusCode: 404, Header: defaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte("")))}, nil
+			case p == "/namespaces/rook-system/volumeattachments" && m == "POST":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(req.Body)}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+
+	devicePath := ""
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		ClusterName:  "testCluster",
+		StorageClass: "storageclass1",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "rw",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, &devicePath)
+	assert.Nil(t, err)
+	assert.Equal(t, "/image123/testpool/testCluster", devicePath)
+}
+
+func TestAttachAlreadyExist(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otherpod",
+			Namespace: "Default",
+		},
+		Status: v1.PodStatus{
+			Phase: "running",
+		},
+	}
+	clientset.CoreV1().Pods("Default").Create(&pod)
+
+	existingCRD := &crd.VolumeAttachment{
+		Attachments: []crd.Attachment{
+			{
+				Node:         "node1",
+				PodNamespace: "Default",
+				PodName:      "otherpod",
+				MountDir:     "/tmt/test",
+				ReadOnly:     false,
+			},
+		},
+	}
+
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+		}),
+	}
+
+	var devicePath *string
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		StorageClass: "storageclass1",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "rw",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, devicePath)
+	assert.NotNil(t, err)
+	assert.Equal(t, "failed to attach volume pvc-123. Volume is already attached by pod Default/otherpod. Status running", err.Error())
+}
+
+func TestAttachReadOnlyButRWAlreadyExist(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otherpod",
+			Namespace: "Default",
+		},
+		Status: v1.PodStatus{
+			Phase: "running",
+		},
+	}
+	clientset.CoreV1().Pods("Default").Create(&pod)
+
+	existingCRD := &crd.VolumeAttachment{
+		Attachments: []crd.Attachment{
+			{
+				Node:         "node1",
+				PodNamespace: "Default",
+				PodName:      "otherpod",
+				MountDir:     "/tmt/test",
+				ReadOnly:     false,
+			},
+		},
+	}
+
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+		}),
+	}
+
+	var devicePath *string
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		StorageClass: "storageclass1",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "ro",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, devicePath)
+	assert.NotNil(t, err)
+	assert.Equal(t, "failed to attach volume pvc-123. Volume is already attached by pod Default/otherpod. Status running", err.Error())
+}
+
+func TestAttachRWButROAlreadyExist(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	existingCRD := &crd.VolumeAttachment{
+		Attachments: []crd.Attachment{
+			{
+				Node:         "node1",
+				PodNamespace: "Default",
+				PodName:      "otherpod",
+				MountDir:     "/tmt/test",
+				ReadOnly:     true,
+			},
+		},
+	}
+
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+		}),
+	}
+
+	var devicePath *string
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		StorageClass: "storageclass1",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "rw",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, devicePath)
+	assert.NotNil(t, err)
+	assert.Equal(t, "failed to attach volume pvc-123. Volume is already attached by one or more pods", err.Error())
+}
+
+func TestMultipleAttachReadOnly(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	existingCRD := &crd.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-123",
+			Namespace: "rook-system",
+		},
+		Attachments: []crd.Attachment{
+			{
+				Node:         "otherNode",
+				PodNamespace: "Default",
+				PodName:      "myPod",
+				MountDir:     "/tmt/test",
+				ReadOnly:     true,
+			},
+		},
+	}
+
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		ClusterName:  "testCluster",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "ro",
+	}
+
+	scheme := crd.RegisterFakeAPI()
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)},
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/rook-system/volumeattachments/pvc-123" && m == "GET":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+			case p == "/namespaces/rook-system/volumeattachments/pvc-123" && m == "PUT":
+				o, _ := ioutil.ReadAll(req.Body)
+				var volAtt crd.VolumeAttachment
+				json.Unmarshal(o, &volAtt)
+
+				assert.Equal(t, 2, len(volAtt.Attachments))
+
+				assert.True(t, containsAttachment(
+					crd.Attachment{
+						PodNamespace: opts.PodNamespace,
+						PodName:      opts.Pod,
+						MountDir:     opts.MountDir,
+						ReadOnly:     true,
+						Node:         "node1",
+					}, volAtt.Attachments,
+				), "VolumeAttachment crd does not contain expected attachment")
+
+				assert.True(t, containsAttachment(
+					existingCRD.Attachments[0], volAtt.Attachments,
+				), "VolumeAttachment crd does not contain expected attachment")
+
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(req.Body)}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+
+		}),
+	}
+
+	devicePath := ""
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, &devicePath)
+	assert.Nil(t, err)
+}
+
+func TestOrphanAttach(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	existingCRD := &crd.VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-123",
+			Namespace: "rook-system",
+		},
+		Attachments: []crd.Attachment{
+			{
+				Node:         "otherNode",
+				PodNamespace: "Default",
+				PodName:      "myPod",
+				MountDir:     "/tmt/test",
+				ReadOnly:     false,
+			},
+		},
+	}
+
+	opts := AttachOptions{
+		Image:        "image123",
+		Pool:         "testpool",
+		ClusterName:  "testCluster",
+		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:   "pvc-123",
+		Pod:          "myPod",
+		PodNamespace: "Default",
+		RW:           "rw",
+	}
+
+	scheme := crd.RegisterFakeAPI()
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)},
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/namespaces/rook-system/volumeattachments/pvc-123" && m == "GET":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+			case p == "/namespaces/rook-system/volumeattachments/pvc-123" && m == "PUT":
+				o, _ := ioutil.ReadAll(req.Body)
+				var volAtt crd.VolumeAttachment
+				json.Unmarshal(o, &volAtt)
+
+				assert.Equal(t, 1, len(volAtt.Attachments))
+				assert.True(t, containsAttachment(
+					crd.Attachment{
+						PodNamespace: opts.PodNamespace,
+						PodName:      opts.Pod,
+						MountDir:     opts.MountDir,
+						ReadOnly:     false,
+						Node:         "node1",
+					}, volAtt.Attachments,
+				), "VolumeAttachment crd does not contain expected attachment")
+
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(req.Body)}, nil
+			default:
+				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+				return nil, nil
+			}
+
+		}),
+	}
+
+	devicePath := ""
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Attach(opts, &devicePath)
+	assert.Nil(t, err)
+}
+
+func TestDetach(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	existingCRD := &crd.VolumeAttachment{
+		Attachments: []crd.Attachment{},
+	}
+
+	deleteCRDCalled := false
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.Method == "DELETE" {
+				deleteCRDCalled = true
+				assert.Equal(t, req.URL.Path, "/namespaces/rook-system/volumeattachments/pvc-123")
+			}
+			return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+		}),
+	}
+
+	opts := AttachOptions{
+		VolumeName: "pvc-123",
+		MountDir:   "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Detach(opts, nil)
+	assert.Nil(t, err)
+	assert.True(t, deleteCRDCalled)
+}
+
+func TestDetachWithAttachmentLeft(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	existingCRD := &crd.VolumeAttachment{
+		Attachments: []crd.Attachment{
+			{
+				Node:         "node1",
+				PodNamespace: "Default",
+				PodName:      "myPod",
+				MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+			},
+		},
+	}
+
+	deleteCRDCalled := false
+	fakeClient := &fakerestclient.RESTClient{
+		NegotiatedSerializer: testapi.Default.NegotiatedSerializer(),
+		APIRegistry:          api.Registry,
+		Client: fakerestclient.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			if req.Method == "DELETE" {
+				deleteCRDCalled = true
+			}
+			return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(existingCRD)}, nil
+		}),
+	}
+
+	opts := AttachOptions{
+		VolumeName: "pvc-123",
+		MountDir:   "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fakeClient),
+		volumeManager:              &FakeVolumeManager{},
+	}
+
+	err := controller.Detach(opts, nil)
+	assert.Nil(t, err)
+	assert.Nil(t, err)
+	assert.False(t, deleteCRDCalled)
+}
+
+func TestGetAttachInfoFromMountDir(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.NodeNameEnvVar, "node1")
+	defer os.Unsetenv(k8sutil.NodeNameEnvVar)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pvc-123",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				FlexVolume: &v1.FlexVolumeSource{
+					Driver:   "rook.io/rook",
+					FSType:   "ext4",
+					ReadOnly: false,
+					Options: map[string]string{
+						StorageClassKey: "storageClass1",
+						PoolKey:         "pool123",
+						ImageKey:        "pvc-123",
+					},
+				},
+			},
+			ClaimRef: &v1.ObjectReference{
+				Namespace: "testnamespace",
+			},
+		},
+	}
+	clientset.CoreV1().PersistentVolumes().Create(pv)
+
+	sc := storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "storageClass1",
+		},
+		Provisioner: "rook.io/rook",
+		Parameters:  map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"},
+	}
+	clientset.StorageV1().StorageClasses().Create(&sc)
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myPod",
+			Namespace: "testnamespace",
+			UID:       "pod123",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	clientset.CoreV1().Pods("testnamespace").Create(&pod)
+
+	opts := AttachOptions{
+		VolumeName: "pvc-123",
+		MountDir:   "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+	}
+
+	controller := &FlexvolumeController{
+		clientset:     context.Clientset,
+		volumeManager: &FakeVolumeManager{},
+	}
+
+	err := controller.GetAttachInfoFromMountDir(opts.MountDir, &opts)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "pod123", opts.PodID)
+	assert.Equal(t, "pvc-123", opts.VolumeName)
+	assert.Equal(t, "testnamespace", opts.PodNamespace)
+	assert.Equal(t, "myPod", opts.Pod)
+	assert.Equal(t, "pvc-123", opts.Image)
+	assert.Equal(t, "pool123", opts.Pool)
+	assert.Equal(t, "storageClass1", opts.StorageClass)
+	assert.Equal(t, "testCluster", opts.ClusterName)
+}
+
+func TestParseClusterName(t *testing.T) {
+	clientset := test.New(3)
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+	sc := storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rook-storageclass",
+		},
+		Provisioner: "rook.io/rook",
+		Parameters:  map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"},
+	}
+	clientset.StorageV1().StorageClasses().Create(&sc)
+	fc := &FlexvolumeController{
+		clientset:                  context.Clientset,
+		volumeAttachmentController: crd.New(fake.NewSimpleClientset().CoreV1().RESTClient()),
+	}
+	clusterName, _ := fc.parseClusterName("rook-storageclass")
+	assert.Equal(t, "testCluster", clusterName)
+}
+
+func TestGetPodAndPVNameFromMountDir(t *testing.T) {
+	mountDir := "/var/lib/kubelet/pods/b8b7c55f-99ea-11e7-8994-0800277c89a7/volumes/rook.io~rook/pvc-b8aea7f4-99ea-11e7-8994-0800277c89a7"
+	pod, pv, err := getPodAndPVNameFromMountDir(mountDir)
+	assert.Nil(t, err)
+	assert.Equal(t, "b8b7c55f-99ea-11e7-8994-0800277c89a7", pod)
+	assert.Equal(t, "pvc-b8aea7f4-99ea-11e7-8994-0800277c89a7", pv)
+}
+
+func TestGetCRDNameFromMountDirInvalid(t *testing.T) {
+	mountDir := "volumes/rook.io~rook/pvc-b8aea7f4-99ea-11e7-8994-0800277c89a7"
+	_, _, err := getPodAndPVNameFromMountDir(mountDir)
+	assert.NotNil(t, err)
+}
+
+type FakeVolumeManager struct{}
+
+func (f *FakeVolumeManager) Attach(image, pool, clusterName string) (string, error) {
+	return fmt.Sprintf("/%s/%s/%s", image, pool, clusterName), nil
+}
+
+func (f *FakeVolumeManager) Detach(image, pool, clusterName string) error {
+	return nil
+}
+
+func defaultHeader() http.Header {
+	header := http.Header{}
+	header.Set("Content-Type", runtime.ContentTypeJSON)
+	return header
+}
+
+func objBody(object interface{}) io.ReadCloser {
+	output, err := json.MarshalIndent(object, "", "")
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+}
+
+func containsAttachment(attachment crd.Attachment, attachments []crd.Attachment) bool {
+	for _, a := range attachments {
+		if a.PodNamespace == attachment.PodNamespace && a.PodName == attachment.PodName && a.MountDir == attachment.MountDir && a.ReadOnly == attachment.ReadOnly && a.Node == attachment.Node {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/agent/flexvolume/crd/controller_crd.go
+++ b/pkg/agent/flexvolume/crd/controller_crd.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+package crd
+
+import (
+	"github.com/coreos/pkg/capnslog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "rook-agent-crd")
+
+// VolumeAttachmentCRDController is a controller to manage VolumeAttachment CRD objects
+type VolumeAttachmentCRDController struct {
+	client rest.Interface
+}
+
+// New creates a new VolumeAttachmentCRDController controller
+func New(client rest.Interface) *VolumeAttachmentCRDController {
+	return &VolumeAttachmentCRDController{
+		client: client,
+	}
+}
+
+// NewVolumeAttachment creates a reference of a Volumeattach CRD object
+func NewVolumeAttachment(name, namespace, node, podNamespace, podName, mountDir string, readOnly bool) VolumeAttachment {
+	volumeAttachmentObj := VolumeAttachment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Attachments: []Attachment{
+			{
+				Node:         node,
+				PodNamespace: podNamespace,
+				PodName:      podName,
+				MountDir:     mountDir,
+				ReadOnly:     readOnly,
+			},
+		},
+	}
+
+	return volumeAttachmentObj
+}
+
+// Get queries the VolumeAttachment CRD from Kubernetes
+func (c *VolumeAttachmentCRDController) Get(namespace, name string) (VolumeAttachment, error) {
+	var result VolumeAttachment
+	return result, c.client.Get().
+		Resource(CustomResourceNamePlural).
+		Namespace(namespace).
+		Name(name).
+		Do().Into(&result)
+}
+
+// Create creates the volume attach CRD resource in Kubernetes
+func (c *VolumeAttachmentCRDController) Create(volumeAttachment VolumeAttachment) error {
+	return c.client.Post().
+		Resource(CustomResourceNamePlural).
+		Namespace(volumeAttachment.Namespace).
+		Body(&volumeAttachment).
+		Do().Error()
+}
+
+// Update updates VolumeAttachment resource
+func (c *VolumeAttachmentCRDController) Update(volumeAttachment VolumeAttachment) error {
+	err := c.client.Put().
+		Name(volumeAttachment.ObjectMeta.Name).
+		Namespace(volumeAttachment.ObjectMeta.Namespace).
+		Resource(CustomResourceNamePlural).
+		Body(&volumeAttachment).
+		Do().Error()
+	if err != nil {
+		logger.Errorf("failed to update VolumeAttachment CRD. %+v", err)
+		return err
+	}
+	logger.Infof("updated Volumeattach CRD %s", volumeAttachment.ObjectMeta.Name)
+	return nil
+}
+
+// Delete deletes the volume attach CRD resource in Kubernetes
+func (c *VolumeAttachmentCRDController) Delete(namespace, name string) error {
+	return c.client.Delete().
+		Resource(CustomResourceNamePlural).
+		Namespace(namespace).
+		Name(name).
+		Do().Error()
+}

--- a/pkg/agent/flexvolume/crd/controller_tpr.go
+++ b/pkg/agent/flexvolume/crd/controller_tpr.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+package crd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	tprKind = "Volumeattachment"
+)
+
+var tprlogger = capnslog.NewPackageLogger("github.com/rook/rook", "rook-agent-tpr")
+
+// VolumeAttachmentTPRController is a controller to manage VolumeAttachment TPR objects
+// CRD is available on v1.7.0. TPR became deprecated on v1.7.0
+// Remove this code when TPR is not longer supported
+type VolumeAttachmentTPRController struct {
+	clientset kubernetes.Interface
+}
+
+// NewTPR creates a new VolumeAttachment controller for TPR resources. Only valid for k8s 1.6 and older
+func NewTPR(clientset kubernetes.Interface) *VolumeAttachmentTPRController {
+	return &VolumeAttachmentTPRController{
+		clientset: clientset,
+	}
+}
+
+// Get queries the VolumeAttachment TPR from Kubernetes
+func (c *VolumeAttachmentTPRController) Get(namespace, name string) (VolumeAttachment, error) {
+
+	var result VolumeAttachment
+	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1, namespace, CustomResourceNamePlural)
+	return result, c.clientset.Core().RESTClient().Get().
+		RequestURI(uri).
+		Name(name).
+		Do().
+		Into(&result)
+}
+
+// Create creates the volume attach TPR resource in Kubernetes
+func (c *VolumeAttachmentTPRController) Create(volumeAttachment VolumeAttachment) error {
+	volumeAttachment.APIVersion = fmt.Sprintf("%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1)
+	volumeAttachment.Kind = tprKind
+	body, _ := json.Marshal(volumeAttachment)
+	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1, volumeAttachment.Namespace, CustomResourceNamePlural)
+	return c.clientset.Core().RESTClient().Post().
+		RequestURI(uri).
+		Body(body).
+		Do().Error()
+}
+
+// Update updates VolumeAttachment TPR resource
+func (c *VolumeAttachmentTPRController) Update(volumeAttachment VolumeAttachment) error {
+	volumeAttachment.APIVersion = fmt.Sprintf("%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1)
+	volumeAttachment.Kind = tprKind
+	body, _ := json.Marshal(volumeAttachment)
+	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1, volumeAttachment.Namespace, CustomResourceNamePlural)
+	err := c.clientset.Core().RESTClient().Put().
+		RequestURI(uri).
+		Name(volumeAttachment.Name).
+		Body(body).
+		Do().Error()
+	if err != nil {
+		tprlogger.Errorf("failed to update VolumeAttachment CRD. %+v", err)
+		return err
+	}
+	tprlogger.Infof("updated Volumeattach TPR %s", volumeAttachment.ObjectMeta.Name)
+	return nil
+}
+
+// Delete deletes the volume attach TPR resource in Kubernetes
+func (c *VolumeAttachmentTPRController) Delete(namespace, name string) error {
+	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", k8sutil.CustomResourceGroup, k8sutil.V1Alpha1, namespace, CustomResourceNamePlural)
+	return c.clientset.Core().RESTClient().Delete().
+		RequestURI(uri).
+		Name(name).
+		Do().
+		Error()
+}

--- a/pkg/agent/flexvolume/crd/fake.go
+++ b/pkg/agent/flexvolume/crd/fake.go
@@ -1,0 +1,32 @@
+// /*
+// Copyright 2017 The Rook Authors. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Some of the code below came from https://github.com/coreos/etcd-operator
+// which also has the apache 2.0 license.
+// */
+
+package crd
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func RegisterFakeAPI() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	api.SchemeBuilder.AddToScheme(scheme)
+	api.SchemeBuilder.Register(addKnownTypes)
+	return scheme
+}

--- a/pkg/agent/flexvolume/crd/register.go
+++ b/pkg/agent/flexvolume/crd/register.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package crd to manage volume attachment custom resource.
+package crd
+
+import (
+	"reflect"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/kit"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	CustomResourceName       = "volumeattachment"
+	CustomResourceNamePlural = "volumeattachments"
+)
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+)
+
+// VolumeAttachmentResource represents the VolumeAttachment custom resource object
+var VolumeAttachmentResource = kit.CustomResource{
+	Name:    CustomResourceName,
+	Plural:  CustomResourceNamePlural,
+	Group:   k8sutil.CustomResourceGroup,
+	Version: k8sutil.V1Alpha1,
+	Scope:   apiextensionsv1beta1.NamespaceScoped,
+	Kind:    reflect.TypeOf(VolumeAttachment{}).Name(),
+}
+
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+func Kind(kind string) schema.GroupKind {
+	return schemeGroupVersion.WithKind(kind).GroupKind()
+}
+
+// Resource takes an unqualified resource and returns back a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return schemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+// Adds the list of known types to api.Scheme.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(schemeGroupVersion,
+		&VolumeAttachment{},
+		&VolumeAttachmentList{},
+	)
+	metav1.AddToGroupVersion(scheme, schemeGroupVersion)
+	return nil
+}

--- a/pkg/agent/flexvolume/crd/types.go
+++ b/pkg/agent/flexvolume/crd/types.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+package crd
+
+import (
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// schemeGroupVersion is group version used to register these objects
+var schemeGroupVersion = schema.GroupVersion{Group: k8sutil.CustomResourceGroup, Version: k8sutil.V1Alpha1}
+
+type VolumeAttachment struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+	Attachments       []Attachment `json:"attachments"`
+}
+
+type Attachment struct {
+	Node         string `json:"node"`
+	PodNamespace string `json:"podNamespace"`
+	PodName      string `json:"podName"`
+	MountDir     string `json:"mountDir"`
+	ReadOnly     bool   `json:"readOnly"`
+}
+
+type VolumeAttachmentList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []VolumeAttachment `json:"items"`
+}
+
+// VolumeAttachmentController handles custom resource VolumeAttachment storage operations
+type VolumeAttachmentController interface {
+	Create(volumeAttachment VolumeAttachment) error
+	Get(namespace, name string) (VolumeAttachment, error)
+	Update(volumeAttachment VolumeAttachment) error
+	Delete(namespace, name string) error
+}

--- a/pkg/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/agent/flexvolume/manager/ceph/manager.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+package ceph
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	cephmon "github.com/rook/rook/pkg/ceph/mon"
+	"github.com/rook/rook/pkg/model"
+	"github.com/rook/rook/pkg/util/sys"
+
+	"github.com/coreos/pkg/capnslog"
+	cephclient "github.com/rook/rook/pkg/ceph/client"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/mon"
+)
+
+const (
+	findDevicePathMaxRetries = 10
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "ceph-volumeattacher")
+
+// VolumeManager represents an object for perform volume attachment requests for Ceph volumes
+type VolumeManager struct {
+	context          *clusterd.Context
+	devicePathFinder model.DevicePathFinder
+}
+
+type devicePathFinder struct{}
+
+// NewVolumeManager create attacher for ceph volumes
+func NewVolumeManager(context *clusterd.Context) *VolumeManager {
+	return &VolumeManager{
+		context:          context,
+		devicePathFinder: &devicePathFinder{},
+	}
+}
+
+// Attach a ceph image to the node
+func (vm *VolumeManager) Attach(image, pool, clusterName string) (string, error) {
+
+	// check if the volume is already attached
+	devicePath, err := vm.isAttached(image, pool, clusterName)
+	if err != nil {
+		return "", fmt.Errorf("failed to check if volume %s/%s is already attached: %+v", pool, image, err)
+	}
+	if devicePath != "" {
+		logger.Infof("volume %s/%s is already attached. The device path is %s", pool, image, devicePath)
+		return devicePath, nil
+	}
+
+	// attach and poll until volume is mapped
+	logger.Infof("attaching volume %s/%s cluster %s", pool, image, clusterName)
+	monitors, keyring, err := getClusterInfo(vm.context, clusterName)
+	defer os.Remove(keyring)
+	if err != nil {
+		return "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+	}
+
+	err = cephclient.MapImage(vm.context, image, pool, clusterName, keyring, monitors)
+	if err != nil {
+		return "", fmt.Errorf("failed to map image %s/%s cluster %s. %+v", pool, image, clusterName, err)
+	}
+
+	// poll for device path
+	retryCount := 0
+	for {
+		devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterName)
+		if err != nil {
+			return "", fmt.Errorf("failed to poll for mapped image %s/%s cluster %s. %+v", pool, image, clusterName, err)
+		}
+
+		if devicePath != "" {
+			return devicePath, nil
+		}
+
+		retryCount++
+		if retryCount >= findDevicePathMaxRetries {
+			return "", fmt.Errorf("exceeded retry count while finding device path: %+v", err)
+		}
+
+		logger.Infof("failed to find device path, sleeping 1 second: %+v", err)
+		<-time.After(time.Second)
+	}
+}
+
+// Detach the volume
+func (vm *VolumeManager) Detach(image, pool, clusterName string) error {
+	// check if the volume is attached
+	devicePath, err := vm.isAttached(image, pool, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to check if volume %s/%s is attached cluster %s", pool, image, clusterName)
+	}
+	if devicePath == "" {
+		logger.Infof("volume %s/%s is already detached cluster %s", pool, image, clusterName)
+		return nil
+	}
+
+	logger.Infof("detaching volume %s/%s cluster %s", pool, image, clusterName)
+	monitors, keyring, err := getClusterInfo(vm.context, clusterName)
+	defer os.Remove(keyring)
+	if err != nil {
+		return fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+	}
+
+	err = cephclient.UnMapImage(vm.context, image, pool, clusterName, keyring, monitors)
+	if err != nil {
+		return fmt.Errorf("failed to detach volume %s/%s cluster %s. %+v", pool, image, clusterName, err)
+	}
+	logger.Infof("detached volume %s/%s", pool, image)
+	return nil
+}
+
+// Check if the volume is attached
+func (vm *VolumeManager) isAttached(image, pool, clusterName string) (string, error) {
+	devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterName)
+	if err != nil {
+		return "", err
+	}
+	return devicePath, nil
+}
+
+func getClusterInfo(context *clusterd.Context, clusterName string) (string, string, error) {
+	clusterInfo, _, err := mon.LoadClusterInfo(context, clusterName)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+	}
+
+	// create temp keyring file
+	keyringFile, err := ioutil.TempFile("", clusterName+".keyring")
+	if err != nil {
+		return "", "", err
+	}
+
+	keyring := fmt.Sprintf(cephmon.AdminKeyringTemplate, clusterInfo.AdminSecret)
+	if err := ioutil.WriteFile(keyringFile.Name(), []byte(keyring), 0644); err != nil {
+		return "", "", fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringFile.Name(), err)
+	}
+
+	monEndpoints := make([]string, 0, len(clusterInfo.Monitors))
+	for _, monitor := range clusterInfo.Monitors {
+		monEndpoints = append(monEndpoints, monitor.Endpoint)
+	}
+	return strings.Join(monEndpoints, ","), keyringFile.Name(), nil
+}
+
+// FindDevicePath polls and wait for the mapped ceph image device to show up
+func (f *devicePathFinder) FindDevicePath(image, pool, clusterName string) (string, error) {
+	mappedFile, err := sys.FindRBDMappedFile(image, pool, sys.RBDSysBusPathDefault)
+	if err != nil {
+		return "", fmt.Errorf("failed to find mapped image: %+v", err)
+	}
+
+	if mappedFile != "" {
+		devicePath := sys.RBDDevicePathPrefix + mappedFile
+		if _, err := os.Lstat(devicePath); err != nil {
+			return "", fmt.Errorf("sysfs information for image '%s' in pool '%s' found but the rbd device path %s does not exist", image, pool, devicePath)
+		}
+		return devicePath, nil
+	}
+	return "", nil
+}

--- a/pkg/agent/flexvolume/manager/ceph/manager_test.go
+++ b/pkg/agent/flexvolume/manager/ceph/manager_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ceph
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	cephtest "github.com/rook/rook/pkg/ceph/test"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+)
+
+type fakeDevicePathFinder struct {
+	response []string
+	called   int
+}
+
+func (f *fakeDevicePathFinder) FindDevicePath(image, pool, clusterName string) (string, error) {
+	response := f.response[f.called]
+	f.called++
+	return response, nil
+}
+
+func TestAttach(t *testing.T) {
+	clientset := test.New(3)
+	clusterName := "testCluster"
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	cm := &v1.ConfigMap{
+		Data: map[string]string{
+			"data": "rook-ceph-mon0=10.0.0.1:6790,rook-ceph-mon1=10.0.0.2:6790,rook-ceph-mon2=10.0.0.3:6790",
+		},
+	}
+	cm.Name = "rook-ceph-mon-endpoints"
+	clientset.CoreV1().ConfigMaps(clusterName).Create(cm)
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
+			if strings.Contains(command, "ceph-authtool") {
+				cephtest.CreateClusterInfo(nil, path.Join(configDir, clusterName), nil)
+			}
+
+			return "", nil
+		},
+		MockExecuteCommandWithTimeout: func(debug bool, timeout time.Duration, actionName string, command string, args ...string) (string, error) {
+			assert.Equal(t, "rbd", command)
+			assert.Equal(t, "map", args[0])
+			assert.Equal(t, "testpool/image1", args[1])
+			assert.Equal(t, "admin", args[3])
+			assert.Equal(t, "--cluster=testCluster", args[4])
+			assert.True(t, strings.HasPrefix(args[5], "--keyring="))
+			assert.Contains(t, args[7], "10.0.0.1:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.1:6790"))
+			assert.Contains(t, args[7], "10.0.0.2:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.2:6790"))
+			assert.Contains(t, args[7], "10.0.0.3:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.3:6790"))
+			return "", nil
+		},
+	}
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor,
+		ConfigDir: configDir,
+	}
+	vm := &VolumeManager{
+		context: context,
+		devicePathFinder: &fakeDevicePathFinder{
+			response: []string{"", "/dev/rbd3"},
+			called:   0,
+		},
+	}
+	devicePath, err := vm.Attach("image1", "testpool", clusterName)
+	assert.Equal(t, "/dev/rbd3", devicePath)
+	assert.Nil(t, err)
+}
+
+func TestAttachAlreadyExists(t *testing.T) {
+	vm := &VolumeManager{
+		context: &clusterd.Context{},
+		devicePathFinder: &fakeDevicePathFinder{
+			response: []string{"/dev/rbd3"},
+			called:   0,
+		},
+	}
+	devicePath, err := vm.Attach("image1", "testpool", "testCluster")
+	assert.Equal(t, "/dev/rbd3", devicePath)
+	assert.Nil(t, err)
+}
+
+func TestDetach(t *testing.T) {
+	clientset := test.New(3)
+	clusterName := "testCluster"
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	cm := &v1.ConfigMap{
+		Data: map[string]string{
+			"data": "rook-ceph-mon0=10.0.0.1:6790,rook-ceph-mon1=10.0.0.2:6790,rook-ceph-mon2=10.0.0.3:6790",
+		},
+	}
+	cm.Name = "rook-ceph-mon-endpoints"
+	clientset.CoreV1().ConfigMaps(clusterName).Create(cm)
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
+			if strings.Contains(command, "ceph-authtool") {
+				cephtest.CreateClusterInfo(nil, path.Join(configDir, clusterName), nil)
+			}
+
+			return "", nil
+		},
+		MockExecuteCommandWithTimeout: func(debug bool, timeout time.Duration, actionName string, command string, args ...string) (string, error) {
+			assert.Equal(t, "rbd", command)
+			assert.Equal(t, "unmap", args[0])
+			assert.Equal(t, "testpool/image1", args[1])
+			assert.Equal(t, "admin", args[3])
+			assert.Equal(t, "--cluster=testCluster", args[4])
+			assert.True(t, strings.HasPrefix(args[5], "--keyring="))
+			assert.Contains(t, args[7], "10.0.0.1:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.1:6790"))
+			assert.Contains(t, args[7], "10.0.0.2:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.2:6790"))
+			assert.Contains(t, args[7], "10.0.0.3:6790", fmt.Sprintf("But '%s' does contain '%s'", args[7], "10.0.0.3:6790"))
+			return "", nil
+		},
+	}
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor,
+		ConfigDir: configDir,
+	}
+	vm := &VolumeManager{
+		context: context,
+		devicePathFinder: &fakeDevicePathFinder{
+			response: []string{"/dev/rbd3"},
+			called:   0,
+		},
+	}
+	err := vm.Detach("image1", "testpool", clusterName)
+	assert.Nil(t, err)
+}
+
+func TestAlreadyDetached(t *testing.T) {
+	vm := &VolumeManager{
+		context: &clusterd.Context{},
+		devicePathFinder: &fakeDevicePathFinder{
+			response: []string{""},
+			called:   0,
+		},
+	}
+	err := vm.Detach("image1", "testpool", "testCluster")
+	assert.Nil(t, err)
+}

--- a/pkg/agent/flexvolume/server.go
+++ b/pkg/agent/flexvolume/server.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package flexvolume to manage Kubernetes storage attach events.
+package flexvolume
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"os"
+	"path"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+const (
+	UnixSocketName           = ".rook.sock"
+	FlexvolumeVendor         = "rook.io"
+	FlexvolumeDriver         = "rook"
+	flexvolumeDriverFileName = "flexvolume"
+)
+
+var flexVolumeDriverDir = fmt.Sprintf("/flexmnt/%s~%s", FlexvolumeVendor, FlexvolumeDriver)
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "rook-flexvolume")
+
+// FlexvolumeServer start a unix domain socket server to interact with the flexvolume driver
+type FlexvolumeServer struct {
+	controller *FlexvolumeController
+	listener   net.Listener
+}
+
+// NewFlexvolumeServer creates an Flexvolume server
+func NewFlexvolumeServer(context *clusterd.Context, volumeAttachmentClient rest.Interface, manager VolumeManager) (*FlexvolumeServer, error) {
+	controller, err := newFlexvolumeController(context, volumeAttachmentClient, manager)
+	if err != nil {
+		return nil, err
+	}
+	return &FlexvolumeServer{
+		controller: controller,
+	}, nil
+}
+
+// Start configures the flexvolume driver on the host and starts the unix domain socket server to communicate with the driver
+func (s *FlexvolumeServer) Start() error {
+	err := configureFlexVolume(flexvolumeDriverFileName, flexVolumeDriverDir)
+	if err != nil {
+		return fmt.Errorf("unable to configure flexvolume: %v", err)
+	}
+
+	err = rpc.Register(s.controller)
+	if err != nil {
+		return fmt.Errorf("unable to register rpc: %v", err)
+	}
+	logger.Info("Rook Flexvolume configured")
+
+	unixSocketFile := path.Join(flexVolumeDriverDir, path.Join(UnixSocketName)) // /flextmnt/rook.io~rook/.rook.sock
+
+	// remove unix socket if it existed previously
+	if _, err := os.Stat(unixSocketFile); !os.IsNotExist(err) {
+		logger.Info("Deleting unix domain socket file.")
+		os.Remove(unixSocketFile)
+	}
+
+	s.listener, err = net.Listen("unix", unixSocketFile)
+	if err != nil {
+		return fmt.Errorf("unable to listen at %s: %v", unixSocketFile, err)
+	}
+
+	if err := os.Chmod(unixSocketFile, 0770); err != nil {
+		return fmt.Errorf("unable to set file permission to unix socket %s: %v", unixSocketFile, err)
+	}
+
+	go rpc.Accept(s.listener)
+
+	logger.Info("Listening on unix socket for Kubernetes volume attach commands.")
+	return nil
+}
+
+// Stop the unix domain socket server and deletes the socket file
+func (s *FlexvolumeServer) Stop() {
+	if s.listener != nil {
+		logger.Info("Stopping unix socket rpc server.")
+		if err := s.listener.Close(); err != nil {
+			logger.Errorf("Failed to stop unix socket rpc server: %+v", err)
+		}
+	}
+	// closing the listener should remove the unix socket file. But lets try it remove it just in case.
+	unixSocketFile := path.Join(flexVolumeDriverDir, path.Join(UnixSocketName)) // /flextmnt/rook.io~rook/.rook.sock
+	if _, err := os.Stat(unixSocketFile); !os.IsNotExist(err) {
+		logger.Info("Deleting unix domain socket file.")
+		os.Remove(unixSocketFile)
+	}
+
+}
+
+func configureFlexVolume(driverFileName, driverDir string) error {
+	// copying flex volume
+	if _, err := os.Stat(driverDir); os.IsNotExist(err) {
+		os.Mkdir(driverDir, 0755)
+	}
+	srcFile := path.Join("/", driverFileName)                          // /flexvolume
+	destFile := path.Join(driverDir, "."+FlexvolumeDriver)             // /flextmnt/rook.io~rook/.rook
+	finalDestFile := path.Join(driverDir, path.Join(FlexvolumeDriver)) // /flextmnt/rook.io~rook/rook
+	err := copyFile(srcFile, destFile)
+	if err != nil {
+		return fmt.Errorf("unable to copy flexvolume from %s to %s: %+v", srcFile, destFile, err)
+	}
+
+	// renaming flex volume. Rename is an atomic execution while copying is not.
+	if _, err := os.Stat(finalDestFile); !os.IsNotExist(err) {
+		// Delete old plugin if it exists
+		err = os.Remove(finalDestFile)
+		if err != nil {
+			logger.Warningf("Could not delete old Rook Flexvolume driver at %s: %v", finalDestFile, err)
+		}
+
+	}
+	return os.Rename(destFile, finalDestFile)
+}
+
+func copyFile(src, dest string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("error opening source file %s: %v", src, err)
+	}
+	defer srcFile.Close()
+
+	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755) // creates if file doesn't exist
+	if err != nil {
+		return fmt.Errorf("error creating destination file %s: %v", dest, err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return fmt.Errorf("error copying file from %s to %s: %v", src, dest, err)
+	}
+	return destFile.Sync()
+}

--- a/pkg/agent/flexvolume/server_test.go
+++ b/pkg/agent/flexvolume/server_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package flexvolume to manage Kubernetes storage attach events.
+package flexvolume
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureFlexVolume(t *testing.T) {
+	driverDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(driverDir)
+	driver, _ := os.OpenFile(path.Join(driverDir, "flexvolume"), os.O_RDONLY|os.O_CREATE, 0755)
+
+	err := configureFlexVolume(driver.Name(), driverDir)
+	assert.Nil(t, err)
+	_, err = os.Stat(path.Join(driverDir, "rook"))
+	assert.False(t, os.IsNotExist(err))
+
+}

--- a/pkg/agent/flexvolume/types.go
+++ b/pkg/agent/flexvolume/types.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+package flexvolume
+
+const (
+	ReadOnly  = "ro"
+	ReadWrite = "rw"
+)
+
+// VolumeManager handles flexvolume plugin storage operations
+type VolumeManager interface {
+	Attach(image, pool, clusterName string) (string, error)
+	Detach(image, pool, clusterName string) error
+}
+
+type AttachOptions struct {
+	Image        string `json:"image"`
+	Pool         string `json:"pool"`
+	ClusterName  string `json:"ClusterName"`
+	StorageClass string `json:"storageClass"`
+	MountDir     string `json:"mountDir"`
+	RW           string `json:"kubernetes.io/readwrite"`
+	FsType       string `json:"kubernetes.io/fsType"`
+	VolumeName   string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
+	Pod          string `json:"kubernetes.io/pod.name"`
+	PodID        string `json:"kubernetes.io/pod.uid"`
+	PodNamespace string `json:"kubernetes.io/pod.namespace"`
+}
+
+type LogMessage struct {
+	Message string `json:"message"`
+	IsError bool   `json:"isError"`
+}

--- a/pkg/ceph/client/image.go
+++ b/pkg/ceph/client/image.go
@@ -105,6 +105,46 @@ func DeleteImage(context *clusterd.Context, clusterName, name, poolName string) 
 	return nil
 }
 
+// MapImage maps an RBD image using admin cephfx and returns the device path
+func MapImage(context *clusterd.Context, imageName, poolName, clusterName, keyring, monitors string) error {
+
+	imageSpec := getImageSpec(imageName, poolName)
+	args := []string{
+		"map",
+		imageSpec,
+		"--id", "admin",
+		fmt.Sprintf("--cluster=%s", clusterName),
+		fmt.Sprintf("--keyring=%s", keyring),
+		"-m", monitors,
+	}
+
+	output, err := ExecuteRBDCommandWithTimeout(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to map image %s: %+v. output: %s", imageSpec, err, output)
+	}
+
+	return nil
+}
+
+// UnMapImage unmap an RBD image from the node
+func UnMapImage(context *clusterd.Context, imageName, poolName, clusterName, keyring, monitors string) error {
+	deviceImage := getImageSpec(imageName, poolName)
+	args := []string{
+		"unmap",
+		deviceImage,
+		"--id", "admin",
+		fmt.Sprintf("--cluster=%s", clusterName),
+		fmt.Sprintf("--keyring=%s", keyring),
+		"-m", monitors,
+	}
+	output, err := ExecuteRBDCommandWithTimeout(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to unmap image %s: %+v. output: %s", deviceImage, err, output)
+	}
+
+	return nil
+}
+
 func getImageSpec(name, poolName string) string {
 	return fmt.Sprintf("%s/%s", poolName, name)
 }

--- a/pkg/ceph/client/mon.go
+++ b/pkg/ceph/client/mon.go
@@ -22,15 +22,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 )
 
 const (
-	AdminUsername = "client.admin"
-	CephTool      = "ceph"
-	RBDTool       = "rbd"
-	CrushTool     = "crushtool"
+	AdminUsername     = "client.admin"
+	CephTool          = "ceph"
+	RBDTool           = "rbd"
+	CrushTool         = "crushtool"
+	cmdExecuteTimeout = 1 * time.Minute
 )
 
 // represents the response from a mon_status mon_command (subset of all available fields, only
@@ -102,6 +104,11 @@ func ExecuteRBDCommand(context *clusterd.Context, clusterName string, args []str
 func ExecuteRBDCommandNoFormat(context *clusterd.Context, clusterName string, args []string) ([]byte, error) {
 	args = AppendAdminConnectionArgs(args, context.ConfigDir, clusterName)
 	return executeCommand(context, RBDTool, args)
+}
+
+func ExecuteRBDCommandWithTimeout(context *clusterd.Context, clusterName string, args []string) (string, error) {
+	output, err := context.Executor.ExecuteCommandWithTimeout(false, cmdExecuteTimeout, "", RBDTool, args...)
+	return output, err
 }
 
 func executeCommand(context *clusterd.Context, tool string, args []string) ([]byte, error) {

--- a/pkg/ceph/mon/agent.go
+++ b/pkg/ceph/mon/agent.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	monitorAgentName       = "monitor"
-	monitorKeyringTemplate = `
+	MonitorKeyringTemplate = `
 [mon.]
 	key = %s
 	caps mon = "allow *"` + AdminKeyringTemplate

--- a/pkg/ceph/mon/config.go
+++ b/pkg/ceph/mon/config.go
@@ -111,7 +111,7 @@ func GenerateAdminConnectionConfig(context *clusterd.Context, cluster *ClusterIn
 
 func writeMonKeyring(context *clusterd.Context, c *ClusterInfo, name string) error {
 	keyringPath := getMonKeyringPath(context.ConfigDir, name)
-	keyring := fmt.Sprintf(monitorKeyringTemplate, c.MonitorSecret, c.AdminSecret)
+	keyring := fmt.Sprintf(MonitorKeyringTemplate, c.MonitorSecret, c.AdminSecret)
 	return writeKeyring(keyring, keyringPath)
 }
 

--- a/pkg/model/block-image.go
+++ b/pkg/model/block-image.go
@@ -22,3 +22,8 @@ type BlockImage struct {
 	Device     string `json:"device"`
 	MountPoint string `json:"mountPoint"`
 }
+
+// DevicePathFinder is used to find the device path after the volume has been attached
+type DevicePathFinder interface {
+	FindDevicePath(image, pool, clusterName string) (string, error)
+}

--- a/pkg/operator/agent/agent.go
+++ b/pkg/operator/agent/agent.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package agent to manage Kubernetes storage attach events.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	kserrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	agentDaemonsetName       = "rook-agent"
+	flexvolumePathDirEnv     = "FLEXVOLUME_DIR_PATH"
+	flexvolumeDefaultDirPath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-agent")
+
+// New creates an instance of Agent
+func New(clientset kubernetes.Interface) *Agent {
+	return &Agent{
+		clientset: clientset,
+	}
+}
+
+// Start the agent
+func (a *Agent) Start(namespace string) error {
+	err := a.createAgentDaemonSet(namespace)
+	if err != nil {
+		return fmt.Errorf("Error starting agent daemonset: %v", err)
+	}
+	return nil
+}
+
+func (a *Agent) createAgentDaemonSet(namespace string) error {
+
+	serviceAccount := os.Getenv(k8sutil.RookOperatorServiceAccount)
+
+	// Using the rook-operator image to deploy the rook-agents
+	agentImage, err := getContainerImage(a.clientset)
+	if err != nil {
+		return err
+	}
+	privileged := true
+	ds := &extensions.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: agentDaemonsetName,
+		},
+		Spec: extensions.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": agentDaemonsetName,
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: serviceAccount,
+					Containers: []v1.Container{
+						{
+							Name:  agentDaemonsetName,
+							Image: agentImage,
+							Args:  []string{"agent"},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &privileged,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "flexvolume",
+									MountPath: "/flexmnt",
+								},
+								{
+									Name:      "dev",
+									MountPath: "/dev",
+								},
+								{
+									Name:      "sys",
+									MountPath: "/sys",
+								},
+								{
+									Name:      "libmodules",
+									MountPath: "/lib/modules",
+								},
+							},
+							Env: []v1.EnvVar{
+								k8sutil.NamespaceEnvVar(),
+								k8sutil.NodeEnvVar(),
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "flexvolume",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: a.discoverFlexvolumeDir(),
+								},
+							},
+						},
+						{
+							Name: "dev",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/dev",
+								},
+							},
+						},
+						{
+							Name: "sys",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/sys",
+								},
+							},
+						},
+						{
+							Name: "libmodules",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/lib/modules",
+								},
+							},
+						},
+					},
+					HostNetwork: true,
+					Tolerations: []v1.Toleration{
+						{
+							Effect:   v1.TaintEffectNoSchedule,
+							Operator: v1.TolerationOpExists,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = a.clientset.Extensions().DaemonSets(namespace).Create(ds)
+	if err != nil {
+		if !kserrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create rook-agent daemon set. %+v", err)
+		}
+		logger.Infof("rook-agent daemonset already exists")
+	} else {
+		logger.Infof("rook-agent daemonset started")
+	}
+	return nil
+
+}
+
+func (a *Agent) discoverFlexvolumeDir() string {
+	//copy flexvolume to flexvolume dir
+	nodeName := os.Getenv(k8sutil.NodeNameEnvVar)
+	if nodeName == "" {
+		logger.Warningf("cannot detect the node name. Please provide using the downward API in the rook operator manifest file")
+		return getDefaultFlexvolumeDir()
+	}
+
+	// determining where the path of the flexvolume dir on the node
+	var flexvolumeDirPath string
+	nodeConfigURI, err := k8sutil.NodeConfigURI()
+	if err != nil {
+		logger.Warningf(err.Error())
+		return getDefaultFlexvolumeDir()
+	}
+	nodeConfig, err := a.clientset.Core().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
+	if err != nil {
+		logger.Warningf("unable to query node configuration: %v", err)
+		return getDefaultFlexvolumeDir()
+	}
+
+	// unmarshall to a NodeConfigKubelet
+	configKubelet := NodeConfigKubelet{}
+	if err := json.Unmarshal(nodeConfig, &configKubelet); err != nil {
+		logger.Warningf("unable to parse node config from Kubelet: %+v", err)
+		return getDefaultFlexvolumeDir()
+	}
+	flexvolumeDirPath = configKubelet.ComponentConfig.VolumePluginDir
+	if flexvolumeDirPath == "" {
+		// unmarshall to a NodeConfigControllerManager
+		configControllerManager := NodeConfigControllerManager{}
+		if err := json.Unmarshal(nodeConfig, &configControllerManager); err != nil {
+			logger.Warningf("unable to parse node config from controller manager: %+v", err)
+			return getDefaultFlexvolumeDir()
+		}
+		flexvolumeDirPath = configControllerManager.ComponentConfig.VolumeConfiguration.FlexVolumePluginDir
+		if flexvolumeDirPath == "" {
+			flexvolumeDirPath = getDefaultFlexvolumeDir()
+		}
+	}
+
+	logger.Infof("using flexvolume dir path: %s", flexvolumeDirPath)
+	return flexvolumeDirPath
+}
+
+func getDefaultFlexvolumeDir() string {
+	logger.Info("getting flexvolume dir path from provided env var")
+	flexvolumeDirPath := os.Getenv("FLEXVOLUME_DIR_PATH")
+	if flexvolumeDirPath == "" {
+		logger.Infof("flexvolume dir path is not provided. Defaulting to: %s", flexvolumeDefaultDirPath)
+		flexvolumeDirPath = flexvolumeDefaultDirPath
+	}
+	return flexvolumeDirPath
+}
+
+func getContainerImage(clientset kubernetes.Interface) (string, error) {
+
+	podName := os.Getenv(k8sutil.PodNameEnvVar)
+	if podName == "" {
+		return "", fmt.Errorf("cannot detect the pod name. Please provide it using the downward API in the manifest file")
+	}
+	podNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	if podName == "" {
+		return "", fmt.Errorf("cannot detect the pod namespace. Please provide it using the downward API in the manifest file")
+	}
+
+	pod, err := clientset.Core().Pods(podNamespace).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if len(pod.Spec.Containers) != 1 {
+		return "", fmt.Errorf("failed to get container image. There should only be exactly one container in this pod")
+	}
+
+	return pod.Spec.Containers[0].Image, nil
+}

--- a/pkg/operator/agent/agent_test.go
+++ b/pkg/operator/agent/agent_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package agent to manage Kubernetes storage attach events.
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStartAgentDaemonset(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "rook-system")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.PodNameEnvVar, "rook-operator")
+	defer os.Unsetenv(k8sutil.PodNameEnvVar)
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-operator",
+			Namespace: "rook-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "mypodContainer",
+					Image: "rook/test",
+				},
+			},
+		},
+	}
+	clientset.CoreV1().Pods("rook-system").Create(&pod)
+
+	namespace := "ns"
+	a := New(clientset)
+
+	// start a basic cluster
+	err := a.Start(namespace)
+	assert.Nil(t, err)
+
+	agentDS, err := clientset.Extensions().DaemonSets(namespace).Get("rook-agent", metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, namespace, agentDS.Namespace)
+	assert.Equal(t, "rook-agent", agentDS.Name)
+	assert.True(t, *agentDS.Spec.Template.Spec.Containers[0].SecurityContext.Privileged)
+	volumes := agentDS.Spec.Template.Spec.Volumes
+	assert.Equal(t, 4, len(volumes))
+	volumeMounts := agentDS.Spec.Template.Spec.Containers[0].VolumeMounts
+	assert.Equal(t, 4, len(volumeMounts))
+	envs := agentDS.Spec.Template.Spec.Containers[0].Env
+	assert.Equal(t, 2, len(envs))
+	image := agentDS.Spec.Template.Spec.Containers[0].Image
+	assert.Equal(t, "rook/test", image)
+}
+
+func TestGetContainerImage(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "Default")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.PodNameEnvVar, "mypod")
+	defer os.Unsetenv(k8sutil.PodNameEnvVar)
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mypod",
+			Namespace: "Default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "mypodContainer",
+					Image: "rook/test",
+				},
+			},
+		},
+	}
+	clientset.CoreV1().Pods("Default").Create(&pod)
+
+	// start a basic cluster
+	image, err := getContainerImage(clientset)
+	assert.Nil(t, err)
+	assert.Equal(t, "rook/test", image)
+}
+
+func TestGetContainerImageMultipleContainers(t *testing.T) {
+	clientset := test.New(3)
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, "Default")
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	os.Setenv(k8sutil.PodNameEnvVar, "mypod")
+	defer os.Unsetenv(k8sutil.PodNameEnvVar)
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mypod",
+			Namespace: "Default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "mypodContainer",
+					Image: "rook/test",
+				},
+				{
+					Name:  "otherPodContainer",
+					Image: "rook/test2",
+				},
+			},
+		},
+	}
+	clientset.CoreV1().Pods("Default").Create(&pod)
+
+	// start a basic cluster
+	_, err := getContainerImage(clientset)
+	assert.NotNil(t, err)
+	assert.Equal(t, "failed to get container image. There should only be exactly one container in this pod", err.Error())
+}

--- a/pkg/operator/agent/types.go
+++ b/pkg/operator/agent/types.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package agent to manage Kubernetes storage attach events.
+package agent
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/apis/componentconfig"
+	kubeletcomponentconfig "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"
+)
+
+// Agent reference to be deployed
+type Agent struct {
+	clientset kubernetes.Interface
+}
+
+// NodeConfigControllerManager is a reference of all the configuration for the K8S node from the controllermanager
+type NodeConfigControllerManager struct {
+	ComponentConfig componentconfig.KubeControllerManagerConfiguration `json:"componentconfig"`
+}
+
+// NodeConfigKubelet is a reference of all the configuration for the K8S node from kubelet
+type NodeConfigKubelet struct {
+	ComponentConfig kubeletcomponentconfig.KubeletConfiguration `json:"componentconfig"`
+}

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -174,7 +174,7 @@ func (c *Cluster) apiContainer() v1.Container {
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOK_VERSION_TAG", Value: c.Version},
-			k8sutil.NamespaceEnvVar(),
+			{Name: "ROOK_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
 			k8sutil.RepoPrefixEnvVar(),
 			opmon.SecretEnvVar(),
 			opmon.AdminSecretEnvVar(),

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 package api
 
 import (
-	"strings"
+	"sort"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -77,9 +77,20 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 1, len(cont.VolumeMounts))
 	assert.Equal(t, 7, len(cont.Env))
-	for _, v := range cont.Env {
-		assert.True(t, strings.HasPrefix(v.Name, "ROOK_"))
+
+	var envs [7]string
+	for i, v := range cont.Env {
+		envs[i] = v.Name
 	}
+	sort.Strings(envs[:])
+
+	assert.Equal(t, "ROOK_ADMIN_SECRET", envs[0])
+	assert.Equal(t, "ROOK_CLUSTER_NAME", envs[1])
+	assert.Equal(t, "ROOK_MON_ENDPOINTS", envs[2])
+	assert.Equal(t, "ROOK_MON_SECRET", envs[3])
+	assert.Equal(t, "ROOK_NAMESPACE", envs[4])
+	assert.Equal(t, "ROOK_REPO_PREFIX", envs[5])
+	assert.Equal(t, "ROOK_VERSION_TAG", envs[6])
 
 	assert.Equal(t, "api", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])

--- a/pkg/operator/cluster/controller_test.go
+++ b/pkg/operator/cluster/controller_test.go
@@ -20,42 +20,14 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func TestCreateSecrets(t *testing.T) {
-	clientset := testop.New(3)
-	info := testop.CreateClusterInfo(1)
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
-			return "{\"key\":\"mysecurekey\"}", nil
-		},
-	}
-	c := &Cluster{Spec: ClusterSpec{VersionTag: "myversion"}}
-	c.Name = "myrook"
-	c.Namespace = "myns"
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
-	c.init(&clusterd.Context{Clientset: clientset, ConfigDir: configDir, Executor: executor})
-	defer os.RemoveAll(c.context.ConfigDir)
-	err := c.createClientAccess(info)
-	assert.Nil(t, err)
-
-	secretName := fmt.Sprintf("%s-rook-user", c.Namespace)
-	secret, err := clientset.CoreV1().Secrets(k8sutil.DefaultNamespace).Get(secretName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.Equal(t, secretName, secret.Name)
-	assert.Equal(t, 1, len(secret.StringData))
-}
 
 func TestCreateInitialCrushMap(t *testing.T) {
 	clientset := testop.New(3)

--- a/pkg/operator/cluster/register.go
+++ b/pkg/operator/cluster/register.go
@@ -32,7 +32,6 @@ import (
 
 var (
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	addToScheme   = schemeBuilder.AddToScheme
 )
 
 var ClusterResource = kit.CustomResource{

--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -20,7 +20,13 @@ which also has the apache 2.0 license.
 // Package k8sutil for Kubernetes helpers.
 package k8sutil
 
-import "github.com/coreos/pkg/capnslog"
+import (
+	"fmt"
+
+	"github.com/coreos/pkg/capnslog"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/util/version"
+)
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-k8sutil")
 
@@ -48,6 +54,21 @@ const (
 	DataDir = "/var/lib/rook"
 	// RookType for the CRD
 	RookType = "kubernetes.io/rook"
-	// RbdType for the RBD mounts
-	RbdType = "kubernetes.io/rbd"
+	// PodNameEnvVar is the env variable for getting the pod name via downward api
+	PodNameEnvVar = "POD_NAME"
+	// PodNamespaceEnvVar is the env variable for getting the pod namespace via downward api
+	PodNamespaceEnvVar = "POD_NAMESPACE"
+	// NodeNameEnvVar is the env variable for getting the node via downward api
+	NodeNameEnvVar = "NODE_NAME"
+	// RookOperatorServiceAccount is the env variable for getting the rook-operator service account via downward api
+	RookOperatorServiceAccount = "ROOK_OPERATOR_SERVICE_ACCOUNT"
 )
+
+// GetK8SVersion gets the version of the running K8S cluster
+func GetK8SVersion(clientset kubernetes.Interface) (*version.Version, error) {
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting server version: %v", err)
+	}
+	return version.MustParseSemantic(serverVersion.GitVersion), nil
+}

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -81,7 +81,17 @@ func PodIPEnvVar(property string) v1.EnvVar {
 
 // NamespaceEnvVar namespace env var
 func NamespaceEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: "ROOK_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}
+	return v1.EnvVar{Name: PodNamespaceEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}}
+}
+
+// NameEnvVar pod name env var
+func NameEnvVar() v1.EnvVar {
+	return v1.EnvVar{Name: PodNameEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}}}
+}
+
+// NodeEnvVar node env var
+func NodeEnvVar() v1.EnvVar {
+	return v1.EnvVar{Name: NodeNameEnvVar, ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}}
 }
 
 // RepoPrefixEnvVar repo prefix env var

--- a/pkg/operator/k8sutil/volume.go
+++ b/pkg/operator/k8sutil/volume.go
@@ -18,6 +18,8 @@ limitations under the License.
 package k8sutil
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -34,4 +36,13 @@ func PathToVolumeName(path string) string {
 	volumeName = strings.TrimSuffix(volumeName, "-")
 
 	return volumeName
+}
+
+// NodeConfigURI returns the node config URI path for this node
+func NodeConfigURI() (string, error) {
+	nodeName := os.Getenv(NodeNameEnvVar)
+	if nodeName == "" {
+		return "", fmt.Errorf("cannot detect the node name. Please provide using the downward API in the rook operator manifest file")
+	}
+	return fmt.Sprintf("api/v1/nodes/%s/proxy/configz", nodeName), nil
 }

--- a/pkg/operator/kit/client.go
+++ b/pkg/operator/kit/client.go
@@ -32,7 +32,7 @@ const (
 )
 
 // NewHTTPClient creates a Kubernetes client to interact with API extensions for Custom Resources
-func NewHTTPClient(group, version string, schemeBuilder runtime.SchemeBuilder) (*rest.RESTClient, *runtime.Scheme, error) {
+func NewHTTPClient(group, version string, schemeBuilder runtime.SchemeBuilder) (rest.Interface, *runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 	if err := schemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, nil, err

--- a/pkg/operator/kit/resource.go
+++ b/pkg/operator/kit/resource.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rook/rook/pkg/operator/k8sutil"
+
 	"k8s.io/api/extensions/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -70,11 +72,10 @@ type Context struct {
 func CreateCustomResources(context Context, resources []CustomResource) error {
 
 	// CRD is available on v1.7.0. TPR became deprecated on v1.7.0
-	serverVersion, err := context.Clientset.Discovery().ServerVersion()
+	kubeVersion, err := k8sutil.GetK8SVersion(context.Clientset)
 	if err != nil {
 		return fmt.Errorf("Error getting server version: %v", err)
 	}
-	kubeVersion := version.MustParseSemantic(serverVersion.GitVersion)
 
 	if kubeVersion.AtLeast(version.MustParseSemantic(serverVersionV170)) {
 		for _, resource := range resources {

--- a/pkg/operator/kit/watcher.go
+++ b/pkg/operator/kit/watcher.go
@@ -40,12 +40,13 @@ type ResourceWatcher struct {
 	resource              CustomResource
 	namespace             string
 	resourceEventHandlers cache.ResourceEventHandlerFuncs
-	client                *rest.RESTClient
+	client                rest.Interface
 	scheme                *runtime.Scheme
+	labels                map[string]string
 }
 
 // NewWatcher creates an instance of a custom resource watcher for the given resource
-func NewWatcher(resource CustomResource, namespace string, handlers cache.ResourceEventHandlerFuncs, client *rest.RESTClient) *ResourceWatcher {
+func NewWatcher(resource CustomResource, namespace string, handlers cache.ResourceEventHandlerFuncs, client rest.Interface) *ResourceWatcher {
 	return &ResourceWatcher{
 		resource:              resource,
 		namespace:             namespace,
@@ -69,7 +70,6 @@ func (w *ResourceWatcher) Watch(objType runtime.Object, done chan struct{}) erro
 		w.resource.Plural,
 		w.namespace,
 		fields.Everything())
-
 	_, controller := cache.NewInformer(
 		source,
 

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -42,6 +42,7 @@ const (
 	dataPoolSuffix     = "-data"
 	metadataPoolSuffix = "-metadata"
 	keyringName        = "keyring"
+	adminSecretName    = "rook-admin"
 )
 
 func CreateFileSystem(context *clusterd.Context, clusterName string, f *model.FilesystemRequest, version string, hostNetwork bool) error {
@@ -79,6 +80,11 @@ func (f *Filesystem) Create(context *clusterd.Context, version string, hostNetwo
 	filesystem, err := client.GetFilesystem(context, f.Namespace, f.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get file system %s. %+v", f.Name, err)
+	}
+
+	err = f.createAdminSecret(context)
+	if err != nil {
+		return fmt.Errorf("failed to create admin secret. %+v", err)
 	}
 
 	logger.Infof("start running mds for file system %s", f.Name)
@@ -120,6 +126,37 @@ func (f *Filesystem) Delete(context *clusterd.Context) error {
 
 func (f *Filesystem) instanceName() string {
 	return fmt.Sprintf("%s-%s", appName, f.Name)
+}
+
+func (f *Filesystem) createAdminSecret(context *clusterd.Context) error {
+	_, err := context.Clientset.CoreV1().Secrets(f.Namespace).Get(adminSecretName, metav1.GetOptions{})
+	if err == nil {
+		logger.Infof("the admin secret was already generated")
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get admin secret. %+v", err)
+	}
+
+	clusterInfo, _, err := opmon.LoadClusterInfo(context, f.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to load cluster information from cluster %s: %+v", f.Namespace, err)
+	}
+
+	s := map[string]string{
+		"key": clusterInfo.AdminSecret,
+	}
+	adminSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: adminSecretName, Namespace: f.Namespace},
+		StringData: s,
+		Type:       k8sutil.RookType,
+	}
+	_, err = context.Clientset.CoreV1().Secrets(f.Namespace).Create(adminSecret)
+	if err != nil {
+		return fmt.Errorf("failed to save admin secret. %+v", err)
+	}
+
+	return nil
 }
 
 func (f *Filesystem) makeDeployment(filesystemID, version string, hostNetwork bool) *extensions.Deployment {

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -205,7 +205,7 @@ func (c *Cluster) removeMon(name string) error {
 	}
 
 	// make sure to rewrite the config so NO new connections are made to the removed mon
-	if err := c.writeConnectionConfig(); err != nil {
+	if err := WriteConnectionConfig(c.context, c.clusterInfo); err != nil {
 		return fmt.Errorf("failed to write connection config after failing over mon %s. %+v", name, err)
 	}
 

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -83,16 +83,14 @@ func TestStartMonPods(t *testing.T) {
 	c := newCluster(context, namespace, false)
 
 	// start a basic cluster
-	info, err := c.Start()
+	err := c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 
 	// starting again should be a no-op, but still results in an error
-	info, err = c.Start()
+	err = c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 }
@@ -103,18 +101,16 @@ func TestOperatorRestart(t *testing.T) {
 	c := newCluster(context, namespace, false)
 
 	// start a basic cluster
-	info, err := c.Start()
+	err := c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 
 	c = newCluster(context, namespace, false)
 
 	// starting again should be a no-op, but still results in an error
-	info, err = c.Start()
+	err = c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 }
@@ -126,29 +122,22 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	c := newCluster(context, namespace, true)
 
 	// start a basic cluster
-	info, err := c.Start()
+	err := c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 
 	c = newCluster(context, namespace, true)
 
 	// starting again should be a no-op, but still results in an error
-	info, err = c.Start()
+	err = c.Start()
 	assert.Nil(t, err)
-	assert.NotNil(t, info)
 
 	validateStart(t, c)
 }
 
 func validateStart(t *testing.T, c *Cluster) {
-	s, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get("rook-admin", metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(s.StringData))
-
-	s, err = c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
-	assert.Nil(t, err)
+	s, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
 	assert.Equal(t, 4, len(s.StringData))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start

--- a/pkg/operator/mon/util.go
+++ b/pkg/operator/mon/util.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mon for the Ceph monitors.
+package mon
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rook/rook/pkg/ceph/client"
+	"github.com/rook/rook/pkg/ceph/mon"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	helper "k8s.io/kubernetes/pkg/api/v1/helper"
+)
+
+// LoadClusterInfo constructs or loads a clusterinfo and returns it along with the maxMonID
+func LoadClusterInfo(context *clusterd.Context, namespace string) (*mon.ClusterInfo, int, error) {
+
+	var clusterInfo *mon.ClusterInfo
+	maxMonID := -1
+
+	secrets, err := context.Clientset.CoreV1().Secrets(namespace).Get(appName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, maxMonID, fmt.Errorf("failed to get mon secrets. %+v", err)
+		}
+
+		clusterInfo, err = mon.CreateNamedClusterInfo(context, "", namespace)
+		if err != nil {
+			return nil, maxMonID, fmt.Errorf("failed to create mon secrets. %+v", err)
+		}
+
+		err = createClusterAccessSecret(context.Clientset, namespace, clusterInfo)
+		if err != nil {
+			return nil, maxMonID, err
+		}
+	} else {
+		clusterInfo = &mon.ClusterInfo{
+			Name:          string(secrets.Data[clusterSecretName]),
+			FSID:          string(secrets.Data[fsidSecretName]),
+			MonitorSecret: string(secrets.Data[monSecretName]),
+			AdminSecret:   string(secrets.Data[adminSecretName]),
+		}
+		logger.Debugf("found existing monitor secrets for cluster %s", clusterInfo.Name)
+	}
+
+	// get the existing monitor config
+	clusterInfo.Monitors, maxMonID, err = loadMonConfig(context.Clientset, namespace)
+	if err != nil {
+		return nil, maxMonID, fmt.Errorf("failed to get mon config. %+v", err)
+	}
+
+	return clusterInfo, maxMonID, nil
+}
+
+// WriteConnectionConfig save monitor connection config to disk
+func WriteConnectionConfig(context *clusterd.Context, clusterInfo *mon.ClusterInfo) error {
+	// write the latest config to the config dir
+	if err := mon.GenerateAdminConnectionConfig(context, clusterInfo); err != nil {
+		return fmt.Errorf("failed to write connection config. %+v", err)
+	}
+
+	return nil
+}
+
+// loadMonConfig returns the monitor endpoints and maxMonID
+func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string]*mon.CephMonitorConfig, int, error) {
+
+	monEndpointMap := map[string]*mon.CephMonitorConfig{}
+	maxMonID := -1
+
+	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, -1, err
+		}
+		// If the config map was not found, initialize the empty set of monitors
+		return monEndpointMap, maxMonID, nil
+	}
+
+	// Parse the monitor List
+	if info, ok := cm.Data[EndpointDataKey]; ok {
+		monEndpointMap = mon.ParseMonEndpoints(info)
+	}
+
+	// Parse the max monitor id
+	if id, ok := cm.Data[MaxMonIDKey]; ok {
+		maxMonID, err = strconv.Atoi(id)
+		if err != nil {
+			logger.Errorf("invalid max mon id %s. %+v", id, err)
+		}
+	}
+
+	// Make sure the max id is consistent with the current monitors
+	for _, m := range monEndpointMap {
+		id, _ := getMonID(m.Name)
+		if maxMonID < id {
+			maxMonID = id
+		}
+	}
+
+	logger.Infof("loaded: maxMonID=%d, mons=%+v", maxMonID, monEndpointMap)
+	return monEndpointMap, maxMonID, nil
+}
+
+// get the ID of a monitor from its name
+func getMonID(name string) (int, error) {
+	if strings.Index(name, appName) != 0 || len(name) < len(appName) {
+		return -1, fmt.Errorf("unexpected mon name")
+	}
+	id, err := strconv.Atoi(name[len(appName):])
+	if err != nil {
+		return -1, err
+	}
+	return id, nil
+}
+
+func createClusterAccessSecret(clientset kubernetes.Interface, namespace string, clusterInfo *mon.ClusterInfo) error {
+	logger.Infof("creating mon secrets for a new cluster")
+	var err error
+
+	// store the secrets for internal usage of the rook pods
+	secrets := map[string]string{
+		clusterSecretName: clusterInfo.Name,
+		fsidSecretName:    clusterInfo.FSID,
+		monSecretName:     clusterInfo.MonitorSecret,
+		adminSecretName:   clusterInfo.AdminSecret,
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: appName, Namespace: namespace},
+		StringData: secrets,
+		Type:       k8sutil.RookType,
+	}
+
+	if _, err = clientset.CoreV1().Secrets(namespace).Create(secret); err != nil {
+		return fmt.Errorf("failed to save mon secrets. %+v", err)
+	}
+
+	return nil
+}
+
+func monInQuorum(monitor client.MonMapEntry, quorum []int) bool {
+	for _, rank := range quorum {
+		if rank == monitor.Rank {
+			return true
+		}
+	}
+	return false
+}
+
+func validNode(node v1.Node, placement k8sutil.Placement) bool {
+	// a node cannot be disabled
+	if node.Spec.Unschedulable {
+		return false
+	}
+
+	// a node matches the NodeAffinity configuration
+	// ignoring `PreferredDuringSchedulingIgnoredDuringExecution` terms: they
+	// should not be used to judge a node unusable
+	if placement.NodeAffinity != nil && placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		nodeMatches := false
+		for _, req := range placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			nodeSelector, err := helper.NodeSelectorRequirementsAsSelector(req.MatchExpressions)
+			if err != nil {
+				logger.Infof("failed to parse MatchExpressions: %+v, regarding as not match.", req.MatchExpressions)
+				return false
+			}
+			if nodeSelector.Matches(labels.Set(node.Labels)) {
+				nodeMatches = true
+				break
+			}
+		}
+		if !nodeMatches {
+			return false
+		}
+	}
+
+	// a node is tainted and cannot be tolerated
+	for _, taint := range node.Spec.Taints {
+		isTolerated := false
+		for _, toleration := range placement.Tolerations {
+			if toleration.ToleratesTaint(&taint) {
+				isTolerated = true
+				break
+			}
+		}
+		if !isTolerated {
+			return false
+		}
+	}
+
+	// a node must be Ready
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return true
+		}
+	}
+	logger.Infof("node %s is not ready. %+v", node.Name, node.Status.Conditions)
+	return false
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -29,8 +29,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/rook/rook/pkg/agent/flexvolume/crd"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/agent"
 	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/kit"
 	"github.com/rook/rook/pkg/operator/mds"
 	"github.com/rook/rook/pkg/operator/pool"
@@ -64,12 +67,12 @@ type Operator struct {
 func New(context *clusterd.Context) *Operator {
 	clusterController, err := cluster.NewClusterController(context)
 	if err != nil {
-		logger.Errorf("failed to create Operator. %+v.", err)
+		logger.Errorf("failed to create ClusterController. %+v.", err)
 		return nil
 	}
 	volumeProvisioner := provisioner.New(context)
 
-	schemes := []kit.CustomResource{cluster.ClusterResource, pool.PoolResource, rgw.ObjectStoreResource, mds.FilesystemResource}
+	schemes := []kit.CustomResource{cluster.ClusterResource, pool.PoolResource, rgw.ObjectStoreResource, mds.FilesystemResource, crd.VolumeAttachmentResource}
 	return &Operator{
 		context:           context,
 		clusterController: clusterController,
@@ -81,6 +84,11 @@ func New(context *clusterd.Context) *Operator {
 // Run the operator instance
 func (o *Operator) Run() error {
 
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	if namespace == "" {
+		return fmt.Errorf("Rook operator namespace is not provided. Expose it via downward API in the rook operator manifest file using environment variable %s", k8sutil.PodNamespaceEnvVar)
+	}
+
 	for {
 		err := o.initResources()
 		if err == nil {
@@ -88,6 +96,12 @@ func (o *Operator) Run() error {
 		}
 		logger.Errorf("failed to init resources. %+v. retrying...", err)
 		<-time.After(initRetryDelay)
+	}
+
+	rookAgent := agent.New(o.context.Clientset)
+
+	if err := rookAgent.Start(namespace); err != nil {
+		return fmt.Errorf("Error starting agent daemonset: %v", err)
 	}
 
 	signalChan := make(chan os.Signal, 1)
@@ -108,6 +122,7 @@ func (o *Operator) Run() error {
 		serverVersion.GitVersion,
 	)
 	go pc.Run(stopChan)
+	logger.Infof("rook-provisioner started")
 
 	// watch for changes to the rook clusters
 	o.clusterController.StartWatch(v1.NamespaceAll, stopChan)

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rook/rook/pkg/agent/flexvolume/crd"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/cluster"
 	"github.com/rook/rook/pkg/operator/mds"
@@ -38,9 +39,9 @@ func TestOperator(t *testing.T) {
 	assert.NotNil(t, o.resources)
 	assert.NotNil(t, o.volumeProvisioner)
 	assert.Equal(t, context, o.context)
-	assert.Equal(t, len(o.resources), 4)
+	assert.Equal(t, len(o.resources), 5)
 	for _, r := range o.resources {
-		if r.Name != cluster.ClusterResource.Name && r.Name != pool.PoolResource.Name && r.Name != rgw.ObjectStoreResource.Name && r.Name != mds.FilesystemResource.Name {
+		if r.Name != cluster.ClusterResource.Name && r.Name != pool.PoolResource.Name && r.Name != rgw.ObjectStoreResource.Name && r.Name != mds.FilesystemResource.Name && r.Name != crd.VolumeAttachmentResource.Name {
 			assert.Fail(t, fmt.Sprintf("Resource %s is not valid", r.Name))
 		}
 	}

--- a/pkg/operator/pool/controller.go
+++ b/pkg/operator/pool/controller.go
@@ -49,11 +49,10 @@ type PoolController struct {
 }
 
 // NewPoolController create controller for watching pool custom resources created
-func NewPoolController(context *clusterd.Context) (*PoolController, error) {
+func NewPoolController(context *clusterd.Context) *PoolController {
 	return &PoolController{
 		context: context,
-	}, nil
-
+	}
 }
 
 // Watch watches for instances of Pool custom resources and acts on them
@@ -81,7 +80,7 @@ func (c *PoolController) onAdd(obj interface{}) {
 	// Use scheme.Copy() to make a deep copy of original object.
 	copyObj, err := c.scheme.Copy(pool)
 	if err != nil {
-		fmt.Printf("ERROR creating a deep copy of pool object: %v\n", err)
+		logger.Errorf("failed to create a deep copy of pool object: %v\n", err)
 		return
 	}
 	poolCopy := copyObj.(*Pool)

--- a/pkg/operator/pool/register.go
+++ b/pkg/operator/pool/register.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	addToScheme   = schemeBuilder.AddToScheme
 )
 
 // PoolResource represents the Pool custom resource object

--- a/pkg/operator/provisioner/provisioner_test.go
+++ b/pkg/operator/provisioner/provisioner_test.go
@@ -17,62 +17,80 @@ limitations under the License.
 package provisioner
 
 import (
-	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
-
-	"strings"
-
+	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	cephtest "github.com/rook/rook/pkg/ceph/test"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/mon"
 	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	storagebeta "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestProcessMonAddresses(t *testing.T) {
+func TestProvisionImage(t *testing.T) {
 	clientset := test.New(3)
-	context := &clusterd.Context{Clientset: clientset}
-	ns := "myns"
-	config := provisionerConfig{clusterName: ns}
-	p := &RookVolumeProvisioner{context: context, provConfig: config}
+	namespace := "ns"
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
+			if strings.Contains(command, "ceph-authtool") {
+				cephtest.CreateClusterInfo(nil, path.Join(configDir, namespace), nil)
+			}
 
-	// create the test set of mons
-	testConfigMap := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: mon.EndpointConfigMapName},
-		Data: map[string]string{mon.EndpointDataKey: "mon1=10.0.0.1:6790,mon2=10.0.0.2:8125,mon3=10.0.0.3:6790"}}
-	_, err := clientset.CoreV1().ConfigMaps(ns).Create(testConfigMap)
-	require.Nil(t, err)
+			if command == "rbd" && args[0] == "create" {
+				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
+			}
 
-	formattedMons, err := p.getMonitorEndpoints()
-	require.Nil(t, err)
-	findMon(t, "10.0.0.1:6790", formattedMons)
-	findMon(t, "10.0.0.2:8125", formattedMons)
-	findMon(t, "10.0.0.3:6790", formattedMons)
-}
-
-func findMon(t *testing.T, expected string, mons []string) {
-	for _, mon := range mons {
-		if expected == mon {
-			return
-		}
+			if command == "rbd" && args[0] == "ls" && args[1] == "-l" {
+				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
+			}
+			return "", nil
+		},
 	}
-	assert.Fail(t, fmt.Sprintf("expected: %s in %v", expected, mons))
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor,
+		ConfigDir: configDir,
+	}
+
+	provisioner := New(context)
+	volume := newVolumeOptions(newStorageClass("class-1", "rook.io/block", map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
+
+	pv, err := provisioner.Provision(volume)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "pvc-uid-1-1", pv.Name)
+	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
+	assert.Equal(t, "rook.io/rook", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
+	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
+	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
+	assert.Equal(t, "testpool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["pool"])
+	assert.Equal(t, "pvc-uid-1-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["image"])
 }
 
 func TestParseClassParameters(t *testing.T) {
 	cfg := make(map[string]string)
 	cfg["pool"] = "testPool"
-	cfg["clusterNamespace"] = "mynamespace"
 	cfg["clustername"] = "myname"
+	cfg["fstype"] = "ext4"
 
 	provConfig, err := parseClassParameters(cfg)
 	assert.Nil(t, err)
 
 	assert.Equal(t, "testPool", provConfig.pool)
-	assert.Equal(t, "mynamespace", provConfig.clusterNamespace)
 	assert.Equal(t, "myname", provConfig.clusterName)
+	assert.Equal(t, "ext4", provConfig.fstype)
 }
 
 func TestParseClassParametersDefault(t *testing.T) {
@@ -83,13 +101,12 @@ func TestParseClassParametersDefault(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "testPool", provConfig.pool)
-	assert.Equal(t, "rook", provConfig.clusterNamespace)
 	assert.Equal(t, "rook", provConfig.clusterName)
+	assert.Equal(t, "", provConfig.fstype)
 }
 
 func TestParseClassParametersNoPool(t *testing.T) {
 	cfg := make(map[string]string)
-	cfg["clusterNamespace"] = "mynamespace"
 	cfg["clustername"] = "myname"
 
 	_, err := parseClassParameters(cfg)
@@ -106,19 +123,50 @@ func TestParseClassParametersInvalidOption(t *testing.T) {
 	assert.EqualError(t, err, "invalid option \"foo\" for volume plugin rookVolumeProvisioner")
 }
 
-func TestCreateImageName(t *testing.T) {
-	// use a PV name that is typical, it should not be truncated because the resultant image name is not over max length
-	pvName := "pvc-023d0ff3-261d-11e7-aa63-001c42669caf"
-	imageName := createImageName(pvName)
-	assert.True(t, strings.HasPrefix(imageName, "k8s-dynamic-pvc-023d0ff3-261d-11e7-aa63-001c42669caf-"))
-	assert.Equal(t, 89, len(imageName))
+func newVolumeOptions(storageClass *storagebeta.StorageClass, claim *v1.PersistentVolumeClaim) controller.VolumeOptions {
+	return controller.VolumeOptions{
+		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+		PVName:     "pvc-" + string(claim.ObjectMeta.UID),
+		PVC:        claim,
+		Parameters: storageClass.Parameters,
+	}
+}
 
-	// now try a PV name that is too long, it should be properly truncated
-	pvName = "pvc-0fd5988f-2516-11e7-aa55-02420ac00002-2d8-this-is-where-it-gets-too-long"
-	imageName = createImageName(pvName)
-	assert.True(t, strings.HasPrefix(imageName, "k8s-dynamic-pvc-0fd5988f-2516-11e7-aa55-02420ac00002-2d8-"))
+func newStorageClass(name, provisioner string, parameters map[string]string) *storagebeta.StorageClass {
+	return &storagebeta.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner,
+		Parameters:  parameters,
+	}
+}
 
-	// length of our image name plus the rbd ID prefix that the RBD kernel module will add should be equal to the max allowed
-	assert.Equal(t, imageNameMaxLen, len(imageName)+len(rbdIDPrefix),
-		fmt.Sprintf("unexpected image name length: %d, image name: '%s'", len(imageName), imageName))
+func newClaim(name, claimUID, provisioner, volumeName, storageclassName string, annotations map[string]string) *v1.PersistentVolumeClaim {
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       v1.NamespaceDefault,
+			UID:             types.UID(claimUID),
+			ResourceVersion: "0",
+			SelfLink:        "/api/v1/namespaces/" + v1.NamespaceDefault + "/persistentvolumeclaims/" + name,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Mi"),
+				},
+			},
+			VolumeName:       volumeName,
+			StorageClassName: &storageclassName,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimPending,
+		},
+	}
+	for k, v := range annotations {
+		claim.Annotations[k] = v
+	}
+	return claim
 }

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -18,6 +18,7 @@ package test
 import (
 	"os"
 	"os/exec"
+	"time"
 )
 
 // ******************** MockExecutor ********************
@@ -27,6 +28,7 @@ type MockExecutor struct {
 	MockExecuteCommandWithOutput         func(debug bool, actionName string, command string, arg ...string) (string, error)
 	MockExecuteCommandWithCombinedOutput func(debug bool, actionName string, command string, arg ...string) (string, error)
 	MockExecuteCommandWithOutputFile     func(debug bool, actionName string, command, outfileArg string, arg ...string) (string, error)
+	MockExecuteCommandWithTimeout        func(debug bool, timeout time.Duration, actionName string, command string, arg ...string) (string, error)
 	MockExecuteStat                      func(name string) (os.FileInfo, error)
 }
 
@@ -50,6 +52,15 @@ func (e *MockExecutor) StartExecuteCommand(debug bool, actionName string, comman
 func (e *MockExecutor) ExecuteCommandWithOutput(debug bool, actionName string, command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutput != nil {
 		return e.MockExecuteCommandWithOutput(debug, actionName, command, arg...)
+	}
+
+	return "", nil
+}
+
+func (e *MockExecutor) ExecuteCommandWithTimeout(debug bool, timeout time.Duration, actionName string, command string, arg ...string) (string, error) {
+
+	if e.MockExecuteCommandWithTimeout != nil {
+		return e.MockExecuteCommandWithTimeout(debug, time.Second, actionName, command, arg...)
 	}
 
 	return "", nil

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -17,6 +17,7 @@ package sys
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,11 +29,14 @@ import (
 )
 
 const (
-	DiskType = "disk"
-	SSDType  = "ssd"
-	PartType = "part"
-	sgdisk   = "sgdisk"
-	mountCmd = "mount"
+	DiskType             = "disk"
+	SSDType              = "ssd"
+	PartType             = "part"
+	sgdisk               = "sgdisk"
+	mountCmd             = "mount"
+	RBDSysBusPathDefault = "/sys/bus/rbd"
+	RBDDevicesDir        = "devices"
+	RBDDevicePathPrefix  = "/dev/rbd"
 )
 
 type Partition struct {
@@ -321,4 +325,32 @@ func parseKeyValuePairString(propsRaw string) map[string]string {
 	}
 
 	return propMap
+}
+
+// FindRBDMappedFile search for the mapped RBD volume and returns its device path
+func FindRBDMappedFile(imageName, poolName, sysBusDir string) (string, error) {
+
+	sysBusDeviceDir := filepath.Join(sysBusDir, RBDDevicesDir)
+	// if sysPath does not exist, no attachments has happened
+	if _, err := os.Stat(sysBusDeviceDir); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	files, err := ioutil.ReadDir(sysBusDeviceDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read rbd device dir: %+v", err)
+	}
+
+	for _, idFile := range files {
+		nameContent, err := ioutil.ReadFile(filepath.Join(sysBusDeviceDir, idFile.Name(), "name"))
+		if err == nil && imageName == strings.TrimSpace(string(nameContent)) {
+			// the image for the current rbd device matches, now try to match pool
+			poolContent, err := ioutil.ReadFile(filepath.Join(sysBusDeviceDir, idFile.Name(), "pool"))
+			if err == nil && poolName == strings.TrimSpace(string(poolContent)) {
+				// match current device matches both image name and pool name, return the device
+				return idFile.Name(), nil
+			}
+		}
+	}
+	return "", nil
 }

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -17,6 +17,9 @@ package sys
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -193,4 +196,19 @@ NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda"`, nil
 	partitions, unused, err = GetDevicePartitions("sdx", executor)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(partitions))
+}
+
+func TestFindDevicePath(t *testing.T) {
+	// set up a mock RBD sys bus file system
+	mockRBDSysBusPath, err := ioutil.TempDir("", "TestFindDevicePath")
+	if err != nil {
+		t.Fatalf("failed to create temp rbd sys bus dir: %+v", err)
+	}
+	defer os.RemoveAll(mockRBDSysBusPath)
+	dev0Path := filepath.Join(mockRBDSysBusPath, "devices", "3")
+	os.MkdirAll(dev0Path, 0777)
+	ioutil.WriteFile(filepath.Join(dev0Path, "name"), []byte("myimage1"), 0777)
+	ioutil.WriteFile(filepath.Join(dev0Path, "pool"), []byte("mypool1"), 0777)
+	mappedImageFile, _ := FindRBDMappedFile("myimage1", "mypool1", mockRBDSysBusPath)
+	assert.Equal(t, "3", mappedImageFile)
 }

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -144,9 +144,9 @@ func (rb *BlockOperation) BlockRead(name string, mountpath string, filename stri
 
 }
 
-// BlockUnmap Function to map a Block using Rook
+// BlockUnmap Function to unmap a Block using Rook
 // Input parameters -
-//name - ppod definition - the pod described in yam file is deleted
+//name - pod definition - the pod described in yaml file is deleted
 //mountpath - not used in this impl since mountpath is defined in the pod definition
 //Output  - k8s delete pod operation output and/or error
 func (rb *BlockOperation) BlockUnmap(name string, mountpath string) (string, error) {

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -26,10 +26,11 @@ import (
 var (
 	logger = capnslog.NewPackageLogger("github.com/rook/rook", "integrationTest")
 
-	defaultNamespace     = "default"
-	defaultRookNamespace = "test-rook"
-	clusterNamespace1    = "test-cluster-1"
-	clusterNamespace2    = "test-cluster-2"
+	defaultNamespace           = "default"
+	defaultRookSystemNamespace = "rook-system"
+	defaultRookNamespace       = "rook"
+	clusterNamespace1          = "test-cluster-1"
+	clusterNamespace2          = "test-cluster-2"
 )
 
 //Test to make sure all rook components are installed and Running
@@ -37,6 +38,8 @@ func checkIfRookClusterIsInstalled(k8sh *utils.K8sHelper, s suite.Suite, oNamesp
 	logger.Infof("Make sure all Pods in Rook Cluster %s are running", cNamespace)
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-operator", oNamespace, 1, "Running"),
 		"Make sure there is 1 rook-operator present in Running state")
+	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-agent", oNamespace, 1, "Running"),
+		"Make sure there is 1 rook-agent present in Running state")
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-api", cNamespace, 1, "Running"),
 		"Make sure there is 1 rook-api present in Running state")
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-mgr", cNamespace, 1, "Running"),
@@ -50,6 +53,7 @@ func checkIfRookClusterIsInstalled(k8sh *utils.K8sHelper, s suite.Suite, oNamesp
 func gatherAllRookLogs(k8sh *utils.K8sHelper, s suite.Suite, oNamespace string, cNamespace string) {
 	logger.Infof("Gathering all logs from Rook Cluster %s", cNamespace)
 	k8sh.GetRookLogs("rook-operator", oNamespace, s.T().Name())
+	k8sh.GetRookLogs("rook-agent", oNamespace, s.T().Name())
 	k8sh.GetRookLogs("rook-api", cNamespace, s.T().Name())
 	k8sh.GetRookLogs("rook-ceph-mgr", cNamespace, s.T().Name())
 	k8sh.GetRookLogs("rook-ceph-mon", cNamespace, s.T().Name())

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -99,10 +99,10 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-   name: rook-block
+  name: rook-block
 provisioner: rook.io/block
 parameters:
-    pool: {{.poolName}}`
+  pool: {{.poolName}}`
 }
 
 // Test case when persistentvolumeclaim is created for a storage class that doesn't exist

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -45,6 +45,9 @@ func (hs *HelmSuite) SetupSuite() {
 	require.True(hs.T(), kh.IsPodInExpectedState("rook-operator", defaultRookNamespace, "Running"),
 		"Make sure rook-operator is in running state")
 
+	require.True(hs.T(), kh.IsPodInExpectedState("rook-agent", defaultRookNamespace, "Running"),
+		"Make sure rook-agent is in running state")
+
 	time.Sleep(10 * time.Second)
 
 	err = hs.installer.CreateK8sRookCluster(defaultRookNamespace)

--- a/tests/integration/multi_cluster_deploy_test.go
+++ b/tests/integration/multi_cluster_deploy_test.go
@@ -40,8 +40,11 @@ func (mrc *MultiRookClusterDeploySuite) SetupSuite() {
 	err = mrc.installer.CreateK8sRookOperator()
 	require.NoError(mrc.T(), err)
 
-	require.True(mrc.T(), kh.IsPodInExpectedState("rook-operator", "default", "Running"),
+	require.True(mrc.T(), kh.IsPodInExpectedState("rook-operator", defaultRookSystemNamespace, "Running"),
 		"Make sure rook-operator is in running state")
+
+	require.True(mrc.T(), kh.IsPodInExpectedState("rook-agent", defaultRookSystemNamespace, "Running"),
+		"Make sure rook-agent is in running state")
 
 	time.Sleep(10 * time.Second)
 
@@ -67,8 +70,8 @@ func (mrc *MultiRookClusterDeploySuite) SetupSuite() {
 
 func (mrc *MultiRookClusterDeploySuite) TearDownSuite() {
 	if mrc.T().Failed() {
-		gatherAllRookLogs(mrc.k8sh, mrc.Suite, defaultNamespace, clusterNamespace1)
-		gatherAllRookLogs(mrc.k8sh, mrc.Suite, defaultNamespace, clusterNamespace2)
+		gatherAllRookLogs(mrc.k8sh, mrc.Suite, defaultRookSystemNamespace, clusterNamespace1)
+		gatherAllRookLogs(mrc.k8sh, mrc.Suite, defaultRookSystemNamespace, clusterNamespace2)
 	}
 	deleteArgs := []string{"delete", "-f", "-"}
 
@@ -142,10 +145,10 @@ func (mrc *MultiRookClusterDeploySuite) TearDownSuite() {
 func (mrc *MultiRookClusterDeploySuite) TestInstallingMultipleRookClusters() {
 
 	//Check if Rook cluster 1 is deployed successfully
-	checkIfRookClusterIsInstalled(mrc.k8sh, mrc.Suite, defaultNamespace, clusterNamespace1)
+	checkIfRookClusterIsInstalled(mrc.k8sh, mrc.Suite, defaultRookSystemNamespace, clusterNamespace1)
 
 	//Check if Rook cluster 1 is deployed successfully
-	checkIfRookClusterIsInstalled(mrc.k8sh, mrc.Suite, defaultNamespace, clusterNamespace2)
+	checkIfRookClusterIsInstalled(mrc.k8sh, mrc.Suite, defaultRookSystemNamespace, clusterNamespace2)
 
 }
 

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -55,7 +55,7 @@ func (suite *SmokeSuite) SetupSuite() {
 
 func (suite *SmokeSuite) TearDownSuite() {
 	if suite.T().Failed() {
-		gatherAllRookLogs(suite.k8sh, suite.Suite, defaultNamespace, defaultRookNamespace)
+		gatherAllRookLogs(suite.k8sh, suite.Suite, defaultRookSystemNamespace, defaultRookNamespace)
 
 	}
 	suite.installer.UninstallRookFromK8s(defaultRookNamespace, false)
@@ -73,5 +73,5 @@ func (suite *SmokeSuite) TestObjectStorage_SmokeTest() {
 
 //Test to make sure all rook components are installed and Running
 func (suite *SmokeSuite) TestRookClusterInstallation_smokeTest() {
-	checkIfRookClusterIsInstalled(suite.k8sh, suite.Suite, defaultNamespace, defaultRookNamespace)
+	checkIfRookClusterIsInstalled(suite.k8sh, suite.Suite, defaultRookSystemNamespace, defaultRookNamespace)
 }

--- a/tests/longhaul/block_test.go
+++ b/tests/longhaul/block_test.go
@@ -88,8 +88,7 @@ metadata:
 provisioner: rook.io/block
 parameters:
     pool: {{.poolName}}
-    clusterName: {{.namespace}}
-    clusterNamespace: {{.namespace}}`
+    clusterName: {{.namespace}}`
 
 	s.mysqlAppPath = `apiVersion: v1
 kind: Service

--- a/tests/scripts/kubeadm-rbd
+++ b/tests/scripts/kubeadm-rbd
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/bin/docker run --rm -v /sys:/sys --net=host --privileged=true ceph/base rbd "$@"

--- a/tests/scripts/minikube-rbd
+++ b/tests/scripts/minikube-rbd
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/bin/docker run --rm -v /sys:/sys --net=host --privileged=true ceph/base rbd "$@"


### PR DESCRIPTION
Rook plugin for Kubernetes implemented as flexvolume
- Operator is deployed under namespace rook-system
- Operator deploys rook-agent on all nodes as daemonset also on rook-system
- Rook-agent installs flexvolume driver on hosts
- Rook-agent listens on unix socket for driver requests
- Rook-agent perform attach/detach on its node
- Rook-agent creates/delete CRD volumeattach objects
- Supports fencing for RW and multiple attachments for RO
- Added unit and integration tests
- Updated docs

fixes #432 