### PR TITLE
Bump golang dep to v0.4.1 version

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -65,7 +65,7 @@ endif
 GOPATH := $(shell go env GOPATH)
 
 # setup tools used during the build
-DEP_VERSION=v0.3.2
+DEP_VERSION=v0.4.1
 DEP := $(TOOLS_HOST_DIR)/dep-$(DEP_VERSION)
 GOLINT := $(TOOLS_HOST_DIR)/golint
 GOJUNIT := $(TOOLS_HOST_DIR)/go-junit-report


### PR DESCRIPTION
golang dep release v0.4.1 version on Jan 25 [1], this PR
bump its version from v0.3.2 to the latest version.

[1] https://github.com/golang/dep/releases

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
