### PR TITLE
adding support for testing with all devices on cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,9 +67,9 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'rook-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
-                        "aws_1.6": "v1.6.7",
-                        "gce_1.7": "v1.7.8",
-                        "gce_1.8": "v1.8.0"
+                        "gce_1.6": "v1.6.7",
+                        "aws_1.7": "v1.7.8",
+                        "gce_1.8": "v1.8.2",
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {
@@ -140,7 +140,7 @@ def RunIntegrationTest(k, v) {
                             echo "Running Smoke Tests"
                             sh '''#!/bin/bash
                                   set -o pipefail
-                                  export host_type='''+ "${k}" + '''
+                                  export HOST_TYPE='''+ "${k}" + '''
                                   export KUBECONFIG=$HOME/admin.conf
                                   kubectl config view
                                   _output/tests/linux_amd64/integration -test.v -test.timeout 600s -test.run SmokeSuite 2>&1 | tee _output/tests/integrationTests.log'''

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package installer
 
+import (
+	"strconv"
+)
+
 //InstallData wraps rook yaml definitions
 type InstallData struct {
 }
@@ -181,7 +185,7 @@ spec:
 }
 
 //GetRookCluster returns rook-cluster manifest
-func (i *InstallData) GetRookCluster(namespace string, storeType string, dataDirHostPath string) string {
+func (i *InstallData) GetRookCluster(namespace string, storeType string, dataDirHostPath string, useAllDevices bool) string {
 	return `apiVersion: v1
 kind: Namespace
 metadata:
@@ -198,7 +202,7 @@ spec:
   hostNetwork: false
   storage:
     useAllNodes: true
-    useAllDevices: false
+    useAllDevices: ` + strconv.FormatBool(useAllDevices) + `
     deviceFilter:
     metadataDevice:
     location:

--- a/tests/integration/multi_cluster_deploy_test.go
+++ b/tests/integration/multi_cluster_deploy_test.go
@@ -52,13 +52,13 @@ func (mrc *MultiRookClusterDeploySuite) SetupSuite() {
 
 	time.Sleep(10 * time.Second)
 
-	err = mrc.installer.CreateK8sRookCluster(mrc.namespace1, "bluestore")
+	err = mrc.installer.CreateK8sRookClusterWithHostPathAndDevices(mrc.namespace1, "bluestore", "", installer.IsAdditionalDeviceAvailableOnCluster())
 	require.NoError(mrc.T(), err)
 
 	err = mrc.installer.CreateK8sRookToolbox(mrc.namespace1)
 	require.NoError(mrc.T(), err)
 
-	err = mrc.installer.CreateK8sRookCluster(mrc.namespace2, "filestore")
+	err = mrc.installer.CreateK8sRookClusterWithHostPathAndDevices(mrc.namespace2, "filestore", "", false)
 	require.NoError(mrc.T(), err)
 
 	err = mrc.installer.CreateK8sRookToolbox(mrc.namespace2)

--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash +e
 
-KUBE_VERSION=${1:-"v1.7.5"}
+KUBE_VERSION=${1:-"v1.8.2"}
 
 null_str=
 KUBE_INSTALL_VERSION="${KUBE_VERSION/v/$null_str}"-00

--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -5,7 +5,7 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tarname=image.tar
 tarfile=${WORK_DIR}/tests/${tarname}
 
-export KUBE_VERSION=${KUBE_VERSION:-"v1.7.5"}
+export KUBE_VERSION=${KUBE_VERSION:-"v1.8.2"}
 
 usage(){
     echo "usage:" >&2


### PR DESCRIPTION
going to run useAllDevices_test.go if the k8s cluster has aditional devices. The test is skipped if there are not additional(raw) devices. 
fix #1039 