### PR TITLE
api: recreate mon endpoint watcher when the result channel is closed

### DIFF
--- a/pkg/operator/mon/mon.go
+++ b/pkg/operator/mon/mon.go
@@ -417,7 +417,7 @@ func (c *Cluster) getAvailableMonNodes() ([]v1.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
+	logger.Debugf("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
 
 	// get the nodes that have mons assigned
 	nodesInUse, err := c.getNodesWithMons()


### PR DESCRIPTION
(cherry picked from commit 9da4d286d2be8ad58bc2c04195745eb1150dba62)