### PR TITLE
rgw: proper naming for ObjectStore CRD

### DIFF
--- a/Documentation/object-store-crd.md
+++ b/Documentation/object-store-crd.md
@@ -13,7 +13,7 @@ for object stores.
 
 ```yaml
 apiVersion: rook.io/v1alpha1
-kind: Objectstore
+kind: ObjectStore
 metadata:
   name: my-store
   namespace: rook
@@ -49,6 +49,12 @@ spec:
 ```
 
 ## Object Store Settings
+
+### Kind
+If you are using a version of Kubernetes **earlier than 1.7**, you will need to slightly modify the `kind` to be compatible with TPRs (deprecated in 1.7). Notice the different casing.
+```yaml
+kind: Objectstore
+```
 
 ### Metadata
 

--- a/cluster/examples/kubernetes/1.6/rook-object.yaml
+++ b/cluster/examples/kubernetes/1.6/rook-object.yaml
@@ -1,6 +1,6 @@
 apiVersion: rook.io/v1alpha1
 # For earlier versions than K8s 1.7, the kind must be Objectstore
-kind: ObjectStore
+kind: Objectstore
 metadata:
   name: my-store
   namespace: rook

--- a/cluster/examples/kubernetes/rgw-external.yaml
+++ b/cluster/examples/kubernetes/rgw-external.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: rook-ceph-rgw-external
+  name: rook-ceph-rgw-my-store-external
   namespace: rook
   labels:
     app: rook-ceph-rgw
     rook_cluster: rook
+    rook_object_store: my-store
 spec:
   ports:
   - name: rgw
@@ -15,5 +16,6 @@ spec:
   selector:
     app: rook-ceph-rgw
     rook_cluster: rook
+    rook_object_store: my-store
   sessionAffinity: None
   type: NodePort

--- a/pkg/api/k8s/cluster_handler.go
+++ b/pkg/api/k8s/cluster_handler.go
@@ -109,7 +109,7 @@ func (s *clusterHandler) EnableObjectStore(config model.ObjectStore) error {
 }
 
 func (s *clusterHandler) RemoveObjectStore(name string) error {
-	store := &k8srgw.Objectstore{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: s.clusterInfo.Name}}
+	store := &k8srgw.ObjectStore{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: s.clusterInfo.Name}}
 	return store.Delete(s.context)
 }
 

--- a/pkg/operator/rgw/controller.go
+++ b/pkg/operator/rgw/controller.go
@@ -62,12 +62,12 @@ func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{
 		DeleteFunc: c.onDelete,
 	}
 	watcher := kit.NewWatcher(ObjectStoreResource, namespace, resourceHandlerFuncs, client)
-	go watcher.Watch(&Objectstore{}, stopCh)
+	go watcher.Watch(&ObjectStore{}, stopCh)
 	return nil
 }
 
 func (c *ObjectStoreController) onAdd(obj interface{}) {
-	objectStore := obj.(*Objectstore)
+	objectStore := obj.(*ObjectStore)
 
 	// NEVER modify objects from the store. It's a read-only, local cache.
 	// Use scheme.Copy() to make a deep copy of original object.
@@ -76,7 +76,7 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 		fmt.Printf("ERROR creating a deep copy of object store: %v\n", err)
 		return
 	}
-	objectStoreCopy := copyObj.(*Objectstore)
+	objectStoreCopy := copyObj.(*ObjectStore)
 
 	err = objectStoreCopy.Create(c.context, c.versionTag, c.hostNetwork)
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 
 func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 	//oldObjectStore := oldObj.(*ObjectStore)
-	newObjectStore := newObj.(*Objectstore)
+	newObjectStore := newObj.(*ObjectStore)
 
 	// if the object store is modified, allow the object store to be created if it wasn't already
 	err := newObjectStore.Update(c.context, c.versionTag, c.hostNetwork)
@@ -96,7 +96,7 @@ func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *ObjectStoreController) onDelete(obj interface{}) {
-	objectStore := obj.(*Objectstore)
+	objectStore := obj.(*ObjectStore)
 	err := objectStore.Delete(c.context)
 	if err != nil {
 		logger.Errorf("failed to delete object store %s. %+v", objectStore.Name, err)

--- a/pkg/operator/rgw/register.go
+++ b/pkg/operator/rgw/register.go
@@ -40,7 +40,7 @@ var ObjectStoreResource = kit.CustomResource{
 	Group:   k8sutil.CustomResourceGroup,
 	Version: k8sutil.V1Alpha1,
 	Scope:   apiextensionsv1beta1.NamespaceScoped,
-	Kind:    reflect.TypeOf(Objectstore{}).Name(),
+	Kind:    reflect.TypeOf(ObjectStore{}).Name(),
 }
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
@@ -56,7 +56,9 @@ func Resource(resource string) schema.GroupResource {
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(schemeGroupVersion,
-		&Objectstore{},
+		&ObjectStore{},
+		&ObjectStoreList{},
+		// Remove the ObjectstoreList after TPRs are not supported anymore
 		&ObjectstoreList{},
 	)
 	metav1.AddToGroupVersion(scheme, schemeGroupVersion)

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -48,15 +48,15 @@ const (
 )
 
 // Start the rgw manager
-func (s *Objectstore) Create(context *clusterd.Context, version string, hostNetwork bool) error {
+func (s *ObjectStore) Create(context *clusterd.Context, version string, hostNetwork bool) error {
 	return s.createOrUpdate(context, version, hostNetwork, false)
 }
 
-func (s *Objectstore) Update(context *clusterd.Context, version string, hostNetwork bool) error {
+func (s *ObjectStore) Update(context *clusterd.Context, version string, hostNetwork bool) error {
 	return s.createOrUpdate(context, version, hostNetwork, true)
 }
 
-func (s *Objectstore) createOrUpdate(context *clusterd.Context, version string, hostNetwork, update bool) error {
+func (s *ObjectStore) createOrUpdate(context *clusterd.Context, version string, hostNetwork, update bool) error {
 	// validate the object store settings
 	if err := s.validate(); err != nil {
 		return fmt.Errorf("invalid object store %s arguments. %+v", s.Name, err)
@@ -99,7 +99,7 @@ func (s *Objectstore) createOrUpdate(context *clusterd.Context, version string, 
 	return nil
 }
 
-func (s *Objectstore) startRGWPods(context *clusterd.Context, version string, hostNetwork, update bool) error {
+func (s *ObjectStore) startRGWPods(context *clusterd.Context, version string, hostNetwork, update bool) error {
 
 	// if intended to update, remove the old pods so they can be created with the new spec settings
 	if update {
@@ -129,7 +129,7 @@ func (s *Objectstore) startRGWPods(context *clusterd.Context, version string, ho
 	return nil
 }
 
-func (s *Objectstore) createObjectStore(context *cephrgw.Context, serviceIP string) error {
+func (s *ObjectStore) createObjectStore(context *cephrgw.Context, serviceIP string) error {
 
 	mModel := model.Pool{}
 	dModel := model.Pool{}
@@ -146,7 +146,7 @@ func (s *Objectstore) createObjectStore(context *cephrgw.Context, serviceIP stri
 
 // Delete the object store.
 // WARNING: This is a very destructive action that deletes all metadata and data pools.
-func (s *Objectstore) Delete(context *clusterd.Context) error {
+func (s *ObjectStore) Delete(context *clusterd.Context) error {
 	// check if the object store  exists
 	exists, err := s.exists(context)
 	if err != nil {
@@ -189,7 +189,7 @@ func (s *Objectstore) Delete(context *clusterd.Context) error {
 }
 
 // deleteRGWPods makes a best effort at deleting the RGW pods, including the deployment and daemonset
-func (s *Objectstore) deleteRGWPods(context *clusterd.Context) {
+func (s *ObjectStore) deleteRGWPods(context *clusterd.Context) {
 	logger.Infof("removing rgw pods if they exist")
 
 	var gracePeriod int64
@@ -235,7 +235,7 @@ func (s *Objectstore) deleteRGWPods(context *clusterd.Context) {
 }
 
 // Check if the object store exists depending on either the deployment or the daemonset
-func (s *Objectstore) exists(context *clusterd.Context) (bool, error) {
+func (s *ObjectStore) exists(context *clusterd.Context) (bool, error) {
 	_, err := context.Clientset.ExtensionsV1beta1().Deployments(s.Namespace).Get(s.instanceName(), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
@@ -259,7 +259,7 @@ func (s *Objectstore) exists(context *clusterd.Context) (bool, error) {
 }
 
 // Validate the object store arguments
-func (s *Objectstore) validate() error {
+func (s *ObjectStore) validate() error {
 	logger.Debugf("validating object store: %+v", s)
 	if s.Name == "" {
 		return fmt.Errorf("missing name")
@@ -277,7 +277,7 @@ func (s *Objectstore) validate() error {
 	return nil
 }
 
-func (s *Objectstore) createKeyring(context *clusterd.Context) error {
+func (s *ObjectStore) createKeyring(context *clusterd.Context) error {
 	_, err := context.Clientset.CoreV1().Secrets(s.Namespace).Get(s.instanceName(), metav1.GetOptions{})
 	if err == nil {
 		logger.Infof("the rgw keyring was already generated")
@@ -311,7 +311,7 @@ func (s *Objectstore) createKeyring(context *clusterd.Context) error {
 	return nil
 }
 
-func (s *Objectstore) instanceName() string {
+func (s *ObjectStore) instanceName() string {
 	return InstanceName(s.Name)
 }
 
@@ -319,8 +319,8 @@ func InstanceName(name string) string {
 	return fmt.Sprintf("%s-%s", appName, name)
 }
 
-func ModelToSpec(store model.ObjectStore, namespace string) *Objectstore {
-	return &Objectstore{
+func ModelToSpec(store model.ObjectStore, namespace string) *ObjectStore {
+	return &ObjectStore{
 		ObjectMeta: metav1.ObjectMeta{Name: store.Name, Namespace: namespace},
 		Spec: ObjectStoreSpec{
 			MetadataPool: pool.ModelToSpec(store.MetadataConfig),
@@ -336,7 +336,7 @@ func ModelToSpec(store model.ObjectStore, namespace string) *Objectstore {
 	}
 }
 
-func (s *Objectstore) makeRGWPodSpec(version string, hostNetwork bool) v1.PodTemplateSpec {
+func (s *ObjectStore) makeRGWPodSpec(version string, hostNetwork bool) v1.PodTemplateSpec {
 	podSpec := v1.PodSpec{
 		Containers:    []v1.Container{s.rgwContainer(version)},
 		RestartPolicy: v1.RestartPolicyAlways,
@@ -372,7 +372,7 @@ func (s *Objectstore) makeRGWPodSpec(version string, hostNetwork bool) v1.PodTem
 	}
 }
 
-func (s *Objectstore) startDeployment(context *clusterd.Context, version string, replicas int32, hostNetwork bool) error {
+func (s *ObjectStore) startDeployment(context *clusterd.Context, version string, replicas int32, hostNetwork bool) error {
 
 	deployment := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -385,7 +385,7 @@ func (s *Objectstore) startDeployment(context *clusterd.Context, version string,
 	return err
 }
 
-func (s *Objectstore) startDaemonset(context *clusterd.Context, version string, hostNetwork bool) error {
+func (s *ObjectStore) startDaemonset(context *clusterd.Context, version string, hostNetwork bool) error {
 
 	daemonset := &extensions.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -399,7 +399,7 @@ func (s *Objectstore) startDaemonset(context *clusterd.Context, version string, 
 	return err
 }
 
-func (s *Objectstore) rgwContainer(version string) v1.Container {
+func (s *ObjectStore) rgwContainer(version string) v1.Container {
 
 	container := v1.Container{
 		Args: []string{
@@ -441,7 +441,7 @@ func (s *Objectstore) rgwContainer(version string) v1.Container {
 	return container
 }
 
-func (s *Objectstore) startService(context *clusterd.Context, hostNetwork bool) (string, error) {
+func (s *ObjectStore) startService(context *clusterd.Context, hostNetwork bool) (string, error) {
 	labels := s.getLabels()
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -485,7 +485,7 @@ func addPort(service *v1.Service, name string, port int32) {
 	})
 }
 
-func (s *Objectstore) getLabels() map[string]string {
+func (s *ObjectStore) getLabels() map[string]string {
 	return map[string]string{
 		k8sutil.AppAttr:     appName,
 		k8sutil.ClusterAttr: s.Namespace,

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -65,7 +65,7 @@ func TestStartRGW(t *testing.T) {
 	validateStart(t, store, clientset, true)
 }
 
-func validateStart(t *testing.T, store *Objectstore, clientset *fake.Clientset, allNodes bool) {
+func validateStart(t *testing.T, store *ObjectStore, clientset *fake.Clientset, allNodes bool) {
 	if !allNodes {
 		r, err := clientset.ExtensionsV1beta1().Deployments(store.Namespace).Get(store.instanceName(), metav1.GetOptions{})
 		assert.Nil(t, err)
@@ -197,8 +197,8 @@ func TestValidateSpec(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func simpleStore() *Objectstore {
-	return &Objectstore{
+func simpleStore() *ObjectStore {
+	return &ObjectStore{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "mycluster"},
 		Spec: ObjectStoreSpec{
 			MetadataPool: pool.PoolSpec{Replicated: pool.ReplicatedSpec{Size: 1}},

--- a/pkg/operator/rgw/types.go
+++ b/pkg/operator/rgw/types.go
@@ -30,18 +30,25 @@ import (
 // schemeGroupVersion is group version used to register these objects
 var schemeGroupVersion = schema.GroupVersion{Group: k8sutil.CustomResourceGroup, Version: k8sutil.V1Alpha1}
 
-// Objectstore is the definition of the object store custom resource
-type Objectstore struct {
+// ObjectStore is the definition of the object store custom resource
+type ObjectStore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 	Spec              ObjectStoreSpec `json:"spec"`
 }
 
-// ObjectstoreList is the definition of a list of object stores
+// ObjectstoreList is the definition of a list of object stores for CRDs (1.7+)
+type ObjectStoreList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []ObjectStore `json:"items"`
+}
+
+// ObjectstoreList is the definition of a list of object stores for TPRs (pre-1.7)
 type ObjectstoreList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`
-	Items           []Objectstore `json:"items"`
+	Items           []ObjectStore `json:"items"`
 }
 
 // ObjectStoreSpec represent the spec of a pool

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -51,10 +51,13 @@ func (ro *ObjectOperation) ObjectCreate(namespace, storeName string, replicaCoun
 			return fmt.Errorf("failed to create rest api object store. %+v", err)
 		}
 	} else {
-
+		kind := "ObjectStore"
+		if !k8sh.VersionAtLeast("1.7.0") {
+			kind = "Objectstore"
+		}
 		logger.Infof("creating the object store via CRD")
 		storeSpec := fmt.Sprintf(`apiVersion: rook.io/v1alpha1
-kind: Objectstore
+kind: %s
 metadata:
   name: %s
   namespace: %s
@@ -72,7 +75,7 @@ spec:
     securePort:
     instances: %d
     allNodes: false
-`, store.Name, namespace, store.Gateway.Port, store.Gateway.Instances)
+`, kind, store.Name, namespace, store.Gateway.Port, store.Gateway.Instances)
 
 		if _, err := k8sh.ResourceOperation("create", storeSpec); err != nil {
 			return err

--- a/tests/integration/block_createBlock_api_test.go
+++ b/tests/integration/block_createBlock_api_test.go
@@ -50,10 +50,10 @@ type BlockImageCreateSuite struct {
 
 func (s *BlockImageCreateSuite) SetupSuite() {
 
-	kh, err := utils.CreateK8sHelper()
+	kh, err := utils.CreateK8sHelper(s.T)
 	require.NoError(s.T(), err)
 
-	s.installer = installer.NewK8sRookhelper(kh.Clientset)
+	s.installer = installer.NewK8sRookhelper(kh.Clientset, s.T)
 
 	err = s.installer.InstallRookOnK8s("rook")
 	require.NoError(s.T(), err)

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -53,10 +53,10 @@ type K8sBlockImageCreateSuite struct {
 func (s *K8sBlockImageCreateSuite) SetupSuite() {
 
 	var err error
-	s.kh, err = utils.CreateK8sHelper()
+	s.kh, err = utils.CreateK8sHelper(s.T)
 	require.NoError(s.T(), err)
 
-	s.installer = installer.NewK8sRookhelper(s.kh.Clientset)
+	s.installer = installer.NewK8sRookhelper(s.kh.Clientset, s.T)
 
 	err = s.installer.InstallRookOnK8s("rook")
 	require.NoError(s.T(), err)

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -3,6 +3,8 @@ package integration
 import (
 	"testing"
 
+	"time"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/enums"
@@ -10,7 +12,6 @@ import (
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"time"
 )
 
 var (
@@ -30,13 +31,13 @@ type HelmSuite struct {
 }
 
 func (hs *HelmSuite) SetupSuite() {
-	kh, err := utils.CreateK8sHelper()
+	kh, err := utils.CreateK8sHelper(hs.T)
 	require.NoError(hs.T(), err)
 
 	hs.k8sh = kh
 	hs.hh = utils.NewHelmHelper()
 
-	hs.installer = installer.NewK8sRookhelper(kh.Clientset)
+	hs.installer = installer.NewK8sRookhelper(kh.Clientset, hs.T)
 
 	err = hs.installer.CreateK8sRookOperatorViaHelm(defaultRookNamespace)
 	require.NoError(hs.T(), err)

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -39,12 +39,12 @@ type SmokeSuite struct {
 }
 
 func (suite *SmokeSuite) SetupSuite() {
-	kh, err := utils.CreateK8sHelper()
+	kh, err := utils.CreateK8sHelper(suite.T)
 	require.NoError(suite.T(), err)
 
 	suite.k8sh = kh
 
-	suite.installer = installer.NewK8sRookhelper(kh.Clientset)
+	suite.installer = installer.NewK8sRookhelper(kh.Clientset, suite.T)
 
 	err = suite.installer.InstallRookOnK8s(defaultRookNamespace)
 	require.NoError(suite.T(), err)

--- a/tests/longhaul/block_test.go
+++ b/tests/longhaul/block_test.go
@@ -51,10 +51,10 @@ type K8sBlockLongHaulSuite struct {
 func (s *K8sBlockLongHaulSuite) SetupSuite() {
 
 	var err error
-	s.kh, err = utils.CreateK8sHelper()
+	s.kh, err = utils.CreateK8sHelper(s.T)
 	assert.Nil(s.T(), err)
 
-	s.installer = installer.NewK8sRookhelper(s.kh.Clientset)
+	s.installer = installer.NewK8sRookhelper(s.kh.Clientset, s.T)
 	if !s.kh.IsRookInstalled(defaultRookNamespace) {
 		err = s.installer.InstallRookOnK8s(defaultRookNamespace)
 		require.NoError(s.T(), err)


### PR DESCRIPTION
The ObjectStore CRD should be named as such rather than being named `Objectstore` just to pacify deprecated TPRs. Fixes #1010.
