### PR TITLE
Enable Prometheus metrics on Ceph mgr

### DIFF
--- a/Documentation/k8s-monitoring.md
+++ b/Documentation/k8s-monitoring.md
@@ -54,6 +54,14 @@ You should now see the Prometheus monitoring website.  Click on `Graph` in the t
 select any metric you would like to see, for example `ceph_cluster_used_bytes`, followed by clicking on the `Execute` button.  Below the `Execute` button, ensure
 the `Graph` tab is selected and you should now see a graph of your chosen metric over time.
 
+## Prometheus Consoles
+You can find Prometheus Consoles here: https://github.com/ceph/cephmetrics/tree/master/dashboards/current.
+A guide to how you can write your own Prometheus consoles can be found on the official Prometheus site here: https://prometheus.io/docs/visualization/consoles/
+
+## Grafana Dashboards
+Currently there are no official Rook dashboards, which will change soon, but you can find some here: https://github.com/SUSE/DeepSea/tree/master/srv/salt/ceph/monitoring/grafana/files
+To use the dashboards, just download the JSON file(s) and in Grafan import them by uploading the JSON file.
+
 ## Teardown
 
 To clean up all the artifacts created by the monitoring walkthrough, copy/paste the entire block below (note that errors about resources "not found" can be ignored):

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,11 +3,12 @@
 ## Action Required
 
 ## Notable Features
+- Monitoring is now done through the Ceph MGR service for Ceph storage.
 
 ## Breaking Changes
 
 ### Cluster CRD
-- Removed the `versionTag` property. The container version to launch in all pods will be the same as the version of the operator container. 
+- Removed the `versionTag` property. The container version to launch in all pods will be the same as the version of the operator container.
 
 ### Operator
 - Removed the `ROOK_REPO_PREFIX` env var. All containers will be launched with the same image as the operator
@@ -15,3 +16,4 @@
 ## Known Issues
 
 ## Deprecations
+- Monitoring through rook-api is deprecated. The Ceph MGR service named `rook-ceph-mgr` port `9283` path `/` should be used instead.

--- a/cluster/examples/kubernetes/monitoring/service-monitor.yaml
+++ b/cluster/examples/kubernetes/monitoring/service-monitor.yaml
@@ -1,16 +1,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: rook-api
+  name: rook-ceph-mgr
   namespace: rook
   labels:
     team: rook
 spec:
   selector:
     matchLabels:
-      app: rook-api
+      app: rook-ceph-mgr
       rook_cluster: rook
   endpoints:
-  - port: rook-api
-    path: /metrics
+  - port: http-metrics
+    path: /
     interval: 5s

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -25,7 +25,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yy -q --no-install-recommends \
         python-setuptools \
         gperf \
-        \
         cython:${ARCH} \
         python:${ARCH} \
         libaio-dev:${ARCH} \

--- a/images/rook/Dockerfile.base
+++ b/images/rook/Dockerfile.base
@@ -44,6 +44,9 @@ RUN BOOST_VERSION=1.62.0 && \
         libsnappy1v5 \
         python-prettytable \
         python2.7-minimal \
+        python-cherrypy3:${ARCH} \
+        python-pecan:${ARCH} \
+        python-openssl:${ARCH} \
         ${EXTRALIBS} && \
     DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+// MgrEnableModule Enable module for mgr
+func MgrEnableModule(context *clusterd.Context, clusterName, name string, force bool) error {
+	args := []string{"mgr", "module", "enable", name}
+	if force {
+		args = append(args, "--force")
+	}
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to mgr module enable for %s: %+v", name, err)
+	}
+
+	return nil
+}

--- a/pkg/operator/cluster/ceph/mgr/mgr_test.go
+++ b/pkg/operator/cluster/ceph/mgr/mgr_test.go
@@ -83,6 +83,7 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, "mgr1", d.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, d.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, 2, len(d.Spec.Template.Spec.Volumes))
+	assert.Equal(t, 2, len(d.Spec.Template.Spec.Containers[0].Ports))
 	assert.Equal(t, "rook-data", d.Spec.Template.Spec.Volumes[0].Name)
 
 	assert.Equal(t, "mgr1", d.ObjectMeta.Name)
@@ -99,6 +100,15 @@ func TestPodSpec(t *testing.T) {
 
 	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
+}
+
+func TestServiceSpec(t *testing.T) {
+	c := New(nil, "ns", "myversion", rookalpha.Placement{}, false, v1.ResourceRequirements{})
+
+	s := c.makeService("rook-mgr")
+	assert.NotNil(t, s)
+	assert.Equal(t, "rook-mgr", s.Name)
+	assert.Equal(t, 1, len(s.Spec.Ports))
 }
 
 func TestHostNetwork(t *testing.T) {


### PR DESCRIPTION
Fixes #1111.

***

This **a)** create a service in front of the Ceph mgrs and **b)** enable the mgrs Prometheus module to provide prometheus metrics (instead of the rook-api).

This hasn't been tested yet. Will do in the next few days.

**ToDo**:
- [x] Update prometheus-operator service monitor manifest
- [x] Test it

/cc @jpds