### PR TITLE
api: recreate mon endpoint watcher when the result channel is closed

### DIFF
--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -440,7 +440,7 @@ func (c *Cluster) getAvailableMonNodes() ([]v1.Node, *v1.NodeList, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	logger.Infof("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
+	logger.Debugf("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
 
 	// get the nodes that have mons assigned
 	nodesInUse, err := c.getNodesWithMons()


### PR DESCRIPTION
Fixes #1195 