### PR TITLE
ci updates

### DIFF
--- a/build/run
+++ b/build/run
@@ -175,6 +175,7 @@ docker run \
     -e GITHUB_TOKEN \
     -e VERSION \
     -e CHANNEL \
+    -v ${PWD}/_output:${BUILDER_HOME}/go/bin \
     ${TTY_ARGS} \
     ${KUBE_ARGS} \
     ${KUBEADM_DIND_ARGS} \

--- a/tests/framework/installer/install_helper.go
+++ b/tests/framework/installer/install_helper.go
@@ -117,6 +117,8 @@ func (h *InstallHelper) createk8sRookCluster(k8sHelper *utils.K8sHelper, k8svers
 
 //InstallRookOnK8s installs rook on k8s
 func (h *InstallHelper) InstallRookOnK8s() (err error) {
+	//creating clusterrolebinding for kubeadm env.
+	h.k8shelper.Kubectl([]string{"create", "clusterrolebinding", "anon-user-access", "--clusterrole", "cluster-admin", "--user", "system:anonymous"}...)
 
 	//flag used for local debuggin purpose, when rook is pre-installed
 	skipRookInstall := strings.EqualFold(h.Env.SkipInstallRook, "true")
@@ -223,6 +225,7 @@ func (h *InstallHelper) UninstallRookFromK8s() {
 	}
 
 	isRookUninstalled := k8sHelp.WaitUntilPodInNamespaceIsDeleted("rook-ceph-mon", "rook")
+	h.k8shelper.Clientset.RbacV1beta1().ClusterRoleBindings().Delete("anon-user-access", nil)
 
 	if isRookUninstalled {
 		logger.Infof("Rook uninstalled successfully")

--- a/tests/longhaul/block_on_k8s_test.go
+++ b/tests/longhaul/block_on_k8s_test.go
@@ -44,9 +44,10 @@ func (s *K8sBlockLongHaulSuite) SetupSuite() {
 	assert.Nil(s.T(), err)
 
 	s.installer = installer.NewK8sRookhelper(s.kh.Clientset)
-
-	err = s.installer.InstallRookOnK8s()
-	require.NoError(s.T(), err)
+	if !s.kh.IsRookInstalled() {
+		err = s.installer.InstallRookOnK8s()
+		require.NoError(s.T(), err)
+	}
 
 	s.testClient, err = clients.CreateTestClient(enums.Kubernetes, s.kh)
 	require.Nil(s.T(), err)
@@ -207,7 +208,6 @@ func (s *K8sBlockLongHaulSuite) TearDownSuite() {
 	s.db.CloseConnection()
 	s.kh.ResourceOperation("delete", s.mysqlAppPath)
 	s.storageClassOperation("mysql-pool", "delete")
-	s.installer.UninstallRookFromK8s()
 	s.testClient = nil
 	s.bc = nil
 	s.kh = nil

--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,33 +1,37 @@
 #!/bin/bash +e
 
-KUBE_VERSION=${1:-"v1.7.2"}
+KUBE_VERSION=${1:-"v1.7.4"}
 
 null_str=
 KUBE_INSTALL_VERSION="${KUBE_VERSION/v/$null_str}"-00
 
 
+wait_for_dpkg_unlock() {
+    #wait for dpkg lock to disappear.
+    retry=0
+    maxRetries=20
+    retryInterval=10
+    until [ ${retry} -ge ${maxRetries} ]
+    do
+	    if [[ `sudo lsof /var/lib/dpkg/lock|wc -l` -le 0 ]]; then
+	        break
+	    fi
+	    ((++retry))
+	    echo "."
+	    sleep ${retryInterval}
+    done
+
+    if [ ${retry} -ge ${maxRetries} ]; then
+        echo "Failed after ${maxRetries} attempts! - cannot install kubeadm"
+        exit 1
+    fi
+
+}
+
 sudo apt-get update
-
-#wait for dpkg lock to disappear.
-retry=0
-maxRetries=20
-retryInterval=10
-until [ ${retry} -ge ${maxRetries} ]
-do
-	if [[ `sudo lsof /var/lib/dpkg/lock|wc -l` -le 0 ]]; then
-	    break
-	fi
-	((++retry))
-	echo "."
-	sleep ${retryInterval}
-done
-
-if [ ${retry} -ge ${maxRetries} ]; then
-  echo "Failed after ${maxRetries} attempts! - cannot install kubeadm"
-  exit 1
-fi
-
-
+wait_for_dpkg_unlock
+sleep 5
+wait_for_dpkg_unlock
 
 sudo apt-get install -y apt-transport-https
 sudo curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -36,7 +40,12 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
 #install kubeadm and kubelet
-sudo apt-get update && sudo apt-get install -y kubelet=${KUBE_INSTALL_VERSION}  && sudo apt-get install -y kubeadm=${KUBE_INSTALL_VERSION}
+sudo apt-get update
+wait_for_dpkg_unlock
+sleep 5
+wait_for_dpkg_unlock
+
+sudo apt-get install -y kubelet=${KUBE_INSTALL_VERSION}  && sudo apt-get install -y kubeadm=${KUBE_INSTALL_VERSION}
 
 #get matching kubectl
 wget https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl

--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -5,7 +5,7 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tarname=image.tar
 tarfile=${WORK_DIR}/tests/${tarname}
 
-export KUBE_VERSION=${KUBE_VERSION:-"v1.7.2"}
+export KUBE_VERSION=${KUBE_VERSION:-"v1.7.4"}
 
 
 install() {

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -55,7 +55,7 @@ KUBE_VERSION=${KUBE_VERSION:-"v1.7.2"}
 
 case "${1:-}" in
   up)
-    minikube start --memory=3000 --iso-url=https://s3-us-west-2.amazonaws.com/minikube-cephfs/minikube.iso --kubernetes-version ${KUBE_VERSION}
+    minikube start --memory=3000 --kubernetes-version ${KUBE_VERSION}
     wait_for_ssh
  
     echo setting up rbd


### PR DESCRIPTION
 - converting results to junit
 - better handling for apt-get install on slaves
 - user standard minikube image, now that minikube v0.21.0 and above support cephfs
 - update test framework to handle minikube and kubeadm env