### PR TITLE
Op/RGW Expose DNS configuration to CRD

### DIFF
--- a/Documentation/k8s-object.md
+++ b/Documentation/k8s-object.md
@@ -33,6 +33,7 @@ spec:
       codingChunks: 1
   gateway:
     type: s3
+    dnsName: my-store.rook
     sslCertificateRef: 
     port: 80
     securePort:
@@ -130,3 +131,5 @@ rook-ceph-rgw-my-store-external   10.0.0.26    <nodes>       53390:30041/TCP   1
 ```
 
 Internally the rgw service is running on port `53390`. The external port in this case is `30041`. Now you can access the object store from anywhere! All you need is the hostname for any machine in the cluster, the external port, and the user credentials.
+
+Note that you will have to change the objectstore resource `dnsName` value to the hostname with which you make requests to the objectstore. Otherwise, a `403: SignatureDoesNotMatch` will show up.

--- a/Documentation/object-store-crd.md
+++ b/Documentation/object-store-crd.md
@@ -27,7 +27,7 @@ spec:
       codingChunks: 1
   gateway:
     type: s3
-    dnsHost: my-store.rook
+    dnsName: my-store.rook
     sslCertificateRef:
     port: 80
     securePort:

--- a/Documentation/object-store-crd.md
+++ b/Documentation/object-store-crd.md
@@ -27,6 +27,7 @@ spec:
       codingChunks: 1
   gateway:
     type: s3
+    dnsHost: my-store.rook
     sslCertificateRef:
     port: 80
     securePort:
@@ -80,6 +81,7 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 The gateway settings correspond to the RGW daemon settings.
 
 - `type`: `S3` is supported
+- `dnsHost`: Hostname trusted by the RGW daemons. If left unspecified, it will default to the service name, which will only make the daemon accesible inside the kubernetes namespace where the service exists.
 - `sslCertificateRef`: If the certificate is not specified, SSL will not be configured. If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](http://docs.ceph.com/docs/master/install/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form."
 - `port`: The port on which the RGW pods and the RGW service will be listening (not encrypted).
 - `securePort`: The secure port on which RGW pods will be listening. An SSL certificate must be specified.

--- a/Documentation/object-store-crd.md
+++ b/Documentation/object-store-crd.md
@@ -81,7 +81,7 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 The gateway settings correspond to the RGW daemon settings.
 
 - `type`: `S3` is supported
-- `dnsHost`: Hostname trusted by the RGW daemons. If left unspecified, it will default to the service name, which will only make the daemon accesible inside the kubernetes namespace where the service exists.
+- `dnsName`: Hostname trusted by the RGW daemons. If left unspecified, it will default to the service name, which will only make the daemon accesible inside the kubernetes namespace where the service exists.
 - `sslCertificateRef`: If the certificate is not specified, SSL will not be configured. If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](http://docs.ceph.com/docs/master/install/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form."
 - `port`: The port on which the RGW pods and the RGW service will be listening (not encrypted).
 - `securePort`: The secure port on which RGW pods will be listening. An SSL certificate must be specified.

--- a/cluster/examples/kubernetes/rook-object.yaml
+++ b/cluster/examples/kubernetes/rook-object.yaml
@@ -20,10 +20,12 @@ spec:
     # erasureCoded:
     #   dataChunks: 2
     #   codingChunks: 1
-  # The gaeteway service configuration
+  # The gateway service configuration
   gateway:
     # type of the gateway (s3)
     type: s3
+    # Hostname that the object store will accept.
+    dnsName: my-store.rook
     # A reference to the secret in the rook namespace where the ssl certificate is stored
     sslCertificateRef:
     # The port that RGW pods will listen on (http)

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -44,7 +44,7 @@ func init() {
 	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
 	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "RGW hostname")
-	rgwCmd.Flags().StringVar(&rgwDnsName, "rgw-dnsname", rgwHost, "RGW DNS name")
+	rgwCmd.Flags().StringVar(&rgwDnsName, "rgw-dns-name", rgwHost, "RGW DNS name")
 	rgwCmd.Flags().StringVar(&rgwCert, "rgw-cert", "", "path to the ssl certificate in pem format")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port (http)")
 	rgwCmd.Flags().IntVar(&rgwSecurePort, "rgw-secure-port", 0, "rgw secure port number (https)")
@@ -56,7 +56,7 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-host", "rgw-dnsname", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
 	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}

--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -34,6 +34,7 @@ var (
 	rgwName       string
 	rgwKeyring    string
 	rgwHost       string
+	rgwDnsName    string
 	rgwCert       string
 	rgwPort       int
 	rgwSecurePort int
@@ -42,7 +43,8 @@ var (
 func init() {
 	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
-	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "dns host name")
+	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "RGW hostname")
+	rgwCmd.Flags().StringVar(&rgwDnsName, "rgw-dnsname", rgwHost, "RGW DNS name")
 	rgwCmd.Flags().StringVar(&rgwCert, "rgw-cert", "", "path to the ssl certificate in pem format")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port (http)")
 	rgwCmd.Flags().IntVar(&rgwSecurePort, "rgw-secure-port", 0, "rgw secure port number (https)")
@@ -54,7 +56,7 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-host", "rgw-dnsname", "rgw-keyring", "public-ipv4", "private-ipv4"}
 	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}
@@ -73,6 +75,7 @@ func startRGW(cmd *cobra.Command, args []string) error {
 		Name:            rgwName,
 		Keyring:         rgwKeyring,
 		Host:            rgwHost,
+		DnsName:         rgwDnsName,
 		Port:            rgwPort,
 		SecurePort:      rgwSecurePort,
 		CertificatePath: rgwCert,

--- a/cmd/rookctl/object/create.go
+++ b/cmd/rookctl/object/create.go
@@ -48,6 +48,7 @@ func init() {
 	createCmd.Flags().StringVarP(&store.Name, "name", "n", "default", "The name of the object store instance")
 	createCmd.Flags().Int32VarP(&store.Gateway.Port, "port", "p", model.RGWPort, "The port on which to expose the object store (http)")
 	createCmd.Flags().Int32VarP(&store.Gateway.SecurePort, "secure-port", "s", 0, "The port on which to expose the object store (https)")
+	createCmd.Flags().StringVarP(&store.Gateway.DnsName, "dns-name", "d", store.Name, "The DNS name that will be used to access the objecstore (defaults to the objectstore service name)")
 	createCmd.Flags().Int32VarP(&store.Gateway.Instances, "rgw-instances", "i", 1, "The number of RGW pods for load balancing (ignored if all nodes is set)")
 	createCmd.Flags().BoolVarP(&store.Gateway.AllNodes, "rgw-all-nodes", "a", false, "Whether RGW pods should be started on all nodes")
 	createCmd.Flags().StringVarP(&certificateFile, "certificate", "c", "", "Path to the ssl cert file (pem format)")

--- a/pkg/ceph/rgw/daemon.go
+++ b/pkg/ceph/rgw/daemon.go
@@ -34,6 +34,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephrgw")
 type Config struct {
 	Name            string
 	Host            string
+	DnsName         string
 	Port            int
 	SecurePort      int
 	Keyring         string
@@ -86,7 +87,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	settings := map[string]string{
 		"host":                           config.Host,
 		"rgw data":                       dataDir,
-		"rgw dns name":                   config.Host,
+		"rgw dns name":                   config.DnsName,
 		"rgw log nonexistent bucket":     "true",
 		"rgw intent log object name utc": "true",
 		"rgw enable usage log":           "true",

--- a/pkg/model/object.go
+++ b/pkg/model/object.go
@@ -40,6 +40,7 @@ type ObjectStore struct {
 type Gateway struct {
 	Port           int32  `json:"port"`
 	SecurePort     int32  `json:"securePort"`
+	DnsName        string `json:"dnsName"`
 	Instances      int32  `json:"instances"`
 	AllNodes       bool   `json:"allNodes"`
 	Certificate    string `json:"certificate"`

--- a/pkg/operator/rgw/controller.go
+++ b/pkg/operator/rgw/controller.go
@@ -118,6 +118,10 @@ func storeChanged(oldStore, newStore ObjectStoreSpec) bool {
 		logger.Infof("metadata pool replication changed from %d to %d", oldStore.MetadataPool.Replicated.Size, newStore.MetadataPool.Replicated.Size)
 		return true
 	}
+	if oldStore.Gateway.DnsName != newStore.Gateway.DnsName {
+		logger.Infof("The DNS for the object store changed from %s to %s", oldStore.Gateway.DnsName, newStore.Gateway.DnsName)
+		return true
+	}
 	if oldStore.Gateway.Instances != newStore.Gateway.Instances {
 		logger.Infof("RGW instances changed from %d to %d", oldStore.Gateway.Instances, newStore.Gateway.Instances)
 		return true

--- a/pkg/operator/rgw/controller_test.go
+++ b/pkg/operator/rgw/controller_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestObjectStoreChanged(t *testing.T) {
-	old := ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
-	new := ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	old := ObjectStoreSpec{Gateway: GatewaySpec{DnsName: "stinky-domain.net", Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	new := ObjectStoreSpec{Gateway: GatewaySpec{DnsName: "stinky-domain.net", Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
 	// nothing changed
 	assert.False(t, storeChanged(old, new))
 
@@ -46,5 +46,8 @@ func TestObjectStoreChanged(t *testing.T) {
 	assert.True(t, storeChanged(old, new))
 
 	new = ObjectStoreSpec{Gateway: GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: "mysecret"}}
+	assert.True(t, storeChanged(old, new))
+
+	new = ObjectStoreSpec{Gateway: GatewaySpec{DnsName: "cool.io", Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
 	assert.True(t, storeChanged(old, new))
 }

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -365,7 +365,7 @@ func (s *ObjectStore) rgwContainer(version string) v1.Container {
 			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
 			fmt.Sprintf("--rgw-name=%s", s.Name),
 			fmt.Sprintf("--rgw-host=%s", s.instanceName()),
-			fmt.Sprintf("--rgw-dnsName=%s", s.Spec.Gateway.DnsName),
+			fmt.Sprintf("--rgw-dns-name=%s", s.Spec.Gateway.DnsName),
 			fmt.Sprintf("--rgw-port=%d", s.Spec.Gateway.Port),
 			fmt.Sprintf("--rgw-secure-port=%d", s.Spec.Gateway.SecurePort),
 		},
@@ -398,7 +398,7 @@ func (s *ObjectStore) rgwContainer(version string) v1.Container {
 	}
 
 	if s.Spec.Gateway.DnsName == "" {
-		container.Args[4] = fmt.Sprintf("--rgw-dnsName=%s", s.instanceName())
+		container.Args[4] = fmt.Sprintf("--rgw-dns-name=%s", s.instanceName())
 		// s.Spec.Gateway.DnsName = s.instanceName()
 	}
 

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -398,7 +398,7 @@ func (s *ObjectStore) rgwContainer(version string) v1.Container {
 	}
 
 	if s.Spec.Gateway.DnsName == "" {
-		container.Args[4] = fmt.Sprintf("--rgw-dns-name=%s", s.instanceName())
+		container.Args[4] = fmt.Sprintf("--rgw-dns-name=%s.%s", s.instanceName(), s.Namespace)
 		// s.Spec.Gateway.DnsName = s.instanceName()
 	}
 

--- a/pkg/operator/rgw/rgw.go
+++ b/pkg/operator/rgw/rgw.go
@@ -282,6 +282,7 @@ func ModelToSpec(store model.ObjectStore, namespace string) *ObjectStore {
 			Gateway: GatewaySpec{
 				Port:              store.Gateway.Port,
 				SecurePort:        store.Gateway.SecurePort,
+				DnsName:           store.Gateway.DnsName,
 				Instances:         store.Gateway.Instances,
 				AllNodes:          store.Gateway.AllNodes,
 				SSLCertificateRef: store.Gateway.CertificateRef,
@@ -304,6 +305,7 @@ func (s *ObjectStore) makeRGWPodSpec(version string, hostNetwork bool) v1.PodTem
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	s.Spec.Gateway.Placement.ApplyToPodSpec(&podSpec)
+	// Set the DnsName to the hostname if left unspecified
 
 	// Set the ssl cert if specified
 	if s.Spec.Gateway.SSLCertificateRef != "" {
@@ -363,6 +365,7 @@ func (s *ObjectStore) rgwContainer(version string) v1.Container {
 			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
 			fmt.Sprintf("--rgw-name=%s", s.Name),
 			fmt.Sprintf("--rgw-host=%s", s.instanceName()),
+			fmt.Sprintf("--rgw-dnsName=%s", s.Spec.Gateway.DnsName),
 			fmt.Sprintf("--rgw-port=%d", s.Spec.Gateway.Port),
 			fmt.Sprintf("--rgw-secure-port=%d", s.Spec.Gateway.SecurePort),
 		},
@@ -392,6 +395,11 @@ func (s *ObjectStore) rgwContainer(version string) v1.Container {
 		// Pass the flag for using the ssl cert
 		path := path.Join(certMountPath, certFilename)
 		container.Args = append(container.Args, fmt.Sprintf("--rgw-cert=%s", path))
+	}
+
+	if s.Spec.Gateway.DnsName == "" {
+		container.Args[4] = fmt.Sprintf("--rgw-dnsName=%s", s.instanceName())
+		// s.Spec.Gateway.DnsName = s.instanceName()
 	}
 
 	return container

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -125,7 +125,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
 	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", store.instanceName()), cont.Args[3])
-	assert.Equal(t, fmt.Sprintf("--rgw-dns-name=%s", store.instanceName()), cont.Args[4])
+	assert.Equal(t, fmt.Sprintf("--rgw-dns-name=%s.%s", store.instanceName(), store.Namespace), cont.Args[4])
 	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[5])
 	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[6])
 

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -105,7 +105,6 @@ func TestPodSpecs(t *testing.T) {
 
 	s := store.makeRGWPodSpec("myversion", true)
 	assert.NotNil(t, s)
-	//assert.Equal(t, store.instanceName(), s.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, s.Spec.RestartPolicy)
 	assert.Equal(t, 2, len(s.Spec.Volumes))
 	assert.Equal(t, "rook-data", s.Spec.Volumes[0].Name)
@@ -121,16 +120,30 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
 
-	assert.Equal(t, 6, len(cont.Args))
+	assert.Equal(t, 7, len(cont.Args))
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
 	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", store.instanceName()), cont.Args[3])
-	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[4])
-	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[5])
+	assert.Equal(t, fmt.Sprintf("--rgw-dnsName=%s", store.instanceName()), cont.Args[4])
+	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[5])
+	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[6])
 
 	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
+}
+
+func TestCustomDNS(t *testing.T) {
+	store := simpleStore()
+	store.Spec.Gateway.DnsName = "rook-s3-endpoint.io"
+
+	s := store.makeRGWPodSpec("v1.0", true)
+	assert.NotNil(t, s)
+	assert.Equal(t, store.instanceName(), s.Name)
+	assert.Equal(t, 2, len(s.Spec.Volumes))
+	cont := s.Spec.Containers[0]
+	assert.Equal(t, 7, len(cont.Args))
+	assert.Equal(t, fmt.Sprintf("--rgw-dnsName=%s", store.Spec.Gateway.DnsName), cont.Args[4])
 }
 
 func TestSSLPodSpec(t *testing.T) {
@@ -151,9 +164,9 @@ func TestSSLPodSpec(t *testing.T) {
 	assert.Equal(t, certVolumeName, cont.VolumeMounts[2].Name)
 	assert.Equal(t, certMountPath, cont.VolumeMounts[2].MountPath)
 
-	assert.Equal(t, 7, len(cont.Args))
-	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 443), cont.Args[5])
-	assert.Equal(t, fmt.Sprintf("--rgw-cert=%s/%s", certMountPath, certFilename), cont.Args[6])
+	assert.Equal(t, 8, len(cont.Args))
+	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 443), cont.Args[6])
+	assert.Equal(t, fmt.Sprintf("--rgw-cert=%s/%s", certMountPath, certFilename), cont.Args[7])
 }
 
 func TestCreateObjectStore(t *testing.T) {

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -125,7 +125,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
 	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", store.instanceName()), cont.Args[3])
-	assert.Equal(t, fmt.Sprintf("--rgw-dnsName=%s", store.instanceName()), cont.Args[4])
+	assert.Equal(t, fmt.Sprintf("--rgw-dns-name=%s", store.instanceName()), cont.Args[4])
 	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[5])
 	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[6])
 
@@ -143,7 +143,7 @@ func TestCustomDNS(t *testing.T) {
 	assert.Equal(t, 2, len(s.Spec.Volumes))
 	cont := s.Spec.Containers[0]
 	assert.Equal(t, 7, len(cont.Args))
-	assert.Equal(t, fmt.Sprintf("--rgw-dnsName=%s", store.Spec.Gateway.DnsName), cont.Args[4])
+	assert.Equal(t, fmt.Sprintf("--rgw-dns-name=%s", store.Spec.Gateway.DnsName), cont.Args[4])
 }
 
 func TestSSLPodSpec(t *testing.T) {

--- a/pkg/operator/rgw/types.go
+++ b/pkg/operator/rgw/types.go
@@ -74,6 +74,9 @@ type GatewaySpec struct {
 	// The number of pods in the rgw replicaset. If "allNodes" is specified, a daemonset is created.
 	Instances int32 `json:"instances"`
 
+	// The DNS name that will be accepted within the RGW
+	DnsName string `json:"dnsName"`
+
 	// Whether the rgw pods should be started as a daemonset on all nodes
 	AllNodes bool `json:"allNodes"`
 

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -40,8 +40,8 @@ func CreateObjectOperation(rookRestClient contracts.RestAPIOperator) *ObjectOper
 //ObjectCreate Function to create a object store in rook
 //Input parameters -None
 //Output - output returned by rook Rest API client
-func (ro *ObjectOperation) ObjectCreate(namespace, storeName string, replicaCount int32, callAPI bool, k8sh *utils.K8sHelper) error {
-	store := model.ObjectStore{Name: storeName, Gateway: model.Gateway{Instances: replicaCount, Port: model.RGWPort}}
+func (ro *ObjectOperation) ObjectCreate(namespace, storeName string, replicaCount int32, dnsName string, callAPI bool, k8sh *utils.K8sHelper) error {
+	store := model.ObjectStore{Name: storeName, Gateway: model.Gateway{Instances: replicaCount, Port: model.RGWPort, DnsName: dnsName}}
 	store.DataConfig.ReplicatedConfig.Size = 1
 	store.MetadataConfig.ReplicatedConfig.Size = 1
 	if callAPI {
@@ -70,12 +70,13 @@ spec:
       size: 1
   gateway:
     type: s3
+    dnsName: %s
     sslCertificateRef: 
     port: %d
     securePort:
     instances: %d
     allNodes: false
-`, kind, store.Name, namespace, store.Gateway.Port, store.Gateway.Instances)
+`, kind, store.Name, namespace, dnsName, store.Gateway.Port, store.Gateway.Instances)
 
 		if _, err := k8sh.ResourceOperation("create", storeSpec); err != nil {
 			return err

--- a/tests/framework/contracts/operations.go
+++ b/tests/framework/contracts/operations.go
@@ -45,7 +45,7 @@ type FileSystemOperator interface {
 
 //ObjectOperator - interface for rook object operations
 type ObjectOperator interface {
-	ObjectCreate(namespace, storeName string, replicaCount int32, callAPI bool, k8sh *utils.K8sHelper) error
+	ObjectCreate(namespace, storeName string, replicaCount int32, dnsName string, callAPI bool, k8sh *utils.K8sHelper) error
 	ObjectDelete(namespace, storeName string, replicaCount int32, callAPI bool, k8sh *utils.K8sHelper) error
 	ObjectBucketList(storeName string) ([]model.ObjectBucket, error)
 	ObjectConnection(storeName string) (*model.ObjectStoreConnectInfo, error)

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/rook/rook/pkg/model"
 	"github.com/rook/rook/tests/framework/clients"
@@ -41,6 +42,7 @@ var (
 //Delete user
 func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
 	storeName := "teststore"
+	dnsName := fmt.Sprintf("%s.%s", storeName, namespace)
 	defer objectTestDataCleanUp(helper, k8sh, namespace, storeName)
 	oc := helper.GetObjectClient()
 
@@ -48,7 +50,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Running on Rook Cluster %s", namespace)
 
 	logger.Infof("Step 0 : Create Object Store")
-	cobsErr := oc.ObjectCreate(namespace, storeName, 1, true, k8sh)
+	cobsErr := oc.ObjectCreate(namespace, storeName, 1, dnsName, true, k8sh)
 	require.Nil(s.T(), cobsErr)
 	logger.Infof("Object store created successfully")
 
@@ -130,12 +132,13 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 
 //Test Object StoreCreation on Rook that was installed via helm
 func runObjectE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, name string, replicaSize int) {
+	dnsName := fmt.Sprintf("%s.%s", name, namespace)
 	logger.Infof("Object Storage End To End Integration Test - Create Object Store and check if rgw service is Running")
 	logger.Infof("Running on Rook Cluster %s", namespace)
 
 	logger.Infof("Step 1 : Create Object Store")
 	oc := helper.GetObjectClient()
-	err := oc.ObjectCreate(namespace, name, int32(replicaSize), false, k8sh)
+	err := oc.ObjectCreate(namespace, name, int32(replicaSize), dnsName, false, k8sh)
 	require.Nil(s.T(), err)
 
 	logger.Infof("Step 2 : check rook-ceph-rgw service status and count")

--- a/tests/longhaul/base_object_test.go
+++ b/tests/longhaul/base_object_test.go
@@ -1,6 +1,7 @@
 package longhaul
 
 import (
+	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -45,7 +46,8 @@ func setUpRook(t func() *testing.T, namespace string) (*utils.K8sHelper, *instal
 
 func createObjectStoreAndUser(t func() *testing.T, kh *utils.K8sHelper, tc *clients.TestClient, namespace string, storeName string, userId string, userName string) *utils.S3Helper {
 	if !isObjectStorePresent(kh, namespace, storeName) {
-		tc.GetObjectClient().ObjectCreate(namespace, storeName, 3, false, kh)
+		dnsName := fmt.Sprintf("%s.%s", storeName, namespace)
+		tc.GetObjectClient().ObjectCreate(namespace, storeName, 3, dnsName, false, kh)
 	}
 
 	ou, err := tc.GetObjectClient().ObjectGetUser(storeName, userId)

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -5,7 +5,7 @@ install() {
     #Download and unpack helm
     local dist=`uname -s`
     dist=`echo ${dist} | tr "[A-Z]" "[a-z]"`
-    if [ ! -f https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-amd64.tar.gz ] ; then 
+    if [ ! -f ./helm-v2.6.0-${dist}-amd64.tar.gz ] ; then 
         wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-amd64.tar.gz
     fi 
     tar -zxvf helm-v2.6.0-${dist}-amd64.tar.gz

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -5,7 +5,9 @@ install() {
     #Download and unpack helm
     local dist=`uname -s`
     dist=`echo ${dist} | tr "[A-Z]" "[a-z]"`
-    wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-amd64.tar.gz
+    if [ ! -f https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-amd64.tar.gz ] ; then 
+        wget https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-amd64.tar.gz
+    fi 
     tar -zxvf helm-v2.6.0-${dist}-amd64.tar.gz
     sudo mv ${dist}-amd64/helm /usr/local/bin/helm
 


### PR DESCRIPTION
This makes DNS settings configurable, so that object stores can be accessed from different hostnames than the service name.  