### PR TITLE
Document discover DaemonSet toleration key

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -108,6 +108,8 @@ The following tables lists the configurable parameters of the rook-operator char
 | `agent.flexVolumeDirPath` | Path where the Rook agent discovers the flex volume plugins (*) | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
 | `agent.toleration`        | Toleration for the agent pods | <none> |
 | `agent.tolerationKey`     | The specific key of the taint to tolerate | <none> |
+| `discover.toleration`        | Toleration for the discover pods | <none> |
+| `discover.tolerationKey`     | The specific key of the taint to tolerate | <none> |
 | `mon.healthCheckInterval` | The frequency for the operator to check the mon health | `45s` |
 | `mon.monOutTimeout`       | The time to wait before failing over an unhealthy mon | `300s` |
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -41,6 +41,16 @@ spec:
           value: {{ .Values.agent.flexVolumeDirPath }}
 {{- end }}
 {{- end }}
+{{- if .Values.discover }}
+{{- if .Values.discover.toleration }}
+        - name: DISCOVER_TOLERATION
+          value: {{ .Values.agent.toleration }}
+{{- end }}
+{{- if .Values.discover.tolerationKey }}
+        - name: DISCOVER_TOLERATION_KEY
+          value: {{ .Values.discover.tolerationKey }}
+{{- end }}
+{{- end }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
         - name: NODE_NAME

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -45,3 +45,10 @@ pspEnable: true
 #   tolerationKey: key
 ## For Kubernetes >= 1.9.x flexVolumeDirPath should be changed to /var/lib/kubelet/volumeplugins/
 #   flexVolumeDirPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+
+## Rook Discover configuration
+## toleration: NoSchedule, PreferNoSchedule or NoExecute
+## tolerationKey: Set this to the specific key of the taint to tolerate
+# discover:
+#   toleration: NoSchedule
+#   tolerationKey: key

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -222,6 +222,13 @@ spec:
         # Set the path where the Rook agent can find the flex volumes
         # - name: FLEXVOLUME_DIR_PATH
         #  value: "<PathToFlexVolumes>"
+        # Rook Discover toleration. Will tolerate all taints with all keys.
+        # Choose between NoSchedule, PreferNoSchedule and NoExecute:
+        # - name: DISCOVER_TOLERATION
+        #  value: "NoSchedule"
+        # (Optional) Rook Discover toleration key. Set this to the key of the taint you want to tolerate
+        # - name: DISCOVER_TOLERATION_KEY
+        #  value: "<KeyOfTheTaintToTolerate>"
         # Allow rook to create multiple file systems. Note: This is considered
         # an experimental feature in Ceph as described at
         # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -179,7 +179,11 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage string) erro
 		if !kserrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create rook-discover daemon set. %+v", err)
 		}
-		logger.Infof("rook-discover daemonset already exists")
+		logger.Infof("rook-discover daemonset already exists, updating ...")
+		_, err = d.clientset.Extensions().DaemonSets(namespace).Update(ds)
+		if err != nil {
+			return fmt.Errorf("failed to update rook-discover daemon set. %+v", err)
+		}
 	} else {
 		logger.Infof("rook-discover daemonset started")
 	}


### PR DESCRIPTION
Description of your changes:
* Document the discover DaemonSet toleration env vars in the helm chart and `operator.yaml`.
* Updates the discover DaemonSet when it already exists, this allows the toleration env vars to be changed "on the fly" of the operator and then directly rollout the change to the DaemonSet as already with the rook-agent DaemonSet.

Which issue is resolved by this Pull Request:
Resolves #1732.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.