### PR TITLE
Added fstype: xfs as default in the examples

### DIFF
--- a/Documentation/block.md
+++ b/Documentation/block.md
@@ -35,8 +35,10 @@ metadata:
 provisioner: ceph.rook.io/block
 parameters:
   pool: replicapool
-  #The value of "clusterNamespace" MUST be the same as the one in which your rook cluster exist
+  # The value of "clusterNamespace" MUST be the same as the one in which your rook cluster exist
   clusterNamespace: rook-ceph
+  # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
+  fstype: xfs
 ```
 
 Create the storage class.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Action Required
 
 ## Notable Features
+- The `fsType` default for StorageClass examples are now using XFS to bring it in line with Ceph recommendations.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/ceph/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass.yaml
@@ -24,4 +24,4 @@ parameters:
   # This is also the namespace where the cluster will be
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
-  # fstype: ext4
+  fstype: xfs


### PR DESCRIPTION
**Description of your changes:**
This brings Rook in line with the Ceph recommendations to use `xfs` for RBD volumes.

**Which issue is resolved by this Pull Request:**
Resurrects PR #1835.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.

[skip ci]