### PR TITLE
helm: give operator permissions for removing storage nodes

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -69,7 +69,7 @@ To deploy from a local build from your development environment:
 1. Install the helm chart
 ```console
 cd cluster/charts/rook
-helm install --name rook --namespace rook .
+helm install --name rook --namespace rook-system .
 ```
 
 ## Uninstalling the Chart

--- a/cluster/charts/rook/templates/clusterrole.yaml
+++ b/cluster/charts/rook/templates/clusterrole.yaml
@@ -41,6 +41,7 @@ rules:
   - list
   - watch
   - create
+  - update
   - delete
 - apiGroups:
   - apiextensions.k8s.io


### PR DESCRIPTION
Description of your changes:  Updates helm chart files to ensure the operator has the permissions needed to complete the remove node flow (specifically updating replicasets).

Which issue is resolved by this Pull Request:
Resolves #1447 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
