### PR TITLE
Debug logging for the osd health check

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -123,7 +123,7 @@ func GetOSDPerfStats(context *clusterd.Context, clusterName string) (*OSDPerfSta
 
 func GetOSDDump(context *clusterd.Context, clusterName string) (*OSDDump, error) {
 	args := []string{"osd", "dump"}
-	buf, err := ExecuteCephCommand(context, clusterName, args)
+	buf, err := executeCephCommandWithOutputFile(context, clusterName, true, args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get osd dump: %+v", err)
 	}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The health checks for osds every minute in the operator are filling the logs. This only should be debug-level logging.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.

[skip ci]
(added the skip ci flag since we have two successful builds and integration tests passing on 3/4 of the platforms, but just failed on known random issues)