### PR TITLE
include stderr output in CommandError.Error() output

### DIFF
--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -168,7 +168,20 @@ If one or neither of them is not in the `Bound` status, then look for details of
 ```console
 kubectl -n rook-system logs `kubectl -n rook-system -l app=rook-operator get pods -o jsonpath='{.items[*].metadata.name}'`
 ```
-If the volume is failing to be created, there should be details in the log output, especially those tagged with `op-provisioner`.
+
+If the volume is failing to be created, there should be details in the `rook-operator` log output, especially those tagged with `op-provisioner`.
+
+One common cause for the `rook-operator` failing to create the volume is when the `clusterName` field of the `StorageClass` doesn't match the **namespace** of the Rook cluster, as described in [#1502](https://github.com/rook/rook/issues/1502).
+In that scenario, the `rook-operator` log would show a failure similar to the following:
+
+```
+2018-03-28 18:58:32.041603 I | op-provisioner: creating volume with configuration {pool:replicapool clusterName:rook fstype:}
+2018-03-28 18:58:32.041728 I | exec: Running command: rbd create replicapool/pvc-fd8aba49-32b9-11e8-978e-08002762c796 --size 20480 --cluster=rook --conf=/var/lib/rook/rook/rook.config --keyring=/var/lib/rook/rook/client.admin.keyring
+E0328 18:58:32.060893       5 controller.go:801] Failed to provision volume for claim "default/mysql-pv-claim" with StorageClass "rook-block": Failed to create rook block image replicapool/pvc-fd8aba49-32b9-11e8-978e-08002762c796: failed to create image pvc-fd8aba49-32b9-11e8-978e-08002762c796 in pool replicapool of size 21474836480: Failed to complete '': exit status 1. global_init: unable to open config file from search list /var/lib/rook/rook/rook.config
+. output:
+```
+
+The solution is to ensure that the [`clusterName`](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/rook-storageclass.yaml#L25) field matches the **namespace** of the Rook cluster when creating the `StorageClass`.
 
 ### Volume Mounting
 The final step in preparing Rook storage for your pod is for the `rook-agent` pod to mount and format it.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,6 +4,7 @@
 
 ## Notable Features
 - Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
+- Output from stderr will be included in error messages returned from the `exec` of external tools
 
 ## Breaking Changes
 

--- a/pkg/util/exec/error.go
+++ b/pkg/util/exec/error.go
@@ -27,7 +27,13 @@ type CommandError struct {
 }
 
 func (e *CommandError) Error() string {
-	return fmt.Sprintf("Failed to complete %s: %+v", e.ActionName, e.Err)
+	var exitErrMsg string
+	if exitErr, ok := e.Err.(*exec.ExitError); ok {
+		// the error is an ExitError, include the stderr output in the final error output
+		exitErrMsg = string(exitErr.Stderr)
+	}
+
+	return fmt.Sprintf("Failed to complete '%s': %+v. %s", e.ActionName, e.Err, exitErrMsg)
 }
 
 func (e *CommandError) ExitStatus() int {


### PR DESCRIPTION
Description of your changes: In the `Error()` function for the `CommandError` type, include any output from stderr if the underlying error type is an `os/exec.ExitError`.  This will make error messages much more useful instead of losing stderr.

Also include a common issue entry for the behavior in #1502, which we've seen users hit recently.  Note that the new common issue entry has the new error output that includes stderr, making this issue much easier to troubleshoot.

Which issue is resolved by this Pull Request:
Resolves #1612 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
