### PR TITLE
operator/osd: Use UpdateStrategy Recreate

### DIFF
--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -168,6 +168,9 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 			},
 		},
 		Spec: extensions.DeploymentSpec{
+			Strategy: extensions.DeploymentStrategy{
+				Type: extensions.RecreateDeploymentStrategyType,
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: appName,


### PR DESCRIPTION
**Description of your changes:**
The change of the UpdateStrategy fixes issues with a new OSD Pod in the same Deployment coming up and directly entering CrashLoopBackOff because the old OSD Pod hasn't been fully
terminated yet (released it's locks).

**Which issue is resolved by this Pull Request:**
Resolves #1920 and #1922.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.

***

@travisn @jbw976 Should I update the pending release notes to note that one should edit each Deployment with the new updateStrategy?