### PR TITLE
operator: Update rook-agent DaemonSet if it already exists

### DIFF
--- a/pkg/operator/agent/agent.go
+++ b/pkg/operator/agent/agent.go
@@ -201,7 +201,11 @@ func (a *Agent) createAgentDaemonSet(namespace, agentImage string) error {
 		if !kserrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create rook-agent daemon set. %+v", err)
 		}
-		logger.Infof("rook-agent daemonset already exists")
+		logger.Infof("rook-agent daemonset already exists, updating ...")
+		_, err = a.clientset.Extensions().DaemonSets(namespace).Update(ds)
+		if err != nil {
+			return fmt.Errorf("failed to update rook-agent daemon set. %+v", err)
+		}
 	} else {
 		logger.Infof("rook-agent daemonset started")
 	}


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

Description of your changes:
Currently when the rook-operator flexvolume directory is updated the rook-agent has to be manually deleted and the operator restarted again for the rook-agent DaemonSet to be started with the correct flexvolume directory.
This makes a bit more convenient for users when they have used the wrong flexvolume directory path on the first operator start.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
