### PR TITLE
WIP: Design for supporting multiple backends

### DIFF
--- a/cluster/examples/kubernetes/rook-cluster.yaml
+++ b/cluster/examples/kubernetes/rook-cluster.yaml
@@ -9,65 +9,15 @@ metadata:
   name: rook
   namespace: rook
 spec:
-  # the storage backend (only ceph is currently implemented)
-  backend: ceph
   # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
   dataDirHostPath: /var/lib/rook
   # toggle to use hostNetwork
   hostNetwork: false
-  # set the amount of mons to be started
-  monCount: 3
-# To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
-# The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
-# tolerate taints with a key of 'storage-node'.
-#  placement:
-#    all:
-#      nodeAffinity:
-#        requiredDuringSchedulingIgnoredDuringExecution:
-#          nodeSelectorTerms:
-#          - matchExpressions:
-#            - key: role
-#              operator: In
-#              values:
-#              - storage-node
-#      podAffinity:
-#      podAntiAffinity:
-#      tolerations:
-#      - key: storage-node
-#        operator: Exists
-#    api:
-#      nodeAffinity:
-#      podAffinity:
-#      podAntiAffinity:
-#      tolerations:
-#    mgr:
-#      nodeAffinity:
-#      podAffinity:
-#      podAntiAffinity:
-#      tolerations:
-#    mon:
-#      nodeAffinity:
-#      tolerations:
-#    osd:
-#      nodeAffinity:
-#      podAffinity:
-#      podAntiAffinity:
-#      tolerations:
-  resources:
-#    api:
-# The requests and limits set here, allow the api Pod to use half of one CPU core and 1 gigabyte of memory
-#      limits:
-#        cpu: "500m"
-#        memory: "1024Mi"
-#      requests:
-#        cpu: "500m"
-#        memory: "1024Mi"
-# the above example requests/limits can also be added to the other components too
-#    mgr:
-#    mon:
-#    osd:
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
+  # tolerate taints with a key of 'storage-node'.
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: false
@@ -75,32 +25,76 @@ spec:
     metadataDevice:
     location:
     storeConfig:
+      # Cluster level list of directories to use for storage. These directories will be created for all nodes that do not have `directories` set.
+      directories:
+        # - path: /rook/storage-dir
+      # Individual nodes and their config can be specified, but 'useAllNodes' above must be set to false. Then, only the named
+      # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
+      nodes:
+        # - name: "172.17.4.101"
+          # directories: # specific directories to use for storage can be specified for each node
+          # - path: "/rook/storage-dir"
+        # - name: "172.17.4.201"
+          # devices: # specific devices to use for storage can be specified for each node
+            # - name: "sdb"
+            # - name: "sdc"
+          # osd:  # any settings found under the overall cluster ceph osd settings can be overridden on a per-node basis here
+            # storeType: bluestore
+        # - name: "172.17.4.301"
+          # deviceFilter: "^sd."
+  placement:
+    all:
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchExpressions:
+      #       - key: role
+      #         operator: In
+      #         values:
+      #         - storage-node
+      # podAffinity:
+      # podAntiAffinity:
+      # tolerations:
+      #  - key: storage-node
+      #    operator: Exists
+    api:
+      # nodeAffinity:
+      # tolerations:
+      # podAffinity:
+      # podAntiAffinity:
+  resources:
+    api:
+      # The requests and limits set in this example allow the Rook api pod to use half of one CPU core and 1 gigabyte of memory
+      # limits:
+      #   cpu: "500m"
+      #   memory: "1024Mi"
+      # requests:
+      #   cpu: "500m"
+      #   memory: "1024Mi"
+  ceph:
+    # set the amount of mons to be started
+    mon:
+      # the desired number of mons
+      count: 3
+      placement:
+        # nodeAffinity:
+        # tolerations:
+      resources:
+        # for an example of setting resource limits see the example above for the api service
+    mgr:
+      placement:
+        # nodeAffinity:
+        # tolerations:
+        # podAffinity:
+        # podAntiAffinity:
+      resources:
+        # for an example of setting resource limits see the example above for the api service
+    osd:
       storeType: bluestore
       databaseSizeMB: 1024 # this value can be removed for environments with normal sized disks (100 GB or larger)
       journalSizeMB: 1024  # this value can be removed for environments with normal sized disks (20 GB or larger)
-# Cluster level list of directories to use for storage. These values will be set for all nodes that have no `directories` set.
-#    directories:
-#    - path: /rook/storage-dir
-# Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
-# nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
-#    nodes:
-#    - name: "172.17.4.101"
-#      directories: # specific directories to use for storage can be specified for each node
-#      - path: "/rook/storage-dir"
-# you can override the cluster wide resource requests/limits per node, but only
-# when using `useAllNodes: false`!
-#      resources:
-#        limits:
-#          cpu: "500m"
-#          memory: "1024Mi"
-#        requests:
-#          cpu: "500m"
-#          memory: "1024Mi"
-#    - name: "172.17.4.201"
-#      devices: # specific devices to use for storage can be specified for each node
-#      - name: "sdb"
-#      - name: "sdc"
-#      storeConfig: # configuration can be specified at the node level which overrides the cluster level config
-#        storeType: bluestore
-#    - name: "172.17.4.301"
-#      deviceFilter: "^sd."
+      placement:
+        # nodeAffinity:
+        # tolerations:
+      resources:
+        # for an example of setting resource limits see the example above for the api service

--- a/cluster/examples/kubernetes/rook-pool.yaml
+++ b/cluster/examples/kubernetes/rook-pool.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook
 spec:
   # The failure domain will spread the replicas of the data across different failure zones
-  failureDomain: osd
+  failureDomain: device
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 1

--- a/design/multiple-backends.md
+++ b/design/multiple-backends.md
@@ -1,0 +1,124 @@
+# Multiple Backends
+
+Rook is a storage platform for Kubernetes clusters and is designed to hide the complexity of the underlying platform
+so that the client does not need to understand the details. When there are too many configuration options,
+it becomes a burden for the admin and is too easy to misconfigure. Rook exposes storage concepts and configurations that are
+common across storage technologies to simplify deploying storage in Kubernetes.
+
+Still, there is a need to expose some of the details of a storage platform. Otherwise, characteristics of the platform could
+be lost or watered down such as high availability, high performance, durability, and other critical attributes.
+- Administrators need the ability to tune and configure the storage
+- Storage consumers may need settings for a specific storage platform
+
+Rook currently implements Ceph as the storage backend. In the future, other backends can also be added for block, file, and object
+storage as the following design principles are followed.
+
+## Custom Resource Definitions
+The CRDs are the public interface for configuring Rook storage in the cluster. The majority of settings will apply to multiple 
+backends, but some settings will only apply to a specific backend. All settings settings specific to a backend will be found
+under a property with that backend's name.
+
+### General Settings
+Settings that apply to all backends in the Cluster CRD include the following. The first setting indicates which backend is in use
+for this configuration. 
+```yaml
+spec:
+  backend: ceph
+  dataDirHostPath: /var/lib/rook
+  hostNetwork: false
+  storage: 
+    useAllNodes: false
+    useAllDevices: true
+    nodes:
+    - nodeA
+    - nodeB
+```
+
+The `backend` setting cannot be changed after the cluster is configured.
+
+### Ceph Settings
+Settings specific to Ceph will be found under the `ceph` property at various locations in the CRD.
+
+The overall `mon`, `mgr`, and `osd` settings are found under the top-level `ceph` property. Here are a few simple
+settings as an example:
+```yaml
+  ceph:
+    mon:
+      count: 3
+    osd:
+      storeType: bluestore
+    mgr:
+      resources: # resource limits can be set
+```
+
+Configuring storage directories and devices will also allow configuration of backend-specific properties.
+In this example, a node can specify `osd` properties specific to the devices on that node. Any property that could be set
+at the cluster level under the `ceph`, `osd` node can be overridden at the node level, such as `storeType`, `databaseSizeMB`,
+`journalSizeMB`, or `resources`. The only setting that cannot be overridden is the `placement` since that decision must be made
+centrally by the operator.
+```yaml
+      nodes:
+        - name: "172.17.4.101"
+          devices:
+          - name: "sdb"
+          - name: "sdc"
+          osd:  # any settings found under the overall cluster ceph osd settings can be overridden on a per-node basis here
+            storeType: bluestore
+```
+
+
+## Source tree
+To follow the pattern in the CRDs, some Rook code will apply to all backends, and some will apply to specific backends.
+Most code is expected to apply to all backends so it is safe to assume that by default code will apply generally.
+Code specific to a backend will be placed under a folder with its name. This means that currently the subfolder `ceph`
+is found in a number of places. Code in the `ceph` subfolders will implement code specific to the orchestration of 
+the `mon`, `osd`, `mgr`, `rgw`, and `mds` orchestrators and daemons.
+
+All Rook code is written in `Go` and all Rook code, both general and specific to backends, is compiled into a 
+single `Go` binary. 
+
+## Deployment
+Rook is deployed to Kubernetes in a container. The Rook Operator deployment is created first, followed by an
+orchestration of other containers to run daemons depending on the backend. The backend that will be 
+used will depend on the docker image that is running. The operator running in the Ceph image will 
+know to create a Ceph backend. 
+
+### CONFLICTING CONCLUSION 
+The decision to contain one backend per docker image leads us to a significant conclusion:
+- A separate operator must be running for each backend supported in the cluster
+- A separate CRD must be defined for each backend since only one operator can watch each CRD type
+
+This defeats the goal of using the same CRD for multiple backends. To support multiple backends from the same
+CRD, you would need to include all backends in the same docker image.
+
+### Docker Image
+When the Rook operator or daemons run, Rook will execute commands to configure the specific backend. 
+For example, the operator will execute commands to detect whether Ceph mons are in quorum, and the `mon`
+daemon will shell out to the `ceph-mon` daemon to run the Ceph monitor. The tools that are required 
+to run a backend must be found in the docker image. 
+
+A docker image is created for each backend.
+- A single image for all backends could get extremely bloated
+- Only one backend can be run in a cluster
+
+The image is published to dockerhub.com under `rook/rook-ceph`. If Gluster were added as a backend, it
+would be published to `rook/rook-gluster`.
+
+#### Ceph
+The Ceph docker image will contain the `rook` Go binary as well as the Ceph tools such as 
+`ceph`, `ceph-authtool`, `ceph-mon`, `ceph-mgr`, `ceph-osd`, and a number of others that are needed to configure
+and run all of the Ceph daemons.
+
+### Entrypoints
+Rook implements the entrypoint to both the operator and the daemons. Whether Rook starts the operator or a daemon
+depends on the command line arguments.
+
+To run the operator in the Rook container:
+```
+rook operator
+```
+
+To run a Ceph mon:
+```
+rook mon
+```


### PR DESCRIPTION
This is the design doc and corresponding CRD update for Rook to support multiple backends. In its current state it cannot be merged since the implementation is not there to support the CRD changes, and there is a major design question. 

The design issue comes when trying to run a single operator with a single cluster CRD definition and multiple backends with their own docker image. See the design doc below in the section "Conflicting Conclusion" for more details of the issue.

A solution to the design question appears to have two possible outcomes:
1. Define shared CRDs that have backend-specific sections. Include all backends in a single docker image.
2. Define separate CRDs for each backend. A separate Rook docker image would be created for each backend. A separate operator would watch each type of backend. Commonality across the storage platform would be at the Go code level instead of at the CRD level.

[skip ci]