### PR TITLE
RGWs: Make multiple instances do not interfere with MGRs

### DIFF
--- a/cmd/rook/rgw.go
+++ b/cmd/rook/rgw.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/daemon/ceph/rgw"
@@ -42,7 +43,7 @@ var (
 func init() {
 	rgwCmd.Flags().StringVar(&rgwName, "rgw-name", "", "name of the object store")
 	rgwCmd.Flags().StringVar(&rgwKeyring, "rgw-keyring", "", "the rgw keyring")
-	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", "", "dns host name")
+	rgwCmd.Flags().StringVar(&rgwHost, "rgw-host", os.Getenv("HOSTNAME"), "RGW host name. Becomes the only accepted hostname if the rgw dns name property is unset. Defaults to the pod hostname")
 	rgwCmd.Flags().StringVar(&rgwCert, "rgw-cert", "", "path to the ssl certificate in pem format")
 	rgwCmd.Flags().IntVar(&rgwPort, "rgw-port", 0, "rgw port (http)")
 	rgwCmd.Flags().IntVar(&rgwSecurePort, "rgw-secure-port", 0, "rgw secure port number (https)")
@@ -54,7 +55,7 @@ func init() {
 }
 
 func startRGW(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-host", "rgw-keyring", "public-ipv4", "private-ipv4"}
+	required := []string{"mon-endpoints", "cluster-name", "rgw-name", "rgw-keyring", "public-ipv4", "private-ipv4"}
 	if err := flags.VerifyRequiredFlags(rgwCmd, required); err != nil {
 		return err
 	}

--- a/pkg/operator/object/ceph/rgw.go
+++ b/pkg/operator/object/ceph/rgw.go
@@ -352,7 +352,6 @@ func rgwContainer(store rookalpha.ObjectStore, version string) v1.Container {
 			"rgw",
 			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
 			fmt.Sprintf("--rgw-name=%s", store.Name),
-			fmt.Sprintf("--rgw-host=%s", fmt.Sprintf("%s.%s", instanceName(store), store.Namespace)),
 			fmt.Sprintf("--rgw-port=%d", store.Spec.Gateway.Port),
 			fmt.Sprintf("--rgw-secure-port=%d", store.Spec.Gateway.SecurePort),
 		},

--- a/pkg/operator/object/ceph/rgw_test.go
+++ b/pkg/operator/object/ceph/rgw_test.go
@@ -121,13 +121,12 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
 
-	assert.Equal(t, 6, len(cont.Args))
+	assert.Equal(t, 5, len(cont.Args))
 	assert.Equal(t, "rgw", cont.Args[0])
 	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[1])
 	assert.Equal(t, fmt.Sprintf("--rgw-name=%s", "default"), cont.Args[2])
-	assert.Equal(t, fmt.Sprintf("--rgw-host=%s.%s", instanceName(store), store.Namespace), cont.Args[3])
-	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[4])
-	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[5])
+	assert.Equal(t, fmt.Sprintf("--rgw-port=%d", 123), cont.Args[3])
+	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 0), cont.Args[4])
 
 	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
@@ -151,9 +150,9 @@ func TestSSLPodSpec(t *testing.T) {
 	assert.Equal(t, certVolumeName, cont.VolumeMounts[2].Name)
 	assert.Equal(t, certMountPath, cont.VolumeMounts[2].MountPath)
 
-	assert.Equal(t, 7, len(cont.Args))
-	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 443), cont.Args[5])
-	assert.Equal(t, fmt.Sprintf("--rgw-cert=%s/%s", certMountPath, certFilename), cont.Args[6])
+	assert.Equal(t, 6, len(cont.Args))
+	assert.Equal(t, fmt.Sprintf("--rgw-secure-port=%d", 443), cont.Args[4])
+	assert.Equal(t, fmt.Sprintf("--rgw-cert=%s/%s", certMountPath, certFilename), cont.Args[5])
 }
 
 func TestCreateObjectStore(t *testing.T) {


### PR DESCRIPTION
Description of your changes: This makes the RGWs commandline tool use the HOSTNAME environment variable, which has a randomized suffix, so the need of different name for different gateways is true.

Resolves #1483