### PR TITLE
Default pool size for a single osd

### DIFF
--- a/cluster/examples/kubernetes/rook-filesystem.yaml
+++ b/cluster/examples/kubernetes/rook-filesystem.yaml
@@ -7,13 +7,17 @@ spec:
   # The metadata pool spec
   metadataPool:
     replicated:
-      size: 3
+      # Increase the replication size if you have more than one osd
+      size: 1
   # The list of data pool specs
   dataPools:
     - failureDomain: osd
-      erasureCoded:
-        dataChunks: 2
-        codingChunks: 1
+      replicated:
+        size: 1
+      # If you have at least three osds, erasure coding can be specified
+      # erasureCoded:
+      #   dataChunks: 2
+      #   codingChunks: 1
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/rook-object.yaml
+++ b/cluster/examples/kubernetes/rook-object.yaml
@@ -9,13 +9,17 @@ spec:
   metadataPool:
     failureDomain: host
     replicated:
-      size: 3
+      # Increase the replication size if you have more than one osd
+      size: 1
   # The pool spec used to create the data pool
   dataPool:
     failureDomain: osd
-    erasureCoded:
-      dataChunks: 2
-      codingChunks: 1
+    replicated:
+      size: 1
+    # If you have at least three osds, erasure coding can be specified
+    # erasureCoded:
+    #   dataChunks: 2
+    #   codingChunks: 1
   # The gaeteway service configuration
   gateway:
     # type of the gateway (s3)


### PR DESCRIPTION
The sample yaml files should work in all deployments by default, in particular where there is only a single osd
[skip ci]