### PR TITLE
Set rook-api service clusterIP to None when hostNetwork is used

### DIFF
--- a/cluster/examples/kubernetes/rook-tools.yaml
+++ b/cluster/examples/kubernetes/rook-tools.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rook-tools
   namespace: rook
 spec:
-  hostNetwork: false
+  dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: rook-tools
     image: rook/toolbox:master
@@ -25,6 +25,7 @@ spec:
         name: sysbus
       - mountPath: /lib/modules
         name: libmodules
+  hostNetwork: false
   volumes:
     - name: dev
       hostPath:

--- a/images/toolbox/toolbox.sh
+++ b/images/toolbox/toolbox.sh
@@ -26,14 +26,21 @@ CEPH_CONFIG="/etc/ceph/ceph.conf"
 # without specifying any arguments
 if [[ -d ${ROOK_DIR} ]]; then
     # there is a rook directory, try to find one of rook's ceph config files and copy it
-    ROOK_CONFIG=`find ${ROOK_DIR} -regex '.*mon[0-9]+/.*\.config' | head -1`
+    ROOK_CONFIG=$(find ${ROOK_DIR} -regex '.*mon[0-9]+/.*\.config' | head -1)
     if [[ ! -z ${ROOK_CONFIG} ]]; then
         cp ${ROOK_CONFIG} ${CEPH_CONFIG}
     fi
-elif [[ ! -z ${ROOK_API_SERVICE_HOST} ]] && [[ ! -z ${ROOK_API_SERVICE_PORT} ]]; then
-    # we have some rook env vars set, get client info from the rook API server and construct
-    # a ceph config file from that
-    ROOK_API_SERVER_ENDPOINT=${ROOK_API_SERVICE_HOST}:${ROOK_API_SERVICE_PORT}
+else
+    if [[ -z ${ROOK_API_SERVER_ENDPOINT} ]]; then
+        if [[ ! -z ${ROOK_API_SERVICE_HOST} ]] && [[ ! -z ${ROOK_API_SERVICE_PORT} ]]; then
+            # we have some rook env vars set, get client info from the rook API server and construct
+            # a ceph config file from that
+            ROOK_API_SERVER_ENDPOINT=${ROOK_API_SERVICE_HOST}:${ROOK_API_SERVICE_PORT}
+        else
+            # default to the dns name of the rook-api svc
+            ROOK_API_SERVER_ENDPOINT="rook-api:8124"
+        fi
+    fi
 
     # append to the bashrc file so that the rook tool can find the API server easily
     cat <<EOF >> ~/.bashrc

--- a/pkg/operator/api/api.go
+++ b/pkg/operator/api/api.go
@@ -238,6 +238,10 @@ func (c *Cluster) startService() error {
 		},
 	}
 
+	if c.HostNetwork {
+		s.Spec.ClusterIP = v1.ClusterIPNone
+	}
+
 	s, err := c.context.Clientset.CoreV1().Services(c.Namespace).Create(s)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
```
fix rook-api service clusterIP when hostNetwork is used

allow ROOK_API_SERVER_ENDPOINT to be set by user

toolbox: default to rook-api dns name when no k8s service env vars are
given

Added dnsPolicy to rook-tools (K8s required version >1.6)
```
This PR changes/fixes:
1. Fix the rook-api service to be also set to `None` when `hostNetwork: true` is used.
2. Allow the user to set the `ROOK_API_SERVER_ENDPOINT` by env var.
3. The rook-toolbox entrypoint script to fallback to the dns name when no K8s service env vars are given (this happens when `hostNetwork: true` is used).
4. Added the `dnsPolicy: ClusterFirstWithHostNet` to the rook-tools pod. This allows the fallback for `hostNetwork: true` for the dns name of the rook-api service to be used.