### PR TITLE
chart: add optional nodeSelector to deployment in chart

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,8 +3,12 @@
 ## Action Required
 
 ## Notable Features
+<<<<<<< 181d71c4e3816474c0563e5f4fa93d888afbb6fa
 - Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
 - Output from stderr will be included in error messages returned from the `exec` of external tools
+=======
+- added nodeSelector for operator deployment to chart
+>>>>>>> chart: added nodeSelector to operator deployment
 
 ## Breaking Changes
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,24 +3,21 @@
 ## Action Required
 
 ## Notable Features
-<<<<<<< 181d71c4e3816474c0563e5f4fa93d888afbb6fa
 - Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
 - Output from stderr will be included in error messages returned from the `exec` of external tools
-=======
 - added nodeSelector for operator deployment to chart
->>>>>>> chart: added nodeSelector to operator deployment
 
 ## Breaking Changes
 
 ### Removal of the API service and rookctl tool
-The [REST API service](https://github.com/rook/rook/issues/1122) has been removed. All cluster configuration is now accomplished through the 
-[CRDs](https://rook.io/docs/rook/master/crds.html) or with the Ceph tools in the [toolbox](https://rook.io/docs/rook/master/toolbox.html). 
+The [REST API service](https://github.com/rook/rook/issues/1122) has been removed. All cluster configuration is now accomplished through the
+[CRDs](https://rook.io/docs/rook/master/crds.html) or with the Ceph tools in the [toolbox](https://rook.io/docs/rook/master/toolbox.html).
 
-The tool `rookctl` has been removed from the toolbox pod. Cluster status and configuration can be queried and changed with the Ceph tools. 
+The tool `rookctl` has been removed from the toolbox pod. Cluster status and configuration can be queried and changed with the Ceph tools.
 Here are some sample commands to help with your transition.
 
  `rookctl` Command | Replaced by | Description
- --- | --- | --- 
+ --- | --- | ---
 `rookctl status` | `ceph status` | Query the status of the storage components
 `rookctl block` | See the [Block storage](Documentation/block.md) and [direct Block](Documentation/direct-tools.md#block-storage-tools) config | Create, configure, mount, or unmount a block image
 `rookctl filesystem` | See the [Filesystem](Documentation/filesystem.md) and [direct File](Documentation/direct-tools.md#shared-filesystem-tools) config | Create, configure, mount, or unmount a file system

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -72,6 +72,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}
-    {{- if .Values.rbacEnable }}
+{{- if .Values.rbacEnable }}
       serviceAccountName: rook-operator
-    {{- end }}
+{{- end }}

--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
     {{- if .Values.rbacEnable }}
       serviceAccountName: rook-operator
     {{- end }}


### PR DESCRIPTION
This allows for confining your deployment to a subset of kubernetes
nodes

Signed-off-by: Peter W Developer <peter@bitfusion.io>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:
chart: added nodeSelector to operator deployment

This allows for confining your deployment to a subset of kubernetes nodes

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
