### PR TITLE
Name mgr and mds pods more consistently

### DIFF
--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -276,15 +276,13 @@ kubectl -n rook get pod -l app=rook-ceph-osd -o jsonpath='{range .items[*]}{.met
 Remember after each OSD pod to verify the cluster health using the instructions found in the [health verification section](#health-verification).
 
 ### Ceph Manager
-Similar to the Rook operator, the Ceph manager pods are managed by a deployment.
-We will edit the deployment to use the new image version of `rook/ceph:master`:
-```bash
-kubectl -n rook set image deploy/rook-ceph-mgr0 rook-ceph-mgr0=rook/ceph:master
-```
+The ceph manager has been renamed in 0.8. The new manager will be started automatically by the operator. 
+The old manager and its secret can simply be deleted.
 
-To verify that the manager pod is `Running` and on the new version, use the following:
+To delete the 0.7 manager, run the following:
 ```bash
-kubectl -n rook get pod -l app=rook-ceph-mgr -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{" "}{.spec.containers[0].image}{"\n"}{end}'
+kubectl -n rook delete deploy rook-ceph-mgr0
+kubectl -n rook delete secret rook-ceph-mgr0
 ```
 
 ### Legacy Custom Resource Definitions (CRDs)

--- a/cmd/rook/ceph/mds_test.go
+++ b/cmd/rook/ceph/mds_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ceph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractMdsName(t *testing.T) {
+	name := extractMdsID("random")
+	assert.Equal(t, "random", name)
+
+	name = extractMdsID("rook-ceph-mds")
+	assert.Equal(t, "rook-ceph-mds", name)
+
+	name = extractMdsID("rook-ceph-mds-a")
+	assert.Equal(t, "a", name)
+
+	name = extractMdsID("rook-ceph-mds-rook-ceph-mds-foo")
+	assert.Equal(t, "rook-ceph-mds-foo", name)
+
+	name = extractMdsID("rook-ceph-mds-myfs-64b66569f6-5tz2s")
+	assert.Equal(t, "myfs-64b66569f6-5tz2s", name)
+}

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -109,7 +109,7 @@ func startMgr(context *clusterd.Context, config *Config) error {
 }
 
 func getMgrConfDir(dir, name string) string {
-	return path.Join(dir, fmt.Sprintf("mgr%s", name))
+	return path.Join(dir, fmt.Sprintf("mgr-%s", name))
 }
 
 func getMgrConfFilePath(dir, name, clusterName string) string {

--- a/pkg/operator/ceph/file/mds.go
+++ b/pkg/operator/ceph/file/mds.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	appName = "rook-ceph-mds"
+	AppName = "rook-ceph-mds"
 )
 
 // Create the file system
@@ -97,7 +97,7 @@ func DeleteFilesystem(context *clusterd.Context, fs cephv1alpha1.Filesystem) err
 }
 
 func instanceName(fs cephv1alpha1.Filesystem) string {
-	return fmt.Sprintf("%s-%s", appName, fs.Name)
+	return fmt.Sprintf("%s-%s", AppName, fs.Name)
 }
 
 func makeDeployment(fs cephv1alpha1.Filesystem, filesystemID, version string, hostNetwork bool, ownerRefs []metav1.OwnerReference) *extensions.Deployment {
@@ -171,7 +171,7 @@ func mdsContainer(fs cephv1alpha1.Filesystem, filesystemID, version string) v1.C
 
 func getLabels(fs cephv1alpha1.Filesystem) map[string]string {
 	return map[string]string{
-		k8sutil.AppAttr:     appName,
+		k8sutil.AppAttr:     AppName,
 		k8sutil.ClusterAttr: fs.Namespace,
 		"rook_file_system":  fs.Name,
 	}

--- a/pkg/operator/ceph/file/mds_test.go
+++ b/pkg/operator/ceph/file/mds_test.go
@@ -119,7 +119,7 @@ func validateStart(t *testing.T, context *clusterd.Context, fs cephv1alpha1.File
 
 	r, err := context.Clientset.ExtensionsV1beta1().Deployments(fs.Namespace).Get("rook-ceph-mds-myfs", metav1.GetOptions{})
 	assert.Nil(t, err)
-	assert.Equal(t, appName+"-myfs", r.Name)
+	assert.Equal(t, AppName+"-myfs", r.Name)
 }
 
 func TestPodSpecs(t *testing.T) {
@@ -143,13 +143,13 @@ func TestPodSpecs(t *testing.T) {
 
 	d := makeDeployment(fs, mdsID, "rook/rook:myversion", false, []metav1.OwnerReference{})
 	assert.NotNil(t, d)
-	assert.Equal(t, appName+"-myfs", d.Name)
+	assert.Equal(t, AppName+"-myfs", d.Name)
 	assert.Equal(t, v1.RestartPolicyAlways, d.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, 2, len(d.Spec.Template.Spec.Volumes))
 	assert.Equal(t, "rook-data", d.Spec.Template.Spec.Volumes[0].Name)
 
-	assert.Equal(t, appName+"-myfs", d.ObjectMeta.Name)
-	assert.Equal(t, appName, d.Spec.Template.ObjectMeta.Labels["app"])
+	assert.Equal(t, AppName+"-myfs", d.ObjectMeta.Name)
+	assert.Equal(t, AppName, d.Spec.Template.ObjectMeta.Labels["app"])
 	assert.Equal(t, fs.Namespace, d.Spec.Template.ObjectMeta.Labels["rook_cluster"])
 	assert.Equal(t, 0, len(d.ObjectMeta.Annotations))
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

The naming of the deployments and pods will now be more correlated with the ceph daemon names when troubleshooting the ceph cluster.
- The name of the mgr is now `rook-ceph-mgr` instead of `rook-ceph-mgr0`. There is only ever one of them.
- The name of the mds daemon is now the entire suffix of the pod instead of just the last suffix. For example, if the pod name is `rook-ceph-mds-myfs-7b9c79f684-h7dqj`, the mds daemon name would be `myfs-7b9c79f684-h7dqj` as seen in `ceph -s`, instead of `h7dqj`.

Which issue is resolved by this Pull Request:
Resolves #1752 

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
