### PR TITLE
Set owner reference on remaining components

### DIFF
--- a/pkg/operator/cluster/ceph/mgr/mgr.go
+++ b/pkg/operator/cluster/ceph/mgr/mgr.go
@@ -111,25 +111,26 @@ func (c *Cluster) Start() error {
 }
 
 func (c *Cluster) makeService(name string) *v1.Service {
-	service := &v1.Service{}
-	service.Name = name
-	service.Namespace = c.Namespace
-
-	service.Labels = c.getLabels()
-
-	service.Spec = v1.ServiceSpec{
-		Selector: service.Labels,
-		Type:     v1.ServiceTypeClusterIP,
-		Ports: []v1.ServicePort{
-			{
-				Name:     "http-metrics",
-				Port:     int32(9283),
-				Protocol: v1.ProtocolTCP,
+	labels := c.getLabels()
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       c.Namespace,
+			OwnerReferences: []metav1.OwnerReference{c.ownerRef},
+			Labels:          labels,
+		},
+		Spec: v1.ServiceSpec{
+			Selector: labels,
+			Type:     v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http-metrics",
+					Port:     int32(9283),
+					Protocol: v1.ProtocolTCP,
+				},
 			},
 		},
 	}
-
-	return service
 }
 
 func (c *Cluster) makeDeployment(name string) *extensions.Deployment {

--- a/pkg/operator/cluster/ceph/osd/osd_test.go
+++ b/pkg/operator/cluster/ceph/osd/osd_test.go
@@ -199,7 +199,7 @@ func TestOrchestrationStatus(t *testing.T) {
 	assert.True(t, errors.IsNotFound(err))
 
 	// make the initial status map
-	err = makeOrchestrationStatusMap(c.context.Clientset, c.Namespace)
+	err = makeOrchestrationStatusMap(c.context.Clientset, c.Namespace, nil)
 	assert.Nil(t, err)
 
 	// the status map should exist now


### PR DESCRIPTION
During deletion of the cluster CRD we expect all the k8s artifacts to be cleaned up for the cluster. An osd configmap and a mgr service had been missed previously, so this finishes that cleanup process. Now the only remaining cleanup between deleting and re-creating a cluster should be the dataDirHostPath. Resolves #1438