### PR TITLE
crush: set host properly in the crush map

### DIFF
--- a/pkg/ceph/client/crush.go
+++ b/pkg/ceph/client/crush.go
@@ -200,7 +200,7 @@ func CreateDefaultCrushMap(context *clusterd.Context, clusterName string) (strin
 	return "", nil
 }
 
-func FormatLocation(location string) ([]string, error) {
+func FormatLocation(location, hostName string) ([]string, error) {
 	var pairs []string
 	if location == "" {
 		pairs = []string{}
@@ -217,6 +217,12 @@ func FormatLocation(location string) ([]string, error) {
 	// set a default root if it's not already set
 	if !isCrushFieldSet("root", pairs) {
 		pairs = append(pairs, formatProperty("root", "default"))
+	}
+	// set the host name
+	if !isCrushFieldSet("host", pairs) {
+		// keep the fully qualified host name in the crush map, but replace the dots with dashes to satisfy ceph
+		hostName = strings.Replace(hostName, ".", "-", -1)
+		pairs = append(pairs, formatProperty("host", hostName))
 	}
 
 	return pairs, nil

--- a/pkg/ceph/client/crush_test.go
+++ b/pkg/ceph/client/crush_test.go
@@ -249,16 +249,17 @@ func TestCrushLocation(t *testing.T) {
 	loc := "dc=datacenter1"
 
 	// test that root will get filled in with default/runtime values
-	res, err := FormatLocation(loc)
+	res, err := FormatLocation(loc, "my.node")
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(res))
+	assert.Equal(t, 3, len(res))
 	locSet := util.CreateSet(res)
 	assert.True(t, locSet.Contains("root=default"))
 	assert.True(t, locSet.Contains("dc=datacenter1"))
+	assert.True(t, locSet.Contains("host=my-node"))
 
 	// test that if host name and root are already set they will be honored
 	loc = "root=otherRoot,dc=datacenter2,host=node123"
-	res, err = FormatLocation(loc)
+	res, err = FormatLocation(loc, "othernode")
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(res))
 	locSet = util.CreateSet(res)
@@ -268,7 +269,7 @@ func TestCrushLocation(t *testing.T) {
 
 	// test an invalid CRUSH location format
 	loc = "root=default,prop:value"
-	_, err = FormatLocation(loc)
+	_, err = FormatLocation(loc, "othernode")
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "is not in a valid format")
 }

--- a/pkg/ceph/mds/daemon.go
+++ b/pkg/ceph/mds/daemon.go
@@ -81,7 +81,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 
 	keyringPath := getMDSKeyringPath(context.ConfigDir)
 	_, err = mon.GenerateConfigFile(context, config.ClusterInfo, getMDSConfDir(context.ConfigDir),
-		fmt.Sprintf("mds.%s", config.ID), keyringPath, false, nil, settings)
+		fmt.Sprintf("mds.%s", config.ID), keyringPath, nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create mds config file. %+v", err)
 	}

--- a/pkg/ceph/mgr/daemon.go
+++ b/pkg/ceph/mgr/daemon.go
@@ -72,7 +72,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	}
 	logger.Infof("Conf files: dir=%s keyring=%s", confDir, keyringPath)
 	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, confDir,
-		username, keyringPath, false, nil, settings)
+		username, keyringPath, nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create config file. %+v", err)
 	}

--- a/pkg/ceph/mon/config_test.go
+++ b/pkg/ceph/mon/config_test.go
@@ -53,20 +53,14 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 		},
 	}
 
-	cephConfig := CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1", false)
-	verifyConfig(t, cephConfig, monMembers, "", "filestore", 0)
-
-	cephConfig = CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1", true)
-	verifyConfig(t, cephConfig, monMembers, "bluestore rocksdb", "bluestore", 0)
+	cephConfig := CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1")
+	verifyConfig(t, cephConfig, monMembers, 0)
 
 	// now use DEBUG level logging
 	context.LogLevel = capnslog.DEBUG
 
-	cephConfig = CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1", false)
-	verifyConfig(t, cephConfig, monMembers, "", "filestore", 10)
-
-	cephConfig = CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1", true)
-	verifyConfig(t, cephConfig, monMembers, "bluestore rocksdb", "bluestore", 10)
+	cephConfig = CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1")
+	verifyConfig(t, cephConfig, monMembers, 10)
 
 	// verify the network info config
 	assert.Equal(t, "10.1.1.1", cephConfig.PublicAddr)
@@ -108,7 +102,7 @@ debug bluestore = 1234`
 	}
 
 	// generate the config file to disk now
-	configFilePath, err := GenerateConfigFile(context, clusterInfo, configDir, "myuser", filepath.Join(configDir, "mykeyring"), false, nil, nil)
+	configFilePath, err := GenerateConfigFile(context, clusterInfo, configDir, "myuser", filepath.Join(configDir, "mykeyring"), nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, filepath.Join(configDir, "foo-cluster.config"), configFilePath)
 
@@ -121,7 +115,7 @@ debug bluestore = 1234`
 	verifyConfigValue(t, actualConf, "global", "debug bluestore", "1234")
 }
 
-func verifyConfig(t *testing.T, cephConfig *cephConfig, expectedMonMembers, experimental, objectStore string, loggingLevel int) {
+func verifyConfig(t *testing.T, cephConfig *cephConfig, expectedMonMembers string, loggingLevel int) {
 
 	for _, expectedMon := range strings.Split(expectedMonMembers, " ") {
 		contained := false
@@ -135,8 +129,6 @@ func verifyConfig(t *testing.T, cephConfig *cephConfig, expectedMonMembers, expe
 		assert.True(t, contained, "expectedMons: %+v, actualMons: %+v", expectedMonMembers, cephConfig.MonMembers)
 	}
 
-	assert.Equal(t, experimental, cephConfig.EnableExperimental)
-	assert.Equal(t, objectStore, cephConfig.OsdObjectStore)
 	assert.Equal(t, loggingLevel, cephConfig.DebugLogDefaultLevel)
 	assert.Equal(t, loggingLevel, cephConfig.DebugLogMonLevel)
 	assert.Equal(t, loggingLevel, cephConfig.DebugLogRadosLevel)

--- a/pkg/ceph/osd/agent.go
+++ b/pkg/ceph/osd/agent.go
@@ -361,7 +361,7 @@ func (a *OsdAgent) startOSD(context *clusterd.Context, config *osdConfig) error 
 		}
 	} else {
 		// update the osd config file
-		err := writeConfigFile(config, context, a.cluster)
+		err := writeConfigFile(config, context, a.cluster, a.location)
 		if err != nil {
 			logger.Warningf("failed to update config file. %+v", err)
 		}

--- a/pkg/ceph/osd/daemon.go
+++ b/pkg/ceph/osd/daemon.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"path"
 	"regexp"
 	"time"
 
@@ -38,13 +39,12 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephosd")
 
 func Run(context *clusterd.Context, agent *OsdAgent) error {
-	if err := setNodeName(context, agent.nodeName); err != nil {
-		// It's best effort so will not block creation of osd if there is a failure.
-		logger.Warningf("failed to set hostname: %+v", err)
-	}
+	// set the crush location in the osd config file
+	cephConfig := mon.CreateDefaultCephConfig(context, agent.cluster, path.Join(context.ConfigDir, agent.cluster.Name))
+	cephConfig.GlobalConfig.CrushLocation = agent.location
 
 	// write the latest config to the config dir
-	if err := mon.GenerateAdminConnectionConfig(context, agent.cluster); err != nil {
+	if err := mon.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig); err != nil {
 		return fmt.Errorf("failed to write connection config. %+v", err)
 	}
 
@@ -89,21 +89,6 @@ func Run(context *clusterd.Context, agent *OsdAgent) error {
 	log.Printf("sleeping a while to let the osds run...")
 	<-time.After(1000000 * time.Second)
 
-	return nil
-}
-
-// Set the name of the node. We don't want the name of the pod,
-// which would change if the pod is re-created.
-func setNodeName(context *clusterd.Context, nodeName string) error {
-	nodeName = strings.Replace(nodeName, ".", "-", -1)
-	if nodeName == "" {
-		return fmt.Errorf("node name is not set")
-	}
-
-	err := context.ProcMan.Run("", "hostname", nodeName)
-	if err != nil {
-		return fmt.Errorf("hostname failed to set: %+v", err)
-	}
 	return nil
 }
 

--- a/pkg/ceph/osd/daemon_test.go
+++ b/pkg/ceph/osd/daemon_test.go
@@ -30,18 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSetNodeName(t *testing.T) {
-	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommand = func(debug bool, name string, command string, args ...string) error {
-		assert.Equal(t, "hostname", command)
-		assert.Equal(t, args[0], "myhost")
-		return nil
-	}
-
-	context := &clusterd.Context{ProcMan: proc.New(executor), Executor: executor}
-	setNodeName(context, "myhost")
-}
-
 func TestStoreOSDDirMap(t *testing.T) {
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)

--- a/pkg/ceph/rgw/daemon.go
+++ b/pkg/ceph/rgw/daemon.go
@@ -98,7 +98,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		"rgw_zonegroup":                  config.Name,
 	}
 	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, getRGWConfDir(context.ConfigDir),
-		"client.radosgw.gateway", getRGWKeyringPath(context.ConfigDir), false, nil, settings)
+		"client.radosgw.gateway", getRGWKeyringPath(context.ConfigDir), nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create config file. %+v", err)
 	}


### PR DESCRIPTION
The host name in the crush map is set by the `crush location` setting in the config file, rather than a hack to set the `hostname` of the pod. Fixes #1135