### PR TITLE
Skip ceph config args for default ceph cluster

### DIFF
--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -63,6 +63,10 @@ type MonMapEntry struct {
 }
 
 func AppendAdminConnectionArgs(args []string, configDir, clusterName string) []string {
+	if clusterName == "ceph" && configDir == "/etc" {
+		// no need to append the args if it's the default ceph cluster
+		return args
+	}
 	confFile := fmt.Sprintf("%s.config", clusterName)
 	keyringFile := fmt.Sprintf("%s.keyring", AdminUsername)
 	configArgs := []string{

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code below came from https://github.com/digitalocean/ceph_exporter
+which has the same license.
+*/
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCephArgs(t *testing.T) {
+	// cluster a under /etc
+	args := []string{}
+	result := AppendAdminConnectionArgs(args, "/etc", "a")
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, "--cluster=a", result[0])
+	assert.Equal(t, "--conf=/etc/a/a.config", result[1])
+	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", result[2])
+
+	// cluster under /var/lib/rook
+	args = []string{"myarg"}
+	result = AppendAdminConnectionArgs(args, "/var/lib/rook", "rook")
+	assert.Equal(t, 4, len(result))
+	assert.Equal(t, "myarg", result[0])
+	assert.Equal(t, "--cluster=rook", result[1])
+	assert.Equal(t, "--conf=/var/lib/rook/rook/rook.config", result[2])
+	assert.Equal(t, "--keyring=/var/lib/rook/rook/client.admin.keyring", result[3])
+
+	// the default ceph cluster will not need the config args
+	args = []string{"myarg"}
+	result = AppendAdminConnectionArgs(args, "/etc", "ceph")
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, "myarg", result[0])
+}


### PR DESCRIPTION
Ceph commands do not require arguments for the ceph.conf and keyring if the config is found under /etc/ceph/ceph.conf. All the rook pods would ideally follow this pattern so the arguments are simpler to read in the logs, this is just the first step.