### PR TITLE
Fix typo in Cluster Example

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -72,7 +72,7 @@ spec:
     # toggle to use hostNetwork
     hostNetwork: false
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
-  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-role' and
   # tolerate taints with a key of 'storage-node'.
 #  placement:
 #    all:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Fix a typo in cluster example.
From the commented yaml it match storage-node not storage.

**Which issue is resolved by this Pull Request:**
None

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.

[skip ci]