### PR TITLE
Fix the condition: Time since added to list <= monOutTimeout

### DIFF
--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -95,7 +95,7 @@ func (c *Cluster) checkHealth() error {
 
 			// when the timeout for the mon has been reached, continue to the
 			// normal failover/delete mon pod part of the code
-			if time.Since(c.monTimeoutList[mon.Name]) > MonOutTimeout {
+			if time.Since(c.monTimeoutList[mon.Name]) <= MonOutTimeout {
 				logger.Warningf("mon %s NOT found in quorum, STILL in mon out timeout", mon.Name)
 				continue
 			}


### PR DESCRIPTION
Not the other way arround.

***

Oops, I accidentally used the wrong conditional here for the time.
This fixes the condition of the time comparison, as in the commit written, it has to be:
```
Time since the mon has been added to list (duration) <= monOutTimeout (duration)
```