### PR TITLE
Add hostNetwork option to cluster spec

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -23,6 +23,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 - `versionTag`: The version (tag) of the `rook/rook` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
 - `dataDirHostPath`: The host path where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.  Therefore, for test scenarios, the path must be deleted if you are going to delete a cluster and start a new cluster on the same hosts.  More details can be found in the Kubernetes [host path docs](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).
 If this value is empty, each pod will get an ephemeral directory to store their config files that is tied to the lifetime of the pod running on that node. More details can be found in the Kubernetes [empty dir docs](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
+- `hostNetwork`: uses host network instead of using the SDN below the containers
 - `placement`: [placement configuration settings](#placement-configuration-settings)
 - `storage`: Storage selection and configuration that will be used across the cluster.  Note that these settings can be overridden for specific nodes.
   - `useAllNodes`: `true` or `false`, indicating if all nodes in the cluster should be used for storage according to the cluster level storage selection and configuration values.

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   versionTag: master
   dataDirHostPath:
+  # toggle to use hostNetwork
+  hostNetwork: false
 # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
 # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
 # tolerate taints with a key of 'storage-node'.

--- a/cluster/examples/kubernetes/rook-tools.yaml
+++ b/cluster/examples/kubernetes/rook-tools.yaml
@@ -4,6 +4,7 @@ metadata:
   name: rook-tools
   namespace: rook
 spec:
+  hostNetwork: false
   containers:
   - name: rook-tools
     image: rook/toolbox:master

--- a/cmd/rook/api.go
+++ b/cmd/rook/api.go
@@ -31,10 +31,11 @@ var (
 		Use:   "api",
 		Short: "Runs the Rook API service",
 	}
-	apiPort    int
-	repoPrefix string
-	namespace  string
-	versionTag string
+	apiPort     int
+	repoPrefix  string
+	namespace   string
+	versionTag  string
+	hostNetwork bool
 )
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	apiCmd.Flags().StringVar(&repoPrefix, "repo-prefix", "rook", "the repo from which to pull images")
 	apiCmd.Flags().StringVar(&versionTag, "version-tag", "latest", "version of the rook container to launch")
 	apiCmd.Flags().StringVar(&namespace, "namespace", "", "the namespace in which the api service is running")
+	apiCmd.Flags().BoolVar(&hostNetwork, "hostnetwork", false, "if the hostnetwork should be used")
 	addCephFlags(apiCmd)
 
 	flags.SetFlagsFromEnv(apiCmd.Flags(), RookEnvVarPrefix)
@@ -74,7 +76,7 @@ func startAPI(cmd *cobra.Command, args []string) error {
 	apiCfg := &api.Config{
 		Port:           apiPort,
 		ClusterInfo:    &clusterInfo,
-		ClusterHandler: apik8s.New(context, &clusterInfo, namespace, versionTag),
+		ClusterHandler: apik8s.New(context, &clusterInfo, namespace, versionTag, hostNetwork),
 	}
 
 	err = api.Run(context, apiCfg)

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -32,7 +32,7 @@ var monCmd = &cobra.Command{
 
 var (
 	monName string
-	monPort int
+	monPort int32
 )
 
 func addCephFlags(command *cobra.Command) {
@@ -49,7 +49,7 @@ func addCephFlags(command *cobra.Command) {
 
 func init() {
 	monCmd.Flags().StringVar(&monName, "name", "", "name of the monitor")
-	monCmd.Flags().IntVar(&monPort, "port", 0, "port of the monitor")
+	monCmd.Flags().Int32Var(&monPort, "port", 0, "port of the monitor")
 	addCephFlags(monCmd)
 
 	flags.SetFlagsFromEnv(monCmd.Flags(), RookEnvVarPrefix)
@@ -73,9 +73,13 @@ func startMon(cmd *cobra.Command, args []string) error {
 
 	// at first start the local monitor needs to be added to the list of mons
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddrIPv4)
+	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddrIPv4, monPort)
 
-	monCfg := &mon.Config{Name: monName, Cluster: &clusterInfo}
+	monCfg := &mon.Config{
+		Name:    monName,
+		Cluster: &clusterInfo,
+		Port:    monPort,
+	}
 	err := mon.Run(createContext(), monCfg)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -35,10 +35,11 @@ type clusterHandler struct {
 	clusterInfo *mon.ClusterInfo
 	namespace   string
 	versionTag  string
+	hostNetwork bool
 }
 
-func New(context *clusterd.Context, clusterInfo *mon.ClusterInfo, namespace, versionTag string) *clusterHandler {
-	return &clusterHandler{context: context, clusterInfo: clusterInfo, namespace: namespace, versionTag: versionTag}
+func New(context *clusterd.Context, clusterInfo *mon.ClusterInfo, namespace, versionTag string, hostNetwork bool) *clusterHandler {
+	return &clusterHandler{context: context, clusterInfo: clusterInfo, namespace: namespace, versionTag: versionTag, hostNetwork: hostNetwork}
 }
 
 func (s *clusterHandler) GetClusterInfo() (*mon.ClusterInfo, error) {
@@ -66,7 +67,7 @@ func (s *clusterHandler) EnableObjectStore(config model.ObjectStore) error {
 
 	// Passing an empty Placement{} as the api doesn't know about placement
 	// information. This should be resolved with the transition to CRD (TPR).
-	r := k8srgw.New(s.context, config, s.namespace, s.versionTag, k8sutil.Placement{})
+	r := k8srgw.New(s.context, config, s.namespace, s.versionTag, k8sutil.Placement{}, s.hostNetwork)
 	err := r.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
@@ -98,7 +99,7 @@ func (s *clusterHandler) StartFileSystem(fs *model.FilesystemRequest) error {
 	logger.Infof("Starting the MDS")
 	// Passing an empty Placement{} as the api doesn't know about placement
 	// information. This should be resolved with the transition to CRD (TPR).
-	c := k8smds.New(s.context, s.namespace, s.versionTag, k8sutil.Placement{})
+	c := k8smds.New(s.context, s.namespace, s.versionTag, k8sutil.Placement{}, s.hostNetwork)
 	return c.Start()
 }
 

--- a/pkg/ceph/client/image.go
+++ b/pkg/ceph/client/image.go
@@ -21,8 +21,9 @@ import (
 
 	"strconv"
 
-	"github.com/rook/rook/pkg/clusterd"
 	"regexp"
+
+	"github.com/rook/rook/pkg/clusterd"
 )
 
 const (
@@ -44,17 +45,17 @@ func ListImages(context *clusterd.Context, clusterName, poolName string) ([]Ceph
 
 	//The regex expression captures the json result at the end buf
 	//When logLevel is DEBUG buf contains log statements of librados (see tests for examples)
-	res := regexp.MustCompile(`\[(.*)\]$`).FindStringSubmatch(string(buf))
+	//It can happen that the end of the "real" output doesn't not contain a new line
+	//that's why looking for the end isn't an option here (anymore?)
+	res := regexp.MustCompile(`(?m)^\[(.*)\]`).FindStringSubmatch(string(buf))
 	if len(res) == 0 {
 		return []CephBlockImage{}, nil
-	} else {
-		buf = []byte(res[0])
 	}
+	buf = []byte(res[0])
 
 	var images []CephBlockImage
-	err = json.Unmarshal(buf, &images)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal failed: %+v.  raw buffer response: %s", err, string(buf))
+	if err = json.Unmarshal(buf, &images); err != nil {
+		return nil, fmt.Errorf("unmarshal failed: %+v. raw buffer response: %s", err, string(buf))
 	}
 
 	return images, nil

--- a/pkg/ceph/mon/config.go
+++ b/pkg/ceph/mon/config.go
@@ -102,8 +102,7 @@ func GenerateAdminConnectionConfig(context *clusterd.Context, cluster *ClusterIn
 		return fmt.Errorf("failed to write keyring to %s. %+v", root, err)
 	}
 
-	_, err = GenerateConfigFile(context, cluster, root, client.AdminUsername, keyringPath, false, nil, nil)
-	if err != nil {
+	if _, err = GenerateConfigFile(context, cluster, root, client.AdminUsername, keyringPath, false, nil, nil); err != nil {
 		return fmt.Errorf("failed to write config to %s. %+v", root, err)
 	}
 	logger.Infof("generated admin config in %s", root)
@@ -251,7 +250,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 	cephLogLevel := logLevelToCephLogLevel(context.LogLevel)
 
 	return &cephConfig{
-		&GlobalConfig{
+		GlobalConfig: &GlobalConfig{
 			EnableExperimental:     experimental,
 			FSID:                   cluster.FSID,
 			RunDir:                 runDir,

--- a/pkg/ceph/mon/daemon.go
+++ b/pkg/ceph/mon/daemon.go
@@ -25,17 +25,18 @@ import (
 )
 
 const (
-	Port = 6790
+	DefaultPort = 6790
 )
 
 type Config struct {
 	Name     string
 	Cluster  *ClusterInfo
 	isDaemon bool
+	Port     int32
 }
 
-func NewConfig(name string, cluster *ClusterInfo, isDaemon bool) *Config {
-	return &Config{Name: name, Cluster: cluster, isDaemon: isDaemon}
+func NewConfig(name string, cluster *ClusterInfo, isDaemon bool, port int32) *Config {
+	return &Config{Name: name, Cluster: cluster, isDaemon: isDaemon, Port: port}
 }
 
 func FlattenMonEndpoints(mons map[string]*CephMonitorConfig) string {
@@ -61,8 +62,8 @@ func ParseMonEndpoints(input string) map[string]*CephMonitorConfig {
 	return mons
 }
 
-func ToCephMon(name, ip string) *CephMonitorConfig {
-	return &CephMonitorConfig{Name: name, Endpoint: fmt.Sprintf("%s:%d", ip, Port)}
+func ToCephMon(name, ip string, port int32) *CephMonitorConfig {
+	return &CephMonitorConfig{Name: name, Endpoint: fmt.Sprintf("%s:%d", ip, port)}
 }
 
 func Run(context *clusterd.Context, config *Config) error {
@@ -150,8 +151,8 @@ func startMon(context *clusterd.Context, config *Config, confFilePath, monDataDi
 		fmt.Sprintf("--mon-data=%s", monDataDir),
 		fmt.Sprintf("--conf=%s", confFilePath),
 		fmt.Sprintf("--keyring=%s", keyringPath),
-		fmt.Sprintf("--public-addr=%s:%d", context.NetworkInfo.PublicAddrIPv4, Port),
-		fmt.Sprintf("--public-bind-addr=%s:%d", context.NetworkInfo.ClusterAddrIPv4, Port),
+		fmt.Sprintf("--public-addr=%s:%d", context.NetworkInfo.PublicAddrIPv4, config.Port),
+		fmt.Sprintf("--public-bind-addr=%s:%d", context.NetworkInfo.ClusterAddrIPv4, config.Port),
 	}
 	err = context.ProcMan.Run(config.Name, "ceph-mon", args...)
 	if err != nil {

--- a/pkg/operator/api/api_test.go
+++ b/pkg/operator/api/api_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestStartAPI(t *testing.T) {
 	clientset := testop.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{}, false)
 
 	// start a basic cluster
 	err := c.Start()
@@ -59,7 +59,7 @@ func validateStart(t *testing.T, c *Cluster) {
 
 func TestPodSpecs(t *testing.T) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{}, false)
 
 	d := c.makeDeployment()
 	assert.NotNil(t, d)
@@ -88,7 +88,7 @@ func TestPodSpecs(t *testing.T) {
 
 func TestClusterRole(t *testing.T) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", k8sutil.Placement{}, false)
 
 	// the role is create
 	err := c.makeClusterRole()

--- a/pkg/operator/cluster/controller.go
+++ b/pkg/operator/cluster/controller.go
@@ -164,7 +164,7 @@ func (c *Cluster) createInstance() error {
 	}
 
 	// Start the mon pods
-	c.mons = mon.New(c.context, c.Namespace, c.Spec.DataDirHostPath, c.Spec.VersionTag, c.Spec.Placement.GetMON())
+	c.mons = mon.New(c.context, c.Namespace, c.Spec.DataDirHostPath, c.Spec.VersionTag, c.Spec.Placement.GetMON(), c.Spec.HostNetwork)
 	clusterInfo, err := c.mons.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the mons. %+v", err)
@@ -175,20 +175,20 @@ func (c *Cluster) createInstance() error {
 		return fmt.Errorf("failed to create initial crushmap: %+v", err)
 	}
 
-	c.mgrs = mgr.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Placement.GetMGR())
+	c.mgrs = mgr.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Placement.GetMGR(), c.Spec.HostNetwork)
 	err = c.mgrs.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the ceph mgr. %+v", err)
 	}
 
-	c.apis = api.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Placement.GetAPI())
+	c.apis = api.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Placement.GetAPI(), c.Spec.HostNetwork)
 	err = c.apis.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the REST api. %+v", err)
 	}
 
 	// Start the OSDs
-	c.osds = osd.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Storage, c.Spec.DataDirHostPath, c.Spec.Placement.GetOSD())
+	c.osds = osd.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Storage, c.Spec.DataDirHostPath, c.Spec.Placement.GetOSD(), c.Spec.HostNetwork)
 	err = c.osds.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the osds. %+v", err)

--- a/pkg/operator/cluster/types.go
+++ b/pkg/operator/cluster/types.go
@@ -76,6 +76,9 @@ type ClusterSpec struct {
 
 	// A spec for available storage in the cluster and how it should be used
 	Storage osd.StorageSpec `json:"storage"`
+
+	// HostNetwork to enable host network
+	HostNetwork bool `json:"hostNetwork"`
 }
 
 // PlacementSpec is a set of Placement configurations for the rook cluster.

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -43,23 +43,25 @@ const (
 
 // Cluster for mds management
 type Cluster struct {
-	Namespace string
-	Version   string
-	Replicas  int32
-	context   *clusterd.Context
-	dataDir   string
-	placement k8sutil.Placement
+	Namespace   string
+	Version     string
+	Replicas    int32
+	context     *clusterd.Context
+	dataDir     string
+	placement   k8sutil.Placement
+	HostNetwork bool
 }
 
 // New creates an instance of the mds manager
-func New(context *clusterd.Context, namespace, version string, placement k8sutil.Placement) *Cluster {
+func New(context *clusterd.Context, namespace, version string, placement k8sutil.Placement, hostNetwork bool) *Cluster {
 	return &Cluster{
-		context:   context,
-		Namespace: namespace,
-		placement: placement,
-		Version:   version,
-		Replicas:  1,
-		dataDir:   k8sutil.DataDir,
+		context:     context,
+		Namespace:   namespace,
+		placement:   placement,
+		Version:     version,
+		Replicas:    1,
+		dataDir:     k8sutil.DataDir,
+		HostNetwork: hostNetwork,
 	}
 }
 
@@ -133,6 +135,10 @@ func (c *Cluster) makeDeployment(id string) *extensions.Deployment {
 			{Name: k8sutil.DataDirVolume, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			k8sutil.ConfigOverrideVolume(),
 		},
+		HostNetwork: c.HostNetwork,
+	}
+	if c.HostNetwork {
+		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.placement.ApplyToPodSpec(&podSpec)
 

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -42,7 +42,7 @@ func TestStartMDS(t *testing.T) {
 		Executor:  executor,
 		ConfigDir: configDir,
 		Clientset: testop.New(3)}
-	c := New(context, "ns", "myversion", k8sutil.Placement{})
+	c := New(context, "ns", "myversion", k8sutil.Placement{}, false)
 	defer os.RemoveAll(c.dataDir)
 
 	// start a basic cluster
@@ -64,7 +64,7 @@ func validateStart(t *testing.T, c *Cluster) {
 }
 
 func TestPodSpecs(t *testing.T) {
-	c := New(nil, "ns", "myversion", k8sutil.Placement{})
+	c := New(nil, "ns", "myversion", k8sutil.Placement{}, false)
 	mdsID := "mds1"
 
 	d := c.makeDeployment(mdsID)
@@ -86,4 +86,14 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "mds", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, "--mds-id=mds1", cont.Args[2])
+}
+
+func TestHostNetwork(t *testing.T) {
+	c := New(nil, "ns", "myversion", k8sutil.Placement{}, true)
+	mdsID := "mds1"
+
+	d := c.makeDeployment(mdsID)
+
+	assert.Equal(t, true, d.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, v1.DNSClusterFirstWithHostNet, d.Spec.Template.Spec.DNSPolicy)
 }

--- a/pkg/operator/mgr/mgr_test.go
+++ b/pkg/operator/mgr/mgr_test.go
@@ -43,7 +43,7 @@ func TestStartMGR(t *testing.T) {
 		Executor:  executor,
 		ConfigDir: configDir,
 		Clientset: testop.New(3)}
-	c := New(context, "ns", "myversion", k8sutil.Placement{})
+	c := New(context, "ns", "myversion", k8sutil.Placement{}, false)
 	defer os.RemoveAll(c.dataDir)
 
 	// start a basic service
@@ -68,7 +68,7 @@ func validateStart(t *testing.T, c *Cluster) {
 }
 
 func TestPodSpec(t *testing.T) {
-	c := New(nil, "ns", "myversion", k8sutil.Placement{})
+	c := New(nil, "ns", "myversion", k8sutil.Placement{}, false)
 
 	d := c.makeDeployment("mgr1")
 	assert.NotNil(t, d)
@@ -88,4 +88,14 @@ func TestPodSpec(t *testing.T) {
 
 	assert.Equal(t, "mgr", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
+}
+
+func TestHostNetwork(t *testing.T) {
+	c := New(nil, "ns", "myversion", k8sutil.Placement{}, true)
+
+	d := c.makeDeployment("mgr1")
+	assert.NotNil(t, d)
+
+	assert.Equal(t, true, d.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, v1.DNSClusterFirstWithHostNet, d.Spec.Template.Spec.DNSPolicy)
 }

--- a/pkg/operator/mon/spec.go
+++ b/pkg/operator/mon/spec.go
@@ -96,6 +96,10 @@ func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
 			{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
 			k8sutil.ConfigOverrideVolume(),
 		},
+		HostNetwork: c.HostNetwork,
+	}
+	if c.HostNetwork {
+		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.placement.ApplyToPodSpec(&podSpec)
 

--- a/pkg/operator/mon/spec_test.go
+++ b/pkg/operator/mon/spec_test.go
@@ -34,7 +34,7 @@ func TestPodSpecs(t *testing.T) {
 
 func testPodSpec(t *testing.T, dataDir string) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "myversion", k8sutil.Placement{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "myversion", k8sutil.Placement{}, false)
 	c.clusterInfo = testop.CreateClusterInfo(0)
 	config := &monConfig{Name: "mon0", Port: 6790}
 

--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -51,10 +51,11 @@ type Cluster struct {
 	Version         string
 	Storage         StorageSpec
 	dataDirHostPath string
+	HostNetwork     bool
 }
 
 // New creates an instance of the OSD manager
-func New(context *clusterd.Context, namespace, version string, storageSpec StorageSpec, dataDirHostPath string, placement k8sutil.Placement) *Cluster {
+func New(context *clusterd.Context, namespace, version string, storageSpec StorageSpec, dataDirHostPath string, placement k8sutil.Placement, hostNetwork bool) *Cluster {
 	return &Cluster{
 		context:         context,
 		Namespace:       namespace,
@@ -62,6 +63,7 @@ func New(context *clusterd.Context, namespace, version string, storageSpec Stora
 		Version:         version,
 		Storage:         storageSpec,
 		dataDirHostPath: dataDirHostPath,
+		HostNetwork:     hostNetwork,
 	}
 }
 
@@ -162,6 +164,10 @@ func (c *Cluster) podTemplateSpec(devices []Device, directories []Directory, sel
 		Containers:    []v1.Container{c.osdContainer(devices, directories, selection, config)},
 		RestartPolicy: v1.RestartPolicyAlways,
 		Volumes:       volumes,
+		HostNetwork:   c.HostNetwork,
+	}
+	if c.HostNetwork {
+		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.placement.ApplyToPodSpec(&podSpec)
 

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -29,7 +29,19 @@ func New(nodes int) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 	for i := 0; i < nodes; i++ {
 		ready := v1.NodeCondition{Type: v1.NodeReady}
-		n := &v1.Node{Status: v1.NodeStatus{Conditions: []v1.NodeCondition{ready}}}
+		n := &v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					ready,
+				},
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeExternalIP,
+						Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i),
+					},
+				},
+			},
+		}
 		n.Name = fmt.Sprintf("node%d", i)
 		clientset.CoreV1().Nodes().Create(n)
 	}

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -48,7 +48,7 @@ spec:
         args: ["operator", "--mon-healthcheck-interval=5s", "--mon-out-timeout=1s"]
         env:
         - name: ROOK_REPO_PREFIX
-          value: roo`
+          value: rook`
 	}
 
 	return `kind: ClusterRole
@@ -167,7 +167,9 @@ spec:
         args: ["operator", "--mon-healthcheck-interval=5s", "--mon-out-timeout=1s"]
         env:
         - name: ROOK_REPO_PREFIX
-          value: rook`
+          value: rook
+        - name: ROOK_LOG_LEVEL
+          value: DEBUG`
 
 }
 
@@ -186,6 +188,7 @@ metadata:
 spec:
   versionTag: master
   dataDirHostPath:
+  hostNetwork: false
 # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
 # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
 # tolerate taints with a key of 'storage-node'.


### PR DESCRIPTION
See rook/rook#561.

***

This hasn't been tested yet as minikube or any other single node clusters won't work as Kubernetes detects which ports are used on host. I'll try to test on a three node cluster to verify the functionality.

Edit: ~~I'm looking at the failed tests.~~ Tests fixed.