### PR TITLE
Add dataPool parameter to StorageClass

### DIFF
--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -3,7 +3,13 @@ title: Ceph Shared File System
 weight: 35
 indent: true
 ---
-
+{% assign url = page.url | split: '/' %}
+{% assign currentVersion = url[3] %}
+{% if currentVersion != 'master' %}
+{% assign branchName = currentVersion | replace: 'v', '' | prepend: 'release-' %}
+{% else %}
+{% assign branchName = currentVersion %}
+{% endif %}
 # Ceph Shared File System CRD
 
 Rook allows creation and customization of shared file systems through the custom resource definitions (CRDs). The following settings are available
@@ -71,5 +77,5 @@ The metadata server settings correspond to the MDS daemon settings.
 
 - `activeCount`: The number of active MDS instances. As load increases, CephFS will automatically partition the file system across the MDS instances. Rook will create double the number of MDS instances as requested by the active count. The extra instances will be in standby mode for failover.
 - `activeStandby`: If true, the extra MDS instances will be in active standby mode and will keep a warm cache of the file system metadata for faster failover. The instances will be assigned by CephFS in failover pairs. If false, the extra MDS instances will all be on passive standby mode and will not maintain a warm cache of the metadata.
-- `placement`: The mds pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
+- `placement`: The mds pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph/cluster.yaml).
 - `resources`: Set resource requests/limits for the Filesystem MDS Pod(s), see [Resource Requirements/Limits](ceph-cluster-crd.md#resource-requirementslimits).

--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -63,7 +63,7 @@ When creating an erasure-coded pool, it is highly recommended to create the pool
   - `dataChunks`: Number of chunks to divide the original object into
   - `codingChunks`: Number of redundant chunks to store
 - `failureDomain`: The failure domain across which the replicas or chunks of data will be spread. Possible values are `osd` or `host`,
-with the default of `host`.   For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be
+with the default of `host`. For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be
 placed on osds that are found on unique hosts. In that case you would be guaranteed to tolerate the failure of two hosts. If the failure domain were `osd`,
 you would be able to tolerate the loss of two devices. Similarly for erasure coding, the data and coding chunks would be spread across the requested failure domain.
 - `crushRoot`: The root in the crush map to be used by the pool. If left empty or unspecified, the default root will be used. Creating a crush hierarchy for the OSDs currently requires the Rook toolbox to run the Ceph tools described [here](http://docs.ceph.com/docs/master/rados/operations/crush-map/#modifying-the-crush-map).

--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -183,7 +183,7 @@ E0328 18:58:32.060893       5 controller.go:801] Failed to provision volume for 
 . output:
 ```
 
-The solution is to ensure that the [`clusterNamespace`](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/rook-storageclass.yaml#L25) field matches the **namespace** of the Rook cluster when creating the `StorageClass`.
+The solution is to ensure that the [`clusterNamespace`](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/storageclass.yaml#L20) field matches the **namespace** of the Rook cluster when creating the `StorageClass`.
 
 ### Volume Mounting
 The final step in preparing Rook storage for your pod is for the `rook-ceph-agent` pod to mount and format it.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,6 +6,7 @@
 - The `fsType` default for StorageClass examples are now using XFS to bring it in line with Ceph recommendations.
 - Ceph is updated from Luminous 12.2.5 to 12.2.7.
 - Ceph OSDs will be automatically updated by the operator when there is a change to the operator version or when the OSD configuration changes. See the [OSD upgrade notes](Documentation/upgrade-patch.md#object-storage-daemons-osds).
+- Rook Ceph block storage provisioner can now correctly create erasure coded block images. See [Advanced Example: Erasure Coded Block Storage](Documentation/block.md#advanced-example-erasure-coded-block-storage) for an example usage.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/ceph/ec-storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/ec-storageclass.yaml
@@ -1,0 +1,39 @@
+apiVersion: ceph.rook.io/v1beta1
+kind: Pool
+metadata:
+  name: replicated-metadata-pool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1
+---
+apiVersion: ceph.rook.io/v1beta1
+kind: Pool
+metadata:
+  name: ec-data-pool
+  namespace: rook-ceph
+spec:
+  # Make sure you have enough nodes and OSDs running bluestore to support the replica size or erasure code chunks.
+  # For the below settings, you need at least 3 OSDs on different nodes (because the `failureDomain` is `host` by default).
+  erasureCoded:
+    dataChunks: 2
+    codingChunks: 1
+---
+# The nodes that are going to mount the erasure coded RBD block storage must have Linux kernel >= `4.11`.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: rook-ceph-block
+provisioner: ceph.rook.io/block
+parameters:
+  # If you want to use erasure coded pool with RBD, you need to create two pools (as seen above): one erasure coded and one replicated.
+  # You need to specify the replicated pool here in the `pool` parameter, it is used for the metadata of the images.
+  # The erasure coded pool must be set as the `dataPool` parameter below.
+  pool: replicated-metadata-pool
+  dataPool: ec-data-pool
+  # Specify the namespace of the rook cluster from which to create volumes.
+  # If not specified, it will use `rook` as the default namespace of the cluster.
+  # This is also the namespace where the cluster will be
+  clusterNamespace: rook-ceph
+  # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
+  fstype: xfs

--- a/cluster/examples/kubernetes/ceph/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   replicated:
     size: 1
-  # For an erasure-coded pool, comment out the replication size above and uncomment the following settings.
-  # Make sure you have enough OSDs to support the replica size or erasure code chunks.
-  #erasureCoded:
-  #  dataChunks: 2
-  #  codingChunks: 1
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -45,6 +45,7 @@ const (
 	StorageClassKey       = "storageClass"
 	PoolKey               = "pool"
 	ImageKey              = "image"
+	DataPoolKey           = "dataPool"
 	kubeletDefaultRootDir = "/var/lib/kubelet"
 )
 

--- a/pkg/daemon/ceph/agent/flexvolume/controller_test.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller_test.go
@@ -724,6 +724,7 @@ func TestGetAttachInfoFromMountDir(t *testing.T) {
 						StorageClassKey: "storageClass1",
 						PoolKey:         "pool123",
 						ImageKey:        "pvc-123",
+						DataPoolKey:     "",
 					},
 				},
 			},

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -39,7 +39,7 @@ func TestCreateImage(t *testing.T) {
 		}
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
-	image, err := CreateImage(context, "foocluster", "image1", "pool1", uint64(1048576)) // 1MB
+	image, err := CreateImage(context, "foocluster", "image1", "pool1", "", uint64(1048576)) // 1MB
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "mocked detailed ceph error output stream"))
 
@@ -61,7 +61,7 @@ func TestCreateImage(t *testing.T) {
 
 	// 0 byte --> 0 MB
 	expectedSizeArg = "0"
-	image, err = CreateImage(context, "foocluster", "image1", "pool1", uint64(0))
+	image, err = CreateImage(context, "foocluster", "image1", "pool1", "", uint64(0))
 	assert.Nil(t, err)
 	assert.NotNil(t, image)
 	assert.True(t, createCalled)
@@ -69,7 +69,7 @@ func TestCreateImage(t *testing.T) {
 
 	// 1 byte --> 1 MB
 	expectedSizeArg = "1"
-	image, err = CreateImage(context, "foocluster", "image1", "pool1", uint64(1))
+	image, err = CreateImage(context, "foocluster", "image1", "pool1", "", uint64(1))
 	assert.Nil(t, err)
 	assert.NotNil(t, image)
 	assert.True(t, createCalled)
@@ -77,7 +77,7 @@ func TestCreateImage(t *testing.T) {
 
 	// (1 MB - 1 byte) --> 1 MB
 	expectedSizeArg = "1"
-	image, err = CreateImage(context, "foocluster", "image1", "pool1", uint64(1048575))
+	image, err = CreateImage(context, "foocluster", "image1", "pool1", "", uint64(1048575))
 	assert.Nil(t, err)
 	assert.NotNil(t, image)
 	assert.True(t, createCalled)
@@ -85,11 +85,20 @@ func TestCreateImage(t *testing.T) {
 
 	// 1 MB
 	expectedSizeArg = "1"
-	image, err = CreateImage(context, "foocluster", "image1", "pool1", uint64(1048576))
+	image, err = CreateImage(context, "foocluster", "image1", "pool1", "", uint64(1048576))
 	assert.Nil(t, err)
 	assert.NotNil(t, image)
 	assert.True(t, createCalled)
 	createCalled = false
+
+	// Pool with data pool
+	expectedSizeArg = "1"
+	image, err = CreateImage(context, "foocluster", "image1", "pool1", "datapool1", uint64(1048576))
+	assert.Nil(t, err)
+	assert.NotNil(t, image)
+	assert.True(t, createCalled)
+	createCalled = false
+
 }
 
 func TestListImageLogLevelInfo(t *testing.T) {

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -67,7 +67,7 @@ func TestProvisionImage(t *testing.T) {
 	}
 
 	provisioner := New(context, "foo.io")
-	volume := newVolumeOptions(newStorageClass("class-1", "foo.io/block", map[string]string{"pool": "testpool", "clusterNamespace": "testCluster", "fsType": "ext3"}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
+	volume := newVolumeOptions(newStorageClass("class-1", "foo.io/block", map[string]string{"pool": "testpool", "clusterNamespace": "testCluster", "fsType": "ext3", "dataPool": ""}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
 
 	pv, err := provisioner.Provision(volume)
 	assert.Nil(t, err)
@@ -80,6 +80,22 @@ func TestProvisionImage(t *testing.T) {
 	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
 	assert.Equal(t, "testpool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["pool"])
 	assert.Equal(t, "pvc-uid-1-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["image"])
+	assert.Equal(t, "", pv.Spec.PersistentVolumeSource.FlexVolume.Options["dataPool"])
+
+	volume = newVolumeOptions(newStorageClass("class-1", "foo.io/block", map[string]string{"pool": "testpool", "clusterNamespace": "testCluster", "fsType": "ext3", "dataPool": "iamdatapool"}), newClaim("claim-1", "uid-1-1", "class-1", "", "class-1", nil))
+
+	pv, err = provisioner.Provision(volume)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "pvc-uid-1-1", pv.Name)
+	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
+	assert.Equal(t, "foo.io/rook-system", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
+	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
+	assert.Equal(t, "testCluster", pv.Spec.PersistentVolumeSource.FlexVolume.Options["clusterNamespace"])
+	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
+	assert.Equal(t, "testpool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["pool"])
+	assert.Equal(t, "pvc-uid-1-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["image"])
+	assert.Equal(t, "iamdatapool", pv.Spec.PersistentVolumeSource.FlexVolume.Options["dataPool"])
 }
 
 func TestParseClassParameters(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**
This change allows block storage to use a given Ceph pool for it's data. `dataPool` must be given if soemone wants to use erasure coded RBD data.
The `pool` paramter would then be the metadata pool.

I haven't updated the docs yet, but just want to get some feedback in, if this seems sane. :)

**Which issue is resolved by this Pull Request:**
Resolves #1733

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.