### PR TITLE
Fix assignment of node address to mon in failover

### DIFF
--- a/pkg/operator/cluster/ceph/mon/mon.go
+++ b/pkg/operator/cluster/ceph/mon/mon.go
@@ -224,7 +224,7 @@ func (c *Cluster) initMonIPs(mons []*monConfig) error {
 			logger.Infof("setting mon endpoints for hostnetwork mode")
 			node, ok := c.mapping.Node[m.Name]
 			if !ok {
-				return fmt.Errorf("mon doesn't exit in assignment map")
+				return fmt.Errorf("mon doesn't exist in assignment map")
 			}
 			m.PublicIP = node.Address
 		} else {

--- a/pkg/operator/cluster/ceph/mon/mon_test.go
+++ b/pkg/operator/cluster/ceph/mon/mon_test.go
@@ -60,7 +60,7 @@ func newTestStartCluster(namespace string) *clusterd.Context {
 
 func newCluster(context *clusterd.Context, namespace string, hostNetwork bool, resources v1.ResourceRequirements) *Cluster {
 	return &Cluster{
-		HostNetwork:         true,
+		HostNetwork:         hostNetwork,
 		context:             context,
 		Namespace:           namespace,
 		Version:             "myversion",


### PR DESCRIPTION
```
Signed-off-by: Alexander Trost <galexrt@googlemail.com>
```

***

Description of your changes:
This fixes the assignment of the `PublicIP` for a new spawned mon during `failoverMon()`.

From the code logic this should fix the issue, but I'm going to test this in minikube soon to 100% verify the fix.

Which issue is resolved by this Pull Request:
Resolves #1548

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.