### PR TITLE
Set default k8s version for minikube to 1.10.0

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -90,7 +90,7 @@ function check_context() {
 }
 
 # configure minikube
-KUBE_VERSION=${KUBE_VERSION:-"v1.9.1"}
+KUBE_VERSION=${KUBE_VERSION:-"v1.10.0"}
 MEMORY=${MEMORY:-"3000"}
 
 case "${1:-}" in


### PR DESCRIPTION
Set the default version of k8s to be launched by the minikube test script to 1.10.0 rather than 1.9. Does not affect the integration tests. A next step will be to enable 1.10 in jenkins tests per #1623

[skip ci]