### PR TITLE
Log when mon is back in quorum and exceeded timeout

### DIFF
--- a/pkg/operator/cluster/ceph/mon/health.go
+++ b/pkg/operator/cluster/ceph/mon/health.go
@@ -111,9 +111,10 @@ func (c *Cluster) checkHealth() error {
 			// delete the "timeout" for a mon if the pod is in quorum again
 			if _, ok := c.monTimeoutList[mon.Name]; ok {
 				delete(c.monTimeoutList, mon.Name)
+				logger.Infof("mon %s is back in quorum, removed from mon out timeout list", mon.Name)
 			}
 		} else {
-			logger.Warningf("mon %s NOT found in quorum. %+v", mon.Name, status)
+			logger.Debugf("mon %s NOT found in quorum. Mon status: %+v", mon.Name, status)
 
 			// If not yet set, add the current time, for the timeout
 			// calculation, to the list
@@ -124,10 +125,11 @@ func (c *Cluster) checkHealth() error {
 			// when the timeout for the mon has been reached, continue to the
 			// normal failover/delete mon pod part of the code
 			if time.Since(c.monTimeoutList[mon.Name]) <= MonOutTimeout {
-				logger.Warningf("mon %s NOT found in quorum, STILL in mon out timeout", mon.Name)
+				logger.Warningf("mon %s not found in quorum, still in mon out timeout", mon.Name)
 				continue
 			}
 
+			logger.Warningf("mon %s NOT found in quorum and timeout exceeded, mon will be failed over", mon.Name)
 			c.failMon(len(status.MonMap.Mons), mon.Name)
 			// only deal with one unhealthy mon per health check
 			return nil


### PR DESCRIPTION
Description of your changes:
* Log a info message when a mon that was in timeout is back in quorum.
* Log a warning when a mon has exceeded the out timeout and will be failovered.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
