### PR TITLE
Add podAffinity and podAntiAffinity to placement spec

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -71,6 +71,8 @@ Placement configuration for the cluster services. It includes the following keys
 
 A Placement configuration is specified (according to the kubernetes [PodSpec](https://kubernetes.io/docs/api-reference/v1.6/#podspec-v1-core)) as:
 - `nodeAffinity`: kubernetes [NodeAffinity](https://kubernetes.io/docs/api-reference/v1.6/#nodeaffinity-v1-core)
+- `podAffinity`: kubernetes [PodAffinity](https://kubernetes.io/docs/api-reference/v1.6/#podaffinity-v1-core)
+- `podAntiAffinity`: kubernetes [PodAntiAffinity](https://kubernetes.io/docs/api-reference/v1.6/#podantiaffinity-v1-core)
 - `tolerations`: list of kubernetes [Toleration](https://kubernetes.io/docs/api-reference/v1.6/#toleration-v1-core)
 
 ## Samples
@@ -106,7 +108,7 @@ spec:
 
 ### Storage Configuration: Specific devices
 
-Individual nodes and their config can be specified so that only the named nodes below will be used as storage resources. 
+Individual nodes and their config can be specified so that only the named nodes below will be used as storage resources.
 Each node's 'name' field should match their 'kubernetes.io/hostname' label.
 
 ```

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -24,20 +24,30 @@ spec:
 #              operator: In
 #              values:
 #              - storage-node
+#      podAffinity:
+#      podAntiAffinity:
 #      tolerations:
 #      - key: storage-node
 #        operator: Exists
 #    api:
 #      nodeAffinity:
+#      podAffinity:
+#      podAntiAffinity:
 #      tolerations:
 #    mgr:
 #      nodeAffinity:
+#      podAffinity:
+#      podAntiAffinity:
 #      tolerations:
 #    mon:
 #      nodeAffinity:
+#      podAffinity:
+#      podAntiAffinity:
 #      tolerations:
 #    osd:
 #      nodeAffinity:
+#      podAffinity:
+#      podAntiAffinity:
 #      tolerations:
   storage:                # cluster level storage configuration and selection
     useAllNodes: true

--- a/pkg/operator/k8sutil/placement.go
+++ b/pkg/operator/k8sutil/placement.go
@@ -24,18 +24,27 @@ import (
 // Placement encapsulates the various kubernetes options that control where
 // pods are scheduled and executed.
 type Placement struct {
-	NodeAffinity *v1.NodeAffinity `json:"nodeAffinity,omitempty"`
-	Tolerations  []v1.Toleration  `json:"tolerations,omitemtpy"`
+	NodeAffinity    *v1.NodeAffinity    `json:"nodeAffinity,omitempty"`
+	PodAffinity     *v1.PodAffinity     `json:"podAffinity,omitempty"`
+	PodAntiAffinity *v1.PodAntiAffinity `json:"podAntiAffinity,omitempty"`
+	Tolerations     []v1.Toleration     `json:"tolerations,omitemtpy"`
 }
 
 // ApplyToPodSpec adds placement to a pod spec
 func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
+	if t.Affinity == nil {
+		t.Affinity = &v1.Affinity{}
+	}
 	if p.NodeAffinity != nil {
-		if t.Affinity == nil {
-			t.Affinity = &v1.Affinity{}
-		}
 		t.Affinity.NodeAffinity = p.NodeAffinity
 	}
+	if p.PodAffinity != nil {
+		t.Affinity.PodAffinity = p.PodAffinity
+	}
+	if p.PodAntiAffinity != nil {
+		t.Affinity.PodAntiAffinity = p.PodAntiAffinity
+	}
+
 	if p.Tolerations != nil {
 		t.Tolerations = p.Tolerations
 	}
@@ -48,6 +57,12 @@ func (p Placement) Merge(with Placement) Placement {
 	ret := p
 	if with.NodeAffinity != nil {
 		ret.NodeAffinity = with.NodeAffinity
+	}
+	if with.PodAffinity != nil {
+		ret.PodAffinity = with.PodAffinity
+	}
+	if with.PodAntiAffinity != nil {
+		ret.PodAntiAffinity = with.PodAntiAffinity
 	}
 	if with.Tolerations != nil {
 		ret.Tolerations = with.Tolerations


### PR DESCRIPTION
This adds `podAffinity` and `podAntiAffinity` to the placement spec.

Example: Setting the `podAntiAffinity` for mons would allow for having one mon per node and not multiple mons on one node.

**NOTE** `podAffinity` and `podAntiAffinity` feature isn't available in Kubernetes 1.5. The compatiblity is guaranteed as long as the specs aren't used/filled out in the rook cluster spec.