### PR TITLE
Set UID + GID based on Pod SecurityContext

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -321,7 +321,7 @@
   branch = "master"
   name = "github.com/rook/operator-kit"
   packages = ["."]
-  revision = "4b6dbaaf83c346155175c4553b26ee362718f5a2"
+  revision = "4041a1b434c046113ff88030ad7acaf58548d81b"
 
 [[projects]]
   name = "github.com/spf13/cobra"

--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -159,7 +159,7 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 			log(client, fmt.Sprintf("Rook: chown failed. Cannot set permissions to: %d:%d, %v", opts.PodUser, opts.PodGroup, err), true)
 			return err
 		}
-		log(client, fmt.Sprintf("Chowning %s to %d:%d", opts.MountDir, opts.PodUser, opts.PodGroup), false)
+		log(client, fmt.Sprintf("Chowned %s to %d:%d", opts.MountDir, opts.PodUser, opts.PodGroup), false)
 	}
 	return nil
 }

--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -154,6 +154,12 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 			"Ignore error about Mount failed: exit status 32. Kubernetes does this to check whether the volume has been formatted. It will format and retry again. https://github.com/kubernetes/kubernetes/blob/release-1.7/pkg/util/mount/mount_linux.go#L360",
 			false)
 		log(client, fmt.Sprintf("formatting volume %v devicePath %v deviceMountPath %v fs %v with options %+v", opts.VolumeName, devicePath, globalVolumeMountPath, opts.FsType, options), false)
+		err = os.Chown(opts.MountDir, int(opts.PodUser), int(opts.PodGroup))
+		if err != nil {
+			log(client, fmt.Sprintf("Rook: chown failed. Cannot set permissions to: %d:%d, %v", opts.PodUser, opts.PodGroup, err), true)
+			return err
+		}
+		log(client, fmt.Sprintf("Chowning %s to %d:%d", opts.MountDir, opts.PodUser, opts.PodGroup), false)
 	}
 	return nil
 }

--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -22,8 +22,12 @@ import (
 	"fmt"
 	"net/rpc"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 
+	"github.com/golang/glog"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
 	"github.com/spf13/cobra"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
@@ -32,6 +36,8 @@ import (
 )
 
 const (
+	rwMask                       = os.FileMode(0660)
+	roMask                       = os.FileMode(0440)
 	mds_namespace_kernel_support = "4.7"
 )
 
@@ -54,21 +60,23 @@ func handleMount(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Rook: Error getting RPC client: %v", err)
 	}
 
+	log(client, fmt.Sprintf("%#+v", args), false)
 	var opts = &flexvolume.AttachOptions{}
 	if err := json.Unmarshal([]byte(args[1]), opts); err != nil {
 		return fmt.Errorf("Rook: Could not parse options for mounting %s. Got %v", args[1], err)
 	}
 	opts.MountDir = args[0]
+	log(client, fmt.Sprintf("%#+v", opts), false)
 
 	if opts.FsType == cephFS {
 		return mountCephFS(client, opts)
 	}
 
-	err = client.Call("Controller.GetAttachInfoFromMountDir", opts.MountDir, &opts)
-	if err != nil {
-		log(client, fmt.Sprintf("Attach volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
-		return fmt.Errorf("Rook: Mount volume failed: %v", err)
-	}
+	// err = client.Call("Controller.GetAttachInfoFromMountDir", opts.MountDir, &opts)
+	// if err != nil {
+	// 	log(client, fmt.Sprintf("Attach volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
+	// 	return fmt.Errorf("Rook: Mount volume failed: %v", err)
+	// }
 
 	// Attach volume to node
 	devicePath, err := attach(client, opts)
@@ -154,12 +162,19 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 			"Ignore error about Mount failed: exit status 32. Kubernetes does this to check whether the volume has been formatted. It will format and retry again. https://github.com/kubernetes/kubernetes/blob/release-1.7/pkg/util/mount/mount_linux.go#L360",
 			false)
 		log(client, fmt.Sprintf("formatting volume %v devicePath %v deviceMountPath %v fs %v with options %+v", opts.VolumeName, devicePath, globalVolumeMountPath, opts.FsType, options), false)
-		err = os.Chown(opts.MountDir, int(opts.PodUser), int(opts.PodGroup))
+	}
+
+	// This code works here, but not in mount
+	if opts.FsGroup != "" {
+		fsGroupInt, err := strconv.Atoi(opts.FsGroup)
+		fsGroup := int64(fsGroupInt)
+		err = SetVolumeOwnership(client, opts.MountDir, &fsGroup)
 		if err != nil {
-			log(client, fmt.Sprintf("Rook: chown failed. Cannot set permissions to: %d:%d, %v", opts.PodUser, opts.PodGroup, err), true)
+			log(client, fmt.Sprintf("Rook: chown failed. Cannot set group to: %d, %v", fsGroup, err), true)
 			return err
 		}
-		log(client, fmt.Sprintf("Chowned %s to %d:%d", opts.MountDir, opts.PodUser, opts.PodGroup), false)
+		log(client, fmt.Sprintf("Chowned %s to %d", opts.MountDir, fsGroup), false)
+		return nil
 	}
 	return nil
 }
@@ -200,6 +215,20 @@ func mount(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, globalVolum
 	if err != nil {
 		log(client, fmt.Sprintf("mount volume %s/%s failed: %v", opts.Pool, opts.Image, err), true)
 	}
+
+	// This code will run without error, but it won't actually change permissions
+	// if opts.FsGroup != "" {
+	// 	fsGroupInt, err := strconv.Atoi(opts.FsGroup)
+	// 	fsGroup := int64(fsGroupInt)
+	// 	err = SetVolumeOwnership(client, opts.MountDir, &fsGroup)
+	// 	if err != nil {
+	// 		log(client, fmt.Sprintf("Rook: chown failed. Cannot set group to: %d, %v", fsGroup, err), true)
+	// 		return err
+	// 	}
+	// 	log(client, fmt.Sprintf("Chowned %s to %d", opts.MountDir, fsGroup), false)
+	// 	return nil
+	// }
+	// log(client, fmt.Sprintf("Rook: chown failed. Cannot chown %s to: %s", opts.MountDir, opts.FsGroup), true)
 	return err
 }
 
@@ -297,4 +326,69 @@ func mountCephFS(client *rpc.Client, opts *flexvolume.AttachOptions) error {
 	}
 
 	return err
+}
+
+func SetVolumeOwnership(client *rpc.Client, path string, fsGroup *int64) error {
+
+	log(client, fmt.Sprintf("Entered SetVolumeOwnership"), false)
+	if fsGroup == nil {
+		return errors.New("No fsgroup???")
+	}
+
+	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		log(client, fmt.Sprintf("Processing %s with fsGroup %d, info %#+v, err %#+v", path, *fsGroup, info, err), false)
+		if err != nil {
+			log(client, fmt.Sprintf("Returning err %#+v", err), true)
+			return err
+		}
+
+		// chown and chmod pass through to the underlying file for symlinks.
+		// Symlinks have a mode of 777 but this really doesn't mean anything.
+		// The permissions of the underlying file are what matter.
+		// However, if one reads the mode of a symlink then chmods the symlink
+		// with that mode, it changes the mode of the underlying file, overridden
+		// the defaultMode and permissions initialized by the volume plugin, which
+		// is not what we want; thus, we skip chown/chmod for symlinks.
+		if info.Mode()&os.ModeSymlink != 0 {
+			log(client, fmt.Sprintf("Skipping chown/chmod for symlinks"), true)
+			return errors.New("info.Mode()&os.ModeSymlink failed or whatever")
+		}
+
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			log(client, fmt.Sprintf("syscall.Stat_t not ok"), true)
+			return errors.New("The syscall.Stat_t thing failed")
+		}
+
+		if stat == nil {
+			log(client, fmt.Sprintf("Got nil stat_t for path %v while setting ownership of volume", path), true)
+			glog.Errorf("Got nil stat_t for path %v while setting ownership of volume", path)
+			return fmt.Errorf("Got nil stat_t for path %v while setting ownership of volume", path)
+		}
+
+		err = os.Chown(path, int(stat.Uid), int(*fsGroup))
+		if err != nil {
+			log(client, fmt.Sprintf("Returning err %#+v", err), true)
+			glog.Errorf("Chown failed on %v: %v", path, err)
+			return err
+		}
+
+		mask := rwMask
+		log(client, fmt.Sprintf("mask:  %#+v", mask), false)
+
+		if info.IsDir() {
+			mask |= os.ModeSetgid
+			log(client, fmt.Sprintf(" isDir, mask changing to:  %#+v", mask), false)
+		}
+
+		err = os.Chmod(path, info.Mode()|mask)
+		if err != nil {
+			glog.Errorf("Chmod failed on %v: %v", path, err)
+			log(client, fmt.Sprintf("Returning err %#+v", err), true)
+			return err
+		}
+
+		log(client, fmt.Sprintf("path %s chowned to %d", path, *fsGroup), false)
+		return nil
+	})
 }

--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -48,6 +48,7 @@ type AttachOptions struct {
 	Path             string `json:"path"` // Path within the CephFS to mount
 	RW               string `json:"kubernetes.io/readwrite"`
 	FsType           string `json:"kubernetes.io/fsType"`
+	FsGroup          string `json:"kubernetes.io/fsGroup"`
 	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
 	Pod              string `json:"kubernetes.io/pod.name"`
 	PodID            string `json:"kubernetes.io/pod.uid"`

--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -52,6 +52,8 @@ type AttachOptions struct {
 	Pod              string `json:"kubernetes.io/pod.name"`
 	PodID            string `json:"kubernetes.io/pod.uid"`
 	PodNamespace     string `json:"kubernetes.io/pod.namespace"`
+	PodUser          int64  `json:"kubernetes.io/pod.user"`
+	PodGroup         int64  `json:"kubernetes.io/pod.group"`
 }
 
 type LogMessage struct {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When a volume is being attached to a pod, rook now pulls the user and group set in the Pod's SecurityContext, and sets the ownership of the mounted volume to match.

**Which issue is resolved by this Pull Request:**
Resolves #1921

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
