### PR TITLE
Make daemonset use rolling update controller

### DIFF
--- a/pkg/operator/agent/agent.go
+++ b/pkg/operator/agent/agent.go
@@ -101,6 +101,9 @@ func (a *Agent) createAgentDaemonSet(namespace, agentImage string) error {
 			Name: agentDaemonsetName,
 		},
 		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/operator/cluster/ceph/osd/pod.go
+++ b/pkg/operator/cluster/ceph/osd/pod.go
@@ -47,7 +47,12 @@ func (c *Cluster) makeDaemonSet(selection rookalpha.Selection, config rookalpha.
 				k8sutil.ClusterAttr: c.Namespace,
 			},
 		},
-		Spec: extensions.DaemonSetSpec{Template: podSpec},
+		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
+			Template: podSpec,
+		},
 	}
 }
 

--- a/pkg/operator/object/ceph/rgw.go
+++ b/pkg/operator/object/ceph/rgw.go
@@ -334,6 +334,9 @@ func startDaemonset(context *clusterd.Context, store rookalpha.ObjectStore, vers
 			OwnerReferences: ownerRefs,
 		},
 		Spec: extensions.DaemonSetSpec{
+			UpdateStrategy: extensions.DaemonSetUpdateStrategy{
+				Type: extensions.RollingUpdateDaemonSetStrategyType,
+			},
 			Template: makeRGWPodSpec(store, version, hostNetwork),
 		},
 	}


### PR DESCRIPTION
- Daemonsets deployed by rook currently use the "delete" update
  controller. Which means the pods have to be manually deleted
  before being upgraded.

- Using the update controller will make daemonset behave like
  deployments when it comes to upgrade.

Partially fixes https://github.com/rook/rook/issues/997
