### PR TITLE
Make sed usage compatible with GNU and BSD

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,6 +12,7 @@
 - Rook-Operator no longer creates the resources CRD's or TPR's at the runtime. Instead, those resources are provisioned during deployment via `helm` or `kubectl`.
 - The 'rook' image is now based on the ceph-container project's 'daemon-base' image so that Rook no
   longer has to manage installs of Ceph in image.
+- Rook CRD code generation is now working with BSD (Mac) and GNU sed.
 
 ## Breaking Changes
 

--- a/build/codegen/header.txt
+++ b/build/codegen/header.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 The Rook Authors. All rights reserved.
+Copyright 2018 The Rook Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
```
Update codegen header.txt to current year

Fixes #1664

Signed-off-by: Alexander Trost <galexrt@googlemail.com>
```
Description of your changes:
This fixes issues with GNU and allows for GNU and BSD sed versions to work.

Which issue is resolved by this Pull Request:
Resolves #1664

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.

[skip ci]