### PR TITLE
build: update dep ensure hash

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -387,6 +387,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39454bb679c497ef9ee296e5ddd81df83f1b64583ac2349bb798553e5d641ad8"
+  inputs-digest = "8cdf401487ba3a25dd7005c5e15521d72a29a67ea044a1ef203d7f51b4b84c60"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Description of your changes:
`dep ensure` was showing that a new hash was needed for the dep tool. This was causing the builds to show as dirty on jenkins

Which issue is resolved by this Pull Request:
Resolves #1428
