### PR TITLE
Failover mon when there is more than one mon on one node

### DIFF
--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -17,7 +17,7 @@ resources:
     memory: 128Mi
 
 mon:
-  healthCheckInterval: "20s"
+  healthCheckInterval: "45s"
   monOutTimeout: "300s"
 
 ## LogLevel can be set to: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR or CRITICAL

--- a/cluster/examples/kubernetes/1.5/rook-operator.yaml
+++ b/cluster/examples/kubernetes/1.5/rook-operator.yaml
@@ -24,7 +24,7 @@ spec:
           value: rook
         # The interval to check if every mon is in the quorum.
         - name: ROOK_MON_HEALTHCHECK_INTERVAL
-          value: "20s"
+          value: "45s"
         # The duration to wait before trying to failover or remove/replace the
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -125,7 +125,7 @@ spec:
           value: rook
         # The interval to check if every mon is in the quorum.
         - name: ROOK_MON_HEALTHCHECK_INTERVAL
-          value: "20s"
+          value: "45s"
         # The duration to wait before trying to failover or remove/replace the
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT

--- a/design/mon-health.md
+++ b/design/mon-health.md
@@ -1,58 +1,58 @@
 # Monitor Health
 
-Failure in a distributed system is to be expected. Ceph was designed from the ground up to deal with the failures of a distributed system. 
+Failure in a distributed system is to be expected. Ceph was designed from the ground up to deal with the failures of a distributed system.
 At the next layer, Rook was designed from the ground up to automate recovery of Ceph components that traditionally required admin intervention.
-Monitor health is the most critical piece of the equation that Rook actively monitors. If they are not in a good state, 
+Monitor health is the most critical piece of the equation that Rook actively monitors. If they are not in a good state,
 the operator will take action to restore their health and keep your cluster protected from disaster.
 
 The Ceph monitors (mons) are the brains of the distributed cluster. They control all of the metadata that is necessary
 to store and retrieve your data as well as keep it safe. If the monitors are not in a healthy state you will risk losing all the data in your system.
 
 ## Monitor Identity
-Each monitor in a Ceph cluster has a static identity. Every component in the cluster is aware of the identity, and that identity 
+Each monitor in a Ceph cluster has a static identity. Every component in the cluster is aware of the identity, and that identity
 must be immutable. The identity of a mon is its IP address.
 
-To have an immutable IP address in Kubernetes, Rook creates a K8s service for each monitor. The clusterIP of the service will act as the stable identity. 
+To have an immutable IP address in Kubernetes, Rook creates a K8s service for each monitor. The clusterIP of the service will act as the stable identity.
 
 When a monitor pod starts, it will bind to its podIP and it will expect communication to be via its service IP address.
 
 ## Monitor Quorum
-Multiple mons work together to provide redundancy by each keeping a copy of the metadata. A variation of the distributed algorithm Paxos 
-is used to establish consensus about the state of the cluster. Paxos requires a super-majority of mons to be running in order to establish 
-quorum and perform operations in the cluster. If the majority of mons are not running, quorum is lost and nothing can be done in the cluster. 
+Multiple mons work together to provide redundancy by each keeping a copy of the metadata. A variation of the distributed algorithm Paxos
+is used to establish consensus about the state of the cluster. Paxos requires a super-majority of mons to be running in order to establish
+quorum and perform operations in the cluster. If the majority of mons are not running, quorum is lost and nothing can be done in the cluster.
 
 ### How many mons?
-Most commonly a cluster will have three mons. This would mean that one mon could go down and allow the cluster to remain healthy. 
+Most commonly a cluster will have three mons. This would mean that one mon could go down and allow the cluster to remain healthy.
 You would still have 2/3 mons running to give you consensus in the cluster for any operation.
 
-You will always want an odd number of mons. Fifty percent of mons will not be sufficient to maintain quorum. If you had two mons and one 
+You will always want an odd number of mons. Fifty percent of mons will not be sufficient to maintain quorum. If you had two mons and one
 of them went down, you would have 1/2 of quorum. Since that is not a super-majority, the cluster would have to wait until the second mon is up again.
 
-The number of mons to create in a cluster depends on your tolerance for losing a node. If you have 1 mon zero nodes can be lost 
-to maintain quorum. With 3 mons one node can be lost, and with 5 mons two nodes can be lost. Because the Rook operator will automatically 
-start a new new monitor if one dies, you typically only need three mons. The more mons you have, the more overhead there will be to make 
-a change to the cluster, which could become a performance issue in a large cluster. 
+The number of mons to create in a cluster depends on your tolerance for losing a node. If you have 1 mon zero nodes can be lost
+to maintain quorum. With 3 mons one node can be lost, and with 5 mons two nodes can be lost. Because the Rook operator will automatically
+start a new new monitor if one dies, you typically only need three mons. The more mons you have, the more overhead there will be to make
+a change to the cluster, which could become a performance issue in a large cluster.
 
 ## Mitigating Monitor Failure
-Whatever the reason that a mon may fail (power failure, software crash, software hang, etc), there are several layers of mitigation in place 
-to help recover the mon. It is always better to bring an existing mon back up than to failover to bring up a new mon. 
+Whatever the reason that a mon may fail (power failure, software crash, software hang, etc), there are several layers of mitigation in place
+to help recover the mon. It is always better to bring an existing mon back up than to failover to bring up a new mon.
 
-The Rook operator creates a mon with a ReplicaSet to ensure that the mon pod will always be restarted if it fails. If a mon pod stops 
+The Rook operator creates a mon with a ReplicaSet to ensure that the mon pod will always be restarted if it fails. If a mon pod stops
 for any reason, Kubernetes will automatically start the pod up again.
 
-In order for a mon to support a pod/node restart, you will need to set the `dataDirHostPath` so the mon metadata will be persisted to disk 
-in this folder. This will allow the mon to start back up with its existing metadata and continue where it left off even if the pod had 
+In order for a mon to support a pod/node restart, you will need to set the `dataDirHostPath` so the mon metadata will be persisted to disk
+in this folder. This will allow the mon to start back up with its existing metadata and continue where it left off even if the pod had
 to be re-created. Without this host path, the mon cannot start again.
 
 ## Failing over a Monitor
 If the mitigating steps for mon failure don't bring a mon back up, the operator will make the decision to terminate the old monitor pod
-and bring up a new monitor with a new identity. This is an operation that must be done while there is mon quorum. 
+and bring up a new monitor with a new identity. This is an operation that must be done while there is mon quorum.
 
-The operator checks for mon health every 20 seconds. If a monitor is down, the operator will wait 5 minutes before failing over the bad mon. 
+The operator checks for mon health every 20 seconds. If a monitor is down, the operator will wait 5 minutes before failing over the bad mon.
 These two intervals can be configured as parameters to the rook [operator pod](/cluster/examples/kubernetes/rook-operator.yaml). If the intervals are too short, it could be unhealthy if the mons are failed over too aggressively. If the intervals are too long, the cluster could be at risk of losing quorum if a new monitor is not brought up before another mon fails.
 ```
 - name: ROOK_MON_HEALTHCHECK_INTERVAL
-    value: "20s"
+    value: "45s"
 - name: ROOK_MON_OUT_TIMEOUT
     value: "300s"
 ```

--- a/pkg/agent/flexvolume/controller.go
+++ b/pkg/agent/flexvolume/controller.go
@@ -318,7 +318,7 @@ func (c *FlexvolumeController) GetGlobalMountPath(volumeName string, globalMount
 
 // GetClientAccessInfo obtains the cluster monitor endpoints, username and secret
 func (c *FlexvolumeController) GetClientAccessInfo(clusterName string, clientAccessInfo *model.ClientAccessInfo) error {
-	clusterInfo, _, err := mon.LoadClusterInfo(c.context, clusterName)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
 	}

--- a/pkg/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/agent/flexvolume/manager/ceph/manager.go
@@ -169,7 +169,7 @@ func (vm *VolumeManager) isAttached(image, pool, clusterName string) (string, er
 }
 
 func getClusterInfo(context *clusterd.Context, clusterName string) (string, string, error) {
-	clusterInfo, _, err := mon.LoadClusterInfo(context, clusterName)
+	clusterInfo, _, _, err := mon.LoadClusterInfo(context, clusterName)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
 	}

--- a/pkg/ceph/client/mon.go
+++ b/pkg/ceph/client/mon.go
@@ -121,7 +121,7 @@ func executeCommandWithOutputFile(context *clusterd.Context, debug bool, tool st
 	return []byte(output), err
 }
 
-// calls mon_status mon_command
+// GetMonStatus calls mon_status mon_command
 func GetMonStatus(context *clusterd.Context, clusterName string, debug bool) (MonStatusResponse, error) {
 	args := []string{"mon_status"}
 	buf, err := executeCephCommandWithOutputFile(context, clusterName, debug, args)

--- a/pkg/ceph/client/test/mon.go
+++ b/pkg/ceph/client/test/mon.go
@@ -17,6 +17,7 @@ package test
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/rook/rook/pkg/ceph/client"
 )
@@ -24,6 +25,16 @@ import (
 func MonInQuorumResponse() string {
 	resp := client.MonStatusResponse{Quorum: []int{0}}
 	resp.MonMap.Mons = []client.MonMapEntry{{Name: "mon1", Rank: 0, Address: "1.2.3.4"}}
+	serialized, _ := json.Marshal(resp)
+	return string(serialized)
+}
+
+func MonInQuorumResponseMany(count int) string {
+	resp := client.MonStatusResponse{Quorum: []int{0}}
+	resp.MonMap.Mons = []client.MonMapEntry{}
+	for i := 1; i <= count; i++ {
+		resp.MonMap.Mons = append(resp.MonMap.Mons, client.MonMapEntry{Name: "mon" + strconv.Itoa(i), Rank: 0, Address: "1.2.3.4"})
+	}
 	serialized, _ := json.Marshal(resp)
 	return string(serialized)
 }

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -143,7 +143,63 @@ func (c *Cluster) checkHealth() error {
 		return nil
 	}
 
+	// check if there are more than two mons running on the same node, failover one mon in that case
+	done, err := c.checkMonsOnSameNode()
+	if done || err != nil {
+		return err
+	}
+
+	done, err = c.checkMonsOnValidNodes()
+	if done || err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (c *Cluster) checkMonsOnSameNode() (bool, error) {
+	nodesUsed := map[string]struct{}{}
+	for name, node := range c.mapping.Node {
+		// when the node is already in the list we have more than one mon on that node
+		if _, ok := nodesUsed[node.Name]; ok {
+			// get list of available nodes for mons
+			availableNodes, _, err := c.getAvailableMonNodes()
+			if err != nil {
+				return true, fmt.Errorf("failed to get available mon nodes. %+v", err)
+			}
+			// if there are enough nodes for one mon "that is too much" to be failovered,
+			// fail it over to an other node
+			if len(availableNodes) > 0 {
+				logger.Infof("rebalance: enough nodes available %d to failover mon %s", len(availableNodes), name)
+				c.failMon(len(c.clusterInfo.Monitors), name)
+			} else {
+				logger.Debugf("rebalance: not enough nodes available to failover mon %s", name)
+			}
+
+			// deal with one mon too much on a node at a time
+			return true, nil
+		}
+		nodesUsed[node.Name] = struct{}{}
+	}
+	return false, nil
+}
+
+func (c *Cluster) checkMonsOnValidNodes() (bool, error) {
+	for mon, nInfo := range c.mapping.Node {
+		// get node to use for validNode() func
+		node, err := c.context.Clientset.CoreV1().Nodes().Get(nInfo.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		// check if node the mon is on is still valid
+		if !validNode(*node, c.placement) {
+			logger.Warningf("node %s isn't valid anymore, failover mon %s", nInfo.Name, mon)
+			c.failoverMon(mon)
+			return true, nil
+		}
+		logger.Debugf("node %s with mon %s is still valid", nInfo.Name, mon)
+	}
+	return false, nil
 }
 
 // failMon monCount is compared against c.Size (wanted mon count)

--- a/pkg/operator/mon/health.go
+++ b/pkg/operator/mon/health.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	// HealthCheckInterval interval to check the mons to be in quorum
-	HealthCheckInterval = 20 * time.Second
+	HealthCheckInterval = 45 * time.Second
 	// MonOutTimeout the duration to wait before removing/failover to a new mon pod
 	MonOutTimeout = 300 * time.Second
 )

--- a/pkg/operator/mon/health_test.go
+++ b/pkg/operator/mon/health_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2017 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"os"
+
+	"github.com/rook/rook/pkg/ceph/client"
+	clienttest "github.com/rook/rook/pkg/ceph/client/test"
+	cephmon "github.com/rook/rook/pkg/ceph/mon"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+func TestCheckHealth(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return clienttest.MonInQuorumResponse(), nil
+		},
+	}
+	clientset := test.New(1)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	context := &clusterd.Context{
+		Clientset: clientset,
+		ConfigDir: configDir,
+		Executor:  executor,
+	}
+	c := New(context, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
+	c.clusterInfo = test.CreateConfigDir(1)
+	c.waitForStart = false
+	defer os.RemoveAll(c.context.ConfigDir)
+
+	c.mapping.Node["mon1"] = &NodeInfo{
+		Name:    "node0",
+		Address: "",
+	}
+	c.mapping.Port["node0"] = cephmon.DefaultPort
+	c.maxMonID = 10
+
+	err := c.checkHealth()
+	assert.Nil(t, err)
+
+	err = c.failoverMon("mon1")
+	assert.Nil(t, err)
+
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
+}
+
+func TestCheckHealthNotFound(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return clienttest.MonInQuorumResponse(), nil
+		},
+	}
+	clientset := test.New(1)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	context := &clusterd.Context{
+		Clientset: clientset,
+		ConfigDir: configDir,
+		Executor:  executor,
+	}
+	c := New(context, "ns", "", "myversion", 2, k8sutil.Placement{}, false)
+	c.clusterInfo = test.CreateConfigDir(2)
+	c.waitForStart = false
+	defer os.RemoveAll(c.context.ConfigDir)
+
+	c.mapping.Node["mon1"] = &NodeInfo{
+		Name:    "node0",
+		Address: "",
+	}
+	c.mapping.Node["mon2"] = &NodeInfo{
+		Name:    "node0",
+		Address: "",
+	}
+	c.mapping.Port["node0"] = cephmon.DefaultPort
+	c.maxMonID = 10
+
+	c.saveMonConfig()
+
+	// Check if the two mons are found in the configmap
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.Nil(t, err)
+	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790" {
+		assert.Equal(t, "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790", cm.Data[EndpointDataKey])
+	} else {
+		assert.Equal(t, "mon2=1.2.3.2:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
+	}
+
+	// Because mon2 isn't in the MonInQuorumResponse() this will create a mon11
+	err = c.checkHealth()
+	assert.Nil(t, err)
+
+	// recheck that the "not found" mon has been replaced with a new one
+	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.Nil(t, err)
+	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790" {
+		assert.Equal(t, "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
+	} else {
+		assert.Equal(t, "rook-ceph-mon11=:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
+	}
+}
+
+func TestCheckHealthTwoMonsOneNode(t *testing.T) {
+	executorNextMons := false
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			if executorNextMons {
+				resp := client.MonStatusResponse{Quorum: []int{0}}
+				resp.MonMap.Mons = []client.MonMapEntry{
+					{
+						Name:    "mon1",
+						Rank:    0,
+						Address: "1.2.3.4",
+					},
+					{
+						Name:    "rook-ceph-mon3",
+						Rank:    0,
+						Address: "1.2.3.4",
+					},
+				}
+				serialized, _ := json.Marshal(resp)
+				return string(serialized), nil
+			}
+			return clienttest.MonInQuorumResponseMany(2), nil
+		},
+	}
+	clientset := test.New(1)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	context := &clusterd.Context{
+		Clientset: clientset,
+		ConfigDir: configDir,
+		Executor:  executor,
+	}
+	c := New(context, "ns", "", "myversion", 2, k8sutil.Placement{}, false)
+	c.clusterInfo = test.CreateConfigDir(2)
+	c.waitForStart = false
+	defer os.RemoveAll(c.context.ConfigDir)
+
+	// add two mons to the mapping on node0
+	c.mapping.Node["mon1"] = &NodeInfo{
+		Name:    "node0",
+		Address: "0.0.0.0",
+	}
+	c.mapping.Node["mon2"] = &NodeInfo{
+		Name:    "node0",
+		Address: "0.0.0.0",
+	}
+	c.maxMonID = 2
+	c.saveMonConfig()
+
+	for i := 1; i <= 2; i++ {
+		rs := c.makeReplicaSet(&monConfig{Name: fmt.Sprintf("mon%d", i)}, "node0")
+		_, err := clientset.ExtensionsV1beta1().ReplicaSets(c.Namespace).Create(rs)
+		assert.Nil(t, err)
+		po := c.makeMonPod(&monConfig{Name: fmt.Sprintf("mon%d", i)}, "node0")
+		_, err = clientset.CoreV1().Pods(c.Namespace).Create(po)
+		assert.Nil(t, err)
+	}
+
+	// initial health check should already see that there is more than one mon on one node (node1)
+	_, err := c.checkMonsOnSameNode()
+	assert.Nil(t, err)
+	assert.Equal(t, "node0", c.mapping.Node["mon1"].Name)
+	assert.Equal(t, "node0", c.mapping.Node["mon2"].Name)
+
+	// add new node and check if the second mon gets failovered to it
+	n := &v1.Node{
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type: v1.NodeReady,
+				},
+			},
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeExternalIP,
+					Address: "2.2.2.2",
+				},
+			},
+		},
+	}
+	n.Name = "node2"
+	clientset.CoreV1().Nodes().Create(n)
+
+	_, err = c.checkMonsOnSameNode()
+	assert.Nil(t, err)
+
+	// check that mon rook-ceph-mon3 exists
+	assert.NotNil(t, c.mapping.Node["rook-ceph-mon3"])
+	assert.Equal(t, "node2", c.mapping.Node["rook-ceph-mon3"].Name)
+
+	// check if mon2 has been deleted
+	var rsses *v1beta1.ReplicaSetList
+	rsses, err = clientset.ExtensionsV1beta1().ReplicaSets(c.Namespace).List(metav1.ListOptions{})
+	assert.Nil(t, err)
+
+	deleted := false
+	for _, rs := range rsses.Items {
+		if rs.Name == "mon1" || rs.Name == "rook-ceph-mon3" {
+			deleted = true
+		} else {
+			deleted = false
+		}
+	}
+	assert.Equal(t, true, deleted, "mon2 not failovered/deleted after health check")
+
+	// enable different ceph mon map output
+	executorNextMons = true
+	_, err = c.checkMonsOnSameNode()
+	assert.Nil(t, err)
+
+	// check that nothing has changed
+	rsses, err = clientset.ExtensionsV1beta1().ReplicaSets(c.Namespace).List(metav1.ListOptions{})
+	assert.Nil(t, err)
+
+	for _, rs := range rsses.Items {
+		// both mons should always be on the same node as in this test due to the order
+		//the mons are processed in the loop
+		if (rs.Name == "mon1" && rs.Spec.Template.Spec.NodeSelector[apis.LabelHostname] == "node1") || (rs.Name != "rook-ceph-mon3" && rs.Spec.Template.Spec.NodeSelector[apis.LabelHostname] == "node2") {
+			assert.Fail(t, fmt.Sprintf("mon %s shouldn't exist", rs.Name))
+		}
+	}
+}
+
+func TestCheckMonsValid(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return clienttest.MonInQuorumResponse(), nil
+		},
+	}
+	clientset := test.New(1)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	context := &clusterd.Context{
+		Clientset: clientset,
+		ConfigDir: configDir,
+		Executor:  executor,
+	}
+	c := New(context, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
+	c.clusterInfo = test.CreateConfigDir(1)
+	c.waitForStart = false
+	defer os.RemoveAll(c.context.ConfigDir)
+
+	// add two mons to the mapping on node0
+	c.mapping.Node["mon1"] = &NodeInfo{
+		Name:    "node0",
+		Address: "0.0.0.0",
+	}
+	c.mapping.Node["mon2"] = &NodeInfo{
+		Name:    "node1",
+		Address: "0.0.0.0",
+	}
+
+	// add three nodes
+	for i := 0; i < 3; i++ {
+		n := &v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type: v1.NodeReady,
+					},
+				},
+				Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeExternalIP,
+						Address: "0.0.0.0",
+					},
+				},
+			},
+		}
+		n.Name = fmt.Sprintf("node%d", i)
+		clientset.CoreV1().Nodes().Create(n)
+	}
+
+	_, err := c.checkMonsOnValidNodes()
+	assert.Nil(t, err)
+	assert.Equal(t, "node0", c.mapping.Node["mon1"].Name)
+	assert.Equal(t, "node1", c.mapping.Node["mon2"].Name)
+
+	// set node1 unschedulable and check that mon2 gets failovered to be mon3 to node2
+	node0, err := c.context.Clientset.CoreV1().Nodes().Get("node0", metav1.GetOptions{})
+	assert.Nil(t, err)
+	node0.Spec.Unschedulable = true
+	_, err = c.context.Clientset.CoreV1().Nodes().Update(node0)
+	assert.Nil(t, err)
+
+	// add the pods so the getNodesInUse() works correctly
+	for i := 1; i <= 2; i++ {
+		po := c.makeMonPod(&monConfig{Name: fmt.Sprintf("mon%d", i)}, fmt.Sprintf("node%d", i-1))
+		_, err = clientset.CoreV1().Pods(c.Namespace).Create(po)
+		assert.Nil(t, err)
+	}
+
+	_, err = c.checkMonsOnValidNodes()
+	assert.Nil(t, err)
+
+	assert.Len(t, c.mapping.Node, 2)
+	assert.Nil(t, c.mapping.Node["mon1"])
+	// the new mon should always be on the empty node2
+	// the failovered mon's name is "rook-ceph-mon0"
+	assert.Equal(t, "node2", c.mapping.Node["rook-ceph-mon0"].Name)
+	assert.Equal(t, "node1", c.mapping.Node["mon2"].Name)
+}

--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -77,7 +77,7 @@ type Cluster struct {
 	monPodTimeout       time.Duration
 	monTimeoutList      map[string]time.Time
 	HostNetwork         bool
-	mapping             *mapping
+	mapping             *Mapping
 }
 
 // monConfig for a single monitor
@@ -87,13 +87,14 @@ type monConfig struct {
 	Port     int32
 }
 
-// mapping mon node and port mapping
-type mapping struct {
-	Node map[string]*nodeInfo `json:"node"`
+// Mapping mon node and port mapping
+type Mapping struct {
+	Node map[string]*NodeInfo `json:"node"`
 	Port map[string]int32     `json:"port"`
 }
 
-type nodeInfo struct {
+// NodeInfo contains name and address of a node
+type NodeInfo struct {
 	Name    string
 	Address string
 }
@@ -113,8 +114,8 @@ func New(context *clusterd.Context, namespace, dataDirHostPath, version string, 
 		monPodTimeout:       5 * time.Minute,
 		monTimeoutList:      map[string]time.Time{},
 		HostNetwork:         hostNetwork,
-		mapping: &mapping{
-			Node: map[string]*nodeInfo{},
+		mapping: &Mapping{
+			Node: map[string]*NodeInfo{},
 			Port: map[string]int32{},
 		},
 	}
@@ -182,7 +183,7 @@ func (c *Cluster) initClusterInfo() error {
 
 	var err error
 	// get the cluster info from secret
-	c.clusterInfo, c.maxMonID, err = LoadClusterInfo(c.context, c.Namespace)
+	c.clusterInfo, c.maxMonID, c.mapping, err = LoadClusterInfo(c.context, c.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster info. %+v", err)
 	}
@@ -279,7 +280,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 
 func (c *Cluster) assignMons(mons []*monConfig) error {
 	// schedule the mons on different nodes if we have enough nodes to be unique
-	availableNodes, err := c.getAvailableMonNodes()
+	availableNodes, err := c.getMonNodes()
 	if err != nil {
 		return fmt.Errorf("failed to get available nodes for mons. %+v", err)
 	}
@@ -291,11 +292,8 @@ func (c *Cluster) assignMons(mons []*monConfig) error {
 			continue
 		}
 
-		// when the available nodes are >= than the mon size we just begin taking
-		// "node0" through nodeX (X = c.Size-1)
-		var node v1.Node
 		// pick one of the available nodes where the mon will be assigned
-		node = availableNodes[nodeIndex%len(availableNodes)]
+		node := availableNodes[nodeIndex%len(availableNodes)]
 		logger.Debugf("mon %s assigned to node %s", m.Name, node.Name)
 		nodeInfo, err := getNodeInfoFromNode(node)
 		if err != nil {
@@ -318,8 +316,8 @@ func (c *Cluster) assignMons(mons []*monConfig) error {
 	return nil
 }
 
-func getNodeInfoFromNode(n v1.Node) (*nodeInfo, error) {
-	nr := &nodeInfo{}
+func getNodeInfoFromNode(n v1.Node) (*NodeInfo, error) {
+	nr := &NodeInfo{}
 	nr.Name = n.Name
 	for _, ip := range n.Status.Addresses {
 		if ip.Type == v1.NodeExternalIP || ip.Type == v1.NodeInternalIP {
@@ -410,28 +408,10 @@ func (c *Cluster) saveMonConfig() error {
 }
 
 // detect the nodes that are available for new mons to start.
-func (c *Cluster) getAvailableMonNodes() ([]v1.Node, error) {
-	nodeOptions := metav1.ListOptions{}
-	nodeOptions.TypeMeta.Kind = "Node"
-	nodes, err := c.context.Clientset.CoreV1().Nodes().List(nodeOptions)
+func (c *Cluster) getMonNodes() ([]v1.Node, error) {
+	availableNodes, nodes, err := c.getAvailableMonNodes()
 	if err != nil {
 		return nil, err
-	}
-	logger.Infof("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
-
-	// get the nodes that have mons assigned
-	nodesInUse, err := c.getNodesWithMons()
-	if err != nil {
-		logger.Warningf("could not get nodes with mons. %+v", err)
-		nodesInUse = util.NewSet()
-	}
-
-	// choose nodes for the new mons that don't have mons currently
-	availableNodes := []v1.Node{}
-	for _, node := range nodes.Items {
-		if !nodesInUse.Contains(node.Name) && validNode(node, c.placement) {
-			availableNodes = append(availableNodes, node)
-		}
 	}
 	logger.Infof("Found %d running nodes without mons", len(availableNodes))
 
@@ -449,6 +429,33 @@ func (c *Cluster) getAvailableMonNodes() ([]v1.Node, error) {
 	}
 
 	return availableNodes, nil
+}
+
+func (c *Cluster) getAvailableMonNodes() ([]v1.Node, *v1.NodeList, error) {
+	nodeOptions := metav1.ListOptions{}
+	nodeOptions.TypeMeta.Kind = "Node"
+	nodes, err := c.context.Clientset.CoreV1().Nodes().List(nodeOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+	logger.Infof("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
+
+	// get the nodes that have mons assigned
+	nodesInUse, err := c.getNodesWithMons()
+	if err != nil {
+		logger.Warningf("could not get nodes with mons. %+v", err)
+		nodesInUse = util.NewSet()
+	}
+
+	// choose nodes for the new mons that don't have mons currently
+	availableNodes := []v1.Node{}
+	for _, node := range nodes.Items {
+		if !nodesInUse.Contains(node.Name) && validNode(node, c.placement) {
+			availableNodes = append(availableNodes, node)
+		}
+	}
+
+	return availableNodes, nodes, nil
 }
 
 func (c *Cluster) getNodesWithMons() (*util.Set, error) {

--- a/pkg/operator/mon/mon_test.go
+++ b/pkg/operator/mon/mon_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package mon
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -27,7 +28,6 @@ import (
 	"os"
 
 	"github.com/rook/rook/pkg/ceph/client"
-	clienttest "github.com/rook/rook/pkg/ceph/client/test"
 	cephmon "github.com/rook/rook/pkg/ceph/mon"
 	cephtest "github.com/rook/rook/pkg/ceph/test"
 	"github.com/rook/rook/pkg/clusterd"
@@ -70,8 +70,8 @@ func newCluster(context *clusterd.Context, namespace string, hostNetwork bool) *
 		monPodRetryInterval: 10 * time.Millisecond,
 		monPodTimeout:       1 * time.Second,
 		monTimeoutList:      map[string]time.Time{},
-		mapping: &mapping{
-			Node: map[string]*nodeInfo{},
+		mapping: &Mapping{
+			Node: map[string]*NodeInfo{},
 			Port: map[string]int32{},
 		},
 	}
@@ -98,7 +98,40 @@ func TestStartMonPods(t *testing.T) {
 func TestOperatorRestart(t *testing.T) {
 	namespace := "ns"
 	context := newTestStartCluster(namespace)
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, arg ...string) (string, error) {
+			if strings.Contains(command, "ceph-authtool") {
+				cephtest.CreateConfigDir(path.Join(context.ConfigDir, namespace))
+			}
+			return "", nil
+		},
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			cephtest.CreateConfigDir(path.Join(context.ConfigDir, namespace))
+			resp := client.MonStatusResponse{Quorum: []int{0}}
+			resp.MonMap.Mons = []client.MonMapEntry{
+				{
+					Name:    "rook-ceph-mon0",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+				{
+					Name:    "rook-ceph-mon1",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+				{
+					Name:    "rook-ceph-mon2",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+			}
+			serialized, _ := json.Marshal(resp)
+			return string(serialized), nil
+		},
+	}
+	context.Executor = executor
 	c := newCluster(context, namespace, false)
+	c.clusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
 	err := c.Start()
@@ -108,7 +141,7 @@ func TestOperatorRestart(t *testing.T) {
 
 	c = newCluster(context, namespace, false)
 
-	// starting again should be a no-op, but still results in an error
+	// starting again should be a no-op, but will not result in an error
 	err = c.Start()
 	assert.Nil(t, err)
 
@@ -119,7 +152,40 @@ func TestOperatorRestart(t *testing.T) {
 func TestOperatorRestartHostNetwork(t *testing.T) {
 	namespace := "ns"
 	context := newTestStartCluster(namespace)
-	c := newCluster(context, namespace, true)
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, arg ...string) (string, error) {
+			if strings.Contains(command, "ceph-authtool") {
+				cephtest.CreateConfigDir(path.Join(context.ConfigDir, namespace))
+			}
+			return "", nil
+		},
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			cephtest.CreateConfigDir(path.Join(context.ConfigDir, namespace))
+			resp := client.MonStatusResponse{Quorum: []int{0}}
+			resp.MonMap.Mons = []client.MonMapEntry{
+				{
+					Name:    "rook-ceph-mon0",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+				{
+					Name:    "rook-ceph-mon1",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+				{
+					Name:    "rook-ceph-mon2",
+					Rank:    0,
+					Address: "0.0.0.0",
+				},
+			}
+			serialized, _ := json.Marshal(resp)
+			return string(serialized), nil
+		},
+	}
+	context.Executor = executor
+	c := newCluster(context, namespace, false)
+	c.clusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
 	err := c.Start()
@@ -138,6 +204,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster) {
 	s, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
+	assert.Nil(t, err) // there shouldn't be an error due the secret existing
 	assert.Equal(t, 4, len(s.StringData))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start
@@ -165,7 +232,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	// update the config map
 	c.clusterInfo.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
 	c.maxMonID = 2
-	c.mapping.Node["mon1"] = &nodeInfo{
+	c.mapping.Node["mon1"] = &NodeInfo{
 		Name:    "node0",
 		Address: "1.1.1.1",
 	}
@@ -178,43 +245,6 @@ func TestSaveMonEndpoints(t *testing.T) {
 	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data[EndpointDataKey])
 	assert.Equal(t, `{"node":{"mon1":{"Name":"node0","Address":"1.1.1.1"}},"port":{"node0":12345}}`, cm.Data[MappingKey])
 	assert.Equal(t, "2", cm.Data[MaxMonIDKey])
-}
-
-func TestCheckHealth(t *testing.T) {
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
-			return clienttest.MonInQuorumResponse(), nil
-		},
-	}
-	clientset := test.New(1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
-	context := &clusterd.Context{
-		Clientset: clientset,
-		ConfigDir: configDir,
-		Executor:  executor,
-	}
-	c := New(context, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
-	c.clusterInfo = test.CreateConfigDir(1)
-	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
-
-	c.mapping.Node["mon1"] = &nodeInfo{
-		Name:    "node0",
-		Address: "",
-	}
-	c.mapping.Port["node0"] = cephmon.DefaultPort
-	c.maxMonID = 10
-
-	err := c.checkHealth()
-	assert.Nil(t, err)
-
-	err = c.failoverMon("mon1")
-	assert.Nil(t, err)
-
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
 }
 
 func TestMonInQuourm(t *testing.T) {
@@ -259,7 +289,7 @@ func TestAvailableMonNodes(t *testing.T) {
 	clientset := test.New(1)
 	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
-	nodes, err := c.getAvailableMonNodes()
+	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(nodes))
 
@@ -267,7 +297,7 @@ func TestAvailableMonNodes(t *testing.T) {
 	nodes[0].Status = v1.NodeStatus{Conditions: []v1.NodeCondition{conditions}}
 	clientset.CoreV1().Nodes().Update(&nodes[0])
 
-	emptyNodes, err := c.getAvailableMonNodes()
+	emptyNodes, err := c.getMonNodes()
 	assert.NotNil(t, err)
 	assert.Nil(t, emptyNodes)
 }
@@ -278,7 +308,7 @@ func TestAvailableNodesInUse(t *testing.T) {
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	// all three nodes are available by default
-	nodes, err := c.getAvailableMonNodes()
+	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(nodes))
 
@@ -288,7 +318,7 @@ func TestAvailableNodesInUse(t *testing.T) {
 		_, err = clientset.CoreV1().Pods(c.Namespace).Create(pod)
 		assert.Nil(t, err)
 	}
-	reducedNodes, err := c.getAvailableMonNodes()
+	reducedNodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(reducedNodes))
 	assert.Equal(t, nodes[2].Name, reducedNodes[0].Name)
@@ -298,7 +328,7 @@ func TestAvailableNodesInUse(t *testing.T) {
 	pod := c.makeMonPod(&monConfig{Name: "mon2"}, nodes[2].Name)
 	_, err = clientset.CoreV1().Pods(c.Namespace).Create(pod)
 	assert.Nil(t, err)
-	nodes, err = c.getAvailableMonNodes()
+	nodes, err = c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(nodes))
 }
@@ -308,14 +338,14 @@ func TestTaintedNodes(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
-	nodes, err := c.getAvailableMonNodes()
+	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(nodes))
 
 	// mark a node as unschedulable
 	nodes[0].Spec.Unschedulable = true
 	clientset.CoreV1().Nodes().Update(&nodes[0])
-	nodesSchedulable, err := c.getAvailableMonNodes()
+	nodesSchedulable, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(nodesSchedulable))
 	nodes[0].Spec.Unschedulable = false
@@ -330,7 +360,7 @@ func TestTaintedNodes(t *testing.T) {
 	clientset.CoreV1().Nodes().Update(&nodes[0])
 	clientset.CoreV1().Nodes().Update(&nodes[1])
 	clientset.CoreV1().Nodes().Update(&nodes[2])
-	cleanNodes, err := c.getAvailableMonNodes()
+	cleanNodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(cleanNodes))
 	assert.Equal(t, nodes[2].Name, cleanNodes[0].Name)
@@ -341,7 +371,7 @@ func TestNodeAffinity(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, false)
 	c.clusterInfo = test.CreateConfigDir(0)
 
-	nodes, err := c.getAvailableMonNodes()
+	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(nodes))
 
@@ -368,7 +398,7 @@ func TestNodeAffinity(t *testing.T) {
 	clientset.CoreV1().Nodes().Update(&nodes[0])
 	clientset.CoreV1().Nodes().Update(&nodes[1])
 	clientset.CoreV1().Nodes().Update(&nodes[2])
-	cleanNodes, err := c.getAvailableMonNodes()
+	cleanNodes, err := c.getMonNodes()
 
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(cleanNodes))
@@ -383,7 +413,7 @@ func TestHostNetwork(t *testing.T) {
 
 	c.HostNetwork = true
 
-	nodes, err := c.getAvailableMonNodes()
+	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(nodes))
 
@@ -411,7 +441,7 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, k8sutil.Placement{}, true)
 	c.clusterInfo = test.CreateConfigDir(0)
 
-	var info *nodeInfo
+	var info *NodeInfo
 	info, err = getNodeInfoFromNode(*node)
 	assert.Nil(t, err)
 
@@ -464,60 +494,4 @@ func TestHostNetworkPortIncrease(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort), sEndpoint[1])
 	sEndpoint = strings.Split(c.clusterInfo.Monitors["mon2"].Endpoint, ":")
 	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort+1), sEndpoint[1])
-}
-
-func TestCheckHealthNotFound(t *testing.T) {
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
-			return clienttest.MonInQuorumResponse(), nil
-		},
-	}
-	clientset := test.New(1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
-	context := &clusterd.Context{
-		Clientset: clientset,
-		ConfigDir: configDir,
-		Executor:  executor,
-	}
-	c := New(context, "ns", "", "myversion", 2, k8sutil.Placement{}, false)
-	c.clusterInfo = test.CreateConfigDir(2)
-	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
-	fmt.Printf("TEST: %+v\n", c.clusterInfo)
-
-	c.mapping.Node["mon1"] = &nodeInfo{
-		Name:    "node0",
-		Address: "",
-	}
-	c.mapping.Node["mon2"] = &nodeInfo{
-		Name:    "node0",
-		Address: "",
-	}
-	c.mapping.Port["node0"] = cephmon.DefaultPort
-	c.maxMonID = 10
-
-	c.saveMonConfig()
-
-	// Check if the two mons are found in the configmap
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790" {
-		assert.Equal(t, "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790", cm.Data[EndpointDataKey])
-	} else {
-		assert.Equal(t, "mon2=1.2.3.2:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
-	}
-
-	// Because mon2 isn't in the MonInQuorumResponse() this will create a mon11
-	err = c.checkHealth()
-	assert.Nil(t, err)
-
-	// recheck that the "not found" mon has been replaced with a new one
-	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790" {
-		assert.Equal(t, "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
-	} else {
-		assert.Equal(t, "rook-ceph-mon11=:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
-	}
 }


### PR DESCRIPTION
Fixes #1193 and fixes #961

***

This adds a logic to the health check which checks if more than one mon is on one node. If one or more mons are on a node, one mon will be failovered to an available node.
This prevents single point of failures in cases for example when only three nodes are used for mons and one fails and comes back ready. When the third node appears again as "ready", the single point of failure is then removed by failovering one of mons to the third(/new) node.

***

**Edit**: This adds two checks. One for checking if there runs more than one mon on one node. Second is for checking that the nodes the mon(s) run on are still valid after the `placement` Cluster CRD spec.