### PR TITLE
Updated upgrade path for monCount

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -43,7 +43,7 @@ This will bring up your default text editor and allow you to add and remove stor
 This feature is only available when `useAllNodes` has been set to `false`.
 
 ### Mon Settings
-- `count`: set the number of mons to be started. The number should be odd and between `1` and `9`. Default if not specified is `3`.
+- `count`: set the number of mons to be started. The number should be odd and between `1` and `9`. If not specified will be set to `3` and `allowMultiplePerNode` is also set to `true`.
 - `allowMultiplePerNode`: enable (`true`) or disable (`false`) the placement of multiple mons on one node. Default is `false`.
 
 ### Node Settings

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,8 @@
   longer has to manage installs of Ceph in image.
 - Rook CRD code generation is now working with BSD (Mac) and GNU sed.
 - The [Ceph dashboard](Documentation/ceph-dashboard.md) can be enabled by the cluster CRD.
+- `monCount` has been renamed to `count`, which has been moved into the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings). Additionally the default if unspecified or `0`, is now `3`.
+- You can now toggle if multiple Ceph mons might be placed on one node with the `allowMultiplePerNode` option (default `false`) in the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings).
 
 ## Breaking Changes
 

--- a/pkg/apis/ceph.rook.io/v1alpha1/types.go
+++ b/pkg/apis/ceph.rook.io/v1alpha1/types.go
@@ -91,8 +91,8 @@ const (
 )
 
 type MonSpec struct {
-	Count                int  `json:"count,omitempty"`
-	AllowMultiplePerNode bool `json:"allowMultiplePerNode,omitempty"`
+	Count                int  `json:"count"`
+	AllowMultiplePerNode bool `json:"allowMultiplePerNode"`
 }
 
 // +genclient

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -183,8 +183,9 @@ func (c *ClusterController) onAdd(obj interface{}) {
 	}
 
 	if cluster.Spec.Mon.Count <= 0 {
-		logger.Warning("mon count is 0 or less, should be at least 1, will use default value of %d", mon.DefaultMonCount)
-		cluster.Spec.Mon.Count = 0
+		logger.Warningf("mon count is 0 or less, should be at least 1, will use default value of %d", mon.DefaultMonCount)
+		cluster.Spec.Mon.Count = mon.DefaultMonCount
+		cluster.Spec.Mon.AllowMultiplePerNode = true
 	}
 	if cluster.Spec.Mon.Count > mon.MaxMonCount {
 		logger.Warningf("mon count is bigger than %d (given: %d), not supported, changing to %d", mon.MaxMonCount, cluster.Spec.Mon.Count, mon.MaxMonCount)

--- a/pkg/operator/ceph/cluster/migration_test.go
+++ b/pkg/operator/ceph/cluster/migration_test.go
@@ -226,7 +226,7 @@ func TestConvertLegacyCluster(t *testing.T) {
 			DataDirHostPath: "/var/lib/rook302",
 			Mon: cephv1alpha1.MonSpec{
 				Count:                5,
-				AllowMultiplePerNode: false,
+				AllowMultiplePerNode: true,
 			},
 			Network: rookv1alpha2.NetworkSpec{HostNetwork: true},
 			Placement: rookv1alpha2.PlacementSpec{
@@ -300,6 +300,11 @@ func TestConvertLegacyCluster(t *testing.T) {
 	}
 
 	// convert the legacy cluster and compare it to the expected cluster result
+	assert.Equal(t, expectedCluster, *(convertLegacyCluster(&legacyCluster)))
+
+	// check if legacy monCount is `0` that we default to `3`
+	legacyCluster.Spec.MonCount = 0
+	expectedCluster.Spec.Mon.Count = 3
 	assert.Equal(t, expectedCluster, *(convertLegacyCluster(&legacyCluster)))
 }
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -58,7 +58,7 @@ const (
 	adminSecretName   = "admin-secret"
 	clusterSecretName = "cluster-name"
 
-	// DefaultMonCount Default mon count for cluster
+	// DefaultMonCount Default mon count for a cluster
 	DefaultMonCount = 3
 	// MaxMonCount Maximum allowed mon count for a cluster
 	MaxMonCount = 9


### PR DESCRIPTION
```
Default to 3 mons when no `mon.count` is given.
The documentation and upgrade page has been updated accordingly to reflect the new
default.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>
```
Description of your changes:
This is breaks some lines at around 80 chars in the example Ceph `cluster.yaml`.
Default `mon.count` to `3` when not set, in addition to that `allowMultiplePerNode` is set to `true` to ease the migration of users that may not set a `monCount` before doing the upgrade.
That the `monCount` must be set has been added to the upgrade guide.

Relates #1710.
These default changes are needed now because if no `mon.count` and/or `monCount` is/was not given would cause the operator to start no mons at all.

I don't see an issue with enforcing the users to set a `monCount`/`mon.count` in their Cluster CRD during upgrade and general usage.

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.