### PR TITLE
Remove versionTag from the cluster crd docs

### DIFF
--- a/Documentation/cluster-crd.md
+++ b/Documentation/cluster-crd.md
@@ -122,7 +122,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   # cluster level storage configuration and selection
   storage:
@@ -154,7 +153,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   # cluster level storage configuration and selection
   storage:
@@ -198,7 +196,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   # cluster level storage configuration and selection
   storage:
@@ -236,7 +233,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   placement:
     all:
@@ -284,7 +280,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   # cluster level resource requests/limits configuration
   resources:

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -192,7 +192,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   storage:
     useAllNodes: true

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -43,7 +43,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: v0.5.0
   dataDirHostPath: /var/lib/rook
   storage:
     useAllNodes: true
@@ -131,16 +130,6 @@ The general flow of the upgrade process will be to upgrade the version of a Rook
 
 In this guide, we will be upgrading a live Rook cluster running `v0.5.0` to the next available version of `v0.5.1`.
 Let's get started!
-
-### Cluster Version Tag
-The first step in the upgrade process is to update the Cluster spec's `versionTag` field.
-This value is used as the version for any other Rook components that the operator may bring up later on in the cluster's lifecycle.
-We can begin editing it with the following `kubectl` command:
-```bash
-kubectl -n rook edit cluster.rook.io rook
-```
-This will bring up your default text editor with the cluster spec loaded and ready for editing.
-In your editor, simply update `versionTag: v0.5.0` to now be `versionTag: v0.5.1`, then save and quit your editor.
 
 ### Operator
 The Rook operator is the management brains of the cluster, so it should be upgraded first before other components.

--- a/design/resource-constraints.md
+++ b/design/resource-constraints.md
@@ -80,7 +80,6 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  versionTag: master
   dataDirHostPath: /var/lib/rook
   hostNetwork: false
   monCount: 3

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -191,7 +191,6 @@ metadata:
   name: ` + namespace + `
   namespace: ` + namespace + `
 spec:
-  versionTag: master
   dataDirHostPath: ` + dataDirHostPath + `
   hostNetwork: false
   monCount: ` + strconv.Itoa(mons) + `


### PR DESCRIPTION
Description of your changes:
The versionTag was removed in a previous PR, but the docs were not updated. 

Resolves #1378 
[skip ci]