### PR TITLE
Run ceph tools from any rook pod

### DIFF
--- a/Documentation/toolbox.md
+++ b/Documentation/toolbox.md
@@ -90,3 +90,6 @@ When you are done with the toolbox, remove the pod:
 ```bash
 kubectl -n rook delete pod rook-tools
 ```
+
+## Troubleshooting without the Toolbox
+The Ceph tools will commonly be the only tools needed to troubleshoot a cluster. In that case, you can connect to any of the rook pods and execute the ceph commands in the same way that you would in the toolbox pod. For example, you can connect to the mon, osd, or even the operator pod to execute commands such as `ceph status`. 

--- a/Documentation/tools.md
+++ b/Documentation/tools.md
@@ -8,4 +8,4 @@ weight: 70
 Rook provides a number of tools to help you manage your cluster.
 - [Toolbox](toolbox.md): A pod from which you can run all of the tools to troubleshoot the storage cluster
 - [Advanced Configuration](advanced-configuration.md): Tips and tricks for configuring for cluster
-- [Common Issues](common-problems.md): Common issues and their potential solutions
+- [Common Issues](common-issues.md): Common issues and their potential solutions

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Action Required
 
 ## Notable Features
-- Ceph tools can be run [from any rook pod](Documentation/common-problems.md#ceph-tools).
+- Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
 
 ## Breaking Changes
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Action Required
 
 ## Notable Features
+- Ceph tools can be run [from any rook pod](Documentation/common-problems.md#ceph-tools).
 
 ## Breaking Changes
 

--- a/pkg/daemon/agent/flexvolume/server.go
+++ b/pkg/daemon/agent/flexvolume/server.go
@@ -177,6 +177,6 @@ func checkIfKubeletRestartRequired(context *clusterd.Context) {
 	if err != nil || kubeVersion.LessThan(version.MustParseSemantic(serverVersionV180)) {
 		logger.Warning("NOTE: The Kubelet must be restarted on this node since this pod appears to " +
 			"be running on a Kubernetes version prior to 1.8. More details can be found in the Rook docs at " +
-			"https://rook.io/docs/rook/master/common-problems.html#kubelet-restart")
+			"https://rook.io/docs/rook/master/common-issues.html#kubelet-restart")
 	}
 }


### PR DESCRIPTION
The ceph tools are already found in all the rook pods. However, they were not easily accessible because the config files were found in non-default paths that are inconvenient to track down. Now whenever the config is written, it is also copied to the default location `/etc/ceph` so the tools can run without any arguments. This is a convenience for troubleshooting so you don't have to load the toolbox. It does have the following issues:
- The pods do not update the config when mons failover. The config is only generated at pod startup, so the mons could be outdated and cause the commands to fail. The operator pod, however, will always be up to date
- If there is more than one cluster, the operator pod will have default config pointing at only one of the clusters, which will be indeterministic depending on the last cluster to start or update its config. In this case it is recommended to use a cluster-specific pod

Also added some troubleshooting documentation around running the tools.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.