### PR TITLE
docs: fix minio service name and include minio in pending release notes

### DIFF
--- a/Documentation/minio-object-store.md
+++ b/Documentation/minio-object-store.md
@@ -27,7 +27,7 @@ kubectl create -f operator.yaml
 You can check if the operator is up and running with:
 
 ```console
- kubectl -n rook-minio-system get pod
+kubectl -n rook-minio-system get pod
 ```
 
 ## Create and Initialize a Distributed Minio Object Store 
@@ -73,7 +73,7 @@ If you are using [Minikube](https://github.com/kubernetes/minikube), you can get
 The full address of the Minio service when using Minikube can be obtained with the following:
 
 ```console
-echo http://$(minikube ip):$(kubectl -n rook-minio get service my-store-service -o jsonpath='{.spec.ports[0].nodePort}')
+echo http://$(minikube ip):$(kubectl -n rook-minio get service minio-service -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
 Copy and paste the full address and port into an internet browser and you will be taken to the Minio web console login page, as shown in the screenshot below:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -7,7 +7,8 @@
 ## Notable Features
 
 - Rook is now architected to be a general cloud-native storage orchestrator, and can now support multiple types of storage and providers beyond Ceph.
-  - [CockroachDB](https://www.cockroachlabs.com/) is now supported by Rook with a new operator to deploy, configure and manage instances of this popular and resilient SQL database.  Databases can be automatically deployed by creating an instance of the new `cluster.cockroachdb.rook.io` custom resource. See the [user guide](Documentation/cockroachdb.md) to get started with CockroachDB.
+  - [CockroachDB](https://www.cockroachlabs.com/) is now supported by Rook with a new operator to deploy, configure and manage instances of this popular and resilient SQL database.  Databases can be automatically deployed by creating an instance of the new `cluster.cockroachdb.rook.io` custom resource. See the [CockroachDB user guide](Documentation/cockroachdb.md) to get started with CockroachDB.
+  - [Minio](https://www.minio.io/) is also supported now with an operator to deploy and manage this popular high performance distributed object storage server.  To get started with Minio using the new `objectstore.minio.rook.io` custom resource, follow the steps in the [Minio user guide](Documentation/minio-object-store.md).
 - Ceph tools can be run [from any rook pod](Documentation/common-issues.md#ceph-tools).
 - Output from stderr will be included in error messages returned from the `exec` of external tools.
 - Rook-Operator no longer creates the resources CRD's or TPR's at the runtime. Instead, those resources are provisioned during deployment via `helm` or `kubectl`.


### PR DESCRIPTION
Description of your changes: small docs changes to fix minio service name in the minikube URL command and include minio in pending release notes.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.

[skip ci]