### PR TITLE
Ceph MDS: Control multi file system creation

### DIFF
--- a/Documentation/filesystem.md
+++ b/Documentation/filesystem.md
@@ -10,9 +10,15 @@ A shared file system can be mounted read-write from multiple pods. This may be u
 
 This example runs a shared file system for the [kube-registry](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/registry).
 
-## Prerequisites
+### Prerequisites
 
 This guide assumes you have created a Rook cluster as explained in the main [Kubernetes guide](quickstart.md)
+
+### Multiple File Systems Not Supported
+
+By default only one shared file system can be created with Rook. Multiple file system support in Ceph is still considered experimental and can be enabled with the environment variable `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` defined in `rook-operator.yaml`.
+
+Please refer to [cephfs experimental features](http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster) page for more information.
 
 ## Create the File System
 

--- a/cluster/examples/kubernetes/rook-operator.yaml
+++ b/cluster/examples/kubernetes/rook-operator.yaml
@@ -195,6 +195,12 @@ spec:
         # Set the path where the Rook agent can find the flex volumes
         # - name: FLEXVOLUME_DIR_PATH
         #  value: "<PathToFlexVolumes>"
+        # Allow rook to create multiple file systems. Note: This is considered
+        # an experimental feature in Ceph as described at
+        # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster
+        # which might cause mons to crash as seen in https://github.com/rook/rook/issues/1027
+        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
+          value: "false"
         # The interval to check if every mon is in the quorum.
         - name: ROOK_MON_HEALTHCHECK_INTERVAL
           value: "45s"


### PR DESCRIPTION
Multiple file system support is still considered experimental in Ceph.
Disabling that as default in rook until such time it is production
ready.
A small code cleanup in filesystem file
Resolves #1720

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
