### PR TITLE
Allow multiple containers in rook pods

### DIFF
--- a/cmd/rook/operator.go
+++ b/cmd/rook/operator.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const containerName = "rook-operator"
+
 var operatorCmd = &cobra.Command{
 	Use:   "operator",
 	Short: "Runs the rook operator tool for storage in a kubernetes cluster",
@@ -66,7 +68,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	}
 
 	// Using the rook-operator image to deploy other rook pods
-	rookImage, err := k8sutil.GetContainerImage(clientset)
+	rookImage, err := k8sutil.GetContainerImage(clientset, containerName)
 	if err != nil {
 		terminateFatal(fmt.Errorf("failed to get container image. %+v\n", err))
 	}

--- a/pkg/operator/agent/agent_test.go
+++ b/pkg/operator/agent/agent_test.go
@@ -117,7 +117,7 @@ func TestGetContainerImage(t *testing.T) {
 	clientset.CoreV1().Pods("Default").Create(&pod)
 
 	// start a basic cluster
-	image, err := k8sutil.GetContainerImage(clientset)
+	image, err := k8sutil.GetContainerImage(clientset, "")
 	assert.Nil(t, err)
 	assert.Equal(t, "rook/test", image)
 }
@@ -152,9 +152,9 @@ func TestGetContainerImageMultipleContainers(t *testing.T) {
 	clientset.CoreV1().Pods("Default").Create(&pod)
 
 	// start a basic cluster
-	_, err := k8sutil.GetContainerImage(clientset)
+	_, err := k8sutil.GetContainerImage(clientset, "foo")
 	assert.NotNil(t, err)
-	assert.Equal(t, "failed to get container image. There should only be exactly one container in this pod", err.Error())
+	assert.Equal(t, "failed to find image for container foo", err.Error())
 }
 
 func TestStartAgentDaemonsetWithToleration(t *testing.T) {

--- a/pkg/operator/cluster/ceph/osd/osd.go
+++ b/pkg/operator/cluster/ceph/osd/osd.go
@@ -506,11 +506,11 @@ func (c *Cluster) discoverStorageNodes() ([]rookalpha.Node, error) {
 			return nil, fmt.Errorf("osd replicaset %s doesn't have a node name on its node selector: %+v", osdReplicaSet.Name, osdPodSpec.NodeSelector)
 		}
 
-		// get the osd container, there should be exactly 1
-		if len(osdPodSpec.Containers) != 1 {
-			return nil, fmt.Errorf("osd pod spec should have exactly 1 container: %+v", osdPodSpec.Containers)
+		// get the osd container
+		osdContainer, err := k8sutil.GetMatchingContainer(osdPodSpec.Containers, appName)
+		if err != nil {
+			return nil, err
 		}
-		osdContainer := osdPodSpec.Containers[0]
 
 		// populate the discovered node with the properties discovered from its running artifacts.
 		// note that we are populating just a subset here, the minimum subset needed to be able

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -93,7 +93,7 @@ func ConfigDirEnvVar() v1.EnvVar {
 	return v1.EnvVar{Name: "ROOK_CONFIG_DIR", Value: DataDir}
 }
 
-func GetContainerImage(clientset kubernetes.Interface) (string, error) {
+func GetContainerImage(clientset kubernetes.Interface, name string) (string, error) {
 
 	podName := os.Getenv(PodNameEnvVar)
 	if podName == "" {
@@ -109,11 +109,33 @@ func GetContainerImage(clientset kubernetes.Interface) (string, error) {
 		return "", err
 	}
 
-	if len(pod.Spec.Containers) != 1 {
-		return "", fmt.Errorf("failed to get container image. There should only be exactly one container in this pod")
+	image, err := GetMatchingContainer(pod.Spec.Containers, name)
+	if err != nil {
+		return "", err
+	}
+	return image.Image, nil
+}
+
+func GetMatchingContainer(containers []v1.Container, name string) (v1.Container, error) {
+	var result *v1.Container
+	if len(containers) == 1 {
+		// if there is only one pod, use its image rather than require a set container name
+		result = &containers[0]
+	} else {
+		// if there are multiple pods, we require the container to have the expected name
+		for _, container := range containers {
+			if container.Name == name {
+				result = &container
+				break
+			}
+		}
 	}
 
-	return pod.Spec.Containers[0].Image, nil
+	if result == nil {
+		return v1.Container{}, fmt.Errorf("failed to find image for container %s", name)
+	}
+
+	return *result, nil
 }
 
 // MakeRookImage formats the container name

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -19,9 +19,37 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
 )
 
 func TestMakeRookImage(t *testing.T) {
 	assert.Equal(t, "rook/rook:v1", MakeRookImage("rook/rook:v1"))
 	assert.Equal(t, defaultVersion, MakeRookImage(""))
+}
+
+func TestGetContainerInPod(t *testing.T) {
+	expectedName := "mycontainer"
+	imageName := "myimage"
+
+	// no container fails
+	container, err := GetMatchingContainer([]v1.Container{}, expectedName)
+	assert.NotNil(t, err)
+
+	// one container will allow any name
+	container, err = GetMatchingContainer([]v1.Container{{Name: "foo", Image: imageName}}, expectedName)
+	assert.Nil(t, err)
+	assert.Equal(t, imageName, container.Image)
+
+	// multiple container fails if we don't find the correct name
+	container, err = GetMatchingContainer(
+		[]v1.Container{{Name: "foo", Image: imageName}, {Name: "bar", Image: imageName}},
+		expectedName)
+	assert.NotNil(t, err)
+
+	// multiple container succeeds if we find the correct name
+	container, err = GetMatchingContainer(
+		[]v1.Container{{Name: "foo", Image: imageName}, {Name: expectedName, Image: imageName}},
+		expectedName)
+	assert.Nil(t, err)
+	assert.Equal(t, imageName, container.Image)
 }


### PR DESCRIPTION
The operator and osd pods need to know information about the container that they are running in such as the version of the image. Rook assumed pods were running with a single image, however this doesn't work with Istio which injects other containers to the pods for monitoring. This will allow multiple containers to be running in the rook pods. Rook does require that the container names are a constant name in order to find them. The operator pod must have a `rook-operator` container and the osd pod must have a `rook-ceph-osd` container.

Resolves #1633, #1638