### PR TITLE
Run ceph osd in its own pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /_output
 /vendor/
 /vendor.orig/
+
+/tests/integration/rook-test/

--- a/Documentation/teardown.md
+++ b/Documentation/teardown.md
@@ -44,8 +44,6 @@ This will begin the process of all cluster resources being cleaned up, after whi
 ```console
 kubectl delete -n rook-ceph-system daemonset rook-ceph-agent
 kubectl delete -f operator.yaml
-kubectl delete clusterroles rook-ceph-agent
-kubectl delete clusterrolebindings rook-ceph-agent
 ```
 
 Optionally remove the rook-ceph namespace if it is not in use by any other resources.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,8 @@ def RunIntegrationTest(k, v) {
             }
             finally{
                 archive '_output/tests/*.log'
+                sh 'sudo rm -rf ${PWD}/rook-test'
+                sh 'sudo ls -l ${PWD}'
                 deleteDir()
             }
         }

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -18,6 +18,7 @@
 - The [Ceph dashboard](Documentation/ceph-dashboard.md) can be enabled by the cluster CRD.
 - `monCount` has been renamed to `count`, which has been moved into the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings). Additionally the default if unspecified or `0`, is now `3`.
 - You can now toggle if multiple Ceph mons might be placed on one node with the `allowMultiplePerNode` option (default `false`) in the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings).
+- One OSD will run per pod to increase the reliability and maintainability of the OSDs. No longer will restarting an OSD pod mean that all OSDs on that node will go down. See the [design doc](design/dedicated-osd-pod.md).
 
 ## Breaking Changes
 
@@ -32,6 +33,7 @@
 - Ceph container images now use CentOS 7 as a base
 - Minimal privileges are configured with a new cluster role for the operator and Ceph daemons, following the new [security design](design/security-model.md).
   - A role binding must be defined for each cluster to be managed by the operator.
+- OSD pods are started by a deployment, instead of a daemonset or a replicaset. The new OSD pods will crash loop until the old daemonset or replicasets are removed.
 
 ### Removal of the API service and rookctl tool
 

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -82,6 +82,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete  
+- apiGroups:
   - ceph.rook.io
   resources:
   - "*"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -201,6 +201,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete   
+- apiGroups:
   - ceph.rook.io
   resources:
   - "*"

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -175,7 +175,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 			Status:  oposd.OrchestrationStatusFailed,
 			Message: err.Error(),
 		}
-		oposd.UpdateOrchestrationStatusMap(clientset, clusterInfo.Name, cfg.nodeName, status)
+		oposd.UpdateNodeStatus(kv, cfg.nodeName, status)
 
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -104,8 +104,8 @@ func runFilestoreDeviceOSD(cmd *cobra.Command, args []string) error {
 	}
 
 	args = append(args, []string{
-		fmt.Sprintf("--public-addr=%s", cfg.networkInfo.PublicAddrIPv4),
-		fmt.Sprintf("--cluster-addr=%s", cfg.networkInfo.ClusterAddrIPv4),
+		fmt.Sprintf("--public-addr=%s", cfg.NetworkInfo().PublicAddr),
+		fmt.Sprintf("--cluster-addr=%s", cfg.NetworkInfo().ClusterAddr),
 	}...)
 
 	commonOSDInit(filestoreDeviceCmd)

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -18,9 +18,7 @@ package ceph
 import (
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -36,46 +34,97 @@ import (
 
 var osdCmd = &cobra.Command{
 	Use:    "osd",
-	Short:  "Generates osd config and runs the osd daemon",
+	Short:  "Provisions and runs the osd daemon",
+	Hidden: true,
+}
+var provisionCmd = &cobra.Command{
+	Use:    "provision",
+	Short:  "Generates osd config and prepares an osd for runtime",
+	Hidden: true,
+}
+var filestoreDeviceCmd = &cobra.Command{
+	Use:    "filestore-device",
+	Short:  "Runs the ceph daemon for a filestore device",
 	Hidden: true,
 }
 var (
 	osdDataDeviceFilter string
 	ownerRefID          string
 	prepareOnly         bool
+	mountSourcePath     string
+	mountPath           string
 )
 
 func addOSDFlags(command *cobra.Command) {
-	command.Flags().StringVar(&cfg.devices, "data-devices", "", "comma separated list of devices to use for storage")
-	command.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CRD that owns this cluster")
-	command.Flags().StringVar(&osdDataDeviceFilter, "data-device-filter", "", "a regex filter for the device names to use, or \"all\"")
-	command.Flags().StringVar(&cfg.directories, "data-directories", "", "comma separated list of directory paths to use for storage")
-	command.Flags().StringVar(&cfg.metadataDevice, "metadata-device", "", "device to use for metadata (e.g. a high performance SSD/NVMe device)")
-	command.Flags().StringVar(&cfg.location, "location", "", "location of this node for CRUSH placement")
-	command.Flags().BoolVar(&cfg.forceFormat, "force-format", false,
+	provisionCmd.Flags().StringVar(&cfg.devices, "data-devices", "", "comma separated list of devices to use for storage")
+	provisionCmd.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CRD that owns this cluster")
+	provisionCmd.Flags().StringVar(&osdDataDeviceFilter, "data-device-filter", "", "a regex filter for the device names to use, or \"all\"")
+	provisionCmd.Flags().StringVar(&cfg.directories, "data-directories", "", "comma separated list of directory paths to use for storage")
+	provisionCmd.Flags().StringVar(&cfg.metadataDevice, "metadata-device", "", "device to use for metadata (e.g. a high performance SSD/NVMe device)")
+	provisionCmd.Flags().StringVar(&cfg.location, "location", "", "location of this node for CRUSH placement")
+	provisionCmd.Flags().BoolVar(&cfg.forceFormat, "force-format", false,
 		"true to force the format of any specified devices, even if they already have a filesystem.  BE CAREFUL!")
-	command.Flags().StringVar(&cfg.nodeName, "node-name", os.Getenv("HOSTNAME"), "the host name of the node")
+	provisionCmd.Flags().StringVar(&cfg.nodeName, "node-name", os.Getenv("HOSTNAME"), "the host name of the node")
 
 	// OSD store config flags
-	command.Flags().IntVar(&cfg.storeConfig.WalSizeMB, "osd-wal-size", osdcfg.WalDefaultSizeMB, "default size (MB) for OSD write ahead log (WAL) (bluestore)")
-	command.Flags().IntVar(&cfg.storeConfig.DatabaseSizeMB, "osd-database-size", osdcfg.DBDefaultSizeMB, "default size (MB) for OSD database (bluestore)")
-	command.Flags().IntVar(&cfg.storeConfig.JournalSizeMB, "osd-journal-size", osdcfg.JournalDefaultSizeMB, "default size (MB) for OSD journal (filestore)")
-	command.Flags().StringVar(&cfg.storeConfig.StoreType, "osd-store", "", "type of backing OSD store to use (bluestore or filestore)")
+	provisionCmd.Flags().IntVar(&cfg.storeConfig.WalSizeMB, "osd-wal-size", osdcfg.WalDefaultSizeMB, "default size (MB) for OSD write ahead log (WAL) (bluestore)")
+	provisionCmd.Flags().IntVar(&cfg.storeConfig.DatabaseSizeMB, "osd-database-size", osdcfg.DBDefaultSizeMB, "default size (MB) for OSD database (bluestore)")
+	provisionCmd.Flags().IntVar(&cfg.storeConfig.JournalSizeMB, "osd-journal-size", osdcfg.JournalDefaultSizeMB, "default size (MB) for OSD journal (filestore)")
+	provisionCmd.Flags().StringVar(&cfg.storeConfig.StoreType, "osd-store", "", "type of backing OSD store to use (bluestore or filestore)")
 
 	// only prepare devices but not start ceph-osd daemon
-	command.Flags().BoolVar(&prepareOnly, "osd-prepare-only", true, "true to only prepare ceph osd directories or devices but not start ceph-osd daemon")
+	provisionCmd.Flags().BoolVar(&prepareOnly, "osd-prepare-only", true, "true to only prepare ceph osd directories or devices but not start ceph-osd daemon")
+
+	// flags for running filestore on a device
+	filestoreDeviceCmd.Flags().StringVar(&mountSourcePath, "source-path", "", "the source path of the device to mount")
+	filestoreDeviceCmd.Flags().StringVar(&mountPath, "mount-path", "", "the path where the device should be mounted")
+
+	// add the subcommands to the parent osd command
+	osdCmd.AddCommand(provisionCmd)
+	osdCmd.AddCommand(filestoreDeviceCmd)
+
 }
 
 func init() {
 	addOSDFlags(osdCmd)
 	addCephFlags(osdCmd)
 	flags.SetFlagsFromEnv(osdCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetFlagsFromEnv(provisionCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetFlagsFromEnv(filestoreDeviceCmd.Flags(), rook.RookEnvVarPrefix)
 
-	osdCmd.RunE = startOSD
+	provisionCmd.RunE = prepareOSD
+	filestoreDeviceCmd.RunE = runFilestoreDeviceOSD
 }
 
-func startOSD(cmd *cobra.Command, args []string) error {
-	required := []string{"cluster-name", "cluster-id", "mon-endpoints", "mon-secret", "admin-secret", "node-name"}
+// Start the osd daemon for filestore running on a device
+func runFilestoreDeviceOSD(cmd *cobra.Command, args []string) error {
+	required := []string{"source-path", "mount-path"}
+	if err := flags.VerifyRequiredFlags(filestoreDeviceCmd, required); err != nil {
+		return err
+	}
+
+	args = append(args, []string{
+		fmt.Sprintf("--public-addr=%s", cfg.networkInfo.PublicAddrIPv4),
+		fmt.Sprintf("--cluster-addr=%s", cfg.networkInfo.ClusterAddrIPv4),
+	}...)
+
+	commonOSDInit(filestoreDeviceCmd)
+
+	context := createContext()
+	err := osd.RunFilestoreOnDevice(context, mountSourcePath, mountPath, args)
+	if err != nil {
+		rook.TerminateFatal(err)
+	}
+	return nil
+}
+
+// Provision a device or directory for an OSD
+func prepareOSD(cmd *cobra.Command, args []string) error {
+	required := []string{"cluster-id", "node-name"}
+	if err := flags.VerifyRequiredFlags(provisionCmd, required); err != nil {
+		return err
+	}
+	required = []string{"cluster-name", "mon-endpoints", "mon-secret", "admin-secret"}
 	if err := flags.VerifyRequiredFlags(osdCmd, required); err != nil {
 		return err
 	}
@@ -97,10 +146,6 @@ func startOSD(cmd *cobra.Command, args []string) error {
 		dataDevices = cfg.devices
 	}
 
-	rook.SetLogLevel()
-
-	rook.LogStartupInfo(osdCmd.Flags())
-
 	clientset, _, rookClientset, err := rook.GetClientset()
 	if err != nil {
 		rook.TerminateFatal(fmt.Errorf("failed to init k8s client. %+v\n", err))
@@ -109,6 +154,7 @@ func startOSD(cmd *cobra.Command, args []string) error {
 	context := createContext()
 	context.Clientset = clientset
 	context.RookClientset = rookClientset
+	commonOSDInit(provisionCmd)
 
 	locArgs, err := client.FormatLocation(cfg.location, cfg.nodeName)
 	if err != nil {
@@ -117,15 +163,12 @@ func startOSD(cmd *cobra.Command, args []string) error {
 	crushLocation := strings.Join(locArgs, " ")
 
 	forceFormat := false
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 	ownerRef := cluster.ClusterOwnerRef(clusterInfo.Name, ownerRefID)
 	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Name, clientset, ownerRef)
 	agent := osd.NewAgent(context, dataDevices, usingDeviceFilter, cfg.metadataDevice, cfg.directories, forceFormat,
 		crushLocation, cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, prepareOnly)
 
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGTERM)
-	err = osd.Run(context, agent, sigc)
+	err = osd.Provision(context, agent)
 	if err != nil {
 		// something failed in the OSD orchestration, update the status map with failure details
 		status := oposd.OrchestrationStatus{
@@ -138,4 +181,11 @@ func startOSD(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func commonOSDInit(cmd *cobra.Command) {
+	rook.SetLogLevel()
+	rook.LogStartupInfo(cmd.Flags())
+
+	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
 }

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -35,7 +35,7 @@ func GetAvailableDevices(devices []*sys.LocalDisk) []string {
 	var available []string
 	for _, device := range devices {
 		logger.Debugf("Evaluating device %+v", device)
-		if getDeviceEmpty(device) {
+		if GetDeviceEmpty(device) {
 			logger.Debugf("Available device: %s", device.Name)
 			available = append(available, device.Name)
 		}
@@ -45,8 +45,8 @@ func GetAvailableDevices(devices []*sys.LocalDisk) []string {
 }
 
 // check whether a device is completely empty
-func getDeviceEmpty(device *sys.LocalDisk) bool {
-	return device.Parent == "" && (device.Type == sys.DiskType || device.Type == sys.SSDType || device.Type == sys.CryptType) && device.Filesystem == ""
+func GetDeviceEmpty(device *sys.LocalDisk) bool {
+	return device.Parent == "" && (device.Type == sys.DiskType || device.Type == sys.SSDType || device.Type == sys.CryptType || device.Type == sys.LVMType) && len(device.Partitions) == 0 && device.Filesystem == ""
 }
 
 func ignoreDevice(d string) bool {
@@ -120,8 +120,6 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		if val, ok := diskProps["PKNAME"]; ok {
 			disk.Parent = val
 		}
-
-		disk.Empty = getDeviceEmpty(disk)
 
 		// parse udev info output
 		if val, ok := udevInfo["DEVLINKS"]; ok {

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
@@ -58,21 +59,33 @@ type OsdAgent struct {
 	kv                *k8sutil.ConfigMapKVStore
 	configCounter     int32
 	osdsCompleted     chan struct{}
+	prepareOnly       bool
 }
 
 func NewAgent(context *clusterd.Context, devices string, usingDeviceFilter bool, metadataDevice, directories string, forceFormat bool,
-	location string, storeConfig config.StoreConfig, cluster *mon.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore) *OsdAgent {
+	location string, storeConfig config.StoreConfig, cluster *mon.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore, prepareOnly bool) *OsdAgent {
 
-	return &OsdAgent{devices: devices, usingDeviceFilter: usingDeviceFilter, metadataDevice: metadataDevice,
-		directories: directories, forceFormat: forceFormat, location: location, storeConfig: storeConfig,
-		cluster: cluster, nodeName: nodeName, kv: kv,
-		procMan: proc.New(context.Executor), osdProc: make(map[int]*proc.MonitoredProc),
+	return &OsdAgent{
+		devices:           devices,
+		usingDeviceFilter: usingDeviceFilter,
+		metadataDevice:    metadataDevice,
+		directories:       directories,
+		forceFormat:       forceFormat,
+		location:          location,
+		storeConfig:       storeConfig,
+		cluster:           cluster,
+		nodeName:          nodeName,
+		kv:                kv,
+		procMan:           proc.New(context.Executor),
+		osdProc:           make(map[int]*proc.MonitoredProc),
+		prepareOnly:       prepareOnly,
 	}
 }
 
-func (a *OsdAgent) configureDirs(context *clusterd.Context, dirs map[string]int) error {
+func (a *OsdAgent) configureDirs(context *clusterd.Context, dirs map[string]int) ([]oposd.OSDInfo, error) {
+	var osds []oposd.OSDInfo
 	if len(dirs) == 0 {
-		return nil
+		return osds, nil
 	}
 
 	succeeded := 0
@@ -85,7 +98,7 @@ func (a *OsdAgent) configureDirs(context *clusterd.Context, dirs map[string]int)
 			// the osd hasn't been registered with ceph yet, do so now to give it a cluster wide ID
 			osdID, osdUUID, err := registerOSD(context, a.cluster.Name)
 			if err != nil {
-				return err
+				return osds, err
 			}
 
 			dirs[dirPath] = *osdID
@@ -93,17 +106,18 @@ func (a *OsdAgent) configureDirs(context *clusterd.Context, dirs map[string]int)
 			config.uuid = *osdUUID
 		}
 
-		err := a.startOSD(context, config)
+		osd, err := a.startOSD(context, config)
 		if err != nil {
 			logger.Errorf("failed to config osd in path %s. %+v", dirPath, err)
 			lastErr = err
 		} else {
 			succeeded++
+			osds = append(osds, *osd)
 		}
 	}
 
 	logger.Infof("%d/%d osd dirs succeeded on this node", succeeded, len(dirs))
-	return lastErr
+	return osds, lastErr
 }
 
 func (a *OsdAgent) removeDirs(context *clusterd.Context, removedDirs map[string]int) error {
@@ -134,22 +148,23 @@ func (a *OsdAgent) removeDirs(context *clusterd.Context, removedDirs map[string]
 	return nil
 }
 
-func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOsdMapping) error {
+func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOsdMapping) ([]oposd.OSDInfo, error) {
+	var osds []oposd.OSDInfo
 	if devices == nil || len(devices.Entries) == 0 {
-		return nil
+		return osds, nil
 	}
 
 	// compute an OSD layout scheme that will optimize performance
 	scheme, err := a.getPartitionPerfScheme(context, devices)
 	logger.Debugf("partition scheme: %+v, err: %+v", scheme, err)
 	if err != nil {
-		return fmt.Errorf("failed to get OSD partition scheme: %+v", err)
+		return osds, fmt.Errorf("failed to get OSD partition scheme: %+v", err)
 	}
 
 	if scheme.Metadata != nil {
 		// partition the dedicated metadata device
 		if err := partitionMetadata(context, scheme.Metadata, a.kv, config.GetConfigStoreName(a.nodeName)); err != nil {
-			return fmt.Errorf("failed to partition metadata %+v: %+v", scheme.Metadata, err)
+			return osds, fmt.Errorf("failed to partition metadata %+v: %+v", scheme.Metadata, err)
 		}
 	}
 
@@ -158,16 +173,17 @@ func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOs
 	for _, entry := range scheme.Entries {
 		config := &osdConfig{id: entry.ID, uuid: entry.OsdUUID, configRoot: context.ConfigDir,
 			partitionScheme: entry, storeConfig: a.storeConfig, kv: a.kv, storeName: config.GetConfigStoreName(a.nodeName)}
-		err := a.startOSD(context, config)
+		osd, err := a.startOSD(context, config)
 		if err != nil {
-			return fmt.Errorf("failed to config osd %d. %+v", entry.ID, err)
+			return osds, fmt.Errorf("failed to config osd %d. %+v", entry.ID, err)
 		} else {
 			succeeded++
+			osds = append(osds, *osd)
 		}
 	}
 
 	logger.Infof("%d/%d osd devices succeeded on this node", succeeded, len(scheme.Entries))
-	return nil
+	return osds, nil
 }
 
 func (a *OsdAgent) removeDevices(context *clusterd.Context, removedDevicesScheme *config.PerfScheme) error {
@@ -370,20 +386,20 @@ func refreshDeviceInfo(name string, nameToUUID map[string]string, scheme *config
 	}
 }
 
-func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) error {
+func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) (*oposd.OSDInfo, error) {
 
 	cfg.rootPath = getOSDRootDir(cfg.configRoot, cfg.id)
 
 	// if the osd is using filestore on a device and it's previously been formatted/partitioned,
 	// go ahead and remount the device now.
 	if err := remountFilestoreDeviceIfNeeded(context, cfg); err != nil {
-		return err
+		return nil, err
 	}
 
 	// prepare the osd root dir, which will tell us if it's a new osd
 	newOSD, err := prepareOSDRoot(cfg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if newOSD {
@@ -391,7 +407,7 @@ func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) error {
 			// format and partition the device if needed
 			savedScheme, err := config.LoadScheme(a.kv, config.GetConfigStoreName(a.nodeName))
 			if err != nil {
-				return fmt.Errorf("failed to load the saved partition scheme from %s: %+v", cfg.configRoot, err)
+				return nil, fmt.Errorf("failed to load the saved partition scheme from %s: %+v", cfg.configRoot, err)
 			}
 
 			skipFormat := false
@@ -406,7 +422,7 @@ func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) error {
 			if !skipFormat {
 				err = formatDevice(context, cfg, a.forceFormat, a.storeConfig)
 				if err != nil {
-					return fmt.Errorf("failed format/partition of osd %d. %+v", cfg.id, err)
+					return nil, fmt.Errorf("failed format/partition of osd %d. %+v", cfg.id, err)
 				}
 
 				logger.Notice("waiting after partition/format...")
@@ -415,13 +431,13 @@ func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) error {
 		}
 
 		// osd_data_dir/ready does not exist yet, create/initialize the OSD
-		err := initializeOSD(cfg, context, a.cluster, a.location)
+		err := initializeOSD(cfg, context, a.cluster, a.location, a.prepareOnly)
 		if err != nil {
-			return fmt.Errorf("failed to initialize OSD at %s: %+v", cfg.rootPath, err)
+			return nil, fmt.Errorf("failed to initialize OSD at %s: %+v", cfg.rootPath, err)
 		}
 	} else {
 		// update the osd config file
-		err := writeConfigFile(cfg, context, a.cluster, a.location)
+		err := writeConfigFile(cfg, context, a.cluster, a.location, a.prepareOnly)
 		if err != nil {
 			logger.Warningf("failed to update config file. %+v", err)
 		}
@@ -430,17 +446,21 @@ func (a *OsdAgent) startOSD(context *clusterd.Context, cfg *osdConfig) error {
 		// look up some basic information about it so we can run it.
 		err = loadOSDInfo(cfg)
 		if err != nil {
-			return fmt.Errorf("failed to get OSD information from %s: %+v", cfg.rootPath, err)
+			return nil, fmt.Errorf("failed to get OSD information from %s: %+v", cfg.rootPath, err)
 		}
 	}
-
+	osdInfo := getOSDInfo(a.cluster.Name, cfg)
+	if a.prepareOnly {
+		logger.Infof("done with preparing osd %v", osdInfo)
+		return osdInfo, nil
+	}
 	// run the OSD in a child process now that it is fully initialized and ready to go
-	err = a.runOSD(context, a.cluster.Name, cfg)
+	err = a.runOSD(osdInfo)
 	if err != nil {
-		return fmt.Errorf("failed to run osd %d: %+v", cfg.id, err)
+		return osdInfo, fmt.Errorf("failed to run osd %d: %+v", cfg.id, err)
 	}
 
-	return nil
+	return osdInfo, nil
 }
 
 func prepareOSDRoot(cfg *osdConfig) (newOSD bool, err error) {
@@ -464,41 +484,57 @@ func prepareOSDRoot(cfg *osdConfig) (newOSD bool, err error) {
 	return newOSD, nil
 }
 
-// runs an OSD with the given config in a child process
-func (a *OsdAgent) runOSD(context *clusterd.Context, clusterName string, config *osdConfig) error {
-	// start the OSD daemon in the foreground with the given config
-	logger.Infof("starting osd %d at %s", config.id, config.rootPath)
-
+func getOSDInfo(clusterName string, config *osdConfig) *oposd.OSDInfo {
 	confFile := getOSDConfFilePath(config.rootPath, clusterName)
 	util.WriteFileToLog(logger, confFile)
-
-	osdUUIDArg := fmt.Sprintf("--osd-uuid=%s", config.uuid.String())
-	params := []string{"--foreground",
-		fmt.Sprintf("--id=%d", config.id),
-		fmt.Sprintf("--cluster=%s", clusterName),
-		fmt.Sprintf("--osd-data=%s", config.rootPath),
-		fmt.Sprintf("--conf=%s", confFile),
-		fmt.Sprintf("--keyring=%s", getOSDKeyringPath(config.rootPath)),
-		osdUUIDArg,
+	osd := &oposd.OSDInfo{
+		ID:          config.id,
+		DataPath:    config.rootPath,
+		Config:      confFile,
+		Cluster:     clusterName,
+		KeyringPath: getOSDKeyringPath(config.rootPath),
+		UUID:        config.uuid.String(),
+		IsFileStore: isFilestore(config),
 	}
 
 	if isFilestore(config) {
-		params = append(params, fmt.Sprintf("--osd-journal=%s", getOSDJournalPath(config.rootPath)))
+		osd.Journal = getOSDJournalPath(config.rootPath)
+	}
+	return osd
+}
+
+// runs an OSD with the given config in a child process
+func (a *OsdAgent) runOSD(osdInfo *oposd.OSDInfo) error {
+	// start the OSD daemon in the foreground with the given config
+	logger.Infof("starting osd %s at %s", osdInfo.ID, osdInfo.DataPath)
+
+	osdUUIDArg := fmt.Sprintf("--osd-uuid=%s", osdInfo.UUID)
+	params := []string{"--foreground",
+		fmt.Sprintf("--id=%d", osdInfo.ID),
+		fmt.Sprintf("--cluster=%s", osdInfo.Cluster),
+		fmt.Sprintf("--osd-data=%s", osdInfo.DataPath),
+		fmt.Sprintf("--conf=%s", osdInfo.Config),
+		fmt.Sprintf("--keyring=%s", osdInfo.KeyringPath),
+		osdUUIDArg,
+	}
+
+	if osdInfo.IsFileStore {
+		params = append(params, fmt.Sprintf("--osd-journal=%s", osdInfo.Journal))
 	}
 
 	process, err := a.procMan.Start(
-		fmt.Sprintf("osd%d", config.id),
+		fmt.Sprintf("osd%d", osdInfo.ID),
 		"ceph-osd",
 		regexp.QuoteMeta(osdUUIDArg),
 		proc.ReuseExisting,
 		params...)
 	if err != nil {
-		return fmt.Errorf("failed to start osd %d: %+v", config.id, err)
+		return fmt.Errorf("failed to start osd %d: %+v", osdInfo.ID, err)
 	}
 
 	if process != nil {
 		// if the process was already running Start will return nil in which case we don't want to overwrite it
-		a.osdProc[config.id] = process
+		a.osdProc[osdInfo.ID] = process
 	}
 
 	return nil

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -495,6 +495,7 @@ func getOSDInfo(clusterName string, config *osdConfig) *oposd.OSDInfo {
 		KeyringPath: getOSDKeyringPath(config.rootPath),
 		UUID:        config.uuid.String(),
 		IsFileStore: isFilestore(config),
+		IsDirectory: config.dir,
 	}
 
 	if isFilestore(config) {

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -226,7 +226,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig)
 		"sdx": {Data: -1},
 		"sdy": {Data: -1},
 	}}
-	err = agent.configureDevices(context, devices)
+	_, err = agent.configureDevices(context, devices)
 	assert.Nil(t, err)
 
 	assert.Equal(t, int32(0), agent.configCounter)
@@ -293,7 +293,7 @@ func TestOSDAgentNoDevices(t *testing.T) {
 		filepath.Join(configDir, "sdx"): -1,
 		filepath.Join(configDir, "sdy"): -1,
 	}
-	err = agent.configureDirs(context, dirs)
+	_, err = agent.configureDirs(context, dirs)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, runCount)
 	assert.Equal(t, 2, startCount)
@@ -353,7 +353,7 @@ func createTestAgent(t *testing.T, devices, configDir, nodeName string, storeCon
 	cluster := &mon.ClusterInfo{Name: "myclust"}
 	context := &clusterd.Context{ConfigDir: configDir, Executor: executor, Clientset: testop.New(1)}
 	agent := NewAgent(context, devices, false, "", "", forceFormat, location, *storeConfig,
-		cluster, nodeName, mockKVStore())
+		cluster, nodeName, mockKVStore(), false /* prepareOnly */)
 
 	return agent, executor, context
 }

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -101,8 +101,6 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig)
 		cmd := &exec.Cmd{Args: append([]string{command}, args...)}
 
 		switch {
-		case startCount < 2:
-			assert.Equal(t, "ceph-osd", command)
 		default:
 			assert.Fail(t, fmt.Sprintf("unexpected case %d", startCount))
 		}
@@ -153,28 +151,32 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig)
 				// the osd mkfs for sdx
 				assert.Equal(t, "--mkfs", args[0])
 				createTestKeyring(t, configDir, args)
-			case execCount == 2: // all remaining execs are for partitioning sdy then mkfs sdy
+			case execCount == 2:
+				assert.Equal(t, "umount", command)
+			case execCount == 3: // all remaining execs are for partitioning sdy then mkfs sdy
 				assert.Equal(t, "sgdisk", command)
 				assert.Equal(t, "--zap-all", args[0])
 				assert.Equal(t, "/dev/"+nameSuffix, args[1])
-			case execCount == 3:
+			case execCount == 4:
 				assert.Equal(t, "sgdisk", command)
 				assert.Equal(t, "--clear", args[0])
 				assert.Equal(t, "/dev/"+nameSuffix, args[2])
-			case execCount == 4:
+			case execCount == 5:
 				// the partitioning for sdy.
 				assert.Equal(t, "sgdisk", command)
 				assert.Equal(t, "/dev/"+nameSuffix, args[4])
-			case execCount == 5:
+			case execCount == 6:
 				// mkfs.ext4 for sdy filestore
 				assert.Equal(t, "mkfs.ext4", command)
-			case execCount == 6:
+			case execCount == 7:
 				// the mount for sdy filestore
 				assert.Equal(t, "mount", command)
-			case execCount == 7:
+			case execCount == 8:
 				// the osd mkfs for sdy filestore
 				assert.Equal(t, "--mkfs", args[0])
 				createTestKeyring(t, configDir, args)
+			case execCount == 9:
+				assert.Equal(t, "umount", command)
 			default:
 				assert.Fail(t, fmt.Sprintf("unexpected case %d", execCount))
 			}
@@ -230,15 +232,14 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig)
 	assert.Nil(t, err)
 
 	assert.Equal(t, int32(0), agent.configCounter)
-	assert.Equal(t, 2, startCount) // 2 OSD procs should be started
-	assert.Equal(t, 2, len(agent.osdProc), fmt.Sprintf("procs=%+v", agent.osdProc))
+	assert.Equal(t, 0, startCount) // 2 OSD procs should be started
 
 	if storeConfig.StoreType == config.Bluestore {
 		assert.Equal(t, 11, outputExecCount) // Bluestore has 2 extra output exec calls to get device properties of each device to determine CRUSH weight
 		assert.Equal(t, 5, execCount)        // 1 osd mkfs for sdx, 3 partition steps for sdy, 1 osd mkfs for sdy
 	} else {
 		assert.Equal(t, 9, outputExecCount)
-		assert.Equal(t, 8, execCount) // 1 for remount sdx, 1 osd mkfs for sdx, 3 partition steps for sdy, 1 mkfs for sdy, 1 mount for sdy, 1 osd mkfs for sdy
+		assert.Equal(t, 10, execCount) // 1 for remount sdx, 1 osd mkfs for sdx, 3 partition steps for sdy, 1 mkfs for sdy, 1 mount for sdy, 1 osd mkfs for sdy
 	}
 }
 
@@ -296,10 +297,9 @@ func TestOSDAgentNoDevices(t *testing.T) {
 	_, err = agent.configureDirs(context, dirs)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, runCount)
-	assert.Equal(t, 2, startCount)
+	assert.Equal(t, 0, startCount)
 	assert.Equal(t, 6, execWithOutputFileCount)
 	assert.Equal(t, 2, execWithOutputCount)
-	assert.Equal(t, 1, len(agent.osdProc))
 }
 
 func TestRemoveDevices(t *testing.T) {

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -60,7 +60,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
-	if err := oposd.UpdateOrchestrationStatusMap(context.Clientset, agent.cluster.Name, agent.nodeName, status); err != nil {
+	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
 		return err
 	}
 
@@ -115,7 +115,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 
 	// orchestration is about to start, update the status
 	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating}
-	if err := oposd.UpdateOrchestrationStatusMap(context.Clientset, agent.cluster.Name, agent.nodeName, status); err != nil {
+	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
 		return err
 	}
 
@@ -174,7 +174,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 
 	// orchestration is completed, update the status
 	status = oposd.OrchestrationStatus{OSDs: osds, Status: oposd.OrchestrationStatusCompleted}
-	if err := oposd.UpdateOrchestrationStatusMap(context.Clientset, agent.cluster.Name, agent.nodeName, status); err != nil {
+	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -19,9 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -71,13 +69,8 @@ func TestRunDaemon(t *testing.T) {
 
 	agent, _, context := createTestAgent(t, "none", configDir, "node5375", &config.StoreConfig{StoreType: config.Bluestore})
 	agent.usingDeviceFilter = true
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGTERM)
-	go func() {
-		sigc <- syscall.SIGTERM
-	}()
 
-	err := Run(context, agent, sigc)
+	err := Provision(context, agent)
 	assert.Nil(t, err)
 }
 

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -69,13 +71,13 @@ func TestRunDaemon(t *testing.T) {
 
 	agent, _, context := createTestAgent(t, "none", configDir, "node5375", &config.StoreConfig{StoreType: config.Bluestore})
 	agent.usingDeviceFilter = true
-
-	done := make(chan struct{})
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, syscall.SIGTERM)
 	go func() {
-		done <- struct{}{}
+		sigc <- syscall.SIGTERM
 	}()
 
-	err := Run(context, agent, done)
+	err := Run(context, agent, sigc)
 	assert.Nil(t, err)
 }
 

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -600,32 +600,6 @@ func addOSDToCrushMap(context *clusterd.Context, config *osdConfig, clusterName,
 	return nil
 }
 
-func markOSDOut(context *clusterd.Context, clusterName string, id int) error {
-	_, err := client.OSDOut(context, clusterName, id)
-	return err
-}
-
-func purgeOSD(context *clusterd.Context, clusterName string, id int) error {
-	// remove the OSD from the crush map
-	_, err := client.CrushRemove(context, clusterName, fmt.Sprintf("osd.%d", id))
-	if err != nil {
-		return fmt.Errorf("failed to remove osd.%d from crush map. %v", id, err)
-	}
-
-	// delete the auth for the OSD
-	err = client.AuthDelete(context, clusterName, fmt.Sprintf("osd.%d", id))
-	if err != nil {
-		return err
-	}
-
-	// delete the OSD from the cluster
-	_, err = client.OSDRemove(context, clusterName, id)
-	if err != nil {
-		return fmt.Errorf("failed to rm osd.%d. %v", id, err)
-	}
-	return nil
-}
-
 func getBluestorePartitionPaths(cfg *osdConfig) (string, string, string, error) {
 	if !isBluestoreDevice(cfg) {
 		return "", "", "", fmt.Errorf("must be bluestore device to get bluestore partition paths: %+v", cfg)

--- a/pkg/daemon/ceph/osd/device_test.go
+++ b/pkg/daemon/ceph/osd/device_test.go
@@ -100,29 +100,26 @@ func TestOverwriteRookOwnedPartitions(t *testing.T) {
 		logger.Infof("OUTPUT %d for %s. %s %+v", outputExecCount, name, command, args)
 		var output string
 		switch outputExecCount {
-		case 0, 7: // we'll call this twice, once explicitly below to verify rook owns the partitions and a 2nd time within formatDevice
+		case 0: // we'll call this twice, once explicitly below to verify rook owns the partitions and a 2nd time within formatDevice
 			assert.Equal(t, command, "lsblk")
 			output = `NAME="sda" SIZE="65" TYPE="disk" PKNAME=""
 NAME="sda1" SIZE="30" TYPE="part" PKNAME="sda"
 NAME="sda2" SIZE="10" TYPE="part" PKNAME="sda"
 NAME="sda3" SIZE="20" TYPE="part" PKNAME="sda"`
-		case 1, 8:
-			assert.Equal(t, "udevadm /dev/sda1", name)
+		case 1:
+			assert.Equal(t, "udevadm info sda1", name)
 			output = "ID_PART_ENTRY_NAME=ROOK-OSD0-WAL"
-		case 2, 9:
-			assert.Equal(t, "get filesystem type for sda1", name)
-			output = ""
-		case 3, 10:
-			assert.Equal(t, "udevadm /dev/sda2", name)
+		case 2:
+			assert.Equal(t, "udevadm info sda2", name)
 			output = "ID_PART_ENTRY_NAME=ROOK-OSD0-DB"
-		case 4, 11:
-			assert.Equal(t, "get filesystem type for sda2", name)
-			output = ""
-		case 5, 12:
-			assert.Equal(t, "udevadm /dev/sda3", name)
+		case 3:
+			assert.Equal(t, "udevadm info sda3", name)
 			output = "ID_PART_ENTRY_NAME=ROOK-OSD0-BLOCK"
-		case 6, 13:
-			assert.Equal(t, "get filesystem type for sda3", name)
+		case 4:
+			assert.Equal(t, "lsblk /dev/sda", name)
+			output = ""
+		case 5:
+			assert.Equal(t, "get filesystem type for sda", name)
 			output = ""
 		}
 		outputExecCount++
@@ -153,7 +150,7 @@ NAME="sda3" SIZE="20" TYPE="part" PKNAME="sda"`
 	// to format and the format/partitioning will happen.
 	err = formatDevice(context, config, false, storeConfig)
 	assert.Nil(t, err)
-	assert.Equal(t, 15, outputExecCount)
+	assert.Equal(t, 6, outputExecCount)
 }
 
 func TestPartitionBluestoreMetadata(t *testing.T) {

--- a/pkg/daemon/ceph/osd/filesystem_test.go
+++ b/pkg/daemon/ceph/osd/filesystem_test.go
@@ -97,15 +97,15 @@ func createMockMetadata(t *testing.T, configDir, name, content string) {
 	assert.Nil(t, err)
 }
 
-func assertBackedUpFile(t *testing.T, config *osdConfig, kv *k8sutil.ConfigMapKVStore, name, expectedContent string) {
-	storeName := fmt.Sprintf(osdFSStoreNameFmt, config.id)
+func assertBackedUpFile(t *testing.T, c *osdConfig, kv *k8sutil.ConfigMapKVStore, name, expectedContent string) {
+	storeName := fmt.Sprintf(config.OSDFSStoreNameFmt, c.id)
 	val, err := kv.GetValue(storeName, name)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedContent, val)
 }
 
-func assertNotBackedUpFile(t *testing.T, config *osdConfig, kv *k8sutil.ConfigMapKVStore, name string) {
-	storeName := fmt.Sprintf(osdFSStoreNameFmt, config.id)
+func assertNotBackedUpFile(t *testing.T, c *osdConfig, kv *k8sutil.ConfigMapKVStore, name string) {
+	storeName := fmt.Sprintf(config.OSDFSStoreNameFmt, c.id)
 	_, err := kv.GetValue(storeName, name)
 	assert.NotNil(t, err)
 	assert.True(t, errors.IsNotFound(err))
@@ -130,7 +130,7 @@ func TestRepairOSDFileSystem(t *testing.T) {
 	}
 
 	// mock a backed up OSD filesystem
-	storeName := fmt.Sprintf(osdFSStoreNameFmt, cfg.id)
+	storeName := fmt.Sprintf(config.OSDFSStoreNameFmt, cfg.id)
 	kv.SetValue(storeName, "foo", "bar")
 	kv.SetValue(storeName, "bif", "bonk")
 

--- a/pkg/daemon/ceph/osd/health_test.go
+++ b/pkg/daemon/ceph/osd/health_test.go
@@ -84,9 +84,9 @@ func TestOSDStatus(t *testing.T) {
 	// After creating an OSD, the dump has to be the 4th mocked cmd
 	assert.Equal(t, 4, execCount)
 	// Only one OSD proc was mocked
-	assert.Equal(t, 1, len(agent.osdProc))
-	// OSD monitoring should start tracking an osd with Down status
-	assert.Equal(t, 1, len(osdMon.lastStatus))
+	//assert.Equal(t, 1, len(agent.osdProc))
+	// FIX: OSD monitoring should start tracking an osd with Down status
+	//assert.Equal(t, 1, len(osdMon.lastStatus))
 
 	// Run OSD monitoring routine again to trigger an action on tracked proc
 	err = osdMon.osdStatus()

--- a/pkg/daemon/ceph/osd/health_test.go
+++ b/pkg/daemon/ceph/osd/health_test.go
@@ -73,7 +73,7 @@ func TestOSDStatus(t *testing.T) {
 		"sdx": {Data: -1},
 	}}
 	// Creating an OSD for which Down status will be returned
-	err = agent.configureDevices(context, devices)
+	_, err = agent.configureDevices(context, devices)
 	assert.Nil(t, err)
 
 	// Initializing an OSD monitoring

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster to manage a Ceph cluster.
+package cluster
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	cephv1alpha1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1alpha1"
+	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type cluster struct {
+	context   *clusterd.Context
+	Namespace string
+	Spec      *cephv1alpha1.ClusterSpec
+	mons      *mon.Cluster
+	mgrs      *mgr.Cluster
+	osds      *osd.Cluster
+	stopCh    chan struct{}
+	ownerRef  metav1.OwnerReference
+}
+
+func newCluster(c *cephv1alpha1.Cluster, context *clusterd.Context) *cluster {
+	return &cluster{Namespace: c.Namespace, Spec: &c.Spec, context: context,
+		stopCh:   make(chan struct{}),
+		ownerRef: ClusterOwnerRef(c.Namespace, string(c.UID))}
+}
+
+func (c *cluster) createInstance(rookImage string) error {
+
+	// Create a configmap for overriding ceph config settings
+	// These settings should only be modified by a user after they are initialized
+	placeholderConfig := map[string]string{
+		k8sutil.ConfigOverrideVal: "",
+	}
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: k8sutil.ConfigOverrideName,
+		},
+		Data: placeholderConfig,
+	}
+	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
+
+	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)
+	}
+
+	// Start the mon pods
+	c.mons = mon.New(c.context, c.Namespace, c.Spec.DataDirHostPath, rookImage, c.Spec.Mon, cephv1alpha1.GetMonPlacement(c.Spec.Placement),
+		c.Spec.Network.HostNetwork, cephv1alpha1.GetMonResources(c.Spec.Resources), c.ownerRef)
+	err = c.mons.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start the mons. %+v", err)
+	}
+
+	err = c.createInitialCrushMap()
+	if err != nil {
+		return fmt.Errorf("failed to create initial crushmap: %+v", err)
+	}
+
+	c.mgrs = mgr.New(c.context, c.Namespace, rookImage, cephv1alpha1.GetMgrPlacement(c.Spec.Placement),
+		c.Spec.Network.HostNetwork, c.Spec.Dashboard, cephv1alpha1.GetMgrResources(c.Spec.Resources), c.ownerRef)
+	err = c.mgrs.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start the ceph mgr. %+v", err)
+	}
+
+	// Start the OSDs
+	c.osds = osd.New(c.context, c.Namespace, rookImage, c.Spec.ServiceAccount, c.Spec.Storage, c.Spec.DataDirHostPath,
+		cephv1alpha1.GetOSDPlacement(c.Spec.Placement), c.Spec.Network.HostNetwork, cephv1alpha1.GetOSDResources(c.Spec.Resources), c.ownerRef)
+	err = c.osds.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start the osds. %+v", err)
+	}
+
+	logger.Infof("Done creating rook instance in namespace %s", c.Namespace)
+	return nil
+}
+
+func (c *cluster) createInitialCrushMap() error {
+	configMapExists := false
+	createCrushMap := false
+
+	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(crushConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		// crush config map was not found, meaning we haven't created the initial crush map
+		createCrushMap = true
+	} else {
+		// crush config map was found, look in it to verify we've created the initial crush map
+		configMapExists = true
+		val, ok := cm.Data[crushmapCreatedKey]
+		if !ok {
+			createCrushMap = true
+		} else if val != "1" {
+			createCrushMap = true
+		}
+	}
+
+	if !createCrushMap {
+		// no need to create the crushmap, bail out
+		return nil
+	}
+
+	logger.Info("creating initial crushmap")
+	out, err := client.CreateDefaultCrushMap(c.context, c.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to create initial crushmap: %+v. output: %s", err, out)
+	}
+
+	logger.Info("created initial crushmap")
+
+	// save the fact that we've created the initial crushmap to a configmap
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crushConfigMapName,
+			Namespace: c.Namespace,
+		},
+		Data: map[string]string{crushmapCreatedKey: "1"},
+	}
+	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &configMap.ObjectMeta, &c.ownerRef)
+
+	if !configMapExists {
+		if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {
+			return fmt.Errorf("failed to create configmap %s: %+v", crushConfigMapName, err)
+		}
+	} else {
+		if _, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(configMap); err != nil {
+			return fmt.Errorf("failed to update configmap %s: %+v", crushConfigMapName, err)
+		}
+	}
+
+	return nil
+}
+
+func clusterChanged(oldCluster, newCluster cephv1alpha1.ClusterSpec) bool {
+	changeFound := false
+	oldStorage := oldCluster.Storage
+	newStorage := newCluster.Storage
+
+	// sort the nodes by name then compare to see if there are changes
+	sort.Sort(rookv1alpha2.NodesByName(oldStorage.Nodes))
+	sort.Sort(rookv1alpha2.NodesByName(newStorage.Nodes))
+	if !reflect.DeepEqual(oldStorage.Nodes, newStorage.Nodes) {
+		logger.Infof("The list of nodes has changed")
+		changeFound = true
+	}
+
+	if oldCluster.Dashboard.Enabled != newCluster.Dashboard.Enabled {
+		logger.Infof("dashboard enabled has changed from %t to %t", oldCluster.Dashboard.Enabled, newCluster.Dashboard.Enabled)
+		changeFound = true
+	}
+
+	return changeFound
+}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -32,12 +32,14 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
+	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -381,6 +383,7 @@ func (c *ClusterController) onDelete(obj interface{}) {
 	if clust.Spec.Storage.AnyUseAllDevices() {
 		c.devicesInUse = false
 	}
+	discover.FreeDevicesByCluster(c.context, clust.Name)
 }
 
 func (c *ClusterController) handleDelete(cluster *cephv1alpha1.Cluster, retryInterval time.Duration) error {

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -52,7 +52,7 @@ func (hc *HealthChecker) Check(stopCh chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			logger.Infof("Stopping monitoring of cluster in namespace %s", hc.monCluster.Namespace)
+			logger.Infof("Stopping monitoring of mons in namespace %s", hc.monCluster.Namespace)
 			return
 
 		case <-time.After(HealthCheckInterval):

--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	OSDFSStoreNameFmt  = "rook-ceph-osd-%d-fs-backup"
 	configStoreNameFmt = "rook-ceph-osd-%s-config"
 	osdDirsKeyName     = "osd-dirs"
 )

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/util/proc"
 )
 
 const upStatus = 1
@@ -32,8 +31,8 @@ var (
 
 // Monitor defines OSD process monitoring
 type Monitor struct {
-	context *clusterd.Context
-	agent   *OsdAgent
+	context     *clusterd.Context
+	clusterName string
 
 	// lastStatus keeps track of OSDs status
 	// key - OSD id; value: time of the status change.
@@ -41,8 +40,8 @@ type Monitor struct {
 }
 
 // NewMonitor instantiates OSD monitoring
-func NewMonitor(context *clusterd.Context, agent *OsdAgent) *Monitor {
-	return &Monitor{context, agent, make(map[int]time.Time)}
+func NewMonitor(context *clusterd.Context, clusterName string) *Monitor {
+	return &Monitor{context, clusterName, make(map[int]time.Time)}
 }
 
 // Run runs monitoring logic for osds status at set intervals
@@ -60,29 +59,28 @@ func (m *Monitor) Run() {
 // OSDStatus validates osd dump output
 func (m *Monitor) osdStatus() error {
 	logger.Debugf("OSDs with previously detected Down status: %+v", m.lastStatus)
-	osdDump, err := client.GetOSDDump(m.context, m.agent.cluster.Name)
+	osdDump, err := client.GetOSDDump(m.context, m.clusterName)
 	if err != nil {
 		return err
 	}
+	logger.Debugf("osd dump %v", osdDump)
 
-	evalDownStatus := func(id int, proc *proc.MonitoredProc) {
+	evalDownStatus := func(id int) {
 		if now := time.Now(); now.Sub(m.lastStatus[id]) > osdGracePeriod {
-			logger.Infof("stopping osd.%d, it has been down for longer than the grace period (down since %+v)", id, m.lastStatus[id])
-			// Stopping the process, continuing monitoring so that ProcMan would replace it with a new proc
-			err = proc.Stop(true)
-			if err != nil {
-				// Logging the error and continuing with the next osd.id status check.
-				logger.Warningf("failed to stop osd.%d: %+v", id, err)
-			} else {
-				logger.Infof("stopped osd.%d", id)
-				delete(m.lastStatus, id)
-			}
+			logger.Warningf("osd.%d has been down for longer than the grace period (down since %+v)", id, m.lastStatus[id])
+			m.lastStatus[id] = time.Now()
 		} else {
 			logger.Warningf("waiting for the osd.%d to exceed the grace period", id)
 		}
 	}
 
-	for id, proc := range m.agent.osdProc {
+	for _, osdStatus := range osdDump.OSDs {
+		id64, err := osdStatus.OSD.Int64()
+		if err != nil {
+			continue
+		}
+		id := int(id64)
+
 		logger.Debugf("validating status of osd.%d", id)
 		_, tracked := m.lastStatus[id]
 
@@ -95,7 +93,7 @@ func (m *Monitor) osdStatus() error {
 		if status != upStatus {
 			logger.Infof("osd.%d is marked 'DOWN'", id)
 			if tracked {
-				evalDownStatus(id, proc)
+				evalDownStatus(id)
 			} else {
 				m.lastStatus[id] = time.Now()
 			}

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -75,3 +75,11 @@ func TestOSDStatus(t *testing.T) {
 	// OSD monitor should stop tracking that process once the action is triggered
 	assert.Equal(t, 1, len(osdMon.lastStatus))
 }
+
+func TestMonitorStart(t *testing.T) {
+	stopCh := make(chan struct{})
+	osdMon := NewMonitor(&clusterd.Context{}, "cluster")
+	logger.Infof("starting osd monitor")
+	go osdMon.Start(stopCh)
+	close(stopCh)
+}

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -16,14 +16,12 @@ limitations under the License.
 package osd
 
 import (
-	"io/ioutil"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,58 +29,40 @@ func TestOSDStatus(t *testing.T) {
 	// Overwriting default grace period to speed up testing
 	osdGracePeriod = 1 * time.Microsecond
 
-	configDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to create temp config dir: %+v", err)
-	}
-	defer os.RemoveAll(configDir)
-
-	storeConfig := &config.StoreConfig{StoreType: "bluestore"}
-	// Mocking agent and executor, re-using a function from agent tests
-	agent, executor, _ := createTestAgent(t, "sdx", configDir, "node1271", storeConfig)
+	cluster := "fake"
 
 	var execCount = 0
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
+		},
+	}
 	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 		execCount++
 		if args[1] == "dump" {
 			// Mock executor for OSD Dump command, returning an osd in Down state
-			return `{"OSDs": [{"OSD": 1, "Up": 0, "In": 1}]}`, nil
-		} else if args[1] == "create" {
-			// Mock executor for osd creation
-			return `{"osdid": 1.0}`, nil
+			return `{"OSDs": [{"OSD": 0, "Up": 0, "In": 1}]}`, nil
 		}
 		return "", nil
 	}
 
 	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutput: %s %v", command, args)
-		// Mocking execution of lsbk of existing devices
-		if strings.HasPrefix(actionName, "lsblk /dev/disk/by-partuuid") {
-			return `SIZE="111" TYPE="part"`, nil
-		}
 		return "", nil
 	}
 
 	// Setting up objects needed to create OSD
 	context := &clusterd.Context{
-		Executor:  executor,
-		ConfigDir: configDir,
+		Executor: executor,
 	}
-	devices := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{
-		"sdx": {Data: -1},
-	}}
-	// Creating an OSD for which Down status will be returned
-	_, err = agent.configureDevices(context, devices)
-	assert.Nil(t, err)
-
 	// Initializing an OSD monitoring
-	osdMon := NewMonitor(context, agent)
+	osdMon := NewMonitor(context, cluster)
 	// Run OSD monitoring routine
-	err = osdMon.osdStatus()
+	err := osdMon.osdStatus()
 	assert.Nil(t, err)
-	// After creating an OSD, the dump has to be the 4th mocked cmd
-	assert.Equal(t, 4, execCount)
+	// After creating an OSD, the dump has to be the 1 mocked cmd
+	assert.Equal(t, 1, execCount)
 	// Only one OSD proc was mocked
 	//assert.Equal(t, 1, len(agent.osdProc))
 	// FIX: OSD monitoring should start tracking an osd with Down status
@@ -91,7 +71,7 @@ func TestOSDStatus(t *testing.T) {
 	// Run OSD monitoring routine again to trigger an action on tracked proc
 	err = osdMon.osdStatus()
 	assert.Nil(t, err)
-	assert.Equal(t, 5, execCount)
+	assert.Equal(t, 2, execCount)
 	// OSD monitor should stop tracking that process once the action is triggered
-	assert.Equal(t, 0, len(osdMon.lastStatus))
+	assert.Equal(t, 1, len(osdMon.lastStatus))
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -174,6 +174,9 @@ func (c *Cluster) Start() error {
 
 	if len(config.errorMessages) == 0 {
 		logger.Infof("completed running osds in namespace %s", c.Namespace)
+		// start osd health monitor
+		mon := NewMonitor(c.context, c.Namespace)
+		go mon.Run()
 		return nil
 	}
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -20,6 +20,7 @@ package osd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -52,7 +53,11 @@ const (
 	OrchestrationStatusCompleted     = "completed"
 	OrchestrationStatusFailed        = "failed"
 	appName                          = "rook-ceph-osd"
+	prepareAppName                   = "rook-ceph-osd-prepare"
+	prepareAppNameFmt                = "rook-ceph-osd-prepare-%s"
+	osdAppNameFmt                    = "rook-ceph-osd-id-%d"
 	appNameFmt                       = "rook-ceph-osd-%s"
+	osdLabelKey                      = "ceph-osd-id"
 	clusterAvailableSpaceReserve     = 0.05
 	defaultServiceAccountName        = "rook-ceph-cluster"
 )
@@ -97,9 +102,26 @@ func New(context *clusterd.Context, namespace, version, serviceAccount string, s
 	}
 }
 
+type OSDInfo struct {
+	ID          int    `json:"id"`
+	DataPath    string `json:"data-path"`
+	Config      string `json:"conf"`
+	Cluster     string `json:"cluster"`
+	KeyringPath string `json:"keyring-path"`
+	UUID        string `json:"uuid"`
+	Journal     string `json:"journal"`
+	IsFileStore bool   `json:"is-file-store"`
+}
+
 type OrchestrationStatus struct {
-	Status  string `json:"status"`
-	Message string `json:"message"`
+	OSDs    []OSDInfo `json:"osds"`
+	Status  string    `json:"status"`
+	Message string    `json:"message"`
+}
+
+type deploymentPerNode struct {
+	node        rookalpha.Node
+	deployments []*extensions.Deployment
 }
 
 // Start the osd management
@@ -126,34 +148,35 @@ func (c *Cluster) Start() error {
 	}()
 
 	if c.Storage.UseAllNodes {
-		// make a daemonset for all nodes in the cluster
-		storeConfig := config.ToStoreConfig(c.Storage.Config)
-		metadataDevice := config.MetadataDevice(c.Storage.Config)
-		ds := c.makeDaemonSet(c.Storage.Selection, storeConfig, metadataDevice, c.Storage.Location)
-		_, err := c.context.Clientset.Extensions().DaemonSets(c.Namespace).Create(ds)
+		// resolve all storage nodes
+		c.Storage.Nodes = nil
+		rookSystemNS := os.Getenv(k8sutil.PodNamespaceEnvVar)
+		allNodeDevices, err := discover.ListDevices(c.context, rookSystemNS, "" /* all nodes */)
 		if err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create osd daemon set. %+v", err)
-			}
-			logger.Infof("osd daemon set already exists")
-		} else {
-			logger.Infof("osd daemon set started")
+			logger.Warningf("failed to get storage nodes from namespace %s: %v", rookSystemNS, err)
+			return err
 		}
-
-		return nil
+		for nodeName := range allNodeDevices {
+			storageNode := rookalpha.Node{
+				Name: nodeName,
+			}
+			c.Storage.Nodes = append(c.Storage.Nodes, storageNode)
+		}
+		logger.Debugf("storage nodes: %+v", c.Storage.Nodes)
 	}
 
 	// orchestrate individual nodes, starting with any that are still ongoing (in the case that we
 	// are resuming a previous orchestration attempt)
 	if inProgressNode, status := c.findInProgressNode(); inProgressNode != "" {
 		logger.Infof("resuming orchestration of in progress node %s, status: %+v", inProgressNode, status)
-		if err := c.waitForCompletion(inProgressNode); err != nil {
+		if _, err := c.waitForCompletion(inProgressNode); err != nil {
 			logger.Warningf("failed waiting for in progress node %s, will continue with orchestration.  %+v", inProgressNode, err)
 		}
 	}
 
 	errorMessages := make([]string, 0)
-
+	clusterName := c.Namespace
+	devicesToUse := make(map[string][]rookalpha.Device, len(c.Storage.Nodes))
 	// start with nodes currently in the storage spec
 	for i := range c.Storage.Nodes {
 		// fully resolve the storage config and resources for this node
@@ -167,41 +190,99 @@ func (c *Cluster) Start() error {
 			errorMessages = append(errorMessages, fmt.Sprintf("failed to set orchestration starting status for node %s: %+v", n.Name, err))
 			continue
 		}
-		devicesToUse := n.Devices
-		availDev, deviceErr := discover.GetAvailableDevices(c.context, n.Name, c.Namespace, n.Devices, n.Selection.DeviceFilter, n.Selection.GetUseAllDevices())
+		devicesToUse[n.Name] = n.Devices
+		availDev, deviceErr := discover.GetAvailableDevices(c.context, n.Name, clusterName, n.Devices, n.Selection.DeviceFilter, n.Selection.GetUseAllDevices())
 		if deviceErr != nil {
-			logger.Warningf("failed to get devices for node %s cluster %s: %v", n.Name, c.Namespace, deviceErr)
+			logger.Warningf("failed to get devices for node %s cluster %s: %v", n.Name, clusterName, deviceErr)
 		} else {
-			devicesToUse = availDev
+			devicesToUse[n.Name] = availDev
 			logger.Infof("avail devices for node %s: %+v", n.Name, availDev)
 		}
-		// create the replicaSet that will run the OSDs for this node
-		rs := c.makeReplicaSet(n.Name, devicesToUse, n.Selection, n.Resources, storeConfig, metadataDevice, n.Location)
-		_, err := c.context.Clientset.Extensions().ReplicaSets(c.Namespace).Create(rs)
+		if len(availDev) == 0 && len(c.dataDirHostPath) == 0 {
+			errorMessages = append(errorMessages, fmt.Sprintf("empty volumes for node %s", n.Name))
+			continue
+		}
+		// create the job that prepares osds on the node
+		job, err := c.makeJob(n.Name, devicesToUse[n.Name], n.Selection, n.Resources, storeConfig, metadataDevice, n.Location)
+		if err != nil {
+			message := fmt.Sprintf("failed to create prepare job node %s: %v", n.Name, err)
+			logger.Info(message)
+			status := OrchestrationStatus{Status: OrchestrationStatusCompleted, Message: message}
+			if err := UpdateOrchestrationStatusMap(c.context.Clientset, c.Namespace, n.Name, status); err != nil {
+				errorMessages = append(errorMessages, message)
+				continue
+			}
+		}
+		_, err = c.context.Clientset.Batch().Jobs(c.Namespace).Create(job)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
-				// we failed to create the replica set, update the orchestration status for this node
-				message := fmt.Sprintf("failed to create osd replica set for node %s. %+v", n.Name, err)
+				// we failed to create job, update the orchestration status for this node
+				message := fmt.Sprintf("failed to create osd prepare job for node %s. %+v", n.Name, err)
 				c.handleOrchestrationFailure(*n, message, &errorMessages)
+				err = discover.FreeDevices(c.context, n.Name, clusterName)
+				if err != nil {
+					logger.Warningf("failed to free devices: %s", err)
+				}
 				continue
 			} else {
-				// TODO: if the replica set already exists, we may need to edit the pod template spec, for example if device filter has changed
-				message := fmt.Sprintf("osd replica set already exists for node %s", n.Name)
+				// TODO: if the job already exists, we may need to edit the pod template spec, for example if device filter has changed
+				message := fmt.Sprintf("failed to set orchestration status for node %s, status: %+v: %+v", n.Name, status, err)
 				logger.Info(message)
 				status := OrchestrationStatus{Status: OrchestrationStatusCompleted, Message: message}
 				if err := UpdateOrchestrationStatusMap(c.context.Clientset, c.Namespace, n.Name, status); err != nil {
-					errorMessages = append(errorMessages, fmt.Sprintf("failed to set orchestration status for node %s, status: %+v: %+v", n.Name, status, err))
+					errorMessages = append(errorMessages, message)
 					continue
 				}
 			}
 		} else {
-			logger.Infof("osd replica set started for node %s", n.Name)
+			logger.Infof("osd prepare job started for node %s", n.Name)
 		}
+	}
+	for i := range c.Storage.Nodes {
+		// fully resolve the storage config and resources for this node
+		n := c.resolveNode(c.Storage.Nodes[i])
+		storeConfig := config.ToStoreConfig(n.Config)
+		metadataDevice := config.MetadataDevice(n.Config)
 
 		// wait for the current node's orchestration to be completed
-		if err := c.waitForCompletion(n.Name); err != nil {
-			errorMessages = append(errorMessages, err.Error())
+		if status, err := c.waitForCompletion(n.Name); err != nil {
+			logger.Warningf("failed to prepare node %s: %v", n.Name, err)
+			err = discover.FreeDevices(c.context, n.Name, clusterName)
+			if err != nil {
+				logger.Warningf("failed to free devices: %s", err)
+				errorMessages = append(errorMessages, err.Error())
+			}
 			continue
+		} else {
+			// start osds
+			osds := status.OSDs
+			logger.Debugf("osds prepared on node %s: %+v", n.Name, osds)
+			for _, osd := range osds {
+				logger.Debugf("start osd %v", osd)
+				dp, err := c.makeDeployment(n.Name, devicesToUse[n.Name], n.Selection, n.Resources, storeConfig, metadataDevice, n.Location, osd)
+				if err != nil {
+					errMsg := fmt.Sprintf("nil deployment for node %s: %v", n.Name, err)
+					logger.Warningf(errMsg)
+					errorMessages = append(errorMessages, errMsg)
+					err = discover.FreeDevices(c.context, n.Name, clusterName)
+					if err != nil {
+						logger.Warningf("failed to free devices: %s", err)
+					}
+					continue
+				}
+				dp, err = c.context.Clientset.Extensions().Deployments(c.Namespace).Create(dp)
+				if err != nil {
+					if !errors.IsAlreadyExists(err) {
+						// we failed to create job, update the orchestration status for this node
+						logger.Warningf("failed to create osd deployment for node %s, osd %v: %+v", n.Name, osd, err)
+						err = discover.FreeDevices(c.context, n.Name, clusterName)
+						if err != nil {
+							logger.Warningf("failed to free devices: %s", err)
+						}
+						continue
+					}
+				}
+			}
 		}
 	}
 
@@ -213,53 +294,60 @@ func (c *Cluster) Start() error {
 
 	for i := range removedNodes {
 		n := removedNodes[i]
-		storeConfig := config.ToStoreConfig(n.Config)
-		metadataDevice := config.MetadataDevice(n.Config)
+		storeConfig := config.ToStoreConfig(n.node.Config)
+		metadataDevice := config.MetadataDevice(n.node.Config)
 
-		if err := c.isSafeToRemoveNode(n); err != nil {
-			message := fmt.Sprintf("skipping the removal of node %s because it is not safe to do so: %+v", n.Name, err)
-			c.handleOrchestrationFailure(n, message, &errorMessages)
+		if err := c.isSafeToRemoveNode(n.node); err != nil {
+			message := fmt.Sprintf("skipping the removal of node %s because it is not safe to do so: %+v", n.node.Name, err)
+			c.handleOrchestrationFailure(n.node, message, &errorMessages)
 			continue
 		}
-
-		logger.Infof("removing node %s from the cluster", n.Name)
+		if len(n.node.Name) == 0 {
+			continue
+		}
+		logger.Infof("removing node %s from the cluster", n.node.Name)
 
 		// update the orchestration status of this removed node to the starting state
-		if err := UpdateOrchestrationStatusMap(c.context.Clientset, c.Namespace, n.Name, OrchestrationStatus{Status: OrchestrationStatusStarting}); err != nil {
-			errorMessages = append(errorMessages, fmt.Sprintf("failed to set orchestration starting status for removed node %s: %+v", n.Name, err))
+		if err := UpdateOrchestrationStatusMap(c.context.Clientset, c.Namespace, n.node.Name, OrchestrationStatus{Status: OrchestrationStatusStarting}); err != nil {
+			errorMessages = append(errorMessages, fmt.Sprintf("failed to set orchestration starting status for removed node %s: %+v", n.node.Name, err))
 			continue
 		}
 
 		// trigger orchestration on the removed node by telling it not to use any storage at all.  note that the directories are still passed in
 		// so that the pod will be able to mount them and migrate data from them.
-		rs := c.makeReplicaSet(n.Name, nil, rookalpha.Selection{DeviceFilter: "none", Directories: n.Directories},
-			v1.ResourceRequirements{}, storeConfig, metadataDevice, n.Location)
-		rs, err := c.context.Clientset.Extensions().ReplicaSets(c.Namespace).Update(rs)
+		job, err := c.makeJob(n.node.Name, nil, rookalpha.Selection{DeviceFilter: "none", Directories: n.node.Directories}, v1.ResourceRequirements{}, storeConfig, metadataDevice, "")
 		if err != nil {
-			message := fmt.Sprintf("failed to update osd replica set for removed node %s. %+v", n.Name, err)
-			c.handleOrchestrationFailure(n, message, &errorMessages)
+			message := fmt.Sprintf("failed to create osd job for removed node %s. %+v", n.node.Name, err)
+			c.handleOrchestrationFailure(n.node, message, &errorMessages)
+			continue
+		}
+		job, err = c.context.Clientset.Batch().Jobs(c.Namespace).Update(job)
+		if err != nil {
+			message := fmt.Sprintf("failed to update osd job for removed node %s. %+v", n.node.Name, err)
+			c.handleOrchestrationFailure(n.node, message, &errorMessages)
 			continue
 		} else {
-			logger.Infof("osd replica set updated for node %s", n.Name)
+			logger.Infof("osd job updated for node %s", n.node.Name)
 		}
+		for _, dp := range n.deployments {
+			// delete the pod associated with the deployment so that it will be restarted with the new template
+			if err := c.deleteOSDPod(dp); err != nil {
+				message := fmt.Sprintf("failed to find and delete OSD pod for deployments %s. %+v", dp.Name, err)
+				c.handleOrchestrationFailure(n.node, message, &errorMessages)
+				continue
+			}
 
-		// delete the pod associated with the replica set so that it will be restarted with the new template
-		if err := c.deleteOSDPod(rs); err != nil {
-			message := fmt.Sprintf("failed to find and delete OSD pod for replica set %s. %+v", rs.Name, err)
-			c.handleOrchestrationFailure(n, message, &errorMessages)
-			continue
-		}
+			// wait for the removed node's orchestration to be completed
+			if _, err := c.waitForCompletion(n.node.Name); err != nil {
+				errorMessages = append(errorMessages, err.Error())
+				continue
+			}
 
-		// wait for the removed node's orchestration to be completed
-		if err := c.waitForCompletion(n.Name); err != nil {
-			errorMessages = append(errorMessages, err.Error())
-			continue
-		}
-
-		// orchestration of the removed node completed, we can delete the replica set now
-		if err := c.context.Clientset.Extensions().ReplicaSets(c.Namespace).Delete(rs.Name, &metav1.DeleteOptions{}); err != nil {
-			errorMessages = append(errorMessages, fmt.Sprintf("failed to delete replica set %s: %+v", rs.Name, err))
-			continue
+			// orchestration of the removed node completed, we can delete the deployment now
+			if err := c.context.Clientset.Extensions().Deployments(c.Namespace).Delete(dp.Name, &metav1.DeleteOptions{}); err != nil {
+				errorMessages = append(errorMessages, fmt.Sprintf("failed to delete deployment %s: %+v", dp.Name, err))
+				continue
+			}
 		}
 	}
 
@@ -393,12 +481,12 @@ func (c *Cluster) findInProgressNode() (string, *OrchestrationStatus) {
 	return "", nil
 }
 
-func (c *Cluster) waitForCompletion(node string) error {
+func (c *Cluster) waitForCompletion(node string) (*OrchestrationStatus, error) {
 	// check the status map to see if the node is already completed before we start watching
 	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(OrchestrationStatusMapName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return err
+			return nil, err
 		}
 		// the status map doesn't exist yet, watching below is still an OK thing to do
 	} else {
@@ -406,27 +494,28 @@ func (c *Cluster) waitForCompletion(node string) error {
 		status := parseOrchestrationStatus(cm.Data, node)
 		if status != nil {
 			if status.Status == OrchestrationStatusCompleted {
-				return nil
+				return status, nil
 			} else if status.Status == OrchestrationStatusFailed {
-				return fmt.Errorf("orchestration for node %s failed: %+v", node, status)
+				return nil, fmt.Errorf("orchestration for node %s failed: %+v", node, status)
 			}
 		}
 	}
 
 	// start watching for changes on the orchestration status map
-	var startingVersion string
+	startingVersion := "0"
 	if cm != nil {
 		startingVersion = cm.ResourceVersion
 	}
 	opts := metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector(api.ObjectNameField, OrchestrationStatusMapName).String(),
 		ResourceVersion: startingVersion,
+		Watch:           true,
 	}
 
 	for {
 		w, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Watch(opts)
 		if err != nil {
-			return fmt.Errorf("failed to start watch on %s: %+v", OrchestrationStatusMapName, err)
+			return nil, fmt.Errorf("failed to start watch on %s: %+v", OrchestrationStatusMapName, err)
 		}
 		defer w.Stop()
 
@@ -440,7 +529,6 @@ func (c *Cluster) waitForCompletion(node string) error {
 					<-time.After(100 * time.Millisecond)
 					break ResultLoop
 				}
-
 				if e.Type == watch.Modified {
 					statusMap := e.Object.(*v1.ConfigMap)
 					status := parseOrchestrationStatus(statusMap.Data, node)
@@ -449,9 +537,9 @@ func (c *Cluster) waitForCompletion(node string) error {
 					}
 
 					if status.Status == OrchestrationStatusCompleted {
-						return nil
+						return status, nil
 					} else if status.Status == OrchestrationStatusFailed {
-						return fmt.Errorf("orchestration for node %s failed: %+v", node, status)
+						return nil, fmt.Errorf("orchestration for node %s failed: %+v", node, status)
 					}
 				}
 
@@ -467,8 +555,8 @@ func IsRemovingNode(devices string) bool {
 	return devices == "none"
 }
 
-func (c *Cluster) findRemovedNodes() ([]rookalpha.Node, error) {
-	var removedNodes []rookalpha.Node
+func (c *Cluster) findRemovedNodes() ([]deploymentPerNode, error) {
+	var removedNodes []deploymentPerNode
 
 	// first discover the storage nodes that are still running
 	discoveredNodes, err := c.discoverStorageNodes()
@@ -480,7 +568,7 @@ func (c *Cluster) findRemovedNodes() ([]rookalpha.Node, error) {
 		found := false
 		for _, newNode := range c.Storage.Nodes {
 			// discovered storage node still exists in the current storage spec, move on to next discovered node
-			if discoveredNode.Name == newNode.Name {
+			if discoveredNode.node.Name == newNode.Name {
 				found = true
 				break
 			}
@@ -495,25 +583,23 @@ func (c *Cluster) findRemovedNodes() ([]rookalpha.Node, error) {
 	return removedNodes, nil
 }
 
-func (c *Cluster) discoverStorageNodes() ([]rookalpha.Node, error) {
-	var discoveredNodes []rookalpha.Node
+func (c *Cluster) discoverStorageNodes() ([]deploymentPerNode, error) {
+	var discoveredNodes []deploymentPerNode
 
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appName)}
-	osdReplicaSets, err := c.context.Clientset.Extensions().ReplicaSets(c.Namespace).List(listOpts)
+	osdDeployments, err := c.context.Clientset.Extensions().Deployments(c.Namespace).List(listOpts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list osd replica sets: %+v", err)
+		return nil, fmt.Errorf("failed to list osd deployment: %+v", err)
 	}
-
-	discoveredNodes = make([]rookalpha.Node, len(osdReplicaSets.Items))
-	for i, osdReplicaSet := range osdReplicaSets.Items {
-		osdPodSpec := osdReplicaSet.Spec.Template.Spec
+	discoveredNodes = make([]deploymentPerNode, len(osdDeployments.Items))
+	for i, osdDeployment := range osdDeployments.Items {
+		osdPodSpec := osdDeployment.Spec.Template.Spec
 
 		// get the node name from the node selector
 		nodeName, ok := osdPodSpec.NodeSelector[apis.LabelHostname]
 		if !ok || nodeName == "" {
-			return nil, fmt.Errorf("osd replicaset %s doesn't have a node name on its node selector: %+v", osdReplicaSet.Name, osdPodSpec.NodeSelector)
+			return nil, fmt.Errorf("osd deployment %s doesn't have a node name on its node selector: %+v", osdDeployment.Name, osdPodSpec.NodeSelector)
 		}
-
 		// get the osd container
 		osdContainer, err := k8sutil.GetMatchingContainer(osdPodSpec.Containers, appName)
 		if err != nil {
@@ -532,8 +618,18 @@ func (c *Cluster) discoverStorageNodes() ([]rookalpha.Node, error) {
 			Location: rookalpha.GetLocationFromContainer(osdContainer),
 			Config:   getConfigFromContainer(osdContainer),
 		}
-
-		discoveredNodes[i] = node
+		found := false
+		for _, n := range discoveredNodes {
+			if nodeName == n.node.Name {
+				n.deployments = append(n.deployments, &osdDeployment)
+				found = true
+				break
+			}
+		}
+		if !found {
+			discoveredNodes[i].node = node
+			discoveredNodes[i].deployments = append(discoveredNodes[i].deployments, &osdDeployment)
+		}
 	}
 
 	return discoveredNodes, nil
@@ -597,7 +693,10 @@ func (c *Cluster) isSafeToRemoveNode(node rookalpha.Node) error {
 	return nil
 }
 
-func (c *Cluster) deleteOSDPod(rs *extensions.ReplicaSet) error {
+func (c *Cluster) deleteOSDPod(dp *extensions.Deployment) error {
+	if dp == nil {
+		return nil
+	}
 	// list all OSD pods first
 	opts := metav1.ListOptions{LabelSelector: fields.OneTermEqualSelector(k8sutil.AppAttr, appName).String()}
 	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(opts)
@@ -605,13 +704,13 @@ func (c *Cluster) deleteOSDPod(rs *extensions.ReplicaSet) error {
 		return err
 	}
 
-	// iterate over all the OSD pods, looking for a match to the given replica set and the pod's owner
+	// iterate over all the OSD pods, looking for a match to the given deployment and the pod's owner
 	var pod *v1.Pod
 	for i := range pods.Items {
 		p := &pods.Items[i]
 		for _, owner := range p.OwnerReferences {
-			if owner.Name == rs.Name && owner.UID == rs.UID {
-				// the owner of this pod matches the name and UID of the given replica set
+			if owner.Name == dp.Name && owner.UID == dp.UID {
+				// the owner of this pod matches the name and UID of the given deployment
 				pod = p
 				break
 			}
@@ -623,7 +722,7 @@ func (c *Cluster) deleteOSDPod(rs *extensions.ReplicaSet) error {
 	}
 
 	if pod == nil {
-		return fmt.Errorf("pod for replica set %s not found", rs.Name)
+		return fmt.Errorf("pod for deployment %s not found", dp.Name)
 	}
 
 	err = c.context.Clientset.CoreV1().Pods(c.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -111,6 +111,7 @@ type OSDInfo struct {
 	UUID        string `json:"uuid"`
 	Journal     string `json:"journal"`
 	IsFileStore bool   `json:"is-file-store"`
+	IsDirectory bool   `json:"is-directory"`
 }
 
 type OrchestrationStatus struct {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -125,9 +125,8 @@ func TestAddRemoveNode(t *testing.T) {
 
 	// simulate the OSD pod having been created
 	osdPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-		Name:            "osdPod",
-		Labels:          map[string]string{k8sutil.AppAttr: appName},
-		OwnerReferences: []metav1.OwnerReference{{Name: "rook-ceph-osd-id-1"}}}}
+		Name:   "osdPod",
+		Labels: map[string]string{k8sutil.AppAttr: appName}}}
 	c.context.Clientset.CoreV1().Pods(c.Namespace).Create(osdPod)
 
 	// mock the ceph calls that will be called during remove node

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -135,13 +137,40 @@ func TestAddRemoveNode(t *testing.T) {
 			if args[0] == "status" {
 				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
-			if args[0] == "osd" && args[1] == "df" {
-				return `{"nodes":[{"id":0,"name":"osd.0","kb_used":1}]}`, nil
+			if args[0] == "osd" {
+				if args[1] == "df" {
+					return `{"nodes":[{"id":0,"name":"osd.0","kb_used":0},{"id":1,"name":"osd.1","kb_used":0}]}`, nil
+				}
+				if args[1] == "set" {
+					return "", nil
+				}
+				if args[1] == "unset" {
+					return "", nil
+				}
+				if args[1] == "crush" {
+					if args[2] == "reweight" {
+						return "", nil
+					}
+					if args[2] == "rm" {
+						return "", nil
+					}
+				}
+				if args[1] == "out" {
+					return "", nil
+				}
+				if args[1] == "rm" {
+					assert.Equal(t, "1", args[2])
+					return "", nil
+				}
 			}
 			if args[0] == "df" && args[1] == "detail" {
-				return `{"stats":{"total_bytes":4096,"total_used_bytes":1024,"total_avail_bytes":3072}}`, nil
+				return `{"stats":{"total_bytes":0,"total_used_bytes":0,"total_avail_bytes":3072}}`, nil
 			}
-			if args[0] == "osd" && (args[1] == "set" || args[1] == "unset") {
+			if args[0] == "pg" && args[1] == "dump" {
+				return `[]`, nil
+			}
+			if args[0] == "auth" && args[1] == "del" {
+				assert.Equal(t, "osd.1", args[2])
 				return "", nil
 			}
 			return "", fmt.Errorf("unexpected ceph command '%v'", args)
@@ -165,15 +194,64 @@ func TestAddRemoveNode(t *testing.T) {
 		startCompleted = true
 	}()
 
-	// simulate the completion of the removed nodes orchestration
-	mockNodeOrchestrationCompletion(c, nodeName, statusMapWatcher)
-
 	// wait for orchestration to complete
 	waitForOrchestrationCompletion(c, nodeName, &startCompleted)
 
 	// verify orchestration for removing the node succeeded
 	assert.True(t, startCompleted)
 	assert.Nil(t, startErr)
+}
+
+func TestGetIDFromDeployment(t *testing.T) {
+	d := &extensions.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+	d.Labels = map[string]string{"ceph-osd-id": "0"}
+	assert.Equal(t, 0, getIDFromDeployment(d))
+
+	d.Labels = map[string]string{}
+	assert.Equal(t, -1, getIDFromDeployment(d))
+
+	d.Labels = map[string]string{"ceph-osd-id": "101"}
+	assert.Equal(t, 101, getIDFromDeployment(d))
+}
+
+func TestDiscoverOSDs(t *testing.T) {
+	c := New(&clusterd.Context{}, "ns", "myversion", "",
+		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	node1 := "n1"
+	node2 := "n2"
+
+	osd1 := OSDInfo{ID: 0, IsDirectory: true, IsFileStore: true, DataPath: "/rook/path"}
+	d1, err := c.makeDeployment(node1, []rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", osd1)
+	assert.Nil(t, err)
+	assert.NotNil(t, d1)
+
+	osd2 := OSDInfo{ID: 101, IsDirectory: true, IsFileStore: true, DataPath: "/rook/path"}
+	d2, err := c.makeDeployment(node1, []rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", osd2)
+	assert.Nil(t, err)
+	assert.NotNil(t, d2)
+
+	osd3 := OSDInfo{ID: 23, IsDirectory: true, IsFileStore: true, DataPath: "/rook/path"}
+	d3, err := c.makeDeployment(node2, []rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", osd3)
+	assert.Nil(t, err)
+	assert.NotNil(t, d3)
+
+	clientset := fake.NewSimpleClientset(d1, d2, d3)
+	c.context.Clientset = clientset
+
+	discovered, err := c.discoverStorageNodes()
+	require.Nil(t, err)
+	assert.Equal(t, 2, len(discovered))
+
+	assert.Equal(t, 2, len(discovered[node1]))
+	if discovered[node1][0].Name == "rook-ceph-osd-id-0" {
+		assert.Equal(t, "rook-ceph-osd-id-101", discovered[node1][1].Name)
+	} else {
+		assert.Equal(t, "rook-ceph-osd-id-101", discovered[node1][0].Name)
+		assert.Equal(t, "rook-ceph-osd-id-0", discovered[node1][1].Name)
+	}
+
+	assert.Equal(t, 1, len(discovered[node2]))
+	assert.Equal(t, "rook-ceph-osd-id-23", discovered[node2][0].Name)
 }
 
 func TestAddNodeFailure(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -162,6 +162,9 @@ func TestAddRemoveNode(t *testing.T) {
 					assert.Equal(t, "1", args[2])
 					return "", nil
 				}
+				if args[1] == "find" {
+					return `{"crush_location":{"host":"my-host"}}`, nil
+				}
 			}
 			if args[0] == "df" && args[1] == "detail" {
 				return `{"stats":{"total_bytes":0,"total_used_bytes":0,"total_avail_bytes":3072}}`, nil
@@ -193,6 +196,9 @@ func TestAddRemoveNode(t *testing.T) {
 		startErr = c.Start()
 		startCompleted = true
 	}()
+
+	// simulate the completion of the nodes orchestration
+	mockNodeOrchestrationCompletion(c, nodeName, statusMapWatcher)
 
 	// wait for orchestration to complete
 	waitForOrchestrationCompletion(c, nodeName, &startCompleted)

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -182,6 +182,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 					NodeSelector:  map[string]string{apis.LabelHostname: nodeName},
 					RestartPolicy: v1.RestartPolicyAlways,
 					HostNetwork:   c.HostNetwork,
+					HostPID:       true,
 					DNSPolicy:     DNSPolicy,
 					Containers: []v1.Container{
 						{

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -116,6 +116,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 		nodeNameEnvVar(),
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
+		{Name: "TINI_SUBREAPER", Value: ""},
 	}
 
 	commonArgs := []string{

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -58,9 +58,8 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 
 	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf(prepareAppNameFmt, nodeName),
-			Namespace:       c.Namespace,
-			OwnerReferences: []metav1.OwnerReference{c.ownerRef},
+			Name:      fmt.Sprintf(prepareAppNameFmt, nodeName),
+			Namespace: c.Namespace,
 			Labels: map[string]string{
 				k8sutil.AppAttr:     prepareAppName,
 				k8sutil.ClusterAttr: c.Namespace,

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -34,8 +34,9 @@ import (
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{Namespace: "myosd", Version: "23"}
-	c := cluster.podTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "")
+	c, err := cluster.podTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", false /* prepareOnly */, v1.RestartPolicyAlways)
 	assert.NotNil(t, c)
+	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.Spec.Containers))
 	container := c.Spec.Containers[0]
 	assert.Equal(t, "ceph", container.Args[0])
@@ -49,74 +50,64 @@ func TestDaemonset(t *testing.T) {
 	testPodDevices(t, "", "", false)
 }
 
-func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool) {
+func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	storageSpec := rookalpha.StorageScopeSpec{
-		Selection: rookalpha.Selection{UseAllDevices: &allDevices, DeviceFilter: deviceFilter},
+		Selection: rookalpha.Selection{UseAllDevices: &allDevices, DeviceFilter: deviceName},
 		Nodes:     []rookalpha.Node{{Name: "node1"}},
+	}
+	devices := []rookalpha.Device{
+		{Name: deviceName},
 	}
 
 	clientset := fake.NewSimpleClientset()
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "rook/rook:myversion", "mysa",
 		storageSpec, dataDir, rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
 
-	devMountNeeded := deviceFilter != "" || allDevices
+	devMountNeeded := deviceName != "" || allDevices
 
-	n := c.resolveNode(storageSpec.Nodes[0])
-	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location)
-	assert.NotNil(t, replicaSet)
-	assert.Equal(t, "rook-ceph-osd-node1", replicaSet.Name)
-	assert.Equal(t, c.Namespace, replicaSet.Namespace)
+	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
+	if len(devices) == 0 && len(dataDir) == 0 {
+		return
+	}
+	osd := OSDInfo{
+		ID: 0,
+	}
+
+	deployment, err := c.makeDeployment(n.Name, devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	assert.Nil(t, err)
+	assert.NotNil(t, deployment)
+	assert.Equal(t, "rook-ceph-osd-id-0", deployment.Name)
+	assert.Equal(t, c.Namespace, deployment.Namespace)
 	assert.Equal(t, c.serviceAccount, replicaSet.Spec.Template.Spec.ServiceAccountName)
-	assert.Equal(t, int32(1), *(replicaSet.Spec.Replicas))
-	assert.Equal(t, "node1", replicaSet.Spec.Template.Spec.NodeSelector[apis.LabelHostname])
-	assert.Equal(t, v1.RestartPolicyAlways, replicaSet.Spec.Template.Spec.RestartPolicy)
-	if devMountNeeded {
-		assert.Equal(t, 4, len(replicaSet.Spec.Template.Spec.Volumes))
-	} else {
-		assert.Equal(t, 2, len(replicaSet.Spec.Template.Spec.Volumes))
+	assert.Equal(t, int32(1), *(deployment.Spec.Replicas))
+	assert.Equal(t, "node1", deployment.Spec.Template.Spec.NodeSelector[apis.LabelHostname])
+	assert.Equal(t, v1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
+	if devMountNeeded && len(dataDir) > 0 {
+		assert.Equal(t, 3, len(deployment.Spec.Template.Spec.Volumes))
 	}
-	assert.Equal(t, "rook-data", replicaSet.Spec.Template.Spec.Volumes[0].Name)
-	assert.Equal(t, "rook-config-override", replicaSet.Spec.Template.Spec.Volumes[1].Name)
-	if devMountNeeded {
-		assert.Equal(t, "devices", replicaSet.Spec.Template.Spec.Volumes[2].Name)
+	if devMountNeeded && len(dataDir) == 0 {
+		assert.Equal(t, 2, len(deployment.Spec.Template.Spec.Volumes))
 	}
-	if dataDir == "" {
-		assert.NotNil(t, replicaSet.Spec.Template.Spec.Volumes[0].EmptyDir)
-		assert.Nil(t, replicaSet.Spec.Template.Spec.Volumes[0].HostPath)
-	} else {
-		assert.Nil(t, replicaSet.Spec.Template.Spec.Volumes[0].EmptyDir)
-		assert.Equal(t, dataDir, replicaSet.Spec.Template.Spec.Volumes[0].HostPath.Path)
+	if !devMountNeeded && len(dataDir) > 0 {
+		assert.Equal(t, 2, len(deployment.Spec.Template.Spec.Volumes))
 	}
 
-	assert.Equal(t, appName, replicaSet.Spec.Template.ObjectMeta.Name)
-	assert.Equal(t, appName, replicaSet.Spec.Template.ObjectMeta.Labels["app"])
-	assert.Equal(t, c.Namespace, replicaSet.Spec.Template.ObjectMeta.Labels["rook_cluster"])
-	assert.Equal(t, 0, len(replicaSet.Spec.Template.ObjectMeta.Annotations))
+	//assert.Equal(t, "rook-data", deployment.Spec.Template.Spec.Volumes[0].Name)
+	assert.Equal(t, "rook-config-override", deployment.Spec.Template.Spec.Volumes[0].Name)
 
-	cont := replicaSet.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, appName, deployment.Spec.Template.ObjectMeta.Name)
+	assert.Equal(t, appName, deployment.Spec.Template.ObjectMeta.Labels["app"])
+	assert.Equal(t, c.Namespace, deployment.Spec.Template.ObjectMeta.Labels["rook_cluster"])
+	assert.Equal(t, 0, len(deployment.Spec.Template.ObjectMeta.Annotations))
+
+	cont := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	if devMountNeeded {
-		assert.Equal(t, 4, len(cont.VolumeMounts))
+		assert.Equal(t, 3, len(cont.VolumeMounts))
 	} else {
-		assert.Equal(t, 2, len(cont.VolumeMounts))
+		assert.Equal(t, 3, len(cont.VolumeMounts))
 	}
-	assert.Equal(t, "ceph", cont.Args[0])
-	assert.Equal(t, "osd", cont.Args[1])
-
-	// verify the config dir env var
-	verifyEnvVar(t, cont.Env, "ROOK_CONFIG_DIR", "/var/lib/rook", true)
-
-	// verify the osd store type env var uses the default
-	verifyEnvVar(t, cont.Env, "ROOK_OSD_STORE", "", false)
-
-	// verify the device filter env var
-	if deviceFilter != "" {
-		verifyEnvVar(t, cont.Env, "ROOK_DATA_DEVICE_FILTER", deviceFilter, true)
-	} else if allDevices {
-		verifyEnvVar(t, cont.Env, "ROOK_DATA_DEVICE_FILTER", "all", true)
-	} else {
-		verifyEnvVar(t, cont.Env, "ROOK_DATA_DEVICE_FILTER", "", false)
-	}
+	assert.Equal(t, "sh", cont.Command[0])
 }
 
 func verifyEnvVar(t *testing.T, envVars []v1.EnvVar, expectedName, expectedValue string, expectedFound bool) {
@@ -152,24 +143,16 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "rook/rook:myversion", "",
 		storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
 
-	n := c.resolveNode(storageSpec.Nodes[0])
-	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location)
-	assert.NotNil(t, replicaSet)
-
+	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
+	osd := OSDInfo{
+		ID: 0,
+	}
+	deployment, err := c.makeDeployment(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	assert.NotNil(t, deployment)
+	assert.Nil(t, err)
 	// pod spec should have a volume for the given dir
-	podSpec := replicaSet.Spec.Template.Spec
-	assert.Equal(t, 5, len(podSpec.Volumes))
-	assert.Equal(t, "rook-dir1", podSpec.Volumes[4].Name)
-	assert.Equal(t, "/rook/dir1", podSpec.Volumes[4].VolumeSource.HostPath.Path)
-
-	// container should have a volume mount for the given dir
-	container := podSpec.Containers[0]
-	assert.Equal(t, "rook-dir1", container.VolumeMounts[4].Name)
-	assert.Equal(t, "/rook/dir1", container.VolumeMounts[4].MountPath)
-
-	// container command should have the given dir and device
-	verifyEnvVar(t, container.Env, "ROOK_DATA_DIRECTORIES", "/rook/dir1", true)
-	verifyEnvVar(t, container.Env, "ROOK_DATA_DEVICES", "sda", true)
+	podSpec := deployment.Spec.Template.Spec
+	assert.Equal(t, 2, len(podSpec.Volumes))
 }
 
 func TestStorageSpecConfig(t *testing.T) {
@@ -204,13 +187,14 @@ func TestStorageSpecConfig(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "rook/rook:myversion", "",
 		storageSpec, "", rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
 
-	n := c.resolveNode(storageSpec.Nodes[0])
+	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
 	storeConfig := config.ToStoreConfig(storageSpec.Nodes[0].Config)
 	metadataDevice := config.MetadataDevice(storageSpec.Nodes[0].Config)
-	replicaSet := c.makeReplicaSet(n.Name, n.Devices, n.Selection, c.Storage.Nodes[0].Resources, storeConfig, metadataDevice, n.Location)
-	assert.NotNil(t, replicaSet)
 
-	container := replicaSet.Spec.Template.Spec.Containers[0]
+	job, err := c.makeJob(n.Name, n.Devices, n.Selection, c.Storage.Nodes[0].Resources, storeConfig, metadataDevice, n.Location)
+	assert.NotNil(t, job)
+	assert.Nil(t, err)
+	container := job.Spec.Template.Spec.Containers[0]
 	assert.NotNil(t, container)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_STORE", "bluestore", true)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_DATABASE_SIZE", "10", true)
@@ -249,9 +233,13 @@ func TestHostNetwork(t *testing.T) {
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "myversion", "",
 		storageSpec, "", rookalpha.Placement{}, true, v1.ResourceRequirements{}, metav1.OwnerReference{})
 
-	n := c.resolveNode(storageSpec.Nodes[0])
-	r := c.makeReplicaSet(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location)
+	n := c.Storage.ResolveNode(storageSpec.Nodes[0].Name)
+	osd := OSDInfo{
+		ID: 0,
+	}
+	r, err := c.makeDeployment(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.NotNil(t, r)
+	assert.Nil(t, err)
 
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -78,7 +78,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.NotNil(t, deployment)
 	assert.Equal(t, "rook-ceph-osd-id-0", deployment.Name)
 	assert.Equal(t, c.Namespace, deployment.Namespace)
-	assert.Equal(t, c.serviceAccount, replicaSet.Spec.Template.Spec.ServiceAccountName)
+	assert.Equal(t, "", deployment.Spec.Template.Spec.ServiceAccountName)
 	assert.Equal(t, int32(1), *(deployment.Spec.Replicas))
 	assert.Equal(t, "node1", deployment.Spec.Template.Spec.NodeSelector[apis.LabelHostname])
 	assert.Equal(t, v1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{Namespace: "myosd", Version: "23"}
-	c, err := cluster.podTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", false /* prepareOnly */, v1.RestartPolicyAlways)
+	c, err := cluster.provisionPodTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", v1.RestartPolicyAlways)
 	assert.NotNil(t, c)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.Spec.Containers))
@@ -107,7 +107,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	} else {
 		assert.Equal(t, 3, len(cont.VolumeMounts))
 	}
-	assert.Equal(t, "sh", cont.Command[0])
+	assert.Equal(t, "/tini", cont.Command[0])
 }
 
 func verifyEnvVar(t *testing.T, envVars []v1.EnvVar, expectedName, expectedValue string, expectedFound bool) {

--- a/pkg/operator/ceph/cluster/osd/remove.go
+++ b/pkg/operator/ceph/cluster/osd/remove.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package osd for the Ceph OSDs.
+package osd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func removeOSD(context *clusterd.Context, namespace, deploymentName string, id int) error {
+	// get a baseline for OSD usage so we can compare usage to it later on to know when migration has started
+	initialUsage, err := client.GetOSDUsage(context, namespace)
+	if err != nil {
+		logger.Warningf("failed to get baseline OSD usage, but will still continue")
+	}
+
+	// first reweight the OSD to be 0.0, which will begin the data migration
+	o, err := client.CrushReweight(context, namespace, id, 0.0)
+	if err != nil {
+		return fmt.Errorf("failed to reweight osd.%d to 0.0: %+v. %s", id, err, o)
+	}
+
+	// mark the OSD as out
+	if err := markOSDOut(context, namespace, id); err != nil {
+		return fmt.Errorf("failed to mark osd.%d out: %+v", id, err)
+	}
+
+	// wait for the OSDs data to be migrated
+	if err := waitForRebalance(context, namespace, id, initialUsage); err != nil {
+		return fmt.Errorf("failed to wait for cluster rebalancing after removing osd.%d: %+v", id, err)
+	}
+
+	// data is migrated off the osd, we can delete the deployment now
+	if err := k8sutil.DeleteDeployment(context.Clientset, namespace, deploymentName); err != nil {
+		return fmt.Errorf("failed to delete deployment %s: %+v", deploymentName, err)
+	}
+
+	// purge the OSD from the cluster
+	if err := purgeOSD(context, namespace, id); err != nil {
+		return fmt.Errorf("failed to purge osd.%d from the cluster: %+v", id, err)
+	}
+
+	// delete any backups of the OSD filesystem
+	if err := deleteOSDFileSystem(context.Clientset, namespace, id); err != nil {
+		logger.Warningf("failed to delete osd.%d filesystem, it may need to be cleaned up manually: %+v", id, err)
+	}
+
+	return nil
+}
+
+func waitForRebalance(context *clusterd.Context, namespace string, osdID int, initialUsage *client.OSDUsage) error {
+	if initialUsage != nil {
+		// start a retry loop to wait for rebalancing to start
+		err := util.Retry(20, 5*time.Second, func() error {
+			currUsage, err := client.GetOSDUsage(context, namespace)
+			if err != nil {
+				return err
+			}
+
+			init := initialUsage.ByID(osdID)
+			curr := currUsage.ByID(osdID)
+
+			if init == nil || curr == nil {
+				return fmt.Errorf("initial OSD usage or current OSD usage for osd.%d not found. init: %+v, curr: %+v",
+					osdID, initialUsage, currUsage)
+			}
+
+			if curr.UsedKB == "0" && curr.Pgs == "" {
+				return nil
+			}
+
+			if curr.UsedKB >= init.UsedKB && curr.Pgs >= init.Pgs {
+				return fmt.Errorf("current used space and pg count for osd.%d has not decreased still. curr=%+v", osdID, curr)
+			}
+
+			// either the used space or the number of PGs has decreased for the OSD, data rebalancing has started
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// wait until the cluster gets fully rebalanced again
+	err := util.Retry(3000, 15*time.Second, func() error {
+		// get a dump of all placement groups
+		pgDump, err := client.GetPGDumpBrief(context, namespace)
+		if err != nil {
+			return err
+		}
+
+		// ensure that the given OSD is no longer assigned to any placement groups
+		for _, pg := range pgDump {
+			if pg.UpPrimaryID == osdID {
+				return fmt.Errorf("osd.%d is still up primary for pg %s", osdID, pg.ID)
+			}
+			if pg.ActingPrimaryID == osdID {
+				return fmt.Errorf("osd.%d is still acting primary for pg %s", osdID, pg.ID)
+			}
+			for _, id := range pg.UpOsdIDs {
+				if id == osdID {
+					return fmt.Errorf("osd.%d is still up for pg %s", osdID, pg.ID)
+				}
+			}
+			for _, id := range pg.ActingOsdIDs {
+				if id == osdID {
+					return fmt.Errorf("osd.%d is still acting for pg %s", osdID, pg.ID)
+				}
+			}
+		}
+
+		// finally, ensure the cluster gets back to a clean state, meaning rebalancing is complete
+		return client.IsClusterClean(context, namespace)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func markOSDOut(context *clusterd.Context, namespace string, id int) error {
+	_, err := client.OSDOut(context, namespace, id)
+	return err
+}
+
+func purgeOSD(context *clusterd.Context, namespace string, id int) error {
+	// remove the OSD from the crush map
+	_, err := client.CrushRemove(context, namespace, fmt.Sprintf("osd.%d", id))
+	if err != nil {
+		return fmt.Errorf("failed to remove osd.%d from crush map. %v", id, err)
+	}
+
+	// delete the auth for the OSD
+	err = client.AuthDelete(context, namespace, fmt.Sprintf("osd.%d", id))
+	if err != nil {
+		return err
+	}
+
+	// delete the OSD from the cluster
+	_, err = client.OSDRemove(context, namespace, id)
+	if err != nil {
+		return fmt.Errorf("failed to rm osd.%d. %v", id, err)
+	}
+	return nil
+}
+
+func deleteOSDFileSystem(clientset kubernetes.Interface, namespace string, id int) error {
+	logger.Infof("Deleting OSD %d file system", id)
+	storeName := fmt.Sprintf(config.OSDFSStoreNameFmt, id)
+	err := clientset.CoreV1().ConfigMaps(namespace).Delete(storeName, &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package osd for the Ceph OSDs.
+package osd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	OrchestrationStatusStarting      = "starting"
+	OrchestrationStatusComputingDiff = "computingDiff"
+	OrchestrationStatusOrchestrating = "orchestrating"
+	OrchestrationStatusCompleted     = "completed"
+	OrchestrationStatusFailed        = "failed"
+	orchestrationStatusMapName       = "rook-ceph-osd-%s-status"
+	orchestrationStatusKey           = "status"
+	provisioningLabelKey             = "provisioning"
+	nodeLabelKey                     = "node"
+)
+
+type provisionConfig struct {
+	devicesToUse  map[string][]rookalpha.Device
+	errorMessages []string
+}
+
+func newProvisionConfig() *provisionConfig {
+	return &provisionConfig{}
+}
+
+func (c *provisionConfig) addError(message string, args ...interface{}) {
+	logger.Errorf(message, args)
+	c.errorMessages = append(c.errorMessages, fmt.Sprintf(message, args))
+}
+
+func (c *Cluster) updateNodeStatus(node string, status OrchestrationStatus) error {
+	return UpdateNodeStatus(c.kv, node, status)
+}
+
+func UpdateNodeStatus(kv *k8sutil.ConfigMapKVStore, node string, status OrchestrationStatus) error {
+	labels := map[string]string{
+		k8sutil.AppAttr:        appName,
+		orchestrationStatusKey: provisioningLabelKey,
+		nodeLabelKey:           node,
+	}
+
+	// update the status map with the given status now
+	s, _ := json.Marshal(status)
+	if err := kv.SetValueWithLabels(
+		fmt.Sprintf(orchestrationStatusMapName, node),
+		orchestrationStatusKey,
+		string(s),
+		labels); err != nil {
+		return fmt.Errorf("failed to set node %s status. %+v", node, err)
+	}
+	return nil
+}
+
+func (c *Cluster) handleOrchestrationFailure(config *provisionConfig, n rookalpha.Node, message string) {
+	config.addError(message)
+	status := OrchestrationStatus{Status: OrchestrationStatusFailed, Message: message}
+	if err := c.updateNodeStatus(n.Name, status); err != nil {
+		config.addError("failed to update status for node %s. %+v", n.Name, err)
+	}
+}
+
+func isStatusCompleted(status OrchestrationStatus) bool {
+	return status.Status == OrchestrationStatusCompleted || status.Status == OrchestrationStatusFailed
+}
+
+func parseOrchestrationStatus(data map[string]string) *OrchestrationStatus {
+	if data == nil {
+		return nil
+	}
+
+	statusRaw, ok := data[orchestrationStatusKey]
+	if !ok {
+		return nil
+	}
+
+	// we have status for this node, unmarshal it
+	var status OrchestrationStatus
+	if err := json.Unmarshal([]byte(statusRaw), &status); err != nil {
+		logger.Warningf("failed to unmarshal orchestration status. status: %s. %+v", statusRaw, err)
+		return nil
+	}
+
+	return &status
+}
+
+func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig) bool {
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		k8sutil.AppAttr, appName,
+		orchestrationStatusKey, provisioningLabelKey,
+	)
+	return c.processOSDsWithLabels(config, selector, true)
+}
+
+func (c *Cluster) completeOSDsForNodeRemoval(config *provisionConfig, node string) bool {
+	selector := fmt.Sprintf("%s=%s,%s=%s,%s=%s",
+		k8sutil.AppAttr, appName,
+		orchestrationStatusKey, provisioningLabelKey,
+		nodeLabelKey, node,
+	)
+	return c.processOSDsWithLabels(config, selector, false)
+}
+
+func (c *Cluster) processOSDsWithLabels(config *provisionConfig, labelSelector string, configOSDs bool) bool {
+
+	opts := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+
+	// check the status map to see if the node is already completed before we start watching
+	remainingNodes := util.NewSet()
+	statuses, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).List(opts)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			config.addError("failed to get config status. %+v", err)
+			return false
+		}
+		// the status map doesn't exist yet, watching below is still an OK thing to do
+	}
+
+	// check the nodes to see which ones are already completed
+	originalNodes := len(statuses.Items)
+	for _, configMap := range statuses.Items {
+		node, ok := configMap.Labels[nodeLabelKey]
+		if !ok {
+			logger.Infof("missing node label on configmap %s", configMap.Name)
+			continue
+		}
+
+		completed := c.handleStatusConfigMapStatus(node, config, &configMap, configOSDs)
+		if !completed {
+			remainingNodes.Add(node)
+		}
+	}
+
+	// start watching for changes on the orchestration status map
+	opts.ResourceVersion = statuses.ResourceVersion
+
+	if remainingNodes.Count() == 0 {
+		return true
+	}
+
+	opts.Watch = true
+	timeoutMinutes := 10
+	currentTimeoutMinutes := 0
+	for {
+		logger.Infof("%d/%d node(s) completed osd provisioning", (originalNodes - remainingNodes.Count()), originalNodes)
+		w, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Watch(opts)
+		if err != nil {
+			logger.Warningf("failed to start watch on osd status, trying again. %+v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		defer w.Stop()
+
+	ResultLoop:
+		for {
+			select {
+			case e, ok := <-w.ResultChan():
+				if !ok {
+					logger.Infof("orchestration status config map result channel closed, will restart watch.")
+					w.Stop()
+					<-time.After(100 * time.Millisecond)
+					break ResultLoop
+				}
+				if e.Type == watch.Modified {
+					configMap := e.Object.(*v1.ConfigMap)
+					node, ok := configMap.Labels[nodeLabelKey]
+					if !ok {
+						logger.Infof("missing node label on configmap %s", configMap.Name)
+						continue
+					}
+					if !remainingNodes.Contains(node) {
+						logger.Infof("skipping event from node %s status update since it is already completed", node)
+						continue
+					}
+					completed := c.handleStatusConfigMapStatus(node, config, configMap, configOSDs)
+					if completed {
+						remainingNodes.Remove(node)
+						if remainingNodes.Count() == 0 {
+							logger.Infof("%d/%d node(s) completed osd provisioning", originalNodes, originalNodes)
+							return true
+						}
+					}
+				}
+
+			case <-time.After(time.Minute):
+				// log every so often while we are waiting
+				currentTimeoutMinutes++
+				if currentTimeoutMinutes == timeoutMinutes {
+					config.addError("timed out waiting for %d nodes: %+v", remainingNodes.Count(), remainingNodes)
+					return false
+				}
+				logger.Infof("waiting on orchestration status update from %d remaining nodes", remainingNodes.Count())
+			}
+		}
+	}
+}
+
+func (c *Cluster) handleStatusConfigMapStatus(nodeName string, config *provisionConfig, configMap *v1.ConfigMap, configOSDs bool) bool {
+
+	status := parseOrchestrationStatus(configMap.Data)
+	if status == nil {
+		return false
+	}
+
+	logger.Infof("osd orchestration status for node %s is %s", nodeName, status.Status)
+	if status.Status == OrchestrationStatusCompleted {
+		if !configOSDs || c.startOSDDaemon(nodeName, config, configMap, status) {
+			// upon success provisioning or removing OSDs on the node, remove the status configmap
+			c.kv.ClearStore(fmt.Sprintf(orchestrationStatusMapName, nodeName))
+		}
+		return true
+	}
+
+	if status.Status == OrchestrationStatusFailed {
+		config.addError("orchestration for node %s failed: %+v", nodeName, status)
+		return true
+	}
+	return false
+}
+
+func IsRemovingNode(devices string) bool {
+	return devices == "none"
+}
+
+func (c *Cluster) findRemovedNodes() ([]deploymentPerNode, error) {
+	var removedNodes []deploymentPerNode
+
+	// first discover the storage nodes that are still running
+	discoveredNodes, err := c.discoverStorageNodes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover storage nodes: %+v", err)
+	}
+
+	for i, discoveredNode := range discoveredNodes {
+		found := false
+		for _, newNode := range c.Storage.Nodes {
+			// discovered storage node still exists in the current storage spec, move on to next discovered node
+			if discoveredNode.node.Name == newNode.Name {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// the discovered storage node was not found in the current storage spec, add it to the removed nodes set
+			logger.Infof("adding node %s to the removed nodes list. %+v", discoveredNode.node.Name, discoveredNode.node)
+			removedNodes = append(removedNodes, discoveredNodes[i])
+		}
+	}
+
+	return removedNodes, nil
+}

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package osd
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestOrchestrationStatus(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "myversion", "",
+		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	kv := k8sutil.NewConfigMapKVStore(c.Namespace, clientset, metav1.OwnerReference{})
+	nodeName := "mynode"
+	cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)
+
+	// status map should not exist yet
+	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(cmName, metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err))
+
+	// update the status map with some status
+	status := OrchestrationStatus{Status: OrchestrationStatusOrchestrating, Message: "doing work"}
+	err = UpdateNodeStatus(kv, nodeName, status)
+	assert.Nil(t, err)
+
+	// retrieve the status and verify it
+	statusMap, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(cmName, metav1.GetOptions{})
+	assert.Nil(t, err)
+	assert.NotNil(t, statusMap)
+	retrievedStatus := parseOrchestrationStatus(statusMap.Data)
+	assert.NotNil(t, retrievedStatus)
+	assert.Equal(t, status, *retrievedStatus)
+}
+
+func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatcher *watch.FakeWatcher) {
+	for {
+		// wait for the node's orchestration status to change to "starting"
+		cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)
+		cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(cmName, metav1.GetOptions{})
+		if err == nil {
+			status := parseOrchestrationStatus(cm.Data)
+			if status != nil && status.Status == OrchestrationStatusStarting {
+				// the node has started orchestration, simulate its completion now by performing 2 tasks:
+				// 1) update the config map manually (which doesn't trigger a watch event, see https://github.com/kubernetes/kubernetes/issues/54075#issuecomment-337298950)
+				status = &OrchestrationStatus{
+					OSDs: []OSDInfo{
+						{
+							ID:          1,
+							DataPath:    "/tmp",
+							Config:      "/foo/bar/ceph.conf",
+							Cluster:     "rook",
+							KeyringPath: "/foo/bar/key",
+						},
+					},
+					Status: OrchestrationStatusCompleted,
+				}
+				UpdateNodeStatus(c.kv, nodeName, *status)
+
+				// 2) call modify on the fake watcher so a watch event will get triggered
+				s, _ := json.Marshal(status)
+				cm.Data[orchestrationStatusKey] = string(s)
+				statusMapWatcher.Modify(cm)
+				break
+			} else {
+				logger.Debugf("waiting for node %s orchestration to start. status: %+v", nodeName, *status)
+			}
+		} else {
+			logger.Warningf("failed to get node %s orchestration status, will try again: %+v", nodeName, err)
+		}
+		<-time.After(50 * time.Millisecond)
+	}
+}
+
+func waitForOrchestrationCompletion(c *Cluster, nodeName string, startCompleted *bool) {
+	for {
+		if *startCompleted {
+			break
+		}
+		cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(orchestrationStatusMapName, metav1.GetOptions{})
+		if err == nil {
+			status := parseOrchestrationStatus(cm.Data)
+			if status != nil {
+				logger.Debugf("start has not completed, status is %+v", status)
+			}
+		}
+		<-time.After(50 * time.Millisecond)
+	}
+}

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -153,6 +153,7 @@ func (o *Operator) Run() error {
 		case <-signalChan:
 			logger.Infof("shutdown signal received, exiting...")
 			close(stopChan)
+			o.clusterController.StopWatch()
 			return nil
 		}
 	}

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
@@ -42,6 +43,9 @@ const (
 	discoverDaemonsetName             = "rook-discover"
 	discoverDaemonsetTolerationEnv    = "DISCOVER_TOLERATION"
 	discoverDaemonsetTolerationKeyEnv = "DISCOVER_TOLERATION_KEY"
+	deviceInUseCMName                 = "local-device-in-use-cluster-%s-node-%s"
+	deviceInUseAppName                = "rook-claimed-devices"
+	deviceInUseClusterAttr            = "rook.io/cluster"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-discover")
@@ -106,7 +110,8 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 								{
 									Name:      "dev",
 									MountPath: "/dev",
-									ReadOnly:  true,
+									// discovery pod could fail to start if /dev is mounted ro
+									ReadOnly: false,
 								},
 								{
 									Name:      "sys",
@@ -186,21 +191,81 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 
 }
 
+// ListDevices lists all devices discovered on all nodes or specific node if node name is provided.
 func ListDevices(context *clusterd.Context, namespace, nodeName string) (map[string][]sys.LocalDisk, error) {
 	var devices map[string][]sys.LocalDisk
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, discoverDaemon.AppName)}
+	// wait for device discovery configmaps
+	retryCount := 0
+	retryMax := 30
+	sleepTime := 5
+	for {
+		retryCount++
+		if retryCount > retryMax {
+			return devices, fmt.Errorf("exceeded max retry count waiting for device configmap to appear")
+		}
+
+		if retryCount > 1 {
+			// only sleep after the first time
+			<-time.After(time.Duration(sleepTime) * time.Second)
+		}
+
+		cms, err := context.Clientset.CoreV1().ConfigMaps(namespace).List(listOpts)
+		if err != nil {
+			logger.Warningf("failed to list device configmaps: %v", err)
+			return devices, fmt.Errorf("failed to list device configmaps: %+v", err)
+		}
+		if len(cms.Items) == 0 {
+			logger.Infof("no configmap match, retry #%d", retryCount)
+			continue
+		}
+		devices = make(map[string][]sys.LocalDisk, len(cms.Items))
+		for _, cm := range cms.Items {
+			node := cm.ObjectMeta.Labels[discoverDaemon.NodeAttr]
+			if len(nodeName) > 0 && node != nodeName {
+				continue
+			}
+			deviceJson := cm.Data[discoverDaemon.LocalDiskCMData]
+			logger.Debugf("node %s, device %s", node, deviceJson)
+
+			if len(node) == 0 || len(deviceJson) == 0 {
+				continue
+			}
+			var d []sys.LocalDisk
+			err = json.Unmarshal([]byte(deviceJson), &d)
+			if err != nil {
+				logger.Warningf("failed to unmarshal %s", deviceJson)
+				continue
+			}
+			devices[node] = d
+		}
+		break
+	}
+	logger.Debugf("discovery found the following devices %+v", devices)
+	return devices, nil
+}
+
+// ListDevicesInUse lists all devices on a node that are already used by existing clusters.
+func ListDevicesInUse(context *clusterd.Context, namespace, nodeName string) ([]sys.LocalDisk, error) {
+	var devices []sys.LocalDisk
+
+	if len(nodeName) == 0 {
+		return devices, fmt.Errorf("empty node name")
+	}
+
+	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, deviceInUseAppName)}
 	cms, err := context.Clientset.CoreV1().ConfigMaps(namespace).List(listOpts)
 	if err != nil {
-		return devices, fmt.Errorf("failed to list device configmaps: %+v", err)
+		return devices, fmt.Errorf("failed to list device in use configmaps: %+v", err)
 	}
-	devices = make(map[string][]sys.LocalDisk, len(cms.Items))
+
 	for _, cm := range cms.Items {
 		node := cm.ObjectMeta.Labels[discoverDaemon.NodeAttr]
-		if len(nodeName) > 0 && node != nodeName {
+		if node != nodeName {
 			continue
 		}
 		deviceJson := cm.Data[discoverDaemon.LocalDiskCMData]
-		logger.Debugf("node %s, device %s", node, deviceJson)
+		logger.Debugf("node %s, device in use %s", node, deviceJson)
 
 		if len(node) == 0 || len(deviceJson) == 0 {
 			continue
@@ -211,31 +276,97 @@ func ListDevices(context *clusterd.Context, namespace, nodeName string) (map[str
 			logger.Warningf("failed to unmarshal %s", deviceJson)
 			continue
 		}
-		devices[node] = d
+		for i := range d {
+			devices = append(devices, d[i])
+		}
 	}
-	logger.Debugf("devices %+v", devices)
+	logger.Debugf("devices in use %+v", devices)
 	return devices, nil
 }
 
+// FreeDevices frees up devices used by a cluster on a node.
+func FreeDevices(context *clusterd.Context, nodeName, clusterName string) error {
+	if len(nodeName) == 0 || len(clusterName) == 0 {
+		return nil
+	}
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	cmName := fmt.Sprintf(deviceInUseCMName, clusterName, nodeName)
+	// delete configmap
+	err := context.Clientset.CoreV1().ConfigMaps(namespace).Delete(cmName, &metav1.DeleteOptions{})
+	if err != nil && !kserrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete configmap %s/%s. %+v", namespace, cmName, err)
+	}
+
+	return nil
+}
+
+// FreeDevicesByCluster frees devices on all nodes that are used by the cluster
+func FreeDevicesByCluster(context *clusterd.Context, clusterName string) error {
+	logger.Infof("freeing devices used by cluster %s", clusterName)
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", deviceInUseClusterAttr, clusterName)}
+	cms, err := context.Clientset.CoreV1().ConfigMaps(namespace).List(listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to list device in use configmaps for cluster %s: %+v", clusterName, err)
+	}
+
+	for _, cm := range cms.Items {
+		// delete configmap
+		cmName := cm.Name
+		err := context.Clientset.CoreV1().ConfigMaps(namespace).Delete(cmName, &metav1.DeleteOptions{})
+		logger.Infof("deleting configmap %s: %+v", cmName, err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetAvailableDevices conducts outter join using input filters with free devices that a node has. It marks the devices from join result as in-use.
 func GetAvailableDevices(context *clusterd.Context, nodeName, clusterName string, devices []rookalpha.Device, filter string, useAllDevices bool) ([]rookalpha.Device, error) {
 	results := []rookalpha.Device{}
 	if len(devices) == 0 && len(filter) == 0 && !useAllDevices {
 		return results, nil
 	}
 	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	// find all devices
 	allDevices, err := ListDevices(context, namespace, nodeName)
 	if err != nil {
 		return results, err
 	}
-	nodeDevices, ok := allDevices[nodeName]
+	// find those on the node
+	nodeAllDevices, ok := allDevices[nodeName]
 	if !ok {
 		return results, fmt.Errorf("node %s has no devices", nodeName)
 	}
+	// find those in use on the node
+	devicesInUse, err := ListDevicesInUse(context, namespace, nodeName)
+	if err != nil {
+		return results, err
+	}
+
+	// filter those in use
+	nodeDevices := []sys.LocalDisk{}
+	for i := range nodeAllDevices {
+		isInUse := false
+		for j := range devicesInUse {
+			if nodeAllDevices[i].Name == devicesInUse[j].Name {
+				isInUse = true
+				break
+			}
+		}
+		if !isInUse {
+			nodeDevices = append(nodeDevices, nodeAllDevices[i])
+		}
+	}
+	claimedDevices := []sys.LocalDisk{}
+	// now those left are free to use
 	if len(devices) > 0 {
 		for i := range devices {
 			for j := range nodeDevices {
 				if devices[i].Name == nodeDevices[j].Name {
 					results = append(results, devices[i])
+					claimedDevices = append(claimedDevices, nodeDevices[j])
 				}
 			}
 		}
@@ -247,6 +378,7 @@ func GetAvailableDevices(context *clusterd.Context, nodeName, clusterName string
 				d := rookalpha.Device{
 					Name: nodeDevices[i].Name,
 				}
+				claimedDevices = append(claimedDevices, nodeDevices[i])
 				results = append(results, d)
 			}
 		}
@@ -256,8 +388,37 @@ func GetAvailableDevices(context *clusterd.Context, nodeName, clusterName string
 				Name: nodeDevices[i].Name,
 			}
 			results = append(results, d)
+			claimedDevices = append(claimedDevices, nodeDevices[i])
 		}
 	}
+	// mark these devices in use
+	if len(claimedDevices) > 0 {
+		deviceJson, err := json.Marshal(claimedDevices)
+		if err != nil {
+			logger.Infof("failed to marshal: %v", err)
+			return results, err
+		}
+		data := make(map[string]string, 1)
+		data[discoverDaemon.LocalDiskCMData] = string(deviceJson)
 
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf(deviceInUseCMName, clusterName, nodeName),
+				Namespace: namespace,
+				Labels: map[string]string{
+					k8sutil.AppAttr:         deviceInUseAppName,
+					discoverDaemon.NodeAttr: nodeName,
+					deviceInUseClusterAttr:  clusterName,
+				},
+			},
+			Data: data,
+		}
+		cm, err = context.Clientset.CoreV1().ConfigMaps(namespace).Create(cm)
+
+		if err != nil {
+			logger.Warningf("failed to update device in use for cluster %s node %s: %v", clusterName, nodeName, err)
+		}
+		return results, err
+	}
 	return results, nil
 }

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -112,10 +112,33 @@ func TestGetAvailableDevices(t *testing.T) {
 	devices, err := GetAvailableDevices(context, nodeName, ns, d, "^sd.", false)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(devices))
+	// devices should be in use now, 2nd try gets empty devices
+	devices, err = GetAvailableDevices(context, nodeName, ns, d, "^sd.", false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(devices))
+
+	err = FreeDevices(context, nodeName, ns)
+	assert.Nil(t, err)
+	// all devices freed
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(devices))
+	// devices should be in use now, 2nd try gets empty devices
+	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(devices))
+
+	err = FreeDevices(context, nodeName, ns)
+	assert.Nil(t, err)
+
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(devices))
+	// devices should be in use now, 2nd try gets empty devices
+	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(devices))
+
+	err = FreeDevices(context, nodeName, ns)
+	assert.Nil(t, err)
 }

--- a/pkg/operator/k8sutil/kvstore.go
+++ b/pkg/operator/k8sutil/kvstore.go
@@ -54,6 +54,10 @@ func (kv *ConfigMapKVStore) GetValue(storeName, key string) (string, error) {
 }
 
 func (kv *ConfigMapKVStore) SetValue(storeName, key, value string) error {
+	return kv.SetValueWithLabels(storeName, key, value, nil)
+}
+
+func (kv *ConfigMapKVStore) SetValueWithLabels(storeName, key, value string, labels map[string]string) error {
 	cm, err := kv.clientset.CoreV1().ConfigMaps(kv.namespace).Get(storeName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -67,6 +71,9 @@ func (kv *ConfigMapKVStore) SetValue(storeName, key, value string) error {
 				Namespace: kv.namespace,
 			},
 			Data: map[string]string{key: value},
+		}
+		if labels != nil {
+			cm.Labels = labels
 		}
 		SetOwnerRef(kv.clientset, kv.namespace, &cm.ObjectMeta, &kv.ownerRef)
 

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -93,10 +93,9 @@ func (c *MinioController) makeMinioHeadlessService(name, namespace string, spec 
 
 	svc, err := coreV1Client.Services(namespace).Create(&v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			Labels:          map[string]string{k8sutil.AppAttr: minioLabel},
-			OwnerReferences: []meta_v1.OwnerReference{ownerRef},
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{k8sutil.AppAttr: minioLabel},
 		},
 		Spec: v1.ServiceSpec{
 			Selector:  map[string]string{k8sutil.AppAttr: minioLabel},
@@ -104,6 +103,7 @@ func (c *MinioController) makeMinioHeadlessService(name, namespace string, spec 
 			ClusterIP: v1.ClusterIPNone,
 		},
 	})
+	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &ownerRef)
 
 	return svc, err
 }
@@ -209,10 +209,9 @@ func (c *MinioController) makeMinioStatefulSet(name, namespace string, spec mini
 	nodeCount := int32(spec.Storage.NodeCount)
 	ss := v1beta2.StatefulSet{
 		ObjectMeta: meta_v1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			Labels:          map[string]string{k8sutil.AppAttr: minioLabel},
-			OwnerReferences: []meta_v1.OwnerReference{ownerRef},
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{k8sutil.AppAttr: minioLabel},
 		},
 		Spec: v1beta2.StatefulSetSpec{
 			Replicas: &nodeCount,
@@ -240,6 +239,7 @@ func (c *MinioController) makeMinioStatefulSet(name, namespace string, spec mini
 			// TODO: liveness probe
 		},
 	}
+	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &ss.ObjectMeta, &ownerRef)
 
 	return appsClient.StatefulSets(namespace).Create(&ss)
 }

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -30,6 +30,7 @@ const (
 	SSDType   = "ssd"
 	PartType  = "part"
 	CryptType = "crypt"
+	LVMType   = "lvm"
 	sgdisk    = "sgdisk"
 	mountCmd  = "mount"
 )
@@ -118,17 +119,16 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 			}
 			totalPartitionSize += p.Size
 
-			label, err := GetPartitionLabel(name, executor)
+			info, err := GetUdevInfo(name, executor)
 			if err != nil {
 				return nil, 0, err
 			}
-			p.Label = label
-
-			fs, err := GetDeviceFilesystems(name, executor)
-			if err != nil {
-				return nil, 0, err
+			if v, ok := info["ID_PART_ENTRY_NAME"]; ok {
+				p.Label = v
 			}
-			p.Filesystem = fs
+			if v, ok := info["ID_FS_TYPE"]; ok {
+				p.Filesystem = v
+			}
 
 			partitions = append(partitions, p)
 		}

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -304,14 +304,18 @@ func CheckIfDeviceAvailable(executor exec.Executor, name string) (bool, string, 
 func RookOwnsPartitions(partitions []Partition) bool {
 
 	// if there are partitions, they must all have the rook osd label
+	ownPartitions := true
 	for _, p := range partitions {
-		if !strings.HasPrefix(p.Label, "ROOK-OSD") {
-			return false
+		if strings.HasPrefix(p.Label, "ROOK-OSD") {
+			logger.Infof("rook partition: %s", p.Label)
+		} else {
+			logger.Infof("non-rook partition: %s", p.Label)
+			ownPartitions = false
 		}
 	}
 
 	// if there are no partitions, or the partitions are all from rook OSDs, then rook owns the device
-	return true
+	return ownPartitions
 }
 
 // finds the disk uuid in the output of sgdisk

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -97,7 +97,6 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get device %s partitions. %+v", device, err)
 	}
-
 	partInfo := strings.Split(output, "\n")
 	var deviceSize uint64
 	var totalPartitionSize uint64
@@ -124,6 +123,9 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 				return nil, 0, err
 			}
 			if v, ok := info["ID_PART_ENTRY_NAME"]; ok {
+				p.Label = v
+			}
+			if v, ok := info["PARTNAME"]; ok {
 				p.Label = v
 			}
 			if v, ok := info["ID_FS_TYPE"]; ok {

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -155,14 +155,11 @@ NAME="sdb3" SIZE="20" TYPE="part" PKNAME="sdb"
 NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 			case run == 3:
 				return fmt.Sprintf(udevPartOutput, "ROOK-OSD0-DB"), nil
-			case run == 4 || run == 6 || run == 8:
-				// get filesystem
-				return "", nil
-			case run == 5:
+			case run == 4:
 				return fmt.Sprintf(udevPartOutput, "ROOK-OSD0-BLOCK"), nil
-			case run == 7:
+			case run == 5:
 				return fmt.Sprintf(udevPartOutput, "ROOK-OSD0-WAL"), nil
-			case run == 9:
+			case run == 6:
 				return `NAME="sda" SIZE="19818086400" TYPE="disk" PKNAME=""
 NAME="sda4" SIZE="1073741824" TYPE="part" PKNAME="sda"
 NAME="sda2" SIZE="2097152" TYPE="part" PKNAME="sda"
@@ -172,14 +169,6 @@ NAME="sda3" SIZE="1073741824" TYPE="part" PKNAME="sda"
 NAME="usr" SIZE="1065345024" TYPE="crypt" PKNAME="sda3"
 NAME="sda1" SIZE="134217728" TYPE="part" PKNAME="sda"
 NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda"`, nil
-			case run == 9:
-				return fmt.Sprintf(udevPartOutput, "ROOT"), nil
-			case run == 10:
-				return fmt.Sprintf(udevPartOutput, "OEM-CONFIG"), nil
-			case run == 11:
-				return fmt.Sprintf(udevPartOutput, "USR-A"), nil
-			case run == 12:
-				return fmt.Sprintf(udevPartOutput, "EFI-SYSTEM"), nil
 			}
 			return "", nil
 		},

--- a/tests/framework/installer/install_data.go
+++ b/tests/framework/installer/install_data.go
@@ -17,8 +17,9 @@ limitations under the License.
 package installer
 
 import (
-	"github.com/google/uuid"
 	"strconv"
+
+	"github.com/google/uuid"
 )
 
 //InstallData wraps rook yaml definitions
@@ -457,7 +458,7 @@ spec:
 }
 
 //GetCleanupPod gets a cleanup Pod manifest
-func (i *InstallData) GetCleanupPod(removalDir string) string {
+func (i *InstallData) GetCleanupPod(node, removalDir string) string {
 	return `apiVersion: batch/v1
 kind: Job
 metadata:
@@ -478,6 +479,8 @@ spec:
                     - "sh"
                     - "-c"
                     - "rm -rf /scrub/*"
+          nodeSelector:
+            kubernetes.io/hostname: ` + node + `
           volumes:
               - name: cleaner
                 hostPath:

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -977,15 +977,16 @@ func (k8sh *K8sHelper) WaitUntilPodInNamespaceIsDeleted(podNamePattern string, n
 
 //WaitUntilPodIsDeleted waits for 90s for a pod to be terminated
 //If the pod disappears within 90s true is returned,  if not false
-func (k8sh *K8sHelper) WaitUntilPodIsDeleted(podNamePattern string) bool {
+func (k8sh *K8sHelper) WaitUntilPodIsDeleted(name, namespace string) bool {
 	inc := 0
 	for inc < RetryLoop {
-		out, _ := k8sh.GetResource("pods", "-l", "app="+podNamePattern)
-		if !strings.Contains(out, podNamePattern) {
+		_, err := k8sh.Clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
 			return true
 		}
 
 		inc++
+		logger.Infof("pod %s in namespace %s is not deleted yet", name, namespace)
 		time.Sleep(RetryInterval * time.Second)
 	}
 	return false

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -126,9 +126,9 @@ func StartBaseTestOperations(t func() *testing.T, namespace, storeType string, h
 func (op BaseTestOperations) SetUp() {
 	isRookInstalled, err := op.installer.InstallRookOnK8sWithHostPathAndDevices(op.namespace, op.storeType,
 		op.helmInstalled, op.useDevices, cephv1alpha1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */)
-	assert.NoError(op.T(), err)
-	if !isRookInstalled {
-		logger.Errorf("Rook was not installed successfully")
+
+	if !isRookInstalled || err != nil {
+		logger.Errorf("Rook was not installed successfully: %v", err)
 		if !op.installer.T().Failed() {
 			op.installer.GatherAllRookLogs(op.namespace, installer.SystemNamespace(op.namespace), op.installer.T().Name())
 		}

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -18,6 +18,8 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"time"
 
 	"testing"
@@ -125,6 +127,16 @@ func StartBaseTestOperations(t func() *testing.T, namespace, storeType, dataDirH
 
 //SetUpRook is a wrapper for setting up rook
 func (op BaseTestOperations) SetUp() {
+	if err := os.MkdirAll(op.dataDirHostPath, 0755); err != nil {
+		logger.Warningf("failed to mkdir %s:%v", op.dataDirHostPath, err)
+		return
+	}
+	dataDir, err := ioutil.TempDir(op.dataDirHostPath, "test-")
+	if err != nil {
+		logger.Warningf("failed to make temp dir %s: %v", op.dataDirHostPath, err)
+		return
+	}
+	op.dataDirHostPath = dataDir
 	isRookInstalled, err := op.installer.InstallRookOnK8sWithHostPathAndDevices(op.namespace, op.storeType,
 		op.dataDirHostPath, op.helmInstalled, op.useDevices,
 		cephv1alpha1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */)

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -56,7 +56,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 
 	var err error
 	s.namespace = "block-k8s-ns"
-	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", "", false, false, 1)
+	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", installer.DefaultDataDirHostPath(s.namespace), false, false, 1)
 	s.testClient = GetTestClient(s.kh, s.namespace, s.op, s.T)
 	initialBlocks, err := s.testClient.BlockClient.List(s.namespace)
 	assert.Nil(s.T(), err)

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -56,7 +56,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 
 	var err error
 	s.namespace = "block-k8s-ns"
-	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", installer.DefaultDataDirHostPath(s.namespace), false, false, 1)
+	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", false, false, 1)
 	s.testClient = GetTestClient(s.kh, s.namespace, s.op, s.T)
 	initialBlocks, err := s.testClient.BlockClient.List(s.namespace)
 	assert.Nil(s.T(), err)

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -18,8 +18,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/rook/rook/tests/framework/installer"
-
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/contracts"
@@ -65,7 +63,7 @@ type HelmSuite struct {
 
 func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
-	hs.op, hs.kh = StartBaseTestOperations(hs.T, hs.namespace, "bluestore", installer.DefaultDataDirHostPath(hs.namespace), true, false, 1)
+	hs.op, hs.kh = StartBaseTestOperations(hs.T, hs.namespace, "bluestore", true, false, 1)
 	hs.helper = GetTestClient(hs.kh, hs.namespace, hs.op, hs.T)
 }
 

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -18,6 +18,8 @@ package integration
 import (
 	"testing"
 
+	"github.com/rook/rook/tests/framework/installer"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/contracts"
@@ -63,7 +65,7 @@ type HelmSuite struct {
 
 func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
-	hs.op, hs.kh = StartBaseTestOperations(hs.T, hs.namespace, "bluestore", "", true, false, 1)
+	hs.op, hs.kh = StartBaseTestOperations(hs.T, hs.namespace, "bluestore", installer.DefaultDataDirHostPath(hs.namespace), true, false, 1)
 	hs.helper = GetTestClient(hs.kh, hs.namespace, hs.op, hs.T)
 }
 

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -75,7 +75,8 @@ type SmokeSuite struct {
 
 func (suite *SmokeSuite) SetupSuite() {
 	suite.namespace = "smoke-ns"
-	suite.op, suite.k8sh = StartBaseTestOperations(suite.T, suite.namespace, "bluestore", installer.DefaultDataDirHostPath(suite.namespace), false, false, 3)
+	useDevices := true
+	suite.op, suite.k8sh = StartBaseTestOperations(suite.T, suite.namespace, "bluestore", false, useDevices, 3)
 	suite.helper = GetTestClient(suite.k8sh, suite.namespace, suite.op, suite.T)
 }
 

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -75,7 +75,7 @@ type SmokeSuite struct {
 
 func (suite *SmokeSuite) SetupSuite() {
 	suite.namespace = "smoke-ns"
-	suite.op, suite.k8sh = StartBaseTestOperations(suite.T, suite.namespace, "bluestore", "", false, false, 3)
+	suite.op, suite.k8sh = StartBaseTestOperations(suite.T, suite.namespace, "bluestore", installer.DefaultDataDirHostPath(suite.namespace), false, false, 3)
 	suite.helper = GetTestClient(suite.k8sh, suite.namespace, suite.op, suite.T)
 }
 

--- a/tests/integration/zblock_mount_unmount_test.go
+++ b/tests/integration/zblock_mount_unmount_test.go
@@ -85,8 +85,9 @@ func (s *BlockMountUnMountSuite) SetupSuite() {
 	s.namespace = "block-test-ns"
 	s.pvcNameRWO = "block-persistent-rwo"
 	s.pvcNameRWX = "block-persistent-rwx"
-
-	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", installer.DefaultDataDirHostPath(s.namespace), false, false, 1)
+	useHelm := false
+	useDevices := true
+	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "filestore", useHelm, useDevices, 1)
 	s.testClient = GetTestClient(s.kh, s.namespace, s.op, s.T)
 	s.bc = s.testClient.BlockClient
 }

--- a/tests/integration/zblock_mount_unmount_test.go
+++ b/tests/integration/zblock_mount_unmount_test.go
@@ -85,7 +85,8 @@ func (s *BlockMountUnMountSuite) SetupSuite() {
 	s.namespace = "block-test-ns"
 	s.pvcNameRWO = "block-persistent-rwo"
 	s.pvcNameRWX = "block-persistent-rwx"
-	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", "", false, false, 1)
+
+	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", installer.DefaultDataDirHostPath(s.namespace), false, false, 1)
 	s.testClient = GetTestClient(s.kh, s.namespace, s.op, s.T)
 	s.bc = s.testClient.BlockClient
 }

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -159,7 +159,7 @@ func (o BaseLoadTestOperations) SetUp() {
 
 	if !o.kh.IsRookInstalled(o.namespace) {
 		isRookInstalled, err := o.installer.InstallRookOnK8sWithHostPathAndDevices(o.namespace, "bluestore",
-			"/temp/rookBackup", false, true, cephv1alpha1.MonSpec{Count: 3, AllowMultiplePerNode: true},
+			false, true, cephv1alpha1.MonSpec{Count: 3, AllowMultiplePerNode: true},
 			true /* startWithAllNodes */)
 		require.NoError(o.T(), err)
 		require.True(o.T(), isRookInstalled)

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -115,6 +115,7 @@ case "${1:-}" in
       wait_for_ssh
     fi
     # create a link so the default dataDirHostPath will work for this environment
+    minikube ssh "sudo mkdir -p /mnt/sda1/${PWD}; sudo mkdir -p $(dirname $PWD); sudo ln -s /mnt/sda1/${PWD} $(dirname $PWD)/"    
     minikube ssh "sudo mkdir /mnt/sda1/var/lib/rook;sudo ln -s /mnt/sda1/var/lib/rook /var/lib/rook"
     copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
     copy_image_to_cluster "${BUILD_REGISTRY}/ceph-toolbox-amd64" rook/ceph-toolbox:master


### PR DESCRIPTION
Description of your changes:
(this is a continuation of #1637)
Once device discovery is merged,  operator resolves devices before creating osds, creates job on each node to prepare osds, and then creates one replica set per osd.

Which issue is resolved by this Pull Request:
Resolves #1656 

Followups
- [x] Ensure no device holders before declaring the devices empty (from @leseb )  #1839 
- [x] Cleanup in CI tests without Jenkins change 
- [x] Integration testing with devices, and OSD pod restart during tests
- [x] Multiple people have run manual test scenarios (including upgrade) in multi-node multi-device environments
- [x] Upgrade process documentation or scripting (from @travisn )
- [x] Remove node scenario has been manually tested.  data is rebalanced, cluster is healthy, and all resources from removed node have been cleaned up (from @jbw976)
- [x] finalize whether monitor OSD health in prepare pod or operator (from @travisn and @galexrt )
- [x] set `ownerRef` In-use device configmap, pending on investigating openshift compatability (from @travisn )
- [x] improve osd `start()` readability (from @travisn )
- [x] deal with bad node or failed provisioning job (from @travisn )
- [x] document impact of mount propagation on minikube (per tests from @travisn )
- [x] test cluster upgrade: add/remove nodes/devices (per @jcsp )

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
