### PR TITLE
Support 1.10 in the integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,8 @@ pipeline {
                     def data = [
                         "aws_1.7.x": "v1.7.11",
                         "aws_1.8.x": "v1.8.5",
-                        "gce_1.9.x": "v1.9.1"
+                        "gce_1.9.x": "v1.9.6",
+                        "aws_1.10.x": "v1.10.1"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/tests/framework/clients/filesystem.go
+++ b/tests/framework/clients/filesystem.go
@@ -64,7 +64,9 @@ spec:
 	}
 
 	logger.Infof("Make sure rook-ceph-mds pod is running")
-	assert.True(f.k8sh.T(), f.k8sh.IsPodWithLabelRunning(fmt.Sprintf("rook_file_system=%s", name), namespace))
+	running, err := f.k8sh.WaitForLabeledPodToRun(fmt.Sprintf("rook_file_system=%s", name), namespace)
+	assert.Nil(f.k8sh.T(), err)
+	assert.True(f.k8sh.T(), running)
 
 	assert.True(f.k8sh.T(), f.k8sh.CheckPodCountAndState("rook-ceph-mds", namespace, 2, "Running"),
 		"Make sure there are two rook-ceph-mds pods present in Running state")

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -66,8 +66,9 @@ spec:
 		return err
 	}
 
-	if !ro.k8sh.IsPodWithLabelRunning(fmt.Sprintf("rook_object_store=%s", storeName), namespace) {
-		return fmt.Errorf("rgw did not start via crd")
+	running, err := ro.k8sh.WaitForLabeledPodToRun(fmt.Sprintf("rook_object_store=%s", storeName), namespace)
+	if !running || err != nil {
+		return fmt.Errorf("rgw did not start via crd. %+v", err)
 	}
 
 	// create the external service

--- a/tests/framework/installer/install_helper.go
+++ b/tests/framework/installer/install_helper.go
@@ -225,7 +225,8 @@ func (h *InstallHelper) CreateK8sRookClusterWithHostPathAndDevices(namespace, st
 	}
 
 	logger.Infof("Rook Cluster started")
-	return nil
+	_, err = h.k8shelper.WaitForLabeledPodToRun("app=rook-ceph-osd", namespace)
+	return err
 }
 
 func SystemNamespace(namespace string) string {

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -320,43 +320,24 @@ func (k8sh *K8sHelper) GetMonitorServices(namespace string) (map[string]string, 
 	}, nil
 }
 
-func (k8sh *K8sHelper) IsPodWithLabelPresent(label string, namespace string) bool {
-	options := metav1.ListOptions{LabelSelector: label}
-	pods, err := k8sh.Clientset.CoreV1().Pods(namespace).List(options)
-	if errors.IsNotFound(err) {
-		return false
-	}
-	if len(pods.Items) == 0 {
-		return false
-	}
-	return true
-}
-
-//IsPodWithLabelRunning returns true if a Pod is running status or goes to Running status within 90s else returns false
-func (k8sh *K8sHelper) IsPodWithLabelRunning(label string, namespace string) bool {
+//WaitForLabeledPodToRun returns true if a Pod is running status or goes to Running status within 90s else returns false
+func (k8sh *K8sHelper) WaitForLabeledPodToRun(label string, namespace string) (bool, error) {
 	options := metav1.ListOptions{LabelSelector: label}
 	inc := 0
 	for inc < RetryLoop {
 		pods, err := k8sh.Clientset.CoreV1().Pods(namespace).List(options)
-		if err != nil {
-			logger.Errorf("failed to find pod with label %s. %+v", label, err)
-			return false
-		}
-
-		if len(pods.Items) > 0 {
+		if err == nil && len(pods.Items) > 0 {
 			for _, pod := range pods.Items {
 				if pod.Status.Phase == "Running" {
-					return true
+					return true, nil
 				}
 			}
 		}
 		inc++
+		logger.Infof("waiting for pod with label %s in namespace %s to be running. err=%+v", label, namespace, err)
 		time.Sleep(RetryInterval * time.Second)
-		logger.Infof("waiting for pod with label %s in namespace %s to be running", label, namespace)
-
 	}
-	logger.Infof("Giving up waiting for pod with label %s in namespace %s to be running", label, namespace)
-	return false
+	return false, fmt.Errorf("Giving up waiting for pod with label %s in namespace %s to be running", label, namespace)
 }
 
 //WaitUntilPodWithLabelDeleted returns true if a Pod is deleted within 90s else returns false
@@ -380,6 +361,37 @@ func (k8sh *K8sHelper) WaitUntilPodWithLabelDeleted(label string, namespace stri
 	}
 	logger.Infof("Giving up waiting for pod with label %s in namespace %s to be deleted", label, namespace)
 	return false
+}
+
+func (k8sh *K8sHelper) PrintPodStatus(namespace string) {
+	pods, err := k8sh.Clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Info("failed to get pod status in namespace %s. %+v", namespace, err)
+		return
+	}
+	for _, pod := range pods.Items {
+		logger.Infof("%s (%s) pod status: %+v", pod.Name, namespace, pod.Status)
+	}
+}
+
+func (k8sh *K8sHelper) PrintPodDescribe(name, namespace string) {
+	pod, err := k8sh.Clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Warningf("failed to get pod %s in namespace %s. %+v", name, namespace)
+		return
+	}
+	logger.Infof("pod %s in namespace %s: %+v", name, namespace, pod)
+
+	events, err := k8sh.Clientset.CoreV1().Events(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Warningf("failed to get events in namespace %s. %+v", namespace, err)
+		return
+	}
+	logger.Infof("DUMPING events in namespace %s", namespace)
+	for _, event := range events.Items {
+		logger.Infof("%+v", event)
+	}
+	logger.Infof("DONE DUMPING events in namespace %s", namespace)
 }
 
 //IsPodRunning returns true if a Pod is running status or goes to Running status within 90s else returns false
@@ -523,7 +535,49 @@ func (k8sh *K8sHelper) waitForVolumeAttachment(namespace, volumeAttachmentName s
 		inc++
 
 	}
+	k8sh.printVolumeAttachments(namespace, volumeAttachmentName)
+	k8sh.printPVs()
+	k8sh.printPVCs(namespace)
 	return fmt.Errorf("timeout for VolumeAttachment %s in namespace %s wait to %s", volumeAttachmentName, namespace, action)
+}
+
+func (k8sh *K8sHelper) printPVs() {
+	pvs, err := k8sh.Clientset.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+	if err != nil {
+		logger.Infof("failed to list pvs. %+v", err)
+	}
+
+	var names []string
+	for _, pv := range pvs.Items {
+		names = append(names, pv.Name)
+	}
+	logger.Infof("Found PVs: %v", names)
+}
+
+func (k8sh *K8sHelper) printPVCs(namespace string) {
+	pvcs, err := k8sh.Clientset.CoreV1().PersistentVolumeClaims(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Infof("failed to list pvcs. %+v", err)
+	}
+
+	var names []string
+	for _, pvc := range pvcs.Items {
+		names = append(names, pvc.Name)
+	}
+	logger.Infof("Found PVCs: %v", names)
+}
+
+func (k8sh *K8sHelper) printVolumeAttachments(namespace, desiredVolumeAttachment string) {
+	attachments, err := k8sh.RookClientset.RookV1alpha1().VolumeAttachments(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Infof("failed to list volume attachments in ns %s. %+v", namespace, err)
+	}
+
+	var names []string
+	for _, attachment := range attachments.Items {
+		names = append(names, attachment.Name)
+	}
+	logger.Infof("looking for volume attachment %s in namespace %s. Found attachments: %v", desiredVolumeAttachment, namespace, names)
 }
 
 func (k8sh *K8sHelper) isVolumeAttachmentExist(namespace, name string) (bool, error) {

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -29,10 +29,8 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/agent/flexvolume/attachment"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
@@ -529,13 +527,7 @@ func (k8sh *K8sHelper) waitForVolumeAttachment(namespace, volumeAttachmentName s
 }
 
 func (k8sh *K8sHelper) isVolumeAttachmentExist(namespace, name string) (bool, error) {
-	var result rookalpha.VolumeAttachment
-	uri := fmt.Sprintf("apis/%s/%s/namespaces/%s/%s", rookalpha.CustomResourceGroup, rookalpha.Version, namespace, attachment.CustomResourceNamePlural)
-	err := k8sh.Clientset.CoreV1().RESTClient().Get().
-		RequestURI(uri).
-		Name(name).
-		Do().
-		Into(&result)
+	_, err := k8sh.RookClientset.RookV1alpha1().VolumeAttachments(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -77,7 +77,7 @@ func runBlockE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.
 	logger.Infof("step 4: Read from  block storage")
 	read, rErr := helper.BlockClient.Read(blockPodName, blockMountPath, "bsFile1", "")
 	require.Nil(s.T(), rErr)
-	require.Contains(s.T(), read, "Smoke Test Data form Block storage", "make sure content of the files is unchanged")
+	assert.Contains(s.T(), read, "Smoke Test Data form Block storage", "make sure content of the files is unchanged")
 	logger.Infof("Read from  Block storage successfully")
 
 	logger.Infof("step 5: Mount same block storage on a different pod. Should not be allowed")
@@ -123,9 +123,9 @@ func runBlockE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s su
 
 	volumeDef := installer.GetBlockPoolStorageClassAndPvcDef(clusterNamespace, poolName, "rook-block", "test-block-claim", "ReadWriteOnce")
 	res1, err := installer.BlockResourceOperation(k8sh, volumeDef, "create")
-	require.Contains(s.T(), res1, fmt.Sprintf("pool \"%s\" created", poolName), "Make sure test pool is created")
-	require.Contains(s.T(), res1, "storageclass \"rook-block\" created", "Make sure storageclass is created")
-	require.Contains(s.T(), res1, "persistentvolumeclaim \"test-block-claim\" created", "Make sure pvc is created")
+	assert.Contains(s.T(), res1, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
+	assert.Contains(s.T(), res1, "\"rook-block\" created", "Make sure storageclass is created")
+	assert.Contains(s.T(), res1, "\"test-block-claim\" created", "Make sure pvc is created")
 	require.NoError(s.T(), err)
 
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, "test-block-claim"))

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -111,8 +111,8 @@ type BaseTestOperations struct {
 	mons            int
 }
 
-//NewBaseTestOperations creates new instance of BaseTestOperations struct
-func NewBaseTestOperations(t func() *testing.T, namespace, storeType, dataDirHostPath string, helmInstalled, useDevices bool, mons int) (BaseTestOperations, *utils.K8sHelper) {
+// StartBaseTestOperations creates new instance of BaseTestOperations struct
+func StartBaseTestOperations(t func() *testing.T, namespace, storeType, dataDirHostPath string, helmInstalled, useDevices bool, mons int) (BaseTestOperations, *utils.K8sHelper) {
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
 

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -53,7 +53,13 @@ func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	logger.Infof("Step 2: Mount file System")
 	mtfsErr := podWithFilesystem(k8sh, s, filePodName, namespace, filesystemName, fileMountPath, "create")
 	require.Nil(s.T(), mtfsErr)
-	require.True(s.T(), k8sh.IsPodRunning(filePodName, namespace), "make sure file-test pod is in running state")
+	filePodRunning := k8sh.IsPodRunning(filePodName, namespace)
+	if !filePodRunning {
+		k8sh.PrintPodDescribe(filePodName, namespace)
+		k8sh.PrintPodStatus(namespace)
+		k8sh.PrintPodStatus(installer.SystemNamespace(namespace))
+	}
+	require.True(s.T(), filePodRunning, "make sure file-test pod is in running state")
 	logger.Infof("File system mounted successfully")
 
 	logger.Infof("Step 3: Write to file system")
@@ -108,6 +114,7 @@ func podWithFilesystem(k8sh *utils.K8sHelper, s suite.Suite, podname string, nam
 	}
 
 	testPod := getFilesystemTestPod(podname, namespace, filesystemName, fileMountPath, driverName)
+	logger.Infof("creating test pod: %s", testPod)
 	_, err := k8sh.ResourceOperation(action, testPod)
 	if err != nil {
 		return fmt.Errorf("failed to %s pod -- %s. %+v", action, testPod, err)

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"k8s.io/kubernetes/pkg/util/version"
@@ -63,7 +64,7 @@ func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	logger.Infof("Step 4: Read from file system")
 	read, rdErr := helper.FSClient.Read(filePodName, fileMountPath, "fsFile1", namespace)
 	require.Nil(s.T(), rdErr)
-	require.Contains(s.T(), read, "Smoke Test Data for file system storage", "make sure content of the files is unchanged")
+	assert.Contains(s.T(), read, "Smoke Test Data for file system storage", "make sure content of the files is unchanged")
 	logger.Infof("Read from file system successful")
 
 	logger.Infof("Step 5: UnMount file System")

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -74,13 +74,13 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	defer s.tearDownTest(claimName, poolName, storageClassName, "ReadWriteOnce")
 
 	result, err := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	require.Contains(s.T(), result, fmt.Sprintf("persistentvolumeclaim \"%s\" created", claimName), "Make sure pvc is created. "+result)
+	assert.Contains(s.T(), result, fmt.Sprintf("persistentvolumeclaim \"%s\" created", claimName), "Make sure pvc is created. "+result)
 	require.NoError(s.T(), err)
 
 	//check status of PVC
 	pvcStatus, err := s.kh.GetPVCStatus(defaultNamespace, claimName)
 	require.Nil(s.T(), err)
-	require.Contains(s.T(), pvcStatus, "Pending", "Makes sure PVC is in Pending state")
+	assert.Contains(s.T(), pvcStatus, "Pending", "Makes sure PVC is in Pending state")
 
 	//check block image count
 	b, _ := s.testClient.BlockClient.List(s.namespace)
@@ -107,10 +107,11 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	logger.Infof("create pool and storageclass")
 	pool := model.Pool{Name: poolName, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	result0, err0 := s.testClient.PoolClient.Create(pool, s.namespace)
-	require.Contains(s.T(), result0, fmt.Sprintf("pool \"%s\" created", poolName), "Make sure test pool is created")
+	assert.Contains(s.T(), result0, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
 	require.NoError(s.T(), err0)
+
 	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
-	require.Contains(s.T(), result1, fmt.Sprintf("storageclass \"%s\" created", storageClassName), "Make sure storageclass is created")
+	assert.Contains(s.T(), result1, fmt.Sprintf("\"%s\" created", storageClassName), "Make sure storageclass is created")
 	require.NoError(s.T(), err1)
 
 	logger.Infof("make sure storageclass is created")
@@ -120,7 +121,7 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("create pvc")
 	result2, err2 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	require.Contains(s.T(), result2, fmt.Sprintf("persistentvolumeclaim \"%s\" created", claimName), "Make sure pvc is created. "+result2)
+	assert.Contains(s.T(), result2, fmt.Sprintf("\"%s\" created", claimName), "Make sure pvc is created. "+result2)
 	require.NoError(s.T(), err2)
 
 	logger.Infof("check status of PVC")
@@ -132,7 +133,7 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("Create same pvc again")
 	result3, err3 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	require.Contains(s.T(), err3.Error(), fmt.Sprintf("persistentvolumeclaims \"%s\" already exists", claimName), "make sure PVC is not created again. "+result3)
+	assert.Contains(s.T(), err3.Error(), fmt.Sprintf("\"%s\" already exists", claimName), "make sure PVC is not created again. "+result3)
 
 	logger.Infof("check status of PVC")
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
@@ -222,10 +223,10 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	//create pool and storageclass
 	result0, err0 := installer.BlockResourceOperation(s.kh, installer.GetBlockPoolDef(poolName, s.namespace, "1"), "create")
-	require.Contains(s.T(), result0, fmt.Sprintf("pool \"%s\" created", poolName), "Make sure test pool is created")
+	assert.Contains(s.T(), result0, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
 	require.NoError(s.T(), err0)
 	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
-	require.Contains(s.T(), result1, fmt.Sprintf("storageclass \"%s\" created", storageClassName), "Make sure storageclass is created")
+	assert.Contains(s.T(), result1, fmt.Sprintf("\"%s\" created", storageClassName), "Make sure storageclass is created")
 	require.NoError(s.T(), err1)
 
 	//make sure storageclass is created
@@ -235,7 +236,7 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	//create pvc
 	result2, err2 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, pvcAccessMode), "create")
-	require.Contains(s.T(), result2, fmt.Sprintf("persistentvolumeclaim \"%s\" created", claimName), "Make sure pvc is created. "+result2)
+	assert.Contains(s.T(), result2, fmt.Sprintf("\"%s\" created", claimName), "Make sure pvc is created. "+result2)
 	require.NoError(s.T(), err2)
 
 	//check status of PVC

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -56,7 +56,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 
 	var err error
 	s.namespace = "block-k8s-ns"
-	s.op, s.kh = NewBaseTestOperations(s.T, s.namespace, "bluestore", "", false, false, 1)
+	s.op, s.kh = StartBaseTestOperations(s.T, s.namespace, "bluestore", "", false, false, 1)
 	s.testClient = GetTestClient(s.kh, s.namespace, s.op, s.T)
 	initialBlocks, err := s.testClient.BlockClient.List(s.namespace)
 	assert.Nil(s.T(), err)

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -63,7 +63,7 @@ type HelmSuite struct {
 
 func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
-	hs.op, hs.kh = NewBaseTestOperations(hs.T, hs.namespace, "bluestore", "", true, false, 3)
+	hs.op, hs.kh = StartBaseTestOperations(hs.T, hs.namespace, "bluestore", "", true, false, 3)
 	hs.helper = GetTestClient(hs.kh, hs.namespace, hs.op, hs.T)
 
 }

--- a/tests/integration/multi_cluster_deploy_test.go
+++ b/tests/integration/multi_cluster_deploy_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/tests/framework/contracts"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -80,13 +81,13 @@ func (mrc *MultiClusterDeploySuite) createPools() {
 	poolName := "multi-cluster-pool1"
 	logger.Infof("Creating pool %s", poolName)
 	result, err := installer.BlockResourceOperation(mrc.k8sh, installer.GetBlockPoolDef(poolName, mrc.namespace1, "1"), "create")
-	require.Contains(mrc.T(), result, fmt.Sprintf("pool \"%s\" created", poolName))
+	assert.Contains(mrc.T(), result, fmt.Sprintf("\"%s\" created", poolName))
 	require.Nil(mrc.T(), err)
 
 	poolName = "multi-cluster-pool2"
 	logger.Infof("Creating pool %s", poolName)
 	result, err = installer.BlockResourceOperation(mrc.k8sh, installer.GetBlockPoolDef(poolName, mrc.namespace2, "1"), "create")
-	require.Contains(mrc.T(), result, fmt.Sprintf("pool \"%s\" created", poolName))
+	assert.Contains(mrc.T(), result, fmt.Sprintf("\"%s\" created", poolName))
 	require.Nil(mrc.T(), err)
 }
 

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -75,7 +75,7 @@ type SmokeSuite struct {
 
 func (suite *SmokeSuite) SetupSuite() {
 	suite.namespace = "smoke-ns"
-	suite.op, suite.k8sh = NewBaseTestOperations(suite.T, suite.namespace, "bluestore", "", false, false, 3)
+	suite.op, suite.k8sh = StartBaseTestOperations(suite.T, suite.namespace, "bluestore", "", false, false, 3)
 	suite.helper = GetTestClient(suite.k8sh, suite.namespace, suite.op, suite.T)
 }
 

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -142,8 +142,8 @@ type BaseLoadTestOperations struct {
 	namespace string
 }
 
-//NewBaseTestOperations creates new instance of BaseTestOperations struct
-func NewBaseLoadTestOperations(t func() *testing.T, namespace string) (BaseLoadTestOperations, *utils.K8sHelper, *installer.InstallHelper) {
+// StartBaseTestOperations creates new instance of BaseTestOperations struct
+func StartBaseLoadTestOperations(t func() *testing.T, namespace string) (BaseLoadTestOperations, *utils.K8sHelper, *installer.InstallHelper) {
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
 

--- a/tests/longhaul/block_test.go
+++ b/tests/longhaul/block_test.go
@@ -21,11 +21,12 @@ import (
 	"sync"
 	"testing"
 
+	"time"
+
 	"github.com/rook/rook/tests/framework/contracts"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/suite"
-	"time"
 )
 
 // Rook Block Storage longhaul test
@@ -53,7 +54,7 @@ type BlockLongHaulSuite struct {
 //create pool and storage class, create a PVC, Create a MySQL app/service that uses pvc
 func (s *BlockLongHaulSuite) SetupSuite() {
 	s.namespace = "longhaul-ns"
-	s.op, s.kh, s.installer = NewBaseLoadTestOperations(s.T, s.namespace)
+	s.op, s.kh, s.installer = StartBaseLoadTestOperations(s.T, s.namespace)
 	createStorageClassAndPool(s.T, s.kh, s.namespace, "rook-block", "rook-pool")
 }
 

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -58,7 +58,7 @@ type BlockLongHaulSuiteWithFencing struct {
 func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 	var err error
 	s.namespace = "longhaul-ns"
-	s.op, s.kh, s.installer = NewBaseLoadTestOperations(s.T, s.namespace)
+	s.op, s.kh, s.installer = StartBaseLoadTestOperations(s.T, s.namespace)
 	createStorageClassAndPool(s.T, s.kh, s.namespace, "rook-block", "rook-pool")
 	s.testClient, err = clients.CreateTestClient(s.kh, s.namespace)
 	require.Nil(s.T(), err)

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/tests/framework/contracts"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -92,7 +93,7 @@ func blockVolumeFencingOperations(s *BlockLongHaulSuiteWithFencing, wg *sync.Wai
 	require.True(s.T(), s.kh.IsPodRunning(podName, defaultNamespace))
 	read, rErr := s.testClient.BlockClient.Read(podName, "/tmp/rook1", "longhaul", "default")
 	require.Nil(s.T(), rErr)
-	require.Contains(s.T(), read, "this is long running test")
+	assert.Contains(s.T(), read, "this is long running test")
 	mountUnmountPVCOnPod(s.kh, podName, pvcName, "true", "delete")
 	require.True(s.T(), s.kh.IsPodTerminated(podName, defaultNamespace))
 }

--- a/tests/longhaul/object_test.go
+++ b/tests/longhaul/object_test.go
@@ -56,7 +56,7 @@ type ObjectLongHaulSuite struct {
 func (s *ObjectLongHaulSuite) SetupSuite() {
 	var err error
 	s.namespace = "longhaul-ns"
-	s.op, s.kh, s.installer = NewBaseLoadTestOperations(s.T, s.namespace)
+	s.op, s.kh, s.installer = StartBaseLoadTestOperations(s.T, s.namespace)
 	s.tc, err = clients.CreateTestClient(s.kh, s.namespace)
 	require.Nil(s.T(), err)
 }

--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -41,7 +41,7 @@ EOF
     echo "wait for K8s master node to be Ready"
     INC=0
     while [[ $INC -lt 20 ]]; do
-        kube_ready=$(kubectl get node -o jsonpath='{.items[0].status.conditions[3].status}')
+        kube_ready=$(kubectl get node -o jsonpath='{.items['$count'].status.conditions[?(@.reason == "KubeletReady")].status}')
         if [ "${kube_ready}" == "True" ]; then
             break
         fi
@@ -88,8 +88,7 @@ wait_for_ready(){
         echo "wait for K8s node $count to be Ready."        
         INC=0
         while [[ $INC -lt 90 ]]; do
-            kubectl get node -o jsonpath='{.items['$count'].status.conditions[?(@.reason == "KubeletReady")]}'
-            kube_ready=$(kubectl get node -o jsonpath='{.items['$count'].status.conditions[3].status}')
+            kube_ready=$(kubectl get node -o jsonpath='{.items['$count'].status.conditions[?(@.reason == "KubeletReady")].status}')
             if [ "${kube_ready}" != "True" ]; then
               break
             fi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Add support for K8s 1.10 in the jenkins integration tests. Given some changes in shutdown behavior, this had been dependent on #1701. A number of test improvements to help troubleshoot #1701 are also included in this PR.

Which issue is resolved by this Pull Request:
Resolves #1623

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
