### PR TITLE
Detect disk uuid with sgdisk

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -84,7 +84,7 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		// get the UUID for disks
 		var diskUUID string
 		if diskType != sys.PartType {
-			diskUUID, err = sys.GetFSUUID(d, executor)
+			diskUUID, err = sys.GetDiskUUID(d, executor)
 			if err != nil {
 				logger.Warningf("skipping device %s with an unknown uuid. %+v", d, err)
 				continue
@@ -126,12 +126,6 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		// parse udev info output
 		if val, ok := udevInfo["DEVLINKS"]; ok {
 			disk.DevLinks = val
-		}
-		if val, ok := udevInfo["ID_FS_UUID"]; ok {
-			disk.UUID = val
-		} else if val, ok := udevInfo["ID_PART_TABLE_UUID"]; ok {
-			// fall back to the part_table_uuid if the fs_uuid was not found
-			disk.UUID = val
 		}
 		if val, ok := udevInfo["ID_FS_TYPE"]; ok {
 			disk.Filesystem = val

--- a/pkg/daemon/discover/discover_test.go
+++ b/pkg/daemon/discover/discover_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const udevOutput = `DEVLINKS=/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c /dev/disk/by-id/wwn-0x6001405d27e5d898829468b90ce4ef8c /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-0 /dev/disk/by-uuid/f2d38cba-37da-411d-b7ba-9a6696c58174
+const (
+	udevOutput = `DEVLINKS=/dev/disk/by-id/scsi-36001405d27e5d898829468b90ce4ef8c /dev/disk/by-id/wwn-0x6001405d27e5d898829468b90ce4ef8c /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2016-06.world.srv:storage.target01-lun-0 /dev/disk/by-uuid/f2d38cba-37da-411d-b7ba-9a6696c58174
 DEVNAME=/dev/sdk
 DEVPATH=/devices/platform/host6/session2/target6:0:0/6:0:0:0/block/sdk
 DEVTYPE=disk
@@ -58,6 +59,12 @@ SUBSYSTEM=block
 TAGS=:systemd:
 USEC_INITIALIZED=15981915740802
 `
+	sgdiskOutput = `Disk /dev/sdb: 20971520 sectors, 10.0 GiB
+Logical sector size: 512 bytes
+Disk identifier (GUID): 819C2F95-7015-438F-A624-D40DBA2C2069
+Partition table holds up to 128 entries
+`
+)
 
 func TestProbeDevices(t *testing.T) {
 	// set up mock execute so we can verify the partitioning happens on sda
@@ -80,8 +87,8 @@ testa2   centos_host13-root
 testa2   centos_host13-swap
 testa2   centos_host13-home
 `
-		case "get disk testa fs uuid":
-			output = udevOutput
+		case "get disk testa uuid":
+			output = sgdiskOutput
 
 		case "get disk testa fs serial":
 			output = udevOutput

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -282,16 +282,6 @@ func UnmountDevice(devicePath string, executor exec.Executor) error {
 	return nil
 }
 
-func GetFSUUID(device string, executor exec.Executor) (string, error) {
-	cmd := fmt.Sprintf("get disk %s fs uuid", device)
-	output, err := executor.ExecuteCommandWithOutput(false, cmd,
-		"udevadm", "info", "--query=property", fmt.Sprintf("/dev/%s", device))
-	if err != nil {
-		return "", err
-	}
-	return parseFSUUID(output), nil
-}
-
 func CheckIfDeviceAvailable(executor exec.Executor, name string) (bool, string, error) {
 	ownPartitions := true
 	partitions, _, err := GetDevicePartitions(name, executor)


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

In 0.7 and earlier, the detection of disk uuid was done by `sgdisk`. This is critical for maintaining a consistent disk id at restart so that we can decide whether to start the same osd or create a new one. With the change to `udevadm` with #1637, some environments do not return the disk uuid. This change will revert to the 0.7 behavior for sgdisk to detect the uuid more reliably, while still detecting the more detailed device properties with udevadm.

Which issue is resolved by this Pull Request:
Resolves #1776

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
