### PR TITLE
Add ability to autodetect flexvolume plugin path depending of kubernetes version for helm chart

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
 {{- end }}
 
 {{- if .Values.agent.flexVolumeDirPath }}
-        - name FLEXVOLUME_DIR_PATH
+        - name: FLEXVOLUME_DIR_PATH
           value: {{ .Values.agent.flexVolumeDirPath }}
 {{- else }}
 {{- if (semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -36,10 +36,21 @@ spec:
         - name: AGENT_TOLERATION_KEY
           value: {{ .Values.agent.tolerationKey }}
 {{- end }}
+
 {{- if .Values.agent.flexVolumeDirPath }}
-        - name: FLEXVOLUME_DIR_PATH
+        - name FLEXVOLUME_DIR_PATH
           value: {{ .Values.agent.flexVolumeDirPath }}
+{{- else }}
+{{- if (semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion) }}
+        - name: FLEXVOLUME_DIR_PATH
+          value: "/var/lib/kubelet/volumeplugins/"
+{{- else }}
+        - name: FLEXVOLUME_DIR_PATH
+          value: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 {{- end }}
+{{- end }}
+
+
 {{- end }}
 {{- if .Values.discover }}
 {{- if .Values.discover.toleration }}

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -48,11 +48,15 @@ pspEnable: true
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute
 ## tolerationKey: Set this to the specific key of the taint to tolerate
 ## flexVolumeDirPath: The path where the Rook agent discovers the flex volume plugins
-# agent:
+agent:
+  enabled: true
 #   toleration: NoSchedule
 #   tolerationKey: key
 ## For Kubernetes >= 1.9.x flexVolumeDirPath should be changed to /var/lib/kubelet/volumeplugins/
+## Trying to guess if not defined
 #   flexVolumeDirPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
+
+
 
 ## Rook Discover configuration
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute


### PR DESCRIPTION
This small fix  is trying to substitute right flexvolume plugins dir path based on kubernetes version

Resolves general newcommers  question.