### PR TITLE
Remove duplicate of serviceAccountName definition

### DIFF
--- a/cluster/charts/rook/templates/deployment.yaml
+++ b/cluster/charts/rook/templates/deployment.yaml
@@ -16,7 +16,6 @@ spec:
         app: rook-operator
         chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     spec:
-      serviceAccountName: rook-operator
       containers:
       - name: rook-operator
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Correct definition of serviceAccountName already provided on the last lines of deployment.yaml