### PR TITLE
WIP: ceph/mon: Use per node a single mon identity

### DIFF
--- a/pkg/daemon/ceph/client/test/mon.go
+++ b/pkg/daemon/ceph/client/test/mon.go
@@ -17,6 +17,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -24,7 +25,7 @@ import (
 
 func MonInQuorumResponse() string {
 	resp := client.MonStatusResponse{Quorum: []int{0}}
-	resp.MonMap.Mons = []client.MonMapEntry{{Name: "mon1", Rank: 0, Address: "1.2.3.4"}}
+	resp.MonMap.Mons = []client.MonMapEntry{{Name: "rook-ceph-mon1", Rank: 0, Address: "1.1.1.1"}}
 	serialized, _ := json.Marshal(resp)
 	return string(serialized)
 }
@@ -33,7 +34,11 @@ func MonInQuorumResponseMany(count int) string {
 	resp := client.MonStatusResponse{Quorum: []int{0}}
 	resp.MonMap.Mons = []client.MonMapEntry{}
 	for i := 1; i <= count; i++ {
-		resp.MonMap.Mons = append(resp.MonMap.Mons, client.MonMapEntry{Name: "mon" + strconv.Itoa(i), Rank: 0, Address: "1.2.3.4"})
+		resp.MonMap.Mons = append(resp.MonMap.Mons, client.MonMapEntry{
+			Name:    "rook-ceph-mon" + strconv.Itoa(i),
+			Rank:    0,
+			Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i),
+		})
 	}
 	serialized, _ := json.Marshal(resp)
 	return string(serialized)

--- a/pkg/daemon/ceph/mon/config_test.go
+++ b/pkg/daemon/ceph/mon/config_test.go
@@ -35,12 +35,12 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 		AdminSecret:   "adminsecret",
 		Name:          "foo-cluster",
 		Monitors: map[string]*CephMonitorConfig{
-			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6790"},
-			"node1": {Name: "mon1", Endpoint: "10.0.0.2:6790"},
+			"node0": {Name: "rook-ceph-mon0", Endpoint: "10.0.0.1:6790"},
+			"node1": {Name: "rook-ceph-mon1", Endpoint: "10.0.0.2:6790"},
 		},
 	}
 
-	monMembers := "mon0 mon1"
+	monMembers := "rook-ceph-mon0 rook-ceph-mon1"
 
 	// start with INFO level logging
 	context := &clusterd.Context{
@@ -97,7 +97,7 @@ debug bluestore = 1234`
 		AdminSecret:   "adminsecret",
 		Name:          "foo-cluster",
 		Monitors: map[string]*CephMonitorConfig{
-			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6790"},
+			"node0": {Name: "rook-ceph-mon0", Endpoint: "10.0.0.1:6790"},
 		},
 	}
 

--- a/pkg/operator/cluster/ceph/mon/health_test.go
+++ b/pkg/operator/cluster/ceph/mon/health_test.go
@@ -38,7 +38,7 @@ func TestCheckHealth(t *testing.T) {
 			return clienttest.MonInQuorumResponse(), nil
 		},
 	}
-	clientset := test.New(1)
+	clientset := test.New(3)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
 	context := &clusterd.Context{
@@ -47,32 +47,90 @@ func TestCheckHealth(t *testing.T) {
 		Executor:  executor,
 	}
 	c := New(context, "ns", "", "myversion", 3, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
-	c.clusterInfo = test.CreateConfigDir(1)
+	c.clusterInfo = test.CreateConfigDir(3)
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
-	c.mapping.MonsToNodes[0] = "node0"
-	c.mapping.Addresses[0] = "0.0.0.0"
-	c.maxMonID = 10
+	c.mapping.MonsToNodes[1] = "node0"
+	c.mapping.NodesToMons["node0"] = 1
+	c.mapping.MonsToNodes[2] = "node1"
+	c.mapping.NodesToMons["node1"] = 2
+	c.mapping.MonsToNodes[3] = "node2"
+	c.mapping.NodesToMons["node2"] = 3
 
 	err := c.checkHealth()
 	assert.Nil(t, err)
 
-	err = c.failoverMon("mon1")
+	c.maxMonID = 10
+	err = c.failoverMon("rook-ceph-mon1")
 	assert.Nil(t, err)
 
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.Equal(t, "rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
+	fmt.Printf("=== TEST: %+v\n", c.clusterInfo.Monitors)
+
+	_, ok := c.clusterInfo.Monitors["rook-ceph-mon1"]
+	assert.False(t, ok)
+	assert.NotNil(t, c.clusterInfo.Monitors["rook-ceph-mon2"])
+	assert.NotNil(t, c.clusterInfo.Monitors["rook-ceph-mon3"])
+	assert.NotNil(t, c.clusterInfo.Monitors["rook-ceph-mon11"])
 }
 
-func TestCheckHealthNotFound(t *testing.T) {
+// Simulate the behavior for a three nodes env when one mon fails (not in quorum)
+func TestCheckHealthNotInSourceOfTruth(t *testing.T) {
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			return clienttest.MonInQuorumResponse(), nil
 		},
 	}
-	clientset := test.New(1)
+	clientset := test.New(3)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	context := &clusterd.Context{
+		Clientset: clientset,
+		ConfigDir: configDir,
+		Executor:  executor,
+	}
+	c := New(context, "ns", "", "myversion", 2, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c.clusterInfo = test.CreateConfigDir(1)
+	c.waitForStart = false
+	defer os.RemoveAll(c.context.ConfigDir)
+
+	c.mapping.MonsToNodes[1] = "node0"
+	c.mapping.NodesToMons["node0"] = 1
+	c.mapping.MonsToNodes[2] = "node1"
+	c.mapping.NodesToMons["node1"] = 2
+
+	c.maxMonID = 10
+
+	c.saveMonConfig()
+
+	// Check if the two mons are found in the configmap
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.Nil(t, err)
+
+	assert.Equal(t, "rook-ceph-mon1=1.1.1.1:6790", cm.Data[EndpointDataKey])
+
+	// Because rook-ceph-mon2 isn't in the MonInQuorumResponse() but in the
+	// clusterinfo this will create a rook-ceph-mon2
+	err = c.checkHealth()
+	assert.Nil(t, err)
+
+	// recheck that the "not found" mon has been replaced with a new one
+	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
+	assert.Nil(t, err)
+	if cm.Data[EndpointDataKey] == "rook-ceph-mon1=:6790,rook-ceph-mon11=:6790" {
+		assert.Equal(t, "rook-ceph-mon1=:6790,rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
+	} else {
+		assert.Equal(t, "rook-ceph-mon11=:6790,rook-ceph-mon1=:6790", cm.Data[EndpointDataKey])
+	}
+}
+
+func TestCheckHealthMonsValid(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return clienttest.MonInQuorumResponse(), nil
+		},
+	}
+	clientset := test.New(3)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
 	context := &clusterd.Context{
@@ -85,89 +143,22 @@ func TestCheckHealthNotFound(t *testing.T) {
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
-	c.mapping.MonsToNodes[0] = "node0"
-	c.mapping.Addresses[0] = "0.0.0.0"
-	c.mapping.Addresses[0] = "0.0.0.0"
-	c.mapping.MonsToNodes[2] = "node0"
-	c.maxMonID = 10
-
-	c.saveMonConfig()
-
-	// Check if the two mons are found in the configmap
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790" {
-		assert.Equal(t, "mon1=1.2.3.1:6790,mon2=1.2.3.2:6790", cm.Data[EndpointDataKey])
-	} else {
-		assert.Equal(t, "mon2=1.2.3.2:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
-	}
-
-	// Because mon2 isn't in the MonInQuorumResponse() this will create a mon11
-	err = c.checkHealth()
-	assert.Nil(t, err)
-
-	// recheck that the "not found" mon has been replaced with a new one
-	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	if cm.Data[EndpointDataKey] == "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790" {
-		assert.Equal(t, "mon1=1.2.3.1:6790,rook-ceph-mon11=:6790", cm.Data[EndpointDataKey])
-	} else {
-		assert.Equal(t, "rook-ceph-mon11=:6790,mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
-	}
-}
-
-func TestCheckMonsValid(t *testing.T) {
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
-			return clienttest.MonInQuorumResponse(), nil
-		},
-	}
-	clientset := test.New(1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
-	context := &clusterd.Context{
-		Clientset: clientset,
-		ConfigDir: configDir,
-		Executor:  executor,
-	}
-	c := New(context, "ns", "", "myversion", 3, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
-	c.clusterInfo = test.CreateConfigDir(1)
-	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
-
 	// add two mons to the mapping on node0
 	c.mapping.MonsToNodes[1] = "node0"
 	c.mapping.NodesToMons["node0"] = 1
 	c.mapping.MonsToNodes[2] = "node1"
 	c.mapping.NodesToMons["node1"] = 2
 
-	// add three nodes
-	for i := 0; i < 3; i++ {
-		n := &v1.Node{
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{
-					{
-						Type: v1.NodeReady,
-					},
-				},
-				Addresses: []v1.NodeAddress{
-					{
-						Type:    v1.NodeExternalIP,
-						Address: "0.0.0.0",
-					},
-				},
-			},
-		}
-		n.Name = fmt.Sprintf("node%d", i)
-		clientset.CoreV1().Nodes().Create(n)
-	}
-
 	_, err := c.checkMonsOnValidNodes()
 	assert.Nil(t, err)
 	assert.Equal(t, "node0", c.mapping.MonsToNodes[1])
 	assert.Equal(t, "node1", c.mapping.MonsToNodes[2])
+	assert.Len(t, c.mapping.MonsToNodes, 2)
+	assert.Len(t, c.mapping.NodesToMons, 2)
 
-	// set node1 unschedulable and check that mon2 gets failovered to be mon3 to node2
+	c.maxMonID = 10
+
+	// set node1 unschedulable and check that rook-ceph-mon2 gets failovered to be mon3 to node2
 	node0, err := c.context.Clientset.CoreV1().Nodes().Get("node0", metav1.GetOptions{})
 	assert.Nil(t, err)
 	node0.Spec.Unschedulable = true
@@ -176,7 +167,7 @@ func TestCheckMonsValid(t *testing.T) {
 
 	// add the pods so the getNodesInUse() works correctly
 	for i := 1; i <= 2; i++ {
-		po := c.makeMonPod(&monConfig{Name: fmt.Sprintf("mon%d", i)}, fmt.Sprintf("node%d", i-1))
+		po := c.makeMonPod(&monConfig{Name: fmt.Sprintf("rook-ceph-mon%d", i)}, fmt.Sprintf("node%d", i-1))
 		_, err = clientset.CoreV1().Pods(c.Namespace).Create(po)
 		assert.Nil(t, err)
 	}
@@ -184,10 +175,9 @@ func TestCheckMonsValid(t *testing.T) {
 	_, err = c.checkMonsOnValidNodes()
 	assert.Nil(t, err)
 
-	assert.Len(t, c.mapping.MonsToNodes, 2)
-	assert.Nil(t, c.mapping.MonsToNodes[1])
-	// the new mon should always be on the empty node2
-	// the failovered mon's name is "rook-ceph-mon0"
-	assert.Equal(t, "node2", c.mapping.MonsToNodes[0])
+	assert.Len(t, c.mapping.MonsToNodes, 3)
+	assert.Len(t, c.mapping.NodesToMons, 3)
+
 	assert.Equal(t, "node1", c.mapping.MonsToNodes[2])
+	assert.Equal(t, "node2", c.mapping.MonsToNodes[11])
 }

--- a/pkg/operator/cluster/ceph/mon/mon_test.go
+++ b/pkg/operator/cluster/ceph/mon/mon_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -30,7 +29,6 @@ import (
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	cephmon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	cephtest "github.com/rook/rook/pkg/daemon/ceph/test"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -120,12 +118,12 @@ func TestOperatorRestart(t *testing.T) {
 				{
 					Name:    "rook-ceph-mon1",
 					Rank:    0,
-					Address: "0.0.0.0",
+					Address: "1.1.1.1",
 				},
 				{
 					Name:    "rook-ceph-mon2",
 					Rank:    0,
-					Address: "0.0.0.0",
+					Address: "2.2.2.2",
 				},
 			}
 			serialized, _ := json.Marshal(resp)
@@ -134,7 +132,7 @@ func TestOperatorRestart(t *testing.T) {
 	}
 	context.Executor = executor
 	c := newCluster(context, namespace, false, v1.ResourceRequirements{})
-	c.clusterInfo = test.CreateConfigDir(1)
+	c.clusterInfo = test.CreateConfigDir(3)
 
 	// start a basic cluster
 	err := c.Start()
@@ -228,12 +226,12 @@ func TestSaveMonEndpoints(t *testing.T) {
 
 	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "mon1=1.2.3.1:6790", cm.Data[EndpointDataKey])
-	assert.Equal(t, `{"node":{},"port":{}}`, cm.Data[MappingKey])
+	assert.Equal(t, "rook-ceph-mon1=1.1.1.1:6790", cm.Data[EndpointDataKey])
+	assert.Equal(t, `{"monsToNodes":{},"nodesToMons":{},"addresses":{}}`, cm.Data[MappingKey])
 	assert.Equal(t, "-1", cm.Data[MaxMonIDKey])
 
 	// update the config map
-	c.clusterInfo.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
+	c.clusterInfo.Monitors["rook-ceph-mon1"].Endpoint = "2.3.4.5:6790"
 	c.maxMonID = 2
 	c.mapping.MonsToNodes[1] = "node0"
 	c.mapping.NodesToMons["node0"] = 1
@@ -242,8 +240,8 @@ func TestSaveMonEndpoints(t *testing.T) {
 
 	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data[EndpointDataKey])
-	assert.Equal(t, `{"node":{"mon1":{"Name":"node0","Address":"1.1.1.1"}},"port":{"node0":12345}}`, cm.Data[MappingKey])
+	assert.Equal(t, "rook-ceph-mon1=2.3.4.5:6790", cm.Data[EndpointDataKey])
+	assert.Equal(t, `{"monsToNodes":{"1":"node0"},"nodesToMons":{"node0":1},"addresses":{}}`, cm.Data[MappingKey])
 	assert.Equal(t, "2", cm.Data[MaxMonIDKey])
 }
 
@@ -304,7 +302,7 @@ func TestAvailableMonNodes(t *testing.T) {
 
 func TestAvailableNodesInUse(t *testing.T) {
 	clientset := test.New(3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 3, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", "myversion", 2, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
 	c.clusterInfo = test.CreateConfigDir(0)
 
 	// all three nodes are available by default
@@ -323,14 +321,14 @@ func TestAvailableNodesInUse(t *testing.T) {
 	assert.Equal(t, 1, len(reducedNodes))
 	assert.Equal(t, nodes[2].Name, reducedNodes[0].Name)
 
-	// start pods on the remaining node. We expect all nodes to be available for placement
-	// since there is no way to place a mon on an unused node.
-	pod := c.makeMonPod(&monConfig{Name: "mon2"}, nodes[2].Name)
+	// start the third pod on the remaining node. We expect no node to be available
+	// since we don't run more than one mon per node.
+	pod := c.makeMonPod(&monConfig{Name: "rook-ceph-mon2"}, nodes[2].Name)
 	_, err = clientset.CoreV1().Pods(c.Namespace).Create(pod)
 	assert.Nil(t, err)
 	nodes, err = c.getMonNodes()
-	assert.Nil(t, err)
-	assert.Equal(t, 3, len(nodes))
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, len(nodes))
 }
 
 func TestTaintedNodes(t *testing.T) {
@@ -422,52 +420,4 @@ func TestHostNetwork(t *testing.T) {
 
 	assert.Equal(t, true, pod.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
-}
-
-func TestHostNetworkPortIncrease(t *testing.T) {
-	clientset := test.New(1)
-	node, err := clientset.CoreV1().Nodes().Get("node0", metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.NotNil(t, node)
-
-	node.Status = v1.NodeStatus{}
-	node.Status.Addresses = []v1.NodeAddress{
-		{
-			Type:    v1.NodeExternalIP,
-			Address: "1.1.1.1",
-		},
-	}
-
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{
-		Clientset: clientset,
-		ConfigDir: configDir,
-	}, "ns", "", "myversion", 3, rookalpha.Placement{}, true, v1.ResourceRequirements{}, metav1.OwnerReference{})
-	c.clusterInfo = test.CreateConfigDir(0)
-
-	mons := []*monConfig{
-		{
-			Name: "mon1",
-			Port: cephmon.DefaultPort,
-		},
-		{
-			Name: "mon2",
-			Port: cephmon.DefaultPort,
-		},
-	}
-
-	err = c.assignMons(mons)
-	assert.Nil(t, err)
-
-	err = c.initMonIPs(mons)
-	assert.Nil(t, err)
-
-	assert.Equal(t, node.Name, c.mapping.MonsToNodes[1])
-	assert.Equal(t, node.Name, c.mapping.MonsToNodes[2])
-
-	sEndpoint := strings.Split(c.clusterInfo.Monitors["mon1"].Endpoint, ":")
-	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort), sEndpoint[1])
-	sEndpoint = strings.Split(c.clusterInfo.Monitors["mon2"].Endpoint, ":")
-	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort+1), sEndpoint[1])
 }

--- a/pkg/operator/cluster/ceph/mon/util_test.go
+++ b/pkg/operator/cluster/ceph/mon/util_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mon
+
+import (
+	"testing"
+)
+
+func TestCheckQuorumConsensusForRemoval(t *testing.T) {
+	// TODO Add test for checkQuorumConsensusForRemoval() func
+}

--- a/pkg/operator/cluster/ceph/mon/util_test.go
+++ b/pkg/operator/cluster/ceph/mon/util_test.go
@@ -17,8 +17,29 @@ package mon
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckQuorumConsensusForRemoval(t *testing.T) {
-	// TODO Add test for checkQuorumConsensusForRemoval() func
+	// Quorum sizes with failure tolerance can be found here: https://www.consul.io/docs/internals/consensus.html#deployment-table
+	// for quorum below three nodes false is returned
+	assert.False(t, checkQuorumConsensusForRemoval(0, 1))
+	// one mon should not allow a mon removal
+	assert.False(t, checkQuorumConsensusForRemoval(1, 1))
+	// two mons should not allow a mon removal
+	assert.False(t, checkQuorumConsensusForRemoval(2, 1))
+	// three mons should allow one mon removal
+	assert.True(t, checkQuorumConsensusForRemoval(3, 1))
+	// three mons should allow one mon removal
+	assert.True(t, checkQuorumConsensusForRemoval(4, 1))
+	// four mons should allow one mons removal
+	assert.False(t, checkQuorumConsensusForRemoval(4, 2))
+
+	for i := 5; i <= 10; i++ {
+		// i mons, 1 should be allowed to be removed
+		assert.True(t, checkQuorumConsensusForRemoval(i, 1))
+		// i mons, 2 should be allowed to be removed
+		assert.True(t, checkQuorumConsensusForRemoval(i, 2))
+	}
 }

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -31,7 +31,7 @@ func New(nodes int) *fake.Clientset {
 		n := &v1.Node{
 			Status: v1.NodeStatus{
 				Conditions: []v1.NodeCondition{
-					v1.NodeCondition{Type: v1.NodeReady},
+					{Type: v1.NodeReady},
 				},
 				Addresses: []v1.NodeAddress{
 					{

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -28,11 +28,10 @@ import (
 func New(nodes int) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 	for i := 0; i < nodes; i++ {
-		ready := v1.NodeCondition{Type: v1.NodeReady}
 		n := &v1.Node{
 			Status: v1.NodeStatus{
 				Conditions: []v1.NodeCondition{
-					ready,
+					v1.NodeCondition{Type: v1.NodeReady},
 				},
 				Addresses: []v1.NodeAddress{
 					{

--- a/pkg/operator/test/info.go
+++ b/pkg/operator/test/info.go
@@ -33,10 +33,10 @@ func CreateConfigDir(mons int) *mon.ClusterInfo {
 		Monitors:      map[string]*mon.CephMonitorConfig{},
 	}
 	for i := 1; i <= mons; i++ {
-		id := fmt.Sprintf("mon%d", i)
+		id := fmt.Sprintf("rook-ceph-mon%d", i)
 		c.Monitors[id] = &mon.CephMonitorConfig{
 			Name:     id,
-			Endpoint: fmt.Sprintf("1.2.3.%d:6790", i),
+			Endpoint: fmt.Sprintf("%d.%d.%d.%d:6790", i, i, i, i),
 		}
 	}
 	return c


### PR DESCRIPTION
Commit message:
```
ceph/mon: Use per node a single mon identity

Place only one mon on each mon node

Reworked mon health check code to reduce duplicated code

Take quorum consensus into account when doing mon failover
```
Description of your changes:
Only one mon will reside on one node from now on as there is no sense in running more than one mon on one node.
Each mon gets an identity ID per node and keeps it "forever". When a mon is moved to another it uses the ID which the node it is moved has assigned to it. This reduces left over data on nodes when mons failover.
I have also reworked parts of the code to avoid duplication of code.

I still need to finish the tasks from the checklist below.
But please take a look already and let me know what you think.

Which issue is resolved by this Pull Request:
Resolves #1386 and resolves #1387.

Checklist:
- [ ] Fix/Add/Update tests to reflect changes (currently in progress).
- [ ] Fix/Add/Update integration tests (currently in progress).
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Migration script has been written, tested and documented. (Should a migration script be created?)
- [ ] Has been tested properly (currently in progress).