### PR TITLE
Reduce build concurrency for more stable build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,11 +25,12 @@ pipeline {
                     if (body.contains("[skip ci]")) {
                          echo ("'[skip ci]' spotted in PR body text. Aborting.")
                          env.shouldBuild = "false"
-
+                    }
+                    if (body.contains("[skip tests]")) {
+                         env.shouldTest = "false"
                     }
                     if (body.contains("[smoke only]")) {
                           env.smokeOnly = "true"
-
                     }
                 }
             }
@@ -58,7 +59,7 @@ pipeline {
        stage('Integration Tests') {
             when {
                 expression {
-                    return env.shouldBuild != "false"
+                    return env.shouldBuild != "false" && env.shouldTest != "false"
                 }
             }
             steps{
@@ -91,7 +92,7 @@ pipeline {
         stage('Publish') {
             when {
                 expression {
-                    return env.shouldBuild != "false"
+                    return env.shouldBuild != "false" && env.shouldTest != "false"
                 }
             }
             environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'build/run make -j\$(nproc) build.all'
+                sh 'build/run make -j4 build.all'
             }
         }
         stage('Unit Tests') {


### PR DESCRIPTION
Our most frequent build error is an error about a missing go import. The error is about a different import every time. It is suspected that the error occurs due to the high concurrency on the build machine. This is an experiment to see if the build concurrency does have an impact.
[skip tests]