### PR TITLE
Remove ROOK_REPO_PREFIX doc toc entry

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -10,7 +10,6 @@ These examples show how to perform advanced configuration tasks on your Rook
 storage cluster.
 
 - [Log Collection](#log-collection)
-- [Change Rook Docker Image Prefix](#change-rook-docker-image-prefix)
 - [OSD Information](#osd-information)
 - [Separate Storage Groups](#separate-storage-groups)
 - [Configuring Pools](#configuring-pools)


### PR DESCRIPTION
Removes table of contents entry of section that has already been removed.
[skip ci]