### PR TITLE
Increasing map image timeout to 3mins

### DIFF
--- a/pkg/ceph/client/mon.go
+++ b/pkg/ceph/client/mon.go
@@ -32,7 +32,7 @@ const (
 	CephTool          = "ceph"
 	RBDTool           = "rbd"
 	CrushTool         = "crushtool"
-	cmdExecuteTimeout = 1 * time.Minute
+	cmdExecuteTimeout = 3 * time.Minute
 )
 
 // represents the response from a mon_status mon_command (subset of all available fields, only


### PR DESCRIPTION
- It was found that when mapping a big volume like a 5TB, the rbd
  command takes longer than 1 minute. Upping the timeout to 3 minutes.

Partially addresses https://github.com/rook/rook/issues/1214