### PR TITLE
Purge data pools when file, object, and pool CRDs are deleted

### DIFF
--- a/cmd/rookctl/pool/delete.go
+++ b/cmd/rookctl/pool/delete.go
@@ -15,15 +15,38 @@ limitations under the License.
 */
 package pool
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
 
-var Cmd = &cobra.Command{
-	Use:   "pool",
-	Short: "Performs commands and operations on storage pools in the cluster",
+	"github.com/rook/rook/cmd/rookctl/rook"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete [name]",
+	Short: "Deletes a pool from the cluster",
 }
 
 func init() {
-	Cmd.AddCommand(listCmd)
-	Cmd.AddCommand(createCmd)
-	Cmd.AddCommand(deleteCmd)
+	deleteCmd.RunE = deleteObjectStoreEntry
+}
+
+func deleteObjectStoreEntry(cmd *cobra.Command, args []string) error {
+	rook.SetupLogging()
+
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "missing pool name")
+		os.Exit(1)
+	}
+
+	poolName := args[0]
+	c := rook.NewRookNetworkRestClient()
+	err := c.DeletePool(poolName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	return nil
 }

--- a/pkg/api/filesystem_test.go
+++ b/pkg/api/filesystem_test.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/api/core/v1"
 
+	"github.com/rook/rook/pkg/ceph/client"
 	cephtest "github.com/rook/rook/pkg/ceph/test"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/model"
@@ -179,6 +180,16 @@ func TestRemoveFileSystemHandler(t *testing.T) {
 				}
 				if args[1] == "get" {
 					return basicFS, nil
+				}
+			}
+			if args[0] == "osd" {
+				if args[1] == "lspools" {
+					pools := []*client.CephStoragePoolSummary{
+						{Name: "mypool", Number: 0},
+					}
+					output, err := json.Marshal(pools)
+					assert.Nil(t, err)
+					return string(output), nil
 				}
 			}
 			return "", fmt.Errorf("unexpected command '%s'", args[0])

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -194,7 +194,7 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 
 // GetUser gets the passed users info from the object store in this cluster.
 // GET
-// /objectstore/{name}/users/{USER_ID}
+// /objectstore/{name}/users/{id}
 func (h *Handler) GetUser(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 

--- a/pkg/api/pool.go
+++ b/pkg/api/pool.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	ceph "github.com/rook/rook/pkg/ceph/client"
 	"github.com/rook/rook/pkg/model"
 )
@@ -36,6 +37,18 @@ func (h *Handler) GetPools(w http.ResponseWriter, r *http.Request) {
 	}
 
 	FormatJsonResponse(w, pools)
+}
+
+// Creates a storage pool as specified by the request body.
+// DELETE
+// /pool/{name}
+func (h *Handler) DeletePool(w http.ResponseWriter, r *http.Request) {
+	poolName := mux.Vars(r)["name"]
+	if err := ceph.DeletePool(h.config.context, h.config.namespace, poolName); err != nil {
+		logger.Errorf("failed to delete pool '%s'. %+v", poolName, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 // Creates a storage pool as specified by the request body.
@@ -57,7 +70,7 @@ func (h *Handler) CreatePool(w http.ResponseWriter, r *http.Request) {
 
 	err := ceph.CreatePoolWithProfile(h.context, h.config.clusterInfo.Name, newPool, newPool.Name)
 	if err != nil {
-		logger.Errorf("failed to create new pool '%s': %+v", newPool.Name, err)
+		logger.Errorf("failed to create new pool '%s'. %+v", newPool.Name, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -48,6 +48,12 @@ func (h *Handler) GetRoutes() []Route {
 			h.CreatePool,
 		},
 		{
+			"DeletePool",
+			"DELETE",
+			"/pool/{name}",
+			h.DeletePool,
+		},
+		{
 			"GetImages",
 			"GET",
 			"/image",

--- a/pkg/ceph/client/filesystem.go
+++ b/pkg/ceph/client/filesystem.go
@@ -44,6 +44,8 @@ type MDSMap struct {
 	MaxMDS         int                `json:"max_mds"`
 	In             []int              `json:"in"`
 	Up             map[string]int     `json:"up"`
+	MetadataPool   int                `json:"metadata_pool"`
+	DataPools      []int              `json:"data_pools"`
 	Failed         []int              `json:"failed"`
 	Damaged        []int              `json:"damaged"`
 	Stopped        []int              `json:"stopped"`
@@ -150,11 +152,50 @@ func FailMDS(context *clusterd.Context, clusterName string, gid int) error {
 	return nil
 }
 
-func RemoveFilesystem(context *clusterd.Context, clusterName string, fsName string) error {
+func RemoveFilesystem(context *clusterd.Context, clusterName, fsName string) error {
+	fs, err := GetFilesystem(context, clusterName, fsName)
+	if err != nil {
+		return fmt.Errorf("filesystem %s not found. %+v", fsName, err)
+	}
+
 	args := []string{"fs", "rm", fsName, confirmFlag}
-	_, err := ExecuteCephCommand(context, clusterName, args)
+	_, err = ExecuteCephCommand(context, clusterName, args)
 	if err != nil {
 		return fmt.Errorf("Failed to delete ceph fs %s. err=%+v", fsName, err)
 	}
+
+	err = deleteFSPools(context, clusterName, fs)
+	if err != nil {
+		return fmt.Errorf("failed to delete fs %s pools. %+v", fsName, err)
+	}
 	return nil
+}
+
+func deleteFSPools(context *clusterd.Context, clusterName string, fs *CephFilesystemDetails) error {
+	poolNames, err := GetPoolNamesByID(context, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to get pool names. %+v", err)
+	}
+
+	// delete the metadata pool
+	var lastErr error
+	if err := deleteFSPool(context, clusterName, poolNames, fs.MDSMap.MetadataPool); err != nil {
+		lastErr = err
+	}
+
+	// delete the data pools
+	for _, poolID := range fs.MDSMap.DataPools {
+		if err := deleteFSPool(context, clusterName, poolNames, poolID); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func deleteFSPool(context *clusterd.Context, clusterName string, poolNames map[int]string, id int) error {
+	name, ok := poolNames[id]
+	if !ok {
+		return fmt.Errorf("pool %d not found", id)
+	}
+	return DeletePool(context, clusterName, name)
 }

--- a/pkg/ceph/client/pool_test.go
+++ b/pkg/ceph/client/pool_test.go
@@ -98,7 +98,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain string) {
 			assert.NotEqual(t, "", failureDomain)
 			assert.Equal(t, "rule", args[2])
 			assert.Equal(t, "create-simple", args[3])
-			assert.Equal(t, "mypool-rule", args[4])
+			assert.Equal(t, "mypool", args[4])
 			assert.Equal(t, "default", args[5])
 			assert.Equal(t, failureDomain, args[6])
 			return "", nil

--- a/pkg/ceph/mon/config.go
+++ b/pkg/ceph/mon/config.go
@@ -51,6 +51,7 @@ type GlobalConfig struct {
 	ClusterAddr              string `ini:"cluster addr,omitempty"`
 	ClusterNetwork           string `ini:"cluster network,omitempty"`
 	MonKeyValueDb            string `ini:"mon keyvaluedb"`
+	MonAllowPoolDelete       bool   `ini:"mon_allow_pool_delete"`
 	DebugLogDefaultLevel     int    `ini:"debug default"`
 	DebugLogRadosLevel       int    `ini:"debug rados"`
 	DebugLogMonLevel         int    `ini:"debug mon"`
@@ -263,6 +264,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 			ClusterAddr:            context.NetworkInfo.ClusterAddrIPv4,
 			ClusterNetwork:         context.NetworkInfo.ClusterNetwork,
 			MonKeyValueDb:          "rocksdb",
+			MonAllowPoolDelete:     true,
 			DebugLogDefaultLevel:   cephLogLevel,
 			DebugLogRadosLevel:     cephLogLevel,
 			DebugLogMonLevel:       cephLogLevel,

--- a/pkg/ceph/mon/daemon.go
+++ b/pkg/ceph/mon/daemon.go
@@ -82,10 +82,6 @@ func Run(context *clusterd.Context, config *Config) error {
 }
 
 func generateConfigFiles(context *clusterd.Context, config *Config) (string, string, error) {
-	// write the latest config to the config dir
-	if err := GenerateAdminConnectionConfig(context, config.Cluster); err != nil {
-		return "", "", fmt.Errorf("failed to write connection config. %+v", err)
-	}
 
 	// write the keyring to disk
 	if err := writeMonKeyring(context, config.Cluster, config.Name); err != nil {

--- a/pkg/operator/pool/controller.go
+++ b/pkg/operator/pool/controller.go
@@ -136,14 +136,11 @@ func (p *Pool) create(context *clusterd.Context) error {
 
 // Delete the pool
 func (p *Pool) delete(context *clusterd.Context) error {
-	// check if the pool  exists
-	exists, err := p.exists(context)
-	if err == nil && !exists {
-		return nil
+
+	if err := ceph.DeletePool(context, p.Namespace, p.Name); err != nil {
+		return fmt.Errorf("failed to delete pool '%s'. %+v", p.Name, err)
 	}
 
-	logger.Infof("TODO: delete pool %s from namespace %s", p.Name, p.Namespace)
-	//return p.client.DeletePool(p.PoolSpec.Name)
 	return nil
 }
 

--- a/pkg/rook/client/client.go
+++ b/pkg/rook/client/client.go
@@ -35,6 +35,7 @@ type RookRestClient interface {
 	GetNodes() ([]model.Node, error)
 	GetPools() ([]model.Pool, error)
 	CreatePool(pool model.Pool) (string, error)
+	DeletePool(name string) error
 	GetBlockImages() ([]model.BlockImage, error)
 	CreateBlockImage(image model.BlockImage) (string, error)
 	DeleteBlockImage(image model.BlockImage) (string, error)

--- a/pkg/rook/client/pool.go
+++ b/pkg/rook/client/pool.go
@@ -18,6 +18,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"path"
 
 	"github.com/rook/rook/pkg/model"
 )
@@ -53,4 +54,14 @@ func (c *RookNetworkRestClient) CreatePool(newPool model.Pool) (string, error) {
 	}
 
 	return string(resp), nil
+}
+
+func (c *RookNetworkRestClient) DeletePool(name string) error {
+
+	_, err := c.DoDelete(path.Join(poolQueryName, name))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/rook/test/mockclient.go
+++ b/pkg/rook/test/mockclient.go
@@ -33,6 +33,7 @@ type MockRookRestClient struct {
 	MockGetNodes                     func() ([]model.Node, error)
 	MockGetPools                     func() ([]model.Pool, error)
 	MockCreatePool                   func(pool model.Pool) (string, error)
+	MockDeletePool                   func(name string) error
 	MockGetBlockImages               func() ([]model.BlockImage, error)
 	MockCreateBlockImage             func(image model.BlockImage) (string, error)
 	MockDeleteBlockImage             func(image model.BlockImage) (string, error)
@@ -77,6 +78,14 @@ func (m *MockRookRestClient) CreatePool(pool model.Pool) (string, error) {
 	}
 
 	return "", nil
+}
+
+func (m *MockRookRestClient) DeletePool(name string) error {
+	if m.MockDeletePool != nil {
+		return m.MockDeletePool(name)
+	}
+
+	return nil
 }
 
 func (m *MockRookRestClient) GetBlockImages() ([]model.BlockImage, error) {

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -107,7 +107,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	require.Equal(s.T(), uint64(0), ObjNum1)
 	logger.Infof("Object deleted on bucket successfully")
 
-	logger.Infof("Step 6 : Delete  bucket")
+	logger.Infof("Step 7 : Delete bucket")
 	_, bkdelErr := s3client.DeleteBucket(bucketname)
 	require.Nil(s.T(), bkdelErr)
 	BucketsAfterDelete, _ := oc.ObjectBucketList(storeName)
@@ -120,7 +120,6 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	usersAfterDelete, _ := oc.ObjectListUser(storeName)
 	require.Equal(s.T(), len(usersBeforeDelete)-1, len(usersAfterDelete), "Make sure user list count is reducd by 1")
 	logger.Infof("Object store user deleted successfully")
-
 }
 
 //Test Object StoreCreation on Rook that was installed via helm


### PR DESCRIPTION
Currently when a pool, object, or file CRD are deleted, all of their underlying Ceph pools remain in the system. This change will permanently delete the data pools corresponding to the service. Fixes #1001