### PR TITLE
operator/mon: health check improvements

### DIFF
--- a/pkg/ceph/client/test/mon.go
+++ b/pkg/ceph/client/test/mon.go
@@ -23,7 +23,7 @@ import (
 
 func MonInQuorumResponse() string {
 	resp := client.MonStatusResponse{Quorum: []int{0}}
-	resp.MonMap.Mons = []client.MonMapEntry{{Name: "mon0", Rank: 0, Address: "1.2.3.4"}}
+	resp.MonMap.Mons = []client.MonMapEntry{{Name: "mon1", Rank: 0, Address: "1.2.3.4"}}
 	serialized, _ := json.Marshal(resp)
 	return string(serialized)
 }


### PR DESCRIPTION
Fixes #1073 

This overall improves the behavior when a mon isn't in the Ceph mon map anymore.
The mon will be placed in the monOutTimeout list to prevent a mon to be failovered when it is still starting (and simply taking a bit longer than the healthCheck interval).