### PR TITLE
build: Replace /bin/bash with /bin/sh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,13 +134,13 @@ def RunIntegrationTest(k, v) {
                     echo "running tests on k8s version ${v}"
                     sh 'tests/scripts/makeTestImages.sh load amd64'
                     sh "tests/scripts/kubeadm.sh up"
-                    sh '''#!/bin/bash
+                    sh '''#!/bin/sh
                           export KUBECONFIG=$HOME/admin.conf
                           tests/scripts/helm.sh up'''
                     try{
                         if ("${env.smokeOnly}" == "true") {
                             echo "Running Smoke Tests"
-                            sh '''#!/bin/bash
+                            sh '''#!/bin/sh
                                   set -o pipefail
                                   export KUBECONFIG=$HOME/admin.conf
                                   kubectl config view
@@ -148,7 +148,7 @@ def RunIntegrationTest(k, v) {
                         }
                         else {
                         echo "Running full regression"
-                        sh '''#!/bin/bash
+                        sh '''#!/bin/sh
                               set -o pipefail
                               export KUBECONFIG=$HOME/admin.conf
                               kubectl config view
@@ -156,7 +156,7 @@ def RunIntegrationTest(k, v) {
                          }
                     }
                     finally{
-                        sh '''#!/bin/bash
+                        sh '''#!/bin/sh
                               export KUBECONFIG=$HOME/admin.conf
                               tests/scripts/helm.sh clean || true'''
                         sh "mv _output/tests/integrationTests.log _output/tests/${k}_${v}_integrationTests.log"

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ all: build
 # ====================================================================================
 # Build Options
 
-# set the shell to bash in case some environments use sh
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 # Can be used or additional go build flags
 BUILDFLAGS ?=

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/build/common.sh
+++ b/build/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -15,7 +15,7 @@
 # remove default suffixes as we dont use them
 .SUFFIXES:
 
-SHELL := /bin/bash
+SHELL := /bin/sh
 
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)

--- a/build/reset
+++ b/build/reset
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/build/run
+++ b/build/run
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/cluster/examples/coreos/ceph-after-reboot-script.yaml
+++ b/cluster/examples/coreos/ceph-after-reboot-script.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook
 data:
   status-check.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
     # preflightCheck checks for existence of "dependencies"
     preflightCheck() {

--- a/cluster/examples/coreos/ceph-before-reboot-script.yaml
+++ b/cluster/examples/coreos/ceph-before-reboot-script.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: rook
 data:
   status-check.sh: |-
-    #!/bin/bash
+    #!/bin/sh
 
     # preflightCheck checks for existence of "dependencies"
     preflightCheck() {

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -14,12 +14,12 @@
 
 FROM BASEIMAGE
 
-SHELL ["/bin/bash","-c"]
+SHELL ["/bin/sh","-c"]
 
 # APT caching to speed up apt-get downloads
 # see http://www.stuartaxon.com/2015/02/02/docker-and-caching-apt-get-for-guests-on-the-same-host/
 RUN HOST_IP=$(route -n | awk '/^0.0.0.0/ {print $2}') && \
-    echo "#!/bin/bash" > /usr/local/bin/apt-ng-host-discover && \
+    echo "#!/bin/sh" > /usr/local/bin/apt-ng-host-discover && \
     echo "if nc -w1 -z $HOST_IP 3142; then printf http://$HOST_IP:3142; else printf DIRECT; fi" >> /usr/local/bin/apt-ng-host-discover && \
     chmod +x /usr/local/bin/apt-ng-host-discover && \
     echo 'Acquire::http::ProxyAutoDetect "/usr/local/bin/apt-ng-host-discover";' > /etc/apt/apt.conf.d/30proxy
@@ -32,4 +32,4 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARC
 RUN chmod +x /tini
 
 ENTRYPOINT ["/tini", "-g", "--"]
-CMD ["/bin/bash"]
+CMD ["/bin/sh"]

--- a/images/base/Dockerfile.rootfs-builder
+++ b/images/base/Dockerfile.rootfs-builder
@@ -14,7 +14,7 @@
 
 FROM BASEIMAGE
 
-SHELL ["/bin/bash","-c"]
+SHELL ["/bin/sh","-c"]
 
 RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
     # update and upgrade

--- a/images/base/Makefile
+++ b/images/base/Makefile
@@ -43,7 +43,7 @@ rootfs-build:
 
 rootfs:
 	@echo === docker build $(ROOTFS_IMAGE)
-	@CID=`docker create $(ROOTFS_BUILDER_IMAGE) /bin/bash` &&\
+	@CID=`docker create $(ROOTFS_BUILDER_IMAGE) /bin/sh` &&\
 	  docker export $$CID > $(TEMP)/rootfs.tar &&\
 	  docker rm -f $$CID
 	@cp Dockerfile.rootfs $(TEMP)/Dockerfile

--- a/images/cross/rsyncd.sh
+++ b/images/cross/rsyncd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #

--- a/images/cross/run.sh
+++ b/images/cross/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #
@@ -16,7 +16,7 @@
 
 ARGS="$@"
 if [ $# -eq 0 ]; then
-    ARGS=/bin/bash
+    ARGS=/bin/sh
 fi
 
 BUILDER_USER=${BUILDER_USER:-rook}

--- a/images/toolbox/toolbox.sh
+++ b/images/toolbox/toolbox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 # Copyright 2016 The Rook Authors. All rights reserved.
 #
@@ -16,7 +16,7 @@
 
 ARGS="$@"
 if [ $# -eq 0 ]; then
-    ARGS=/bin/bash
+    ARGS=/bin/sh
 fi
 
 ROOK_DIR="/var/lib/rook"

--- a/tests/pipeline/Jenkinsfile.k8sSetup
+++ b/tests/pipeline/Jenkinsfile.k8sSetup
@@ -49,7 +49,7 @@ pipeline {
                     withEnv(["KUBE_VERSION=${env.kube_version}"]){
                         echo "setting up 3 node k8s ${env.kube_version} cluster"
                         setUpRookImages()
-                        sh '''#!/bin/bash
+                        sh '''#!/bin/sh
                               echo " setting up master"
                               export KUBE_VERSION='''+ "${env.kube_version}" + '''
                               kubeadm_join_flags="$(tests/scripts/kubeadm.sh install master | grep '^ *kubeadm join' | sed 's/^ *kubeadm join //')"
@@ -61,7 +61,7 @@ pipeline {
                             unstash 'test-images'
                             setUpRookImages()
                             unstash 'test-scripts'
-                            sh '''#!/bin/bash
+                            sh '''#!/bin/sh
                                   echo " setting up node 1"
                                   export KUBE_VERSION='''+ "${env.kube_version}" + '''
                                   tests/scripts/kubeadm.sh install node ''' + "${token}"
@@ -70,12 +70,12 @@ pipeline {
                             unstash 'test-images'
                             setUpRookImages()
                             unstash 'test-scripts'
-                            sh '''#!/bin/bash
+                            sh '''#!/bin/sh
                                   echo " setting up node 2"
                                   export KUBE_VERSION='''+ "${env.kube_version}" + '''
                                   tests/scripts/kubeadm.sh install node ''' + "${token}"
                         }
-                        sh '''#!/bin/bash
+                        sh '''#!/bin/sh
                               export KUBECONFIG=$HOME/admin.conf
                               tests/scripts/kubeadm.sh wait 3'''
                     }
@@ -95,7 +95,7 @@ def setUpRookImages(){
     //tag rook images need for testing
     env.versionId = readFile('version').trim()
     sh'''
-          #!/bin/bash
+          #!/bin/sh
           docker load -i rook.tar.gz
           docker load -i toolbox.tar.gz
           docker images

--- a/tests/pipeline/Jenkinsfile.longhaul
+++ b/tests/pipeline/Jenkinsfile.longhaul
@@ -51,7 +51,7 @@ pipeline {
                 script {
                     for(i=0; i< "${env.runs}".toInteger() ; i++) {
                         try{
-                            sh '''#!/bin/bash
+                            sh '''#!/bin/sh
                             set -o pipefail
                             export KUBECONFIG=$HOME/admin.conf
                             kubectl config view

--- a/tests/pipeline/Jenkinsfile.regression
+++ b/tests/pipeline/Jenkinsfile.regression
@@ -51,12 +51,12 @@ pipeline {
         stage ("Run Regression") {
             steps{
                 script {
-                    sh '''#!/bin/bash
+                    sh '''#!/bin/sh
                            export KUBECONFIG=$HOME/admin.conf
                            chmod +x helm.sh
                            ./helm.sh up'''
                     try{
-                        sh '''#!/bin/bash
+                        sh '''#!/bin/sh
                               set -o pipefail
                               export KUBECONFIG=$HOME/admin.conf
                               kubectl config view

--- a/tests/scripts/dind-cluster.sh
+++ b/tests/scripts/dind-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright 2017 Mirantis
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -587,7 +587,7 @@ function dind::accelerate-kube-dns {
   # TODO: do this in wrapkubeadm
   # 'kubectl version --short' is a quick check for kubectl 1.4
   # which doesn't support 'kubectl apply --force'
-  docker exec kube-master /bin/bash -c \
+  docker exec kube-master /bin/sh -c \
          "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | if kubectl version --short >&/dev/null; then kubectl apply --force -f -; else kubectl apply -f -; fi"
 }
 

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/bin/sh +e
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 install() {

--- a/tests/scripts/kubeadm-dind.sh
+++ b/tests/scripts/kubeadm-dind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/bin/sh +e
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${scriptdir}/../../build/common.sh"
@@ -13,19 +13,19 @@ copy_image_to_cluster() {
     docker save -o ${tarfile} ${final_image}
     for c in kube-master kube-node-1 kube-node-2; do
         docker cp ${tarfile} ${c}:/
-        docker exec ${c} /bin/bash -c "docker load -i /${tarname}"
+        docker exec ${c} /bin/sh -c "docker load -i /${tarname}"
     done
 }
 
 copy_rbd() {
     for c in kube-master kube-node-1 kube-node-2; do
         docker cp ${scriptdir}/dind-cluster-rbd ${c}:/bin/rbd
-        docker exec ${c} /bin/bash -c "chmod +x /bin/rbd"
+        docker exec ${c} /bin/sh -c "chmod +x /bin/rbd"
         # hack for Azure, after vm is started first docker pull command fails intermittently
         local maxRetry=3
         local cur=1
         while [ $cur -le $maxRetry ]; do
-            docker exec ${c} /bin/bash -c "docker pull ceph/base"
+            docker exec ${c} /bin/sh -c "docker pull ceph/base"
             if [ $? -eq 0 ]; then
                 break
             fi

--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/bin/sh +e
 
 KUBE_VERSION=${1:-"v1.8.5"}
 
@@ -14,7 +14,7 @@ if [[ $KUBE_VERSION == v1.7* ]] ;
 then
     sudo mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/rook.io~rook
     cat << EOF | sudo tee -a /usr/libexec/kubernetes/kubelet-plugins/volume/exec/rook.io~rook/rook
-#!/bin/bash
+#!/bin/sh
 echo -ne '{"status": "Success", "capabilities": {"attach": false}}' >&1
 exit 0
 EOF

--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash +e
+#!/bin/sh +e
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tests/scripts/makeTestImages.sh
+++ b/tests/scripts/makeTestImages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${scriptdir}/../../build/common.sh"

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -1,11 +1,11 @@
-#!/bin/bash -e
+#!/bin/sh -e
 
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${scriptdir}/../../build/common.sh"
 
 function init_flexvolume() {
     cat <<EOF | ssh -i `minikube ssh-key` docker@`minikube ip` -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet 'cat - > ~/rook'
-#!/bin/bash
+#!/bin/sh
 echo -ne '{"status": "Success", "capabilities": {"attach": false}}' >&1
 exit 0
 EOF


### PR DESCRIPTION
We don't currently rely on any bash-specific functionality in our
builds, so it does not make sense to use /bin/bash over /bin/sh. Reasons
for doing so is that sh is standardized and exists on POSIX systems
without bash.

**Description of your changes:**
All instances of /bin/bash have been replaced with /bin/sh.

Which issue is resolved by this Pull Request:
Resolves #1725