### PR TITLE
Native build support on AArch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ build: build.common
 	@$(MAKE) go.build
 # if building on non-linux platforms, also build the linux container
 ifneq ($(GOOS),linux)
-	@$(MAKE) go.build PLATFORM=linux_amd64
+	@$(MAKE) go.build PLATFORM=linux_$(GOHOSTARCH)
 endif
-	@$(MAKE) -C images PLATFORM=linux_amd64
+	@$(MAKE) -C images PLATFORM=linux_$(GOHOSTARCH)
 
 build.all: build.common
 	@$(MAKE) do.build.parallel

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -172,9 +172,15 @@ go.vendor: $(DEP)
 
 $(DEP):
 	@echo === installing dep
-	@mkdir -p $(TOOLS_HOST_DIR)
-	@curl -sL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(GOHOSTOS)-$(GOHOSTARCH)
+	@mkdir -p $(TOOLS_HOST_DIR)/tmp
+	@if [ "$(GOHOSTARCH)" = "arm64" ]; then\
+		GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get -u github.com/golang/dep/cmd/dep;\
+		mv $(TOOLS_HOST_DIR)/dep $@;\
+	else \
+		curl -sL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(GOHOSTOS)-$(GOHOSTARCH);\
+	fi
 	@chmod +x $(DEP)
+	@rm -fr $(TOOLS_HOST_DIR)/tmp
 
 $(GOLINT):
 	@echo === installing golint

--- a/images/image.mk
+++ b/images/image.mk
@@ -21,10 +21,6 @@ override GOOS=linux
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../build/makelib/common.mk
 
-ifneq ($(GOHOSTARCH),amd64)
-$(error image build only supported on amd64 host currently)
-endif
-
 # the registry used for cached images
 CACHE_REGISTRY := cache
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:

This PR is used to support native build of the rook binaries and container images on arm64 system. After this PR is applied, we can build all the binaries and images for arm64 with `make -j4` command.

Which issue is resolved by this Pull Request:
Resolves #1643 

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
