### PR TITLE
JournalPartition Code Cleanup

### DIFF
--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -306,26 +306,6 @@ func getDataPartitionDetails(config *osdConfig) (*config.PerfSchemePartitionDeta
 	return dataDetails, nil
 }
 
-func getMetadataPartitionDetails(cfg *osdConfig) (*config.PerfSchemePartitionDetails, error) {
-	if cfg.partitionScheme == nil {
-		return nil, fmt.Errorf("partition scheme missing from %+v", cfg)
-	}
-
-	metadataPartitionType := cfg.partitionScheme.GetMetadataPartitionType()
-
-	if cfg.partitionScheme.StoreType == config.Filestore {
-		// TODO: support separate metadata device for filestore (just use the data partition details for now)
-		return getDataPartitionDetails(cfg)
-	}
-
-	metadataDetails, ok := cfg.partitionScheme.Partitions[metadataPartitionType]
-	if !ok || metadataDetails == nil {
-		return nil, fmt.Errorf("metadata partition missing from %+v", cfg.partitionScheme)
-	}
-
-	return metadataDetails, nil
-}
-
 func getDiskSize(context *clusterd.Context, name string) (uint64, error) {
 	for _, device := range context.Devices {
 		if device.Name == name {

--- a/pkg/operator/ceph/cluster/osd/config/scheme.go
+++ b/pkg/operator/ceph/cluster/osd/config/scheme.go
@@ -45,7 +45,6 @@ const (
 	DatabasePartitionType
 	BlockPartitionType
 	FilestoreDataPartitionType
-	FilestoreJournalPartitionType
 )
 
 // top level representation of an overall performance oriented partition scheme, with a dedicated metadata device
@@ -431,14 +430,6 @@ func (e *PerfSchemeEntry) GetDataPartitionType() PartitionType {
 	}
 }
 
-func (e *PerfSchemeEntry) GetMetadataPartitionType() PartitionType {
-	if e.StoreType == Filestore {
-		return FilestoreJournalPartitionType
-	} else {
-		return DatabasePartitionType
-	}
-}
-
 // Get the arguments necessary to create an sgdisk partition with the given parameters.
 // number is the partition number.
 // The offset and length are in MB. Under the covers this is translated to sectors.
@@ -475,8 +466,6 @@ func getPartitionLabel(id int, partType PartitionType) string {
 		return fmt.Sprintf("ROOK-OSD%d-BLOCK", id)
 	case FilestoreDataPartitionType:
 		return fmt.Sprintf("ROOK-OSD%d-FS-DATA", id)
-	case FilestoreJournalPartitionType:
-		return fmt.Sprintf("ROOK-OSD%d-FS-JOURNAL", id)
 	}
 
 	return ""


### PR DESCRIPTION
Description of your changes:
JournalPartitionType is defined but will never be used given rook will always
place journal file in the filestore's block partition. Cleaning out the code.

Resolves: #1775

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
