### PR TITLE
Not create rbac roles on k8s cluster that have rbac disabled.

### DIFF
--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         env:
         - name: ROOK_REPO_PREFIX
           value: {{ .Values.image.prefix }}
+{{- if not .Values.rbacEnable }}
+        - name: RBAC_ENABLED
+          value: "false"
+{{- end }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
         - name: NODE_NAME

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -123,6 +123,9 @@ spec:
         env:
         - name: ROOK_REPO_PREFIX
           value: rook
+        # To disable RBAC, uncomment the following:
+        # - name: RBAC_ENABLED
+        #  value: "false"
         # The interval to check if every mon is in the quorum.
         - name: ROOK_MON_HEALTHCHECK_INTERVAL
           value: "20s"


### PR DESCRIPTION
Fixes https://github.com/rook/rook/issues/1221
(cherry picked from commit 735d2e71558ddde16248adfdfd31bd4e53be18f3)
