### PR TITLE
Fix crashloop in Ceph MGRs when running multiple RGWs

### DIFF
--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -41,9 +41,9 @@ var (
 )
 
 func init() {
-	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", os.Getenv("HOSTNAME"), "name of the object store. Defaults to the pod hostname.")
+	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store. Defaults to the pod hostname.")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
-	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "dns host name")
+	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", os.Getenv("HOSTNAME"), "dns host name")
 	rgwCmd.Flags().StringVar(&rgwCert, "rgw-cert", "", "path to the ssl certificate in pem format")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port (http)")
 	rgwCmd.Flags().IntVar(&rgwSecurePort, "rgw-secure-port", 0, "rgw secure port number (https)")
@@ -55,7 +55,7 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-keyring", "public-ipv4", "private-ipv4"}
 	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}

--- a/pkg/operator/object/ceph/rgw.go
+++ b/pkg/operator/object/ceph/rgw.go
@@ -348,7 +348,7 @@ func rgwContainer(store rookalpha.ObjectStore, version string) v1.Container {
 		Args: []string{
 			"rgw",
 			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
-			fmt.Sprintf("--rgw-host=%s", fmt.Sprintf("%s.%s", instanceName(store), store.Namespace)),
+			fmt.Sprintf("--rgw-name=%s", store.Name),
 			fmt.Sprintf("--rgw-port=%d", store.Spec.Gateway.Port),
 			fmt.Sprintf("--rgw-secure-port=%d", store.Spec.Gateway.SecurePort),
 		},

--- a/pkg/operator/object/ceph/rgw_test.go
+++ b/pkg/operator/object/ceph/rgw_test.go
@@ -124,7 +124,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, 5, len(cont.Args))
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
-	assert.Equal(t, fmt.Sprintf("--rgw-host=%s.%s", instanceName(store), store.Namespace), cont.Args[2])
+	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
 	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[3])
 	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[4])
 

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 // Smoke Test for ObjectStore - Test check the following operations on ObjectStore in order
-//Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,
+// Create object store, Create User, Connect to Object Store, Create Bucket, Read/Write/Delete to bucket,
 // Check issues in MGRs, Delete Bucket and Delete user
 func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
 	storeName := "teststore"


### PR DESCRIPTION
Description of your changes: This makes the RGWs commandline tool use the HOSTNAME environment variable, which has a randomized suffix, so the need of different name for different gateways is true. 

Resolves #1483
