### PR TITLE
monitoring: Use new metrics path

### DIFF
--- a/cluster/examples/kubernetes/monitoring/service-monitor.yaml
+++ b/cluster/examples/kubernetes/monitoring/service-monitor.yaml
@@ -15,5 +15,5 @@ spec:
       rook_cluster: rook
   endpoints:
   - port: http-metrics
-    path: /
+    path: /metrics
     interval: 5s


### PR DESCRIPTION
Description of your changes:
Fix the metrics path in the Prometheus ServiceMonitor.
The metrics were previously available at `/` and `/metrics`, which has changed now to only `/metrics`.

[skip ci]