### PR TITLE
Don't set default for IP flags

### DIFF
--- a/cmd/rook/ceph/ceph.go
+++ b/cmd/rook/ceph/ceph.go
@@ -74,13 +74,13 @@ func createContext() *clusterd.Context {
 		ConfigDir:          cfg.dataDir,
 		ConfigFileOverride: cfg.cephConfigOverride,
 		LogLevel:           rook.Cfg.LogLevel,
-		NetworkInfo:        cfg.networkInfo.Simplify(),
+		NetworkInfo:        cfg.NetworkInfo(),
 	}
 }
 
 func addCephFlags(command *cobra.Command) {
-	command.Flags().StringVar(&cfg.networkInfo.PublicAddr, "public-ip", "127.0.0.1", "public IP address for this machine")
-	command.Flags().StringVar(&cfg.networkInfo.ClusterAddr, "private-ip", "127.0.0.1", "private IP address for this machine")
+	command.Flags().StringVar(&cfg.networkInfo.PublicAddr, "public-ip", "", "public IP address for this machine")
+	command.Flags().StringVar(&cfg.networkInfo.ClusterAddr, "private-ip", "", "private IP address for this machine")
 	command.Flags().StringVar(&clusterInfo.Name, "cluster-name", "rookcluster", "ceph cluster name")
 	command.Flags().StringVar(&clusterInfo.FSID, "fsid", "", "the cluster uuid")
 	command.Flags().StringVar(&clusterInfo.MonitorSecret, "mon-secret", "", "the cephx keyring for monitors")
@@ -91,8 +91,8 @@ func addCephFlags(command *cobra.Command) {
 
 	// deprecated ipv4 format address
 	// TODO: remove these legacy flags in the future
-	command.Flags().StringVar(&cfg.networkInfo.PublicAddrIPv4, "public-ipv4", "127.0.0.1", "public IPv4 address for this machine")
-	command.Flags().StringVar(&cfg.networkInfo.ClusterAddrIPv4, "private-ipv4", "127.0.0.1", "private IPv4 address for this machine")
+	command.Flags().StringVar(&cfg.networkInfo.PublicAddrIPv4, "public-ipv4", "", "public IPv4 address for this machine")
+	command.Flags().StringVar(&cfg.networkInfo.ClusterAddrIPv4, "private-ipv4", "", "private IPv4 address for this machine")
 	command.Flags().MarkDeprecated("public-ipv4", "Use --public-ip instead. Will be removed in a future version.")
 	command.Flags().MarkDeprecated("private-ipv4", "Use --private-ip instead. Will be removed in a future version.")
 }
@@ -103,4 +103,8 @@ func verifyRenamedFlags(cmd *cobra.Command) error {
 		{NewFlagName: "private-ip", OldFlagName: "private-ipv4"},
 	}
 	return flags.VerifyRenamedFlags(cmd, renamed)
+}
+
+func (c *config) NetworkInfo() clusterd.NetworkInfo {
+	return c.networkInfo.Simplify()
 }

--- a/cmd/rook/ceph/mon.go
+++ b/cmd/rook/ceph/mon.go
@@ -72,7 +72,7 @@ func startMon(cmd *cobra.Command, args []string) error {
 
 	// at first start the local monitor needs to be added to the list of mons
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.networkInfo.PublicAddr, monPort)
+	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.NetworkInfo().PublicAddr, monPort)
 
 	monCfg := &mon.Config{
 		Name:    monName,

--- a/pkg/clusterd/network.go
+++ b/pkg/clusterd/network.go
@@ -34,8 +34,8 @@ type NetworkInfo struct {
 
 // Simplify adapts deprecated fields
 // TODO: remove this function in the future
-func (in NetworkInfo) Simplify() (out NetworkInfo) {
-	out = NetworkInfo{
+func (in NetworkInfo) Simplify() NetworkInfo {
+	out := NetworkInfo{
 		PublicNetwork:  in.PublicNetwork,
 		ClusterNetwork: in.ClusterNetwork,
 	}

--- a/pkg/daemon/ceph/mon/daemon.go
+++ b/pkg/daemon/ceph/mon/daemon.go
@@ -68,7 +68,6 @@ func ToCephMon(name, ip string, port int32) *CephMonitorConfig {
 }
 
 func Run(context *clusterd.Context, config *Config) error {
-
 	configFile, monDataDir, err := generateConfigFiles(context, config)
 	if err != nil {
 		return fmt.Errorf("failed to generate mon config files. %+v", err)


### PR DESCRIPTION
```
Fixes the issue that when the old IPv4 flags were set, the new flags
were still used because of the default being the new flags not being
empty.
```
Description of your changes:
Don't set a default for the IP flags so the IPv4 flags are not overriden through the "default" of the new IP flags.

Which issue is resolved by this Pull Request:
Resolves https://rook-io.slack.com/archives/CAWE7BW10/p1530078642000121 and (probably) resolves #1823.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.

~~Will test it in a few minutes, but from the Slack discussion this seems like a valid fix.~~