### PR TITLE
fix testify.m flag

### DIFF
--- a/tests/framework/objects/environment_manifest.go
+++ b/tests/framework/objects/environment_manifest.go
@@ -41,7 +41,5 @@ func NewManifest() EnvironmentManifest {
 	flag.IntVar(&e.LoadConcurrentRuns, "load_parallel_runs", 20, "number of routines for load test")
 	flag.IntVar(&e.LoadVolumeNumber, "load_volumes", 1, "number of volumes(file,object or block) to be created for load test")
 	flag.IntVar(&e.LoadTime, "load_time", 1800, "number of seconds each thread perform operations for")
-	flag.Parse()
-
 	return e
 }


### PR DESCRIPTION
found the issue after looking back at the commits and finding the commit the broke testify.m flag.  The current refator fixed the issue and running single test from a suite should be enabled again.
fix #1262 [smoke only]