### PR TITLE
helm: support adding annotations on pod

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -103,6 +103,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `rbacEnable`              | If true, create & use RBAC resources                            | `true`                                                 |
 | `pspEnable`               | If true, create & use PSP resources                             | `true`                                                 |
 | `resources`               | Pod resource requests & limits                                  | `{}`                                                   |
+| `annotations`             | Pod annotations                                                 | `{}`                                                   |
 | `logLevel`                | Global log level                                                | `INFO`                                                 |
 | `nodeSelector`            | Kubernetes `nodeSelector` to add to the Deployment.             | <none>                                                 |
 | `tolerations`             | List of Kubernetes `tolerations` to add to the Deployment.      | `[]`                                                   |

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: rook-ceph-operator
         chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.annotations }}
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: rook-ceph-operator

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -33,6 +33,9 @@ mon:
   healthCheckInterval: "45s"
   monOutTimeout: "300s"
 
+## Annotations to be added to pod
+annotations: {}
+
 ## LogLevel can be set to: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR or CRITICAL
 logLevel: INFO
 


### PR DESCRIPTION
Signed-off-by: Terje Sannum <terje.sannum@nav.no>

Description of your changes:
Added the possibility to add annotations to the rook-ceph-operator pod