### PR TITLE
Fix docker tag for rook image

### DIFF
--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -46,7 +46,7 @@ const (
 	ConfigOverrideName = "rook-config-override"
 	// ConfigOverrideVal config override value
 	ConfigOverrideVal = "config"
-	defaultVersion    = "rook/rook:latest"
+	defaultVersion    = "rook/rook:master"
 	configMountDir    = "/etc/rook/config"
 	overrideFilename  = "override.conf"
 )


### PR DESCRIPTION
Currently, the latest tag is failing.
(I don't know why)