### PR TITLE
Changing OSD replicaset resources to deployments

### DIFF
--- a/pkg/apis/rook.io/v1alpha1/types.go
+++ b/pkg/apis/rook.io/v1alpha1/types.go
@@ -316,7 +316,7 @@ type GatewaySpec struct {
 	// The port the rgw service will be listening on (https)
 	SecurePort int32 `json:"securePort"`
 
-	// The number of pods in the rgw replicaset. If "allNodes" is specified, a daemonset is created.
+	// The number of pods in the rgw deployment. If "allNodes" is specified, a daemonset is created.
 	Instances int32 `json:"instances"`
 
 	// Whether the rgw pods should be started as a daemonset on all nodes

--- a/pkg/operator/agent/agent.go
+++ b/pkg/operator/agent/agent.go
@@ -101,6 +101,9 @@ func (a *Agent) createAgentDaemonSet(namespace, agentImage string) error {
 			Name: agentDaemonsetName,
 		},
 		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/operator/cluster/ceph/osd/pod.go
+++ b/pkg/operator/cluster/ceph/osd/pod.go
@@ -47,18 +47,23 @@ func (c *Cluster) makeDaemonSet(selection rookalpha.Selection, config rookalpha.
 				k8sutil.ClusterAttr: c.Namespace,
 			},
 		},
-		Spec: extensions.DaemonSetSpec{Template: podSpec},
+		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
+			Template: podSpec,
+		},
 	}
 }
 
-func (c *Cluster) makeReplicaSet(nodeName string, devices []rookalpha.Device,
-	selection rookalpha.Selection, resources v1.ResourceRequirements, config rookalpha.Config) *extensions.ReplicaSet {
+func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device,
+	selection rookalpha.Selection, resources v1.ResourceRequirements, config rookalpha.Config) *extensions.Deployment {
 
 	podSpec := c.podTemplateSpec(devices, selection, resources, config)
 	podSpec.Spec.NodeSelector = map[string]string{apis.LabelHostname: nodeName}
 	replicaCount := int32(1)
 
-	return &extensions.ReplicaSet{
+	return &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf(appNameFmt, nodeName),
 			Namespace:       c.Namespace,
@@ -68,7 +73,7 @@ func (c *Cluster) makeReplicaSet(nodeName string, devices []rookalpha.Device,
 				k8sutil.ClusterAttr: c.Namespace,
 			},
 		},
-		Spec: extensions.ReplicaSetSpec{
+		Spec: extensions.DeploymentSpec{
 			Template: podSpec,
 			Replicas: &replicaCount,
 		},

--- a/pkg/operator/object/ceph/rgw.go
+++ b/pkg/operator/object/ceph/rgw.go
@@ -334,6 +334,9 @@ func startDaemonset(context *clusterd.Context, store rookalpha.ObjectStore, vers
 			OwnerReferences: ownerRefs,
 		},
 		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
 			Template: makeRGWPodSpec(store, version, hostNetwork),
 		},
 	}


### PR DESCRIPTION
Also added `RollingUpdate` strategy to daemonsets.
This is a first step to make upgrading Rook easier and less manual
Updated the upgrade design doc to reflect this change.

Partially addresses https://github.com/rook/rook/issues/997

**Non Goal**
Updating the upgrade docs since it has gone stale and not working.
This is currently being tracked separately in https://github.com/rook/rook/issues/1446.


