### PR TITLE
Fix PV delete failure over operator restarts

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -41,6 +41,7 @@ import (
 )
 
 const (
+	ClusterNamespaceKey   = "clusterNamespace"
 	StorageClassKey       = "storageClass"
 	PoolKey               = "pool"
 	ImageKey              = "image"

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -76,6 +76,7 @@ func TestProvisionImage(t *testing.T) {
 	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
 	assert.Equal(t, "foo.io/rook-system", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
 	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
+	assert.Equal(t, "testCluster", pv.Spec.PersistentVolumeSource.FlexVolume.Options["clusterNamespace"])
 	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
 	assert.Equal(t, "testpool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["pool"])
 	assert.Equal(t, "pvc-uid-1-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["image"])


### PR DESCRIPTION
Description of your changes:
This patch attempts to address the issue where an operator restart
 would result in failures to delete any PVs.

Resolves: #1721

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>