### PR TITLE
Fix udevadm providing incomplete info by mounting /run/udev

### DIFF
--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -104,6 +104,8 @@ func (c *Cluster) podTemplateSpec(devices []rookalpha.Device, selection rookalph
 		// create volume config for the data dir and /dev so the pod can access devices on the host
 		devVolume := v1.Volume{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}}
 		volumes = append(volumes, devVolume)
+		udevVolume := v1.Volume{Name: "udev", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}}
+		volumes = append(volumes, udevVolume)
 	}
 
 	// add each OSD directory as another host path volume source
@@ -186,6 +188,8 @@ func (c *Cluster) osdContainer(devices []rookalpha.Device, selection rookalpha.S
 	if devMountNeeded {
 		devMount := v1.VolumeMount{Name: "devices", MountPath: "/dev"}
 		volumeMounts = append(volumeMounts, devMount)
+		udevMount := v1.VolumeMount{Name: "udev", MountPath: "/run/udev"}
+		volumeMounts = append(volumeMounts, udevMount)
 	}
 
 	if len(selection.Directories) > 0 {

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -70,7 +70,7 @@ func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool)
 	assert.Equal(t, "node1", replicaSet.Spec.Template.Spec.NodeSelector[apis.LabelHostname])
 	assert.Equal(t, v1.RestartPolicyAlways, replicaSet.Spec.Template.Spec.RestartPolicy)
 	if devMountNeeded {
-		assert.Equal(t, 3, len(replicaSet.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 4, len(replicaSet.Spec.Template.Spec.Volumes))
 	} else {
 		assert.Equal(t, 2, len(replicaSet.Spec.Template.Spec.Volumes))
 	}
@@ -95,7 +95,7 @@ func testPodDevices(t *testing.T, dataDir, deviceFilter string, allDevices bool)
 	cont := replicaSet.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	if devMountNeeded {
-		assert.Equal(t, 3, len(cont.VolumeMounts))
+		assert.Equal(t, 4, len(cont.VolumeMounts))
 	} else {
 		assert.Equal(t, 2, len(cont.VolumeMounts))
 	}
@@ -157,14 +157,14 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 
 	// pod spec should have a volume for the given dir
 	podSpec := replicaSet.Spec.Template.Spec
-	assert.Equal(t, 4, len(podSpec.Volumes))
-	assert.Equal(t, "rook-dir1", podSpec.Volumes[3].Name)
-	assert.Equal(t, "/rook/dir1", podSpec.Volumes[3].VolumeSource.HostPath.Path)
+	assert.Equal(t, 5, len(podSpec.Volumes))
+	assert.Equal(t, "rook-dir1", podSpec.Volumes[4].Name)
+	assert.Equal(t, "/rook/dir1", podSpec.Volumes[4].VolumeSource.HostPath.Path)
 
 	// container should have a volume mount for the given dir
 	container := podSpec.Containers[0]
-	assert.Equal(t, "rook-dir1", container.VolumeMounts[3].Name)
-	assert.Equal(t, "/rook/dir1", container.VolumeMounts[3].MountPath)
+	assert.Equal(t, "rook-dir1", container.VolumeMounts[4].Name)
+	assert.Equal(t, "/rook/dir1", container.VolumeMounts[4].MountPath)
 
 	// container command should have the given dir and device
 	verifyEnvVar(t, container.Env, "ROOK_DATA_DIRECTORIES", "/rook/dir1", true)


### PR DESCRIPTION
Description of your changes: This change mounts /run/udev in the container if any devices are mounted so that udevadm can provide enough information to correctly setup the OSDs.

Which issue is resolved by this Pull Request:
Resolves #1738

The setup I have tested this on:
OS (e.g. from /etc/os-release): RHEL 7.3
Kernel (e.g. uname -a): 3.10.0-514.6.1.el7
Kubernetes version (use kubectl version): 1.9.3
Kubernetes cluster type (e.g. Tectonic, GKE, OpenShift): open source on-prem

Checklist:
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
