### PR TITLE
Don't set the minikube kubelet ip address

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -92,10 +92,6 @@ function check_context() {
 # configure minikube
 KUBE_VERSION=${KUBE_VERSION:-"v1.9.1"}
 MEMORY=${MEMORY:-"3000"}
-# IP for kubelet to use. This is the default IP when using the virtualbox driver.
-# Using kubeadm bootstrapper, kubelet uses the internal host IP to be used when using NodePort service, which will prevent tests being run
-# outside the host access to any exposed services via NodePort.
-NODE_IP=${NODE_IP:-"192.168.99.100"}
 
 case "${1:-}" in
   up)
@@ -109,7 +105,7 @@ case "${1:-}" in
       init_flexvolume
     else
       echo "starting minikube with kubeadm bootstrapper"
-      minikube start --memory=${MEMORY} -b kubeadm --kubernetes-version ${KUBE_VERSION} --extra-config=kubelet.node-ip=${NODE_IP}
+      minikube start --memory=${MEMORY} -b kubeadm --kubernetes-version ${KUBE_VERSION}
       wait_for_ssh
     fi
     # create a link so the default dataDirHostPath will work for this environment


### PR DESCRIPTION
If the ip address of the host is not the default `192.168.99.100`, the minikube environment will be fraught with dns and other random issues that trace back to setting the ip address to the wrong thing at startup. The integration tests no longer use NodePort for the external rgw service or api service, so we can disable this to unblock the unsuspecting minikube user.

[skip ci]