### PR TITLE
Skips wait in chart when K8S version unavailable

### DIFF
--- a/cluster/charts/rook/templates/wait-on-resources-job.yaml
+++ b/cluster/charts/rook/templates/wait-on-resources-job.yaml
@@ -1,3 +1,4 @@
+{{- if and .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,3 +42,4 @@ spec:
     {{- if .Values.rbacEnable }}
       serviceAccountName: rook-operator
     {{- end }}
+{{- end }}


### PR DESCRIPTION
Description of your changes: Ensures we have non-empty values for Kubernetes Major & Minor versions before using them to wait for TPR\CRD resources to become available.

Which issue is resolved by this Pull Request:
Discussed in #1517