### PR TITLE
updated storage class parameter clusterName to clusterNamespace

### DIFF
--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -171,17 +171,17 @@ kubectl -n rook-system logs `kubectl -n rook-system -l app=rook-operator get pod
 
 If the volume is failing to be created, there should be details in the `rook-operator` log output, especially those tagged with `op-provisioner`.
 
-One common cause for the `rook-operator` failing to create the volume is when the `clusterName` field of the `StorageClass` doesn't match the **namespace** of the Rook cluster, as described in [#1502](https://github.com/rook/rook/issues/1502).
+One common cause for the `rook-operator` failing to create the volume is when the `clusterNamespace` field of the `StorageClass` doesn't match the **namespace** of the Rook cluster, as described in [#1502](https://github.com/rook/rook/issues/1502).
 In that scenario, the `rook-operator` log would show a failure similar to the following:
 
 ```
-2018-03-28 18:58:32.041603 I | op-provisioner: creating volume with configuration {pool:replicapool clusterName:rook fstype:}
+2018-03-28 18:58:32.041603 I | op-provisioner: creating volume with configuration {pool:replicapool clusterNamespace:rook fstype:}
 2018-03-28 18:58:32.041728 I | exec: Running command: rbd create replicapool/pvc-fd8aba49-32b9-11e8-978e-08002762c796 --size 20480 --cluster=rook --conf=/var/lib/rook/rook/rook.config --keyring=/var/lib/rook/rook/client.admin.keyring
 E0328 18:58:32.060893       5 controller.go:801] Failed to provision volume for claim "default/mysql-pv-claim" with StorageClass "rook-block": Failed to create rook block image replicapool/pvc-fd8aba49-32b9-11e8-978e-08002762c796: failed to create image pvc-fd8aba49-32b9-11e8-978e-08002762c796 in pool replicapool of size 21474836480: Failed to complete '': exit status 1. global_init: unable to open config file from search list /var/lib/rook/rook/rook.config
 . output:
 ```
 
-The solution is to ensure that the [`clusterName`](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/rook-storageclass.yaml#L25) field matches the **namespace** of the Rook cluster when creating the `StorageClass`.
+The solution is to ensure that the [`clusterNamespace`](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/rook-storageclass.yaml#L25) field matches the **namespace** of the Rook cluster when creating the `StorageClass`.
 
 ### Volume Mounting
 The final step in preparing Rook storage for your pod is for the `rook-agent` pod to mount and format it.

--- a/Documentation/filesystem.md
+++ b/Documentation/filesystem.md
@@ -113,7 +113,7 @@ spec:
           fsType: ceph
           options:
             fsName: myfs # name of the filesystem specified in the filesystem CRD.
-            clusterName: rook # namespace where the Rook cluster is deployed
+            clusterNamespace: rook # namespace where the Rook cluster is deployed
             # by default the path is /, but you can override and mount a specific path of the filesystem by using the path attribute
             # path: /some/path/inside/cephfs
 ```

--- a/cluster/examples/kubernetes/rook-storageclass.yaml
+++ b/cluster/examples/kubernetes/rook-storageclass.yaml
@@ -19,9 +19,9 @@ metadata:
 provisioner: rook.io/block
 parameters:
   pool: replicapool
-  # Specify the Rook cluster from which to create volumes.
-  # If not specified, it will use `rook` as the name of the cluster.
+  # Specify the namespace of the rook cluster from which to create volumes.
+  # If not specified, it will use `rook` as the default namespace of the cluster.
   # This is also the namespace where the cluster will be
-  clusterName: rook
+  clusterNamespace: rook
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
   # fstype: ext4

--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -195,15 +195,19 @@ func mountCephFS(client *rpc.Client, opts *flexvolume.AttachOptions) error {
 
 	log(client, fmt.Sprintf("mounting ceph filesystem %s on %s", opts.FsName, opts.MountDir), false)
 
-	if opts.ClusterName == "" {
-		return fmt.Errorf("Rook: Attach filesystem %s failed: cluster is not provided", opts.FsName)
+	if opts.ClusterNamespace == "" {
+		if opts.ClusterName == "" {
+			return fmt.Errorf("Rook: Attach filesystem %s failed: cluster namespace is not provided", opts.FsName)
+		} else {
+			opts.ClusterNamespace = opts.ClusterName
+		}
 	}
 
 	// Get client access info
 	var clientAccessInfo flexvolume.ClientAccessInfo
-	err := client.Call("Controller.GetClientAccessInfo", opts.ClusterName, &clientAccessInfo)
+	err := client.Call("Controller.GetClientAccessInfo", opts.ClusterNamespace, &clientAccessInfo)
 	if err != nil {
-		errorMsg := fmt.Sprintf("Attach filesystem %s on cluster %s failed: %v", opts.FsName, opts.ClusterName, err)
+		errorMsg := fmt.Sprintf("Attach filesystem %s on cluster %s failed: %v", opts.FsName, opts.ClusterNamespace, err)
 		log(client, errorMsg, true)
 		return fmt.Errorf("Rook: %v", errorMsg)
 	}

--- a/pkg/daemon/agent/flexvolume/controller_test.go
+++ b/pkg/daemon/agent/flexvolume/controller_test.go
@@ -57,15 +57,15 @@ func TestAttach(t *testing.T) {
 
 	devicePath := ""
 	opts := AttachOptions{
-		Image:        "image123",
-		Pool:         "testpool",
-		ClusterName:  "testCluster",
-		StorageClass: "storageclass1",
-		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
-		VolumeName:   "pvc-123",
-		Pod:          "myPod",
-		PodNamespace: "Default",
-		RW:           "rw",
+		Image:            "image123",
+		Pool:             "testpool",
+		ClusterNamespace: "testCluster",
+		StorageClass:     "storageclass1",
+		MountDir:         "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:       "pvc-123",
+		Pod:              "myPod",
+		PodNamespace:     "Default",
+		RW:               "rw",
 	}
 	att, err := attachment.New(context)
 	assert.Nil(t, err)
@@ -306,14 +306,14 @@ func TestMultipleAttachReadOnly(t *testing.T) {
 	}
 
 	opts := AttachOptions{
-		Image:        "image123",
-		Pool:         "testpool",
-		ClusterName:  "testCluster",
-		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
-		VolumeName:   "pvc-123",
-		Pod:          "myPod",
-		PodNamespace: "Default",
-		RW:           "ro",
+		Image:            "image123",
+		Pool:             "testpool",
+		ClusterNamespace: "testCluster",
+		MountDir:         "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:       "pvc-123",
+		Pod:              "myPod",
+		PodNamespace:     "Default",
+		RW:               "ro",
 	}
 	existingCRD := &rookalpha.VolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -382,14 +382,14 @@ func TestOrphanAttachOriginalPodDoesntExist(t *testing.T) {
 	}
 
 	opts := AttachOptions{
-		Image:        "image123",
-		Pool:         "testpool",
-		ClusterName:  "testCluster",
-		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
-		VolumeName:   "pvc-123",
-		Pod:          "newPod",
-		PodNamespace: "Default",
-		RW:           "rw",
+		Image:            "image123",
+		Pool:             "testpool",
+		ClusterNamespace: "testCluster",
+		MountDir:         "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:       "pvc-123",
+		Pod:              "newPod",
+		PodNamespace:     "Default",
+		RW:               "rw",
 	}
 	existingCRD := &rookalpha.VolumeAttachment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -490,14 +490,14 @@ func TestOrphanAttachOriginalPodNameSame(t *testing.T) {
 	// the pod resource is a different one but for the same pod metadata. This is reflected in the MountDir.
 	// The namespace and name, however, must match.
 	opts := AttachOptions{
-		Image:        "image123",
-		Pool:         "testpool",
-		ClusterName:  "testCluster",
-		MountDir:     "/test/pods/pod456/volumes/rook.io~rook/pvc-123",
-		VolumeName:   "pvc-123",
-		Pod:          "myPod",
-		PodNamespace: "Default",
-		RW:           "rw",
+		Image:            "image123",
+		Pool:             "testpool",
+		ClusterNamespace: "testCluster",
+		MountDir:         "/test/pods/pod456/volumes/rook.io~rook/pvc-123",
+		VolumeName:       "pvc-123",
+		Pod:              "myPod",
+		PodNamespace:     "Default",
+		RW:               "rw",
 	}
 
 	att, err := attachment.New(context)
@@ -547,14 +547,14 @@ func TestVolumeAttachmentExistAttach(t *testing.T) {
 	}
 
 	opts := AttachOptions{
-		Image:        "image123",
-		Pool:         "testpool",
-		ClusterName:  "testCluster",
-		MountDir:     "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
-		VolumeName:   "pvc-123",
-		Pod:          "myPod",
-		PodNamespace: "Default",
-		RW:           "rw",
+		Image:            "image123",
+		Pool:             "testpool",
+		ClusterNamespace: "testCluster",
+		MountDir:         "/test/pods/pod123/volumes/rook.io~rook/pvc-123",
+		VolumeName:       "pvc-123",
+		Pod:              "myPod",
+		PodNamespace:     "Default",
+		RW:               "rw",
 	}
 
 	existingCRD := &rookalpha.VolumeAttachment{
@@ -739,7 +739,7 @@ func TestGetAttachInfoFromMountDir(t *testing.T) {
 			Name: "storageClass1",
 		},
 		Provisioner: "rook.io/rook",
-		Parameters:  map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"},
+		Parameters:  map[string]string{"pool": "testpool", "clusterNamespace": "testCluster", "fsType": "ext3"},
 	}
 	clientset.StorageV1().StorageClasses().Create(&sc)
 
@@ -775,10 +775,18 @@ func TestGetAttachInfoFromMountDir(t *testing.T) {
 	assert.Equal(t, "pvc-123", opts.Image)
 	assert.Equal(t, "pool123", opts.Pool)
 	assert.Equal(t, "storageClass1", opts.StorageClass)
-	assert.Equal(t, "testCluster", opts.ClusterName)
+	assert.Equal(t, "testCluster", opts.ClusterNamespace)
+}
+
+func TestParseClusterNamespace(t *testing.T) {
+	testParseClusterNamespace(t, "clusterNamespace")
 }
 
 func TestParseClusterName(t *testing.T) {
+	testParseClusterNamespace(t, "clusterName")
+}
+
+func testParseClusterNamespace(t *testing.T, namespaceParameter string) {
 	clientset := test.New(3)
 
 	context := &clusterd.Context{
@@ -790,7 +798,7 @@ func TestParseClusterName(t *testing.T) {
 			Name: "rook-storageclass",
 		},
 		Provisioner: "rook.io/rook",
-		Parameters:  map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"},
+		Parameters:  map[string]string{"pool": "testpool", namespaceParameter: "testCluster", "fsType": "ext3"},
 	}
 	clientset.StorageV1().StorageClasses().Create(&sc)
 	volumeAttachment, err := attachment.New(context)
@@ -800,8 +808,8 @@ func TestParseClusterName(t *testing.T) {
 		context:          context,
 		volumeAttachment: volumeAttachment,
 	}
-	clusterName, _ := fc.parseClusterName("rook-storageclass")
-	assert.Equal(t, "testCluster", clusterName)
+	clusterNamespace, _ := fc.parseClusterNamespace("rook-storageclass")
+	assert.Equal(t, "testCluster", clusterNamespace)
 }
 
 func TestGetPodAndPVNameFromMountDir(t *testing.T) {

--- a/pkg/daemon/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/agent/flexvolume/manager/ceph/manager.go
@@ -48,7 +48,7 @@ type devicePathFinder struct{}
 
 // DevicePathFinder is used to find the device path after the volume has been attached
 type pathFinder interface {
-	FindDevicePath(image, pool, clusterName string) (string, error)
+	FindDevicePath(image, pool, clusterNamespace string) (string, error)
 }
 
 // NewVolumeManager create attacher for ceph volumes
@@ -86,10 +86,10 @@ func (vm *VolumeManager) Init() error {
 }
 
 // Attach a ceph image to the node
-func (vm *VolumeManager) Attach(image, pool, clusterName string) (string, error) {
+func (vm *VolumeManager) Attach(image, pool, clusterNamespace string) (string, error) {
 
 	// check if the volume is already attached
-	devicePath, err := vm.isAttached(image, pool, clusterName)
+	devicePath, err := vm.isAttached(image, pool, clusterNamespace)
 	if err != nil {
 		return "", fmt.Errorf("failed to check if volume %s/%s is already attached: %+v", pool, image, err)
 	}
@@ -99,24 +99,24 @@ func (vm *VolumeManager) Attach(image, pool, clusterName string) (string, error)
 	}
 
 	// attach and poll until volume is mapped
-	logger.Infof("attaching volume %s/%s cluster %s", pool, image, clusterName)
-	monitors, keyring, err := getClusterInfo(vm.context, clusterName)
+	logger.Infof("attaching volume %s/%s cluster %s", pool, image, clusterNamespace)
+	monitors, keyring, err := getClusterInfo(vm.context, clusterNamespace)
 	defer os.Remove(keyring)
 	if err != nil {
-		return "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+		return "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterNamespace, err)
 	}
 
-	err = cephclient.MapImage(vm.context, image, pool, clusterName, keyring, monitors)
+	err = cephclient.MapImage(vm.context, image, pool, clusterNamespace, keyring, monitors)
 	if err != nil {
-		return "", fmt.Errorf("failed to map image %s/%s cluster %s. %+v", pool, image, clusterName, err)
+		return "", fmt.Errorf("failed to map image %s/%s cluster %s. %+v", pool, image, clusterNamespace, err)
 	}
 
 	// poll for device path
 	retryCount := 0
 	for {
-		devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterName)
+		devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterNamespace)
 		if err != nil {
-			return "", fmt.Errorf("failed to poll for mapped image %s/%s cluster %s. %+v", pool, image, clusterName, err)
+			return "", fmt.Errorf("failed to poll for mapped image %s/%s cluster %s. %+v", pool, image, clusterNamespace, err)
 		}
 
 		if devicePath != "" {
@@ -134,49 +134,49 @@ func (vm *VolumeManager) Attach(image, pool, clusterName string) (string, error)
 }
 
 // Detach the volume
-func (vm *VolumeManager) Detach(image, pool, clusterName string, force bool) error {
+func (vm *VolumeManager) Detach(image, pool, clusterNamespace string, force bool) error {
 	// check if the volume is attached
-	devicePath, err := vm.isAttached(image, pool, clusterName)
+	devicePath, err := vm.isAttached(image, pool, clusterNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to check if volume %s/%s is attached cluster %s", pool, image, clusterName)
+		return fmt.Errorf("failed to check if volume %s/%s is attached cluster %s", pool, image, clusterNamespace)
 	}
 	if devicePath == "" {
-		logger.Infof("volume %s/%s is already detached cluster %s", pool, image, clusterName)
+		logger.Infof("volume %s/%s is already detached cluster %s", pool, image, clusterNamespace)
 		return nil
 	}
 
-	logger.Infof("detaching volume %s/%s cluster %s", pool, image, clusterName)
-	monitors, keyring, err := getClusterInfo(vm.context, clusterName)
+	logger.Infof("detaching volume %s/%s cluster %s", pool, image, clusterNamespace)
+	monitors, keyring, err := getClusterInfo(vm.context, clusterNamespace)
 	defer os.Remove(keyring)
 	if err != nil {
-		return fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+		return fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterNamespace, err)
 	}
 
-	err = cephclient.UnMapImage(vm.context, image, pool, clusterName, keyring, monitors, force)
+	err = cephclient.UnMapImage(vm.context, image, pool, clusterNamespace, keyring, monitors, force)
 	if err != nil {
-		return fmt.Errorf("failed to detach volume %s/%s cluster %s. %+v", pool, image, clusterName, err)
+		return fmt.Errorf("failed to detach volume %s/%s cluster %s. %+v", pool, image, clusterNamespace, err)
 	}
 	logger.Infof("detached volume %s/%s", pool, image)
 	return nil
 }
 
 // Check if the volume is attached
-func (vm *VolumeManager) isAttached(image, pool, clusterName string) (string, error) {
-	devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterName)
+func (vm *VolumeManager) isAttached(image, pool, clusterNamespace string) (string, error) {
+	devicePath, err := vm.devicePathFinder.FindDevicePath(image, pool, clusterNamespace)
 	if err != nil {
 		return "", err
 	}
 	return devicePath, nil
 }
 
-func getClusterInfo(context *clusterd.Context, clusterName string) (string, string, error) {
-	clusterInfo, _, _, err := mon.LoadClusterInfo(context, clusterName)
+func getClusterInfo(context *clusterd.Context, clusterNamespace string) (string, string, error) {
+	clusterInfo, _, _, err := mon.LoadClusterInfo(context, clusterNamespace)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterName, err)
+		return "", "", fmt.Errorf("failed to load cluster information from cluster %s: %+v", clusterNamespace, err)
 	}
 
 	// create temp keyring file
-	keyringFile, err := ioutil.TempFile("", clusterName+".keyring")
+	keyringFile, err := ioutil.TempFile("", clusterNamespace+".keyring")
 	if err != nil {
 		return "", "", err
 	}
@@ -194,7 +194,7 @@ func getClusterInfo(context *clusterd.Context, clusterName string) (string, stri
 }
 
 // FindDevicePath polls and wait for the mapped ceph image device to show up
-func (f *devicePathFinder) FindDevicePath(image, pool, clusterName string) (string, error) {
+func (f *devicePathFinder) FindDevicePath(image, pool, clusterNamespace string) (string, error) {
 	mappedFile, err := util.FindRBDMappedFile(image, pool, util.RBDSysBusPathDefault)
 	if err != nil {
 		return "", fmt.Errorf("failed to find mapped image: %+v", err)

--- a/pkg/daemon/agent/flexvolume/types.go
+++ b/pkg/daemon/agent/flexvolume/types.go
@@ -38,19 +38,20 @@ type VolumeController interface {
 }
 
 type AttachOptions struct {
-	Image        string `json:"image"`
-	Pool         string `json:"pool"`
-	ClusterName  string `json:"clusterName"`
-	StorageClass string `json:"storageClass"`
-	MountDir     string `json:"mountDir"`
-	FsName       string `json:"fsName"`
-	Path         string `json:"path"` // Path within the CephFS to mount
-	RW           string `json:"kubernetes.io/readwrite"`
-	FsType       string `json:"kubernetes.io/fsType"`
-	VolumeName   string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
-	Pod          string `json:"kubernetes.io/pod.name"`
-	PodID        string `json:"kubernetes.io/pod.uid"`
-	PodNamespace string `json:"kubernetes.io/pod.namespace"`
+	Image            string `json:"image"`
+	Pool             string `json:"pool"`
+	ClusterNamespace string `json:"clusterNamespace"`
+	ClusterName      string `json:"clusterName"`
+	StorageClass     string `json:"storageClass"`
+	MountDir         string `json:"mountDir"`
+	FsName           string `json:"fsName"`
+	Path             string `json:"path"` // Path within the CephFS to mount
+	RW               string `json:"kubernetes.io/readwrite"`
+	FsType           string `json:"kubernetes.io/fsType"`
+	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
+	Pod              string `json:"kubernetes.io/pod.name"`
+	PodID            string `json:"kubernetes.io/pod.uid"`
+	PodNamespace     string `json:"kubernetes.io/pod.namespace"`
 }
 
 type LogMessage struct {

--- a/pkg/operator/provisioner/provisioner_test.go
+++ b/pkg/operator/provisioner/provisioner_test.go
@@ -65,7 +65,7 @@ func TestProvisionImage(t *testing.T) {
 	}
 
 	provisioner := New(context)
-	volume := newVolumeOptions(newStorageClass("class-1", "rook.io/block", map[string]string{"pool": "testpool", "clusterName": "testCluster", "fsType": "ext3"}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
+	volume := newVolumeOptions(newStorageClass("class-1", "rook.io/block", map[string]string{"pool": "testpool", "clusterNamespace": "testCluster", "fsType": "ext3"}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
 
 	pv, err := provisioner.Provision(volume)
 	assert.Nil(t, err)
@@ -89,7 +89,7 @@ func TestParseClassParameters(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "testPool", provConfig.pool)
-	assert.Equal(t, "myname", provConfig.clusterName)
+	assert.Equal(t, "myname", provConfig.clusterNamespace)
 	assert.Equal(t, "ext4", provConfig.fstype)
 }
 
@@ -101,7 +101,7 @@ func TestParseClassParametersDefault(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "testPool", provConfig.pool)
-	assert.Equal(t, "rook", provConfig.clusterName)
+	assert.Equal(t, "rook", provConfig.clusterNamespace)
 	assert.Equal(t, "", provConfig.fstype)
 }
 

--- a/tests/framework/installer/test_data.go
+++ b/tests/framework/installer/test_data.go
@@ -19,7 +19,11 @@ spec:
     size: ` + replicaSize
 }
 
-func GetBlockStorageClassDef(poolName string, storageClassName string, namespace string) string {
+func GetBlockStorageClassDef(poolName string, storageClassName string, namespace string, varClusterName bool) string {
+	namespaceParameter := "clusterNamespace"
+	if varClusterName {
+		namespaceParameter = "clusterName"
+	}
 	return `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -27,7 +31,7 @@ metadata:
 provisioner: rook.io/block
 parameters:
     pool: ` + poolName + `
-    clusterName: ` + namespace
+    ` + namespaceParameter + `: ` + namespace
 }
 
 func GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string {
@@ -53,9 +57,9 @@ func concatYaml(first, second string) string {
 
 func GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, blockName string, accessMode string) string {
 	return concatYaml(GetBlockPoolDef(poolName, namespace, "1"),
-		concatYaml(GetBlockStorageClassDef(poolName, storageClassName, namespace), GetBlockPvcDef(blockName, storageClassName, accessMode)))
+		concatYaml(GetBlockStorageClassDef(poolName, storageClassName, namespace, false), GetBlockPvcDef(blockName, storageClassName, accessMode)))
 }
 
 func GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string) string {
-	return concatYaml(GetBlockPoolDef(poolName, namespace, "1"), GetBlockStorageClassDef(poolName, storageClassName, namespace))
+	return concatYaml(GetBlockPoolDef(poolName, namespace, "1"), GetBlockStorageClassDef(poolName, storageClassName, namespace, false))
 }

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -109,7 +109,7 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	result0, err0 := s.testClient.PoolClient.Create(pool, s.namespace)
 	require.Contains(s.T(), result0, fmt.Sprintf("pool \"%s\" created", poolName), "Make sure test pool is created")
 	require.NoError(s.T(), err0)
-	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace), "create")
+	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
 	require.Contains(s.T(), result1, fmt.Sprintf("storageclass \"%s\" created", storageClassName), "Make sure storageclass is created")
 	require.NoError(s.T(), err1)
 
@@ -205,7 +205,7 @@ func (s *BlockCreateSuite) statefulSetDataCleanup(namespace, poolName, storageCl
 func (s *BlockCreateSuite) tearDownTest(claimName string, poolName string, storageClassName string, accessMode string) {
 	installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, accessMode), "delete")
 	installer.BlockResourceOperation(s.kh, installer.GetBlockPoolDef(poolName, s.namespace, "1"), "delete")
-	installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace), "delete")
+	installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "delete")
 
 }
 
@@ -224,7 +224,7 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 	result0, err0 := installer.BlockResourceOperation(s.kh, installer.GetBlockPoolDef(poolName, s.namespace, "1"), "create")
 	require.Contains(s.T(), result0, fmt.Sprintf("pool \"%s\" created", poolName), "Make sure test pool is created")
 	require.NoError(s.T(), err0)
-	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace), "create")
+	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
 	require.Contains(s.T(), result1, fmt.Sprintf("storageclass \"%s\" created", storageClassName), "Make sure storageclass is created")
 	require.NoError(s.T(), err1)
 

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -23,7 +23,7 @@ func createStorageClassAndPool(t func() *testing.T, kh *utils.K8sHelper, namespa
 		logger.Infof("Install pool and storage class for rook block")
 		_, err := installer.BlockResourceOperation(kh, installer.GetBlockPoolDef(poolName, namespace, "3"), "create")
 		require.NoError(t(), err)
-		_, err = installer.BlockResourceOperation(kh, installer.GetBlockStorageClassDef(poolName, storageClassName, namespace), "create")
+		_, err = installer.BlockResourceOperation(kh, installer.GetBlockStorageClassDef(poolName, storageClassName, namespace, false), "create")
 		require.NoError(t(), err)
 
 		//make sure storageclass is created


### PR DESCRIPTION
cluster name and namespace are required to match.
clusterName still works for backward compatiblity

Signed-off-by: Rohan Gupta <rohanrgupta1996@gmail.com>



Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #1502

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
