### PR TITLE
test: fix integration test flags initilization

### DIFF
--- a/tests/framework/installer/install_helper.go
+++ b/tests/framework/installer/install_helper.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"flag"
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
@@ -42,7 +43,6 @@ var (
 	deleteArgs     = []string{"delete", "-f", "-"}
 	helmChartName  = "local/rook"
 	helmDeployName = "rook"
-	env            objects.EnvironmentManifest
 )
 
 //InstallHelper wraps installing and uninstalling rook on a platform
@@ -53,10 +53,6 @@ type InstallHelper struct {
 	Env         objects.EnvironmentManifest
 	k8sVersion  string
 	T           func() *testing.T
-}
-
-func init() {
-	env = objects.NewManifest()
 }
 
 //CreateK8sRookOperator creates rook-operator via kubectl
@@ -341,14 +337,16 @@ func NewK8sRookhelper(clientset *kubernetes.Clientset, t func() *testing.T) *Ins
 	if err != nil {
 		panic("failed to get kubectl client :" + err.Error())
 	}
-	return &InstallHelper{
+	ih := &InstallHelper{
 		k8shelper:   k8shelp,
 		installData: NewK8sInstallData(),
 		helmHelper:  utils.NewHelmHelper(),
-		Env:         env,
+		Env:         objects.Env,
 		k8sVersion:  version.String(),
 		T:           t,
 	}
+	flag.Parse()
+	return ih
 }
 
 func IsAdditionalDeviceAvailableOnCluster() bool {

--- a/tests/framework/objects/environment_manifest.go
+++ b/tests/framework/objects/environment_manifest.go
@@ -31,15 +31,15 @@ type EnvironmentManifest struct {
 	LoadTime           int
 }
 
-//NewManifest creates a new instance of EnvironmentManifest
-func NewManifest() EnvironmentManifest {
-	e := EnvironmentManifest{}
-	flag.StringVar(&e.HostType, "host_type", "localhost", "Host were tests are run eg - localhost,GCE or AWS")
-	flag.StringVar(&e.RookImageName, "rook_image", "rook/rook", "Docker image name for the rook container to install, must be in docker hub or local environment")
-	flag.StringVar(&e.ToolboxImageName, "toolbox_image", "rook/toolbox", "Docker image name of the toolbox container to install, must be in docker hub or local environment")
-	flag.StringVar(&e.SkipInstallRook, "skip_install_rook", "false", "Indicate if Rook need to installed - false if tests are being running at Rook that is pre-installed")
-	flag.IntVar(&e.LoadConcurrentRuns, "load_parallel_runs", 20, "number of routines for load test")
-	flag.IntVar(&e.LoadVolumeNumber, "load_volumes", 1, "number of volumes(file,object or block) to be created for load test")
-	flag.IntVar(&e.LoadTime, "load_time", 1800, "number of seconds each thread perform operations for")
-	return e
+var Env EnvironmentManifest
+
+func init() {
+	Env = EnvironmentManifest{}
+	flag.StringVar(&Env.HostType, "host_type", "localhost", "Host were tests are run eg - localhost,GCE or AWS")
+	flag.StringVar(&Env.RookImageName, "rook_image", "rook/rook", "Docker image name for the rook container to install, must be in docker hub or local environment")
+	flag.StringVar(&Env.ToolboxImageName, "toolbox_image", "rook/toolbox", "Docker image name of the toolbox container to install, must be in docker hub or local environment")
+	flag.StringVar(&Env.SkipInstallRook, "skip_install_rook", "false", "Indicate if Rook need to installed - false if tests are being running at Rook that is pre-installed")
+	flag.IntVar(&Env.LoadConcurrentRuns, "load_parallel_runs", 20, "number of routines for load test")
+	flag.IntVar(&Env.LoadVolumeNumber, "load_volumes", 1, "number of volumes(file,object or block) to be created for load test")
+	flag.IntVar(&Env.LoadTime, "load_time", 1800, "number of seconds each thread perform operations for")
 }


### PR DESCRIPTION
test

Test flags in integration framework were being declared but not initialized. Moved flags.Parse() out of init function so both test flags and global flags(testify.m) are declated and initialized correctly. 

[smoke only]  fix #1316 