### PR TITLE
Only respond to crd updates when certain properties change

### DIFF
--- a/pkg/operator/cluster/controller.go
+++ b/pkg/operator/cluster/controller.go
@@ -166,7 +166,17 @@ func (c *ClusterController) onAdd(obj interface{}) {
 }
 
 func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
-	logger.Infof("modifying a cluster not implemented")
+	oldCluster := oldObj.(*Cluster)
+	newCluster := newObj.(*Cluster)
+	if !clusterChanged(oldCluster.Spec, newCluster.Spec) {
+		logger.Debugf("no updates made in the cluster")
+		return
+	}
+
+	logger.Infof("updating cluster %s", newCluster.Namespace)
+	if err := newCluster.createInstance(); err != nil {
+		logger.Errorf("failed to update cluster %s in namespace %s. %+v", newCluster.Name, newCluster.Namespace, err)
+	}
 }
 
 func (c *ClusterController) onDelete(obj interface{}) {
@@ -282,4 +292,9 @@ func (c *Cluster) createInitialCrushMap() error {
 	}
 
 	return nil
+}
+
+func clusterChanged(oldCluster, newCluster ClusterSpec) bool {
+	// no updates to the cluster supported yet
+	return false
 }

--- a/pkg/operator/cluster/controller_test.go
+++ b/pkg/operator/cluster/controller_test.go
@@ -51,3 +51,11 @@ func TestCreateInitialCrushMap(t *testing.T) {
 	err = c.createInitialCrushMap()
 	assert.Nil(t, err)
 }
+
+func TestClusterChanged(t *testing.T) {
+	old := ClusterSpec{VersionTag: "v0.6.0", MonCount: 1, HostNetwork: false}
+	new := ClusterSpec{VersionTag: "v0.7.0", MonCount: 3, HostNetwork: true}
+
+	// no changes supported yet
+	assert.False(t, clusterChanged(old, new))
+}

--- a/pkg/operator/mds/controller_test.go
+++ b/pkg/operator/mds/controller_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package mds to manage a rook file system.
+package mds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilesystemChanged(t *testing.T) {
+	// no change
+	old := FilesystemSpec{MetadataServer: MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
+	new := FilesystemSpec{MetadataServer: MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
+	changed := filesystemChanged(old, new)
+	assert.False(t, changed)
+
+	// changed properties
+	new = FilesystemSpec{MetadataServer: MetadataServerSpec{ActiveCount: 2, ActiveStandby: true}}
+	assert.True(t, filesystemChanged(old, new))
+
+	new = FilesystemSpec{MetadataServer: MetadataServerSpec{ActiveCount: 1, ActiveStandby: false}}
+	assert.True(t, filesystemChanged(old, new))
+}

--- a/pkg/operator/pool/controller.go
+++ b/pkg/operator/pool/controller.go
@@ -103,11 +103,24 @@ func (c *PoolController) onUpdate(oldObj, newObj interface{}) {
 		logger.Errorf("failed to update pool %s. erasurecoded update not allowed", pool.Name)
 		return
 	}
+	if !poolChanged(oldPool.Spec, pool.Spec) {
+		logger.Debugf("pool %s not changed", pool.Name)
+		return
+	}
 
 	// if the pool is modified, allow the pool to be created if it wasn't already
+	logger.Infof("updating pool %s", pool.Name)
 	if err := pool.create(c.context); err != nil {
 		logger.Errorf("failed to create (modify) pool %s. %+v", pool.ObjectMeta.Name, err)
 	}
+}
+
+func poolChanged(old, new PoolSpec) bool {
+	if old.Replicated.Size != new.Replicated.Size {
+		logger.Infof("pool replication changed from %d to %d", old.Replicated.Size, new.Replicated.Size)
+		return true
+	}
+	return false
 }
 
 func (c *PoolController) onDelete(obj interface{}) {

--- a/pkg/operator/pool/controller_test.go
+++ b/pkg/operator/pool/controller_test.go
@@ -123,6 +123,20 @@ func TestCreatePool(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestUpdatePool(t *testing.T) {
+	// the pool did not change for properties that are updatable
+	old := PoolSpec{FailureDomain: "osd", ErasureCoded: ErasureCodedSpec{CodingChunks: 2, DataChunks: 2}}
+	new := PoolSpec{FailureDomain: "host", ErasureCoded: ErasureCodedSpec{CodingChunks: 3, DataChunks: 3}}
+	changed := poolChanged(old, new)
+	assert.False(t, changed)
+
+	// the pool changed for properties that are updatable
+	old = PoolSpec{FailureDomain: "osd", Replicated: ReplicatedSpec{Size: 1}}
+	new = PoolSpec{FailureDomain: "osd", Replicated: ReplicatedSpec{Size: 2}}
+	changed = poolChanged(old, new)
+	assert.True(t, changed)
+}
+
 func TestDeletePool(t *testing.T) {
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(debug bool, actionName, command, outfile string, args ...string) (string, error) {

--- a/pkg/operator/rgw/controller_test.go
+++ b/pkg/operator/rgw/controller_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package rgw to manage a rook object store.
+package rgw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObjectStoreChanged(t *testing.T) {
+	old := ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	new := ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	// nothing changed
+	assert.False(t, storeChanged(old, new))
+
+	// there was a change
+	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 81, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, new))
+
+	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 444, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, new))
+
+	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 2, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, new))
+
+	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: true, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, new))
+
+	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: "mysecret"}}
+	assert.True(t, storeChanged(old, new))
+}


### PR DESCRIPTION
The operator responds to an update event for CRDs when there is a change. Sometimes these events are fired when the operator has no intention of updating, either because it is not supported to change the properties or because properties did not change. With this change, updates will only be applied when there were changes that the operator cares about. Fixes #1157