### PR TITLE
Don't set runAsNonRoot explicitly when it is false.

### DIFF
--- a/pkg/operator/osd/osd.go
+++ b/pkg/operator/osd/osd.go
@@ -289,7 +289,9 @@ func (c *Cluster) osdContainer(devices []Device, directories []Directory, select
 		privileged = true
 	}
 	runAsUser := int64(0)
-	runAsNonRoot := false
+	// don't set runAsNonRoot explicitly when it is false, Kubernetes version < 1.6.4 has
+	// an issue with this fixed in https://github.com/kubernetes/kubernetes/pull/47009
+	// runAsNonRoot := false
 	readOnlyRootFilesystem := false
 	return v1.Container{
 		// Set the hostname so we have the pod's host in the crush map rather than the pod container name
@@ -299,9 +301,11 @@ func (c *Cluster) osdContainer(devices []Device, directories []Directory, select
 		VolumeMounts: volumeMounts,
 		Env:          envVars,
 		SecurityContext: &v1.SecurityContext{
-			Privileged:             &privileged,
-			RunAsUser:              &runAsUser,
-			RunAsNonRoot:           &runAsNonRoot,
+			Privileged: &privileged,
+			RunAsUser:  &runAsUser,
+			// don't set runAsNonRoot explicitly when it is false, Kubernetes version < 1.6.4 has
+			// an issue with this fixed in https://github.com/kubernetes/kubernetes/pull/47009
+			// RunAsNonRoot:           &runAsNonRoot,
 			ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 		},
 	}


### PR DESCRIPTION

In kubernetes < 1.6.4, it is being mis-treated as true when the flag runAsNonRoot is present regardless of its value, ref. https://github.com/kubernetes/kubernetes/pull/47009

Instead of removing the line, I decided to leave it and comment it out with a little explanation, so we don't trip that again.

Should fix #1209.

Pull request #1197  should also be updated to reflect this.