### PR TITLE
Remove versionTag in favor of the operator container image version

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -50,11 +50,6 @@ done) | gzip > /tmp/rook-logs.gz
 This gets the logs for every container in every Rook pod and then compresses them into a `.gz` archive
 for easy sharing.  Note that instead of `gzip`, you could instead pipe to `less` or to a single text file.
 
-## Change Rook Docker Image Prefix
-To change the prefix of rook Docker images used, the environment variable `ROOK_REPO_PREFIX` can be changed.
-The variable needs to be, depending on the deployment of the rook-operator, added/changed in the rook-operator deployment.
-The default is `rook` which will pull from [Docker Hub](https://hub.docker.com/r/rook/rook/). For example to use your own built images: `your-registry.example.com/your-name/rook`.
-
 ## OSD Information
 
 Keeping track of OSDs and their underlying storage devices/directories can be

--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -20,7 +20,6 @@ Settings can be specified at the global level to apply to the cluster as a whole
 
 ### Cluster settings
 
-- `versionTag`: The version (tag) of the `rook/rook` container that will be deployed. Upgrades are not yet supported if this setting is updated for an existing cluster, but upgrades will be coming.
 - `dataDirHostPath`: The path on the host ([hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)) where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted.
   - If a path is not specified, an [empty dir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will be used and the config will be lost when the pod or host is restarted. This option is **not recommended**.
   - **WARNING**: For test scenarios, if you delete a cluster and start a new cluster on the same hosts, the path used by `dataDirHostPath` must be deleted. Otherwise, stale keys and other config will remain from the previous cluster and the new mons will fail to start.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,6 +6,12 @@
 
 ## Breaking Changes
 
+### Cluster CRD
+- Removed the `versionTag` property. The container version to launch in all pods will be the same as the version of the operator container. 
+
+### Operator
+- Removed the `ROOK_REPO_PREFIX` env var. All containers will be launched with the same image as the operator
+
 ## Known Issues
 
 ## Deprecations

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -21,8 +21,6 @@ spec:
         args:
           - operator
         env:
-        - name: ROOK_REPO_PREFIX
-          value: {{ .Values.image.prefix }}
 {{- if not .Values.rbacEnable }}
         - name: RBAC_ENABLED
           value: "false"

--- a/cluster/examples/kubernetes/1.5/rook-operator.yaml
+++ b/cluster/examples/kubernetes/1.5/rook-operator.yaml
@@ -20,8 +20,6 @@ spec:
         image: rook/rook:master
         args: ["operator"]
         env:
-        - name: ROOK_REPO_PREFIX
-          value: rook
         # The interval to check if every mon is in the quorum.
         - name: ROOK_MON_HEALTHCHECK_INTERVAL
           value: "45s"

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -9,7 +9,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   dataDirHostPath: /var/lib/rook

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -121,8 +121,6 @@ spec:
         image: rook/rook:master
         args: ["operator"]
         env:
-        - name: ROOK_REPO_PREFIX
-          value: rook
         # To disable RBAC, uncomment the following:
         # - name: RBAC_ENABLED
         #  value: "false"

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -65,10 +65,13 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		terminateFatal(err)
 	}
 
-	op := operator.New(context, volumeAttachment)
-	if op == nil {
-		terminateFatal(fmt.Errorf("failed to create operator."))
+	// Using the rook-operator image to deploy other rook pods
+	rookImage, err := k8sutil.GetContainerImage(clientset)
+	if err != nil {
+		terminateFatal(fmt.Errorf("failed to get container image. %+v\n", err))
 	}
+
+	op := operator.New(context, volumeAttachment, rookImage)
 	err = op.Run()
 	if err != nil {
 		terminateFatal(fmt.Errorf("failed to run operator. %+v\n", err))

--- a/pkg/apis/rook.io/v1alpha1/types.go
+++ b/pkg/apis/rook.io/v1alpha1/types.go
@@ -45,14 +45,6 @@ type ClusterList struct {
 }
 
 type ClusterSpec struct {
-	// VersionTag is the expected version of the rook container to run in the cluster.
-	// The operator will eventually make the rook cluster version
-	// equal to the expected version.
-	VersionTag string `json:"versionTag"`
-
-	// Paused is to pause the control of the operator for the rook cluster.
-	Paused bool `json:"paused,omitempty"`
-
 	// The path on the host where config and data can be persisted.
 	DataDirHostPath string `json:"dataDirHostPath"`
 

--- a/pkg/daemon/api/daemon.go
+++ b/pkg/daemon/api/daemon.go
@@ -38,17 +38,17 @@ type Config struct {
 	port        int
 	clusterInfo *mon.ClusterInfo
 	namespace   string
-	versionTag  string
+	rookImage   string
 	hostNetwork bool
 }
 
-func NewConfig(context *clusterd.Context, port int, clusterInfo *mon.ClusterInfo, namespace, versionTag string, hostNetwork bool) *Config {
+func NewConfig(context *clusterd.Context, port int, clusterInfo *mon.ClusterInfo, namespace, rookImage string, hostNetwork bool) *Config {
 	return &Config{
 		context:     context,
 		port:        port,
 		clusterInfo: clusterInfo,
 		namespace:   namespace,
-		versionTag:  versionTag,
+		rookImage:   rookImage,
 		hostNetwork: hostNetwork,
 	}
 }

--- a/pkg/daemon/api/filesystem.go
+++ b/pkg/daemon/api/filesystem.go
@@ -59,7 +59,7 @@ func (h *Handler) CreateFileSystem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Infof("Starting the MDS")
-	if err := k8smds.CreateFileSystem(h.config.context, h.config.namespace, fs, h.config.versionTag, h.config.hostNetwork); err != nil {
+	if err := k8smds.CreateFileSystem(h.config.context, h.config.namespace, fs, h.config.rookImage, h.config.hostNetwork); err != nil {
 		logger.Errorf("failed to start mds: %+v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/pkg/daemon/api/object.go
+++ b/pkg/daemon/api/object.go
@@ -383,7 +383,7 @@ func enableObjectStore(c *Config, config model.ObjectStore) error {
 	}
 
 	store := k8srgw.ModelToSpec(config, c.namespace)
-	err := k8srgw.UpdateStore(c.context, *store, c.versionTag, c.hostNetwork)
+	err := k8srgw.UpdateStore(c.context, *store, c.rookImage, c.hostNetwork)
 	if err != nil {
 		return fmt.Errorf("failed to start rgw. %+v", err)
 	}

--- a/pkg/operator/agent/agent_test.go
+++ b/pkg/operator/agent/agent_test.go
@@ -61,7 +61,7 @@ func TestStartAgentDaemonset(t *testing.T) {
 	a := New(clientset)
 
 	// start a basic cluster
-	err := a.Start(namespace)
+	err := a.Start(namespace, "rook/rook:myversion")
 	assert.Nil(t, err)
 
 	// check clusters rbac roles
@@ -90,7 +90,7 @@ func TestStartAgentDaemonset(t *testing.T) {
 	envs := agentDS.Spec.Template.Spec.Containers[0].Env
 	assert.Equal(t, 2, len(envs))
 	image := agentDS.Spec.Template.Spec.Containers[0].Image
-	assert.Equal(t, "rook/test", image)
+	assert.Equal(t, "rook/rook:myversion", image)
 	assert.Nil(t, agentDS.Spec.Template.Spec.Tolerations)
 }
 
@@ -120,7 +120,7 @@ func TestGetContainerImage(t *testing.T) {
 	clientset.CoreV1().Pods("Default").Create(&pod)
 
 	// start a basic cluster
-	image, err := getContainerImage(clientset)
+	image, err := k8sutil.GetContainerImage(clientset)
 	assert.Nil(t, err)
 	assert.Equal(t, "rook/test", image)
 }
@@ -155,7 +155,7 @@ func TestGetContainerImageMultipleContainers(t *testing.T) {
 	clientset.CoreV1().Pods("Default").Create(&pod)
 
 	// start a basic cluster
-	_, err := getContainerImage(clientset)
+	_, err := k8sutil.GetContainerImage(clientset)
 	assert.NotNil(t, err)
 	assert.Equal(t, "failed to get container image. There should only be exactly one container in this pod", err.Error())
 }
@@ -192,7 +192,7 @@ func TestStartAgentDaemonsetWithToleration(t *testing.T) {
 	a := New(clientset)
 
 	// start a basic cluster
-	err := a.Start(namespace)
+	err := a.Start(namespace, "rook/test")
 	assert.Nil(t, err)
 
 	// check daemonset toleration

--- a/pkg/operator/cluster/api/api.go
+++ b/pkg/operator/cluster/api/api.go
@@ -176,9 +176,9 @@ func (c *Cluster) apiContainer() v1.Container {
 			{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
 		},
 		Env: []v1.EnvVar{
-			{Name: "ROOK_VERSION_TAG", Value: c.Version},
 			{Name: "ROOK_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
-			k8sutil.RepoPrefixEnvVar(),
+			k8sutil.NameEnvVar(),
+			k8sutil.NamespaceEnvVar(),
 			opmon.SecretEnvVar(),
 			opmon.AdminSecretEnvVar(),
 			opmon.EndpointEnvVar(),

--- a/pkg/operator/cluster/api/api_test.go
+++ b/pkg/operator/cluster/api/api_test.go
@@ -59,7 +59,7 @@ func validateStart(t *testing.T, c *Cluster) {
 
 func TestPodSpecs(t *testing.T) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", rookalpha.Placement{}, false, v1.ResourceRequirements{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "rook/rook:myversion", rookalpha.Placement{}, false, v1.ResourceRequirements{})
 
 	d := c.makeDeployment()
 	assert.NotNil(t, d)
@@ -78,19 +78,19 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, 1, len(cont.VolumeMounts))
 	assert.Equal(t, 7, len(cont.Env))
 
-	var envs [7]string
-	for i, v := range cont.Env {
-		envs[i] = v.Name
+	var envs []string
+	for _, v := range cont.Env {
+		envs = append(envs, v.Name)
 	}
 	sort.Strings(envs[:])
 
-	assert.Equal(t, "ROOK_ADMIN_SECRET", envs[0])
-	assert.Equal(t, "ROOK_CLUSTER_NAME", envs[1])
-	assert.Equal(t, "ROOK_MON_ENDPOINTS", envs[2])
-	assert.Equal(t, "ROOK_MON_SECRET", envs[3])
-	assert.Equal(t, "ROOK_NAMESPACE", envs[4])
-	assert.Equal(t, "ROOK_REPO_PREFIX", envs[5])
-	assert.Equal(t, "ROOK_VERSION_TAG", envs[6])
+	assert.Equal(t, "POD_NAME", envs[0])
+	assert.Equal(t, "POD_NAMESPACE", envs[1])
+	assert.Equal(t, "ROOK_ADMIN_SECRET", envs[2])
+	assert.Equal(t, "ROOK_CLUSTER_NAME", envs[3])
+	assert.Equal(t, "ROOK_MON_ENDPOINTS", envs[4])
+	assert.Equal(t, "ROOK_MON_SECRET", envs[5])
+	assert.Equal(t, "ROOK_NAMESPACE", envs[6])
 
 	assert.Equal(t, "api", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])

--- a/pkg/operator/cluster/controller_test.go
+++ b/pkg/operator/cluster/controller_test.go
@@ -58,8 +58,8 @@ func TestCreateInitialCrushMap(t *testing.T) {
 }
 
 func TestClusterChanged(t *testing.T) {
-	old := rookalpha.ClusterSpec{VersionTag: "v0.6.0", MonCount: 1, HostNetwork: false}
-	new := rookalpha.ClusterSpec{VersionTag: "v0.7.0", MonCount: 3, HostNetwork: true}
+	old := rookalpha.ClusterSpec{MonCount: 1, HostNetwork: false}
+	new := rookalpha.ClusterSpec{MonCount: 3, HostNetwork: true}
 
 	// no changes supported yet
 	assert.False(t, clusterChanged(old, new))
@@ -110,7 +110,7 @@ func TestClusterDelete(t *testing.T) {
 	}
 
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, volumeAttachmentController)
+	controller := NewClusterController(context, "", volumeAttachmentController)
 	clusterToDelete := &rookalpha.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 

--- a/pkg/operator/cluster/mgr/mgr_test.go
+++ b/pkg/operator/cluster/mgr/mgr_test.go
@@ -69,7 +69,7 @@ func validateStart(t *testing.T, c *Cluster) {
 }
 
 func TestPodSpec(t *testing.T) {
-	c := New(nil, "ns", "myversion", rookalpha.Placement{}, false, v1.ResourceRequirements{
+	c := New(nil, "ns", "rook/rook:myversion", rookalpha.Placement{}, false, v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
 		},

--- a/pkg/operator/cluster/mon/mon.go
+++ b/pkg/operator/cluster/mon/mon.go
@@ -66,7 +66,6 @@ type Cluster struct {
 	Version             string
 	MasterHost          string
 	Size                int
-	Paused              bool
 	Port                int32
 	clusterInfo         *mon.ClusterInfo
 	placement           rookalpha.Placement

--- a/pkg/operator/cluster/mon/spec.go
+++ b/pkg/operator/cluster/mon/spec.go
@@ -113,7 +113,6 @@ func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
 		Spec: podSpec,
 	}
 
-	k8sutil.SetPodVersion(pod, k8sutil.VersionAttr, c.Version)
 	return pod
 }
 

--- a/pkg/operator/cluster/mon/spec_test.go
+++ b/pkg/operator/cluster/mon/spec_test.go
@@ -36,7 +36,7 @@ func TestPodSpecs(t *testing.T) {
 
 func testPodSpec(t *testing.T, dataDir string) {
 	clientset := testop.New(1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "myversion", 3, rookalpha.Placement{}, false, v1.ResourceRequirements{
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", dataDir, "rook/rook:myversion", 3, rookalpha.Placement{}, false, v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
 		},
@@ -65,8 +65,6 @@ func testPodSpec(t *testing.T, dataDir string) {
 	assert.Equal(t, "mon0", pod.ObjectMeta.Name)
 	assert.Equal(t, appName, pod.ObjectMeta.Labels["app"])
 	assert.Equal(t, c.Namespace, pod.ObjectMeta.Labels["mon_cluster"])
-	assert.Equal(t, 1, len(pod.ObjectMeta.Annotations))
-	assert.Equal(t, "myversion", pod.ObjectMeta.Annotations["rook_version"])
 
 	cont := pod.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)

--- a/pkg/operator/cluster/osd/osd_test.go
+++ b/pkg/operator/cluster/osd/osd_test.go
@@ -66,7 +66,7 @@ func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool)
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", storageSpec, dataDir, rookalpha.Placement{}, false, v1.ResourceRequirements{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "rook/rook:myversion", storageSpec, dataDir, rookalpha.Placement{}, false, v1.ResourceRequirements{})
 
 	devMountNeeded := deviceFilter != "" || allDevices
 
@@ -157,7 +157,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "rook/rook:myversion", storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{})
 
 	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
 	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, n.Config)
@@ -207,7 +207,7 @@ func TestStorageSpecConfig(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "myversion", storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "rook/rook:myversion", storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{})
 
 	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
 	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Selection, c.Storage.Nodes[0].Resources, n.Config)

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -16,23 +16,12 @@ limitations under the License.
 package k8sutil
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMakeRookImage(t *testing.T) {
-	assert.Equal(t, "rook/rook:v1", MakeRookImage("v1"))
-}
-
-func TestMakeRookImageWithEnv(t *testing.T) {
-	os.Setenv(repoPrefixEnvVar, "myrepo.io/rook")
-	assert.Equal(t, "myrepo.io/rook/rook:v1", MakeRookImage("v1"))
-	os.Setenv(repoPrefixEnvVar, "")
-}
-
-func TestDefaultVersion(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("rook/rook:%s", defaultVersion), MakeRookImage(""))
+	assert.Equal(t, "rook/rook:v1", MakeRookImage("rook/rook:v1"))
+	assert.Equal(t, defaultVersion, MakeRookImage(""))
 }

--- a/pkg/operator/mds/controller.go
+++ b/pkg/operator/mds/controller.go
@@ -45,15 +45,15 @@ var FilesystemResource = opkit.CustomResource{
 // FilesystemController represents a controller for file system custom resources
 type FilesystemController struct {
 	context     *clusterd.Context
-	versionTag  string
+	rookImage   string
 	hostNetwork bool
 }
 
 // NewFilesystemController create controller for watching file system custom resources created
-func NewFilesystemController(context *clusterd.Context, versionTag string, hostNetwork bool) *FilesystemController {
+func NewFilesystemController(context *clusterd.Context, rookImage string, hostNetwork bool) *FilesystemController {
 	return &FilesystemController{
 		context:     context,
-		versionTag:  versionTag,
+		rookImage:   rookImage,
 		hostNetwork: hostNetwork,
 	}
 }
@@ -76,7 +76,7 @@ func (c *FilesystemController) StartWatch(namespace string, stopCh chan struct{}
 func (c *FilesystemController) onAdd(obj interface{}) {
 	filesystem := obj.(*rookalpha.Filesystem).DeepCopy()
 
-	err := CreateFilesystem(c.context, *filesystem, c.versionTag, c.hostNetwork)
+	err := CreateFilesystem(c.context, *filesystem, c.rookImage, c.hostNetwork)
 	if err != nil {
 		logger.Errorf("failed to create file system %s. %+v", filesystem.Name, err)
 	}
@@ -92,7 +92,7 @@ func (c *FilesystemController) onUpdate(oldObj, newObj interface{}) {
 
 	// if the file system is modified, allow the file system to be created if it wasn't already
 	logger.Infof("updating filesystem %s", newFS)
-	err := CreateFilesystem(c.context, *newFS, c.versionTag, c.hostNetwork)
+	err := CreateFilesystem(c.context, *newFS, c.rookImage, c.hostNetwork)
 	if err != nil {
 		logger.Errorf("failed to create (modify) file system %s. %+v", newFS.Name, err)
 	}

--- a/pkg/operator/mds/mds_test.go
+++ b/pkg/operator/mds/mds_test.go
@@ -111,7 +111,7 @@ func TestPodSpecs(t *testing.T) {
 	}
 	mdsID := "mds1"
 
-	d := makeDeployment(fs, mdsID, "myversion", false)
+	d := makeDeployment(fs, mdsID, "rook/rook:myversion", false)
 	assert.NotNil(t, d)
 	assert.Equal(t, appName+"-myfs", d.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, d.Spec.Template.Spec.RestartPolicy)

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -32,7 +32,7 @@ import (
 func TestOperator(t *testing.T) {
 	clientset := test.New(3)
 	context := &clusterd.Context{Clientset: clientset}
-	o := New(context, &attachment.MockAttachment{})
+	o := New(context, &attachment.MockAttachment{}, "")
 
 	assert.NotNil(t, o)
 	assert.NotNil(t, o.clusterController)

--- a/pkg/operator/rgw/controller.go
+++ b/pkg/operator/rgw/controller.go
@@ -45,15 +45,15 @@ var ObjectStoreResource = opkit.CustomResource{
 // ObjectStoreController represents a controller object for object store custom resources
 type ObjectStoreController struct {
 	context     *clusterd.Context
-	versionTag  string
+	rookImage   string
 	hostNetwork bool
 }
 
 // NewObjectStoreController create controller for watching object store custom resources created
-func NewObjectStoreController(context *clusterd.Context, versionTag string, hostNetwork bool) *ObjectStoreController {
+func NewObjectStoreController(context *clusterd.Context, rookImage string, hostNetwork bool) *ObjectStoreController {
 	return &ObjectStoreController{
 		context:     context,
-		versionTag:  versionTag,
+		rookImage:   rookImage,
 		hostNetwork: hostNetwork,
 	}
 }
@@ -75,7 +75,7 @@ func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{
 
 func (c *ObjectStoreController) onAdd(obj interface{}) {
 	store := obj.(*rookalpha.ObjectStore).DeepCopy()
-	err := CreateStore(c.context, *store, c.versionTag, c.hostNetwork)
+	err := CreateStore(c.context, *store, c.rookImage, c.hostNetwork)
 	if err != nil {
 		logger.Errorf("failed to create object store %s. %+v", store.Name, err)
 	}
@@ -91,7 +91,7 @@ func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 	}
 
 	logger.Infof("applying object store %s changes", newStore.Name)
-	err := UpdateStore(c.context, *newStore, c.versionTag, c.hostNetwork)
+	err := UpdateStore(c.context, *newStore, c.rookImage, c.hostNetwork)
 	if err != nil {
 		logger.Errorf("failed to create (modify) object store %s. %+v", newStore.Name, err)
 	}

--- a/pkg/operator/rgw/rgw_test.go
+++ b/pkg/operator/rgw/rgw_test.go
@@ -103,7 +103,7 @@ func TestPodSpecs(t *testing.T) {
 		},
 	}
 
-	s := makeRGWPodSpec(store, "myversion", true)
+	s := makeRGWPodSpec(store, "rook/rook:myversion", true)
 	assert.NotNil(t, s)
 	//assert.Equal(t, instanceName(store), s.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, s.Spec.RestartPolicy)

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -155,8 +155,6 @@ spec:
         image: rook/rook:master
         args: ["operator", "--mon-healthcheck-interval=5s", "--mon-out-timeout=1s"]
         env:
-        - name: ROOK_REPO_PREFIX
-          value: rook
         - name: ROOK_LOG_LEVEL
           value: INFO
         # The interval to check if every mon is in the quorum.


### PR DESCRIPTION
There is no need for the `versionTag` on the cluster.yaml or the `repoPrefix` on the operator. All pods that are launched will use the same container image as the operator pod. Fixes #1215 