### PR TITLE
make: Allow building select images

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,32 +21,19 @@ The following tools are need on the host:
 
 ## Build
 
-You can build Rook by simply running:
+You can build the Rook binaries and all container images for the host platform by simply running the
+command below. Building in parallel with the `-j` option is recommended.
 
 ```
 make -j4
 ```
 
-This will build the Rook binaries and container images for the host platform.
-
-You can also run the build for all supported platforms:
-
-```
-make -j4 build.all
-```
-
-Currently, only `amd64` platform supports this kind of 'cross' build. In order to make `build.all` succeed, we need to follow the steps specified by the below section
-`Building for other platforms` first.
-
-We suggest to use native `build` to create the binaries and container images on `arm{32,64}` platform, but if you do want to build those `arm{32,64}` binaries and images
-on `amd64` platform with `build.all` command, please make sure the multi-arch feature is supported. To test run the following:
+Developers may often wish to make only images for a particular backend in their testing. This can
+be done by specifying the `IMAGES` environment variable with `make` as exemplified below. Possible
+values for are as defined by subdir names in the `/rook/images/` dir.
 
 ```
-> docker run --rm -ti arm32v7/ubuntu uname -a
-Linux bad621a75757 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 armv7l armv7l armv7l GNU/Linux
-
-> docker run --rm -ti arm64v8/ubuntu uname -a
-Linux f51ea93e76a2 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
+make -j4 IMAGES='ceph ceph-toolbox' build
 ```
 
 Run `make help` for more options.
@@ -72,6 +59,35 @@ build/reset
 ```
 
 ## Building for other platforms
+
+You can also run the build for all supported platforms:
+
+```
+make -j4 build.all
+```
+
+Or from the cross container:
+
+```
+build/run make -j4 build.all
+```
+
+Currently, only `amd64` platform supports this kind of 'cross' build. In order to make `build.all`
+succeed, we need to follow the steps specified by the below section `Building for other platforms`
+first.
+
+We suggest to use native `build` to create the binaries and container images on `arm{32,64}`
+platform, but if you do want to build those `arm{32,64}` binaries and images on `amd64` platform
+with `build.all` command, please make sure the multi-arch feature is supported. To test run the
+following:
+
+```
+> docker run --rm -ti arm32v7/ubuntu uname -a
+Linux bad621a75757 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 armv7l armv7l armv7l GNU/Linux
+
+> docker run --rm -ti arm64v8/ubuntu uname -a
+Linux f51ea93e76a2 4.8.0-58-generic #63~16.04.1-Ubuntu SMP Mon Jun 26 18:08:51 UTC 2017 aarch64 aarch64 aarch64 GNU/Linux
+```
 
 In order to build container images for these platforms we rely on cross-compilers and QEMU. Cross compiling is much faster than QEMU and so we lean heavily on it.
 

--- a/Makefile
+++ b/Makefile
@@ -163,35 +163,40 @@ prune:
 # ====================================================================================
 # Help
 
+define HELPTEXT
+Usage: make <OPTIONS> ... <TARGETS>
+
+Targets:
+    build              Build source code for host platform.
+    build.all          Build source code for all platforms.
+                       Best done in the cross build container
+                       due to cross compiler dependencies.
+    check              Runs unit tests.
+    clean              Remove all files that are created by building.
+    codegen            Run code generators.
+    distclean          Remove all files that are created
+                       by building or configuring.
+    fmt                Check formatting of go sources.
+    lint               Check syntax and styling of go sources.
+    help               Show this help info.
+    prune              Prune cached artifacts.
+    test               Runs unit tests.
+    test-integration   Runs integration tests.
+    vendor             Update vendor dependencies.
+    vet                Runs lint checks on go sources.
+
+Options:
+    DEBUG        Whether to generate debug symbols. Default is 0.
+    IMAGES       Backend images to make. All by default. See: /rook/images/ dir
+    PLATFORM     The platform to build.
+    SUITE        The test suite to run.
+    TESTFILTER   Tests to run in a suite.
+    VERSION      The version information compiled into binaries.
+                 The default is obtained from git.
+    V            Set to 1 enable verbose build. Default is 0.
+
+endef
+export HELPTEXT
 .PHONY: help
 help:
-	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
-	@echo ''
-	@echo 'Targets:'
-	@echo '    build              Build source code for host platform.'
-	@echo '    build.all          Build source code for all platforms.'
-	@echo '                       Best done in the cross build container'
-	@echo '                       due to cross compiler dependencies.'
-	@echo '    check              Runs unit tests.'
-	@echo '    clean              Remove all files that are created '
-	@echo '                       by building.'
-	@echo '    codegen            Run code generators.'
-	@echo '    distclean          Remove all files that are created '
-	@echo '                       by building or configuring.'
-	@echo '    fmt                Check formatting of go sources.'
-	@echo '    lint               Check syntax and styling of go sources.'
-	@echo '    help               Show this help info.'
-	@echo '    prune              Prune cached artifacts.'
-	@echo '    test               Runs unit tests.'
-	@echo '    test-integration   Runs integration tests.'
-	@echo '    vendor             Update vendor dependencies.'
-	@echo '    vet                Runs lint checks on go sources.'
-	@echo ''
-	@echo 'Options:'
-	@echo '    DEBUG        Whether to generate debug symbols. Default is 0.'
-	@echo '    PLATFORM     The platform to build.'
-	@echo '    SUITE        The test suite to run.'
-	@echo '    TESTFILTER   Tests to run in a suite.'
-	@echo '    VERSION      The version information compiled into binaries.'
-	@echo '                 The default is obtained from git.'
-	@echo '    V            Set to 1 enable verbose build. Default is 0.'
+	@echo "$$HELPTEXT"

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -94,6 +94,9 @@ ifeq ($(origin BUILD_REGISTRY), undefined)
 BUILD_REGISTRY := build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | shasum -a 256 | cut -c1-8)
 endif
 
+# Select which images (backends) to make; default to all possible images
+IMAGES ?= ceph ceph-toolbox cockroachdb minio
+
 COMMA := ,
 SPACE :=
 SPACE +=

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -58,7 +58,6 @@ endif
 DOCKER_REGISTRY ?= rook
 QUAY_REGISTRY ?= quay.io/rook
 REGISTRIES ?= $(DOCKER_REGISTRY) $(QUAY_REGISTRY)
-IMAGES ?= ceph ceph-toolbox cockroachdb minio
 IMAGE_ARCHS := $(subst linux_,,$(filter linux_%,$(PLATFORMS)))
 IMAGE_PLATFORMS := $(subst _,/,$(subst $(SPACE),$(COMMA),$(filter linux_%,$(PLATFORMS))))
 

--- a/images/Makefile
+++ b/images/Makefile
@@ -38,7 +38,7 @@ cockroachdb.%:
 minio.%:
 	@$(MAKE) -C minio PLATFORM=$*
 
-do.build.images.%: ceph.% ceph-toolbox.% cockroachdb.% minio.% ;
+do.build.images.%: $(foreach i,$(IMAGES), $(i).%);
 
 do.build: do.build.images.$(PLATFORM) ;
 build.all: $(foreach p,$(PLATFORMS), do.build.images.$(p)) ;

--- a/images/ceph-toolbox/Makefile
+++ b/images/ceph-toolbox/Makefile
@@ -16,7 +16,6 @@ include ../image.mk
 
 TOOLBOX_IMAGE = $(BUILD_REGISTRY)/ceph-toolbox-$(GOARCH)
 TOOLBOX_BASE_IMAGE = $(BUILD_REGISTRY)/ceph-toolbox-base-$(GOARCH)
-IMAGES = $(TOOLBOX_IMAGE) $(TOOLBOX_BASE_IMAGE)
 CACHE_IMAGES = $(TOOLBOX_BASE_IMAGE)
 
 CEPH_VERSION = $(shell cat ../ceph/ceph_version)

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,7 +18,6 @@ include ../image.mk
 # Image Build Options
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
-IMAGES = $(CEPH_IMAGE)
 
 CEPH_VERSION = $(shell cat ceph_version)
 BASEIMAGE = $(CEPH_VERSION)-$(PLATFORM_ARCH)

--- a/images/cockroachdb/Makefile
+++ b/images/cockroachdb/Makefile
@@ -18,7 +18,6 @@ include ../image.mk
 # Image Build Options
 
 COCKROACHDB_IMAGE = $(BUILD_REGISTRY)/cockroachdb-$(GOARCH)
-IMAGES = $(COCKROACHDB_IMAGE)
 
 TEMP := $(shell mktemp -d)
 

--- a/images/cross/Makefile
+++ b/images/cross/Makefile
@@ -15,8 +15,7 @@
 include ../image.mk
 
 IMAGE = $(BUILD_REGISTRY)/cross-$(GOARCH)
-IMAGES := $(IMAGE)
-CACHE_IMAGES = $(IMAGES)
+CACHE_IMAGES = $(IMAGE)
 
 TEMP := $(shell mktemp -d)
 

--- a/images/image.mk
+++ b/images/image.mk
@@ -81,7 +81,7 @@ clean: clean.build
 prune: cache.prune
 
 clean.images:
-	@for i in $(IMAGES); do \
+	@for i in $(CLEAN_IMAGES); do \
 		if [ -n "$$(docker images -q $$i)" ]; then \
 			for c in $$(docker ps -a -q --no-trunc --filter=ancestor=$$i); do \
 				if [ "$$c" != "$(SELF_CID)" ]; then \
@@ -98,7 +98,7 @@ clean.images:
 # this will clean everything for this build
 clean.build:
 	@echo === cleaning images for $(BUILD_REGISTRY)
-	@$(MAKE) clean.images IMAGES="$(shell docker images | grep -E '^$(BUILD_REGISTRY)/' | awk '{print $$1":"$$2}')"
+	@$(MAKE) clean.images CLEAN_IMAGES="$(shell docker images | grep -E '^$(BUILD_REGISTRY)/' | awk '{print $$1":"$$2}')"
 
 # =====================================================================================
 # Caching


### PR DESCRIPTION
Raise the scope of the `IMAGES` config variable in the
`build/release/Makefile` to the `build/makelib/common.mk` file, and use
the `IMAGES` variable in the `images/Makefile` to allow users to build
only select images.

Examples of new use:
  make IMAGES='ceph ceph-toolbox' build
  make -C build/release IMAGES='ceph ceph-toolbox' publish

The 'images/image.mk' clean.build target was changed to use
`CLEAN_IMAGES` instead of `IMAGES`, as it was conflicting with use of
the parameter in image builds.

Added IMAGES option to top-level make's help text. The text for this
option exceeded 80 lines in the `Makefile` itself, so the help text was
refactored to eliminate `    @echo '<text>'`. The `Makefile` text should
now match exactly what is output to the user including line length.

Added IMAGES option to `INSTALL.md` file's "Build" section and also
moved some text around and added a few extra points of clarification
there to hopefully improve readability, especially for first-time
readers.

Many of the `rook/images/<image>/` directory Makefiles defined a
variable called `IMAGES`, which was unused and causing some developer
confusion with the feature adding the ability to specify which backend
images to build. Remove these unused instances.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #1803

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
