### PR TITLE
Initialize flag parsing for the logs

### DIFF
--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -45,6 +46,9 @@ func init() {
 func startOperator(cmd *cobra.Command, args []string) error {
 
 	setLogLevel()
+
+	// workaround a k8s logging issue: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
 
 	logStartupInfo(operatorCmd.Flags())
 


### PR DESCRIPTION
Description of your changes:
The log entries written by the kubernetes layer all show a prefix `ERROR: logging before flag.Parse`. This is fixed by simply initializing the flag parsing when the operator starts.

Resolves #1376
