### PR TITLE
Helm chart log-level extension

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -83,6 +83,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `image.pullPolicy` | Image pull policy                    | `IfNotPresent`       |
 | `rbacEnable`       | If true, create & use RBAC resources | `true`               |
 | `resources`        | Pod resource requests & limits       | `{}`                 |
+| `logLevel`        | Global log level        | `INFO`                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example to disable RBAC,
 

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
         env:
         - name: ROOK_REPO_PREFIX
           value: {{ .Values.image.prefix }}
+        - name: ROOK_LOG_LEVEL
+          value: {{ .Values.logLevel }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.rbacEnable }}

--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -16,6 +16,9 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+## LogLevel can be set to: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR or CRITICAL
+logLevel: INFO
+
 ## If true, create & use RBAC resources
 ##
 rbacEnable: true


### PR DESCRIPTION
added log-level env in rook-operator deployment.yaml with variable .Values.logLevel

I hope this PR is complementary to #938 