### PR TITLE
Replacing kubernetes PR link with a link for flexvolume docs

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -40,7 +40,7 @@ kubectl -n rook-system get pod
 ---
 **Restart Kubelet (K8S 1.7 and older)**
 
-For versions of Kubernetes prior to 1.8, the Kubelet process on all nodes will require a restart after the Rook operator and Rook agents have been deployed. As part of their initial setup, the Rook agents deploy and configure a Flexvolume plugin in order to integrate with Kubernetes' volume controller framework. In Kubernetes v1.8+, the [dynamic Flexvolume plugin discovery](https://github.com/kubernetes/community/pull/833) will find and initialize our plugin, but in older versions of Kubernetes a manual restart of the Kubelet will be required.
+For versions of Kubernetes prior to 1.8, the Kubelet process on all nodes will require a restart after the Rook operator and Rook agents have been deployed. As part of their initial setup, the Rook agents deploy and configure a Flexvolume plugin in order to integrate with Kubernetes' volume controller framework. In Kubernetes v1.8+, the [dynamic Flexvolume plugin discovery](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md#dynamic-plugin-discovery) will find and initialize our plugin, but in older versions of Kubernetes a manual restart of the Kubelet will be required.
 
 **Disable Attacher-detacher controller (K8S 1.6.x only)**
 

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -163,7 +163,7 @@ Once you've verified the operator is `Running` and on the new version, verify th
 Instructions for verifying cluster health can be found in the [health verification section](#health-verification).
 
 ### Agents
-The Rook agents are deployed by the operator to run on every node. They are in charged of handling all operations related to the consumption of storage from the cluster.
+The Rook agents are deployed by the operator to run on every node. They are in charge of handling all operations related to the consumption of storage from the cluster.
 
 The agents are deployed and managed by a Kubernetes daemonset. So in order to upgrade the version of the agent pods, we will need to edit the image version of the pod template in the daemonset spec and then delete each agent pod so that a new pod is created by the daemonset.
 


### PR DESCRIPTION
Fixes https://github.com/rook/rook/issues/1050

[skip ci]. Only docs files are changed