### PR TITLE
Base flex driver name on the namespace

### DIFF
--- a/cmd/rookflex/cmd/root.go
+++ b/cmd/rookflex/cmd/root.go
@@ -51,7 +51,7 @@ func getRPCClient() (*rpc.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting path of the Rook flexvolume driver: %v", err)
 	}
-	unixSocketFile := path.Join(path.Dir(ex), path.Join(flexvolume.UnixSocketName)) // /usr/libexec/kubernetes/plugin/volume/rook.io~rook/.rook.sock
+	unixSocketFile := path.Join(path.Dir(ex), flexvolume.UnixSocketName) // /usr/libexec/kubernetes/kubelet-plugins/volume/exec/rook.io~rook/rook/.rook.sock
 	conn, err := net.Dial("unix", unixSocketFile)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to socket %s: %+v", unixSocketFile, err)

--- a/pkg/daemon/agent/flexvolume/controller.go
+++ b/pkg/daemon/agent/flexvolume/controller.go
@@ -325,7 +325,11 @@ func (c *Controller) GetAttachInfoFromMountDir(mountDir string, attachOptions *A
 // GetGlobalMountPath generate the global mount path where the device path is mounted.
 // It is based on the kubelet root dir, which defaults to /var/lib/kubelet
 func (c *Controller) GetGlobalMountPath(volumeName string, globalMountPath *string) error {
-	*globalMountPath = path.Join(c.getKubeletRootDir(), "plugins", FlexvolumeVendor, FlexvolumeDriver, "mounts", volumeName)
+	driverName, err := RookDriverName(c.context)
+	if err != nil {
+		return err
+	}
+	*globalMountPath = path.Join(c.getKubeletRootDir(), "plugins", FlexvolumeVendor, driverName, "mounts", volumeName)
 	return nil
 }
 

--- a/pkg/daemon/agent/flexvolume/server_test.go
+++ b/pkg/daemon/agent/flexvolume/server_test.go
@@ -32,9 +32,11 @@ func TestConfigureFlexVolume(t *testing.T) {
 	driverFile := path.Join(driverDir, flexvolumeDriverFileName)
 	os.OpenFile(driverFile, os.O_RDONLY|os.O_CREATE, 0755)
 
-	err := configureFlexVolume(driverFile, driverDir)
+	driverName := "rook"
+	os.Setenv("POD_NAMESPACE", driverName)
+	defer os.Setenv("POD_NAMESPACE", "")
+	err := configureFlexVolume(driverFile, driverDir, driverName)
 	assert.Nil(t, err)
 	_, err = os.Stat(path.Join(driverDir, "rook"))
 	assert.False(t, os.IsNotExist(err))
-
 }

--- a/pkg/operator/provisioner/provisioner.go
+++ b/pkg/operator/provisioner/provisioner.go
@@ -37,7 +37,6 @@ const (
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-provisioner")
-var flexdriver = fmt.Sprintf("%s/%s", flexvolume.FlexvolumeVendor, flexvolume.FlexvolumeDriver)
 
 // RookVolumeProvisioner is used to provision Rook volumes on Kubernetes
 type RookVolumeProvisioner struct {
@@ -95,6 +94,12 @@ func (p *RookVolumeProvisioner) Provision(options controller.VolumeOptions) (*v1
 		return nil, err
 	}
 
+	driverName, err := flexvolume.RookDriverName(p.context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get driver name. %+v", err)
+	}
+
+	flexdriver := fmt.Sprintf("%s/%s", flexvolume.FlexvolumeVendor, driverName)
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: imageName,

--- a/pkg/operator/provisioner/provisioner_test.go
+++ b/pkg/operator/provisioner/provisioner_test.go
@@ -40,6 +40,8 @@ func TestProvisionImage(t *testing.T) {
 	clientset := test.New(3)
 	namespace := "ns"
 	configDir, _ := ioutil.TempDir("", "")
+	os.Setenv("POD_NAMESPACE", "rook-system")
+	defer os.Setenv("POD_NAMESPACE", "")
 	defer os.RemoveAll(configDir)
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
@@ -72,7 +74,7 @@ func TestProvisionImage(t *testing.T) {
 
 	assert.Equal(t, "pvc-uid-1-1", pv.Name)
 	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
-	assert.Equal(t, "rook.io/rook", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
+	assert.Equal(t, "rook.io/rook-system", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
 	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
 	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
 	assert.Equal(t, "testpool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["pool"])

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -415,12 +415,12 @@ func (k8sh *K8sHelper) IsPodTerminated(name string, namespace string) bool {
 			k8slogger.Infof("Pod  %s in namespace %s terminated ", name, namespace)
 			return true
 		}
-		k8slogger.Infof("waiting for Pod %s in namespace %s to terminated, status : %v", name, namespace, pod.Status.Phase)
+		k8slogger.Infof("waiting for Pod %s in namespace %s to terminate, status : %v", name, namespace, pod.Status.Phase)
 		time.Sleep(RetryInterval * time.Second)
 		inc++
 
 	}
-	k8slogger.Infof("Pod %s in namespace %s did not terminated", name, namespace)
+	k8slogger.Infof("Pod %s in namespace %s did not terminate", name, namespace)
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Multiple rook system namespaces cannot be currently run because of the conflict between using the same flex driver. This change creates a driver name based on the namespace to avoid that conflict. For backward compatibility, the agent will also watch the unix socket for the old driver name (rook).

Which issue is resolved by this Pull Request:
Resolves #1701

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
