### PR TITLE
Added Pod Securoty Policy (PSP) resources to helm chart

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -92,6 +92,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `image.tag`        | Image tag                            | `master`             |
 | `image.pullPolicy` | Image pull policy                    | `IfNotPresent`       |
 | `rbacEnable`       | If true, create & use RBAC resources | `true`               |
+| `pspEnable`        | If true, create & use PSP resources  | `true`               |
 | `resources`        | Pod resource requests & limits       | `{}`                 |
 | `logLevel`         | Global log level        | `INFO`                 |
 | `agent.flexVolumeDirPath` | Path where the Rook agent discovers the flex volume plugins | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
@@ -134,4 +135,5 @@ resources:
     memory: 128Mi
 
 rbacEnable: true
+pspEnable: true
 ```

--- a/cluster/charts/rook/templates/clusterrole.yaml
+++ b/cluster/charts/rook/templates/clusterrole.yaml
@@ -95,4 +95,14 @@ rules:
   - "*"
   verbs:
   - "*"
+{{- if .Values.pspEnable }}
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - 00-rook-operator
+  verbs:
+  - use
+{{- end }}
 {{- end }}

--- a/cluster/charts/rook/templates/psp.yaml
+++ b/cluster/charts/rook/templates/psp.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.pspEnable }}
+# PSP for rook-operator
+# name starts with 00- helps in policy order to keep it at the top - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#policy-order
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: 00-rook-operator
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim
+{{- end }}

--- a/cluster/charts/rook/templates/psp.yaml
+++ b/cluster/charts/rook/templates/psp.yaml
@@ -6,7 +6,6 @@ kind: PodSecurityPolicy
 metadata:
   name: 00-rook-operator
 spec:
-  allowPrivilegeEscalation: false
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: true

--- a/cluster/charts/rook/values.yaml.tmpl
+++ b/cluster/charts/rook/values.yaml.tmpl
@@ -32,6 +32,10 @@ logLevel: INFO
 ##
 rbacEnable: true
 
+## If true, create & use PSP resources
+##
+pspEnable: true
+
 ## Rook Agent configuration
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute
 ## tolerationKey: Set this to the specific key of the taint to tolerate


### PR DESCRIPTION
This helps to run the rook in kubernetes clusters where `psp` admission controller is enabled.