### PR TITLE
helm: make FLEXVOLUME_DIR_PATH configurable via values.yaml

### DIFF
--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -45,7 +45,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-
+{{- if .Values.flexVolumeDirPath }}
+        - name: FLEXVOLUME_DIR_PATH
+          value: {{ .Values.flexVolumeDirPath }}
+{{- end }}
 {{- if .Values.mon }}
 {{- if .Values.mon.healthCheckInterval }}
         - name: ROOK_MON_HEALTHCHECK_INTERVAL

--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -31,3 +31,8 @@ rbacEnable: true
 ## toleration. Choose between NoSchedule, PreferNoSchedule and NoExecute:
 # agent:
 #   toleration: NoSchedule
+
+## Override FlexVolume plugin directory
+## If unset, the Rook operator tries to discover it or uses a compiled in
+## default.
+#flexVolumeDirPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->
Sometimes it is neccessary to override the volume plugin directory, mostly as a temporary solution.  See issue #1330 for an example use case. This pull requests includes this ability into the Helm chart of Rook.
