### PR TITLE
Removed mon Pod(Anti)Affinity

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -81,6 +81,10 @@ A Placement configuration is specified (according to the kubernetes [PodSpec](ht
 - `podAntiAffinity`: kubernetes [PodAntiAffinity](https://kubernetes.io/docs/api-reference/v1.6/#podantiaffinity-v1-core)
 - `tolerations`: list of kubernetes [Toleration](https://kubernetes.io/docs/api-reference/v1.6/#toleration-v1-core)
 
+The `mon` pod does not allow `Pod` affinity or anti-affinity.
+This is because of the mons having built-in anti-affinity with each other through the operator. The operator chooses which nodes are to run a mon on. Each mon is then tied to a node with a node selector using a hostname.
+See the [mon design doc](https://github.com/rook/rook/blob/master/design/mon-health.md) for more details on the mon failover design.
+
 ### Cluster-wide Resources Configuration Settings
 
 Resources should be specified so that the rook components are handled after [Kubernetes Pod Quality of Service classes](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/).

--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -49,8 +49,6 @@ spec:
 #      tolerations:
 #    mon:
 #      nodeAffinity:
-#      podAffinity:
-#      podAntiAffinity:
 #      tolerations:
 #    osd:
 #      nodeAffinity:

--- a/pkg/operator/cluster/ceph/mon/spec.go
+++ b/pkg/operator/cluster/ceph/mon/spec.go
@@ -102,6 +102,9 @@ func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.placement.ApplyToPodSpec(&podSpec)
+	// remove Pod (anti-)affinity because we have our own placement logic
+	c.placement.PodAffinity = nil
+	c.placement.PodAntiAffinity = nil
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Clarify docs for mon Pod(Anti)Affinity

Description of your changes:
Remove Mon `Pod(Anti)Affinity` which when used, potentially breaks our own placement logic that uses `NodeSelector` to place mon Pods.

Which issue is resolved by this Pull Request:
Relates #1369

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.

@travisn I'm not sure if this should be added to the pending release notes and when under which category.