### PR TITLE
crush: set failure domain for pools

### DIFF
--- a/Documentation/pool-crd.md
+++ b/Documentation/pool-crd.md
@@ -39,3 +39,7 @@ spec:
 - `erasureCoded`: Settings for an erasure-coded pool. If specified, `replicated` settings must not be specified.
   - `codingChunks`: Number of coding chunks per object in an erasure coded storage pool
   - `dataChunks`: Number of data chunks per object in an erasure coded storage pool
+- `failureDomain`: The failure domain across which the replicas or chunks of data will be spread. Possible values are `osd` or `host`, 
+with the default of `host`.   For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be 
+placed on osds that are found on unique hosts. In that case you would be guaranteed to tolerate the failure of two hosts. If the failure domain were `osd`, 
+you would be able to tolerate the loss of two devices. Similarly for erasure coding, the data and coding chunks would be spread across the requested failure domain.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -17,9 +17,11 @@
 - Object Store
   - Object Stores are defined by a CRD and handled by the Operator
   - Multiple object stores supported through Ceph realms
-  - Pools created by object stores are configurable with all options defined in the pool CRD
 - OSDs
   - If an OSD loses its metadata and config but still has its data devices, the OSD will automatically regenerate the lost metadata to make the data available again.
+- Pools
+  - The failure domain for the CRUSH map can be specified on pools with the `failureDomain` property
+  - Pools created by file systems or object stores are configurable with all options defined in the pool CRD
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/rook-filesystem.yaml
+++ b/cluster/examples/kubernetes/rook-filesystem.yaml
@@ -7,11 +7,13 @@ spec:
   # The metadata pool spec
   metadataPool:
     replicated:
-      size: 1
+      size: 3
   # The list of data pool specs
   dataPools:
-    - replicated:
-        size: 1
+    - failureDomain: osd
+      erasureCoded:
+        dataChunks: 4
+        codingChunks: 2
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/rook-object.yaml
+++ b/cluster/examples/kubernetes/rook-object.yaml
@@ -7,13 +7,15 @@ metadata:
 spec:
   # The pool spec used to create the metadata pools
   metadataPool:
+    failureDomain: host
     replicated:
-      size: 2
+      size: 3
   # The pool spec used to create the data pool
   dataPool:
+    failureDomain: osd
     erasureCoded:
-      dataChunks: 2
-      codingChunks: 1
+      dataChunks: 4
+      codingChunks: 2
   # The gaeteway service configuration
   gateway:
     # type of the gateway (s3)

--- a/cluster/examples/kubernetes/rook-pool.yaml
+++ b/cluster/examples/kubernetes/rook-pool.yaml
@@ -4,6 +4,8 @@ metadata:
   name: replicapool
   namespace: rook
 spec:
+  # The failure domain will spread the replicas of the data across different failure zones
+  failureDomain: osd
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 1
@@ -12,4 +14,3 @@ spec:
   #erasureCoded:
   #  codingChunks: 2
   #  dataChunks: 2
-  

--- a/cmd/rookctl/pool/create.go
+++ b/cmd/rookctl/pool/create.go
@@ -42,10 +42,11 @@ var createCmd = &cobra.Command{
 }
 
 type Config struct {
-	PoolType     string
-	ReplicaCount uint
-	DataChunks   uint
-	CodingChunks uint
+	PoolType      string
+	ReplicaCount  uint
+	DataChunks    uint
+	CodingChunks  uint
+	FailureDomain string
 }
 
 func init() {
@@ -62,6 +63,13 @@ func AddPoolFlags(cmd *cobra.Command, prefix string, config *Config) {
 	}
 	cmd.Flags().StringVarP(&config.PoolType, prefix+"type", shorthand, PoolTypeReplicated,
 		fmt.Sprintf("Type of storage pool, '%s' or '%s'", PoolTypeReplicated, PoolTypeErasureCoded))
+
+	shorthand = ""
+	if prefix == "" {
+		shorthand = "f"
+	}
+	cmd.Flags().StringVarP(&config.FailureDomain, prefix+"failure-domain", shorthand, "host",
+		"The data failure domain (osd or host)")
 
 	shorthand = ""
 	if prefix == "" {
@@ -117,7 +125,7 @@ func ConfigToModel(config Config) (*model.Pool, error) {
 			config.PoolType, PoolTypeReplicated, PoolTypeErasureCoded)
 	}
 
-	newPool := &model.Pool{}
+	newPool := &model.Pool{FailureDomain: config.FailureDomain}
 
 	if config.PoolType == PoolTypeReplicated {
 		if config.DataChunks > 0 || config.CodingChunks > 0 {

--- a/cmd/rookctl/pool/create_test.go
+++ b/cmd/rookctl/pool/create_test.go
@@ -28,25 +28,26 @@ const (
 	SuccessPoolCreatedMessage = "pool 'pool1' created"
 )
 
-func TestCreatePoolValidTypeRequired(t *testing.T) {
+func TestConfigConversion(t *testing.T) {
 	config := Config{PoolType: "foo"}
 	_, err := ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "invalid pool type 'foo', allowed pool types are 'replicated' and 'erasure-coded'", err.Error())
-}
 
-func TestCreatePoolErasureCodedParamsRequired(t *testing.T) {
-	config := Config{PoolType: PoolTypeErasureCoded}
-	_, err := ConfigToModel(config)
+	config = Config{PoolType: PoolTypeErasureCoded}
+	_, err = ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "both data chunks and coding chunks must be greater than zero for pool type 'erasure-coded'", err.Error())
-}
 
-func TestCreatePoolReplicatedErasureCodedParamsNotAllowed(t *testing.T) {
-	config := Config{PoolType: PoolTypeReplicated, DataChunks: 2, CodingChunks: 1}
-	_, err := ConfigToModel(config)
+	config = Config{PoolType: PoolTypeReplicated, DataChunks: 2, CodingChunks: 1}
+	_, err = ConfigToModel(config)
 	assert.NotNil(t, err)
 	assert.Equal(t, "both data chunks and coding chunks must be zero for pool type 'replicated'", err.Error())
+
+	config = Config{PoolType: PoolTypeReplicated, FailureDomain: "osd"}
+	result, err := ConfigToModel(config)
+	assert.Nil(t, err)
+	assert.Equal(t, "osd", result.FailureDomain)
 }
 
 func TestCreatePoolReplicatedNoParams(t *testing.T) {

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -77,22 +77,6 @@ type overallMonStatus struct {
 	Desired []*mon.CephMonitorConfig `json:"desired"`
 }
 
-// Gets the current crush map for the cluster.
-// GET
-// /crushmap
-func (h *Handler) GetCrushMap(w http.ResponseWriter, r *http.Request) {
-	// get the crush map
-	crushmap, err := ceph.GetCrushMap(h.context, h.config.clusterInfo.Name)
-	if err != nil {
-		logger.Errorf("failed to get crush map, err: %+v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	w.Write([]byte(crushmap))
-}
-
 func handleReadBody(w http.ResponseWriter, r *http.Request, opName string) ([]byte, bool) {
 	if r.Body == nil {
 		logger.Errorf("nil request body for %s", opName)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -72,12 +72,6 @@ func (h *Handler) GetRoutes() []Route {
 			h.GetClientAccessInfo,
 		},
 		{
-			"GetCrushMap",
-			"GET",
-			"/crushmap",
-			h.GetCrushMap,
-		},
-		{
 			"GetObjectStores",
 			"GET",
 			"/objectstore",

--- a/pkg/ceph/client/crush_test.go
+++ b/pkg/ceph/client/crush_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -24,12 +25,224 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testCrushMap = `{
+    "devices": [
+        {
+            "id": 0,
+            "name": "osd.0",
+            "class": "hdd"
+        }
+    ],
+    "types": [
+        {
+            "type_id": 0,
+            "name": "osd"
+        },
+        {
+            "type_id": 1,
+            "name": "host"
+        },
+        {
+            "type_id": 2,
+            "name": "chassis"
+        },
+        {
+            "type_id": 3,
+            "name": "rack"
+        },
+        {
+            "type_id": 4,
+            "name": "row"
+        },
+        {
+            "type_id": 5,
+            "name": "pdu"
+        },
+        {
+            "type_id": 6,
+            "name": "pod"
+        },
+        {
+            "type_id": 7,
+            "name": "room"
+        },
+        {
+            "type_id": 8,
+            "name": "datacenter"
+        },
+        {
+            "type_id": 9,
+            "name": "region"
+        },
+        {
+            "type_id": 10,
+            "name": "root"
+        }
+    ],
+    "buckets": [
+        {
+            "id": -1,
+            "name": "default",
+            "type_id": 10,
+            "type_name": "root",
+            "weight": 1028,
+            "alg": "straw",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -3,
+                    "weight": 1028,
+                    "pos": 0
+                }
+            ]
+        },
+        {
+            "id": -2,
+            "name": "default~hdd",
+            "type_id": 10,
+            "type_name": "root",
+            "weight": 1028,
+            "alg": "straw",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": -4,
+                    "weight": 1028,
+                    "pos": 0
+                }
+            ]
+        },
+        {
+            "id": -3,
+            "name": "minikube",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 1028,
+            "alg": "straw",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 0,
+                    "weight": 1028,
+                    "pos": 0
+                }
+            ]
+        },
+        {
+            "id": -4,
+            "name": "minikube~hdd",
+            "type_id": 1,
+            "type_name": "host",
+            "weight": 1028,
+            "alg": "straw",
+            "hash": "rjenkins1",
+            "items": [
+                {
+                    "id": 0,
+                    "weight": 1028,
+                    "pos": 0
+                }
+            ]
+        }
+    ],
+    "rules": [
+        {
+            "rule_id": 0,
+            "rule_name": "replicated_ruleset",
+            "ruleset": 0,
+            "type": 1,
+            "min_size": 1,
+            "max_size": 10,
+            "steps": [
+                {
+                    "op": "take",
+                    "item": -1,
+                    "item_name": "default"
+                },
+                {
+                    "op": "chooseleaf_firstn",
+                    "num": 0,
+                    "type": "host"
+                },
+                {
+                    "op": "emit"
+                }
+            ]
+        },
+        {
+            "rule_id": 1,
+            "rule_name": "my-store.rgw.buckets.data",
+            "ruleset": 1,
+            "type": 3,
+            "min_size": 3,
+            "max_size": 3,
+            "steps": [
+                {
+                    "op": "set_chooseleaf_tries",
+                    "num": 5
+                },
+                {
+                    "op": "set_choose_tries",
+                    "num": 100
+                },
+                {
+                    "op": "take",
+                    "item": -1,
+                    "item_name": "default"
+                },
+                {
+                    "op": "chooseleaf_indep",
+                    "num": 0,
+                    "type": "host"
+                },
+                {
+                    "op": "emit"
+                }
+            ]
+        }
+    ],
+    "tunables": {
+        "choose_local_tries": 0,
+        "choose_local_fallback_tries": 0,
+        "choose_total_tries": 50,
+        "chooseleaf_descend_once": 1,
+        "chooseleaf_vary_r": 1,
+        "chooseleaf_stable": 0,
+        "straw_calc_version": 1,
+        "allowed_bucket_algs": 22,
+        "profile": "firefly",
+        "optimal_tunables": 0,
+        "legacy_tunables": 0,
+        "minimum_required_version": "firefly",
+        "require_feature_tunables": 1,
+        "require_feature_tunables2": 1,
+        "has_v2_rules": 1,
+        "require_feature_tunables3": 1,
+        "has_v3_rules": 0,
+        "has_v4_buckets": 0,
+        "require_feature_tunables5": 0,
+        "has_v5_rules": 0
+    },
+    "choose_args": {}
+}
+`
+
 func TestGetCrushMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	response, err := GetCrushMap(&clusterd.Context{Executor: executor}, "rook")
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[1] == "crush" && args[2] == "dump" {
+			return testCrushMap, nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+	crush, err := GetCrushMap(&clusterd.Context{Executor: executor}, "rook")
 
 	assert.Nil(t, err)
-	assert.Equal(t, "", response)
+	assert.Equal(t, 11, len(crush.Types))
+	assert.Equal(t, 1, len(crush.Devices))
+	assert.Equal(t, 4, len(crush.Buckets))
+	assert.Equal(t, 2, len(crush.Rules))
 }
 
 func TestCrushLocation(t *testing.T) {

--- a/pkg/ceph/client/erasure-code-profile.go
+++ b/pkg/ceph/client/erasure-code-profile.go
@@ -28,6 +28,7 @@ type CephErasureCodeProfile struct {
 	CodingChunkCount uint   `json:"m,string"`
 	Plugin           string `json:"plugin"`
 	Technique        string `json:"technique"`
+	FailureDomain    string `json:"crush-failure-domain"`
 }
 
 func ListErasureCodeProfiles(context *clusterd.Context, clusterName string) ([]string, error) {
@@ -62,7 +63,7 @@ func GetErasureCodeProfileDetails(context *clusterd.Context, clusterName, name s
 	return ecProfileDetails, nil
 }
 
-func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name string) error {
+func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name, failureDomain string) error {
 	// look up the default profile so we can use the default plugin/technique
 	defaultProfile, err := GetErasureCodeProfileDetails(context, clusterName, "default")
 	if err != nil {
@@ -75,7 +76,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, con
 		fmt.Sprintf("m=%d", config.CodingChunkCount),
 		fmt.Sprintf("plugin=%s", defaultProfile.Plugin),
 		fmt.Sprintf("technique=%s", defaultProfile.Technique),
-		"ruleset-failure-domain=osd",
+	}
+	if failureDomain != "" {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-failure-domain=%s", failureDomain))
 	}
 
 	args := []string{"osd", "erasure-code-profile", "set", name}
@@ -90,8 +93,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, con
 
 func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 	pool := CephStoragePoolDetails{
-		Name:   modelPool.Name,
-		Number: modelPool.Number,
+		Name:          modelPool.Name,
+		Number:        modelPool.Number,
+		FailureDomain: modelPool.FailureDomain,
 	}
 
 	if modelPool.Type == model.Replicated {

--- a/pkg/ceph/client/erasure-code-profile_test.go
+++ b/pkg/ceph/client/erasure-code-profile_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rook/rook/pkg/model"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+func TestCreateProfile(t *testing.T) {
+	testCreateProfile(t, "")
+}
+
+func TestCreateProfileWithFailureDomain(t *testing.T) {
+	testCreateProfile(t, "osd")
+}
+
+func testCreateProfile(t *testing.T, failureDomain string) {
+	cfg := model.ErasureCodedPoolConfig{DataChunkCount: 2, CodingChunkCount: 3, Algorithm: "myalg"}
+
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[1] == "erasure-code-profile" {
+			if args[2] == "get" {
+				assert.Equal(t, "default", args[3])
+				return `{"plugin":"myplugin","technique":"t"}`, nil
+			}
+			if args[2] == "set" {
+				assert.Equal(t, "myapp", args[3])
+				assert.Equal(t, fmt.Sprintf("k=%d", cfg.DataChunkCount), args[4])
+				assert.Equal(t, fmt.Sprintf("m=%d", cfg.CodingChunkCount), args[5])
+				assert.Equal(t, "plugin=myplugin", args[6])
+				assert.Equal(t, "technique=t", args[7])
+				if failureDomain != "" {
+					assert.Equal(t, fmt.Sprintf("crush-failure-domain=%s", failureDomain), args[8])
+				}
+				return "", nil
+			}
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain)
+	assert.Nil(t, err)
+}

--- a/pkg/ceph/client/pool_test.go
+++ b/pkg/ceph/client/pool_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+func TestCreateECPool(t *testing.T) {
+	p := CephStoragePoolDetails{Name: "mypool", Size: 12345, ErasureCodeProfile: "myecprofile", FailureDomain: "host"}
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[1] == "pool" {
+			if args[2] == "create" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "erasure", args[5])
+				assert.Equal(t, p.ErasureCodeProfile, args[6])
+				return "", nil
+			}
+			if args[2] == "set" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "size", args[4])
+				assert.Equal(t, "12345", args[5])
+				return "", nil
+			}
+			if args[2] == "application" {
+				assert.Equal(t, "enable", args[3])
+				assert.Equal(t, "mypool", args[4])
+				assert.Equal(t, "myapp", args[5])
+				return "", nil
+			}
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	err := CreatePoolForApp(context, "myns", p, "myapp")
+	assert.Nil(t, err)
+}
+
+func TestCreateReplicaPool(t *testing.T) {
+	testCreateReplicaPool(t, "")
+}
+func TestCreateReplicaPoolWithFailureDomain(t *testing.T) {
+	testCreateReplicaPool(t, "osd")
+}
+
+func testCreateReplicaPool(t *testing.T, failureDomain string) {
+	crushRuleCreated := false
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[1] == "pool" {
+			if args[2] == "create" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "replicated", args[5])
+				return "", nil
+			}
+			if args[2] == "set" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "size", args[4])
+				assert.Equal(t, "12345", args[5])
+				return "", nil
+			}
+			if args[2] == "application" {
+				assert.Equal(t, "enable", args[3])
+				assert.Equal(t, "mypool", args[4])
+				assert.Equal(t, "myapp", args[5])
+				return "", nil
+			}
+		}
+		if args[1] == "crush" {
+			crushRuleCreated = true
+			assert.NotEqual(t, "", failureDomain)
+			assert.Equal(t, "rule", args[2])
+			assert.Equal(t, "create-simple", args[3])
+			assert.Equal(t, "mypool-rule", args[4])
+			assert.Equal(t, "default", args[5])
+			assert.Equal(t, failureDomain, args[6])
+			return "", nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	p := CephStoragePoolDetails{Name: "mypool", Size: 12345, FailureDomain: failureDomain}
+	err := CreatePoolForApp(context, "myns", p, "myapp")
+	assert.Nil(t, err)
+	if failureDomain == "" {
+		assert.False(t, crushRuleCreated)
+	} else {
+		assert.True(t, crushRuleCreated)
+	}
+}

--- a/pkg/ceph/rgw/objectstore.go
+++ b/pkg/ceph/rgw/objectstore.go
@@ -228,7 +228,7 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 	cephConfig := ceph.ModelPoolToCephPool(poolSpec)
 	if cephConfig.ErasureCodeProfile != "" {
 		// create a new erasure code profile for the new pool
-		if err := ceph.CreateErasureCodeProfile(context.context, context.ClusterName, poolSpec.ErasureCodedConfig, cephConfig.ErasureCodeProfile); err != nil {
+		if err := ceph.CreateErasureCodeProfile(context.context, context.ClusterName, poolSpec.ErasureCodedConfig, cephConfig.ErasureCodeProfile, poolSpec.FailureDomain); err != nil {
 			return fmt.Errorf("failed to create erasure code profile for object store %s: %+v", context.Name, err)
 		}
 	}

--- a/pkg/operator/mds/mds.go
+++ b/pkg/operator/mds/mds.go
@@ -63,7 +63,7 @@ func CreateFileSystem(context *clusterd.Context, clusterName string, f *model.Fi
 
 // Create the file system
 func (f *Filesystem) Create(context *clusterd.Context, version string, hostNetwork bool) error {
-	if err := f.validate(); err != nil {
+	if err := f.validate(context); err != nil {
 		return err
 	}
 
@@ -193,7 +193,7 @@ func (f *Filesystem) getLabels() map[string]string {
 	}
 }
 
-func (f *Filesystem) validate() error {
+func (f *Filesystem) validate(context *clusterd.Context) error {
 	if f.Name == "" {
 		return fmt.Errorf("missing name")
 	}
@@ -203,11 +203,11 @@ func (f *Filesystem) validate() error {
 	if len(f.Spec.DataPools) == 0 {
 		return fmt.Errorf("at least one data pool required")
 	}
-	if err := f.Spec.MetadataPool.Validate(); err != nil {
+	if err := f.Spec.MetadataPool.Validate(context, f.Namespace); err != nil {
 		return fmt.Errorf("invalid metadata pool. %+v", err)
 	}
 	for _, pool := range f.Spec.DataPools {
-		if err := pool.Validate(); err != nil {
+		if err := pool.Validate(context, f.Namespace); err != nil {
 			return fmt.Errorf("Invalid data pool. %+v", err)
 		}
 	}

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -119,29 +119,30 @@ func TestHostNetwork(t *testing.T) {
 }
 
 func TestValidateSpec(t *testing.T) {
+	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
 	fs := &Filesystem{}
 
 	// missing name
-	assert.NotNil(t, fs.validate())
+	assert.NotNil(t, fs.validate(context))
 	fs.Name = "myfs"
 
 	// missing namespace
-	assert.NotNil(t, fs.validate())
+	assert.NotNil(t, fs.validate(context))
 	fs.Namespace = "myns"
 
 	// missing data pools
-	assert.NotNil(t, fs.validate())
+	assert.NotNil(t, fs.validate(context))
 	p := pool.PoolSpec{Replicated: pool.ReplicatedSpec{Size: 1}}
 	fs.Spec.DataPools = append(fs.Spec.DataPools, p)
 
 	// missing metadata pool
-	assert.NotNil(t, fs.validate())
+	assert.NotNil(t, fs.validate(context))
 	fs.Spec.MetadataPool = p
 
 	// missing mds count
-	assert.NotNil(t, fs.validate())
+	assert.NotNil(t, fs.validate(context))
 	fs.Spec.MetadataServer.ActiveCount = 1
 
 	// valid!
-	assert.Nil(t, fs.validate())
+	assert.Nil(t, fs.validate(context))
 }

--- a/pkg/operator/pool/controller_test.go
+++ b/pkg/operator/pool/controller_test.go
@@ -19,6 +19,7 @@ which also has the apache 2.0 license.
 package pool
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -28,19 +29,21 @@ import (
 )
 
 func TestValidatePool(t *testing.T) {
+	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
+
 	// must specify some replication or EC settings
 	p := Pool{ObjectMeta: metav1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
-	err := p.validate()
+	err := p.validate(context)
 	assert.NotNil(t, err)
 
 	// must specify name
 	p = Pool{ObjectMeta: metav1.ObjectMeta{Namespace: "myns"}}
-	err = p.validate()
+	err = p.validate(context)
 	assert.NotNil(t, err)
 
 	// must specify namespace
 	p = Pool{ObjectMeta: metav1.ObjectMeta{Name: "mypool"}}
-	err = p.validate()
+	err = p.validate(context)
 	assert.NotNil(t, err)
 
 	// must not specify both replication and EC settings
@@ -48,21 +51,45 @@ func TestValidatePool(t *testing.T) {
 	p.Spec.Replicated.Size = 1
 	p.Spec.ErasureCoded.CodingChunks = 2
 	p.Spec.ErasureCoded.DataChunks = 3
-	err = p.validate()
+	err = p.validate(context)
 	assert.NotNil(t, err)
 
 	// succeed with replication settings
 	p = Pool{ObjectMeta: metav1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
 	p.Spec.Replicated.Size = 1
-	err = p.validate()
+	err = p.validate(context)
 	assert.Nil(t, err)
 
 	// succeed with ec settings
 	p = Pool{ObjectMeta: metav1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
 	p.Spec.ErasureCoded.CodingChunks = 1
 	p.Spec.ErasureCoded.DataChunks = 2
-	err = p.validate()
+	err = p.validate(context)
 	assert.Nil(t, err)
+}
+
+func TestValidateFailureDomain(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		if args[1] == "crush" && args[2] == "dump" {
+			return `{"types":[{"type_id": 0,"name": "osd"}]}`, nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	// succeed with a failure domain that exists
+	p := Pool{ObjectMeta: metav1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
+	p.Spec.Replicated.Size = 1
+	p.Spec.FailureDomain = "osd"
+	err := p.validate(context)
+	assert.Nil(t, err)
+
+	// fail with a failure domain that doesn't exist
+	p.Spec.FailureDomain = "doesntexist"
+	err = p.validate(context)
+	assert.NotNil(t, err)
 }
 
 func TestCreatePool(t *testing.T) {

--- a/pkg/operator/pool/types.go
+++ b/pkg/operator/pool/types.go
@@ -45,7 +45,7 @@ type PoolList struct {
 
 // PoolSpec represent the spec of a pool
 type PoolSpec struct {
-	// The failure domain: osd, host, rack
+	// The failure domain: osd or host (technically also any type in the crush map)
 	FailureDomain string `json:"failureDomain"`
 
 	// The replication settings

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -57,7 +57,7 @@ func (s *ObjectStore) Update(context *clusterd.Context, version string, hostNetw
 
 func (s *ObjectStore) createOrUpdate(context *clusterd.Context, version string, hostNetwork, update bool) error {
 	// validate the object store settings
-	if err := s.validate(); err != nil {
+	if err := s.validate(context); err != nil {
 		return fmt.Errorf("invalid object store %s arguments. %+v", s.Name, err)
 	}
 
@@ -212,7 +212,7 @@ func (s *ObjectStore) exists(context *clusterd.Context) (bool, error) {
 }
 
 // Validate the object store arguments
-func (s *ObjectStore) validate() error {
+func (s *ObjectStore) validate(context *clusterd.Context) error {
 	logger.Debugf("validating object store: %+v", s)
 	if s.Name == "" {
 		return fmt.Errorf("missing name")
@@ -220,10 +220,10 @@ func (s *ObjectStore) validate() error {
 	if s.Namespace == "" {
 		return fmt.Errorf("missing namespace")
 	}
-	if err := s.Spec.MetadataPool.Validate(); err != nil {
+	if err := s.Spec.MetadataPool.Validate(context, s.Namespace); err != nil {
 		return fmt.Errorf("invalid metadata pool spec. %+v", err)
 	}
-	if err := s.Spec.DataPool.Validate(); err != nil {
+	if err := s.Spec.DataPool.Validate(context, s.Namespace); err != nil {
 		return fmt.Errorf("invalid data pool spec. %+v", err)
 	}
 

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -173,33 +173,35 @@ func TestCreateObjectStore(t *testing.T) {
 }
 
 func TestValidateSpec(t *testing.T) {
+	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
+
 	// valid store
 	s := simpleStore()
-	err := s.validate()
+	err := s.validate(context)
 	assert.Nil(t, err)
 
 	// no name
 	s.Name = ""
-	err = s.validate()
+	err = s.validate(context)
 	assert.NotNil(t, err)
 	s.Name = "default"
-	err = s.validate()
+	err = s.validate(context)
 	assert.Nil(t, err)
 
 	// no namespace
 	s.Namespace = ""
-	err = s.validate()
+	err = s.validate(context)
 	assert.NotNil(t, err)
 	s.Namespace = "mycluster"
-	err = s.validate()
+	err = s.validate(context)
 	assert.Nil(t, err)
 
 	// no replication or EC
 	s.Spec.MetadataPool.Replicated.Size = 0
-	err = s.validate()
+	err = s.validate(context)
 	assert.NotNil(t, err)
 	s.Spec.MetadataPool.Replicated.Size = 1
-	err = s.validate()
+	err = s.validate(context)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
This change allows a failure domain to be set to any value in the crush map. The default is `host`. The recommend setting for erasure coded pools is `osd`. 
Fixes #1002