### PR TITLE
Use generic docker image so the correct arch is pulled internally

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -16,7 +16,7 @@ include image.mk
 
 PLATFORMS ?= linux_amd64 linux_arm64
 
-CEPH_BASE_IMAGE ?= ceph/daemon-base:v3.0.5-stable-3.0-luminous-centos-7-$(PLATFORM_ARCH)
+CEPH_BASE_IMAGE ?= ceph/daemon-base:v3.0.5-stable-3.0-luminous-centos-7
 export CEPH_BASE_IMAGE
 
 # tini's version


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The docker build was picking up the `amd64` build of the base image even for the cross builds. Now the correct image should be picked up from the internal architecture type.

**Which issue is resolved by this Pull Request:**
Resolves #1872 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
