### PR TITLE
Helm Chart: NOTES.txt: Fix label from name to app

### DIFF
--- a/cluster/charts/rook/templates/NOTES.txt
+++ b/cluster/charts/rook/templates/NOTES.txt
@@ -1,5 +1,5 @@
 The Rook Operator has been installed. Check its status by running:
-  kubectl --namespace {{ .Release.Namespace }} get pods -l "name=rook-operator"
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app=rook-operator"
 
 Visit https://rook.io/docs/rook/master for instructions on how
 to create & configure Rook clusters


### PR DESCRIPTION
NOTES instructs users to use the command `kubectl --namespace default get pods -l "name=rook-operator"`. The pods do not have a `name` label but an `app` label.