### PR TITLE
Skips wait in chart when K8S version unavailable

### DIFF
--- a/cluster/charts/rook/templates/wait-on-resources-job.yaml
+++ b/cluster/charts/rook/templates/wait-on-resources-job.yaml
@@ -1,3 +1,4 @@
+{{- if and .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -41,3 +42,4 @@ spec:
     {{- if .Values.rbacEnable }}
       serviceAccountName: rook-operator
     {{- end }}
+{{- end }}


### PR DESCRIPTION
Description of your changes:  Backports https://github.com/rook/rook/commit/7b04022079968f0c816358a95f72e89792d2a5e4 to the 0.7 branch