### PR TITLE
Updated Gopkg.lock by running `make vendor`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -646,6 +646,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4129cd2d02e1a52fb9e459f644e5b0224e363d5b713bdc01f883224db7c88908"
+  inputs-digest = "00879b3ac37e0db13a2ed7f984da41dcfc3b51b10def991871058926db327d5d"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
**Description of your changes:**
Ran `make vendor` to update the `Gopkg.lock` to the latest versions to resolve the `dirty` tag issue for the images.

**Which issue is resolved by this Pull Request:**
Resolves #1933

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes. (Now it doesn't anymore)