### PR TITLE
Rook test script fix for missed name changes from multiple storage type support

### DIFF
--- a/tests/scripts/multi-node/build-rook.sh
+++ b/tests/scripts/multi-node/build-rook.sh
@@ -27,13 +27,13 @@ function purge_rook_pods {
   kubectl delete -n rook-ceph pool replicapool || true
   kubectl delete storageclass rook-ceph-block || true
   kubectl delete -f kube-registry.yaml || true
-  kubectl delete -n rook-ceph cluster rook || true
+  kubectl delete -n rook-ceph cluster rook-ceph || true
   kubectl delete crd clusters.ceph.rook.io pools.ceph.rook.io objectstores.ceph.rook.io filesystems.ceph.rook.io volumes.rook.io || true
-  kubectl delete -n rook-system daemonset rook-ceph-agent || true
+  kubectl delete -n rook-ceph-system daemonset rook-ceph-agent || true
   kubectl delete -f operator.yaml || true
   kubectl delete clusterroles rook-ceph-agent || true
   kubectl delete clusterrolebindings rook-ceph-agent || true
-  kubectl delete namespace rook || true
+  kubectl delete namespace rook-ceph || true
   cd "$rook_git_root"
 }
 
@@ -67,10 +67,10 @@ function run_docker_registry {
 }
 
 function docker_import {
-  img=$(docker images | grep -Eo '^build-[a-z0-9]{8}/rook-[a-z0-9]+\s')
+  img=$(docker images | grep -Eo '^build-[a-z0-9]{8}/ceph-[a-z0-9]+\s')
   # shellcheck disable=SC2086
-  docker tag $img 172.17.8.1:5000/rook/rook:latest
-  docker --debug push 172.17.8.1:5000/rook/rook:latest
+  docker tag $img 172.17.8.1:5000/rook/ceph:latest
+  docker --debug push 172.17.8.1:5000/rook/ceph:latest
   # shellcheck disable=SC2086
   docker rmi $img
 }
@@ -95,8 +95,8 @@ function run_rook {
 
 function edit_rook_cluster_template {
   cd "$rook_kube_templates_dir"
-  sed -i 's|image: .*$|image: 172.17.8.1:5000/rook/rook:latest|' operator.yaml
-  echo "rook-operator.yml has been edited with the new image '172.17.8.1:5000/rook/rook:latest'"
+  sed -i 's|image: .*$|image: 172.17.8.1:5000/rook/ceph:latest|' operator.yaml
+  echo "rook-operator.yml has been edited with the new image '172.17.8.1:5000/rook/ceph:latest'"
   cd -
 }
 


### PR DESCRIPTION
Description of your changes:
Recent change to support multiple backends changed the docker image name
but missed the change in the test script. This patch addresses that
issue.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

[skip ci]