### PR TITLE
wip : make longhaul test go through external rgw endpoint.

### DIFF
--- a/tests/longhaul/base_object_test.go
+++ b/tests/longhaul/base_object_test.go
@@ -56,7 +56,7 @@ func createObjectStoreAndUser(t func() *testing.T, kh *utils.K8sHelper, tc *clie
 
 	conninfo, conninfoError := tc.GetObjectClient().ObjectGetUser(storeName, userId)
 	require.Nil(t(), conninfoError)
-	s3endpoint, _ := kh.GetRGWServiceURL(storeName, namespace)
+	s3endpoint, _ := kh.GetExternalRGWServiceURL(storeName, namespace)
 	s3client := utils.CreateNewS3Helper(s3endpoint, *conninfo.AccessKey, *conninfo.SecretKey)
 
 	return s3client


### PR DESCRIPTION
[skip ci] temp fix for running load test from  outside k8s cluster but inside the same network as nodes(they have ip starting with 10.x.x.x)