### PR TITLE
add optional nodeSelector to deployment in chart

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Action Required
 
 ## Notable Features
+- added nodeSelector for operator deployment to chart
 
 ## Breaking Changes
 

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -65,6 +65,11 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
     {{- if .Values.rbacEnable }}
       serviceAccountName: rook-operator
     {{- end }}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:
chart: added nodeSelector to operator deployment

This allows for confining your deployment to a subset of kubernetes nodes

Which issue is resolved by this Pull Request:
Resolves #


Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
