### PR TITLE
use /dev/null as config file for rbd tool to avoid parsing failure me…

### DIFF
--- a/pkg/ceph/client/image.go
+++ b/pkg/ceph/client/image.go
@@ -107,7 +107,6 @@ func DeleteImage(context *clusterd.Context, clusterName, name, poolName string) 
 
 // MapImage maps an RBD image using admin cephfx and returns the device path
 func MapImage(context *clusterd.Context, imageName, poolName, clusterName, keyring, monitors string) error {
-
 	imageSpec := getImageSpec(imageName, poolName)
 	args := []string{
 		"map",
@@ -116,6 +115,7 @@ func MapImage(context *clusterd.Context, imageName, poolName, clusterName, keyri
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--keyring=%s", keyring),
 		"-m", monitors,
+		"--conf=/dev/null", // no config file needed because we are passing all required config as arguments
 	}
 
 	output, err := ExecuteRBDCommandWithTimeout(context, clusterName, args)
@@ -136,7 +136,9 @@ func UnMapImage(context *clusterd.Context, imageName, poolName, clusterName, key
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--keyring=%s", keyring),
 		"-m", monitors,
+		"--conf=/dev/null", // no config file needed because we are passing all required config as arguments
 	}
+
 	output, err := ExecuteRBDCommandWithTimeout(context, clusterName, args)
 	if err != nil {
 		return fmt.Errorf("failed to unmap image %s: %+v. output: %s", deviceImage, err, output)


### PR DESCRIPTION
…ssages since we are already passing all required config as arguments

Fixes #1112 