### PR TITLE
OSD: Support crypt type devices

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -91,7 +91,7 @@ func DiscoverDevices(executor exec.Executor) ([]*LocalDisk, error) {
 		}
 
 		diskType, ok := diskProps["TYPE"]
-		if !ok || (diskType != sys.SSDType && diskType != sys.DiskType && diskType != sys.PartType) {
+		if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType) {
 			// unsupported disk type, just continue
 			continue
 		}

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -61,7 +61,7 @@ func GetAvailableDevices(devices []*LocalDisk) []string {
 
 // check whether a device is completely empty
 func getDeviceEmpty(device *LocalDisk) bool {
-	return device.Parent == "" && device.Type == sys.DiskType && device.FileSystem == ""
+	return device.Parent == "" && (device.Type == sys.DiskType || device.Type == sys.SSDType || device.Type == sys.CryptType) && device.FileSystem == ""
 }
 
 func ignoreDevice(d string) bool {

--- a/pkg/clusterd/disk_test.go
+++ b/pkg/clusterd/disk_test.go
@@ -50,6 +50,12 @@ func TestAvailableDisks(t *testing.T) {
 	assert.Equal(t, 2, len(disks))
 	assert.Equal(t, "sdb", disks[0])
 	assert.Equal(t, "sdc", disks[1])
+
+	// Crypt disk type results in available disk
+	d6 := &LocalDisk{Name: "sdd", UUID: "myuuid2", Size: 123, Rotational: true, Readonly: false, Type: sys.CryptType, HasChildren: true}
+	disks = GetAvailableDevices([]*LocalDisk{d6})
+	assert.Equal(t, 1, len(disks))
+
 }
 
 func TestDiscoverDevices(t *testing.T) {

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -28,11 +28,12 @@ import (
 )
 
 const (
-	DiskType = "disk"
-	SSDType  = "ssd"
-	PartType = "part"
-	sgdisk   = "sgdisk"
-	mountCmd = "mount"
+	DiskType  = "disk"
+	SSDType   = "ssd"
+	PartType  = "part"
+	CryptType = "crypt"
+	sgdisk    = "sgdisk"
+	mountCmd  = "mount"
 )
 
 type Partition struct {


### PR DESCRIPTION
This PR adds compatibility to clusters using raw devices that are decrypted at boot time with dmcrypt.