### PR TITLE
Remove chart version from deployment selector to allow upgrades

### DIFF
--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rook-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
Description of your changes:

Fixes this error:

Error: UPGRADE FAILED: Deployment.apps "rook-operator" is invalid: spec
.template.metadata.labels: Invalid value:
map[string]string{"chart":"rook-0.7.1", "app":"rook-operator"}:
`selector` does not match template `labels`

See also: https://github.com/kubernetes/helm/issues/2494


Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.