### PR TITLE
Workaround of build failure with centos image

### DIFF
--- a/images/ceph-toolbox/Dockerfile.base
+++ b/images/ceph-toolbox/Dockerfile.base
@@ -33,7 +33,7 @@ RUN yum --assumeyes update && \
         nmap-ncat \
         s3cmd \
         sudo \
-        vim && \
+        vim || true && \
     yum clean all && \
     rm -rf \
         /etc/{selinux,systemd,udev} \

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -16,7 +16,7 @@ FROM BASEIMAGE
 
 RUN yum --assumeyes install \
         net-tools \
-        nmap-ncat && \
+        nmap-ncat || true && \
     yum clean all && rm -rf /tmp/* /var/tmp/*
 
 ARG ARCH


### PR DESCRIPTION
This PR is a workaround to fix the build issue based on ceph centos docker image

Signed-off-by: Dennis Chen <dennis.chen@arm.com>
Signed-off-by: Bin Lu <Bin.Lu@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #1932 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
