### PR TITLE
Backport PR #1909 "operator: Set min_size to dataChunkCount for ec pools"

### DIFF
--- a/pkg/daemon/ceph/rgw/objectstore.go
+++ b/pkg/daemon/ceph/rgw/objectstore.go
@@ -273,7 +273,7 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 			if isECPool {
 				// An EC pool backing an object store does not need to enable EC overwrites, so the pool is
 				// created with that property disabled to avoid unnecessary performance impact.
-				err = ceph.CreateECPoolForApp(context.context, context.ClusterName, cephConfig, appName, false /* enableECOverwrite */)
+				err = ceph.CreateECPoolForApp(context.context, context.ClusterName, cephConfig, appName, false /* enableECOverwrite */, poolSpec.ErasureCodedConfig)
 			} else {
 				err = ceph.CreateReplicatedPoolForApp(context.context, context.ClusterName, cephConfig, appName)
 			}


### PR DESCRIPTION
**Description of your changes:**
Backports PR #1909.
**Which issue is resolved by this Pull Request:**
Resolves #1795.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.

Should I add a separate commit that adds an entry to the pending release notes?