### PR TITLE
operator/mon: Allow to set the mon size by cluster CRD spec

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -23,7 +23,8 @@ Settings can be specified at the global level to apply to the cluster as a whole
 - `versionTag`: The version (tag) of the `rook/rook` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
 - `dataDirHostPath`: The host path where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.  Therefore, for test scenarios, the path must be deleted if you are going to delete a cluster and start a new cluster on the same hosts.  More details can be found in the Kubernetes [host path docs](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).
 If this value is empty, each pod will get an ephemeral directory to store their config files that is tied to the lifetime of the pod running on that node. More details can be found in the Kubernetes [empty dir docs](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
-- `hostNetwork`: uses host network instead of using the SDN below the containers
+- `hostNetwork`: uses network of the hosts instead of using the SDN below the containers.
+- `monCount`: set the amount of mons to be started. The number must be odd and between `1` and `9`. Default if not specified is `3`.
 - `placement`: [placement configuration settings](#placement-configuration-settings)
 - `storage`: Storage selection and configuration that will be used across the cluster.  Note that these settings can be overridden for specific nodes.
   - `useAllNodes`: `true` or `false`, indicating if all nodes in the cluster should be used for storage according to the cluster level storage selection and configuration values.

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -13,6 +13,8 @@ spec:
   dataDirHostPath:
   # toggle to use hostNetwork
   hostNetwork: false
+  # set the amount of mons to be started
+  monCount: 3
 # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
 # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
 # tolerate taints with a key of 'storage-node'.

--- a/pkg/operator/cluster/types.go
+++ b/pkg/operator/cluster/types.go
@@ -75,6 +75,9 @@ type ClusterSpec struct {
 
 	// HostNetwork to enable host network
 	HostNetwork bool `json:"hostNetwork"`
+
+	// MonCount sets the mon size
+	MonCount int `json:"monCount"`
 }
 
 // PlacementSpec is a set of Placement configurations for the rook cluster.

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -99,14 +99,14 @@ type nodeInfo struct {
 }
 
 // New creates an instance of a mon cluster
-func New(context *clusterd.Context, namespace, dataDirHostPath, version string, placement k8sutil.Placement, hostNetwork bool) *Cluster {
+func New(context *clusterd.Context, namespace, dataDirHostPath, version string, size int, placement k8sutil.Placement, hostNetwork bool) *Cluster {
 	return &Cluster{
 		context:             context,
 		placement:           placement,
 		dataDirHostPath:     dataDirHostPath,
 		Namespace:           namespace,
 		Version:             version,
-		Size:                3,
+		Size:                size,
 		maxMonID:            -1,
 		waitForStart:        true,
 		monPodRetryInterval: 6 * time.Second,

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -149,7 +149,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(1)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(1)
 
 	// create the initial config map
@@ -194,8 +194,7 @@ func TestCheckHealth(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(context, "ns", "", "myversion", k8sutil.Placement{}, false)
-	c.Size = 1
+	c := New(context, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(1)
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -258,7 +257,7 @@ func TestMonID(t *testing.T) {
 
 func TestAvailableMonNodes(t *testing.T) {
 	clientset := test.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 	nodes, err := c.getAvailableMonNodes()
 	assert.Nil(t, err)
@@ -275,7 +274,7 @@ func TestAvailableMonNodes(t *testing.T) {
 
 func TestAvailableNodesInUse(t *testing.T) {
 	clientset := test.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	// all three nodes are available by default
@@ -306,7 +305,7 @@ func TestAvailableNodesInUse(t *testing.T) {
 
 func TestTaintedNodes(t *testing.T) {
 	clientset := test.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	nodes, err := c.getAvailableMonNodes()
@@ -339,7 +338,7 @@ func TestTaintedNodes(t *testing.T) {
 
 func TestNodeAffinity(t *testing.T) {
 	clientset := test.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	nodes, err := c.getAvailableMonNodes()
@@ -379,7 +378,7 @@ func TestNodeAffinity(t *testing.T) {
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	c.HostNetwork = true
@@ -409,7 +408,7 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 		},
 	}
 
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", k8sutil.Placement{}, true)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, true)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	var info *nodeInfo
@@ -438,7 +437,7 @@ func TestHostNetworkPortIncrease(t *testing.T) {
 	c := New(&clusterd.Context{
 		Clientset: clientset,
 		ConfigDir: configDir,
-	}, "ns", "", "myversion", k8sutil.Placement{}, true)
+	}, "ns", "", "myversion", 3, k8sutil.Placement{}, true)
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	mons := []*monConfig{
@@ -481,8 +480,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(context, "ns", "", "myversion", k8sutil.Placement{}, false)
-	c.Size = 2
+	c := New(context, "ns", "", "myversion", 2, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(2)
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)

--- a/pkg/operator/mon/spec_test.go
+++ b/pkg/operator/mon/spec_test.go
@@ -34,7 +34,7 @@ func TestPodSpecs(t *testing.T) {
 
 func testPodSpec(t *testing.T, dataDir string) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "myversion", k8sutil.Placement{}, false)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = testop.CreateConfigDir(0)
 	config := &monConfig{Name: "mon0", Port: 6790}
 


### PR DESCRIPTION
Fixes #1074.

This allows setting the mon size/replicas by a key in the rook cluster CRD spec. The key is named `monSize`.

***

**Note**: ~~I'm currently testing this change.~~ Tests successful. I set the `monSize: 5` in the cluster CRD and I get:
```
$ kubectl get -n rook po
NAME                              READY     STATUS    RESTARTS   AGE
rook-api-1435667874-gj81r         1/1       Running   0          2m
rook-ceph-mgr0-2792268363-jb2nb   1/1       Running   0          2m
rook-ceph-mgr1-3797254331-x1fj7   1/1       Running   0          2m
rook-ceph-mon0-j467l              1/1       Running   0          2m
rook-ceph-mon1-kw722              1/1       Running   0          2m
rook-ceph-mon2-lj6xz              1/1       Running   0          2m
rook-ceph-mon3-9t7mt              1/1       Running   0          2m
rook-ceph-mon4-mh48p              1/1       Running   0          2m
rook-ceph-osd-hhhq1               1/1       Running   0          2m
```
When not having set a `monSize` the operator logs:
```
[...]
2017-10-17 21:17:36.940351 I | op-kit: start watching cluster resource in all namespaces at v1alpha1
2017-10-17 21:17:42.843937 W | op-cluster: mon size is 0 or less (given: 0), needs to be greater 0. defaulting to 3
2017-10-17 21:17:42.844010 I | op-cluster: starting cluster rook in namespace rook
2017-10-17 21:17:48.849682 I | op-mon: start running mons
[...]
```