### PR TITLE
Available devices should include previously configured devices

### DIFF
--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -54,7 +54,7 @@ func newProvisionConfig() *provisionConfig {
 }
 
 func (c *provisionConfig) addError(message string, args ...interface{}) {
-	logger.Errorf(message, args)
+	logger.Errorf(message, args...)
 	c.errorMessages = append(c.errorMessages, fmt.Sprintf(message, args...))
 }
 

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -112,10 +112,10 @@ func TestGetAvailableDevices(t *testing.T) {
 	devices, err := GetAvailableDevices(context, nodeName, ns, d, "^sd.", false)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(devices))
-	// devices should be in use now, 2nd try gets empty devices
+	// devices should be in use now, 2nd try gets the same list
 	devices, err = GetAvailableDevices(context, nodeName, ns, d, "^sd.", false)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(devices))
+	assert.Equal(t, 1, len(devices))
 
 	err = FreeDevices(context, nodeName, ns)
 	assert.Nil(t, err)
@@ -123,10 +123,10 @@ func TestGetAvailableDevices(t *testing.T) {
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(devices))
-	// devices should be in use now, 2nd try gets empty devices
+	// devices should be in use now, 2nd try gets the same list
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(devices))
+	assert.Equal(t, 4, len(devices))
 
 	err = FreeDevices(context, nodeName, ns)
 	assert.Nil(t, err)
@@ -134,10 +134,10 @@ func TestGetAvailableDevices(t *testing.T) {
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(devices))
-	// devices should be in use now, 2nd try gets empty devices
+	// devices should be in use now, 2nd try gets the same list
 	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
 	assert.Nil(t, err)
-	assert.Equal(t, 0, len(devices))
+	assert.Equal(t, 5, len(devices))
 
 	err = FreeDevices(context, nodeName, ns)
 	assert.Nil(t, err)


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The available devices passed to the provisioner should include the list of devices previously configured in the same cluster. In other words the provisioner should always be given the desired list of devices and directories. The provisioner is idempotent and will see that the osds were already configured on the devices or directories. 

**Which issue is resolved by this Pull Request:**
Resolves #1864

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] `make vendor` does not cause changes.
