### PR TITLE
operator/mon: Use seperate "timeout" for mons if the node is not ready below

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -9,8 +9,8 @@ indent: true
 These examples show how to perform advanced configuration tasks on your Rook
 storage cluster.
 
-- [Change Rook Docker Image Prefix](#change-rook-docker-image-prefix)
 - [Log Collection](#log-collection)
+- [Change Rook Docker Image Prefix](#change-rook-docker-image-prefix)
 - [OSD Information](#osd-information)
 - [Separate Storage Groups](#separate-storage-groups)
 - [Configuring Pools](#configuring-pools)
@@ -26,33 +26,33 @@ The Kubernetes based examples assume Rook OSD pods are in the `rook` namespace.
 If you run them in a different namespace, modify `kubectl -n rook [...]` to fit
 your situation.
 
-## Change Rook Docker Image Prefix
-To change the prefix of rook Docker images used, the environment variable `ROOK_REPO_PREFIX` can be changed.
-The variable needs to be, depending on the deployment of the rook-operator, added/changed in the rook-operator deployment.
-The default is `rook` which will pull from [Docker Hub](https://hub.docker.com/r/rook/rook/). For example to use your own built images: `your-registry.example.com/your-name/rook`.
-
 ## Log Collection
 
 All Rook logs can be collected in a Kubernetes environment with the following command:
 ```bash
 (for p in $(kubectl -n rook get pods -o jsonpath='{.items[*].metadata.name}')
 do
-  for c in $(kubectl -n rook get pod ${p} -o jsonpath='{.spec.containers[*].name}')
-  do
-    echo "BEGIN logs from pod: ${p} ${c}"
-    kubectl -n rook logs -c ${c} ${p}
-    echo "END logs from pod: ${p} ${c}"
-  done
+    for c in $(kubectl -n rook get pod ${p} -o jsonpath='{.spec.containers[*].name}')
+    do
+        echo "BEGIN logs from pod: ${p} ${c}"
+        kubectl -n rook logs -c ${c} ${p}
+        echo "END logs from pod: ${p} ${c}"
+    done
 done
 for i in $(kubectl -n default get pods -l app=rook-operator -o jsonpath='{.items[*].metadata.name}')
 do
-  echo "BEGIN logs from pod: ${i}"
-  kubectl -n default logs ${i}
-  echo "END logs from pod: ${i}"
+    echo "BEGIN logs from pod: ${i}"
+    kubectl -n default logs ${i}
+    echo "END logs from pod: ${i}"
 done) | gzip > /tmp/rook-logs.gz
 ```
 This gets the logs for every container in every Rook pod and then compresses them into a `.gz` archive
 for easy sharing.  Note that instead of `gzip`, you could instead pipe to `less` or to a single text file.
+
+## Change Rook Docker Image Prefix
+To change the prefix of rook Docker images used, the environment variable `ROOK_REPO_PREFIX` can be changed.
+The variable needs to be, depending on the deployment of the rook-operator, added/changed in the rook-operator deployment.
+The default is `rook` which will pull from [Docker Hub](https://hub.docker.com/r/rook/rook/). For example to use your own built images: `your-registry.example.com/your-name/rook`.
 
 ## OSD Information
 
@@ -312,8 +312,8 @@ PGs in "undersized" and other "unclean" states.  The cluster is essentially
 fixing itself since the number of replicas has been increased, and should go
 back to "active/clean" state shortly, after data has been replicated between
 hosts.  When that's done you will be able to lose two of your storage nodes and
-still have access to all your data in that pool, since the CRUSH algorithm will 
-guarantee that at least one replica will still be available on another storage node. 
+still have access to all your data in that pool, since the CRUSH algorithm will
+guarantee that at least one replica will still be available on another storage node.
 Of course you will only have 1/3 the capacity as a tradeoff.
 
 ### Setting PG Count

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -18,12 +18,23 @@ spec:
       - name: rook-operator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args: ["operator"]
+        args:
+          - operator
         env:
         - name: ROOK_REPO_PREFIX
           value: {{ .Values.image.prefix }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
+{{- if .Values.mon }}
+{{- if .Values.mon.healthCheckInterval }}
+        - name: ROOK_MON_HEALTHCHECK_INTERVAL
+          value: {{ .Values.mon.healthCheckInterval }}
+{{- end }}
+{{- if .Values.mon.monOutTimeout }}
+        - name: ROOK_MON_OUT_TIMEOUT
+          value: {{ .Values.mon.monOutTimeout }}
+{{- end }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
     {{- if .Values.rbacEnable }}

--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -16,6 +16,10 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+mon:
+  healthCheckInterval: "20s"
+  monOutTimeout: "300s"
+
 ## LogLevel can be set to: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR or CRITICAL
 logLevel: INFO
 

--- a/cluster/examples/kubernetes/1.5/rook-operator.yaml
+++ b/cluster/examples/kubernetes/1.5/rook-operator.yaml
@@ -16,3 +16,10 @@ spec:
         env:
         - name: ROOK_REPO_PREFIX
           value: rook
+        # The interval to check if every mon is in the quorum.
+        - name: ROOK_MON_HEALTHCHECK_INTERVAL
+          value: "20s"
+        # The duration to wait before trying to failover or remove/replace the
+        # current mon with a new mon (useful for compensating flapping network).
+        - name: ROOK_MON_OUT_TIMEOUT
+          value: "300s"

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -115,3 +115,10 @@ spec:
         env:
         - name: ROOK_REPO_PREFIX
           value: rook
+        # The interval to check if every mon is in the quorum.
+        - name: ROOK_MON_HEALTHCHECK_INTERVAL
+          value: "20s"
+        # The duration to wait before trying to failover or remove/replace the
+        # current mon with a new mon (useful for compensating flapping network).
+        - name: ROOK_MON_OUT_TIMEOUT
+          value: "300s"

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -37,6 +38,8 @@ https://github.com/rook/rook`,
 }
 
 func init() {
+	operatorCmd.Flags().DurationVar(&mon.HealthCheckInterval, "mon-healthcheck-interval", mon.HealthCheckInterval, "mon health check interval (duration)")
+	operatorCmd.Flags().DurationVar(&mon.MonOutTimeout, "mon-out-timeout", mon.MonOutTimeout, "mon out timeout (duration)")
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), RookEnvVarPrefix)
 
 	operatorCmd.RunE = startOperator

--- a/pkg/operator/cluster/controller.go
+++ b/pkg/operator/cluster/controller.go
@@ -53,9 +53,7 @@ const (
 )
 
 var (
-	healthCheckInterval = 10 * time.Second
-	clientTimeout       = 15 * time.Second
-	logger              = capnslog.NewPackageLogger("github.com/rook/rook", "op-cluster")
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-cluster")
 )
 
 // ClusterController controls an instance of a Rook cluster

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -75,6 +75,7 @@ type Cluster struct {
 	dataDirHostPath     string
 	monPodRetryInterval time.Duration
 	monPodTimeout       time.Duration
+	monTimeoutList      map[string]time.Time
 }
 
 // monConfig for a single monitor
@@ -97,6 +98,7 @@ func New(context *clusterd.Context, namespace, dataDirHostPath, version string, 
 		waitForStart:        true,
 		monPodRetryInterval: 6 * time.Second,
 		monPodTimeout:       5 * time.Minute,
+		monTimeoutList:      map[string]time.Time{},
 	}
 }
 
@@ -104,8 +106,7 @@ func New(context *clusterd.Context, namespace, dataDirHostPath, version string, 
 func (c *Cluster) Start() (*mon.ClusterInfo, error) {
 	logger.Infof("start running mons")
 
-	err := c.initClusterInfo()
-	if err != nil {
+	if err := c.initClusterInfo(); err != nil {
 		return nil, fmt.Errorf("failed to initialize ceph cluster info. %+v", err)
 	}
 
@@ -124,8 +125,7 @@ func (c *Cluster) Start() (*mon.ClusterInfo, error) {
 		}
 	} else {
 		// Check the health of a previously started cluster
-		err = c.checkHealth()
-		if err != nil {
+		if err := c.checkHealth(); err != nil {
 			logger.Warningf("failed to check mon health %+v. %+v", c.clusterInfo.Monitors, err)
 		}
 	}

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -44,7 +44,7 @@ spec:
       containers:
       - name: rook-operator
         image: rook/rook:master
-        args: ["operator"]
+        args: ["operator", "--mon-healthcheck-interval=5s", "--mon-out-timeout=1s"]
         env:
         - name: ROOK_REPO_PREFIX
           value: roo`
@@ -163,7 +163,7 @@ spec:
       containers:
       - name: rook-operator
         image: rook/rook:master
-        args: ["operator"]
+        args: ["operator", "--mon-healthcheck-interval=5s", "--mon-out-timeout=1s"]
         env:
         - name: ROOK_REPO_PREFIX
           value: rook`

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -58,7 +58,7 @@ case "${1:-}" in
   up)
     minikube start --memory=3000 --kubernetes-version ${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
     wait_for_ssh
- 
+
     echo setting up rbd
     minikube_scp ${scriptdir}/minikube-rbd /home/docker/minikube-rbd
     minikube_ssh "sudo cp /home/docker/minikube-rbd /bin/rbd && sudo chmod +x /bin/rbd"
@@ -99,5 +99,5 @@ case "${1:-}" in
     echo "  $0 ssh" >&2
     echo "  $0 update" >&2
     echo "  $0 wordpress" >&2
-    echo "  $0 helm" >&2=
+    echo "  $0 helm" >&2
 esac

--- a/tests/smoke/block_test.go
+++ b/tests/smoke/block_test.go
@@ -19,9 +19,10 @@ package smoke
 import (
 	"time"
 
+	"strings"
+
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/require"
-	"strings"
 )
 
 var (

--- a/tests/smoke/mon_test.go
+++ b/tests/smoke/mon_test.go
@@ -24,9 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
-//Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,Delete Bucket and
-//Delete user
+// Smoke Test for Mon failover - Test check the following operations for the Mon failover in order
+//Delete mon pod, Wait for new mon pod
 func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Mon Failover Smoke Test")
 


### PR DESCRIPTION
```
operator/mon: check if node for the mon is not ready and time it out
separately (240s)
```
This is a try to implement a logic to check the node on which the mon(s) are running to take the readyness state of the node into account and use an extra timeout for it.
Tries to implement it a bit like the second point in #957.

The timeout and interval are not yet configurable.