### PR TITLE
Fixes for filestore OSD removal

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -297,8 +297,16 @@ func getRemovedDevices(agent *OsdAgent) (*config.PerfScheme, *DeviceOsdMapping, 
 	}
 
 	for _, entry := range scheme.Entries {
+		// determine which partition the data lives on for this entry
+		dataDetails, ok := entry.Partitions[entry.GetDataPartitionType()]
+		if !ok || dataDetails == nil {
+			return nil, nil, fmt.Errorf("failed to find data partition for entry %+v", entry)
+		}
+
+		// add the current scheme entry to the removed devices scheme and its device to the removed
+		// devices mapping
 		removedDevicesScheme.Entries = append(removedDevicesScheme.Entries, entry)
-		removedDevicesMapping.Entries[entry.Partitions[config.BlockPartitionType].Device] = &DeviceOsdIDEntry{Data: entry.ID}
+		removedDevicesMapping.Entries[dataDetails.Device] = &DeviceOsdIDEntry{Data: entry.ID}
 	}
 
 	return removedDevicesScheme, removedDevicesMapping, nil

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -77,6 +77,11 @@ type DeviceOsdIDEntry struct {
 	Metadata []int // OSD IDs (multiple) that have metadata stored here
 }
 
+func (m *DeviceOsdMapping) String() string {
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
 // format the given device for usage by an OSD
 func formatDevice(context *clusterd.Context, config *osdConfig, forceFormat bool, storeConfig rookalpha.StoreConfig) error {
 	dataDetails, err := getDataPartitionDetails(config)

--- a/pkg/operator/cluster/ceph/osd/config/scheme.go
+++ b/pkg/operator/cluster/ceph/osd/config/scheme.go
@@ -159,6 +159,11 @@ func RemoveFromScheme(e *PerfSchemeEntry, kv *k8sutil.ConfigMapKVStore, storeNam
 	return nil
 }
 
+func (s *PerfScheme) String() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
 func (s *PerfScheme) UpdateSchemeEntry(e *PerfSchemeEntry) error {
 	return s.doSchemeEntryAction(e, func(scheme *PerfScheme, index int, entry *PerfSchemeEntry) {
 		// the action to perform if the entry is found is to update the entry
@@ -361,6 +366,11 @@ func (m *MetadataDeviceInfo) GetPartitionArgs() []string {
 	args = append(args, []string{fmt.Sprintf("--disk-guid=%s", m.DiskUUID), "/dev/" + m.Device}...)
 
 	return args
+}
+
+func (e *PerfSchemeEntry) String() string {
+	b, _ := json.Marshal(e)
+	return string(b)
 }
 
 func (e *PerfSchemeEntry) GetPartitionArgs() []string {

--- a/pkg/operator/cluster/ceph/osd/pod_test.go
+++ b/pkg/operator/cluster/ceph/osd/pod_test.go
@@ -216,6 +216,10 @@ func TestStorageSpecConfig(t *testing.T) {
 
 	assert.Equal(t, "100", container.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", container.Resources.Requests.Memory().String())
+
+	// verify that osd config can be discovered from the container and matches the original config from the spec
+	cfg := getConfigFromContainer(container)
+	assert.Equal(t, storageSpec.Nodes[0].Config, cfg)
 }
 
 func TestHostNetwork(t *testing.T) {


### PR DESCRIPTION
Description of your changes:
* When marking an OSD device to be removed, ensure the correct data partition name is used.
* If watching the osd orchestration status map fails, ensure the loop is broken out of so a new watcher can be created.
* Log the osd device/dir mapping structures in a more friendly way.

Which issue is resolved by this Pull Request:
Resolves #1461 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
