### PR TITLE
Disable the 'cross' build on AArch64

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,7 +34,19 @@ You can also run the build for all supported platforms:
 make -j4 build.all
 ```
 
-See instructions below for setting up the build environment to support `arm` and `arm64` platforms.
+Currently, only `amd64` platform supports this kind of 'cross' build. In order to make `build.all` succeed, we need to follow the steps specified by the below section
+`Building for other platforms` first.
+
+We suggest to use native `build` to create the binaries and container images on `arm{32,64}` platform, but if you do want to build those `arm{32,64}` binaries and images
+on `amd64` platform with `build.all` command, please make sure the multi-arch feature is supported. To test run the following:
+
+```
+> docker run --rm -ti arm32v7/ubuntu uname -a
+Linux bad621a75757 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 armv7l armv7l armv7l GNU/Linux
+
+> docker run --rm -ti arm64v8/ubuntu uname -a
+Linux f51ea93e76a2 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
+```
 
 Run `make help` for more options.
 
@@ -97,18 +109,6 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable update-binfmt.service
-```
-
-### Checking if multi-arch is supported
-
-To test run the following:
-
-```
-> docker run --rm -ti arm32v7/ubuntu uname -a
-Linux bad621a75757 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 armv7l armv7l armv7l GNU/Linux
-
-> docker run --rm -ti arm64v8/ubuntu uname -a
-Linux f51ea93e76a2 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
 ```
 
 # Improving Build Speed

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ endif
 	@$(MAKE) -C images PLATFORM=linux_$(GOHOSTARCH)
 
 build.all: build.common
+ifneq ($(GOHOSTARCH),amd64)
+	$(error cross platform image build only supported on amd64 host currently)
+endif
 	@$(MAKE) do.build.parallel
 	@$(MAKE) -C images build.all
 

--- a/build/run
+++ b/build/run
@@ -25,6 +25,10 @@ if [ ! -z $DOCKER_HOST ]; then
 fi
 
 # build the the container if we've not done so already
+if [ "`uname -m`" != "x86_64" ]; then
+    echo ERROR: we only support the cross container build on amd64 host.
+    exit 1
+fi
 echo ==== building the cross container \(this could take minutes the first time\)
 make_cmd="make --no-print-directory -C ${scriptdir}/../images cross PULL=0"
 make_output=$($make_cmd 2>&1) || {


### PR DESCRIPTION
AArch64 platform doesn't support the `build.all` command due to the issue of `hypriot/qemu-register` on arm64 system, so we disable this kind of 'cross' build on AArch64 platform.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [* ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
