### PR TITLE
Add urlPrefix setting for ceph dashboard

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -52,6 +52,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 If this value is empty, each pod will get an ephemeral directory to store their config files that is tied to the lifetime of the pod running on that node. More details can be found in the Kubernetes [empty dir docs](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir).
 - `dashboard`: Settings for the Ceph dashboard. To view the dashboard in your browser see the [dashboard guide](ceph-dashboard.md).
   - `enabled`: Whether to enable the dashboard to view cluster status
+  - `urlPrefix`: Allows to serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
 - `serviceAccount`: The service account under which the OSD pods will run that will give access to ConfigMaps in the cluster's namespace. If not set, the default of `rook-ceph-cluster` will be used.
 - `network`: The network settings for the cluster
   - `hostNetwork`: uses network of the hosts instead of using the SDN below the containers.

--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -49,6 +49,16 @@ To retrieve the generated password, you can run the following:
 kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o yaml | grep "password:" | awk '{print $2}' | base64 --decode
 ```
 
+## Configure the Dashboard
+
+If you are accessing the dashboard via a reverse proxy, you may wish to serve it under a URL prefix.
+To get the dashboard to use hyperlinks that include your prefix, you can set the `urlPrefix` setting:
+```yaml
+  spec:
+    dashboard:
+      urlPrefix: /ceph-dashboard
+```
+
 ## Viewing the Dashboard External to the Cluster
 
 Commonly you will want to view the dashboard from outside the cluster. For example, on a development machine with the

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -78,6 +78,8 @@ spec:
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true
+    # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+    # urlPrefix: /ceph-dashboard
   network:
     # toggle to use hostNetwork
     hostNetwork: false

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -36,6 +36,8 @@ spec:
               properties:
                 enabled:
                   type: boolean
+                urlPrefix:
+                  type: string
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string

--- a/pkg/apis/ceph.rook.io/v1beta1/types.go
+++ b/pkg/apis/ceph.rook.io/v1beta1/types.go
@@ -92,6 +92,8 @@ type CephVersionSpec struct {
 type DashboardSpec struct {
 	// Whether to enable the dashboard
 	Enabled bool `json:"enabled,omitempty"`
+	// A prefix for all URLs to use the dashboard with a reverse proxy
+	UrlPrefix string `json:"urlPrefix,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"fmt"
+	"strings"
 
+	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -14,6 +16,40 @@ func MgrEnableModule(context *clusterd.Context, clusterName, name string, force 
 // MgrDisableModule disables a mgr module
 func MgrDisableModule(context *clusterd.Context, clusterName, name string) error {
 	return enableModule(context, clusterName, name, false, "disable")
+}
+
+func MgrSetConfig(context *clusterd.Context, clusterName, cephVersionName, key, val string) (bool, error) {
+	var getArgs, setArgs []string
+
+	if cephVersionName == cephv1beta1.Luminous || cephVersionName == "" {
+		getArgs = append(getArgs, "config-key", "get", key)
+		if val == "" {
+			setArgs = append(setArgs, "config-key", "del", key)
+		} else {
+			setArgs = append(setArgs, "config-key", "set", key, val)
+		}
+	} else {
+		getArgs = append(getArgs, "config", "get", "mgr.", key)
+		if val == "" {
+			setArgs = append(setArgs, "config", "rm", "mgr", key)
+		} else {
+			setArgs = append(setArgs, "config", "set", "mgr", key, val)
+		}
+	}
+
+	// Retrieve previous value to monitor changes
+	var prevVal string
+	buf, err := ExecuteCephCommand(context, clusterName, getArgs)
+	if err == nil {
+		prevVal = strings.TrimSpace(string(buf))
+	}
+
+	if _, err := ExecuteCephCommand(context, clusterName, setArgs); err != nil {
+		return false, fmt.Errorf("failed to set mgr config key %s to \"%s\": %+v", key, val, err)
+	}
+
+	hasChanged := prevVal != val
+	return hasChanged, nil
 }
 
 func enableModule(context *clusterd.Context, clusterName, name string, force bool, action string) error {

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -267,6 +267,10 @@ func clusterChanged(oldCluster, newCluster cephv1beta1.ClusterSpec, clusterRef *
 		logger.Infof("dashboard enabled has changed from %t to %t", oldCluster.Dashboard.Enabled, newCluster.Dashboard.Enabled)
 		changeFound = true
 	}
+	if oldCluster.Dashboard.UrlPrefix != newCluster.Dashboard.UrlPrefix {
+		logger.Infof("dashboard url prefix has changed from \"%s\" to \"%s\"", oldCluster.Dashboard.UrlPrefix, newCluster.Dashboard.UrlPrefix)
+		changeFound = true
+	}
 
 	if oldCluster.Mon.Count != newCluster.Mon.Count {
 		logger.Infof("number of mons have changed from %d to %d. The health check will update the mons...", oldCluster.Mon.Count, newCluster.Mon.Count)

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -53,6 +53,11 @@ func TestStartMGR(t *testing.T) {
 	assert.Nil(t, err)
 	validateStart(t, c)
 
+	c.dashboard.UrlPrefix = "/test"
+	err = c.Start()
+	assert.Nil(t, err)
+	validateStart(t, c)
+
 	// starting again with more replicas
 	c.Replicas = 3
 	c.dashboard.Enabled = false


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Allows serving dashboard behind a reverse proxy under a subpath.

**Which issue is resolved by this Pull Request:**
Resolves #1902

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.

(skipping build due to known build issues)
[skip ci]