### PR TITLE
Object store support for multiple stores and pool parameters

### DIFF
--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -35,6 +35,7 @@ var (
 	rgwName    string
 	rgwKeyring string
 	rgwHost    string
+	rgwCert    string
 	rgwPort    int
 )
 
@@ -42,6 +43,7 @@ func init() {
 	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
 	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "dns host name")
+	rgwCmd.Flags().StringVar(&rgwCert, "rgw-cert", "", "path to the ssl certificate in pem format")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port number")
 	addCephFlags(rgwCmd)
 
@@ -66,12 +68,13 @@ func startRGW(cmd *cobra.Command, args []string) error {
 
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	config := &rgw.Config{
-		ClusterInfo: &clusterInfo,
-		Name:        rgwName,
-		Keyring:     rgwKeyring,
-		Host:        rgwHost,
-		Port:        rgwPort,
-		InProc:      true,
+		ClusterInfo:     &clusterInfo,
+		Name:            rgwName,
+		Keyring:         rgwKeyring,
+		Host:            rgwHost,
+		Port:            rgwPort,
+		CertificatePath: rgwCert,
+		InProc:          true,
 	}
 
 	err := rgw.Run(createContext(), config)

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -32,12 +32,14 @@ var rgwCmd = &cobra.Command{
 }
 
 var (
+	rgwName    string
 	rgwKeyring string
 	rgwHost    string
 	rgwPort    int
 )
 
 func init() {
+	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
 	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "dns host name")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port number")
@@ -49,7 +51,7 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret", "rgw-name", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
 	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}
@@ -65,6 +67,7 @@ func startRGW(cmd *cobra.Command, args []string) error {
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	config := &rgw.Config{
 		ClusterInfo: &clusterInfo,
+		Name:        rgwName,
 		Keyring:     rgwKeyring,
 		Host:        rgwHost,
 		Port:        rgwPort,

--- a/cmd/rookctl/object/connection.go
+++ b/cmd/rookctl/object/connection.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/rook/rook/cmd/rookctl/rook"
 	"github.com/rook/rook/pkg/rook/client"
@@ -70,7 +69,7 @@ func getConnectionInfoEntry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
+	c := rook.NewRookNetworkRestClient()
 	out, err := getConnectionInfo(c, args[0], connOutputFormat)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/rookctl/object/create_test.go
+++ b/cmd/rookctl/object/create_test.go
@@ -21,25 +21,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/rook/test"
 )
 
 func TestCreateObjectStore(t *testing.T) {
 	c := &test.MockRookRestClient{}
 
-	out, err := createObjectStore(c)
+	err := createObjectStore(c)
 	assert.Nil(t, err)
-	assert.Equal(t, "succeeded starting creation of object store", out)
 }
 
 func TestCreateObjectStoreError(t *testing.T) {
 	c := &test.MockRookRestClient{
-		MockCreateObjectStore: func() (string, error) {
+		MockCreateObjectStore: func(store model.ObjectStore) (string, error) {
 			return "", fmt.Errorf("mock create object store failed")
 		},
 	}
 
-	out, err := createObjectStore(c)
+	err := createObjectStore(c)
 	assert.NotNil(t, err)
-	assert.Equal(t, "", out)
 }

--- a/cmd/rookctl/object/user.go
+++ b/cmd/rookctl/object/user.go
@@ -20,17 +20,12 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/rook/rook/cmd/rookctl/rook"
 	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/rook/client"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
-)
-
-const (
-	initObjectStoreTimeout = 60
 )
 
 var (
@@ -73,7 +68,7 @@ func listUsersEntry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
+	c := rook.NewRookNetworkRestClient()
 	out, err := listUsers(c)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -224,7 +219,7 @@ func createUserEntry(cmd *cobra.Command, args []string) error {
 		user.Email = &emailFlag
 	}
 
-	c := rook.NewRookNetworkRestClientWithTimeout(initObjectStoreTimeout * time.Second)
+	c := rook.NewRookNetworkRestClient()
 	out, err := createUser(c, user)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/rookctl/pool/create.go
+++ b/cmd/rookctl/pool/create.go
@@ -32,11 +32,8 @@ const (
 )
 
 var (
-	newPoolName         string
-	newPoolType         string
-	newPoolReplicaCount uint
-	newPoolDataChunks   uint
-	newPoolCodingChunks uint
+	newPoolName string
+	poolConfig  Config
 )
 
 var createCmd = &cobra.Command{
@@ -44,24 +41,48 @@ var createCmd = &cobra.Command{
 	Short: "Creates a new storage pool in the cluster",
 }
 
+type Config struct {
+	PoolType     string
+	ReplicaCount uint
+	DataChunks   uint
+	CodingChunks uint
+}
+
 func init() {
 	createCmd.Flags().StringVarP(&newPoolName, "name", "n", "", "Name of new storage pool to create (required)")
+	AddPoolFlags(createCmd, "", &poolConfig)
 
-	createCmd.Flags().StringVarP(&newPoolType, "type", "t", PoolTypeReplicated,
+	createCmd.RunE = createPoolsEntry
+}
+
+func AddPoolFlags(cmd *cobra.Command, prefix string, config *Config) {
+	shorthand := ""
+	if prefix == "" {
+		shorthand = "t"
+	}
+	cmd.Flags().StringVarP(&config.PoolType, prefix+"type", shorthand, PoolTypeReplicated,
 		fmt.Sprintf("Type of storage pool, '%s' or '%s' (required)", PoolTypeReplicated, PoolTypeErasureCoded))
 
-	createCmd.Flags().UintVarP(&newPoolReplicaCount, "replica-count", "r", 0,
+	shorthand = ""
+	if prefix == "" {
+		shorthand = "r"
+	}
+	cmd.Flags().UintVarP(&config.ReplicaCount, prefix+"replica-count", shorthand, 0,
 		fmt.Sprintf("Number of copies per object in a replicated storage pool, including the object itself (required for %s pool type)", PoolTypeReplicated))
 
-	createCmd.Flags().UintVarP(&newPoolDataChunks, "ec-data-chunks", "d", 0,
+	shorthand = ""
+	if prefix == "" {
+		shorthand = "d"
+	}
+	cmd.Flags().UintVarP(&config.DataChunks, prefix+"ec-data-chunks", shorthand, 0,
 		fmt.Sprintf("Number of data chunks per object in an erasure coded storage pool (required for %s pool type)", PoolTypeErasureCoded))
 
-	createCmd.Flags().UintVarP(&newPoolCodingChunks, "ec-coding-chunks", "c", 0,
+	shorthand = ""
+	if prefix == "" {
+		shorthand = "c"
+	}
+	cmd.Flags().UintVarP(&config.CodingChunks, prefix+"ec-coding-chunks", shorthand, 0,
 		fmt.Sprintf("Number of coding chunks per object in an erasure coded storage pool (required for %s pool type)", PoolTypeErasureCoded))
-
-	createCmd.MarkFlagRequired("name")
-	createCmd.MarkFlagRequired("type")
-	createCmd.RunE = createPoolsEntry
 }
 
 func createPoolsEntry(cmd *cobra.Command, args []string) error {
@@ -71,8 +92,15 @@ func createPoolsEntry(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	newPool, err := ConfigToModel(poolConfig)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	newPool.Name = newPoolName
+
 	c := rook.NewRookNetworkRestClient()
-	out, err := createPool(newPoolName, newPoolType, newPoolReplicaCount, newPoolDataChunks, newPoolCodingChunks, c)
+	out, err := createPool(*newPool, c)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -82,31 +110,36 @@ func createPoolsEntry(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func createPool(poolName, poolType string, replicaCount, dataChunks, codingChunks uint, c client.RookRestClient) (string, error) {
-	if poolType != PoolTypeReplicated && poolType != PoolTypeErasureCoded {
-		return "", fmt.Errorf("invalid pool type '%s', allowed pool types are '%s' and '%s'",
-			poolType, PoolTypeReplicated, PoolTypeErasureCoded)
+func ConfigToModel(config Config) (*model.Pool, error) {
+
+	if config.PoolType != PoolTypeReplicated && config.PoolType != PoolTypeErasureCoded {
+		return nil, fmt.Errorf("invalid pool type '%s', allowed pool types are '%s' and '%s'",
+			config.PoolType, PoolTypeReplicated, PoolTypeErasureCoded)
 	}
 
-	newPool := model.Pool{Name: poolName}
+	newPool := &model.Pool{}
 
-	if poolType == PoolTypeReplicated {
-		if dataChunks > 0 || codingChunks > 0 {
-			return "", fmt.Errorf("both data chunks and coding chunks must be zero for pool type '%s'", PoolTypeReplicated)
+	if config.PoolType == PoolTypeReplicated {
+		if config.DataChunks > 0 || config.CodingChunks > 0 {
+			return nil, fmt.Errorf("both data chunks and coding chunks must be zero for pool type '%s'", PoolTypeReplicated)
 		}
 
 		// note that a replica count of 0 is okay, the pool will get the ceph default when it's created
 		newPool.Type = model.Replicated
-		newPool.ReplicationConfig.Size = replicaCount
+		newPool.ReplicationConfig.Size = config.ReplicaCount
 	} else {
-		if dataChunks == 0 || codingChunks == 0 {
-			return "", fmt.Errorf("both data chunks and coding chunks must be greater than zero for pool type '%s'", PoolTypeErasureCoded)
+		if config.DataChunks == 0 || config.CodingChunks == 0 {
+			return nil, fmt.Errorf("both data chunks and coding chunks must be greater than zero for pool type '%s'", PoolTypeErasureCoded)
 		}
 		newPool.Type = model.ErasureCoded
-		newPool.ErasureCodedConfig.DataChunkCount = dataChunks
-		newPool.ErasureCodedConfig.CodingChunkCount = codingChunks
+		newPool.ErasureCodedConfig.DataChunkCount = config.DataChunks
+		newPool.ErasureCodedConfig.CodingChunkCount = config.CodingChunks
 	}
 
+	return newPool, nil
+}
+
+func createPool(newPool model.Pool, c client.RookRestClient) (string, error) {
 	resp, err := c.CreatePool(newPool)
 	if err != nil {
 		return "", fmt.Errorf("failed to create new pool '%s': %+v", newPool.Name, err)

--- a/cmd/rookctl/pool/create.go
+++ b/cmd/rookctl/pool/create.go
@@ -61,7 +61,7 @@ func AddPoolFlags(cmd *cobra.Command, prefix string, config *Config) {
 		shorthand = "t"
 	}
 	cmd.Flags().StringVarP(&config.PoolType, prefix+"type", shorthand, PoolTypeReplicated,
-		fmt.Sprintf("Type of storage pool, '%s' or '%s' (required)", PoolTypeReplicated, PoolTypeErasureCoded))
+		fmt.Sprintf("Type of storage pool, '%s' or '%s'", PoolTypeReplicated, PoolTypeErasureCoded))
 
 	shorthand = ""
 	if prefix == "" {

--- a/cmd/rookctl/pool/create_test.go
+++ b/cmd/rookctl/pool/create_test.go
@@ -29,27 +29,24 @@ const (
 )
 
 func TestCreatePoolValidTypeRequired(t *testing.T) {
-	c := &test.MockRookRestClient{}
-	out, err := createPool("pool1", "foo", 1, 0, 0, c)
+	config := Config{PoolType: "foo"}
+	_, err := ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "invalid pool type 'foo', allowed pool types are 'replicated' and 'erasure-coded'", err.Error())
-	assert.Equal(t, "", out)
 }
 
 func TestCreatePoolErasureCodedParamsRequired(t *testing.T) {
-	c := &test.MockRookRestClient{}
-	out, err := createPool("pool1", PoolTypeErasureCoded, 0, 0, 0, c)
+	config := Config{PoolType: PoolTypeErasureCoded}
+	_, err := ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "both data chunks and coding chunks must be greater than zero for pool type 'erasure-coded'", err.Error())
-	assert.Equal(t, "", out)
 }
 
 func TestCreatePoolReplicatedErasureCodedParamsNotAllowed(t *testing.T) {
-	c := &test.MockRookRestClient{}
-	out, err := createPool("pool1", PoolTypeReplicated, 0, 2, 1, c)
+	config := Config{PoolType: PoolTypeReplicated, DataChunks: 2, CodingChunks: 1}
+	_, err := ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "both data chunks and coding chunks must be zero for pool type 'replicated'", err.Error())
-	assert.Equal(t, "", out)
 }
 
 func TestCreatePoolReplicatedNoParams(t *testing.T) {
@@ -66,7 +63,8 @@ func TestCreatePoolReplicatedNoParams(t *testing.T) {
 	}
 
 	// replicated pool replica count of 0 is OK, it will get the ceph default
-	out, err := createPool("pool1", PoolTypeReplicated, 0, 0, 0, c)
+	pool := model.Pool{Name: "pool1", Type: model.Replicated}
+	out, err := createPool(pool, c)
 	assert.Nil(t, err)
 	assert.Equal(t, SuccessPoolCreatedMessage, out)
 }
@@ -87,7 +85,9 @@ func TestCreatePoolReplicated(t *testing.T) {
 		},
 	}
 
-	out, err := createPool("pool1", PoolTypeReplicated, 3, 0, 0, c)
+	pool := model.Pool{Name: "pool1", Type: model.Replicated}
+	pool.ReplicationConfig.Size = 3
+	out, err := createPool(pool, c)
 	assert.Nil(t, err)
 	assert.Equal(t, SuccessPoolCreatedMessage, out)
 }
@@ -109,7 +109,11 @@ func TestCreatePoolErasureCoded(t *testing.T) {
 		},
 	}
 
-	out, err := createPool("pool1", PoolTypeErasureCoded, 0, 2, 1, c)
+	pool := model.Pool{Name: "pool1", Type: model.ErasureCoded}
+	pool.ErasureCodedConfig.DataChunkCount = 2
+	pool.ErasureCodedConfig.CodingChunkCount = 1
+
+	out, err := createPool(pool, c)
 	assert.Nil(t, err)
 	assert.Equal(t, SuccessPoolCreatedMessage, out)
 }
@@ -121,7 +125,8 @@ func TestCreatePoolFailure(t *testing.T) {
 		},
 	}
 
-	out, err := createPool("pool1", PoolTypeReplicated, 0, 0, 0, c)
+	pool := model.Pool{Name: "pool1", Type: model.Replicated}
+	out, err := createPool(pool, c)
 	assert.NotNil(t, err)
 	assert.Equal(t, "failed to create new pool 'pool1': mock error", err.Error())
 	assert.Equal(t, "", out)

--- a/pkg/api/cluster_handler.go
+++ b/pkg/api/cluster_handler.go
@@ -29,7 +29,7 @@ import (
 
 type ClusterHandler interface {
 	GetClusterInfo() (*mon.ClusterInfo, error)
-	EnableObjectStore(name string) error
+	EnableObjectStore(config model.ObjectStore) error
 	RemoveObjectStore(name string) error
 	GetObjectStoreConnectionInfo(name string) (s3info *model.ObjectStoreConnectInfo, found bool, err error)
 	StartFileSystem(fs *model.FilesystemRequest) error
@@ -50,7 +50,7 @@ func (e *etcdHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 	return mon.LoadClusterInfo(e.context.EtcdClient)
 }
 
-func (e *etcdHandler) EnableObjectStore(name string) error {
+func (e *etcdHandler) EnableObjectStore(config model.ObjectStore) error {
 	return rgw.EnableObjectStore(e.context.EtcdClient)
 }
 

--- a/pkg/api/cluster_handler.go
+++ b/pkg/api/cluster_handler.go
@@ -29,9 +29,9 @@ import (
 
 type ClusterHandler interface {
 	GetClusterInfo() (*mon.ClusterInfo, error)
-	EnableObjectStore() error
-	RemoveObjectStore() error
-	GetObjectStoreConnectionInfo() (s3info *model.ObjectStoreConnectInfo, found bool, err error)
+	EnableObjectStore(name string) error
+	RemoveObjectStore(name string) error
+	GetObjectStoreConnectionInfo(name string) (s3info *model.ObjectStoreConnectInfo, found bool, err error)
 	StartFileSystem(fs *model.FilesystemRequest) error
 	RemoveFileSystem(fs *model.FilesystemRequest) error
 	GetMonitors() (map[string]*mon.CephMonitorConfig, error)
@@ -50,15 +50,15 @@ func (e *etcdHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 	return mon.LoadClusterInfo(e.context.EtcdClient)
 }
 
-func (e *etcdHandler) EnableObjectStore() error {
+func (e *etcdHandler) EnableObjectStore(name string) error {
 	return rgw.EnableObjectStore(e.context.EtcdClient)
 }
 
-func (e *etcdHandler) RemoveObjectStore() error {
+func (e *etcdHandler) RemoveObjectStore(name string) error {
 	return rgw.RemoveObjectStore(e.context.EtcdClient)
 }
 
-func (e *etcdHandler) GetObjectStoreConnectionInfo() (*model.ObjectStoreConnectInfo, bool, error) {
+func (e *etcdHandler) GetObjectStoreConnectionInfo(name string) (*model.ObjectStoreConnectInfo, bool, error) {
 
 	clusterInventory, err := inventory.LoadDiscoveredNodes(e.context.EtcdClient)
 	if err != nil {

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -43,11 +43,11 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 	return s.clusterInfo, nil
 }
 
-func (s *clusterHandler) EnableObjectStore() error {
+func (s *clusterHandler) EnableObjectStore(name string) error {
 	logger.Infof("Starting the Object store")
 	// Passing an empty Placement{} as the api doesn't know about placement
 	// information. This should be resolved with the transition to CRD (TPR).
-	r := k8srgw.New(s.context, s.namespace, s.versionTag, k8sutil.Placement{})
+	r := k8srgw.New(s.context, name, s.namespace, s.versionTag, k8sutil.Placement{})
 	err := r.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
@@ -55,20 +55,20 @@ func (s *clusterHandler) EnableObjectStore() error {
 	return nil
 }
 
-func (s *clusterHandler) RemoveObjectStore() error {
+func (s *clusterHandler) RemoveObjectStore(name string) error {
 	logger.Infof("TODO: Remove the object store")
 	return nil
 }
 
-func (s *clusterHandler) GetObjectStoreConnectionInfo() (*model.ObjectStoreConnectInfo, bool, error) {
+func (s *clusterHandler) GetObjectStoreConnectionInfo(name string) (*model.ObjectStoreConnectInfo, bool, error) {
 	logger.Infof("Getting the object store connection info")
-	service, err := s.context.Clientset.CoreV1().Services(s.namespace).Get("rook-ceph-rgw", metav1.GetOptions{})
+	service, err := s.context.Clientset.CoreV1().Services(s.namespace).Get(k8srgw.InstanceName(name), metav1.GetOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get rgw service. %+v", err)
 	}
 
 	info := &model.ObjectStoreConnectInfo{
-		Host:       "rook-ceph-rgw",
+		Host:       k8srgw.InstanceName(name),
 		IPEndpoint: rgw.GetRGWEndpoint(service.Spec.ClusterIP),
 	}
 	logger.Infof("Object store connection: %+v", info)

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -43,11 +43,11 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 	return s.clusterInfo, nil
 }
 
-func (s *clusterHandler) EnableObjectStore(name string) error {
+func (s *clusterHandler) EnableObjectStore(config model.ObjectStore) error {
 	logger.Infof("Starting the Object store")
 	// Passing an empty Placement{} as the api doesn't know about placement
 	// information. This should be resolved with the transition to CRD (TPR).
-	r := k8srgw.New(s.context, name, s.namespace, s.versionTag, k8sutil.Placement{})
+	r := k8srgw.New(s.context, config, s.namespace, s.versionTag, k8sutil.Placement{})
 	err := r.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -16,6 +16,7 @@ limitations under the License.
 package k8s
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/rook/rook/pkg/ceph/mon"
@@ -25,6 +26,8 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	k8smds "github.com/rook/rook/pkg/operator/mds"
 	k8srgw "github.com/rook/rook/pkg/operator/rgw"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,6 +48,24 @@ func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
 
 func (s *clusterHandler) EnableObjectStore(config model.ObjectStore) error {
 	logger.Infof("Starting the Object store")
+
+	// save the certificate in a secret if we weren't given a reference to a secret
+	if config.Certificate != "" && config.CertificateRef == "" {
+		certName := fmt.Sprintf("rook-rgw-%s-cert", config.Name)
+		config.CertificateRef = certName
+
+		encodedCert := base64.StdEncoding.EncodeToString([]byte(config.Certificate))
+		data := map[string][]byte{"cert": []byte(encodedCert)}
+		certSecret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: certName, Namespace: s.namespace}, Data: data}
+
+		_, err := s.context.Clientset.Core().Secrets(s.namespace).Create(certSecret)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("failed to create cert secret. %+v", err)
+			}
+		}
+	}
+
 	// Passing an empty Placement{} as the api doesn't know about placement
 	// information. This should be resolved with the transition to CRD (TPR).
 	r := k8srgw.New(s.context, config, s.namespace, s.versionTag, k8sutil.Placement{})

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -142,8 +142,8 @@ func TestListUsers(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedListArgs := []string{"user", "list", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg}
-	expectedInfoArgs := []string{"user", "info", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid"}
+	expectedListArgs := []string{"user", "list", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg}
+	expectedInfoArgs := []string{"user", "info", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid"}
 
 	// Empty list
 	w := runTest(func(args ...string) (string, error) {
@@ -247,7 +247,7 @@ func TestGetUser(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedArgs := []string{"user", "info", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "someuser"}
+	expectedArgs := []string{"user", "info", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "someuser"}
 
 	// Error getting user
 	w := runTest("", fmt.Errorf("some error"), expectedArgs...)
@@ -316,7 +316,7 @@ func TestCreateUser(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedDisplayNameArgs := []string{"user", "create", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo", "--display-name", "the foo"}
+	expectedDisplayNameArgs := []string{"user", "create", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo", "--display-name", "the foo"}
 	expectedDisplayNameAndEmailArgs := append(expectedDisplayNameArgs, "--email", "test@example.com")
 
 	// Empty body
@@ -396,7 +396,7 @@ func TestUpdateUser(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedArgs := []string{"user", "modify", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo"}
+	expectedArgs := []string{"user", "modify", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo"}
 
 	// Empty body
 	w := runTest("", "", nil, "", "")
@@ -479,7 +479,7 @@ func TestDeleteUser(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedArgs := []string{"user", "rm", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo"}
+	expectedArgs := []string{"user", "rm", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--uid", "foo"}
 
 	// Some error
 	w := runTest("", fmt.Errorf("some error"), expectedArgs...)
@@ -528,8 +528,8 @@ func TestListBuckets(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedStatsArgs := []string{"bucket", "stats", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg}
-	expectedMetadataArgs := []string{"metadata", "get", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "bucket:foo"}
+	expectedStatsArgs := []string{"bucket", "stats", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg}
+	expectedMetadataArgs := []string{"metadata", "get", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "bucket:foo"}
 
 	// List error
 	w := runTest(func(args ...string) (string, error) {
@@ -676,8 +676,8 @@ func TestGetBucket(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedStatsArgs := []string{"bucket", "stats", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--bucket", "test"}
-	expectedMetadataArgs := []string{"metadata", "get", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "bucket:test"}
+	expectedStatsArgs := []string{"bucket", "stats", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--bucket", "test"}
+	expectedMetadataArgs := []string{"metadata", "get", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "bucket:test"}
 
 	// Stats fails
 	w := runTest(func(args ...string) (string, error) {
@@ -795,7 +795,7 @@ func TestBucketDelete(t *testing.T) {
 
 	expectedConfigArg := getExectedConfigArg(configSubDir)
 	expectedKeyringArg := getExpectedKeyringArg(configSubDir)
-	expectedArgs := []string{"bucket", "rm", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--bucket", "test"}
+	expectedArgs := []string{"bucket", "rm", "--rgw-realm=default", "--rgw-zonegroup=default", "--cluster=rookcluster", expectedConfigArg, expectedKeyringArg, "--bucket", "test"}
 
 	// errors
 	w := runTest("", fmt.Errorf("some error"), expectedArgs...)

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	cephtest "github.com/rook/rook/pkg/ceph/test"
@@ -41,7 +42,7 @@ func TestCreateObjectStoreHandler(t *testing.T) {
 	etcdClient := util.NewMockEtcdClient()
 	context := &clusterd.Context{DirectContext: clusterd.DirectContext{EtcdClient: etcdClient}}
 
-	req, err := http.NewRequest("POST", "http://10.0.0.100/objectstore", nil)
+	req, err := http.NewRequest("POST", "http://10.0.0.100/objectstore", strings.NewReader(`{"name": "default"}`))
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/pkg/api/pool.go
+++ b/pkg/api/pool.go
@@ -112,7 +112,7 @@ func (h *Handler) CreatePool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newPool := modelPoolToCephPool(newPoolReq)
+	newPool := ceph.ModelPoolToCephPool(newPoolReq)
 
 	if newPoolReq.Type == model.ErasureCoded {
 		// create a new erasure code profile for the new pool
@@ -131,21 +131,6 @@ func (h *Handler) CreatePool(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(fmt.Sprintf("pool '%s' created", newPool.Name)))
-}
-
-func modelPoolToCephPool(modelPool model.Pool) ceph.CephStoragePoolDetails {
-	pool := ceph.CephStoragePoolDetails{
-		Name:   modelPool.Name,
-		Number: modelPool.Number,
-	}
-
-	if modelPool.Type == model.Replicated {
-		pool.Size = modelPool.ReplicationConfig.Size
-	} else if modelPool.Type == model.ErasureCoded {
-		pool.ErasureCodeProfile = fmt.Sprintf("%s_ecprofile", pool.Name)
-	}
-
-	return pool
 }
 
 func cephPoolToModelPool(cephPool ceph.CephStoragePoolDetails, ecpDetails map[string]ceph.CephErasureCodeProfile) (model.Pool, error) {

--- a/pkg/ceph/client/erasure-code-profile.go
+++ b/pkg/ceph/client/erasure-code-profile.go
@@ -87,3 +87,18 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, con
 
 	return nil
 }
+
+func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
+	pool := CephStoragePoolDetails{
+		Name:   modelPool.Name,
+		Number: modelPool.Number,
+	}
+
+	if modelPool.Type == model.Replicated {
+		pool.Size = modelPool.ReplicationConfig.Size
+	} else if modelPool.Type == model.ErasureCoded {
+		pool.ErasureCodeProfile = fmt.Sprintf("%s_ecprofile", pool.Name)
+	}
+
+	return pool
+}

--- a/pkg/ceph/client/pool.go
+++ b/pkg/ceph/client/pool.go
@@ -113,7 +113,7 @@ func CreatePool(context *clusterd.Context, clusterName string, newPool CephStora
 
 func CreatePoolForApp(context *clusterd.Context, clusterName string, newPool CephStoragePoolDetails, appName string) error {
 	args := []string{"osd", "pool", "create", newPool.Name, strconv.Itoa(newPool.Number)}
-	// not implemented: fix the pool create for the different profiles
+
 	if newPool.ErasureCodeProfile != "" {
 		args = append(args, "erasure", newPool.ErasureCodeProfile)
 	} else {

--- a/pkg/ceph/rgw/admin.go
+++ b/pkg/ceph/rgw/admin.go
@@ -23,8 +23,18 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 )
 
-func RunAdminCommand(context *clusterd.Context, getClusterInfo func() (*mon.ClusterInfo, error), command, subcommand string, args ...string) (string, error) {
-	cluster, err := getClusterInfo()
+type Context struct {
+	context        *clusterd.Context
+	objectStore    string
+	getClusterInfo func() (*mon.ClusterInfo, error)
+}
+
+func NewContext(context *clusterd.Context, objectStore string, getClusterInfo func() (*mon.ClusterInfo, error)) *Context {
+	return &Context{context: context, objectStore: objectStore, getClusterInfo: getClusterInfo}
+}
+
+func RunAdminCommand(c *Context, command, subcommand string, args ...string) (string, error) {
+	cluster, err := c.getClusterInfo()
 	if err != nil {
 		return "", fmt.Errorf("failed to get cluster info. %+v", err)
 	}
@@ -32,12 +42,14 @@ func RunAdminCommand(context *clusterd.Context, getClusterInfo func() (*mon.Clus
 	options := []string{
 		command,
 		subcommand,
+		fmt.Sprintf("--rgw-realm=%s", c.objectStore),
+		fmt.Sprintf("--rgw-zonegroup=%s", c.objectStore),
 	}
-	options = client.AppendAdminConnectionArgs(options, context.ConfigDir, cluster.Name)
+	options = client.AppendAdminConnectionArgs(options, c.context.ConfigDir, cluster.Name)
 	options = append(options, args...)
 
 	// start the rgw admin command
-	output, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "radosgw-admin", options...)
+	output, err := c.context.Executor.ExecuteCommandWithCombinedOutput(false, "", "radosgw-admin", options...)
 	if err != nil {
 		return "", fmt.Errorf("failed to run radosgw-admin: %+v", err)
 	}

--- a/pkg/ceph/rgw/agent.go
+++ b/pkg/ceph/rgw/agent.go
@@ -24,13 +24,13 @@ import (
 
 	"github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/util"
 	"github.com/rook/rook/pkg/util/proc"
 )
 
 const (
 	DNSName         = "rook-ceph-rgw"
-	RGWPort         = 53390
 	rgwAgentName    = "rgw"
 	keyringTemplate = `[client.radosgw.gateway]
 	key = %s
@@ -109,7 +109,7 @@ func (a *rgwAgent) startRGW(context *clusterd.Context, cluster *mon.ClusterInfo)
 	}
 	keyring := val.Node.Value
 
-	config := &Config{Keyring: keyring, ClusterInfo: cluster, Host: DNSName, Port: RGWPort}
+	config := &Config{Keyring: keyring, ClusterInfo: cluster, Host: DNSName, Port: model.RGWPort}
 	err = generateConfigFiles(context, config)
 	if err != nil {
 		return fmt.Errorf("failed to generate rgw config files. %+v", err)

--- a/pkg/ceph/rgw/daemon.go
+++ b/pkg/ceph/rgw/daemon.go
@@ -31,6 +31,7 @@ import (
 )
 
 type Config struct {
+	Name        string
 	Host        string
 	Port        int
 	Keyring     string
@@ -73,6 +74,8 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		"rgw log nonexistent bucket":     "true",
 		"rgw intent log object name utc": "true",
 		"rgw enable usage log":           "true",
+		"rgw_zone":                       config.Name,
+		"rgw_zonegroup":                  config.Name,
 	}
 	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, getRGWConfDir(context.ConfigDir),
 		"client.radosgw.gateway", getRGWKeyringPath(context.ConfigDir), false, nil, settings)

--- a/pkg/ceph/rgw/daemon.go
+++ b/pkg/ceph/rgw/daemon.go
@@ -31,12 +31,13 @@ import (
 )
 
 type Config struct {
-	Name        string
-	Host        string
-	Port        int
-	Keyring     string
-	InProc      bool
-	ClusterInfo *mon.ClusterInfo
+	Name            string
+	Host            string
+	Port            int
+	Keyring         string
+	CertificatePath string
+	InProc          bool
+	ClusterInfo     *mon.ClusterInfo
 }
 
 func Run(context *clusterd.Context, config *Config) error {
@@ -66,6 +67,13 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		logger.Warningf("failed to create data directory %s: %+v", dataDir, err)
 	}
 
+	sslSuffix := ""
+	if config.CertificatePath != "" {
+		// the suffix is intended to be appended to the end of the rgw_frontends arg, immediately after the port.
+		// with ssl enabled, the port number must end with the letter s.
+		sslSuffix = fmt.Sprintf("s ssl_certificate=%s", config.CertificatePath)
+	}
+
 	settings := map[string]string{
 		"host":                           config.Host,
 		"rgw port":                       strconv.Itoa(config.Port),
@@ -74,6 +82,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		"rgw log nonexistent bucket":     "true",
 		"rgw intent log object name utc": "true",
 		"rgw enable usage log":           "true",
+		"rgw_frontends":                  fmt.Sprintf("civetweb port=%d%s", config.Port, sslSuffix),
 		"rgw_zone":                       config.Name,
 		"rgw_zonegroup":                  config.Name,
 	}
@@ -104,7 +113,6 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 }
 
 func startRGW(context *clusterd.Context, config *Config) (rgwProc *proc.MonitoredProc, err error) {
-
 	// start the monitor daemon in the foreground with the given config
 	logger.Infof("starting rgw")
 
@@ -118,7 +126,6 @@ func startRGW(context *clusterd.Context, config *Config) (rgwProc *proc.Monitore
 		fmt.Sprintf("--cluster=%s", config.ClusterInfo.Name),
 		fmt.Sprintf("--conf=%s", confFile),
 		fmt.Sprintf("--keyring=%s", getRGWKeyringPath(context.ConfigDir)),
-		fmt.Sprintf("--rgw-frontends=civetweb port=%d", config.Port),
 		fmt.Sprintf("--rgw-mime-types-file=%s", getMimeTypesPath(context.ConfigDir)),
 	}
 	if config.InProc {

--- a/pkg/ceph/rgw/leader.go
+++ b/pkg/ceph/rgw/leader.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/clusterd/inventory"
+	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/pkg/util"
 )
 
@@ -281,5 +282,5 @@ func (r *Leader) getDesiredRGWNodes(context *clusterd.Context, count int) ([]str
 }
 
 func GetRGWEndpoint(addr string) string {
-	return fmt.Sprintf("%s:%d", addr, RGWPort)
+	return fmt.Sprintf("%s:%d", addr, model.RGWPort)
 }

--- a/pkg/ceph/rgw/user.go
+++ b/pkg/ceph/rgw/user.go
@@ -21,8 +21,6 @@ import (
 
 	"strings"
 
-	"github.com/rook/rook/pkg/ceph/mon"
-	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/model"
 )
 
@@ -34,8 +32,8 @@ const (
 	RGWErrorParse    = iota
 )
 
-func ListUsers(context *clusterd.Context, getClusterInfo func() (*mon.ClusterInfo, error)) ([]string, int, error) {
-	result, err := RunAdminCommand(context, getClusterInfo, "user", "list")
+func ListUsers(c *Context) ([]string, int, error) {
+	result, err := RunAdminCommand(c, "user", "list")
 	if err != nil {
 		return nil, RGWErrorUnknown, fmt.Errorf("failed to list users: %+v", err)
 	}
@@ -75,10 +73,10 @@ func decodeUser(data string) (*model.ObjectUser, int, error) {
 	return &rookUser, RGWErrorNone, nil
 }
 
-func GetUser(context *clusterd.Context, id string, getClusterInfo func() (*mon.ClusterInfo, error)) (*model.ObjectUser, int, error) {
+func GetUser(c *Context, id string) (*model.ObjectUser, int, error) {
 	logger.Infof("Getting user: %s", id)
 
-	result, err := RunAdminCommand(context, getClusterInfo, "user", "info", "--uid", id)
+	result, err := RunAdminCommand(c, "user", "info", "--uid", id)
 	if err != nil {
 		return nil, RGWErrorUnknown, fmt.Errorf("failed to get users: %+v", err)
 	}
@@ -88,7 +86,7 @@ func GetUser(context *clusterd.Context, id string, getClusterInfo func() (*mon.C
 	return decodeUser(result)
 }
 
-func CreateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo func() (*mon.ClusterInfo, error)) (*model.ObjectUser, int, error) {
+func CreateUser(c *Context, user model.ObjectUser) (*model.ObjectUser, int, error) {
 	logger.Infof("Creating user: %s", user.UserID)
 
 	if strings.TrimSpace(user.UserID) == "" {
@@ -108,7 +106,7 @@ func CreateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo
 		args = append(args, "--email", *user.Email)
 	}
 
-	result, err := RunAdminCommand(context, getClusterInfo, "user", "create", args...)
+	result, err := RunAdminCommand(c, "user", "create", args...)
 	if err != nil {
 		return nil, RGWErrorUnknown, fmt.Errorf("failed to create user: %+v", err)
 	}
@@ -124,7 +122,7 @@ func CreateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo
 	return decodeUser(result)
 }
 
-func UpdateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo func() (*mon.ClusterInfo, error)) (*model.ObjectUser, int, error) {
+func UpdateUser(c *Context, user model.ObjectUser) (*model.ObjectUser, int, error) {
 	logger.Infof("Updating user: %s", user.UserID)
 
 	args := []string{"--uid", user.UserID}
@@ -136,7 +134,7 @@ func UpdateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo
 		args = append(args, "--email", *user.Email)
 	}
 
-	body, err := RunAdminCommand(context, getClusterInfo, "user", "modify", args...)
+	body, err := RunAdminCommand(c, "user", "modify", args...)
 	if err != nil {
 		return nil, RGWErrorUnknown, fmt.Errorf("failed to update user: %+v", err)
 	}
@@ -148,9 +146,9 @@ func UpdateUser(context *clusterd.Context, user model.ObjectUser, getClusterInfo
 	return decodeUser(body)
 }
 
-func DeleteUser(context *clusterd.Context, id string, getClusterInfo func() (*mon.ClusterInfo, error)) (string, int, error) {
+func DeleteUser(c *Context, id string) (string, int, error) {
 	logger.Infof("Deleting user: %s", id)
-	result, err := RunAdminCommand(context, getClusterInfo, "user", "rm", "--uid", id)
+	result, err := RunAdminCommand(c, "user", "rm", "--uid", id)
 	if err != nil {
 		return "", RGWErrorUnknown, fmt.Errorf("failed to delete user: %+v", err)
 	}

--- a/pkg/model/object.go
+++ b/pkg/model/object.go
@@ -17,6 +17,8 @@ package model
 
 import "time"
 
+const RGWPort = 53390
+
 type ObjectStoreConnectInfo struct {
 	Host       string `json:"host"`
 	IPEndpoint string `json:"ipEndpoint"`

--- a/pkg/model/pool.go
+++ b/pkg/model/pool.go
@@ -27,6 +27,7 @@ type ObjectStore struct {
 	Name           string `json:"name"`
 	Port           int32  `json:"port"`
 	RGWReplicas    int32  `json:"rgwReplicas"`
+	Certificate    string `json:"certificate"`
 	CertificateRef string `json:"certificateRef"`
 	DataConfig     Pool   `json:"dataConfig"`
 	MetadataConfig Pool   `json:"metadataConfig"`

--- a/pkg/model/pool.go
+++ b/pkg/model/pool.go
@@ -23,6 +23,15 @@ const (
 	PoolTypeUnknown
 )
 
+type ObjectStore struct {
+	Name           string `json:"name"`
+	Port           int32  `json:"port"`
+	RGWReplicas    int32  `json:"rgwReplicas"`
+	CertificateRef string `json:"certificateRef"`
+	DataConfig     Pool   `json:"dataConfig"`
+	MetadataConfig Pool   `json:"metadataConfig"`
+}
+
 type ReplicatedPoolConfig struct {
 	Size uint `json:"size"`
 }

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -48,7 +48,7 @@ const (
 	ConfigOverrideVal = "config"
 	repoPrefixEnvVar  = "ROOK_REPO_PREFIX"
 	defaultVersion    = "latest"
-	configMountDir    = "/etc/rook"
+	configMountDir    = "/etc/rook/config"
 	overrideFilename  = "override.conf"
 )
 

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -42,7 +42,7 @@ func TestStartRGW(t *testing.T) {
 
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, Executor: executor, ConfigDir: configDir}, "ns", "version", k8sutil.Placement{})
+	c := New(&clusterd.Context{Clientset: clientset, Executor: executor, ConfigDir: configDir}, "default", "ns", "version", k8sutil.Placement{})
 
 	// start a basic cluster
 	err := c.Start()
@@ -59,35 +59,36 @@ func TestStartRGW(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster, clientset *fake.Clientset) {
 
-	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(appName, metav1.GetOptions{})
+	r, err := clientset.ExtensionsV1beta1().Deployments(c.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, appName, r.Name)
+	assert.Equal(t, c.instanceName(), r.Name)
 
-	s, err := clientset.CoreV1().Services(c.Namespace).Get(appName, metav1.GetOptions{})
+	s, err := clientset.CoreV1().Services(c.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, appName, s.Name)
+	assert.Equal(t, c.instanceName(), s.Name)
 
-	secret, err := clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
+	secret, err := clientset.CoreV1().Secrets(c.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, appName, secret.Name)
+	assert.Equal(t, c.instanceName(), secret.Name)
 	assert.Equal(t, 1, len(secret.StringData))
 
 }
 
 func TestPodSpecs(t *testing.T) {
-	c := New(nil, "ns", "myversion", k8sutil.Placement{})
+	c := New(nil, "default", "ns", "myversion", k8sutil.Placement{})
 
 	d := c.makeDeployment()
 	assert.NotNil(t, d)
-	assert.Equal(t, appName, d.Name)
+	assert.Equal(t, c.instanceName(), d.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, d.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, 2, len(d.Spec.Template.Spec.Volumes))
 	assert.Equal(t, "rook-data", d.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(t, k8sutil.ConfigOverrideName, d.Spec.Template.Spec.Volumes[1].Name)
 
-	assert.Equal(t, appName, d.ObjectMeta.Name)
+	assert.Equal(t, c.instanceName(), d.ObjectMeta.Name)
 	assert.Equal(t, appName, d.Spec.Template.ObjectMeta.Labels["app"])
 	assert.Equal(t, c.Namespace, d.Spec.Template.ObjectMeta.Labels["rook_cluster"])
+	assert.Equal(t, c.Name, d.Spec.Template.ObjectMeta.Labels["rook_object_store"])
 	assert.Equal(t, 0, len(d.ObjectMeta.Annotations))
 
 	cont := d.Spec.Template.Spec.Containers[0]
@@ -96,6 +97,7 @@ func TestPodSpecs(t *testing.T) {
 
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
-	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", cephrgw.RGWPort), cont.Args[2])
-	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", cephrgw.DNSName), cont.Args[3])
+	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
+	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", cephrgw.RGWPort), cont.Args[3])
+	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", cephrgw.DNSName), cont.Args[4])
 }

--- a/pkg/rook/client/client.go
+++ b/pkg/rook/client/client.go
@@ -43,7 +43,7 @@ type RookRestClient interface {
 	CreateFilesystem(model.FilesystemRequest) (string, error)
 	DeleteFilesystem(model.FilesystemRequest) (string, error)
 	GetStatusDetails() (model.StatusDetails, error)
-	CreateObjectStore() (string, error)
+	CreateObjectStore(store model.ObjectStore) (string, error)
 	GetObjectStoreConnectionInfo() (*model.ObjectStoreConnectInfo, error)
 	ListBuckets() ([]model.ObjectBucket, error)
 	GetBucket(string) (*model.ObjectBucket, error)

--- a/pkg/rook/client/client_test.go
+++ b/pkg/rook/client/client_test.go
@@ -35,7 +35,7 @@ const (
 	SuccessDeleteBlockImageContent             = `succeeded deleting image myimage3`
 	SuccessGetClientAccessInfoContent          = `{"monAddresses":["10.37.129.214:6790/0"],"userName":"admin","secretKey":"AQBsCv1X5oD9GhAARHVU9N+kFRWDjyLA1dqzIg=="}`
 	SuccessGetFilesystemsContent               = `[{"name":"myfs1","metadataPool":"myfs1-metadata","dataPools":["myfs1-data"]}]`
-	SuccessGetObjectStoreConnectionInfoContent = `{"host":"rook-ceph-rgw:12345", "accessKey":"UST0JAP8CE61FDE0Q4BE", "secretKey":"tVCuH20xTokjEpVJc7mKjL8PLTfGh4NZ3le3zg9X"}`
+	SuccessGetObjectStoreConnectionInfoContent = `{"host":"rook-ceph-rgw-default:12345", "accessKey":"UST0JAP8CE61FDE0Q4BE", "secretKey":"tVCuH20xTokjEpVJc7mKjL8PLTfGh4NZ3le3zg9X"}`
 )
 
 func TestURL(t *testing.T) {
@@ -266,7 +266,7 @@ func TestGetObjectStoreConnectionInfo(t *testing.T) {
 	client := NewRookNetworkRestClient(mockServer.URL, mockHttpClient)
 
 	expectedResp := model.ObjectStoreConnectInfo{
-		Host: "rook-ceph-rgw:12345",
+		Host: "rook-ceph-rgw-default:12345",
 	}
 
 	resp, err := client.GetObjectStoreConnectionInfo()

--- a/pkg/rook/client/client_test.go
+++ b/pkg/rook/client/client_test.go
@@ -253,7 +253,8 @@ func TestCreateObjectStore(t *testing.T) {
 	mockHttpClient := NewMockHttpClient(mockServer.URL)
 	client := NewRookNetworkRestClient(mockServer.URL, mockHttpClient)
 
-	resp, err := client.CreateObjectStore()
+	store := model.ObjectStore{Name: "default", Port: 123}
+	resp, err := client.CreateObjectStore(store)
 	assert.NotNil(t, err)
 	assert.True(t, IsHttpAccepted(err))
 	assert.Equal(t, "", resp)
@@ -343,7 +344,7 @@ func TestDeleteFilesystemFailure(t *testing.T) {
 
 func TestCreateObjectStoreFailure(t *testing.T) {
 	clientFunc := func(client RookRestClient) (interface{}, error) {
-		return client.CreateObjectStore()
+		return client.CreateObjectStore(model.ObjectStore{Name: "name"})
 	}
 	verifyFunc := getStringVerifyFunc(t)
 	ClientFailureHelperWithVerification(t, clientFunc, verifyFunc)

--- a/pkg/rook/client/object.go
+++ b/pkg/rook/client/object.go
@@ -34,8 +34,17 @@ const (
 	usersQueryName          = "users"
 )
 
-func (c *RookNetworkRestClient) CreateObjectStore() (string, error) {
-	resp, err := c.DoPost(objectStoreQueryName, nil)
+func (c *RookNetworkRestClient) CreateObjectStore(store model.ObjectStore) (string, error) {
+	if store.Name == "" {
+		return "", fmt.Errorf("Name is required")
+	}
+
+	body, err := json.Marshal(store)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.DoPost(objectStoreQueryName, bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/rook/test/mockclient.go
+++ b/pkg/rook/test/mockclient.go
@@ -41,7 +41,7 @@ type MockRookRestClient struct {
 	MockCreateFilesystem             func(model.FilesystemRequest) (string, error)
 	MockDeleteFilesystem             func(model.FilesystemRequest) (string, error)
 	MockGetStatusDetails             func() (model.StatusDetails, error)
-	MockCreateObjectStore            func() (string, error)
+	MockCreateObjectStore            func(store model.ObjectStore) (string, error)
 	MockGetObjectStoreConnectionInfo func() (*model.ObjectStoreConnectInfo, error)
 	MockCreateObjectUser             func(model.ObjectUser) (*model.ObjectUser, error)
 	MockListBuckets                  func() ([]model.ObjectBucket, error)
@@ -141,9 +141,9 @@ func (m *MockRookRestClient) GetStatusDetails() (model.StatusDetails, error) {
 	return model.StatusDetails{}, nil
 }
 
-func (m *MockRookRestClient) CreateObjectStore() (string, error) {
+func (m *MockRookRestClient) CreateObjectStore(store model.ObjectStore) (string, error) {
 	if m.MockCreateObjectStore != nil {
-		return m.MockCreateObjectStore()
+		return m.MockCreateObjectStore(store)
 	}
 
 	return "", nil

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -35,8 +35,10 @@ func CreateObjectOperation(rookRestClient contracts.RestAPIOperator) *ObjectOper
 //Input paramatres -None
 //Output - output returned by rook Rest API client
 func (ro *ObjectOperation) ObjectCreate() (string, error) {
-	return ro.restClient.CreateObjectStore()
-
+	store := model.ObjectStore{Name: "default", RGWReplicas: 1}
+	store.DataConfig.ReplicationConfig.Size = 1
+	store.MetadataConfig.ReplicationConfig.Size = 1
+	return ro.restClient.CreateObjectStore(store)
 }
 
 //ObjectBucketList Function to get Buckets present in rook object store

--- a/tests/framework/clients/rest_client.go
+++ b/tests/framework/clients/rest_client.go
@@ -149,8 +149,8 @@ func (a *RestAPIClient) GetStatusDetails() (model.StatusDetails, error) {
 }
 
 //CreateObjectStore creates object store
-func (a *RestAPIClient) CreateObjectStore() (string, error) {
-	return a.rrc.CreateObjectStore()
+func (a *RestAPIClient) CreateObjectStore(store model.ObjectStore) (string, error) {
+	return a.rrc.CreateObjectStore(store)
 }
 
 //GetObjectStoreConnectionInfo returns object store connection info

--- a/tests/framework/contracts/operations.go
+++ b/tests/framework/contracts/operations.go
@@ -72,7 +72,7 @@ type RestAPIOperator interface {
 	CreateFilesystem(fsmodel model.FilesystemRequest) (string, error)
 	DeleteFilesystem(fsmodel model.FilesystemRequest) (string, error)
 	GetStatusDetails() (model.StatusDetails, error)
-	CreateObjectStore() (string, error)
+	CreateObjectStore(store model.ObjectStore) (string, error)
 	GetObjectStoreConnectionInfo() (*model.ObjectStoreConnectInfo, error)
 	ListBuckets() ([]model.ObjectBucket, error)
 	ListObjectUsers() ([]model.ObjectUser, error)

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"strconv"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/jmoiron/jsonq"
 	"github.com/rook/rook/pkg/util/exec"
@@ -33,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"strconv"
 )
 
 //K8sHelper is a helper for common kubectl commads

--- a/tests/framework/utils/k8s_helper_test.go
+++ b/tests/framework/utils/k8s_helper_test.go
@@ -96,7 +96,7 @@ var rawContext = `{
 
 func TestLoadMinikubeContext(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, subcommand string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, command string, subcommand string, args ...string) (string, error) {
 			return fmt.Sprintf(rawContext, "minikube"), nil
 		}}
 	config, err := getKubeConfig(executor)
@@ -111,7 +111,7 @@ func TestLoadMinikubeContext(t *testing.T) {
 
 func TestLoadDindContext(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, subcommand string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, command string, subcommand string, args ...string) (string, error) {
 			return fmt.Sprintf(rawContext, "dind"), nil
 		}}
 	config, err := getKubeConfig(executor)
@@ -126,7 +126,7 @@ func TestLoadDindContext(t *testing.T) {
 
 func TestLoadVagrantContext(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, subcommand string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(debug bool, command string, subcommand string, args ...string) (string, error) {
 			return fmt.Sprintf(rawContext, "vagrant-single"), nil
 		}}
 	config, err := getKubeConfig(executor)

--- a/tests/smoke/helm_test.go
+++ b/tests/smoke/helm_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/enums"
@@ -12,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"time"
 )
 
 var (
@@ -203,7 +204,7 @@ func (hs *HelmSmokeSuite) TestObjectStoreOnRookInstalledViaHelm() {
 	assert.True(hs.T(), hs.k8sh.CheckPodCountAndState("rook-ceph-rgw", "rook", 2, "Running"),
 		"Make sure there is 1 rook-operator present in Running state")
 
-	require.True(hs.T(), hs.k8sh.IsServiceUpInNameSpace("rook-ceph-rgw"))
+	require.True(hs.T(), hs.k8sh.IsServiceUpInNameSpace("rook-ceph-rgw-default"))
 
 }
 

--- a/tests/smoke/object_test.go
+++ b/tests/smoke/object_test.go
@@ -151,7 +151,7 @@ func getBucket(bucketname string, bucketList []model.ObjectBucket) (model.Object
 func (suite *SmokeSuite) createObjectStore() error {
 	suite.helper.GetObjectClient().ObjectCreate()
 	time.Sleep(time.Second * 2) //wait for rgw service to to started
-	if suite.k8sh.IsServiceUpInNameSpace("rook-ceph-rgw") {
+	if suite.k8sh.IsServiceUpInNameSpace("rook-ceph-rgw-default") {
 		_, err := suite.k8sh.GetService("rgw-external")
 		if err != nil {
 			suite.k8sh.KubectlWithStdin(getRGWExternalServiceDef(), []string{"create", "-f", "-"}...)


### PR DESCRIPTION
The object store now supports:
- Multiple instances of the object store, implemented by separate ceph realms
- Pool parameters for replication and erasure coding
- SSL certificate on the rgw instances

Fixes #310 and #334 and lays a foundation for #698