### PR TITLE
Updated references to charts.rook.io to https

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -40,14 +40,14 @@ If role-based access control (RBAC) is enabled in your cluster, you may need to 
 To install the chart from out published registry, run the following:
 
 ```console
-$ helm repo add rook-<channel> http://charts.rook.io/<channel>
+$ helm repo add rook-<channel> https://charts.rook.io/<channel>
 $ helm install rook-<channel>/rook
 ```
 
 Be sure to replace `<channel>` with `alpha` or `master` (in the future `beta` and `stable` when available), for example:
 
 ```console
-$ helm repo add rook-alpha http://charts.rook.io/alpha
+$ helm repo add rook-alpha https://charts.rook.io/alpha
 $ helm install rook-alpha/rook
 ```
 


### PR DESCRIPTION
Using http based URLs with helm just returns errors when trying to redirect to https. 

````
0:0 ᐅ   helm repo add rook-alpha-test http://charts.rook.io/alpha 
Error: Looks like "http://charts.rook.io/alpha" is not a valid chart repository or cannot be reached: Failed to fetch http://charts.rook.io/alpha/index.yaml : 403 Forbidden
````