### PR TITLE
Enhancement of Ceph volume manager kmod detection

### DIFF
--- a/pkg/daemon/ceph/agent/agent.go
+++ b/pkg/daemon/ceph/agent/agent.go
@@ -53,7 +53,10 @@ func (a *Agent) Run() error {
 		return fmt.Errorf("failed to create volume attachment controller: %+v", err)
 	}
 
-	volumeManager := ceph.NewVolumeManager(a.context)
+	volumeManager, err := ceph.NewVolumeManager(a.context)
+	if err != nil {
+		return fmt.Errorf("failed to create volume manager: %+v", err)
+	}
 
 	flexvolumeController := flexvolume.NewController(a.context, volumeAttachmentController, volumeManager)
 


### PR DESCRIPTION
Current Ceph volume manager code doesn't take the builtin kernel module into
the account, so the `modinfo` will fail in this case. Also, we need to add error handling
code to make sure the volume manager does work when proceeding to continue.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
