### PR TITLE
Set default dataDirHostPath to /var/lib/rook

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -21,7 +21,9 @@ Settings can be specified at the global level to apply to the cluster as a whole
 ### Cluster settings
 
 - `versionTag`: The version (tag) of the `rook/rook` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
-- `dataDirHostPath`: The host path where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.  Therefore, for test scenarios, the path must be deleted if you are going to delete a cluster and start a new cluster on the same hosts.  More details can be found in the Kubernetes [host path docs](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath).
+- `dataDirHostPath`: The path on the host ([hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)) where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.
+  - If a path is not specified, an [empty dir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will be used and the config will be lost when the pod or host is restarted. This option is **not recommended**.
+  - **WARNING**: For test scenarios, if you delete a cluster and start a new cluster on the same hosts, the path used by `dataDirHostPath` must be deleted. Otherwise, stale keys and other config will remain from the previous cluster and the new mons will fail to start. 
 If this value is empty, each pod will get an ephemeral directory to store their config files that is tied to the lifetime of the pod running on that node. More details can be found in the Kubernetes [empty dir docs](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
 - `hostNetwork`: uses network of the hosts instead of using the SDN below the containers.
 - `monCount`: set the amount of mons to be started. The number must be odd and between `1` and `9`. Default if not specified is `3`.
@@ -94,7 +96,7 @@ metadata:
   namespace: rook
 spec:
   versionTag: master
-  dataDirHostPath:
+  dataDirHostPath: /var/lib/rook
   # cluster level storage configuration and selection
   storage:
     useAllNodes: true
@@ -126,7 +128,7 @@ metadata:
   namespace: rook
 spec:
   versionTag: master
-  dataDirHostPath:
+  dataDirHostPath: /var/lib/rook
   # cluster level storage configuration and selection
   storage:                
     useAllNodes: false
@@ -171,7 +173,7 @@ metadata:
   namespace: rook
 spec:
   versionTag: master
-  dataDirHostPath:
+  dataDirHostPath: /var/lib/rook
   placement:
     all:
       nodeAffinity:

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -69,7 +69,7 @@ metadata:
   namespace: rook
 spec:
   versionTag: master
-  dataDirHostPath:
+  dataDirHostPath: /var/lib/rook
   storage:
     useAllNodes: true
     useAllDevices: false

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -10,7 +10,9 @@ metadata:
   namespace: rook
 spec:
   versionTag: master
-  dataDirHostPath:
+  # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
+  # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
+  dataDirHostPath: /var/lib/rook
   # toggle to use hostNetwork
   hostNetwork: false
   # set the amount of mons to be started

--- a/cmd/rook/agent.go
+++ b/cmd/rook/agent.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rook/rook/pkg/agent"
 	"github.com/rook/rook/pkg/clusterd"
@@ -45,8 +44,7 @@ func startAgent(cmd *cobra.Command, args []string) error {
 
 	clientset, apiExtClientset, err := getClientset()
 	if err != nil {
-		fmt.Printf("failed to get k8s client. %+v", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to get k8s client. %+v", err))
 	}
 
 	logger.Info("starting rook agent")
@@ -59,8 +57,7 @@ func startAgent(cmd *cobra.Command, args []string) error {
 	agent := agent.New(context)
 	err = agent.Run()
 	if err != nil {
-		fmt.Printf("failed to run rook agent. %+v\n", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to run rook agent. %+v\n", err))
 	}
 
 	return nil

--- a/cmd/rook/api.go
+++ b/cmd/rook/api.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rook/rook/pkg/api"
 	"github.com/rook/rook/pkg/ceph/mon"
@@ -65,8 +64,7 @@ func startAPI(cmd *cobra.Command, args []string) error {
 
 	clientset, _, err := getClientset()
 	if err != nil {
-		fmt.Printf("failed to init k8s client. %+v\n", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to init k8s client. %+v\n", err))
 	}
 
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
@@ -76,8 +74,7 @@ func startAPI(cmd *cobra.Command, args []string) error {
 
 	err = api.Run(context, c)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/cmd/rook/mds.go
+++ b/cmd/rook/mds.go
@@ -16,8 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/rook/rook/pkg/ceph/mds"
@@ -78,8 +76,7 @@ func startMDS(cmd *cobra.Command, args []string) error {
 
 	err := mds.Run(createContext(), config)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/cmd/rook/mgr.go
+++ b/cmd/rook/mgr.go
@@ -16,9 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/rook/rook/pkg/ceph/mgr"
 	"github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/util/flags"
@@ -65,8 +62,7 @@ func startMgr(cmd *cobra.Command, args []string) error {
 
 	err := mgr.Run(createContext(), config)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -74,8 +74,7 @@ func startMon(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := compareMonSecret(clusterInfo.MonitorSecret, path.Join(cfg.dataDir, monName)); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	// at first start the local monitor needs to be added to the list of mons
@@ -89,8 +88,7 @@ func startMon(cmd *cobra.Command, args []string) error {
 	}
 	err := mon.Run(createContext(), monCfg)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/cmd/rook/mon.go
+++ b/cmd/rook/mon.go
@@ -18,7 +18,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 
+	"github.com/go-ini/ini"
 	"github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
@@ -71,6 +73,11 @@ func startMon(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("missing mon port")
 	}
 
+	if err := compareMonSecret(clusterInfo.MonitorSecret, path.Join(cfg.dataDir, monName)); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	// at first start the local monitor needs to be added to the list of mons
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddrIPv4, monPort)
@@ -86,5 +93,37 @@ func startMon(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	return nil
+}
+
+// Compare the expected mon keyring secret with the cached keyring from a previous run of the monitor.
+// If these don't match we will not want to launch the monitor.
+func compareMonSecret(secret, configDir string) error {
+	cachedKeyringFile := path.Join(configDir, "data", "keyring")
+	if _, err := os.Stat(cachedKeyringFile); os.IsNotExist(err) {
+		// the mon is starting for the first time
+		logger.Infof("mon keyring is not yet cached at %s", cachedKeyringFile)
+		return nil
+	}
+
+	contents, err := ini.Load(cachedKeyringFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read config file %s. %+v. Skipping check for cached keyring.\n", cachedKeyringFile, err)
+		return nil
+	}
+	section, err := contents.GetSection("mon.")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to find mon section in the cached keyring. %+v. Skipping check for cached keyring.\n", err)
+		return nil
+	}
+	cachedKeyring, err := section.GetKey("key")
+	if err != nil || cachedKeyring == nil {
+		fmt.Fprintf(os.Stderr, "failed to find mon keyring in the cached file. %+v. Skipping check for cached keyring.\n", err)
+		return nil
+	}
+	if cachedKeyring.Value() != secret {
+		return fmt.Errorf("The keyring does not match the existing keyring in %s. You may need to delete the contents of dataDirHostPath on the host from a previous deployment.", cachedKeyringFile)
+	}
+	logger.Infof("cached mon secret matches the expected keyring")
 	return nil
 }

--- a/cmd/rook/mon_test.go
+++ b/cmd/rook/mon_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareKeyring(t *testing.T) {
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+
+	keyring := "mytestcomplicatedsecurekeyring"
+	contents := fmt.Sprintf(`
+	[mon.]
+	  key = %s
+	`, keyring)
+	dataPath := path.Join(configDir, "data")
+	keyringPath := path.Join(dataPath, "keyring")
+	err := os.MkdirAll(dataPath, 0755)
+	assert.Nil(t, err)
+	err = ioutil.WriteFile(keyringPath, []byte(contents), 0644)
+	assert.Nil(t, err)
+
+	err = compareMonSecret(keyring, configDir)
+	assert.Nil(t, err)
+
+	err = compareMonSecret("badkeyring", configDir)
+	assert.NotNil(t, err)
+}

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator"
@@ -50,8 +49,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 
 	clientset, apiExtClientset, err := getClientset()
 	if err != nil {
-		fmt.Printf("failed to get k8s client. %+v", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to get k8s client. %+v", err))
 	}
 
 	logger.Infof("starting operator")
@@ -63,13 +61,11 @@ func startOperator(cmd *cobra.Command, args []string) error {
 
 	op := operator.New(context)
 	if op == nil {
-		fmt.Printf("failed to create operator.")
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to create operator."))
 	}
 	err = op.Run()
 	if err != nil {
-		fmt.Printf("failed to run operator. %+v\n", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to run operator. %+v\n", err))
 	}
 
 	return nil

--- a/cmd/rook/osd.go
+++ b/cmd/rook/osd.go
@@ -88,8 +88,7 @@ func startOSD(cmd *cobra.Command, args []string) error {
 
 	clientset, _, err := getClientset()
 	if err != nil {
-		fmt.Printf("failed to init k8s client. %+v\n", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("failed to init k8s client. %+v\n", err))
 	}
 
 	context := createContext()
@@ -99,8 +98,7 @@ func startOSD(cmd *cobra.Command, args []string) error {
 
 	locArgs, err := client.FormatLocation(cfg.location, cfg.nodeName)
 	if err != nil {
-		fmt.Printf("invalid location. %+v\n", err)
-		os.Exit(1)
+		terminateFatal(fmt.Errorf("invalid location. %+v\n", err))
 	}
 	crushLocation := strings.Join(locArgs, " ")
 
@@ -111,8 +109,7 @@ func startOSD(cmd *cobra.Command, args []string) error {
 
 	err = osd.Run(context, agent)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/rook/rook/pkg/ceph/mon"
 	"github.com/rook/rook/pkg/ceph/rgw"
@@ -81,8 +80,7 @@ func startRGW(cmd *cobra.Command, args []string) error {
 
 	err := rgw.Run(createContext(), config)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		terminateFatal(err)
 	}
 
 	return nil

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -97,6 +97,10 @@ case "${1:-}" in
     minikube start --memory=3000 --kubernetes-version ${KUBE_VERSION} --extra-config=apiserver.Authorization.Mode=RBAC
     wait_for_ssh
     enable_roles_for_RBAC
+
+    # create a link so the default dataDirHostPath will work for this environment
+    minikube ssh "sudo mkdir /mnt/sda1/var/lib/rook;sudo ln -s /mnt/sda1/var/lib/rook /var/lib/rook"
+
     copy_image_to_cluster ${BUILD_REGISTRY}/rook-amd64 rook/rook:master
     copy_image_to_cluster ${BUILD_REGISTRY}/toolbox-amd64 rook/toolbox:master
     if [[ $KUBE_VERSION == v1.5* ]] || [[ $KUBE_VERSION == v1.6* ]] || [[ $KUBE_VERSION == v1.7* ]] ;


### PR DESCRIPTION
To survive pod and node restarts, the config dir needs to be persisted to the host. As an interim change until we get the full solution on top of the local storage (#796), this change will by default set the `dataDirHostPath` to `/var/lib/rook` so the default configuration will allow for restarts. If `/var/lib/rook` is not valid for the host, the mons will fail to start and the cluster will not initialize. 

If a test cluster is destroyed and a new one brought up in its place, the path on the host must be deleted. Otherwise, the new cluster will fail to start. The mon log will have an error such as the following and enter a crash backoff loop.
```
new mon keyring does not match existing keyring in /var/lib/rook/rook-ceph-mon0/data/keyring
```

Fixes #1155