### PR TITLE
WIP: Add missing hostPath mount for mgr

### DIFF
--- a/pkg/operator/cluster/controller.go
+++ b/pkg/operator/cluster/controller.go
@@ -180,7 +180,7 @@ func (c *Cluster) createInstance() error {
 		return fmt.Errorf("failed to create initial crushmap: %+v", err)
 	}
 
-	c.mgrs = mgr.New(c.context, c.Namespace, c.Spec.VersionTag, c.Spec.Placement.GetMGR(), c.Spec.HostNetwork)
+	c.mgrs = mgr.New(c.context, c.Namespace, c.Spec.DataDirHostPath, c.Spec.VersionTag, c.Spec.Placement.GetMGR(), c.Spec.HostNetwork)
 	err = c.mgrs.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the ceph mgr. %+v", err)

--- a/pkg/operator/mgr/mgr_test.go
+++ b/pkg/operator/mgr/mgr_test.go
@@ -43,8 +43,7 @@ func TestStartMGR(t *testing.T) {
 		Executor:  executor,
 		ConfigDir: configDir,
 		Clientset: testop.New(3)}
-	c := New(context, "ns", "myversion", k8sutil.Placement{}, false)
-	defer os.RemoveAll(c.dataDir)
+	c := New(context, "ns", "", "myversion", k8sutil.Placement{}, false)
 
 	// start a basic service
 	err := c.Start()
@@ -68,7 +67,7 @@ func validateStart(t *testing.T, c *Cluster) {
 }
 
 func TestPodSpec(t *testing.T) {
-	c := New(nil, "ns", "myversion", k8sutil.Placement{}, false)
+	c := New(nil, "ns", "", "myversion", k8sutil.Placement{}, false)
 
 	d := c.makeDeployment("mgr1")
 	assert.NotNil(t, d)
@@ -91,7 +90,7 @@ func TestPodSpec(t *testing.T) {
 }
 
 func TestHostNetwork(t *testing.T) {
-	c := New(nil, "ns", "myversion", k8sutil.Placement{}, true)
+	c := New(nil, "ns", "", "myversion", k8sutil.Placement{}, true)
 
 	d := c.makeDeployment("mgr1")
 	assert.NotNil(t, d)


### PR DESCRIPTION
This simply adds the `hostPath` to the mgr which was missing before.

***

Fixes #998