### PR TITLE
add helm stable repo to test env

### DIFF
--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -65,6 +65,7 @@ case "${1:-}" in
   up)
     install
     cat _output/version | xargs ${scriptdir}/makeTestImages.sh tag amd64 || true
+    helm repo add stable https://kubernetes-charts.storage.googleapis.com/
     ;;
   clean)
     helm_reset


### PR DESCRIPTION
To make it simpler to install stable helm charts in minikube and kubeadm...
[skip ci]