### PR TITLE
Fix retrieve device label

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -381,6 +381,9 @@ func parsePartLabel(output string) string {
 	if v, ok := m["ID_PART_ENTRY_NAME"]; ok {
 		return v
 	}
+	if v, ok := m["PARTNAME"]; ok {
+		return v
+	}
 	return ""
 }
 


### PR DESCRIPTION
Description of your changes:

There is trouble with retrieve device label In bare metal cluster (vmware vSphere, nodes: ununtu 16.04) configured by kubespray. Command `udevadm info --query=property /dev/sdb1` output only:
```
DEVPATH=/devices/pci0000:00/0000:00:15.0/0000:03:00.0/host32/port-32:1/end_device-32:1/target32:0:1/32:0:1:0/block/sdb/sdb1
DEVTYPE=partition
MAJOR=8
MINOR=17
PARTN=1
PARTNAME=ROOK-OSD0-BLOCK
SUBSYSTEM=block
```

There isn't key `ID_PART_ENTRY_NAME`, however label exists in `PARTNAME`.

I don't know why truncated output from udevadm on some nodes into rook app. But its still full output from same docker container like:

```
[root@node1 /]# udevadm info --query=property /dev/sdb1
DEVLINKS=/dev/disk/by-id/scsi-36000c295222ef6cd1cd2cf2441f918d5-part1 /dev/disk/by-id/wwn-0x6000c295222ef6cd1cd2cf2441f918d5-part1 /dev/disk/by-partlabel/ROOK-OSD0-BLOCK /dev/disk/by-partuuid/ec264623-428d-4763-aacf-12e8b911b028 /dev/disk/by-path/pci-0000:03:00.0-sas-phy1-lun-0-part1
DEVNAME=/dev/sdb1
DEVPATH=/devices/pci0000:00/0000:00:15.0/0000:03:00.0/host32/port-32:1/end_device-32:1/target32:0:1/32:0:1:0/block/sdb/sdb1
DEVTYPE=partition
ID_BUS=scsi
ID_MODEL=Virtual_disk
ID_MODEL_ENC=Virtual\x20disk\x20\x20\x20\x20
ID_PART_ENTRY_DISK=8:16
ID_PART_ENTRY_NAME=ROOK-OSD0-BLOCK
ID_PART_ENTRY_NUMBER=1
ID_PART_ENTRY_OFFSET=2048
ID_PART_ENTRY_SCHEME=gpt
ID_PART_ENTRY_SIZE=209713119
ID_PART_ENTRY_TYPE=0fc63daf-8483-4772-8e79-3d69d8477de4
ID_PART_ENTRY_UUID=ec264623-428d-4763-aacf-12e8b911b028
ID_PART_TABLE_TYPE=gpt
ID_PART_TABLE_UUID=fa899793-057a-4b73-95a3-8fa28b9a2ddf
ID_PATH=pci-0000:03:00.0-sas-phy1-lun-0
ID_PATH_TAG=pci-0000_03_00_0-sas-phy1-lun-0
ID_REVISION=2.0
ID_SCSI=1
ID_SCSI_SERIAL=6000c295222ef6cd1cd2cf2441f918d5
ID_SERIAL=36000c295222ef6cd1cd2cf2441f918d5
ID_SERIAL_SHORT=6000c295222ef6cd1cd2cf2441f918d5
ID_TYPE=disk
ID_VENDOR=VMware
ID_VENDOR_ENC=VMware\x20\x20
ID_WWN=0x6000c295222ef6cd
ID_WWN_VENDOR_EXTENSION=0x1cd2cf2441f918d5
ID_WWN_WITH_EXTENSION=0x6000c295222ef6cd1cd2cf2441f918d5
MAJOR=8
MINOR=17
PARTN=1
PARTNAME=ROOK-OSD0-BLOCK
SUBSYSTEM=block
TAGS=:systemd:
USEC_INITIALIZED=17227525523
```

Which issue is resolved by this Pull Request:
Resolves #

Checklist:
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
