### PR TITLE
Add a warning to OSC cluster operator when no nodes are specified

### DIFF
--- a/pkg/operator/cluster/osd/osd.go
+++ b/pkg/operator/cluster/osd/osd.go
@@ -89,6 +89,10 @@ func (c *Cluster) Start() error {
 		logger.Warningf("failed to init RBAC for OSDs. %+v", err)
 	}
 
+	if c.Storage.UseAllNodes == false && len(c.Storage.Nodes) == 0 {
+		logger.Warningf("useAllNodes is set to false and no nodes are specified, no OSD pods are going to be created")
+	}
+
 	if c.Storage.UseAllNodes {
 		// make a daemonset for all nodes in the cluster
 		ds := c.makeDaemonSet(c.Storage.Selection, c.Storage.Config)


### PR DESCRIPTION
When having a simple misconfiguration or a  unintentional indentation issue on the cluster resource the OCD controller right now fails without any further logs. This PR at least adds a warning on case no nodes are set and UseAllNodes is false.