### PR TITLE
images: switch to ubuntu xenial LTS

### DIFF
--- a/images/image.mk
+++ b/images/image.mk
@@ -29,7 +29,7 @@ endif
 CACHE_REGISTRY := cache
 
 # the base ubuntu image to use
-OSBASE ?= ubuntu:zesty
+OSBASE ?= ubuntu:xenial
 
 ifeq ($(GOARCH),amd64)
 OSBASEIMAGE=$(OSBASE)


### PR DESCRIPTION
Description of your changes:

ubuntu:zesty is longer supported and now that we are not building ceph from source xenial is more appropriate given that its LTS. 

Which issue is resolved by this Pull Request:
Resolves #1417

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
