### PR TITLE
Ensure Helm waits for CRD\TPRs to be available before returning

### DIFF
--- a/cluster/charts/rook/templates/wait-on-resources-job.yaml
+++ b/cluster/charts/rook/templates/wait-on-resources-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-operator-wait-resources
+  annotations:
+    helm.sh/hook: post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: rook-operator-wait-resources
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: rook-operator-wait-resources
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.hyperkube.repository }}:{{ .Values.hyperkube.tag }}"
+          imagePullPolicy: "{{ .Values.hyperkube.pullPolicy }}"
+          command:
+            - ./kubectl
+            - get
+            {{- if printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor | semverCompare ">=1.7" }}
+            - customresourcedefinitions
+            - clusters.rook.io
+            - pools.rook.io
+            - objectstores.rook.io
+            - filesystems.rook.io
+            - volumeattachments.rook.io
+            {{- else }}
+            - thirdpartyresources
+            - cluster.rook.io
+            - pool.rook.io
+            - objectstore.rook.io
+            - filesystem.rook.io
+            - volumeattachment.rook.io
+            {{- end }}
+      restartPolicy: OnFailure
+    {{- if .Values.rbacEnable }}
+      serviceAccountName: rook-operator
+    {{- end }}

--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -8,6 +8,11 @@ image:
   tag: %%VERSION%%
   pullPolicy: IfNotPresent
 
+hyperkube:
+  repository: k8s.gcr.io/hyperkube
+  tag: v1.7.12
+  pullPolicy: IfNotPresent
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
Description of your changes:
Adds a post-install hook to the rook-operator chart to ensure all CRD\TPR resources are available for use before returning.
This greatly helps automated deployment solutions not require 'sleep\wait' logic between applying the operator chart & configuring any rook clusters.

Resolves #1511 

NOTE: I didn't think this change is worth putting in documentation, but would be happy to add a sentence if required.
Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
