### PR TITLE
Allow setting the dns host name on the object store gateway

### DIFF
--- a/Documentation/object-store-crd.md
+++ b/Documentation/object-store-crd.md
@@ -28,6 +28,7 @@ spec:
   gateway:
     type: s3
     sslCertificateRef:
+    host:
     port: 80
     securePort:
     instances: 1
@@ -81,6 +82,7 @@ The gateway settings correspond to the RGW daemon settings.
 
 - `type`: `S3` is supported
 - `sslCertificateRef`: If the certificate is not specified, SSL will not be configured. If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](http://docs.ceph.com/docs/master/install/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form."
+- `host`: The DNS name for the object store. The name must be resolvable by DNS in your cluster. The name must also be provided as the host name in the URL of s3 client requests. The default is: `<rgwService>-<storeName>.<namespace>`. In the example above it would be: `rook-ceph-rgw-my-store.rook`.
 - `port`: The port on which the RGW pods and the RGW service will be listening (not encrypted).
 - `securePort`: The secure port on which RGW pods will be listening. An SSL certificate must be specified.
 - `instances`: The number of pods that will be started to load balance this object store. Ignored if `allNodes` is true.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,6 +11,9 @@
 - `AGENT_TOLERATION`: Toleration can be added to the Rook agent, such as to run on the master node.
 - `FLEXVOLUME_DIR_PATH`: Flex volume directory can be overridden on the Rook agent.
 
+### Object Store
+- The dns host name can be set on the object store. See the `host` property on the [object store gateway settings](https://rook.io/docs/rook/master/object-store-crd.html#gateway-settings).
+
 ## Breaking Changes
 - `armhf` build of Rook have been removed. Ceph is not supported or tested on `armhf`. arm64 support continues.
 

--- a/cluster/examples/kubernetes/rook-object.yaml
+++ b/cluster/examples/kubernetes/rook-object.yaml
@@ -24,12 +24,16 @@ spec:
   gateway:
     # type of the gateway (s3)
     type: s3
-    # A reference to the secret in the rook namespace where the ssl certificate is stored
-    sslCertificateRef:
+    # The dns name that must be resolvable in your cluster and will be expected in the URL provided by s3 client requests.
+    # The default is: <rgwService>-<storeName>.<namespace>
+    # For example: rook-ceph-rgw-my-store.rook
+    host: 
     # The port that RGW pods will listen on (http)
     port: 80
     # The port that RGW pods will listen on (https). An ssl certificate is required.
-    securePort: 443
+    securePort:
+    # A reference to the secret in the rook namespace where the ssl certificate is stored
+    sslCertificateRef:
     # The number of pods in the rgw deployment (ignored if allNodes=true)
     instances: 1
     # Whether the rgw pods should be deployed on all nodes as a daemonset

--- a/pkg/apis/rook.io/v1alpha1/types.go
+++ b/pkg/apis/rook.io/v1alpha1/types.go
@@ -316,6 +316,11 @@ type GatewaySpec struct {
 	// The port the rgw service will be listening on (https)
 	SecurePort int32 `json:"securePort"`
 
+	// The dns name that must be resolvable in your cluster and will be expected in the URL provided by s3 client requests.
+	// The default is: <rgwService>-<storeName>.<namespace>
+	// For example: rook-ceph-rgw-my-store.rook
+	Host string `json:"host"`
+
 	// The number of pods in the rgw replicaset. If "allNodes" is specified, a daemonset is created.
 	Instances int32 `json:"instances"`
 

--- a/pkg/daemon/api/object.go
+++ b/pkg/daemon/api/object.go
@@ -154,7 +154,7 @@ func (h *Handler) GetObjectStoreConnectionInfo(w http.ResponseWriter, r *http.Re
 	}
 
 	s3Info := &model.ObjectStoreConnectInfo{
-		Host:      oprgw.InstanceName(storeName),
+		Host:      fmt.Sprintf("%s.%s", oprgw.InstanceName(storeName), h.config.namespace),
 		IPAddress: service.Spec.ClusterIP,
 		Ports:     []int32{},
 	}

--- a/pkg/daemon/api/object_test.go
+++ b/pkg/daemon/api/object_test.go
@@ -162,7 +162,7 @@ func TestGetObjectStoreConnectionInfoHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	expectedRespObj := model.ObjectStoreConnectInfo{
-		Host:  "rook-ceph-rgw-myinst",
+		Host:  "rook-ceph-rgw-myinst.default",
 		Ports: []int32{80},
 	}
 

--- a/pkg/model/object.go
+++ b/pkg/model/object.go
@@ -40,6 +40,7 @@ type ObjectStore struct {
 type Gateway struct {
 	Port           int32  `json:"port"`
 	SecurePort     int32  `json:"securePort"`
+	Host           string `json:"host"`
 	Instances      int32  `json:"instances"`
 	AllNodes       bool   `json:"allNodes"`
 	Certificate    string `json:"certificate"`

--- a/pkg/operator/cluster/ceph/osd/config/config.go
+++ b/pkg/operator/cluster/ceph/osd/config/config.go
@@ -20,7 +20,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/coreos/capnslog"
+	"github.com/coreos/pkg/capnslog"
 )
 
 const (

--- a/pkg/operator/object/ceph/rgw_test.go
+++ b/pkg/operator/object/ceph/rgw_test.go
@@ -125,7 +125,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
-	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", instanceName(store)), cont.Args[3])
+	assert.Equal(t, fmt.Sprintf("--rgw-host=%s.%s", instanceName(store), store.Namespace), cont.Args[3])
 	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[4])
 	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[5])
 


### PR DESCRIPTION
Description of your changes:
The host name of the object store must be 1) resolvable by DNS and 2) match the host in the URL of s3 client requests. This change will set the default name correctly to include the dns suffix `.rook` on the host name, and allow it to be configurable in the CRD. @jpds would be great to get your review on this.

Which issue is resolved by this Pull Request:
Resolves #1349

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
