### PR TITLE
Consistent capnslog log import path

### DIFF
--- a/pkg/operator/cluster/ceph/osd/config/config.go
+++ b/pkg/operator/cluster/ceph/osd/config/config.go
@@ -20,7 +20,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/coreos/capnslog"
+	"github.com/coreos/pkg/capnslog"
 )
 
 const (


### PR DESCRIPTION
The imports for the capnslog are expected to be in `github.com/coreos/pkg/capnslog` instead of `github.com/coreos/capnslog`. This also appears to be causing dirty builds to be published since `go dep` is adding the parent package to the lock file.
