### PR TITLE
Added GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
+documentation before submitting a Pull Request!
+Thank you for contributing to Rook! -->
+
+Description of your changes:
+
+Which issue is resolved by this Pull Request:
+Resolves #
+
+Checklist:
+- [ ] Documentation has been updated, if necessary.
+- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.


### PR DESCRIPTION
This is the second part of #1307.

The rendered version of the template can be found here: https://github.com/galexrt/rook/blob/feature/1307/.github/PULL_REQUEST_TEMPLATE.md

[skip ci]

***

Resolves #1307.