### PR TITLE
Add standard Prometheus annotations to mgr deployment

### DIFF
--- a/Documentation/monitoring.md
+++ b/Documentation/monitoring.md
@@ -5,9 +5,13 @@ weight: 40
 
 # Monitoring
 
-Each Rook cluster has some built in metrics collectors/exporters for monitoring with [Prometheus](https://prometheus.io/).  To enable monitoring of Rook in your Kubernetes cluster, you can follow the steps below.
+Each Rook cluster has some built in metrics collectors/exporters for monitoring with [Prometheus](https://prometheus.io/).
+If you do not have Prometheus running, follow the steps below to enable monitoring of Rook. If your cluster already
+contains a Prometheus instance, it will automatically discover Rooks scrape endpoint using the standard
+`prometheus.io/scrape` and `prometheus.io/port` annotations.
 
 Note that these steps work only for Kubernetes 1.7.x or higher. For Kubernetes 1.6.x or older, refer to the Rook 0.5.0 [documentation](https://github.com/rook/rook/blob/release-0.5/Documentation/monitoring.md) and use these [manifest files](https://github.com/rook/rook/tree/release-0.5/cluster/examples/kubernetes/monitoring).
+
 
 ## Prometheus Operator
 

--- a/pkg/operator/cluster/ceph/mgr/mgr_test.go
+++ b/pkg/operator/cluster/ceph/mgr/mgr_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha1"
@@ -90,6 +91,10 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, appName, d.Spec.Template.ObjectMeta.Labels["app"])
 	assert.Equal(t, c.Namespace, d.Spec.Template.ObjectMeta.Labels["rook_cluster"])
 	assert.Equal(t, 0, len(d.ObjectMeta.Annotations))
+
+	assert.Equal(t, 2, len(d.Spec.Template.ObjectMeta.Annotations))
+	assert.Equal(t, "true", d.Spec.Template.ObjectMeta.Annotations["prometheus.io/scrape"])
+	assert.Equal(t, strconv.Itoa(metricsPort), d.Spec.Template.ObjectMeta.Annotations["prometheus.io/port"])
 
 	cont := d.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)


### PR DESCRIPTION
Description of your changes:

This allows users to scrape their ceph-mgr deployment without being
forced to use the Prometheus operator

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
