### PR TITLE
minio: remove svc.cluster.local from serverAddress

### DIFF
--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -43,7 +43,6 @@ const (
 	minioCtrName             = "minio"
 	minioLabel               = "minio"
 	minioPVCName             = "minio-pvc"
-	minioServerSuffixFmt     = "%s.svc.cluster.local"
 	minioVolumeName          = "data"
 	objectStoreDataDir       = "/data"
 )
@@ -112,7 +111,7 @@ func (c *MinioController) makeMinioHeadlessService(name, namespace string, spec 
 func (c *MinioController) buildMinioCtrArgs(statefulSetPrefix, headlessServiceName, namespace string, serverCount int32) []string {
 	args := []string{"server"}
 	for i := int32(0); i < serverCount; i++ {
-		serverAddress := fmt.Sprintf("http://%s-%d.%s.%s%s", statefulSetPrefix, i, headlessServiceName, fmt.Sprintf(minioServerSuffixFmt, namespace), objectStoreDataDir)
+		serverAddress := fmt.Sprintf("http://%s-%d.%s.%s%s", statefulSetPrefix, i, headlessServiceName, namespace, objectStoreDataDir)
 		args = append(args, serverAddress)
 	}
 


### PR DESCRIPTION
Services in kubernetes can be reached at <servicename>.<namespace> without specifying svc.cluster.local. Removing this resolves issues with deployments where the kubernetes domain has been changed from the default.

Description of your changes:
Remove svc.cluster.local from the serverAddress

Which issue is resolved by this Pull Request:
Resolves #1836 
