### PR TITLE
log version, arguments and flags at start up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ TEST_PACKAGES = $(GO_PROJECT)/tests/smoke
 # the root go project
 GO_PROJECT=github.com/rook/rook
 
+# inject the version number into the golang version package using the -X linker flag
 LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 
 # ====================================================================================

--- a/cmd/rook/api.go
+++ b/cmd/rook/api.go
@@ -44,7 +44,7 @@ func init() {
 	apiCmd.Flags().StringVar(&namespace, "namespace", "", "the namespace in which the api service is running")
 	addCephFlags(apiCmd)
 
-	flags.SetFlagsFromEnv(apiCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(apiCmd.Flags(), RookEnvVarPrefix)
 
 	apiCmd.RunE = startAPI
 }
@@ -59,6 +59,8 @@ func startAPI(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(apiCmd.Flags())
 
 	clientset, _, err := getClientset()
 	if err != nil {

--- a/cmd/rook/mds.go
+++ b/cmd/rook/mds.go
@@ -41,7 +41,7 @@ func init() {
 	mdsCmd.Flags().StringVar(&mdsKeyring, "mds-keyring", "", "the mds keyring")
 	addCephFlags(mdsCmd)
 
-	flags.SetFlagsFromEnv(mdsCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(mdsCmd.Flags(), RookEnvVarPrefix)
 
 	mdsCmd.RunE = startMDS
 }
@@ -53,6 +53,8 @@ func startMDS(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(mdsCmd.Flags())
 
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	config := &mds.Config{

--- a/cmd/rook/mgr.go
+++ b/cmd/rook/mgr.go
@@ -41,7 +41,7 @@ func init() {
 	mgrCmd.Flags().StringVar(&mgrKeyring, "mgr-keyring", "", "the mgr keyring")
 	addCephFlags(mgrCmd)
 
-	flags.SetFlagsFromEnv(mgrCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(mgrCmd.Flags(), RookEnvVarPrefix)
 
 	mgrCmd.RunE = startMgr
 }
@@ -53,6 +53,8 @@ func startMgr(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(mgrCmd.Flags())
 
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	config := &mgr.Config{

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -52,7 +52,7 @@ func init() {
 	monCmd.Flags().IntVar(&monPort, "port", 0, "port of the monitor")
 	addCephFlags(monCmd)
 
-	flags.SetFlagsFromEnv(monCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(monCmd.Flags(), RookEnvVarPrefix)
 
 	monCmd.RunE = startMon
 }
@@ -64,6 +64,8 @@ func startMon(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(monCmd.Flags())
 
 	if monPort == 0 {
 		return fmt.Errorf("missing mon port")

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -37,7 +37,7 @@ https://github.com/rook/rook`,
 }
 
 func init() {
-	flags.SetFlagsFromEnv(operatorCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(operatorCmd.Flags(), RookEnvVarPrefix)
 
 	operatorCmd.RunE = startOperator
 }
@@ -45,6 +45,8 @@ func init() {
 func startOperator(cmd *cobra.Command, args []string) error {
 
 	setLogLevel()
+
+	logStartupInfo(operatorCmd.Flags())
 
 	clientset, apiExtClientset, err := getClientset()
 	if err != nil {

--- a/cmd/rook/osd.go
+++ b/cmd/rook/osd.go
@@ -55,7 +55,7 @@ func addOSDFlags(command *cobra.Command) {
 func init() {
 	addOSDFlags(osdCmd)
 	addCephFlags(osdCmd)
-	flags.SetFlagsFromEnv(osdCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(osdCmd.Flags(), RookEnvVarPrefix)
 
 	osdCmd.RunE = startOSD
 }
@@ -80,6 +80,8 @@ func startOSD(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(osdCmd.Flags())
 
 	forceFormat := false
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -43,7 +43,7 @@ func init() {
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port number")
 	addCephFlags(rgwCmd)
 
-	flags.SetFlagsFromEnv(rgwCmd.Flags(), "ROOK")
+	flags.SetFlagsFromEnv(rgwCmd.Flags(), RookEnvVarPrefix)
 
 	rgwCmd.RunE = startRGW
 }
@@ -59,6 +59,8 @@ func startRGW(cmd *cobra.Command, args []string) error {
 	}
 
 	setLogLevel()
+
+	logStartupInfo(rgwCmd.Flags())
 
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	config := &rgw.Config{

--- a/pkg/clusterd/join.go
+++ b/pkg/clusterd/join.go
@@ -31,9 +31,6 @@ import (
 func StartJoinCluster(services []*ClusterService, configDir, nodeID, discoveryURL,
 	etcdMembers string, networkInfo NetworkInfo, configFileOverride string, logLevel capnslog.LogLevel) (*Context, error) {
 
-	logger.Infof("Starting cluster. configDir=%s, nodeID=%s, url=%s, members=%s, networkInfo=%+v, configFileOverride=%s, logLevel=%s",
-		configDir, nodeID, discoveryURL, etcdMembers, networkInfo, configFileOverride, logLevel)
-
 	if err := VerifyNetworkInfo(networkInfo); err != nil {
 		return nil, fmt.Errorf("invalid network info: %+v. %+v", networkInfo, err)
 	}

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -18,6 +18,7 @@ package flags
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -71,4 +72,23 @@ func SetFlagsFromEnv(flags *pflag.FlagSet, prefix string) error {
 	})
 
 	return nil
+}
+
+// GetFlagsAndValues returns all flags and their values as a slice with elements in the format of
+// "--<flag>=<value>"
+func GetFlagsAndValues(flags *pflag.FlagSet, excludeFilter string) []string {
+	var flagValues []string
+
+	flags.VisitAll(func(f *pflag.Flag) {
+		val := f.Value.String()
+		if excludeFilter != "" {
+			if matched, _ := regexp.Match(excludeFilter, []byte(f.Name)); matched {
+				val = "*****"
+			}
+		}
+
+		flagValues = append(flagValues, fmt.Sprintf("--%s=%s", f.Name, val))
+	})
+
+	return flagValues
 }

--- a/pkg/util/flags/flags_test.go
+++ b/pkg/util/flags/flags_test.go
@@ -73,3 +73,31 @@ func TestUintFlags(t *testing.T) {
 	err = VerifyRequiredUint64Flags(cmd, []string{"foo", "bar"})
 	assert.Nil(t, err)
 }
+
+func TestGetFlagsAndValues(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Creates a test arg",
+	}
+
+	var arg1 string
+	var arg2 string
+	cmd.Flags().StringVar(&arg1, "foo-data", "", "test 1")
+	cmd.Flags().StringVar(&arg2, "bar-secret", "", "test 2")
+
+	cmd.Flags().Set("foo-data", "1234")
+	cmd.Flags().Set("bar-secret", "mypassword")
+
+	// get all flags and their values, providing no filter.  all of them should be returned.
+	flagValues := GetFlagsAndValues(cmd.Flags(), "")
+	assert.Equal(t, 2, len(flagValues))
+	assert.Contains(t, flagValues, "--foo-data=1234")
+	assert.Contains(t, flagValues, "--bar-secret=mypassword")
+
+	// get all flags and their values, filtering any flags with "secret" in their name.
+	// the --bar-secret flag should be redacted.
+	flagValues = GetFlagsAndValues(cmd.Flags(), "secret")
+	assert.Equal(t, 2, len(flagValues))
+	assert.Contains(t, flagValues, "--foo-data=1234")
+	assert.Contains(t, flagValues, "--bar-secret=*****")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,4 +15,5 @@ limitations under the License.
 */
 package version
 
+// Version will be overridden with the current version at build time using the -X linker flag
 var Version = "0.0.0"


### PR DESCRIPTION
Fixes #286 

This had made debugging something in the field more difficult recently, so I wanted to knock it off since it's not a difficult fix.

Example start of the logs for an OSD pod:
```
2017-08-24 18:49:08.149736 I | rook: starting Rook v0.5.0-35.g136ce41.dirty with arguments '/usr/local/bin/rook osd'
2017-08-24 18:49:08.149850 I | rook: flag values: --admin-secret=*****, --ceph-config-override=/etc/rook/override.conf, --cluster-name=rook, --config-dir=/var/lib/rook, --data-device-filter=, --data-devices=, --data-directories=, --force-format=false, --fsid=, --help=false, --location=, --log-level=INFO, --metadata-device=, --mon-endpoints=rook-ceph-mon1=10.0.0.236:6790,rook-ceph-mon2=10.0.0.7:6790,rook-ceph-mon0=10.0.0.100:6790, --mon-secret=*****, --node-name=minikube, --osd-database-size=1024, --osd-journal-size=1024, --osd-store=filestore, --osd-wal-size=576, --private-ipv4=172.17.0.10, --public-ipv4=172.17.0.10
```