### PR TITLE
Stripping out debug log of rbd command output for ListImages

### DIFF
--- a/pkg/ceph/client/image.go
+++ b/pkg/ceph/client/image.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"regexp"
 )
 
 const (
@@ -39,6 +40,15 @@ func ListImages(context *clusterd.Context, clusterName, poolName string) ([]Ceph
 	buf, err := ExecuteRBDCommand(context, clusterName, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list images for pool %s: %+v", poolName, err)
+	}
+
+	//The regex expression captures the json result at the end buf
+	//When logLevel is DEBUG buf contains log statements of librados (see tests for examples)
+	res := regexp.MustCompile(`\[(.*)\]$`).FindStringSubmatch(string(buf))
+	if len(res) == 0 {
+		return []CephBlockImage{}, nil
+	} else {
+		buf = []byte(res[0])
 	}
 
 	var images []CephBlockImage

--- a/pkg/ceph/client/image_test.go
+++ b/pkg/ceph/client/image_test.go
@@ -91,3 +91,104 @@ func TestCreateImage(t *testing.T) {
 	assert.True(t, createCalled)
 	createCalled = false
 }
+
+func TestListImageLogLevelInfo(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+
+	var images []CephBlockImage
+	var err error
+	listCalled := false
+	emptyListResult := false
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
+		switch {
+		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
+			listCalled = true
+			if emptyListResult {
+				return `[]`, nil
+			} else {
+				return `[{"image":"image1","size":1048576,"format":2},{"image":"image2","size":2048576,"format":2},{"image":"image3","size":3048576,"format":2}]`, nil
+
+			}
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	images, err = ListImages(context, "foocluster", "pool1")
+	assert.Nil(t, err)
+	assert.NotNil(t, images)
+	assert.True(t, len(images) == 3)
+	assert.True(t, listCalled)
+	listCalled = false
+
+	emptyListResult = true
+	images, err = ListImages(context, "foocluster", "pool1")
+	assert.Nil(t, err)
+	assert.NotNil(t, images)
+	assert.True(t, len(images) == 0)
+	assert.True(t, listCalled)
+	listCalled = false
+}
+
+func TestListImageLogLevelDebug(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+
+	var images []CephBlockImage
+	var err error
+	libradosDebugOut := `2017-08-24 19:42:10.693348 7fd64513e0c0  1 librados: starting msgr at -
+2017-08-24 19:42:10.693372 7fd64513e0c0  1 librados: starting objecter
+2017-08-24 19:42:10.784686 7fd64513e0c0  1 librados: setting wanted keys
+2017-08-24 19:42:10.784688 7fd64513e0c0  1 librados: calling monclient init
+2017-08-24 19:42:10.789337 7fd64513e0c0  1 librados: init done
+2017-08-24 19:42:10.789354 7fd64513e0c0 10 librados: wait_for_osdmap waiting
+2017-08-24 19:42:10.790039 7fd64513e0c0 10 librados: wait_for_osdmap done waiting
+2017-08-24 19:42:10.790079 7fd64513e0c0 10 librados: read oid=rbd_directory nspace=
+2017-08-24 19:42:10.792235 7fd64513e0c0 10 librados: Objecter returned from read r=0
+2017-08-24 19:42:10.792307 7fd64513e0c0 10 librados: call oid=rbd_directory nspace=
+2017-08-24 19:42:10.793495 7fd64513e0c0 10 librados: Objecter returned from call r=0
+2017-08-24 19:42:11.684960 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.884609 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.884628 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.985068 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.985084 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.986275 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.986339 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.986498 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.987363 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:11.988165 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:12.385448 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:12.386804 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+2017-08-24 19:42:12.386877 7fd621ffb700 10 librados: set snap write context: seq = 0 and snaps = []
+`
+
+	listCalled := false
+	emptyListResult := false
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
+		switch {
+		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
+			listCalled = true
+			if emptyListResult {
+				return fmt.Sprintf(`%s[]`, libradosDebugOut), nil
+			} else {
+				return fmt.Sprintf(`%s[{"image":"image1","size":1048576,"format":2},{"image":"image2","size":2048576,"format":2},{"image":"image3","size":3048576,"format":2}]`, libradosDebugOut), nil
+			}
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	images, err = ListImages(context, "foocluster", "pool1")
+	assert.Nil(t, err)
+	assert.NotNil(t, images)
+	assert.True(t, len(images) == 3)
+	assert.True(t, listCalled)
+	listCalled = false
+
+	emptyListResult = true
+	images, err = ListImages(context, "foocluster", "pool1")
+	assert.Nil(t, err)
+	assert.NotNil(t, images)
+	assert.True(t, len(images) == 0)
+	assert.True(t, listCalled)
+	listCalled = false
+}


### PR DESCRIPTION
Fixes #942 

## Changes
- Added simple brackets regex for ListImages with the assumption that stdout contains the relevant information as a json-block
- added test for different log-level

## Playground code snippet
https://play.golang.org/p/fxA5beReir