### PR TITLE
Provisioner needs Namespace to get rook-ceph-mon-endpoints 

### DIFF
--- a/pkg/operator/cluster/controller.go
+++ b/pkg/operator/cluster/controller.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/rook/rook/pkg/ceph/client"
 	cephmon "github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/clusterd"
@@ -36,13 +36,13 @@ import (
 	"github.com/rook/rook/pkg/operator/mon"
 	"github.com/rook/rook/pkg/operator/osd"
 	"github.com/rook/rook/pkg/operator/pool"
+	"github.com/rook/rook/pkg/operator/provisioner"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"github.com/rook/rook/pkg/operator/provisioner"
 )
 
 const (

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -34,7 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	helper "k8s.io/kubernetes/pkg/api/v1/helper"
+	"k8s.io/kubernetes/pkg/api/v1/helper"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 )
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -32,7 +32,6 @@ import (
 	"github.com/rook/rook/pkg/operator/cluster"
 	"github.com/rook/rook/pkg/operator/kit"
 	"github.com/rook/rook/pkg/operator/pool"
-	"github.com/rook/rook/pkg/operator/provisioner"
 	"k8s.io/api/core/v1"
 )
 

--- a/pkg/operator/provisioner/provisioner.go
+++ b/pkg/operator/provisioner/provisioner.go
@@ -48,7 +48,7 @@ type RookVolumeProvisioner struct {
 	// Configuration of rook volume provisioner
 	provConfig provisionerConfig
 
-	Namespace           string
+	Namespace string
 }
 
 type provisionerConfig struct {
@@ -68,7 +68,7 @@ type provisionerConfig struct {
 // New creates RookVolumeProvisioner
 func New(context *clusterd.Context, namespace string) controller.Provisioner {
 	return &RookVolumeProvisioner{
-		context: context,
+		context:   context,
 		Namespace: namespace,
 	}
 }

--- a/pkg/operator/provisioner/provisioner.go
+++ b/pkg/operator/provisioner/provisioner.go
@@ -47,6 +47,8 @@ type RookVolumeProvisioner struct {
 
 	// Configuration of rook volume provisioner
 	provConfig provisionerConfig
+
+	Namespace           string
 }
 
 type provisionerConfig struct {
@@ -64,9 +66,10 @@ type provisionerConfig struct {
 }
 
 // New creates RookVolumeProvisioner
-func New(context *clusterd.Context) controller.Provisioner {
+func New(context *clusterd.Context, namespace string) controller.Provisioner {
 	return &RookVolumeProvisioner{
 		context: context,
+		Namespace: namespace,
 	}
 }
 
@@ -200,7 +203,7 @@ func parseClassParameters(params map[string]string) (*provisionerConfig, error) 
 }
 
 func (p *RookVolumeProvisioner) getMonitorEndpoints() ([]string, error) {
-	cm, err := p.context.Clientset.CoreV1().ConfigMaps(p.provConfig.clusterName).Get(mon.EndpointConfigMapName, metav1.GetOptions{})
+	cm, err := p.context.Clientset.CoreV1().ConfigMaps(p.Namespace).Get(mon.EndpointConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mon endpoints. %+v", err)
 	}


### PR DESCRIPTION
## Background
Prior to this PR the field p.provConfig.clusterName (default rook) is used a an namespace equivalent in  provisioner.go breaking any installation when another namespace is used while other controller do respect the namespace.

### Alternatives
The field p.provConfig.clusterNamespace could be used but is currently marked as an optional field in VolumeOptions.Parameters in the StorageClass rook.io/block

## Changes
operator.go/controller.go
- moved creation of provisionerController from operator.go to controller.go in onAdd method

provisioner.go:
- added Namespace to RookVolumeProvisioner struct
- used Namespace in Configmap query in method getMonitorEndpoints()