### PR TITLE
Refactor Rook Operator CRD Initialization

### DIFF
--- a/Documentation/teardown.md
+++ b/Documentation/teardown.md
@@ -43,8 +43,6 @@ kubectl -n rook get cluster
 ## Delete the Operator and Agent 
 This will begin the process of all cluster resources being cleaned up, after which you can delete the rest of the deployment with the following:
 ```console
-kubectl delete thirdpartyresources cluster.rook.io pool.rook.io objectstore.rook.io filesystem.rook.io volumeattachment.rook.io # ignore errors if on K8s 1.7+
-kubectl delete crd clusters.rook.io pools.rook.io objectstores.rook.io filesystems.rook.io volumeattachments.rook.io  # ignore errors if on K8s 1.5 and 1.6
 kubectl delete -n rook-system daemonset rook-agent
 kubectl delete -f rook-operator.yaml
 kubectl delete clusterroles rook-agent

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,6 +5,7 @@
 ## Notable Features
 - Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
 - Output from stderr will be included in error messages returned from the `exec` of external tools
+- Rook-Operator no longer creates the resources CRD's or TPR's at the runtime. Instead, those resources are provisioned during deployment via `helm` or `kubectl`.
 
 ## Breaking Changes
 

--- a/cluster/charts/rook/templates/clusterrole.yaml
+++ b/cluster/charts/rook/templates/clusterrole.yaml
@@ -32,7 +32,6 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - thirdpartyresources
   - deployments
   - daemonsets
   - replicasets
@@ -44,15 +43,29 @@ rules:
   - update
   - delete
 - apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  resourceNames:
+  - cluster.rook.io
+  - pool.rook.io
+  - objectstore.rook.io
+  - filesystem.rook.io
+  - volumeattachment.rook.io
+  verbs:
+  - get
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
+  resourceNames:
+  - clusters.rook.io
+  - pools.rook.io
+  - objectstores.rook.io
+  - filesystems.rook.io
+  - volumeattachments.rook.io
   verbs:
   - get
-  - list
-  - watch
-  - create
-  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/cluster/charts/rook/templates/resources.yaml
+++ b/cluster/charts/rook/templates/resources.yaml
@@ -1,0 +1,115 @@
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" }}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusters.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: filesystems.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Filesystem
+    listKind: FilesystemList
+    plural: filesystems
+    singular: filesystem
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectstores.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: ObjectStore
+    listKind: ObjectStoreList
+    plural: objectstores
+    singular: objectstore
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pools.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Pool
+    listKind: PoolList
+    plural: pools
+    singular: pool
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumeattachments.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    singular: volumeattachment
+  scope: Namespaced
+  version: v1alpha1
+---
+{{- else }}
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for cluster
+kind: ThirdPartyResource
+metadata:
+  name: cluster.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for filesystem
+kind: ThirdPartyResource
+metadata:
+  name: filesystem.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for objectstore
+kind: ThirdPartyResource
+metadata:
+  name: objectstore.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for pool
+kind: ThirdPartyResource
+metadata:
+  name: pool.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for volumeattachment
+kind: ThirdPartyResource
+metadata:
+  name: volumeattachment.rook.io
+versions:
+- name: v1alpha1
+---
+{{- end }}

--- a/cluster/examples/kubernetes/1.6/rook-operator.yaml
+++ b/cluster/examples/kubernetes/1.6/rook-operator.yaml
@@ -1,76 +1,51 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for cluster
+kind: ThirdPartyResource
 metadata:
-  name: clusters.rook.io
-spec:
-  group: rook.io
-  names:
-    kind: Cluster
-    listKind: ClusterList
-    plural: clusters
-    singular: cluster
-  scope: Namespaced
-  version: v1alpha1
+  name: cluster.rook.io
+versions:
+- name: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for filesystem
+kind: ThirdPartyResource
 metadata:
-  name: filesystems.rook.io
-spec:
-  group: rook.io
-  names:
-    kind: Filesystem
-    listKind: FilesystemList
-    plural: filesystems
-    singular: filesystem
-  scope: Namespaced
-  version: v1alpha1
+  name: filesystem.rook.io
+versions:
+- name: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for objectstore
+kind: ThirdPartyResource
 metadata:
-  name: objectstores.rook.io
-spec:
-  group: rook.io
-  names:
-    kind: ObjectStore
-    listKind: ObjectStoreList
-    plural: objectstores
-    singular: objectstore
-  scope: Namespaced
-  version: v1alpha1
+  name: objectstore.rook.io
+versions:
+- name: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for pool
+kind: ThirdPartyResource
 metadata:
-  name: pools.rook.io
-spec:
-  group: rook.io
-  names:
-    kind: Pool
-    listKind: PoolList
-    plural: pools
-    singular: pool
-  scope: Namespaced
-  version: v1alpha1
+  name: pool.rook.io
+versions:
+- name: v1alpha1
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for volumeattachment
+kind: ThirdPartyResource
 metadata:
-  name: volumeattachments.rook.io
-spec:
-  group: rook.io
-  names:
-    kind: VolumeAttachment
-    listKind: VolumeAttachmentList
-    plural: volumeattachments
-    singular: volumeattachment
-  scope: Namespaced
-  version: v1alpha1
+  name: volumeattachment.rook.io
+versions:
+- name: v1alpha1
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-system
+---
 kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
 rules:
@@ -93,19 +68,6 @@ rules:
   - list
   - watch
   - patch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - extensions
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
   - create
   - update
   - delete
@@ -138,11 +100,6 @@ rules:
   - "*"
   verbs:
   - "*"
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: rook-system
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -29,6 +29,121 @@ func NewK8sInstallData() *InstallData {
 	return &InstallData{}
 }
 
+func (i *InstallData) GetRookTPRs(namespace string) string {
+	return `apiVersion: extensions/v1beta1
+description: ThirdPartyResource for cluster
+kind: ThirdPartyResource
+metadata:
+  name: cluster.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for filesystem
+kind: ThirdPartyResource
+metadata:
+  name: filesystem.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for objectstore
+kind: ThirdPartyResource
+metadata:
+  name: objectstore.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for pool
+kind: ThirdPartyResource
+metadata:
+  name: pool.rook.io
+versions:
+- name: v1alpha1
+---
+apiVersion: extensions/v1beta1
+description: ThirdPartyResource for volumeattachment
+kind: ThirdPartyResource
+metadata:
+  name: volumeattachment.rook.io
+versions:
+- name: v1alpha1`
+}
+
+func (i *InstallData) GetRookCRDs(namespace string) string {
+	return `apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusters.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: filesystems.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Filesystem
+    listKind: FilesystemList
+    plural: filesystems
+    singular: filesystem
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectstores.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: ObjectStore
+    listKind: ObjectStoreList
+    plural: objectstores
+    singular: objectstore
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pools.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Pool
+    listKind: PoolList
+    plural: pools
+    singular: pool
+  scope: Namespaced
+  version: v1alpha1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumeattachments.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    singular: volumeattachment
+  scope: Namespaced
+  version: v1alpha1
+`
+}
+
 //GetRookOperator returns rook Operator  manifest
 func (i *InstallData) GetRookOperator(namespace string) string {
 
@@ -67,20 +182,9 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - thirdpartyresources
   - deployments
   - daemonsets
   - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
   verbs:
   - get
   - list

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -70,7 +70,7 @@ function wait_for_ssh() {
 function copy_image_to_cluster() {
     local build_image=$1
     local final_image=$2
-    docker save ${build_image} | (eval $(minikube docker-env) && docker load && docker tag ${build_image} ${final_image})
+    docker save ${build_image} | (eval $(minikube docker-env --shell bash) && docker load && docker tag ${build_image} ${final_image})
 }
 
 # Deletes pods with 'rook-' prefix. Namespace is expected as the first argument


### PR DESCRIPTION
### Overview
Currently, `rook` CRD's are created during `rook-operator` initialization phase. 
This requires for `rook-operator` **ServiceAccount** to have permissions to manipulate [`get`, `list`, `watch`, `create`, `delete`] on `customresourcedefinitions`, which is a ClusterRole/RoleBinding scope. 

By moving `CRD` definitions into a Kubernetes manifest file we can avoid granting `rook-operator` ClusterScope permissions for `customresourcedefinitions` resource.

This work is related to: #1412

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
