### PR TITLE
Added GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!-- **Are you in the right place?**
+1. For issues or feature requests, please create an issue in this repository.
+2. For general technical and non-technical questions, we are happy to help you on our [Rook.io Slack](https://Rook-io.slack.com).
+3. Did you already search the existing open issues for anything similar? -->
+
+Is this a bug report or feature request?
+<!-- Remove only one -->
+* Bug Report
+* Feature Request
+
+**Bug Report**
+
+What happened:
+
+What you expected to happen:
+
+How to reproduce it (minimal and precise):
+<!-- Please let us know any circumstances for reproduction of your bug. -->
+
+**Feature Request**
+
+Are there any similar features already existing:
+
+What should the feature do:
+
+What would be solved through this feature:
+
+Does this have an impact on existing features:
+
+**Environment**:
+* OS (e.g. from /etc/os-release):
+* Kernel (e.g. `uname -a`):
+* Cloud provider or hardware configuration:
+* Rook version (use `rook version` inside of a Rook Pod):
+* Kubernetes version (use `kubectl version`):
+* Kubernetes cluster type (e.g. Tectonic, GKE, OpenShift):
+* Ceph status (use `ceph health` in the [Rook toolbox](https://Rook.io/docs/Rook/master/toolbox.html)):


### PR DESCRIPTION
The first part will be to add an issue template.

The rendered version of the template can be found here: https://github.com/galexrt/rook/blob/feature/1307/.github/ISSUE_TEMPLATE.md

[skip ci]