### PR TITLE
Add k8s 1.11 to the test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,9 @@ pipeline {
                     def data = [
                         "aws_1.7.x": "v1.7.11",
                         "aws_1.8.x": "v1.8.5",
-                        "gce_1.9.x": "v1.9.6",
-                        "aws_1.10.x": "v1.10.1"
+                        "gce_1.9.x": "v1.9.9",
+                        "aws_1.10.x": "v1.10.5",
+                        "aws_1.11.x": "v1.11.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -106,9 +106,13 @@ func (k8sh *K8sHelper) MakeContext() *clusterd.Context {
 
 //Kubectl is wrapper for executing kubectl commands
 func (k8sh *K8sHelper) Kubectl(args ...string) (string, error) {
-	result, err := k8sh.executor.ExecuteCommandWithTimeout(false, 10*time.Second, "kubectl", "kubectl", args...)
+	result, err := k8sh.executor.ExecuteCommandWithTimeout(false, 15*time.Second, "kubectl", "kubectl", args...)
 	if err != nil {
 		k8slogger.Errorf("Failed to execute: kubectl %+v : %+v. %s", args, err, result)
+		if args[0] == "delete" {
+			// allow the tests to continue if we were deleting a resource that timed out
+			return result, nil
+		}
 		return result, fmt.Errorf("Failed to run: kubectl %v : %v", args, err)
 	}
 	return result, nil

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -154,9 +154,7 @@ func runBlockE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s su
 
 	volumeDef := installer.GetBlockPoolStorageClassAndPvcDef(clusterNamespace, poolName, "rook-ceph-block", "test-block-claim", "ReadWriteOnce")
 	res1, err := installer.BlockResourceOperation(k8sh, volumeDef, "create")
-	assert.Contains(s.T(), res1, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
-	assert.Contains(s.T(), res1, "\"rook-ceph-block\" created", "Make sure storageclass is created")
-	assert.Contains(s.T(), res1, "\"test-block-claim\" created", "Make sure pvc is created")
+	checkOrderedSubstrings(s.T(), res1, poolName, "created", "rook-ceph-block", "created", "test-block-claim", "created")
 	require.NoError(s.T(), err)
 
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, "test-block-claim"))

--- a/tests/integration/block_createBlock_k8s_test.go
+++ b/tests/integration/block_createBlock_k8s_test.go
@@ -74,7 +74,7 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	defer s.tearDownTest(claimName, poolName, storageClassName, "ReadWriteOnce")
 
 	result, err := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	assert.Contains(s.T(), result, fmt.Sprintf("persistentvolumeclaim \"%s\" created", claimName), "Make sure pvc is created. "+result)
+	checkOrderedSubstrings(s.T(), result, "persistentvolumeclaim", claimName, "created")
 	require.NoError(s.T(), err)
 
 	//check status of PVC
@@ -107,11 +107,11 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	logger.Infof("create pool and storageclass")
 	pool := model.Pool{Name: poolName, ReplicatedConfig: model.ReplicatedPoolConfig{Size: 1}}
 	result0, err0 := s.testClient.PoolClient.Create(pool, s.namespace)
-	assert.Contains(s.T(), result0, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
+	checkOrderedSubstrings(s.T(), result0, poolName, "created")
 	require.NoError(s.T(), err0)
 
 	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
-	assert.Contains(s.T(), result1, fmt.Sprintf("\"%s\" created", storageClassName), "Make sure storageclass is created")
+	checkOrderedSubstrings(s.T(), result1, storageClassName, "created")
 	require.NoError(s.T(), err1)
 
 	logger.Infof("make sure storageclass is created")
@@ -120,7 +120,7 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("create pvc")
 	result2, err2 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	assert.Contains(s.T(), result2, fmt.Sprintf("\"%s\" created", claimName), "Make sure pvc is created. "+result2)
+	checkOrderedSubstrings(s.T(), result2, claimName, "created")
 	require.NoError(s.T(), err2)
 
 	logger.Infof("check status of PVC")
@@ -131,8 +131,8 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	assert.Equal(s.T(), s.initBlockCount+1, len(b1), "Make sure new block image is created")
 
 	logger.Infof("Create same pvc again")
-	result3, err3 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
-	assert.Contains(s.T(), err3.Error(), fmt.Sprintf("\"%s\" already exists", claimName), "make sure PVC is not created again. "+result3)
+	_, err3 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, "ReadWriteOnce"), "create")
+	checkOrderedSubstrings(s.T(), err3.Error(), claimName, "already exists")
 
 	logger.Infof("check status of PVC")
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
@@ -222,10 +222,10 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	//create pool and storageclass
 	result0, err0 := installer.BlockResourceOperation(s.kh, installer.GetBlockPoolDef(poolName, s.namespace, "1"), "create")
-	assert.Contains(s.T(), result0, fmt.Sprintf("\"%s\" created", poolName), "Make sure test pool is created")
+	checkOrderedSubstrings(s.T(), result0, poolName, "created")
 	require.NoError(s.T(), err0)
 	result1, err1 := installer.BlockResourceOperation(s.kh, installer.GetBlockStorageClassDef(poolName, storageClassName, s.namespace, true), "create")
-	assert.Contains(s.T(), result1, fmt.Sprintf("\"%s\" created", storageClassName), "Make sure storageclass is created")
+	checkOrderedSubstrings(s.T(), result1, storageClassName, "created")
 	require.NoError(s.T(), err1)
 
 	//make sure storageclass is created
@@ -234,7 +234,7 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	//create pvc
 	result2, err2 := installer.BlockResourceOperation(s.kh, installer.GetBlockPvcDef(claimName, storageClassName, pvcAccessMode), "create")
-	assert.Contains(s.T(), result2, fmt.Sprintf("\"%s\" created", claimName), "Make sure pvc is created. "+result2)
+	checkOrderedSubstrings(s.T(), result2, claimName, "created")
 	require.NoError(s.T(), err2)
 
 	//check status of PVC

--- a/tests/integration/multi_cluster_deploy_test.go
+++ b/tests/integration/multi_cluster_deploy_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/rook/rook/tests/framework/contracts"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -81,13 +80,13 @@ func (mrc *MultiClusterDeploySuite) createPools() {
 	poolName := "multi-cluster-pool1"
 	logger.Infof("Creating pool %s", poolName)
 	result, err := installer.BlockResourceOperation(mrc.k8sh, installer.GetBlockPoolDef(poolName, mrc.namespace1, "1"), "create")
-	assert.Contains(mrc.T(), result, fmt.Sprintf("\"%s\" created", poolName))
+	checkOrderedSubstrings(mrc.T(), result, poolName, "created")
 	require.Nil(mrc.T(), err)
 
 	poolName = "multi-cluster-pool2"
 	logger.Infof("Creating pool %s", poolName)
 	result, err = installer.BlockResourceOperation(mrc.k8sh, installer.GetBlockPoolDef(poolName, mrc.namespace2, "1"), "create")
-	assert.Contains(mrc.T(), result, fmt.Sprintf("\"%s\" created", poolName))
+	checkOrderedSubstrings(mrc.T(), result, poolName, "created")
 	require.Nil(mrc.T(), err)
 }
 

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -126,4 +127,13 @@ func (suite *SmokeSuite) TestOperatorGetFlexvolumePath() {
 	assert.True(suite.T(), strings.Contains(logStmt, "discovered flexvolume dir path from source"))
 	assert.False(suite.T(), strings.Contains(logStmt, "discovered flexvolume dir path from source env var"))
 	assert.False(suite.T(), strings.Contains(logStmt, "discovered flexvolume dir path from source default"))
+}
+
+func checkOrderedSubstrings(t *testing.T, input string, substrings ...string) {
+	original := input
+	for i, substring := range substrings {
+		assert.Contains(t, input, substring, fmt.Sprintf("missing substring %d. original=%s", i, original))
+		index := strings.Index(input, substring)
+		input = input[index+len(substring):]
+	}
 }

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -92,7 +92,7 @@ function check_context() {
 }
 
 # configure minikube
-KUBE_VERSION=${KUBE_VERSION:-"v1.10.0"}
+KUBE_VERSION=${KUBE_VERSION:-"v1.11.0"}
 MEMORY=${MEMORY:-"3000"}
 
 case "${1:-}" in


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the release of K8s 1.11, Rook needs to run the integration tests there. This PR also updates the older versions to their latest dot releases.

**Which issue is resolved by this Pull Request:**
Resolves #1840

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
