### PR TITLE
Rename user in helm chart to match the psp username

### DIFF
--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -93,7 +93,7 @@ and
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook-system
+  name: rook-ceph-system
 ---
 # Allow the rook-ceph-system serviceAccount to use the privileged PSP
 apiVersion: rbac.authorization.k8s.io/v1
@@ -107,7 +107,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-system
+  namespace: rook-ceph-system
 ```
 
 Save these definitions to one or multiple yaml files and create them by executing `kubectl apply -f <nameOfYourFile>.yaml`

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -109,7 +109,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-ceph-operator-psp-user
+  name: rook-ceph-system-psp-user
   labels:
     operator: rook
     storage-backend: ceph


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

**Description of your changes:**
The updates to the role names for rbac missed updating this username in the helm chart. 

**Which issue is resolved by this Pull Request:**
Resolves #1833 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.

[skip ci]