### PR TITLE
Apply placement to OSD Pod Spec

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -71,9 +71,18 @@ type Cluster struct {
 }
 
 // New creates an instance of the OSD manager
-func New(context *clusterd.Context, namespace, version, serviceAccount string, storageSpec rookalpha.StorageScopeSpec,
-	dataDirHostPath string, placement rookalpha.Placement, hostNetwork bool,
-	resources v1.ResourceRequirements, ownerRef metav1.OwnerReference) *Cluster {
+func New(
+	context *clusterd.Context,
+	namespace,
+	version,
+	serviceAccount string,
+	storageSpec rookalpha.StorageScopeSpec,
+	dataDirHostPath string,
+	placement rookalpha.Placement,
+	hostNetwork bool,
+	resources v1.ResourceRequirements,
+	ownerRef metav1.OwnerReference,
+) *Cluster {
 
 	if serviceAccount == "" {
 		// if the service account was not set, make a best effort with the example service account name since the default is unlikely to be sufficient.

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -207,6 +207,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 		},
 	}
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &deployment.ObjectMeta, &c.ownerRef)
+	c.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	return deployment, nil
 }
 


### PR DESCRIPTION
**Description of your changes:**
Fix that no `placement` was applied to the Deployment object of an OSD.

**Which issue is resolved by this Pull Request:**
Resolves #1895

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.