### PR TITLE
Docs update for master helm chart

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -8,6 +8,16 @@ Rook integrates deeply into cloud native environments leveraging extension point
 
 Rook is currently in alpha state and has focused initially on orchestrating Ceph on top of Kubernetes. Ceph is a distributed storage system that provides file, block and object storage and is deployed in large scale production clusters. Rook plans to add support for other storage systems beyond Ceph in future releases. 
 
+## Getting Started
+
+Starting Rook in your cluster is as simple as two `kubectl` commands. See our [Quickstart](quickstart.md) guide for the details on what you need to get going.
+
+Once you have a Rook cluster running, walk through the guides for block, object, and file to start consuming the storage in your cluster:
+- **[Block](block.md)**: Create block storage to be consumed by a pod
+- **[Object](object.md)**: Create an object store that is accessible inside or outside the Kubernetes cluster
+- **[Shared File System](filesystem.md)**: Create a file system to be shared across multiple pods
+
+
 ## Design
 
 Rook enables storage software systems to run on Kubernetes using Kubernetes primitives. Although Rook's reference storage system is Ceph, support for other storage systems can be added. The following image illustrates how Rook integrates with Kubernetes:

--- a/Documentation/block.md
+++ b/Documentation/block.md
@@ -6,11 +6,11 @@ indent: true
 
 # Block Storage
 
-Block storage allows you to mount storage to a single pod.
+Block storage allows you to mount storage to a single pod. This example shows how to build a simple, multi-tier web application on Kubernetes using persistent volumes enabled by Rook.
 
 ## Prerequisites
 
-This guide assumes you have created a Rook cluster as explained in the main [Kubernetes guide](quickstart.md)
+This guide assumes you have created a Rook cluster as explained in the main [Quickstart](quickstart.md) guide.
 
 ## Provision Storage
 

--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -102,7 +102,7 @@ your request will be accepted into the rook/rook repo. It is prudent to run all 
 From the root of your local Rook repo execute the following to run all of the unit tests:
 
 ```bash
-build/run make test
+make test
 ```
 
 Unit tests for individual packages can be run with the standard `go test` command. Before you open a PR, confirm that you have sufficient code coverage on the packages that you changed. View the `coverage.html` in a browser to inspect your new code.

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -20,44 +20,56 @@ This chart bootstraps a [rook-operator](https://github.com/rook/rook) deployment
 
 If role-based access control (RBAC) is enabled in your cluster, you may need to give Tiller (the server-side component of Helm) additional permissions. **If RBAC is not enabled, be sure to set `rbacEnable` to `false` when installing the chart.**
 
-1. Create a ServiceAccount for Tiller in the `kube-system` namespace
-  ```console
-  $ kubectl -n kube-system create sa tiller
-  ```
+```console
+# Create a ServiceAccount for Tiller in the `kube-system` namespace
+kubectl -n kube-system create sa tiller
 
-2. Create a ClusterRoleBinding for Tiller
-  ```console
-  $ kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-  ```
+# Create a ClusterRoleBinding for Tiller
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
 
-3. Patch Tiller's Deployment to use the new ServiceAccount
-  ```console
-  $ kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}'
-  ```
+# Patch Tiller's Deployment to use the new ServiceAccount
+kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}'
+```
 
 ## Installing
 
-To install the chart from out published registry, run the following:
+The Rook Operator helm chart will install the basic components necessary to create a storage platform for your Kubernetes cluster. 
+After the helm chart is installed, you will need to [create a Rook cluster](quickstart.md#create-a-rook-cluster).
 
+The `helm install` command deploys rook on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+Rook currently publishes builds to the `alpha` and `master` channels. In the future, `beta` and `stable` will also be available.
+
+### Alpha
+The alpha channel is the most recent release of Rook that is considered ready for testing by the community. 
 ```console
-$ helm repo add rook-<channel> https://charts.rook.io/<channel>
-$ helm install rook-<channel>/rook
+helm repo add rook-alpha https://charts.rook.io/alpha
+helm install rook-alpha/rook
 ```
 
-Be sure to replace `<channel>` with `alpha` or `master` (in the future `beta` and `stable` when available), for example:
+### Master
+The master channel includes the latest commits, with all automated tests green. Historically it has been very stable, though there is no guarantee.
 
+To install the helm chart from master, you will need to pass the specific version returned by the `search` command.
 ```console
-$ helm repo add rook-alpha https://charts.rook.io/alpha
-$ helm install rook-alpha/rook
+helm repo add rook-master https://charts.rook.io/master
+helm search rook
+helm install rook-master/rook --version <version>
 ```
 
-The command deploys rook on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+For example:
+```
+helm install rook-master/rook --version v0.6.0-156.gef983d6
+```
 
-Alternatively, to deploy from a local checkout of the rook codebase:
-
+### Development Build
+To deploy from a local build from your development environment:
+1. Build the Rook docker image: `make`
+1. Copy the image to your K8s cluster, such as with the `docker save` then the `docker load` commands
+1. Install the helm chart
 ```console
-$ cd cluster/charts/rook
-$ helm install --name rook --namespace rook .
+cd cluster/charts/rook
+helm install --name rook --namespace rook .
 ```
 
 ## Uninstalling the Chart
@@ -83,19 +95,20 @@ The following tables lists the configurable parameters of the rook-operator char
 | `resources`        | Pod resource requests & limits       | `{}`                 |
 | `logLevel`        | Global log level        | `INFO`                 |
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example to disable RBAC,
+### Command Line
+You can pass the settings with helm command line parameters. Specify each parameter using the 
+`--set key=value[,key=value]` argument to `helm install`. For example, the following command will install rook where RBAC is not enabled.
 
 ```console
 $ helm install --name rook rook-alpha/rook --set rbacEnable=false
 ```
 
-Alternatively, a yaml file that specifies the values for the above parameters can be provided while installing the chart. For example,
+### Settings File
+Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while installing the chart.
 
 ```console
 $ helm install --name rook rook-alpha/rook -f values.yaml
 ```
-
-### Defaults
 
 Here are the sample settings to get you started.
 

--- a/Documentation/helm.md
+++ b/Documentation/helm.md
@@ -7,3 +7,6 @@ weight: 50
 
 Rook has published a Helm chart for the [operator](helm-operator.md). Other Helm charts will also be developed for each of the 
 Pool, Object Store, and Filesystem CRDs.
+- [Rook Operator](helm-operator.md): Installs the Rook Operator and Agents necessary to run a storage cluster
+
+Contributions are welcome to create our other Helm charts!

--- a/Documentation/quickstart.md
+++ b/Documentation/quickstart.md
@@ -5,7 +5,11 @@ weight: 2
 
 # Quickstart Guide
 
-This example shows how to build a simple, multi-tier web application on Kubernetes using persistent volumes enabled by Rook.
+Welcome to Rook! We hope you have a great experience installing the Rook storage platform to enable highly available, durable storage
+in your cluster. If you have any questions along the way, please don't hesitate to ask us in our [Slack channel](https://Rook-io.slack.com).
+
+This guide will walk you through the basic setup of a Rook cluster. This will enable you to consume block, object, and file storage
+from other pods running in your cluster. 
 
 ## Minimum Version
 
@@ -20,9 +24,20 @@ To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [fo
 
 If you are using `dataDirHostPath` to persist rook data on kubernetes hosts, make sure your host has at least 5GB of space available on the specified path.
 
-## Deploy Rook
+## TL;DR
 
-With your Kubernetes cluster running, Rook can be setup and deployed by simply creating the rook-operator deployment and creating a rook cluster. To customize the operator settings, see the [Rook Helm Chart](helm-operator.md).
+If you're feeling lucky, a simple Rook cluster can be created with the following kubectl commands. For the more detailed install, skip to the next section to [deploy the Rook operator](#deploy-the-rook-operator).
+```
+cd cluster/examples/kubernetes
+kubectl create -f rook-operator.yaml
+kubectl create -f rook-cluster.yaml
+```
+
+After the cluster is running, you can create [block, object, or file](#storage) storage to be consumed by other applications in your cluster.
+
+## Deploy the Rook Operator
+
+The first step is to deploy the Rook system components, which include the Rook agent running on each node in your cluster as well as Rook operator pod. 
 
 ```bash
 cd cluster/examples/kubernetes
@@ -31,6 +46,8 @@ kubectl create -f rook-operator.yaml
 # verify the rook-operator and rook-agents pods are in the `Running` state before proceeding
 kubectl -n rook-system get pod
 ```
+
+You can also deploy the operator with the [Rook Helm Chart](helm-operator.md).
 
 ---
 ### **Restart Kubelet**
@@ -45,7 +62,9 @@ For Kubernetes 1.6, it is also necessary to pass the `--enable-controller-attach
 
 ---
 
-Now that the rook-operator pod is running, we can create the Rook cluster. For the cluster to survive reboots, 
+## Create a Rook Cluster
+
+Now that the Rook operator and agent pods are running, we can create the Rook cluster. For the cluster to survive reboots, 
 make sure you set the `dataDirHostPath` property. For more settings, see the documentation on [configuring the cluster](cluster-crd.md). 
 
 
@@ -96,8 +115,8 @@ rook-ceph-osd-0h6nb               1/1       Running   0          5m
 
 For a walkthrough of the three types of storage exposed by Rook, see the guides for:
 - **[Block](block.md)**: Create block storage to be consumed by a pod
-- **[Shared File System](filesystem.md)**: Create a file system to be shared across multiple pods
 - **[Object](object.md)**: Create an object store that is accessible inside or outside the Kubernetes cluster
+- **[Shared File System](filesystem.md)**: Create a file system to be shared across multiple pods
 
 # Tools
 

--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -7,5 +7,5 @@ weight: 20
 
 Rook provides three types of storage to the Kubernetes cluster.
 - [Block Storage](block.md): Mount storage to a single pod
-- [Object Storage](object.md): Expose an S3 API to the storage cluster for applications to put and get data
-- [Shared File System](filesystem.md): Mount storage to multiple pods 
+- [Object Storage](object.md): Expose an S3 API to the storage cluster for applications to put and get data that is accessible from inside or outside the Kubernetes cluster
+- [Shared File System](filesystem.md): Mount a file system that can be shared across multiple pods 


### PR DESCRIPTION
The docs now have the `--version` flag for installing a master helm chart. Other clarifications to documentation were also added while reading through the install flow, such as readability for the Quickstart guide and more mentions of block, object, and file storage.

Resolves #944

Checklist:
- [x] Documentation has been updated, if necessary.

[skip ci]