### PR TITLE
remove dependency on external-storage project

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -191,12 +191,6 @@
   revision = "5b9ff866471762aa2ab2dced63c9fb6f53921342"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/kubernetes-incubator/external-storage"
-  packages = ["lib/controller","lib/leaderelection","lib/leaderelection/resourcelock"]
-  revision = "0944d3777135a29a532121db4a3282b58d3d3a3f"
-
-[[projects]]
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
   revision = "d5b7844b561a7bc640052f1b935f7b800330d7e0"
@@ -311,7 +305,7 @@
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/autoscaling/v2alpha1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/api/v1/ref","pkg/version","rest","rest/fake","rest/watch","testing","tools/cache","tools/clientcmd/api","tools/metrics","tools/record","transport","util/cert","util/flowcontrol","util/integer"]
+  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/autoscaling/v2alpha1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/api/v1/ref","pkg/version","rest","rest/fake","rest/watch","testing","tools/cache","tools/cache/testing","tools/clientcmd/api","tools/metrics","tools/record","transport","util/cert","util/flowcontrol","util/integer"]
   revision = "42a124578af9e61f5c6902fa7b6b2cb6538f17d2"
 
 [[projects]]
@@ -322,6 +316,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fe7d5bba635382875b12c7e216fa85e2a41d010806a2095c45a934f21a1b9eca"
+  inputs-digest = "ba81d885fd864cfddd61d4ef5e00bde66a202d084af67b9fc2cb1b87a933ac0f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -50,9 +50,6 @@ ignored = ["github.com/rook/rook/.cache","github.com/rook/rook/.work","github.co
   name = "github.com/jbw976/go-ps"
 
 [[constraint]]
-  name = "github.com/kubernetes-incubator/external-storage"
-
-[[constraint]]
   name = "github.com/prometheus/client_golang"
 
 [[constraint]]

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/agent/flexvolume/crd"
 	"github.com/rook/rook/pkg/clusterd"
@@ -38,6 +37,7 @@ import (
 	"github.com/rook/rook/pkg/operator/mds"
 	"github.com/rook/rook/pkg/operator/pool"
 	"github.com/rook/rook/pkg/operator/provisioner"
+	"github.com/rook/rook/pkg/operator/provisioner/controller"
 	"github.com/rook/rook/pkg/operator/rgw"
 	"k8s.io/api/core/v1"
 )

--- a/pkg/operator/provisioner/controller/controller.go
+++ b/pkg/operator/provisioner/controller/controller.go
@@ -1,0 +1,1108 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/rook/rook/pkg/operator/provisioner/controller/leaderelection"
+	rl "github.com/rook/rook/pkg/operator/provisioner/controller/leaderelection/resourcelock"
+	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	storagebeta "k8s.io/api/storage/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1/ref"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/api/v1/helper"
+	"k8s.io/kubernetes/pkg/util/goroutinemap"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
+)
+
+// annClass annotation represents the storage class associated with a resource:
+// - in PersistentVolumeClaim it represents required class to match.
+//   Only PersistentVolumes with the same class (i.e. annotation with the same
+//   value) can be bound to the claim. In case no such volume exists, the
+//   controller will provision a new one using StorageClass instance with
+//   the same name as the annotation value.
+// - in PersistentVolume it represents storage class to which the persistent
+//   volume belongs.
+const annClass = "volume.beta.kubernetes.io/storage-class"
+
+// This annotation is added to a PV that has been dynamically provisioned by
+// Kubernetes. Its value is name of volume plugin that created the volume.
+// It serves both user (to show where a PV comes from) and Kubernetes (to
+// recognize dynamically provisioned PVs in its decisions).
+const annDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
+
+const annStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
+
+// ProvisionController is a controller that provisions PersistentVolumes for
+// PersistentVolumeClaims.
+type ProvisionController struct {
+	client kubernetes.Interface
+
+	// The name of the provisioner for which this controller dynamically
+	// provisions volumes. The value of annDynamicallyProvisioned and
+	// annStorageProvisioner to set & watch for, respectively
+	provisionerName string
+
+	// The provisioner the controller will use to provision and delete volumes.
+	// Presumably this implementer of Provisioner carries its own
+	// volume-specific options and such that it needs in order to provision
+	// volumes.
+	provisioner Provisioner
+
+	// Kubernetes cluster server version:
+	// * 1.4: storage classes introduced as beta. Technically out-of-tree dynamic
+	// provisioning is not officially supported, though it works
+	// * 1.5: storage classes stay in beta. Out-of-tree dynamic provisioning is
+	// officially supported
+	// * 1.6: storage classes enter GA
+	kubeVersion *utilversion.Version
+
+	claimSource      cache.ListerWatcher
+	claimController  cache.Controller
+	volumeSource     cache.ListerWatcher
+	volumeController cache.Controller
+	classSource      cache.ListerWatcher
+	classReflector   *cache.Reflector
+
+	volumes cache.Store
+	claims  cache.Store
+	classes cache.Store
+
+	// Identity of this controller, generated at creation time and not persisted
+	// across restarts. Useful only for debugging, for seeing the source of
+	// events. controller.provisioner may have its own, different notion of
+	// identity which may/may not persist across restarts
+	identity      types.UID
+	eventRecorder record.EventRecorder
+
+	resyncPeriod time.Duration
+
+	// Map of scheduled/running operations.
+	runningOperations goroutinemap.GoRoutineMap
+
+	createProvisionedPVRetryCount int
+	createProvisionedPVInterval   time.Duration
+
+	failedProvisionThreshold, failedDeleteThreshold int
+	// Map of failed claims to provisions/volumes to deletes
+	failedProvisionStats, failedDeleteStats           map[types.UID]int
+	failedProvisionStatsMutex, failedDeleteStatsMutex *sync.Mutex
+
+	// Parameters of leaderelection.LeaderElectionConfig. Leader election is for
+	// when multiple controllers are running: they race to lock (lead) every PVC
+	// so that only one calls Provision for it (saving API calls, CPU cycles...)
+	leaseDuration, renewDeadline, retryPeriod, termLimit time.Duration
+	// Map of claim UID to LeaderElector: for checking if this controller
+	// is the leader of a given claim
+	leaderElectors      map[types.UID]*leaderelection.LeaderElector
+	leaderElectorsMutex *sync.Mutex
+
+	hasRun     bool
+	hasRunLock *sync.Mutex
+}
+
+const (
+	// DefaultResyncPeriod is used when option function ResyncPeriod is omitted
+	DefaultResyncPeriod = 15 * time.Second
+	// DefaultExponentialBackOffOnError is used when option function ExponentialBackOffOnError is omitted
+	DefaultExponentialBackOffOnError = true
+	// DefaultCreateProvisionedPVRetryCount is used when option function CreateProvisionedPVRetryCount is omitted
+	DefaultCreateProvisionedPVRetryCount = 5
+	// DefaultCreateProvisionedPVInterval is used when option function CreateProvisionedPVInterval is omitted
+	DefaultCreateProvisionedPVInterval = 10 * time.Second
+	// DefaultFailedProvisionThreshold is used when option function FailedProvisionThreshold is omitted
+	DefaultFailedProvisionThreshold = 15
+	// DefaultFailedDeleteThreshold is used when option function FailedDeleteThreshold is omitted
+	DefaultFailedDeleteThreshold = 15
+	// DefaultLeaseDuration is used when option function LeaseDuration is omitted
+	DefaultLeaseDuration = 15 * time.Second
+	// DefaultRenewDeadline is used when option function RenewDeadline is omitted
+	DefaultRenewDeadline = 10 * time.Second
+	// DefaultRetryPeriod is used when option function RetryPeriod is omitted
+	DefaultRetryPeriod = 2 * time.Second
+	// DefaultTermLimit is used when option function TermLimit is omitted
+	DefaultTermLimit = 30 * time.Second
+)
+
+var errRuntime = fmt.Errorf("cannot call option functions after controller has Run")
+
+// ResyncPeriod is how often the controller relists PVCs, PVs, & storage
+// classes. OnUpdate will be called even if nothing has changed, meaning failed
+// operations may be retried on a PVC/PV every resyncPeriod regardless of
+// whether it changed. Defaults to 15 seconds.
+func ResyncPeriod(resyncPeriod time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.resyncPeriod = resyncPeriod
+		return nil
+	}
+}
+
+// ExponentialBackOffOnError determines whether to exponentially back off from
+// failures of Provision and Delete. Defaults to true.
+func ExponentialBackOffOnError(exponentialBackOffOnError bool) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.runningOperations = goroutinemap.NewGoRoutineMap(exponentialBackOffOnError)
+		return nil
+	}
+}
+
+// CreateProvisionedPVRetryCount is the number of retries when we create a PV
+// object for a provisioned volume. Defaults to 5.
+func CreateProvisionedPVRetryCount(createProvisionedPVRetryCount int) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.createProvisionedPVRetryCount = createProvisionedPVRetryCount
+		return nil
+	}
+}
+
+// CreateProvisionedPVInterval is the interval between retries when we create a
+// PV object for a provisioned volume. Defaults to 10 seconds.
+func CreateProvisionedPVInterval(createProvisionedPVInterval time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.createProvisionedPVInterval = createProvisionedPVInterval
+		return nil
+	}
+}
+
+// FailedProvisionThreshold is the threshold for max number of retries on
+// failures of Provision. Defaults to 15.
+func FailedProvisionThreshold(failedProvisionThreshold int) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		c.SetFailedProvisionThreshold(failedProvisionThreshold)
+		return nil
+	}
+}
+
+// FailedDeleteThreshold is the threshold for max number of retries on failures
+// of Delete. Defaults to 15.
+func FailedDeleteThreshold(failedDeleteThreshold int) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		c.SetFailedDeleteThreshold(failedDeleteThreshold)
+		return nil
+	}
+}
+
+// LeaseDuration is the duration that non-leader candidates will
+// wait to force acquire leadership. This is measured against time of
+// last observed ack. Defaults to 15 seconds.
+func LeaseDuration(leaseDuration time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.leaseDuration = leaseDuration
+		return nil
+	}
+}
+
+// RenewDeadline is the duration that the acting master will retry
+// refreshing leadership before giving up. Defaults to 10 seconds.
+func RenewDeadline(renewDeadline time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.renewDeadline = renewDeadline
+		return nil
+	}
+}
+
+// RetryPeriod is the duration the LeaderElector clients should wait
+// between tries of actions. Defaults to 2 seconds.
+func RetryPeriod(retryPeriod time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.retryPeriod = retryPeriod
+		return nil
+	}
+}
+
+// TermLimit is the maximum duration that a leader may remain the leader
+// to complete the task before it must give up its leadership. 0 for forever
+// or indefinite. Defaults to 30 seconds.
+func TermLimit(termLimit time.Duration) func(*ProvisionController) error {
+	return func(c *ProvisionController) error {
+		if c.HasRun() {
+			return errRuntime
+		}
+		c.termLimit = termLimit
+		return nil
+	}
+}
+
+// NewProvisionController creates a new provision controller
+func NewProvisionController(
+	client kubernetes.Interface,
+	provisionerName string,
+	provisioner Provisioner,
+	kubeVersion string,
+	options ...func(*ProvisionController) error,
+) *ProvisionController {
+	identity := uuid.NewUUID()
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: client.Core().Events(v1.NamespaceAll)})
+	var eventRecorder record.EventRecorder
+	out, err := exec.Command("hostname").Output()
+	if err != nil {
+		eventRecorder = broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s %s", provisionerName, string(identity))})
+	} else {
+		eventRecorder = broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s %s %s", provisionerName, strings.TrimSpace(string(out)), string(identity))})
+	}
+
+	// TODO: GetReference fails otherwise
+	v1.AddToScheme(scheme.Scheme)
+
+	controller := &ProvisionController{
+		client:                        client,
+		provisionerName:               provisionerName,
+		provisioner:                   provisioner,
+		kubeVersion:                   utilversion.MustParseSemantic(kubeVersion),
+		identity:                      identity,
+		eventRecorder:                 eventRecorder,
+		resyncPeriod:                  DefaultResyncPeriod,
+		runningOperations:             goroutinemap.NewGoRoutineMap(DefaultExponentialBackOffOnError),
+		createProvisionedPVRetryCount: DefaultCreateProvisionedPVRetryCount,
+		createProvisionedPVInterval:   DefaultCreateProvisionedPVInterval,
+		failedProvisionThreshold:      DefaultFailedProvisionThreshold,
+		failedDeleteThreshold:         DefaultFailedDeleteThreshold,
+		failedProvisionStats:          make(map[types.UID]int),
+		failedDeleteStats:             make(map[types.UID]int),
+		failedProvisionStatsMutex:     &sync.Mutex{},
+		failedDeleteStatsMutex:        &sync.Mutex{},
+		leaseDuration:                 DefaultLeaseDuration,
+		renewDeadline:                 DefaultRenewDeadline,
+		retryPeriod:                   DefaultRetryPeriod,
+		termLimit:                     DefaultTermLimit,
+		leaderElectors:                make(map[types.UID]*leaderelection.LeaderElector),
+		leaderElectorsMutex:           &sync.Mutex{},
+		hasRun:                        false,
+		hasRunLock:                    &sync.Mutex{},
+	}
+
+	for _, option := range options {
+		option(controller)
+	}
+
+	controller.claimSource = &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.Core().PersistentVolumeClaims(v1.NamespaceAll).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.Core().PersistentVolumeClaims(v1.NamespaceAll).Watch(options)
+		},
+	}
+	controller.claims, controller.claimController = cache.NewInformer(
+		controller.claimSource,
+		&v1.PersistentVolumeClaim{},
+		controller.resyncPeriod,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    controller.addClaim,
+			UpdateFunc: controller.updateClaim,
+			DeleteFunc: nil,
+		},
+	)
+
+	controller.volumeSource = &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.Core().PersistentVolumes().List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.Core().PersistentVolumes().Watch(options)
+		},
+	}
+	controller.volumes, controller.volumeController = cache.NewInformer(
+		controller.volumeSource,
+		&v1.PersistentVolume{},
+		controller.resyncPeriod,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    nil,
+			UpdateFunc: controller.updateVolume,
+			DeleteFunc: nil,
+		},
+	)
+
+	controller.classes = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	if controller.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.6.0")) {
+		controller.classSource = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return client.StorageV1().StorageClasses().List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return client.StorageV1().StorageClasses().Watch(options)
+			},
+		}
+		controller.classReflector = cache.NewReflector(
+			controller.classSource,
+			&storage.StorageClass{},
+			controller.classes,
+			controller.resyncPeriod,
+		)
+	} else {
+		controller.classSource = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return client.StorageV1beta1().StorageClasses().List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return client.StorageV1beta1().StorageClasses().Watch(options)
+			},
+		}
+		controller.classReflector = cache.NewReflector(
+			controller.classSource,
+			&storagebeta.StorageClass{},
+			controller.classes,
+			controller.resyncPeriod,
+		)
+	}
+
+	return controller
+}
+
+// Run starts all of this controller's control loops
+func (ctrl *ProvisionController) Run(stopCh <-chan struct{}) {
+	glog.Infof("Starting provisioner controller %s!", string(ctrl.identity))
+	ctrl.hasRunLock.Lock()
+	ctrl.hasRun = true
+	ctrl.hasRunLock.Unlock()
+	go ctrl.claimController.Run(stopCh)
+	go ctrl.volumeController.Run(stopCh)
+	go ctrl.classReflector.RunUntil(stopCh)
+	<-stopCh
+}
+
+// HasRun returns whether the controller has Run
+func (ctrl *ProvisionController) HasRun() bool {
+	ctrl.hasRunLock.Lock()
+	defer ctrl.hasRunLock.Unlock()
+	return ctrl.hasRun
+}
+
+// SetFailedProvisionThreshold sets the value of failedProvisionThreshold
+func (ctrl *ProvisionController) SetFailedProvisionThreshold(threshold int) {
+	ctrl.failedProvisionStatsMutex.Lock()
+	ctrl.failedProvisionThreshold = threshold
+	ctrl.failedProvisionStatsMutex.Unlock()
+}
+
+// SetFailedDeleteThreshold sets the value of failedDeleteThreshold
+func (ctrl *ProvisionController) SetFailedDeleteThreshold(threshold int) {
+	ctrl.failedDeleteStatsMutex.Lock()
+	ctrl.failedDeleteThreshold = threshold
+	ctrl.failedDeleteStatsMutex.Unlock()
+}
+
+// On add claim, check if the added claim should have a volume provisioned for
+// it and provision one if so.
+func (ctrl *ProvisionController) addClaim(obj interface{}) {
+	claim, ok := obj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		glog.Errorf("Expected PersistentVolumeClaim but addClaim received %+v", obj)
+		return
+	}
+
+	if ctrl.shouldProvision(claim) {
+		ctrl.leaderElectorsMutex.Lock()
+		le, ok := ctrl.leaderElectors[claim.UID]
+		ctrl.leaderElectorsMutex.Unlock()
+		if ok && le.IsLeader() {
+			opName := fmt.Sprintf("provision-%s[%s]", claimToClaimKey(claim), string(claim.UID))
+			ctrl.scheduleOperation(opName, func() error {
+				err := ctrl.provisionClaimOperation(claim)
+				ctrl.updateProvisionStats(claim, err)
+				return err
+			})
+		} else {
+			opName := fmt.Sprintf("lock-provision-%s[%s]", claimToClaimKey(claim), string(claim.UID))
+			ctrl.scheduleOperation(opName, func() error {
+				ctrl.lockProvisionClaimOperation(claim)
+				return nil
+			})
+		}
+	}
+}
+
+// On update claim, pass the new claim to addClaim. Updates occur at least every
+// resyncPeriod.
+func (ctrl *ProvisionController) updateClaim(oldObj, newObj interface{}) {
+	// If they are exactly the same it must be a forced resync (every
+	// resyncPeriod).
+	if reflect.DeepEqual(oldObj, newObj) {
+		ctrl.addClaim(newObj)
+		return
+	}
+
+	// If not a forced resync, we filter out the frequent leader election record
+	// annotation changes by checking if the only update is in the annotation
+	oldClaim, ok := oldObj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		glog.Errorf("Expected PersistentVolumeClaim but handler received %#v", oldObj)
+		return
+	}
+	newClaim, ok := newObj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		glog.Errorf("Expected PersistentVolumeClaim but handler received %#v", newObj)
+		return
+	}
+
+	skipAddClaim, err := ctrl.isOnlyRecordUpdate(oldClaim, newClaim)
+	if err != nil {
+		glog.Errorf("Error checking if only record was updated in claim: %v", oldClaim)
+		return
+	}
+
+	if !skipAddClaim {
+		ctrl.addClaim(newObj)
+	}
+}
+
+// On update volume, check if the updated volume should be deleted and delete if
+// so. Updates occur at least every resyncPeriod.
+func (ctrl *ProvisionController) updateVolume(oldObj, newObj interface{}) {
+	volume, ok := newObj.(*v1.PersistentVolume)
+	if !ok {
+		glog.Errorf("Expected PersistentVolume but handler received %#v", newObj)
+		return
+	}
+
+	if ctrl.shouldDelete(volume) {
+		opName := fmt.Sprintf("delete-%s[%s]", volume.Name, string(volume.UID))
+		ctrl.scheduleOperation(opName, func() error {
+			err := ctrl.deleteVolumeOperation(volume)
+			ctrl.updateDeleteStats(volume, err)
+			return err
+		})
+	}
+}
+
+// isOnlyRecordUpdate checks if the only update between the old & new claim is
+// the leader election record annotation.
+func (ctrl *ProvisionController) isOnlyRecordUpdate(oldClaim, newClaim *v1.PersistentVolumeClaim) (bool, error) {
+	old, err := ctrl.removeRecord(oldClaim)
+	if err != nil {
+		return false, err
+	}
+	new, err := ctrl.removeRecord(newClaim)
+	if err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(old, new), nil
+}
+
+// removeRecord returns a claim with its leader election record annotation and
+// ResourceVersion set blank
+func (ctrl *ProvisionController) removeRecord(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+	clone, err := scheme.Scheme.DeepCopy(claim)
+	if err != nil {
+		return nil, fmt.Errorf("Error cloning claim: %v", err)
+	}
+	claimClone, ok := clone.(*v1.PersistentVolumeClaim)
+	if !ok {
+		return nil, fmt.Errorf("Unexpected claim cast error: %v", claimClone)
+	}
+
+	if claimClone.Annotations == nil {
+		claimClone.Annotations = make(map[string]string)
+	}
+	claimClone.Annotations[rl.LeaderElectionRecordAnnotationKey] = ""
+
+	claimClone.ResourceVersion = ""
+
+	return claimClone, nil
+}
+
+func (ctrl *ProvisionController) shouldProvision(claim *v1.PersistentVolumeClaim) bool {
+	ctrl.failedProvisionStatsMutex.Lock()
+	if failureCount, exists := ctrl.failedProvisionStats[claim.UID]; exists == true {
+		if failureCount >= ctrl.failedProvisionThreshold && ctrl.failedProvisionThreshold > 0 {
+			glog.Errorf("Exceeded failedProvisionThreshold threshold: %d, for claim %q, provisioner will not attempt retries for this claim", ctrl.failedProvisionThreshold, claimToClaimKey(claim))
+			ctrl.failedProvisionStatsMutex.Unlock()
+			return false
+		}
+	}
+	ctrl.failedProvisionStatsMutex.Unlock()
+
+	if claim.Spec.VolumeName != "" {
+		return false
+	}
+
+	// Kubernetes 1.5 provisioning with annStorageProvisioner
+	if provisioner, found := claim.Annotations[annStorageProvisioner]; found {
+		if provisioner == ctrl.provisionerName {
+			return true
+		}
+		return false
+	}
+
+	// Kubernetes 1.4 provisioning, evaluating class.Provisioner
+	claimClass := helper.GetPersistentVolumeClaimClass(claim)
+	provisioner, _, err := ctrl.getStorageClassFields(claimClass)
+	if err != nil {
+		glog.Errorf("Error getting claim %q's StorageClass's fields: %v", claimToClaimKey(claim), err)
+		return false
+	}
+	if provisioner != ctrl.provisionerName {
+		return false
+	}
+
+	return true
+}
+
+func (ctrl *ProvisionController) shouldDelete(volume *v1.PersistentVolume) bool {
+	ctrl.failedDeleteStatsMutex.Lock()
+	if failureCount, exists := ctrl.failedDeleteStats[volume.UID]; exists == true {
+		if failureCount >= ctrl.failedDeleteThreshold && ctrl.failedDeleteThreshold > 0 {
+			glog.Errorf("Exceeded failedDeleteThreshold threshold: %d, for volume %q, provisioner will not attempt retries for this volume", ctrl.failedDeleteThreshold, volume.Name)
+			ctrl.failedDeleteStatsMutex.Unlock()
+			return false
+		}
+	}
+	ctrl.failedDeleteStatsMutex.Unlock()
+
+	// In 1.5+ we delete only if the volume is in state Released. In 1.4 we must
+	// delete if the volume is in state Failed too.
+	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.5.0")) {
+		if volume.Status.Phase != v1.VolumeReleased {
+			return false
+		}
+	} else {
+		if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
+			return false
+		}
+	}
+
+	if volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimDelete {
+		return false
+	}
+
+	if !metav1.HasAnnotation(volume.ObjectMeta, annDynamicallyProvisioned) {
+		return false
+	}
+
+	if ann := volume.Annotations[annDynamicallyProvisioned]; ann != ctrl.provisionerName {
+		return false
+	}
+
+	return true
+}
+
+// lockProvisionClaimOperation wraps provisionClaimOperation. In case other
+// controllers are serving the same claims, to prevent them all from creating
+// volumes for a claim & racing to submit their PV, each controller creates a
+// LeaderElector to instead race for the leadership (lock), where only the
+// leader is tasked with provisioning & may try to do so
+func (ctrl *ProvisionController) lockProvisionClaimOperation(claim *v1.PersistentVolumeClaim) {
+	stoppedLeading := false
+	rl := rl.ProvisionPVCLock{
+		PVCMeta: claim.ObjectMeta,
+		Client:  ctrl.client,
+		LockConfig: rl.Config{
+			Identity:      string(ctrl.identity),
+			EventRecorder: ctrl.eventRecorder,
+		},
+	}
+	le, err := leaderelection.NewLeaderElector(leaderelection.Config{
+		Lock:          &rl,
+		LeaseDuration: ctrl.leaseDuration,
+		RenewDeadline: ctrl.renewDeadline,
+		RetryPeriod:   ctrl.retryPeriod,
+		TermLimit:     ctrl.termLimit,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(_ <-chan struct{}) {
+				opName := fmt.Sprintf("provision-%s[%s]", claimToClaimKey(claim), string(claim.UID))
+				ctrl.scheduleOperation(opName, func() error {
+					err := ctrl.provisionClaimOperation(claim)
+					ctrl.updateProvisionStats(claim, err)
+					return err
+				})
+			},
+			OnStoppedLeading: func() {
+				stoppedLeading = true
+			},
+		},
+	})
+	if err != nil {
+		glog.Errorf("Error creating LeaderElector, can't provision for claim %q: %v", claimToClaimKey(claim), err)
+		return
+	}
+
+	ctrl.leaderElectorsMutex.Lock()
+	ctrl.leaderElectors[claim.UID] = le
+	ctrl.leaderElectorsMutex.Unlock()
+
+	// To determine when to stop trying to acquire/renew the lock, watch for
+	// provisioning success/failure. (The leader could get the result of its
+	// operation but it has to watch anyway)
+	stopCh := make(chan struct{})
+	successCh, err := ctrl.watchProvisioning(claim, stopCh)
+	if err != nil {
+		glog.Errorf("Error watching for provisioning success, can't provision for claim %q: %v", claimToClaimKey(claim), err)
+	}
+
+	le.Run(successCh)
+
+	close(stopCh)
+
+	// If we were the leader and stopped, give others a chance to acquire
+	// (whether they exist & want to or not). Else, there must have been a
+	// success so just proceed.
+	if stoppedLeading {
+		time.Sleep(ctrl.leaseDuration + ctrl.retryPeriod)
+	}
+
+	ctrl.leaderElectorsMutex.Lock()
+	delete(ctrl.leaderElectors, claim.UID)
+	ctrl.leaderElectorsMutex.Unlock()
+}
+
+func (ctrl *ProvisionController) updateProvisionStats(claim *v1.PersistentVolumeClaim, err error) {
+	ctrl.failedProvisionStatsMutex.Lock()
+	defer ctrl.failedProvisionStatsMutex.Unlock()
+
+	// Do not record the failed claim info when failedProvisionThreshold is not set
+	if ctrl.failedProvisionThreshold <= 0 {
+		return
+	}
+
+	if err != nil {
+		if failureCount, exists := ctrl.failedProvisionStats[claim.UID]; exists == true {
+			failureCount = failureCount + 1
+			ctrl.failedProvisionStats[claim.UID] = failureCount
+		} else {
+			ctrl.failedProvisionStats[claim.UID] = 1
+		}
+	} else {
+		delete(ctrl.failedProvisionStats, claim.UID)
+	}
+}
+
+func (ctrl *ProvisionController) updateDeleteStats(volume *v1.PersistentVolume, err error) {
+	ctrl.failedDeleteStatsMutex.Lock()
+	defer ctrl.failedDeleteStatsMutex.Unlock()
+
+	// Do not record the failed volume info when failedDeleteThreshold is not set
+	if ctrl.failedDeleteThreshold <= 0 {
+		return
+	}
+
+	if err != nil {
+		if failureCount, exists := ctrl.failedDeleteStats[volume.UID]; exists == true {
+			failureCount = failureCount + 1
+			ctrl.failedDeleteStats[volume.UID] = failureCount
+		} else {
+			ctrl.failedDeleteStats[volume.UID] = 1
+		}
+	} else {
+		delete(ctrl.failedDeleteStats, volume.UID)
+	}
+}
+
+// provisionClaimOperation attempts to provision a volume for the given claim.
+// Returns an error for use by goroutinemap when expbackoff is enabled: if nil,
+// the operation is deleted, else the operation may be retried with expbackoff.
+func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVolumeClaim) error {
+	// Most code here is identical to that found in controller.go of kube's PV controller...
+	claimClass := helper.GetPersistentVolumeClaimClass(claim)
+	glog.V(4).Infof("provisionClaimOperation [%s] started, class: %q", claimToClaimKey(claim), claimClass)
+
+	//  A previous doProvisionClaim may just have finished while we were waiting for
+	//  the locks. Check that PV (with deterministic name) hasn't been provisioned
+	//  yet.
+	pvName := ctrl.getProvisionedVolumeNameForClaim(claim)
+	volume, err := ctrl.client.Core().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+	if err == nil && volume != nil {
+		// Volume has been already provisioned, nothing to do.
+		glog.V(4).Infof("provisionClaimOperation [%s]: volume already exists, skipping", claimToClaimKey(claim))
+		return nil
+	}
+
+	// Prepare a claimRef to the claim early (to fail before a volume is
+	// provisioned)
+	claimRef, err := ref.GetReference(scheme.Scheme, claim)
+	if err != nil {
+		glog.Errorf("Unexpected error getting claim reference to claim %q: %v", claimToClaimKey(claim), err)
+		return nil
+	}
+
+	provisioner, parameters, err := ctrl.getStorageClassFields(claimClass)
+	if err != nil {
+		glog.Errorf("Error getting claim %q's StorageClass's fields: %v", claimToClaimKey(claim), err)
+		return nil
+	}
+	if provisioner != ctrl.provisionerName {
+		// class.Provisioner has either changed since shouldProvision() or
+		// annDynamicallyProvisioned contains different provisioner than
+		// class.Provisioner.
+		glog.Errorf("Unknown provisioner %q requested in claim %q's StorageClass %q", provisioner, claimToClaimKey(claim), claimClass)
+		return nil
+	}
+
+	options := VolumeOptions{
+		// TODO SHOULD be set to `Delete` unless user manually congiures other reclaim policy.
+		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+		PVName:     pvName,
+		PVC:        claim,
+		Parameters: parameters,
+	}
+
+	ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("External provisioner is provisioning volume for claim %q", claimToClaimKey(claim)))
+
+	volume, err = ctrl.provisioner.Provision(options)
+	if err != nil {
+		if ierr, ok := err.(*IgnoredError); ok {
+			// Provision ignored, do nothing and hope another provisioner will provision it.
+			glog.Infof("provision of claim %q ignored: %v", claimToClaimKey(claim), ierr)
+			return nil
+		}
+		strerr := fmt.Sprintf("Failed to provision volume with StorageClass %q: %v", claimClass, err)
+		glog.Errorf("Failed to provision volume for claim %q with StorageClass %q: %v", claimToClaimKey(claim), claimClass, err)
+		ctrl.eventRecorder.Event(claim, v1.EventTypeWarning, "ProvisioningFailed", strerr)
+		return err
+	}
+
+	glog.Infof("volume %q for claim %q created", volume.Name, claimToClaimKey(claim))
+
+	// Set ClaimRef and the PV controller will bind and set annBoundByController for us
+	volume.Spec.ClaimRef = claimRef
+
+	metav1.SetMetaDataAnnotation(&volume.ObjectMeta, annDynamicallyProvisioned, ctrl.provisionerName)
+	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.6.0")) {
+		volume.Spec.StorageClassName = claimClass
+	} else {
+		metav1.SetMetaDataAnnotation(&volume.ObjectMeta, annClass, claimClass)
+	}
+
+	// Try to create the PV object several times
+	for i := 0; i < ctrl.createProvisionedPVRetryCount; i++ {
+		glog.V(4).Infof("provisionClaimOperation [%s]: trying to save volume %s", claimToClaimKey(claim), volume.Name)
+		if _, err = ctrl.client.Core().PersistentVolumes().Create(volume); err == nil {
+			// Save succeeded.
+			glog.Infof("volume %q for claim %q saved", volume.Name, claimToClaimKey(claim))
+			break
+		}
+		// Save failed, try again after a while.
+		glog.Infof("failed to save volume %q for claim %q: %v", volume.Name, claimToClaimKey(claim), err)
+		time.Sleep(ctrl.createProvisionedPVInterval)
+	}
+
+	if err != nil {
+		// Save failed. Now we have a storage asset outside of Kubernetes,
+		// but we don't have appropriate PV object for it.
+		// Emit some event here and try to delete the storage asset several
+		// times.
+		strerr := fmt.Sprintf("Error creating provisioned PV object for claim %s: %v. Deleting the volume.", claimToClaimKey(claim), err)
+		glog.Error(strerr)
+		ctrl.eventRecorder.Event(claim, v1.EventTypeWarning, "ProvisioningFailed", strerr)
+
+		for i := 0; i < ctrl.createProvisionedPVRetryCount; i++ {
+			if err = ctrl.provisioner.Delete(volume); err == nil {
+				// Delete succeeded
+				glog.V(4).Infof("provisionClaimOperation [%s]: cleaning volume %s succeeded", claimToClaimKey(claim), volume.Name)
+				break
+			}
+			// Delete failed, try again after a while.
+			glog.Infof("failed to delete volume %q: %v", volume.Name, err)
+			time.Sleep(ctrl.createProvisionedPVInterval)
+		}
+
+		if err != nil {
+			// Delete failed several times. There is an orphaned volume and there
+			// is nothing we can do about it.
+			strerr := fmt.Sprintf("Error cleaning provisioned volume for claim %s: %v. Please delete manually.", claimToClaimKey(claim), err)
+			glog.Error(strerr)
+			ctrl.eventRecorder.Event(claim, v1.EventTypeWarning, "ProvisioningCleanupFailed", strerr)
+		}
+	} else {
+		glog.Infof("volume %q provisioned for claim %q", volume.Name, claimToClaimKey(claim))
+		msg := fmt.Sprintf("Successfully provisioned volume %s", volume.Name)
+		ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "ProvisioningSucceeded", msg)
+	}
+
+	return nil
+}
+
+// watchProvisioning returns a channel to which it sends the results of all
+// provisioning attempts for the given claim. The PVC being modified to no
+// longer need provisioning is considered a success.
+func (ctrl *ProvisionController) watchProvisioning(claim *v1.PersistentVolumeClaim, stopChannel chan struct{}) (<-chan bool, error) {
+	stopWatchPVC := make(chan struct{})
+	pvcCh, err := ctrl.watchPVC(claim, stopWatchPVC)
+	if err != nil {
+		glog.Infof("cannot start watcher for PVC %s/%s: %v", claim.Namespace, claim.Name, err)
+		return nil, err
+	}
+
+	successCh := make(chan bool, 0)
+
+	go func() {
+		defer close(stopWatchPVC)
+		defer close(successCh)
+
+		for {
+			select {
+			case _ = <-stopChannel:
+				return
+
+			case event := <-pvcCh:
+				switch event.Object.(type) {
+				case *v1.PersistentVolumeClaim:
+					// PVC changed
+					claim := event.Object.(*v1.PersistentVolumeClaim)
+					glog.V(4).Infof("claim update received: %s %s/%s %s", event.Type, claim.Namespace, claim.Name, claim.Status.Phase)
+					switch event.Type {
+					case watch.Added, watch.Modified:
+						if claim.Spec.VolumeName != "" {
+							successCh <- true
+						} else if !ctrl.shouldProvision(claim) {
+							glog.Infof("claim %s/%s was modified to not ask for this provisioner", claim.Namespace, claim.Name)
+							successCh <- true
+						}
+
+					case watch.Deleted:
+						glog.Infof("claim %s/%s was deleted", claim.Namespace, claim.Name)
+						successCh <- true
+
+					case watch.Error:
+						glog.Infof("claim %s/%s watcher failed", claim.Namespace, claim.Name)
+						successCh <- true
+					default:
+					}
+				case *v1.Event:
+					// Event received
+					claimEvent := event.Object.(*v1.Event)
+					glog.V(4).Infof("claim event received: %s %s/%s %s/%s %s", event.Type, claimEvent.Namespace, claimEvent.Name, claimEvent.InvolvedObject.Namespace, claimEvent.InvolvedObject.Name, claimEvent.Reason)
+					if claimEvent.Reason == "ProvisioningSucceeded" {
+						successCh <- true
+					} else if claimEvent.Reason == "ProvisioningFailed" {
+						successCh <- false
+					}
+				}
+			}
+		}
+	}()
+
+	return successCh, nil
+}
+
+// watchPVC returns a watch on the given PVC and ProvisioningFailed &
+// ProvisioningSucceeded events involving it
+func (ctrl *ProvisionController) watchPVC(claim *v1.PersistentVolumeClaim, stopChannel chan struct{}) (<-chan watch.Event, error) {
+	options := metav1.ListOptions{
+		FieldSelector:   "metadata.name=" + claim.Name,
+		Watch:           true,
+		ResourceVersion: claim.ResourceVersion,
+	}
+
+	pvcWatch, err := ctrl.claimSource.Watch(options)
+	if err != nil {
+		return nil, err
+	}
+
+	failWatch, err := ctrl.getPVCEventWatch(claim, v1.EventTypeWarning, "ProvisioningFailed")
+	if err != nil {
+		pvcWatch.Stop()
+		return nil, err
+	}
+
+	successWatch, err := ctrl.getPVCEventWatch(claim, v1.EventTypeNormal, "ProvisioningSucceeded")
+	if err != nil {
+		failWatch.Stop()
+		pvcWatch.Stop()
+		return nil, err
+	}
+
+	eventCh := make(chan watch.Event, 0)
+
+	go func() {
+		defer successWatch.Stop()
+		defer failWatch.Stop()
+		defer pvcWatch.Stop()
+		defer close(eventCh)
+
+		for {
+			select {
+			case _ = <-stopChannel:
+				return
+
+			case pvcEvent, ok := <-pvcWatch.ResultChan():
+				if !ok {
+					return
+				}
+				eventCh <- pvcEvent
+
+			case failEvent, ok := <-failWatch.ResultChan():
+				if !ok {
+					return
+				}
+				eventCh <- failEvent
+
+			case successEvent, ok := <-successWatch.ResultChan():
+				if !ok {
+					return
+				}
+				eventCh <- successEvent
+			}
+		}
+	}()
+
+	return eventCh, nil
+}
+
+// getPVCEventWatch returns a watch on the given PVC for the given event from
+// this point forward.
+func (ctrl *ProvisionController) getPVCEventWatch(claim *v1.PersistentVolumeClaim, eventType, reason string) (watch.Interface, error) {
+	claimKind := "PersistentVolumeClaim"
+	claimUID := string(claim.UID)
+	fieldSelector := ctrl.client.Core().Events(claim.Namespace).GetFieldSelector(&claim.Name, &claim.Namespace, &claimKind, &claimUID).String() + ",type=" + eventType + ",reason=" + reason
+
+	list, err := ctrl.client.Core().Events(claim.Namespace).List(metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resourceVersion := ""
+	if len(list.Items) >= 1 {
+		resourceVersion = list.Items[len(list.Items)-1].ResourceVersion
+	}
+
+	return ctrl.client.Core().Events(claim.Namespace).Watch(metav1.ListOptions{
+		FieldSelector:   fieldSelector,
+		Watch:           true,
+		ResourceVersion: resourceVersion,
+	})
+}
+
+func (ctrl *ProvisionController) deleteVolumeOperation(volume *v1.PersistentVolume) error {
+	glog.V(4).Infof("deleteVolumeOperation [%s] started", volume.Name)
+
+	// This method may have been waiting for a volume lock for some time.
+	// Our check does not have to be as sophisticated as PV controller's, we can
+	// trust that the PV controller has set the PV to Released/Failed and it's
+	// ours to delete
+	newVolume, err := ctrl.client.Core().PersistentVolumes().Get(volume.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	if !ctrl.shouldDelete(newVolume) {
+		glog.Infof("volume %q no longer needs deletion, skipping", volume.Name)
+		return nil
+	}
+
+	err = ctrl.provisioner.Delete(volume)
+	if err != nil {
+		if ierr, ok := err.(*IgnoredError); ok {
+			// Delete ignored, do nothing and hope another provisioner will delete it.
+			glog.Infof("deletion of volume %q ignored: %v", volume.Name, ierr)
+			return nil
+		}
+		// Delete failed, emit an event.
+		glog.Errorf("Deletion of volume %q failed: %v", volume.Name, err)
+		ctrl.eventRecorder.Event(volume, v1.EventTypeWarning, "VolumeFailedDelete", err.Error())
+		return err
+	}
+
+	glog.Infof("volume %q deleted", volume.Name)
+
+	glog.V(4).Infof("deleteVolumeOperation [%s]: success", volume.Name)
+	// Delete the volume
+	if err = ctrl.client.Core().PersistentVolumes().Delete(volume.Name, nil); err != nil {
+		// Oops, could not delete the volume and therefore the controller will
+		// try to delete the volume again on next update.
+		glog.Infof("failed to delete volume %q from database: %v", volume.Name, err)
+		return nil
+	}
+
+	glog.Infof("volume %q deleted from database", volume.Name)
+	return nil
+}
+
+// getProvisionedVolumeNameForClaim returns PV.Name for the provisioned volume.
+// The name must be unique.
+func (ctrl *ProvisionController) getProvisionedVolumeNameForClaim(claim *v1.PersistentVolumeClaim) string {
+	return "pvc-" + string(claim.UID)
+}
+
+// scheduleOperation starts given asynchronous operation on given volume. It
+// makes sure the operation is already not running.
+func (ctrl *ProvisionController) scheduleOperation(operationName string, operation func() error) {
+	glog.Infof("scheduleOperation[%s]", operationName)
+
+	err := ctrl.runningOperations.Run(operationName, operation)
+	if err != nil {
+		if goroutinemap.IsAlreadyExists(err) {
+			glog.V(4).Infof("operation %q is already running, skipping", operationName)
+		} else {
+			glog.Errorf("Error scheduling operaion %q: %v", operationName, err)
+		}
+	}
+}
+
+func (ctrl *ProvisionController) getStorageClassFields(name string) (string, map[string]string, error) {
+	classObj, found, err := ctrl.classes.GetByKey(name)
+	if err != nil {
+		return "", nil, err
+	}
+	if !found {
+		return "", nil, fmt.Errorf("StorageClass %q not found", name)
+		// 3. It tries to find a StorageClass instance referenced by annotation
+		//    `claim.Annotations["volume.beta.kubernetes.io/storage-class"]`. If not
+		//    found, it SHOULD report an error (by sending an event to the claim) and it
+		//    SHOULD retry periodically with step i.
+	}
+	switch class := classObj.(type) {
+	case *storage.StorageClass:
+		return class.Provisioner, class.Parameters, nil
+	case *storagebeta.StorageClass:
+		return class.Provisioner, class.Parameters, nil
+	}
+	return "", nil, fmt.Errorf("Cannot convert object to StorageClass: %+v", classObj)
+}
+
+func claimToClaimKey(claim *v1.PersistentVolumeClaim) string {
+	return fmt.Sprintf("%s/%s", claim.Namespace, claim.Name)
+}

--- a/pkg/operator/provisioner/controller/controller_test.go
+++ b/pkg/operator/provisioner/controller/controller_test.go
@@ -1,0 +1,718 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	rl "github.com/rook/rook/pkg/operator/provisioner/controller/leaderelection/resourcelock"
+	"k8s.io/api/core/v1"
+	storagebeta "k8s.io/api/storage/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakev1core "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	"k8s.io/client-go/pkg/api/v1/ref"
+	testclient "k8s.io/client-go/testing"
+	fcache "k8s.io/client-go/tools/cache/testing"
+)
+
+const (
+	resyncPeriod = 100 * time.Millisecond
+)
+
+// TODO clean this up, e.g. remove redundant params (provisionerName: "foo.bar/baz")
+func TestController(t *testing.T) {
+	tests := []struct {
+		name            string
+		objs            []runtime.Object
+		provisionerName string
+		provisioner     Provisioner
+		verbs           []string
+		reaction        testclient.ReactionFunc
+		expectedVolumes []v1.PersistentVolume
+	}{
+		{
+			name: "provision for claim-1 but not claim-2",
+			objs: []runtime.Object{
+				newStorageClass("class-1", "foo.bar/baz"),
+				newStorageClass("class-2", "abc.def/ghi"),
+				newClaim("claim-1", "uid-1-1", "class-1", "", nil),
+				newClaim("claim-2", "uid-1-2", "class-2", "", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newProvisionedVolume(newStorageClass("class-1", "foo.bar/baz"), newClaim("claim-1", "uid-1-1", "class-1", "", nil)),
+			},
+		},
+		{
+			name: "delete volume-1 but not volume-2",
+			objs: []runtime.Object{
+				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+				newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newVolume("volume-2", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+			},
+		},
+		{
+			name: "don't provision for claim-1 because it's already bound",
+			objs: []runtime.Object{
+				newClaim("claim-1", "uid-1-1", "class-1", "volume-1", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume(nil),
+		},
+		{
+			name: "don't provision for claim-1 because its class doesn't exist",
+			objs: []runtime.Object{
+				newClaim("claim-1", "uid-1-1", "class-1", "", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume(nil),
+		},
+		{
+			name: "don't delete volume-1 because it's still bound",
+			objs: []runtime.Object{
+				newVolume("volume-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newVolume("volume-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+		},
+		{
+			name: "don't delete volume-1 because its reclaim policy is not delete",
+			objs: []runtime.Object{
+				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+		},
+		{
+			name: "provisioner fails to provision for claim-1: no pv is created",
+			objs: []runtime.Object{
+				newStorageClass("class-1", "foo.bar/baz"),
+				newClaim("claim-1", "uid-1-1", "class-1", "", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newBadTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume(nil),
+		},
+		{
+			name: "provisioner fails to delete volume-1: pv is not deleted",
+			objs: []runtime.Object{
+				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newBadTestProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+		},
+		{
+			name: "try to provision for claim-1 but fail to save the pv object",
+			objs: []runtime.Object{
+				newStorageClass("class-1", "foo.bar/baz"),
+				newClaim("claim-1", "uid-1-1", "class-1", "", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			verbs:           []string{"create"},
+			reaction: func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.New("fake error")
+			},
+			expectedVolumes: []v1.PersistentVolume(nil),
+		},
+		{
+			name: "try to delete volume-1 but fail to delete the pv object",
+			objs: []runtime.Object{
+				newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newTestProvisioner(),
+			verbs:           []string{"delete"},
+			reaction: func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, errors.New("fake error")
+			},
+			expectedVolumes: []v1.PersistentVolume{
+				*newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			},
+		},
+		{
+			name: "provision for claim-1 but not claim-2, because it is ignored",
+			objs: []runtime.Object{
+				newStorageClass("class-1", "foo.bar/baz"),
+				newClaim("claim-1", "uid-1-1", "class-1", "", nil),
+				newClaim("claim-2", "uid-1-2", "class-1", "", nil),
+			},
+			provisionerName: "foo.bar/baz",
+			provisioner:     newIgnoredProvisioner(),
+			expectedVolumes: []v1.PersistentVolume{
+				*newProvisionedVolume(newStorageClass("class-1", "foo.bar/baz"), newClaim("claim-1", "uid-1-1", "class-1", "", nil)),
+			},
+		},
+	}
+	for _, test := range tests {
+		client := fake.NewSimpleClientset(test.objs...)
+		if len(test.verbs) != 0 {
+			for _, v := range test.verbs {
+				client.Fake.PrependReactor(v, "persistentvolumes", test.reaction)
+			}
+		}
+		ctrl := newTestProvisionController(client, test.provisionerName, test.provisioner, "v1.5.0")
+		stopCh := make(chan struct{})
+		go ctrl.Run(stopCh)
+
+		time.Sleep(2 * resyncPeriod)
+		ctrl.runningOperations.Wait()
+
+		pvList, _ := client.Core().PersistentVolumes().List(metav1.ListOptions{})
+		if !reflect.DeepEqual(test.expectedVolumes, pvList.Items) {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("expected PVs:\n %v\n but got:\n %v\n", test.expectedVolumes, pvList.Items)
+		}
+		close(stopCh)
+	}
+}
+
+func TestMultipleControllers(t *testing.T) {
+	tests := []struct {
+		name            string
+		provisionerName string
+		numControllers  int
+		numClaims       int
+		expectedCalls   int
+	}{
+		{
+			name:            "call provision exactly once",
+			provisionerName: "foo.bar/baz",
+			numControllers:  5,
+			numClaims:       1,
+			expectedCalls:   1,
+		},
+	}
+	for _, test := range tests {
+		client := fake.NewSimpleClientset()
+
+		// Create a reactor to reject Updates if object has already been modified,
+		// like etcd.
+		claimSource := fcache.NewFakePVCControllerSource()
+		reactor := claimReactor{
+			fake:        &fakev1core.FakeCoreV1{Fake: &client.Fake},
+			claims:      make(map[string]*v1.PersistentVolumeClaim),
+			lock:        sync.Mutex{},
+			claimSource: claimSource,
+		}
+		reactor.claims["claim-1"] = newClaim("claim-1", "uid-1-1", "class-1", "", nil)
+		client.PrependReactor("update", "persistentvolumeclaims", reactor.React)
+		client.PrependReactor("get", "persistentvolumeclaims", reactor.React)
+
+		// Create a fake watch so each controller can get ProvisioningSucceeded
+		fakeWatch := watch.NewFakeWithChanSize(test.numControllers, false)
+		client.PrependWatchReactor("events", testclient.DefaultWatchReactor(fakeWatch, nil))
+		client.PrependReactor("create", "events", func(action testclient.Action) (bool, runtime.Object, error) {
+			obj := action.(testclient.CreateAction).GetObject()
+			for i := 0; i < test.numControllers; i++ {
+				fakeWatch.Add(obj)
+			}
+			return true, obj, nil
+		})
+
+		provisioner := newTestProvisioner()
+		ctrls := make([]*ProvisionController, test.numControllers)
+		stopChs := make([]chan struct{}, test.numControllers)
+		for i := 0; i < test.numControllers; i++ {
+			ctrls[i] = NewProvisionController(client, test.provisionerName, provisioner, "v1.5.0", CreateProvisionedPVInterval(10*time.Millisecond))
+			ctrls[i].claimSource = claimSource
+			ctrls[i].claims.Add(newClaim("claim-1", "uid-1-1", "class-1", "", nil))
+			ctrls[i].classes.Add(newStorageClass("class-1", "foo.bar/baz"))
+			stopChs[i] = make(chan struct{})
+		}
+
+		for i := 0; i < test.numControllers; i++ {
+			go ctrls[i].addClaim(newClaim("claim-1", "uid-1-1", "class-1", "", nil))
+		}
+
+		// Sleep for 3 election retry periods
+		time.Sleep(3 * ctrls[0].retryPeriod)
+
+		if test.expectedCalls != len(provisioner.provisionCalls) {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("expected provision calls:\n %v\n but got:\n %v\n", test.expectedCalls, len(provisioner.provisionCalls))
+		}
+
+		for _, stopCh := range stopChs {
+			close(stopCh)
+		}
+	}
+}
+
+func TestShouldProvision(t *testing.T) {
+	tests := []struct {
+		name            string
+		provisionerName string
+		class           *storagebeta.StorageClass
+		claim           *v1.PersistentVolumeClaim
+		expectedShould  bool
+	}{
+		{
+			name:            "should provision",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-1", "foo.bar/baz"),
+			claim:           newClaim("claim-1", "1-1", "class-1", "", nil),
+			expectedShould:  true,
+		},
+		{
+			name:            "claim already bound",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-1", "foo.bar/baz"),
+			claim:           newClaim("claim-1", "1-1", "class-1", "foo", nil),
+			expectedShould:  false,
+		},
+		{
+			name:            "no such class",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-1", "foo.bar/baz"),
+			claim:           newClaim("claim-1", "1-1", "class-2", "", nil),
+			expectedShould:  false,
+		},
+		{
+			name:            "not this provisioner's job",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-1", "abc.def/ghi"),
+			claim:           newClaim("claim-1", "1-1", "class-1", "", nil),
+			expectedShould:  false,
+		},
+		// Kubernetes 1.5 provisioning - annStorageProvisioner is set
+		// and only this annotation is evaluated
+		{
+			name:            "should provision 1.5",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-2", "abc.def/ghi"),
+			claim: newClaim("claim-1", "1-1", "class-1", "",
+				map[string]string{annStorageProvisioner: "foo.bar/baz"}),
+			expectedShould: true,
+		},
+		{
+			name:            "unknown provisioner 1.5",
+			provisionerName: "foo.bar/baz",
+			class:           newStorageClass("class-1", "foo.bar/baz"),
+			claim: newClaim("claim-1", "1-1", "class-1", "",
+				map[string]string{annStorageProvisioner: "abc.def/ghi"}),
+			expectedShould: false,
+		},
+	}
+	for _, test := range tests {
+		client := fake.NewSimpleClientset(test.claim)
+		provisioner := newTestProvisioner()
+		ctrl := newTestProvisionController(client, test.provisionerName, provisioner, "v1.5.0")
+
+		err := ctrl.classes.Add(test.class)
+		if err != nil {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("error adding class %v to cache: %v", test.class, err)
+		}
+
+		should := ctrl.shouldProvision(test.claim)
+		if test.expectedShould != should {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("expected should provision %v but got %v\n", test.expectedShould, should)
+		}
+	}
+}
+
+func TestShouldDelete(t *testing.T) {
+	tests := []struct {
+		name             string
+		provisionerName  string
+		volume           *v1.PersistentVolume
+		serverGitVersion string
+		expectedShould   bool
+	}{
+		{
+			name:             "should delete",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.5.0",
+			expectedShould:   true,
+		},
+		{
+			name:             "1.4 and failed: should delete",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeFailed, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.4.0",
+			expectedShould:   true,
+		},
+		{
+			name:             "1.5 and failed: shouldn't delete",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeFailed, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.5.0",
+			expectedShould:   false,
+		},
+		{
+			name:             "volume still bound",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeBound, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.5.0",
+			expectedShould:   false,
+		},
+		{
+			name:             "non-delete reclaim policy",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimRetain, map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.5.0",
+			expectedShould:   false,
+		},
+		{
+			name:             "not this provisioner's job",
+			provisionerName:  "foo.bar/baz",
+			volume:           newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete, map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+			serverGitVersion: "v1.5.0",
+			expectedShould:   false,
+		},
+	}
+	for _, test := range tests {
+		client := fake.NewSimpleClientset()
+		provisioner := newTestProvisioner()
+		ctrl := newTestProvisionController(client, test.provisionerName, provisioner, test.serverGitVersion)
+
+		should := ctrl.shouldDelete(test.volume)
+		if test.expectedShould != should {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("expected should delete %v but got %v\n", test.expectedShould, should)
+		}
+	}
+}
+
+func TestIsOnlyRecordUpdate(t *testing.T) {
+	tests := []struct {
+		name       string
+		old        *v1.PersistentVolumeClaim
+		new        *v1.PersistentVolumeClaim
+		expectedIs bool
+	}{
+		{
+			name:       "is only record update",
+			old:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			new:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "b"}),
+			expectedIs: true,
+		},
+		{
+			name:       "is seen as only record update, stayed exactly the same",
+			old:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			new:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			expectedIs: true,
+		},
+		{
+			name:       "isn't only record update, class changed as well",
+			old:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			new:        newClaim("claim-1", "1-1", "class-2", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "b"}),
+			expectedIs: false,
+		},
+		{
+			name:       "isn't only record update, only class changed",
+			old:        newClaim("claim-1", "1-1", "class-1", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			new:        newClaim("claim-1", "1-1", "class-2", "", map[string]string{rl.LeaderElectionRecordAnnotationKey: "a"}),
+			expectedIs: false,
+		},
+	}
+	for _, test := range tests {
+		client := fake.NewSimpleClientset()
+		provisioner := newTestProvisioner()
+		ctrl := newTestProvisionController(client, "foo.bar/baz", provisioner, "v1.5.0")
+
+		is, _ := ctrl.isOnlyRecordUpdate(test.old, test.new)
+		if test.expectedIs != is {
+			t.Logf("test case: %s", test.name)
+			t.Errorf("expected is only record update %v but got %v\n", test.expectedIs, is)
+		}
+	}
+}
+
+func newTestProvisionController(
+	client kubernetes.Interface,
+	provisionerName string,
+	provisioner Provisioner,
+	serverGitVersion string,
+) *ProvisionController {
+	ctrl := NewProvisionController(
+		client,
+		provisionerName,
+		provisioner,
+		serverGitVersion,
+		ResyncPeriod(resyncPeriod),
+		ExponentialBackOffOnError(false),
+		CreateProvisionedPVInterval(10*time.Millisecond),
+		LeaseDuration(2*resyncPeriod),
+		RenewDeadline(resyncPeriod),
+		RetryPeriod(resyncPeriod/2),
+		TermLimit(2*resyncPeriod))
+	return ctrl
+}
+
+func newStorageClass(name, provisioner string) *storagebeta.StorageClass {
+	return &storagebeta.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: provisioner,
+	}
+}
+
+func newClaim(name, claimUID, provisioner, volumeName string, annotations map[string]string) *v1.PersistentVolumeClaim {
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       v1.NamespaceDefault,
+			UID:             types.UID(claimUID),
+			ResourceVersion: "0",
+			Annotations:     map[string]string{annClass: provisioner},
+			SelfLink:        "/api/v1/namespaces/" + v1.NamespaceDefault + "/persistentvolumeclaims/" + name,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Mi"),
+				},
+			},
+			VolumeName: volumeName,
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimPending,
+		},
+	}
+	for k, v := range annotations {
+		claim.Annotations[k] = v
+	}
+	return claim
+}
+
+func newVolume(name string, phase v1.PersistentVolumePhase, policy v1.PersistentVolumeReclaimPolicy, annotations map[string]string) *v1.PersistentVolume {
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+			SelfLink:    "/api/v1/persistentvolumes/" + name,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: policy,
+			AccessModes:                   []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany},
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Mi"),
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{
+					Server:   "foo",
+					Path:     "bar",
+					ReadOnly: false,
+				},
+			},
+		},
+		Status: v1.PersistentVolumeStatus{
+			Phase: phase,
+		},
+	}
+
+	return pv
+}
+
+// newProvisionedVolume returns the volume the test controller should provision for the
+// given claim with the given class
+func newProvisionedVolume(storageClass *storagebeta.StorageClass, claim *v1.PersistentVolumeClaim) *v1.PersistentVolume {
+	// pv.Spec MUST be set to match requirements in claim.Spec, especially access mode and PV size. The provisioned volume size MUST NOT be smaller than size requested in the claim, however it MAY be larger.
+	options := VolumeOptions{
+		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+		PVName:     "pvc-" + string(claim.ObjectMeta.UID),
+		PVC:        claim,
+		Parameters: storageClass.Parameters,
+	}
+	volume, _ := newTestProvisioner().Provision(options)
+
+	// pv.Spec.ClaimRef MUST point to the claim that led to its creation (including the claim UID).
+	v1.AddToScheme(scheme.Scheme)
+	volume.Spec.ClaimRef, _ = ref.GetReference(scheme.Scheme, claim)
+
+	// pv.Annotations["pv.kubernetes.io/provisioned-by"] MUST be set to name of the external provisioner. This provisioner will be used to delete the volume.
+	// pv.Annotations["volume.beta.kubernetes.io/storage-class"] MUST be set to name of the storage class requested by the claim.
+	volume.Annotations = map[string]string{annDynamicallyProvisioned: storageClass.Provisioner, annClass: storageClass.Name}
+
+	// TODO implement options.ProvisionerSelector parsing
+	// pv.Labels MUST be set to match claim.spec.selector. The provisioner MAY add additional labels.
+
+	return volume
+}
+
+func newTestProvisioner() *testProvisioner {
+	return &testProvisioner{make(chan bool, 16)}
+}
+
+type testProvisioner struct {
+	provisionCalls chan bool
+}
+
+var _ Provisioner = &testProvisioner{}
+
+func (p *testProvisioner) Provision(options VolumeOptions) (*v1.PersistentVolume, error) {
+	p.provisionCalls <- true
+
+	// Sleep to simulate work done by Provision...for long enough that
+	// TestMultipleControllers will consistently fail with lock disabled. If
+	// Provision happens too fast, the first controller creates the PV too soon
+	// and the next controllers won't call Provision even though they're clearly
+	// racing when there's no lock
+	time.Sleep(50 * time.Millisecond)
+
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options.PVName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
+			AccessModes:                   options.PVC.Spec.AccessModes,
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				NFS: &v1.NFSVolumeSource{
+					Server:   "foo",
+					Path:     "bar",
+					ReadOnly: false,
+				},
+			},
+		},
+	}
+
+	return pv, nil
+}
+
+func (p *testProvisioner) Delete(volume *v1.PersistentVolume) error {
+	return nil
+}
+
+func newBadTestProvisioner() Provisioner {
+	return &badTestProvisioner{}
+}
+
+type badTestProvisioner struct {
+}
+
+var _ Provisioner = &badTestProvisioner{}
+
+func (p *badTestProvisioner) Provision(options VolumeOptions) (*v1.PersistentVolume, error) {
+	return nil, errors.New("fake error")
+}
+
+func (p *badTestProvisioner) Delete(volume *v1.PersistentVolume) error {
+	return errors.New("fake error")
+}
+
+func newIgnoredProvisioner() Provisioner {
+	return &ignoredProvisioner{}
+}
+
+type ignoredProvisioner struct {
+}
+
+var _ Provisioner = &ignoredProvisioner{}
+
+func (i *ignoredProvisioner) Provision(options VolumeOptions) (*v1.PersistentVolume, error) {
+	if options.PVC.Name == "claim-2" {
+		return nil, &IgnoredError{"Ignored"}
+	}
+
+	return newProvisionedVolume(newStorageClass("class-1", "foo.bar/baz"), newClaim("claim-1", "uid-1-1", "class-1", "", nil)), nil
+}
+
+func (i *ignoredProvisioner) Delete(volume *v1.PersistentVolume) error {
+	return nil
+}
+
+type claimReactor struct {
+	fake        *fakev1core.FakeCoreV1
+	claims      map[string]*v1.PersistentVolumeClaim
+	lock        sync.Mutex
+	claimSource *fcache.FakePVCControllerSource
+}
+
+func (r *claimReactor) React(action testclient.Action) (handled bool, ret runtime.Object, err error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	switch {
+	case action.Matches("update", "persistentvolumeclaims"):
+		obj := action.(testclient.UpdateAction).GetObject()
+
+		claim := obj.(*v1.PersistentVolumeClaim)
+
+		// Check and bump object version
+		storedClaim, found := r.claims[claim.Name]
+		if found {
+			storedVer, _ := strconv.Atoi(storedClaim.ResourceVersion)
+			requestedVer, _ := strconv.Atoi(claim.ResourceVersion)
+			if storedVer != requestedVer {
+				return true, obj, errors.New("VersionError")
+			}
+			claim.ResourceVersion = strconv.Itoa(storedVer + 1)
+		} else {
+			return true, nil, fmt.Errorf("Cannot update claim %s: claim not found", claim.Name)
+		}
+
+		r.claims[claim.Name] = claim
+		r.claimSource.Modify(claim)
+		return true, claim, nil
+	case action.Matches("get", "persistentvolumeclaims"):
+		name := action.(testclient.GetAction).GetName()
+		claim, found := r.claims[name]
+		if found {
+			clone, err := conversion.NewCloner().DeepCopy(claim)
+			if err != nil {
+				return true, nil, fmt.Errorf("Error cloning claim %s: %v", name, err)
+			}
+			claimClone, ok := clone.(*v1.PersistentVolumeClaim)
+			if !ok {
+				return true, nil, fmt.Errorf("Error casting clone of claim %s: %v", name, claimClone)
+			}
+			return true, claimClone, nil
+		}
+		return true, nil, fmt.Errorf("Cannot find claim %s", name)
+	}
+
+	return false, nil, nil
+}

--- a/pkg/operator/provisioner/controller/leaderelection/leaderelection.go
+++ b/pkg/operator/provisioner/controller/leaderelection/leaderelection.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a modified version of kube's leaderelection package which uses a
+// dummy endpoints object & its annotation as a lock. Here a pvc is used and
+// the lock is to help ensure only one provisioner (the leader) is trying to
+// provision a volume for the pvc at a time. So the election lasts only until
+// the task is completed. Adds also a 'TermLimit.'
+// https://github.com/kubernetes/kubernetes/tree/release-1.5/pkg/client/leaderelection
+
+package leaderelection
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	rl "github.com/rook/rook/pkg/operator/provisioner/controller/leaderelection/resourcelock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/golang/glog"
+)
+
+const (
+	// JitterFactor is the factor to jitter the RetryPeriod by
+	JitterFactor = 1.2
+)
+
+// NewLeaderElector creates a LeaderElector from a Config
+func NewLeaderElector(lec Config) (*LeaderElector, error) {
+	if lec.LeaseDuration <= lec.RenewDeadline {
+		return nil, fmt.Errorf("leaseDuration must be greater than renewDeadline")
+	}
+	if lec.RenewDeadline <= time.Duration(JitterFactor*float64(lec.RetryPeriod)) {
+		return nil, fmt.Errorf("renewDeadline must be greater than retryPeriod*JitterFactor")
+	}
+	if lec.Lock == nil {
+		return nil, fmt.Errorf("lock must not be nil")
+	}
+	return &LeaderElector{
+		config: lec,
+	}, nil
+}
+
+// Config is a configuration for leader election
+type Config struct {
+	// Lock is the resource that will be used for locking
+	Lock rl.Interface
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack.
+	LeaseDuration time.Duration
+	// RenewDeadline is the duration that the acting master will retry
+	// refreshing leadership before giving up.
+	RenewDeadline time.Duration
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	RetryPeriod time.Duration
+	// TermLimit is the maximum duration that a leader may remain the leader
+	// to complete the task before it must give up its leadership. 0 for forever
+	// or indefinite.
+	TermLimit time.Duration
+
+	// Callbacks are callbacks that are triggered during certain lifecycle
+	// events of the LeaderElector
+	Callbacks LeaderCallbacks
+}
+
+// LeaderCallbacks are callbacks that are triggered during certain
+// lifecycle events of the LeaderElector. These are invoked asynchronously.
+//
+// possible future callbacks:
+//  * OnChallenge()
+type LeaderCallbacks struct {
+	// OnStartedLeading is called when a LeaderElector client starts leading
+	OnStartedLeading func(stop <-chan struct{})
+	// OnStoppedLeading is called when a LeaderElector client stops leading
+	OnStoppedLeading func()
+	// OnNewLeader is called when the client observes a leader that is
+	// not the previously observed leader. This includes the first observed
+	// leader when the client starts.
+	OnNewLeader func(identity string)
+}
+
+// LeaderElector is a leader election client.
+//
+// possible future methods:
+//  * (le *LeaderElector) IsLeader()
+//  * (le *LeaderElector) GetLeader()
+type LeaderElector struct {
+	config Config
+	// internal bookkeeping
+	observedRecord rl.LeaderElectionRecord
+	observedTime   time.Time
+	// used to implement OnNewLeader(), may lag slightly from the
+	// value observedRecord.HolderIdentity if the transition has
+	// not yet been reported.
+	reportedLeader string
+}
+
+// Run starts the leader election loop
+func (le *LeaderElector) Run(task <-chan bool) {
+	defer func() {
+		runtime.HandleCrash()
+	}()
+	over := le.acquire(task)
+	if over {
+		return
+	}
+	stop := make(chan struct{})
+	go le.config.Callbacks.OnStartedLeading(stop)
+	timeout := make(chan bool, 1)
+	go func() {
+		time.Sleep(le.config.TermLimit)
+		timeout <- true
+	}()
+	le.renew(task, timeout)
+	close(stop)
+	le.config.Callbacks.OnStoppedLeading()
+}
+
+// GetLeader returns the identity of the last observed leader or returns the empty string if
+// no leader has yet been observed.
+func (le *LeaderElector) GetLeader() string {
+	return le.observedRecord.HolderIdentity
+}
+
+// IsLeader returns true if the last observed leader was this client else returns false.
+func (le *LeaderElector) IsLeader() bool {
+	return le.observedRecord.HolderIdentity == le.config.Lock.Identity()
+}
+
+// acquire loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew succeeds
+// or the task has successfully finished in which case there is no longer a need to acquire
+func (le *LeaderElector) acquire(task <-chan bool) bool {
+	over := false
+	stop := make(chan struct{})
+	glog.Infof("attempting to acquire leader lease...")
+	wait.JitterUntil(func() {
+		select {
+		case taskSucceeded := <-task:
+			if taskSucceeded {
+				// if the leader succeeded at the task, stop trying to acquire
+				desc := le.config.Lock.Describe()
+				glog.Infof("stopped trying to acquire lease %v, task succeeded", desc)
+				over = true
+				close(stop)
+				return
+			}
+		default:
+		}
+		succeeded := le.tryAcquireOrRenew()
+		le.maybeReportTransition()
+		desc := le.config.Lock.Describe()
+		if !succeeded {
+			glog.V(4).Infof("failed to acquire lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("became leader")
+		glog.Infof("successfully acquired lease %v", desc)
+		close(stop)
+	}, le.config.RetryPeriod, JitterFactor, true, stop)
+
+	return over
+}
+
+// renew loops calling tryAcquireOrRenew and returns immediately when tryAcquireOrRenew fails
+// or the task has either succeeded or failed in which case leadership must be given up.
+func (le *LeaderElector) renew(task <-chan bool, timeout <-chan bool) {
+	stop := make(chan struct{})
+	wait.Until(func() {
+		select {
+		case taskSucceeded := <-task:
+			// if the leader (us) either succeeded or failed at the task, stop trying to renew
+			desc := le.config.Lock.Describe()
+			taskSucceededStr := "succeeded"
+			if !taskSucceeded {
+				taskSucceededStr = "failed"
+			}
+			glog.Infof("stopped trying to renew lease %v, task %s", desc, taskSucceededStr)
+			close(stop)
+			return
+		case <-timeout:
+			// our term limit has ended, let somebody else have a try
+			desc := le.config.Lock.Describe()
+			glog.Infof("stopped trying to renew lease %v, timeout reached", desc)
+			close(stop)
+			return
+		default:
+		}
+		err := wait.Poll(le.config.RetryPeriod, le.config.RenewDeadline, func() (bool, error) {
+			return le.tryAcquireOrRenew(), nil
+		})
+		le.maybeReportTransition()
+		desc := le.config.Lock.Describe()
+		if err == nil {
+			glog.V(4).Infof("succesfully renewed lease %v", desc)
+			return
+		}
+		le.config.Lock.RecordEvent("stopped leading")
+		glog.Infof("failed to renew lease %v", desc)
+		close(stop)
+	}, 0, stop)
+}
+
+// tryAcquireOrRenew tries to acquire a leader lease if it is not already acquired,
+// else it tries to renew the lease if it has already been acquired. Returns true
+// on success else returns false.
+func (le *LeaderElector) tryAcquireOrRenew() bool {
+	now := metav1.Now()
+	leaderElectionRecord := rl.LeaderElectionRecord{
+		HolderIdentity:       le.config.Lock.Identity(),
+		LeaseDurationSeconds: int(le.config.LeaseDuration / time.Second),
+		RenewTime:            now,
+		AcquireTime:          now,
+	}
+
+	// 1. obtain or create the ElectionRecord
+	oldLeaderElectionRecord, err := le.config.Lock.Get()
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			glog.Errorf("error retrieving resource lock %v: %v", le.config.Lock.Describe(), err)
+			return false
+		}
+		if err = le.config.Lock.Create(leaderElectionRecord); err != nil {
+			glog.Errorf("error initially creating leader election record: %v", err)
+			return false
+		}
+		le.observedRecord = leaderElectionRecord
+		le.observedTime = time.Now()
+		return true
+	}
+
+	// 2. Record obtained, check the Identity & Time
+	if !reflect.DeepEqual(le.observedRecord, *oldLeaderElectionRecord) {
+		le.observedRecord = *oldLeaderElectionRecord
+		le.observedTime = time.Now()
+	}
+	if le.observedTime.Add(le.config.LeaseDuration).After(now.Time) &&
+		oldLeaderElectionRecord.HolderIdentity != le.config.Lock.Identity() {
+		glog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
+		return false
+	}
+
+	// 3. We're going to try to update. The leaderElectionRecord is set to it's default
+	// here. Let's correct it before updating.
+	if oldLeaderElectionRecord.HolderIdentity == le.config.Lock.Identity() {
+		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+	} else {
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
+	}
+
+	// update the lock itself
+	if err = le.config.Lock.Update(leaderElectionRecord); err != nil {
+		glog.Errorf("Failed to update lock: %v", err)
+		return false
+	}
+	le.observedRecord = leaderElectionRecord
+	le.observedTime = time.Now()
+	return true
+}
+
+func (le *LeaderElector) maybeReportTransition() {
+	if le.observedRecord.HolderIdentity == le.reportedLeader {
+		return
+	}
+	le.reportedLeader = le.observedRecord.HolderIdentity
+	if le.config.Callbacks.OnNewLeader != nil {
+		go le.config.Callbacks.OnNewLeader(le.reportedLeader)
+	}
+}

--- a/pkg/operator/provisioner/controller/leaderelection/resourcelock/interface.go
+++ b/pkg/operator/provisioner/controller/leaderelection/resourcelock/interface.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	// LeaderElectionRecordAnnotationKey is the annotation key for records
+	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
+)
+
+// LeaderElectionRecord is the record that is stored in the leader election annotation.
+// This information should be used for observational purposes only and could be replaced
+// with a random string (e.g. UUID) with only slight modification of this code.
+// TODO(mikedanese): this should potentially be versioned
+type LeaderElectionRecord struct {
+	HolderIdentity       string      `json:"holderIdentity"`
+	LeaseDurationSeconds int         `json:"leaseDurationSeconds"`
+	AcquireTime          metav1.Time `json:"acquireTime"`
+	RenewTime            metav1.Time `json:"renewTime"`
+	LeaderTransitions    int         `json:"leaderTransitions"`
+}
+
+// Config common data that exists across different
+// resource locks
+type Config struct {
+	Identity      string
+	EventRecorder record.EventRecorder
+}
+
+// Interface offers a common interface for locking on arbitrary
+// resources used in leader election.  The Interface is used
+// to hide the details on specific implementations in order to allow
+// them to change over time.  This interface is strictly for use
+// by the leaderelection code.
+type Interface interface {
+	// Get returns the LeaderElectionRecord
+	Get() (*LeaderElectionRecord, error)
+
+	// Create attempts to create a LeaderElectionRecord
+	Create(ler LeaderElectionRecord) error
+
+	// Update will update and existing LeaderElectionRecord
+	Update(ler LeaderElectionRecord) error
+
+	// RecordEvent is used to record events
+	RecordEvent(string)
+
+	// Identity will return the locks Identity
+	Identity() string
+
+	// Describe is used to convert details on current resource lock
+	// into a string
+	Describe() string
+}

--- a/pkg/operator/provisioner/controller/leaderelection/resourcelock/provisionpvclock.go
+++ b/pkg/operator/provisioner/controller/leaderelection/resourcelock/provisionpvclock.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+// ProvisionPVCLock is a lock on an existing PVC to provision a PV for
+type ProvisionPVCLock struct {
+	// PVCMeta should contain a Name and a Namespace of a PVC
+	// object that the LeaderElector will attempt to lead.
+	PVCMeta    metav1.ObjectMeta
+	Client     clientset.Interface
+	LockConfig Config
+	p          *v1.PersistentVolumeClaim
+}
+
+// Get returns the LeaderElectionRecord
+func (pl *ProvisionPVCLock) Get() (*LeaderElectionRecord, error) {
+	var record LeaderElectionRecord
+	var err error
+	pl.p, err = pl.Client.Core().PersistentVolumeClaims(pl.PVCMeta.Namespace).Get(pl.PVCMeta.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// TODO there should be a way to give up if the pvc is already bound...we are doing a Get regardless
+	if pl.p.Annotations == nil {
+		pl.p.Annotations = make(map[string]string)
+	}
+	if recordBytes, found := pl.p.Annotations[LeaderElectionRecordAnnotationKey]; found {
+		if err := json.Unmarshal([]byte(recordBytes), &record); err != nil {
+			return nil, err
+		}
+	}
+	return &record, nil
+}
+
+// Create is not allowed, the PVC should already exist
+func (pl *ProvisionPVCLock) Create(ler LeaderElectionRecord) error {
+	return errors.New("create not allowed, PVC should already exist")
+}
+
+// Update will update and existing annotation on a given resource.
+func (pl *ProvisionPVCLock) Update(ler LeaderElectionRecord) error {
+	if pl.p == nil {
+		return errors.New("PVC not initialized, call get first")
+	}
+	recordBytes, err := json.Marshal(ler)
+	if err != nil {
+		return err
+	}
+	pl.p.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
+	pl.p, err = pl.Client.Core().PersistentVolumeClaims(pl.PVCMeta.Namespace).Update(pl.p)
+	return err
+}
+
+// RecordEvent in leader election while adding meta-data
+func (pl *ProvisionPVCLock) RecordEvent(s string) {
+	// events := fmt.Sprintf("%v %v", pl.LockConfig.Identity, s)
+	// pl.LockConfig.EventRecorder.Eventf(&v1.PersistentVolumeClaim{ObjectMeta: pl.p.ObjectMeta}, v1.EventTypeNormal, "LeaderElection", events)
+}
+
+// Describe is used to convert details on current resource lock
+// into a string
+func (pl *ProvisionPVCLock) Describe() string {
+	return fmt.Sprintf("to provision for pvc %v/%v", pl.PVCMeta.Namespace, pl.PVCMeta.Name)
+}
+
+// Identity returns the Identity of the lock
+func (pl *ProvisionPVCLock) Identity() string {
+	return pl.LockConfig.Identity
+}

--- a/pkg/operator/provisioner/controller/volume.go
+++ b/pkg/operator/provisioner/controller/volume.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// Provisioner is an interface that creates templates for PersistentVolumes
+// and can create the volume as a new resource in the infrastructure provider.
+// It can also remove the volume it created from the underlying storage
+// provider.
+type Provisioner interface {
+	// Provision creates a volume i.e. the storage asset and returns a PV object
+	// for the volume
+	Provision(VolumeOptions) (*v1.PersistentVolume, error)
+	// Delete removes the storage asset that was created by Provision backing the
+	// given PV. Does not delete the PV object itself.
+	//
+	// May return IgnoredError to indicate that the call has been ignored and no
+	// action taken.
+	Delete(*v1.PersistentVolume) error
+}
+
+// IgnoredError is the value for Delete to return to indicate that the call has
+// been ignored and no action taken. In case multiple provisioners are serving
+// the same storage class, provisioners may ignore PVs they are not responsible
+// for (e.g. ones they didn't create). The controller will act accordingly,
+// i.e. it won't emit a misleading VolumeFailedDelete event.
+type IgnoredError struct {
+	Reason string
+}
+
+func (e *IgnoredError) Error() string {
+	return fmt.Sprintf("ignored because %s", e.Reason)
+}
+
+// VolumeOptions contains option information about a volume
+// https://github.com/kubernetes/kubernetes/blob/release-1.4/pkg/volume/plugins.go
+type VolumeOptions struct {
+	// Reclamation policy for a persistent volume
+	PersistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy
+	// PV.Name of the appropriate PersistentVolume. Used to generate cloud
+	// volume name.
+	PVName string
+	// PVC is reference to the claim that lead to provisioning of a new PV.
+	// Provisioners *must* create a PV that would be matched by this PVC,
+	// i.e. with required capacity, accessMode, labels matching PVC.Selector and
+	// so on.
+	PVC *v1.PersistentVolumeClaim
+	// Volume provisioning parameters from StorageClass
+	Parameters map[string]string
+}

--- a/pkg/operator/provisioner/provisioner.go
+++ b/pkg/operator/provisioner/provisioner.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/rook/rook/pkg/agent/flexvolume"
 	ceph "github.com/rook/rook/pkg/ceph/client"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/cluster"
+	"github.com/rook/rook/pkg/operator/provisioner/controller"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/operator/provisioner/provisioner_test.go
+++ b/pkg/operator/provisioner/provisioner_test.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	cephtest "github.com/rook/rook/pkg/ceph/test"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/provisioner/controller"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
moved external-storage/libcontroller into rook/rook for now. this helps us have a greater control over versioning it and keeping it updated as Kubernetes changes. The plan is to move it back out once https://github.com/kubernetes-incubator/external-storage/issues/423 is resolved.