### PR TITLE
Backport "osd: Truncate too long name for prepare job" #1908

### DIFF
--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -18,10 +18,10 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
 const (
@@ -33,7 +33,7 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "osd-config")
 
 func GetConfigStoreName(nodeName string) string {
-	return fmt.Sprintf(configStoreNameFmt, nodeName)
+	return k8sutil.TruncateNodeName(configStoreNameFmt, nodeName)
 }
 
 const (

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -58,7 +58,7 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 
 	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf(prepareAppNameFmt, nodeName),
+			Name:      k8sutil.TruncateNodeName(prepareAppNameFmt, nodeName),
 			Namespace: c.Namespace,
 			Labels: map[string]string{
 				k8sutil.AppAttr:     prepareAppName,

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -194,6 +194,7 @@ func TestStorageSpecConfig(t *testing.T) {
 	job, err := c.makeJob(n.Name, n.Devices, n.Selection, c.Storage.Nodes[0].Resources, storeConfig, metadataDevice, n.Location)
 	assert.NotNil(t, job)
 	assert.Nil(t, err)
+	assert.Equal(t, "rook-ceph-osd-prepare-node1", job.ObjectMeta.Name)
 	container := job.Spec.Template.Spec.Containers[0]
 	assert.NotNil(t, container)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_STORE", "bluestore", true)
@@ -241,6 +242,7 @@ func TestHostNetwork(t *testing.T) {
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
 
+	assert.Equal(t, "rook-ceph-osd-id-0", r.ObjectMeta.Name)
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
 }

--- a/pkg/operator/k8sutil/k8sutil_test.go
+++ b/pkg/operator/k8sutil/k8sutil_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package k8sutil for Kubernetes helpers.
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateNodeName(t *testing.T) {
+	// An entry's key is the result. The first value in the []string is the format and the second is the nodeName
+	tests := map[string][]string{
+		"rook-ceph-osd-prepare-47d1eb58e063be11c11c995b74cc5fbe-config": { // 61 chras
+			"rook-ceph-osd-prepare-%s-config",                                      // 29 chars (without format)
+			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
+		},
+		"rook-ceph-osd-prepare-k8s01": { // 27 chars
+			"rook-ceph-osd-prepare-%s", // 22 chars (without format)
+			"k8s01",                    // 5 chars
+		},
+		"rook-ceph-osd-prepare-k8s-worker-500.this.is.a.not.so.long.name": { // 63 chars
+			"rook-ceph-osd-prepare-%s",                  // 22 chars (without format)
+			"k8s-worker-500.this.is.a.not.so.long.name", // 41 chars
+		},
+		"47d1eb58e063be11c11c995b74cc5fbe": { // 32 chars
+			"%s", // 0 chars (without format)
+			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
+		},
+		"rook-ceph-osd-prepare-test-very-long-name-47d1eb58e063be11c11c995b74cc5fbe": { // 74 chars
+			"rook-ceph-osd-prepare-test-very-long-name-%s",                         // 42 chars (without format)
+			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
+		},
+	}
+	for result, params := range tests {
+		assert.Equal(t, result, TruncateNodeName(params[0], params[1]))
+	}
+}


### PR DESCRIPTION
**Description of your changes:**
Backport of #1908 "osd: Truncate too long name for prepare job".

**Which issue is resolved by this Pull Request:**
Resolves #1907.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.