### PR TITLE
Enhancement of Ceph volume manager kmod detection

### DIFF
--- a/pkg/daemon/ceph/agent/agent.go
+++ b/pkg/daemon/ceph/agent/agent.go
@@ -53,7 +53,10 @@ func (a *Agent) Run() error {
 		return fmt.Errorf("failed to create volume attachment controller: %+v", err)
 	}
 
-	volumeManager := ceph.NewVolumeManager(a.context)
+	volumeManager, err := ceph.NewVolumeManager(a.context)
+	if err != nil {
+		return fmt.Errorf("failed to create volume manager: %+v", err)
+	}
 
 	flexvolumeController := flexvolume.NewController(a.context, volumeAttachmentController, volumeManager)
 

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -52,17 +52,25 @@ type pathFinder interface {
 }
 
 // NewVolumeManager create attacher for ceph volumes
-func NewVolumeManager(context *clusterd.Context) *VolumeManager {
+func NewVolumeManager(context *clusterd.Context) (*VolumeManager, error) {
 	vm := &VolumeManager{
 		context:          context,
 		devicePathFinder: &devicePathFinder{},
 	}
-	vm.Init()
-	return vm
+	err := vm.Init()
+	return vm, err
 }
 
 // Init the ceph volume manager
 func (vm *VolumeManager) Init() error {
+	// check if the rbd is a builtin kernel module, if it is then we don't need to load it manually
+	in, err := sys.IsBuiltinKernelModule(rbdKernelModuleName, vm.context.Executor)
+	if err != nil {
+		return err
+	}
+	if in == true {
+		return nil
+	}
 
 	// check to see if the rbd kernel module has single_major support
 	hasSingleMajor, err := sys.CheckKernelModuleParam(rbdKernelModuleName, "single_major", vm.context.Executor)
@@ -77,9 +85,9 @@ func (vm *VolumeManager) Init() error {
 	}
 
 	// load the rbd kernel module with options
-	// TODO: should this fail if modprobe fails?
 	if err := sys.LoadKernelModule(rbdKernelModuleName, opts, vm.context.Executor); err != nil {
 		logger.Noticef("failed to load kernel module %s: %+v", rbdKernelModuleName, err)
+		return err
 	}
 
 	return nil

--- a/pkg/util/sys/kmod.go
+++ b/pkg/util/sys/kmod.go
@@ -21,6 +21,18 @@ import (
 	"github.com/rook/rook/pkg/util/exec"
 )
 
+const builtinModDir = "/lib/modules/$(uname -r)/modules.builtin"
+
+func IsBuiltinKernelModule(name string, executor exec.Executor) (bool, error) {
+	out, err := executor.ExecuteCommandWithCombinedOutput(false, "check builtin kmod", "cat", builtinModDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to cat /lib/modules: %+v", err)
+	}
+
+	result := Grep(out, name)
+	return result != "", nil
+}
+
 func LoadKernelModule(name string, options []string, executor exec.Executor) error {
 	if options == nil {
 		options = []string{}


### PR DESCRIPTION
Current Ceph volume manager doesn't take the builtin kernel module into the account, 
so the `modinfo` will fail in this case, this PR will check if the vol manager is a builtin kmod first.
Also, we need to add error handling code to make sure the volume manager is OK when proceed
to continue.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
