### PR TITLE
Mon affinity to nodes based on correct hostname

### DIFF
--- a/pkg/operator/cluster/ceph/mon/health_test.go
+++ b/pkg/operator/cluster/ceph/mon/health_test.go
@@ -168,12 +168,14 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 
 	// add two mons to the mapping on node0
 	c.mapping.Node["mon1"] = &NodeInfo{
-		Name:    "node0",
-		Address: "0.0.0.0",
+		Name:     "node0",
+		Hostname: "mynode0",
+		Address:  "0.0.0.0",
 	}
 	c.mapping.Node["mon2"] = &NodeInfo{
-		Name:    "node0",
-		Address: "0.0.0.0",
+		Name:     "node0",
+		Hostname: "mynode0",
+		Address:  "0.0.0.0",
 	}
 	c.maxMonID = 2
 	c.saveMonConfig()
@@ -192,6 +194,8 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "node0", c.mapping.Node["mon1"].Name)
 	assert.Equal(t, "node0", c.mapping.Node["mon2"].Name)
+	assert.Equal(t, "mynode0", c.mapping.Node["mon1"].Hostname)
+	assert.Equal(t, "mynode0", c.mapping.Node["mon2"].Hostname)
 
 	// add new node and check if the second mon gets failovered to it
 	n := &v1.Node{

--- a/pkg/operator/cluster/ceph/mon/mon_test.go
+++ b/pkg/operator/cluster/ceph/mon/mon_test.go
@@ -235,8 +235,9 @@ func TestSaveMonEndpoints(t *testing.T) {
 	c.clusterInfo.Monitors["mon1"].Endpoint = "2.3.4.5:6790"
 	c.maxMonID = 2
 	c.mapping.Node["mon1"] = &NodeInfo{
-		Name:    "node0",
-		Address: "1.1.1.1",
+		Name:     "node0",
+		Address:  "1.1.1.1",
+		Hostname: "myhost",
 	}
 	c.mapping.Port["node0"] = int32(12345)
 	err = c.saveMonConfig()
@@ -245,7 +246,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	cm, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "mon1=2.3.4.5:6790", cm.Data[EndpointDataKey])
-	assert.Equal(t, `{"node":{"mon1":{"Name":"node0","Address":"1.1.1.1"}},"port":{"node0":12345}}`, cm.Data[MappingKey])
+	assert.Equal(t, `{"node":{"mon1":{"Name":"node0","Hostname":"myhost","Address":"1.1.1.1"}},"port":{"node0":12345}}`, cm.Data[MappingKey])
 	assert.Equal(t, "2", cm.Data[MaxMonIDKey])
 }
 

--- a/pkg/operator/cluster/ceph/mon/spec.go
+++ b/pkg/operator/cluster/ceph/mon/spec.go
@@ -63,7 +63,7 @@ func (c *Cluster) getLabels(name string) map[string]string {
 	}
 }
 
-func (c *Cluster) makeReplicaSet(config *monConfig, nodeName string) *extensions.ReplicaSet {
+func (c *Cluster) makeReplicaSet(config *monConfig, hostname string) *extensions.ReplicaSet {
 	rs := &extensions.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            config.Name,
@@ -72,7 +72,7 @@ func (c *Cluster) makeReplicaSet(config *monConfig, nodeName string) *extensions
 		},
 	}
 
-	pod := c.makeMonPod(config, nodeName)
+	pod := c.makeMonPod(config, hostname)
 	replicaCount := int32(1)
 	rs.Spec = extensions.ReplicaSetSpec{
 		Template: v1.PodTemplateSpec{
@@ -85,7 +85,7 @@ func (c *Cluster) makeReplicaSet(config *monConfig, nodeName string) *extensions
 	return rs
 }
 
-func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
+func (c *Cluster) makeMonPod(config *monConfig, hostname string) *v1.Pod {
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if c.dataDirHostPath != "" {
 		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: c.dataDirHostPath}}
@@ -95,7 +95,7 @@ func (c *Cluster) makeMonPod(config *monConfig, nodeName string) *v1.Pod {
 	podSpec := v1.PodSpec{
 		Containers:    []v1.Container{container},
 		RestartPolicy: v1.RestartPolicyAlways,
-		NodeSelector:  map[string]string{apis.LabelHostname: nodeName},
+		NodeSelector:  map[string]string{apis.LabelHostname: hostname},
 		Volumes: []v1.Volume{
 			{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
 			k8sutil.ConfigOverrideVolume(),

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -29,7 +30,11 @@ func New(nodes int) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
 	for i := 0; i < nodes; i++ {
 		ready := v1.NodeCondition{Type: v1.NodeReady}
+		name := fmt.Sprintf("node%d", i)
 		n := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
 			Status: v1.NodeStatus{
 				Conditions: []v1.NodeCondition{
 					ready,
@@ -42,7 +47,6 @@ func New(nodes int) *fake.Clientset {
 				},
 			},
 		}
-		n.Name = fmt.Sprintf("node%d", i)
 		clientset.CoreV1().Nodes().Create(n)
 	}
 	return clientset


### PR DESCRIPTION
The kubernetes node has both a `name` and a `hostname` label. Rook was assigning node affinity of the mon pods based on the `name`. In some environments such as AWS where the `hostname` is different, this is incorrect. The `hostname` label of the node must match the node affinity of the mon pod. The `name` is still used internally as an immutable key. The `hostname` is only used where the node label is required.

@dgonzalezruiz thanks for providing the basis for these changes in #1289! This just makes a few edits to that change. I assumed you were busy since we hadn't heard from you for a while and wanted to unblock some people on this.
Resolves #1264 