### PR TITLE
Clarify that path must exist for filesystem mount to succeed

### DIFF
--- a/Documentation/filesystem.md
+++ b/Documentation/filesystem.md
@@ -121,6 +121,7 @@ spec:
             fsName: myfs # name of the filesystem specified in the filesystem CRD.
             clusterNamespace: rook-ceph # namespace where the Rook cluster is deployed
             # by default the path is /, but you can override and mount a specific path of the filesystem by using the path attribute
+            # the path must exist on the filesystem, otherwise mounting the filesystem at that path will fail
             # path: /some/path/inside/cephfs
 ```
 

--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -47,4 +47,5 @@ spec:
             fsName: myfs # name of the filesystem specified in the filesystem CRD.
             clusterName: rook-ceph # namespace where the Rook cluster is deployed
             # by default the path is /, but you can override and mount a specific path of the filesystem by using the path attribute
+            # the path must exist on the filesystem, otherwise mounting the filesystem at that path will fail
             # path: /some/path/inside/cephfs


### PR DESCRIPTION
Description of your changes:
This adds a one liner comment to mention that the `path` for filesystem must exist otherwise the mount will fail because the path/directory on the filesystem does not exist.

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.

[skip ci]