### PR TITLE
Init flags parsing in the agent

### DIFF
--- a/cmd/rook/main.go
+++ b/cmd/rook/main.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -113,6 +114,9 @@ func setLogLevel() {
 }
 
 func logStartupInfo(cmdFlags *pflag.FlagSet) {
+	// workaround a k8s logging issue: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
+
 	// log the version number, arguments, and all final flag values (environment variable overrides
 	// have already been taken into account)
 	flagValues := flags.GetFlagsAndValues(cmdFlags, "secret")

--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -16,7 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -46,9 +45,6 @@ func init() {
 func startOperator(cmd *cobra.Command, args []string) error {
 
 	setLogLevel()
-
-	// workaround a k8s logging issue: https://github.com/kubernetes/kubernetes/issues/17162
-	flag.CommandLine.Parse([]string{})
 
 	logStartupInfo(operatorCmd.Flags())
 

--- a/cmd/rookflex/main.go
+++ b/cmd/rookflex/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -30,6 +31,9 @@ type result struct {
 }
 
 func main() {
+	// workaround a k8s logging issue: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
+
 	var r result
 	if err := cmd.RootCmd.Execute(); err != nil {
 		if strings.HasPrefix(err.Error(), "unknown command") {


### PR DESCRIPTION
The flags parsing needs to be initialized in the agent to avoid an error printing in the logs. This change ensures it is initialized everywhere the rook binary runs and also the flex driver. Resolves #1414