### PR TITLE
Device discovery needs to load part uuid after restart

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -129,6 +129,9 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		}
 		if val, ok := udevInfo["ID_FS_UUID"]; ok {
 			disk.UUID = val
+		} else if val, ok := udevInfo["ID_PART_TABLE_UUID"]; ok {
+			// fall back to the part_table_uuid if the fs_uuid was not found
+			disk.UUID = val
 		}
 		if val, ok := udevInfo["ID_FS_TYPE"]; ok {
 			disk.Filesystem = val

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -222,6 +222,9 @@ func (a *OsdAgent) getPartitionPerfScheme(context *clusterd.Context, devices *De
 			nameToUUID[disk.Name] = disk.UUID
 		}
 	}
+	for _, device := range context.Devices {
+		logger.Debugf("context.Device: %+v", device)
+	}
 
 	numDataNeeded := 0
 	var metadataEntry *DeviceOsdIDEntry
@@ -232,12 +235,15 @@ func (a *OsdAgent) getPartitionPerfScheme(context *clusterd.Context, devices *De
 		if isDeviceInUse(name, nameToUUID, perfScheme) {
 			// device is already in use for either data or metadata, update the details for each of its partitions
 			// (i.e. device name could have changed)
+			logger.Infof("device %s (%s) is already in use", name, nameToUUID)
 			refreshDeviceInfo(name, nameToUUID, perfScheme)
 		} else if isDeviceDesiredForData(mapping) {
 			// device needs data partitioning
+			logger.Infof("configuring device %s (%s) for data", name, nameToUUID)
 			numDataNeeded++
 		} else if isDeviceDesiredForMetadata(mapping, perfScheme) {
 			// device is desired to store metadata for other OSDs
+			logger.Infof("configuring device %s (%s) for metadata", name, nameToUUID)
 			if perfScheme.Metadata != nil {
 				// TODO: this perf scheme creation algorithm assumes either zero or one metadata device, enhance to allow multiple
 				// https://github.com/rook/rook/issues/341


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

Description of your changes:
The device and partition uuid was not being parsed after an osd pod was restarted. This resulted in new osd's being created on top of the same device and wiping out the old osds. It is a regression from the switch to udevadm a couple weeks ago.

The issue was that the device or partition UUID are found in three different properties from `udevadm` depending on the device: `ID_FS_UUID`, `ID_PART_TABLE_UUID`, or `ID_PART_ENTRY_UUID`. Only the first property was being parsed.

To see this issue, run the following command for different devices and partitions. In minikube, I see the different properties for sda, sdb, and sdb1.
```
udevadm info --query=property /dev/sdb
```

Resolves: #1754 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
