### PR TITLE
Run two MGRs to have one in standby mode

### DIFF
--- a/pkg/operator/mgr/mgr.go
+++ b/pkg/operator/mgr/mgr.go
@@ -56,7 +56,7 @@ func New(context *clusterd.Context, namespace, version string, placement k8sutil
 		Namespace:   namespace,
 		placement:   placement,
 		Version:     version,
-		Replicas:    1,
+		Replicas:    2,
 		dataDir:     k8sutil.DataDir,
 		HostNetwork: hostNetwork,
 	}


### PR DESCRIPTION
See #1048.
Fixes #1048.

Note: the existing tests already test for a replicas of 3.

***

## Logs from my test:
### After cluster creation
`rook-ceph-mgr0-2792268363-zhznq`:
```
2017-10-09 20:39:52.948648 I | ceph-mgr: 2017-10-09 20:39:52.948122 7f52edac4700  1 mgr.server send_report Not sending PG status to monitor yet, waiting for OSDs
2017-10-09 20:39:53.286555 I | ceph-mgr: 2017-10-09 20:39:53.286450 7f52ef2c7700  1 mgr finish mon failed to return metadata for osd.0: (2) No such file or directory
2017-10-09 20:39:54.306837 I | ceph-mgr: 2017-10-09 20:39:54.306749 7f52ef2c7700  1 mgr finish mon failed to return metadata for osd.0: (2) No such file or directory
2017-10-09 20:39:54.948710 I | ceph-mgr: 2017-10-09 20:39:54.948270 7f52edac4700  1 mgr send_beacon active
2017-10-09 20:39:56.948934 I | ceph-mgr: 2017-10-09 20:39:56.948574 7f52edac4700  1 mgr send_beacon active
2017-10-09 20:39:58.949449 I | ceph-mgr: 2017-10-09 20:39:58.948975 7f52edac4700  1 mgr send_beacon active
```
`rook-ceph-mgr1-3797254331-gch0m`:
```
2017-10-09 20:39:49.034293 I | ceph-mgr: 2017-10-09 20:39:49.034180 7f9f94270500  0 ceph version af31b0aa0 (5af31b0aa028c6a69306c890f8d91fb9463a28f7) luminous (stable), process (unknown), pid 13
2017-10-09 20:39:49.034628 I | ceph-mgr: 2017-10-09 20:39:49.034488 7f9f94270500  0 pidfile_write: ignore empty --pid-file
2017-10-09 20:39:49.043077 I | ceph-mgr: 2017-10-09 20:39:49.043020 7f9f94270500  1 mgr send_beacon standby
2017-10-09 20:39:51.044073 I | ceph-mgr: 2017-10-09 20:39:51.043960 7f9f858c0700  1 mgr send_beacon standby
2017-10-09 20:39:53.044593 I | ceph-mgr: 2017-10-09 20:39:53.044475 7f9f858c0700  1 mgr send_beacon standby
```

### Test Failover
Stopping (scaling the `mgr0` deploy to zero) the `mgr1` takes over:
```
2017-10-09 21:01:32.014876 I | ceph-mgr: 2017-10-09 21:01:32.014690 7f9f858c0700  1 mgr send_beacon standby
2017-10-09 21:01:34.017605 I | ceph-mgr: 2017-10-09 21:01:34.017528 7f9f858c0700  1 mgr send_beacon standby
2017-10-09 21:01:36.018506 I | ceph-mgr: 2017-10-09 21:01:36.018382 7f9f858c0700  1 mgr send_beacon standby
2017-10-09 21:01:36.747405 I | ceph-mgr: 2017-10-09 21:01:36.747067 7f9f888c6700  1 mgr handle_mgr_map Activating!
2017-10-09 21:01:36.747527 I | ceph-mgr: 2017-10-09 21:01:36.747313 7f9f888c6700  1 mgr handle_mgr_map I am now activating
2017-10-09 21:01:36.774672 I | ceph-mgr: 2017-10-09 21:01:36.774505 7f9f848be700  1 mgr init Loading python module 'restful'
2017-10-09 21:01:36.874240 I | ceph-mgr: 2017-10-09 21:01:36.874019 7f9f848be700 -1 mgr load Module not found: 'restful'
2017-10-09 21:01:36.874944 I | ceph-mgr: 2017-10-09 21:01:36.874043 7f9f848be700 -1 mgr load Traceback (most recent call last):
2017-10-09 21:01:36.874952 I | ceph-mgr:   File "/usr/local/lib/ceph/mgr/restful/__init__.py", line 1, in <module>
2017-10-09 21:01:36.874955 I | ceph-mgr:     from module import *  # NOQA
2017-10-09 21:01:36.874957 I | ceph-mgr:   File "/usr/local/lib/ceph/mgr/restful/module.py", line 17, in <module>
2017-10-09 21:01:36.874961 I | ceph-mgr:     from pecan import jsonify, make_app
2017-10-09 21:01:36.875027 I | ceph-mgr: ImportError: No module named pecan
2017-10-09 21:01:36.875046 I | ceph-mgr: 
2017-10-09 21:01:36.875061 I | ceph-mgr: 2017-10-09 21:01:36.874726 7f9f848be700 -1 mgr init Error loading module 'restful': (2) No such file or directory
2017-10-09 21:01:36.875064 I | ceph-mgr: 2017-10-09 21:01:36.874756 7f9f848be700  1 mgr init Loading python module 'status'
2017-10-09 21:01:36.908932 I | ceph-mgr: 2017-10-09 21:01:36.908447 7f9f848be700  1 mgr load Constructed class from module: status
2017-10-09 21:01:36.908956 I | ceph-mgr: 2017-10-09 21:01:36.908538 7f9f848be700 -1 log_channel(cluster) log [ERR] : Failed to load ceph-mgr modules: restful
2017-10-09 21:01:36.908960 I | ceph-mgr: 2017-10-09 21:01:36.908562 7f9f848be700  1 mgr start Creating threads for 1 modules
2017-10-09 21:01:36.908962 I | ceph-mgr: 2017-10-09 21:01:36.908640 7f9f848be700  1 mgr send_beacon active
2017-10-09 21:01:38.022982 I | ceph-mgr: 2017-10-09 21:01:38.021805 7f9f858c0700  1 mgr send_beacon active
2017-10-09 21:01:40.023294 I | ceph-mgr: 2017-10-09 21:01:40.023045 7f9f858c0700  1 mgr send_beacon active
```

### Test standby register after scale up
After scaling `mgr0` up again, it registers as `standby`:
```
2017-10-09 21:02:02.291980 I | ceph-mgr: 2017-10-09 21:02:02.291816 7f9f8ed7d500  1 mgr send_beacon standby
2017-10-09 21:02:04.295700 I | ceph-mgr: 2017-10-09 21:02:04.295271 7f9f803cd700  1 mgr send_beacon standby
2017-10-09 21:02:06.296914 I | ceph-mgr: 2017-10-09 21:02:06.296776 7f9f803cd700  1 mgr send_beacon standby
```