### PR TITLE
Pick up luminous 12.2.3

### DIFF
--- a/images/rook/Dockerfile.base
+++ b/images/rook/Dockerfile.base
@@ -16,7 +16,7 @@ FROM BASEIMAGE
 
 # add Ceph and other packages needed
 ADD 'https://download.ceph.com/keys/release.asc' /tmp/release.asc
-RUN CEPH_VERSION=luminous && \
+RUN CEPH_VERSION=luminous  && \
     apt-key add /tmp/release.asc && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
     DEBIAN_FRONTEND=noninteractive apt-get update && \


### PR DESCRIPTION
To pick up the latest version of luminous, the instruction in the Dockerfile needs to change, even if only the whitespace. This small change will invalidate the docker cache and have the effect of picking up 12.2.3.

Which issue is resolved by this Pull Request:
Resolves #1528
