### PR TITLE
Allow setting crush root on the pool

### DIFF
--- a/Documentation/pool-crd.md
+++ b/Documentation/pool-crd.md
@@ -23,6 +23,7 @@ spec:
   erasureCoded:
     dataChunks: 2
     codingChunks: 1
+  crushRoot: default
 ```
 
 ## Pool Settings
@@ -43,3 +44,4 @@ spec:
 with the default of `host`.   For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be 
 placed on osds that are found on unique hosts. In that case you would be guaranteed to tolerate the failure of two hosts. If the failure domain were `osd`, 
 you would be able to tolerate the loss of two devices. Similarly for erasure coding, the data and coding chunks would be spread across the requested failure domain.
+- `crushRoot`: The root in the crush map to be used by the pool. If left empty or unspecified, the default root will be used. Creating a crush hierarchy for the OSDs currently requires the Rook toolbox to run the Ceph tools described [here](http://docs.ceph.com/docs/master/rados/operations/crush-map/#modifying-the-crush-map). 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,6 +4,7 @@
 
 ## Notable Features
 - Monitoring is now done through the Ceph MGR service for Ceph storage.
+- The CRUSH root can be specified for pools with the `crushRoot` property, rather than always using the `default` root. Configuration of the CRUSH hierarchy is necessary with the `ceph osd crush` commands in the toolbox.
 
 ### Operator Settings
 - `AGENT_TOLERATION`: Toleration can be added to the Rook agent, such as to run on the master node.

--- a/cluster/examples/kubernetes/rook-pool.yaml
+++ b/cluster/examples/kubernetes/rook-pool.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   # The failure domain will spread the replicas of the data across different failure zones
   failureDomain: osd
+  # The root of the crush hierarchy that will be used for the pool. If not set, will use "default".
+  crushRoot: default
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 1

--- a/pkg/apis/rook.io/v1alpha1/pool.go
+++ b/pkg/apis/rook.io/v1alpha1/pool.go
@@ -18,7 +18,7 @@ package v1alpha1
 import "github.com/rook/rook/pkg/model"
 
 func (p *PoolSpec) ToModel(name string) *model.Pool {
-	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain}
+	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot}
 	r := p.Replication()
 	if r != nil {
 		pool.ReplicatedConfig.Size = r.Size

--- a/pkg/apis/rook.io/v1alpha1/types.go
+++ b/pkg/apis/rook.io/v1alpha1/types.go
@@ -155,10 +155,13 @@ type PoolSpec struct {
 	// The failure domain: osd or host (technically also any type in the crush map)
 	FailureDomain string `json:"failureDomain"`
 
+	// The root of the crush hierarchy utilized by the pool
+	CrushRoot string `json:"crushRoot"`
+
 	// The replication settings
 	Replicated ReplicatedSpec `json:"replicated"`
 
-	// The erasure code setteings
+	// The erasure code settings
 	ErasureCoded ErasureCodedSpec `json:"erasureCoded"`
 }
 

--- a/pkg/daemon/api/filesystem_test.go
+++ b/pkg/daemon/api/filesystem_test.go
@@ -122,7 +122,13 @@ func TestCreateFileSystemHandler(t *testing.T) {
 					return "", fmt.Errorf("still need to create FS")
 				}
 			}
-
+			if args[0] == "osd" && args[1] == "crush" {
+				assert.Equal(t, args[2], "rule")
+				assert.Equal(t, args[3], "create-simple")
+				assert.Equal(t, args[5], "default")
+				assert.Equal(t, args[6], "host")
+				return "", nil
+			}
 			return "", fmt.Errorf("unexpected command '%s'", args[0])
 		},
 	}

--- a/pkg/daemon/api/handlers_test.go
+++ b/pkg/daemon/api/handlers_test.go
@@ -120,7 +120,7 @@ func TestGetPoolsHandler(t *testing.T) {
 	h = newTestHandler(context)
 	h.GetPools(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "[{\"poolName\":\"rbd\",\"poolNum\":0,\"type\":0,\"failureDomain\":\"\",\"replicatedConfig\":{\"size\":1},\"erasureCodedConfig\":{\"dataChunkCount\":0,\"codingChunkCount\":0,\"algorithm\":\"\"}},{\"poolName\":\"ecPool1\",\"poolNum\":1,\"type\":1,\"failureDomain\":\"\",\"replicatedConfig\":{\"size\":0},\"erasureCodedConfig\":{\"dataChunkCount\":2,\"codingChunkCount\":1,\"algorithm\":\"jerasure::reed_sol_van\"}}]", w.Body.String())
+	assert.Equal(t, `[{"poolName":"rbd","poolNum":0,"type":0,"failureDomain":"","crushRoot":"","replicatedConfig":{"size":1},"erasureCodedConfig":{"dataChunkCount":0,"codingChunkCount":0,"algorithm":""}},{"poolName":"ecPool1","poolNum":1,"type":1,"failureDomain":"","crushRoot":"","replicatedConfig":{"size":0},"erasureCodedConfig":{"dataChunkCount":2,"codingChunkCount":1,"algorithm":"jerasure::reed_sol_van"}}]`, w.Body.String())
 }
 
 func TestGetPoolsHandlerFailure(t *testing.T) {
@@ -217,9 +217,9 @@ func TestGetClientAccessInfo(t *testing.T) {
 	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		switch {
 		case args[0] == "mon_status":
-			response := "{\"name\":\"mon0\",\"rank\":0,\"state\":\"leader\",\"election_epoch\":3,\"quorum\":[0],\"monmap\":{\"epoch\":1," +
-				"\"fsid\":\"22ae0d50-c4bc-4cfb-9cf4-341acbe35302\",\"modified\":\"2016-09-16 04:21:51.635837\",\"created\":\"2016-09-16 04:21:51.635837\"," +
-				"\"mons\":[{\"rank\":0,\"name\":\"mon0\",\"addr\":\"10.37.129.87:6790\"}]}}"
+			response := `{"name":"mon0","rank":0,"state":"leader","election_epoch":3,"quorum":[0],"monmap":{"epoch":1,` +
+				`"fsid":"22ae0d50-c4bc-4cfb-9cf4-341acbe35302","modified":"2016-09-16 04:21:51.635837","created":"2016-09-16 04:21:51.635837",` +
+				`"mons":[{"rank":0,"name":"mon0","addr":"10.37.129.87:6790"}]}}`
 			return response, nil
 		case args[0] == "auth" && args[1] == "get-key":
 			return `{"key":"AQBsCv1X5oD9GhAARHVU9N+kFRWDjyLA1dqzIg=="}`, nil
@@ -231,7 +231,7 @@ func TestGetClientAccessInfo(t *testing.T) {
 	h := newTestHandler(context)
 	h.GetClientAccessInfo(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "{\"monAddresses\":[\"10.37.129.87:6790\"],\"userName\":\"admin\",\"secretKey\":\"AQBsCv1X5oD9GhAARHVU9N+kFRWDjyLA1dqzIg==\"}", w.Body.String())
+	assert.Equal(t, `{"monAddresses":["10.37.129.87:6790"],"userName":"admin","secretKey":"AQBsCv1X5oD9GhAARHVU9N+kFRWDjyLA1dqzIg=="}`, w.Body.String())
 }
 
 func TestGetClientAccessInfoHandlerFailure(t *testing.T) {

--- a/pkg/daemon/api/object_test.go
+++ b/pkg/daemon/api/object_test.go
@@ -60,6 +60,13 @@ func TestCreateObjectStoreHandler(t *testing.T) {
 					return "", nil
 				}
 			}
+			if args[0] == "osd" && args[1] == "crush" {
+				assert.Equal(t, args[2], "rule")
+				assert.Equal(t, args[3], "create-simple")
+				assert.Equal(t, args[5], "default")
+				assert.Equal(t, args[6], "host")
+				return "", nil
+			}
 			return "", fmt.Errorf("unexpected command '%s'", args[0])
 		},
 		MockExecuteCommandWithCombinedOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -93,7 +93,7 @@ type CrushMap struct {
 			Weight int `json:"weight"`
 			Pos    int `json:"pos"`
 		} `json:"items"`
-	}
+	} `json:"buckets"`
 	Rules []struct {
 		ID      int    `json:"rule_id"`
 		Name    string `json:"rule_name"`
@@ -108,7 +108,7 @@ type CrushMap struct {
 			ItemName  string `json:"item_name"`
 			Type      string `json:"type"`
 		} `json:"steps"`
-	}
+	} `json:"rules"`
 	Tunables struct {
 		// Add if necessary
 	} `json:"tunables"`

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -29,6 +29,7 @@ type CephErasureCodeProfile struct {
 	Plugin           string `json:"plugin"`
 	Technique        string `json:"technique"`
 	FailureDomain    string `json:"crush-failure-domain"`
+	CrushRoot        string `json:"crush-root"`
 }
 
 func ListErasureCodeProfiles(context *clusterd.Context, clusterName string) ([]string, error) {
@@ -63,7 +64,7 @@ func GetErasureCodeProfileDetails(context *clusterd.Context, clusterName, name s
 	return ecProfileDetails, nil
 }
 
-func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name, failureDomain string) error {
+func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name, failureDomain, crushRoot string) error {
 	// look up the default profile so we can use the default plugin/technique
 	defaultProfile, err := GetErasureCodeProfileDetails(context, clusterName, "default")
 	if err != nil {
@@ -79,6 +80,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, con
 	}
 	if failureDomain != "" {
 		profilePairs = append(profilePairs, fmt.Sprintf("crush-failure-domain=%s", failureDomain))
+	}
+	if crushRoot != "" {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-root=%s", crushRoot))
 	}
 
 	args := []string{"osd", "erasure-code-profile", "set", name}
@@ -107,6 +111,7 @@ func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 		Name:          modelPool.Name,
 		Number:        modelPool.Number,
 		FailureDomain: modelPool.FailureDomain,
+		CrushRoot:     modelPool.CrushRoot,
 	}
 
 	if modelPool.Type == model.Replicated {

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -30,14 +30,14 @@ import (
 )
 
 func TestCreateProfile(t *testing.T) {
-	testCreateProfile(t, "")
+	testCreateProfile(t, "", "myroot")
 }
 
 func TestCreateProfileWithFailureDomain(t *testing.T) {
-	testCreateProfile(t, "osd")
+	testCreateProfile(t, "osd", "")
 }
 
-func testCreateProfile(t *testing.T, failureDomain string) {
+func testCreateProfile(t *testing.T, failureDomain, crushRoot string) {
 	cfg := model.ErasureCodedPoolConfig{DataChunkCount: 2, CodingChunkCount: 3, Algorithm: "myalg"}
 
 	executor := &exectest.MockExecutor{}
@@ -55,8 +55,14 @@ func testCreateProfile(t *testing.T, failureDomain string) {
 				assert.Equal(t, fmt.Sprintf("m=%d", cfg.CodingChunkCount), args[5])
 				assert.Equal(t, "plugin=myplugin", args[6])
 				assert.Equal(t, "technique=t", args[7])
+				nextArg := 8
 				if failureDomain != "" {
-					assert.Equal(t, fmt.Sprintf("crush-failure-domain=%s", failureDomain), args[8])
+					assert.Equal(t, fmt.Sprintf("crush-failure-domain=%s", failureDomain), args[nextArg])
+					nextArg++
+				}
+				if crushRoot != "" {
+					assert.Equal(t, fmt.Sprintf("crush-root=%s", crushRoot), args[nextArg])
+					nextArg++
 				}
 				return "", nil
 			}
@@ -64,6 +70,6 @@ func testCreateProfile(t *testing.T, failureDomain string) {
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
 
-	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain)
+	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain, crushRoot)
 	assert.Nil(t, err)
 }

--- a/pkg/daemon/ceph/rgw/objectstore.go
+++ b/pkg/daemon/ceph/rgw/objectstore.go
@@ -255,7 +255,8 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 	cephConfig := ceph.ModelPoolToCephPool(poolSpec)
 	if cephConfig.ErasureCodeProfile != "" {
 		// create a new erasure code profile for the new pool
-		if err := ceph.CreateErasureCodeProfile(context.context, context.ClusterName, poolSpec.ErasureCodedConfig, cephConfig.ErasureCodeProfile, poolSpec.FailureDomain); err != nil {
+		if err := ceph.CreateErasureCodeProfile(context.context, context.ClusterName, poolSpec.ErasureCodedConfig, cephConfig.ErasureCodeProfile,
+			poolSpec.FailureDomain, poolSpec.CrushRoot); err != nil {
 			return fmt.Errorf("failed to create erasure code profile for object store %s: %+v", context.Name, err)
 		}
 	}

--- a/pkg/model/pool.go
+++ b/pkg/model/pool.go
@@ -38,6 +38,7 @@ type Pool struct {
 	Number             int                    `json:"poolNum"`
 	Type               PoolType               `json:"type"`
 	FailureDomain      string                 `json:"failureDomain"`
+	CrushRoot          string                 `json:"crushRoot"`
 	ReplicatedConfig   ReplicatedPoolConfig   `json:"replicatedConfig"`
 	ErasureCodedConfig ErasureCodedPoolConfig `json:"erasureCodedConfig"`
 }

--- a/tests/integration/block_createBlock_api_test.go
+++ b/tests/integration/block_createBlock_api_test.go
@@ -68,7 +68,7 @@ func (s *BlockImageCreateSuite) SetupSuite() {
 func (s *BlockImageCreateSuite) TestCreatingNewBlockImageOnCustomPool() {
 
 	s.T().Log("Test Creating new block image for custom pool")
-	newPool := model.Pool{Name: pool1}
+	newPool := model.Pool{Name: pool1, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	_, err := s.rc.CreatePool(newPool)
 	require.Nil(s.T(), err)
 
@@ -86,7 +86,7 @@ func (s *BlockImageCreateSuite) TestRecreatingBlockImageForSamePool() {
 
 	s.T().Log("Test Case when Block Image is created with Name that is already used by another block on same pool")
 	//create pool1
-	newPool1 := model.Pool{Name: pool1}
+	newPool1 := model.Pool{Name: pool1, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	_, err := s.rc.CreatePool(newPool1)
 	require.Nil(s.T(), err)
 
@@ -114,12 +114,12 @@ func (s *BlockImageCreateSuite) TestRecreatingBlockImageForDifferentPool() {
 	s.T().Log("Test Case when Block Image is created with Name that is already used by another block on different pool")
 
 	//create pool1
-	newPool1 := model.Pool{Name: pool1}
+	newPool1 := model.Pool{Name: pool1, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	_, err := s.rc.CreatePool(newPool1)
 	require.Nil(s.T(), err)
 
 	//create pool2
-	newPool2 := model.Pool{Name: pool2}
+	newPool2 := model.Pool{Name: pool2, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	_, err = s.rc.CreatePool(newPool2)
 	require.Nil(s.T(), err)
 


### PR DESCRIPTION
The performance characteristics of a pool depend on the osds included in the crush root. Now a crush root other than `default` can be specified in the pool spec. The crush root can be specified in the Pool, ObjectStore, or Filesystem CRDs where the pool spec is required. Thanks @dgonzalezruiz for providing the basis for this in #1288

Configuration of the CRUSH hierarchy is necessary with the `ceph osd crush` commands in the toolbox before creating a pool with the non-default root.

Resolves #1204

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
