### PR TITLE
Revert "Run two MGRs to have one in standby mode"

### DIFF
--- a/pkg/operator/cluster/mgr/mgr.go
+++ b/pkg/operator/cluster/mgr/mgr.go
@@ -58,7 +58,7 @@ func New(context *clusterd.Context, namespace, version string, placement rookalp
 		Namespace:   namespace,
 		placement:   placement,
 		Version:     version,
-		Replicas:    2,
+		Replicas:    1,
 		dataDir:     k8sutil.DataDir,
 		HostNetwork: hostNetwork,
 		resources:   resources,


### PR DESCRIPTION
Reverts rook/rook#1060.

This PR is required for #1154 as discussed in the rook meeting.

Fixes #1048.