### PR TITLE
Replace Core() with CoreV1().

### DIFF
--- a/pkg/daemon/agent/flexvolume/attachment/tpr.go
+++ b/pkg/daemon/agent/flexvolume/attachment/tpr.go
@@ -43,7 +43,7 @@ func (t *tpr) Get(namespace, name string) (*rookalpha.VolumeAttachment, error) {
 
 	var result rookalpha.VolumeAttachment
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, namespace, CustomResourceNamePlural)
-	return &result, t.clientset.Core().RESTClient().Get().
+	return &result, t.clientset.CoreV1().RESTClient().Get().
 		RequestURI(uri).
 		Name(name).
 		Do().
@@ -55,7 +55,7 @@ func (t *tpr) List(namespace string) (*rookalpha.VolumeAttachmentList, error) {
 
 	var result rookalpha.VolumeAttachmentList
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, namespace, CustomResourceNamePlural)
-	return &result, t.clientset.Core().RESTClient().Get().
+	return &result, t.clientset.CoreV1().RESTClient().Get().
 		RequestURI(uri).
 		Do().
 		Into(&result)
@@ -67,7 +67,7 @@ func (t *tpr) Create(volumeAttachment *rookalpha.VolumeAttachment) error {
 	volumeAttachment.Kind = tprKind
 	body, _ := json.Marshal(volumeAttachment)
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, volumeAttachment.Namespace, CustomResourceNamePlural)
-	return t.clientset.Core().RESTClient().Post().
+	return t.clientset.CoreV1().RESTClient().Post().
 		RequestURI(uri).
 		Body(body).
 		Do().Error()
@@ -79,7 +79,7 @@ func (t *tpr) Update(volumeAttachment *rookalpha.VolumeAttachment) error {
 	volumeAttachment.Kind = tprKind
 	body, _ := json.Marshal(volumeAttachment)
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, volumeAttachment.Namespace, CustomResourceNamePlural)
-	err := t.clientset.Core().RESTClient().Put().
+	err := t.clientset.CoreV1().RESTClient().Put().
 		RequestURI(uri).
 		Name(volumeAttachment.Name).
 		Body(body).
@@ -95,7 +95,7 @@ func (t *tpr) Update(volumeAttachment *rookalpha.VolumeAttachment) error {
 // Delete deletes the volume attach TPR resource in Kubernetes
 func (t *tpr) Delete(namespace, name string) error {
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, namespace, CustomResourceNamePlural)
-	return t.clientset.Core().RESTClient().Delete().
+	return t.clientset.CoreV1().RESTClient().Delete().
 		RequestURI(uri).
 		Name(name).
 		Do().

--- a/pkg/daemon/agent/flexvolume/controller.go
+++ b/pkg/daemon/agent/flexvolume/controller.go
@@ -121,7 +121,7 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 
 				logger.Infof("Volume attachment record %s/%s exists for pod: %s/%s", volumeattachObj.Namespace, volumeattachObj.Name, attachment.PodNamespace, attachment.PodName)
 				// Note this could return the reference of the pod who is requesting the attach if this pod have the same name as the pod in the attachment record.
-				pod, err := c.context.Clientset.Core().Pods(attachment.PodNamespace).Get(attachment.PodName, metav1.GetOptions{})
+				pod, err := c.context.Clientset.CoreV1().Pods(attachment.PodNamespace).Get(attachment.PodName, metav1.GetOptions{})
 				if err != nil || (attachment.PodNamespace == attachOpts.PodNamespace && attachment.PodName == attachOpts.Pod) {
 					if err != nil && !errors.IsNotFound(err) {
 						return fmt.Errorf("failed to get pod CRD %s/%s. %+v", attachment.PodNamespace, attachment.PodName, err)
@@ -289,7 +289,7 @@ func (c *Controller) GetAttachInfoFromMountDir(mountDir string, attachOptions *A
 		opts := metav1.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector("spec.nodeName", node).String(),
 		}
-		pods, err := c.context.Clientset.Core().Pods(attachOptions.PodNamespace).List(opts)
+		pods, err := c.context.Clientset.CoreV1().Pods(attachOptions.PodNamespace).List(opts)
 		if err != nil {
 			return fmt.Errorf("failed to get pods in namespace %s: %+v", attachOptions.PodNamespace, err)
 		}
@@ -345,7 +345,7 @@ func (c *Controller) GetClientAccessInfo(clusterName string, clientAccessInfo *C
 // GetKernelVersion returns the kernel version of the current node.
 func (c *Controller) GetKernelVersion(_ *struct{} /* no inputs */, kernelVersion *string) error {
 	nodeName := os.Getenv(k8sutil.NodeNameEnvVar)
-	node, err := c.context.Clientset.Core().Nodes().Get(nodeName, metav1.GetOptions{})
+	node, err := c.context.Clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get kernel version from node information for node %s: %+v", nodeName, err)
 	}
@@ -362,7 +362,7 @@ func (c *Controller) getKubeletRootDir() string {
 	}
 
 	// determining where the path of the kubelet root dir and flexvolume dir on the node
-	nodeConfig, err := c.context.Clientset.Core().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
+	nodeConfig, err := c.context.Clientset.CoreV1().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
 	if err != nil {
 		logger.Warningf("unable to query node configuration: %v", err)
 		return kubeletDefaultRootDir

--- a/pkg/operator/agent/agent.go
+++ b/pkg/operator/agent/agent.go
@@ -223,7 +223,7 @@ func (a *Agent) discoverFlexvolumeDir() (flexvolumeDirPath, source string) {
 		logger.Warningf(err.Error())
 		return getDefaultFlexvolumeDir()
 	}
-	nodeConfig, err := a.clientset.Core().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
+	nodeConfig, err := a.clientset.CoreV1().RESTClient().Get().RequestURI(nodeConfigURI).DoRaw()
 	if err != nil {
 		logger.Warningf("unable to query node configuration: %v", err)
 		return getDefaultFlexvolumeDir()

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -104,7 +104,7 @@ func GetContainerImage(clientset kubernetes.Interface) (string, error) {
 		return "", fmt.Errorf("cannot detect the pod namespace. Please provide it using the downward API in the manifest file")
 	}
 
-	pod, err := clientset.Core().Pods(podNamespace).Get(podName, metav1.GetOptions{})
+	pod, err := clientset.CoreV1().Pods(podNamespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/operator/provisioner/controller/controller_test.go
+++ b/pkg/operator/provisioner/controller/controller_test.go
@@ -202,7 +202,7 @@ func TestController(t *testing.T) {
 		time.Sleep(2 * resyncPeriod)
 		ctrl.runningOperations.Wait()
 
-		pvList, _ := client.Core().PersistentVolumes().List(metav1.ListOptions{})
+		pvList, _ := client.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
 		if !reflect.DeepEqual(test.expectedVolumes, pvList.Items) {
 			t.Logf("test case: %s", test.name)
 			t.Errorf("expected PVs:\n %v\n but got:\n %v\n", test.expectedVolumes, pvList.Items)

--- a/pkg/operator/provisioner/controller/leaderelection/resourcelock/provisionpvclock.go
+++ b/pkg/operator/provisioner/controller/leaderelection/resourcelock/provisionpvclock.go
@@ -40,7 +40,7 @@ type ProvisionPVCLock struct {
 func (pl *ProvisionPVCLock) Get() (*LeaderElectionRecord, error) {
 	var record LeaderElectionRecord
 	var err error
-	pl.p, err = pl.Client.Core().PersistentVolumeClaims(pl.PVCMeta.Namespace).Get(pl.PVCMeta.Name, metav1.GetOptions{})
+	pl.p, err = pl.Client.CoreV1().PersistentVolumeClaims(pl.PVCMeta.Namespace).Get(pl.PVCMeta.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (pl *ProvisionPVCLock) Update(ler LeaderElectionRecord) error {
 		return err
 	}
 	pl.p.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
-	pl.p, err = pl.Client.Core().PersistentVolumeClaims(pl.PVCMeta.Namespace).Update(pl.p)
+	pl.p, err = pl.Client.CoreV1().PersistentVolumeClaims(pl.PVCMeta.Namespace).Update(pl.p)
 	return err
 }
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -548,7 +548,7 @@ func (k8sh *K8sHelper) waitForVolumeAttachment(namespace, volumeAttachmentName s
 func (k8sh *K8sHelper) isVolumeAttachmentExist(namespace, name string) (bool, error) {
 	var result rookalpha.VolumeAttachment
 	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, namespace, attachment.CustomResourceNamePlural)
-	err := k8sh.Clientset.Core().RESTClient().Get().
+	err := k8sh.Clientset.CoreV1().RESTClient().Get().
 		RequestURI(uri).
 		Name(name).
 		Do().

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -106,13 +106,13 @@ func (suite *SmokeSuite) TestOperatorGetFlexvolumePath() {
 	// get the operator pod
 	sysNamespace := installer.SystemNamespace(suite.namespace)
 	listOpts := metav1.ListOptions{LabelSelector: "app=rook-operator"}
-	podList, err := suite.k8sh.Clientset.Core().Pods(sysNamespace).List(listOpts)
+	podList, err := suite.k8sh.Clientset.CoreV1().Pods(sysNamespace).List(listOpts)
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), 1, len(podList.Items))
 
 	// get the raw log for the operator pod
 	opPodName := podList.Items[0].Name
-	rawLog, err := suite.k8sh.Clientset.Core().Pods(sysNamespace).GetLogs(opPodName, &v1.PodLogOptions{}).Do().Raw()
+	rawLog, err := suite.k8sh.Clientset.CoreV1().Pods(sysNamespace).GetLogs(opPodName, &v1.PodLogOptions{}).Do().Raw()
 	require.Nil(suite.T(), err)
 
 	r := regexp.MustCompile(`discovered flexvolume dir path from source.*\n`)


### PR DESCRIPTION
Signed off by: Tony Allen tony@allen.gg

**Description of your changes:**
This patch replaces all of the Go Client invocations of "Core()" with "CoreV1()".

**Which issue is resolved by this Pull Request:**
Resolves #1381 
