### PR TITLE
Correct rgw host name and set blank dns name

### DIFF
--- a/pkg/daemon/api/object.go
+++ b/pkg/daemon/api/object.go
@@ -154,7 +154,7 @@ func (h *Handler) GetObjectStoreConnectionInfo(w http.ResponseWriter, r *http.Re
 	}
 
 	s3Info := &model.ObjectStoreConnectInfo{
-		Host:      oprgw.InstanceName(storeName),
+		Host:      fmt.Sprintf("%s.%s", service.Name, service.Namespace),
 		IPAddress: service.Spec.ClusterIP,
 		Ports:     []int32{},
 	}

--- a/pkg/daemon/api/object_test.go
+++ b/pkg/daemon/api/object_test.go
@@ -162,7 +162,7 @@ func TestGetObjectStoreConnectionInfoHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	expectedRespObj := model.ObjectStoreConnectInfo{
-		Host:  "rook-ceph-rgw-myinst",
+		Host:  "rook-ceph-rgw-myinst.default",
 		Ports: []int32{80},
 	}
 

--- a/pkg/daemon/ceph/rgw/daemon.go
+++ b/pkg/daemon/ceph/rgw/daemon.go
@@ -86,7 +86,6 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	settings := map[string]string{
 		"host":                           config.Host,
 		"rgw data":                       dataDir,
-		"rgw dns name":                   config.Host,
 		"rgw log nonexistent bucket":     "true",
 		"rgw intent log object name utc": "true",
 		"rgw enable usage log":           "true",

--- a/pkg/operator/cluster/ceph/osd/config/config.go
+++ b/pkg/operator/cluster/ceph/osd/config/config.go
@@ -20,7 +20,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/coreos/capnslog"
+	"github.com/coreos/pkg/capnslog"
 )
 
 const (

--- a/pkg/operator/object/ceph/rgw.go
+++ b/pkg/operator/object/ceph/rgw.go
@@ -349,7 +349,7 @@ func rgwContainer(store rookalpha.ObjectStore, version string) v1.Container {
 			"rgw",
 			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
 			fmt.Sprintf("--rgw-name=%s", store.Name),
-			fmt.Sprintf("--rgw-host=%s", instanceName(store)),
+			fmt.Sprintf("--rgw-host=%s", fmt.Sprintf("%s.%s", instanceName(store), store.Namespace)),
 			fmt.Sprintf("--rgw-port=%d", store.Spec.Gateway.Port),
 			fmt.Sprintf("--rgw-secure-port=%d", store.Spec.Gateway.SecurePort),
 		},

--- a/pkg/operator/object/ceph/rgw_test.go
+++ b/pkg/operator/object/ceph/rgw_test.go
@@ -125,7 +125,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
-	assert.Equal(t, fmt.Sprintf("--rgw-host=%s", instanceName(store)), cont.Args[3])
+	assert.Equal(t, fmt.Sprintf("--rgw-host=%s.%s", instanceName(store), store.Namespace), cont.Args[3])
 	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[4])
 	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[5])
 


### PR DESCRIPTION
Description of your changes:
There were a couple of incorrect default rgw settings:
- The `rgw dns name` should not be set. Other configuration needs to be finalized as related to #1349 for this setting to be effective.
- The host name returned by the api should include the namespace suffix so clients in other namespaces will be able to connect to rgw.

This is related to #1349 although does not implement the fix.
