### PR TITLE
helm: Added `nodeSelector` to rook-ceph operator chart

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -96,22 +96,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter          | Description                          | Default              |
-|--------------------|--------------------------------------|----------------------|
-| `image.repository` | Image                                | `rook/ceph`          |
-| `image.tag`        | Image tag                            | `master`             |
-| `image.pullPolicy` | Image pull policy                    | `IfNotPresent`       |
-| `rbacEnable`       | If true, create & use RBAC resources | `true`               |
-| `pspEnable`        | If true, create & use PSP resources  | `true`               |
-| `resources`        | Pod resource requests & limits       | `{}`                 |
-| `logLevel`         | Global log level        | `INFO`                 |
+| Parameter                 | Description                                                     | Default                                                |
+| ------------------------- | --------------------------------------------------------------- | ------------------------------------------------------ |
+| `image.repository`        | Image                                                           | `rook/ceph`                                            |
+| `image.tag`               | Image tag                                                       | `master`                                               |
+| `image.pullPolicy`        | Image pull policy                                               | `IfNotPresent`                                         |
+| `rbacEnable`              | If true, create & use RBAC resources                            | `true`                                                 |
+| `pspEnable`               | If true, create & use PSP resources                             | `true`                                                 |
+| `resources`               | Pod resource requests & limits                                  | `{}`                                                   |
+| `logLevel`                | Global log level                                                | `INFO`                                                 |
+| `nodeSelector`            | Kubernetes `nodeSelector` to add to the Deployment.             | <none>                                                 |
 | `agent.flexVolumeDirPath` | Path where the Rook agent discovers the flex volume plugins (*) | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
-| `agent.toleration`        | Toleration for the agent pods | <none> |
-| `agent.tolerationKey`     | The specific key of the taint to tolerate | <none> |
-| `discover.toleration`        | Toleration for the discover pods | <none> |
-| `discover.tolerationKey`     | The specific key of the taint to tolerate | <none> |
-| `mon.healthCheckInterval` | The frequency for the operator to check the mon health | `45s` |
-| `mon.monOutTimeout`       | The time to wait before failing over an unhealthy mon | `300s` |
+| `agent.toleration`        | Toleration for the agent pods                                   | <none>                                                 |
+| `agent.tolerationKey`     | The specific key of the taint to tolerate                       | <none>                                                 |
+| `discover.toleration`     | Toleration for the discover pods                                | <none>                                                 |
+| `discover.tolerationKey`  | The specific key of the taint to tolerate                       | <none>                                                 |
+| `mon.healthCheckInterval` | The frequency for the operator to check the mon health          | `45s`                                                  |
+| `mon.monOutTimeout`       | The time to wait before failing over an unhealthy mon           | `300s`                                                 |
 
 &ast; For Kubernetes 1.9.x `agent.flexVolumeDirPath` should be changed to `/var/lib/kubelet/volumeplugins/`. [Flexvolume documentation](flexvolume.md#for-kubernetes--19x)
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -19,6 +19,7 @@
 - `monCount` has been renamed to `count`, which has been moved into the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings). Additionally the default if unspecified or `0`, is now `3`.
 - You can now toggle if multiple Ceph mons might be placed on one node with the `allowMultiplePerNode` option (default `false`) in the [`mon` spec](Documentation/ceph-cluster-crd.md#mon-settings).
 - One OSD will run per pod to increase the reliability and maintainability of the OSDs. No longer will restarting an OSD pod mean that all OSDs on that node will go down. See the [design doc](design/dedicated-osd-pod.md).
+- Added `nodeSelector` to Rook Ceph operator Helm chart.
 
 ## Breaking Changes
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -77,6 +77,10 @@ spec:
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-    {{- if .Values.rbacEnable }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.rbacEnable }}
       serviceAccountName: rook-ceph-system
-    {{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -21,6 +21,11 @@ resources:
     cpu: 100m
     memory: 128Mi
 
+nodeSelector:
+# Constraint rook-ceph-operator Deployment to nodes with label `disktype: ssd`.
+# For more info, see https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+#  disktype: ssd
+
 mon:
   healthCheckInterval: "45s"
   monOutTimeout: "300s"


### PR DESCRIPTION
```
Closes #1571.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>
```
Description of your changes:
Adds a `nodeSelector` to the rook-ceph operator chart.

Which issue is resolved by this Pull Request:
Resolves #1571.

Checklist:
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.