### PR TITLE
Update only the images desired in minikube

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -91,6 +91,24 @@ function check_context() {
     return 1
 }
 
+function copy_images() {
+    if [[ "$1" == "" || "$1" == "ceph" ]]; then
+      echo "copying ceph images"
+      copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
+      copy_image_to_cluster "${BUILD_REGISTRY}/ceph-toolbox-amd64" rook/ceph-toolbox:master
+    fi
+
+    if [[ "$1" == "" || "$1" == "cockroachdb" ]]; then
+      echo "copying cockroachdb image"
+      copy_image_to_cluster "${BUILD_REGISTRY}/cockroachdb-amd64" rook/cockroachdb:master
+    fi
+
+    if [[ "$1" == "" || "$1" == "minio" ]]; then
+      echo "copying minio image"
+      copy_image_to_cluster "${BUILD_REGISTRY}/minio-amd64" rook/minio:master
+    fi
+}
+
 # configure minikube
 KUBE_VERSION=${KUBE_VERSION:-"v1.10.0"}
 MEMORY=${MEMORY:-"3000"}
@@ -117,10 +135,7 @@ case "${1:-}" in
     # create a link so the default dataDirHostPath will work for this environment
     minikube ssh "sudo mkdir -p /mnt/sda1/${PWD}; sudo mkdir -p $(dirname $PWD); sudo ln -s /mnt/sda1/${PWD} $(dirname $PWD)/"
     minikube ssh "sudo mkdir /mnt/sda1/var/lib/rook;sudo ln -s /mnt/sda1/var/lib/rook /var/lib/rook"
-    copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/ceph-toolbox-amd64" rook/ceph-toolbox:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/cockroachdb-amd64" rook/cockroachdb:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/minio-amd64" rook/minio:master
+    copy_images "$2"
     ;;
   down)
     minikube stop
@@ -130,11 +145,7 @@ case "${1:-}" in
     minikube ssh
     ;;
   update)
-    echo "updating the rook images"
-    copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/ceph-toolbox-amd64" rook/ceph-toolbox:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/cockroachdb-amd64" rook/cockroachdb:master
-    copy_image_to_cluster "${BUILD_REGISTRY}/minio-amd64" rook/minio:master
+    copy_images "$2"
     ;;
   restart)
     if check_context; then
@@ -163,11 +174,11 @@ case "${1:-}" in
     ;;
   *)
     echo "usage:" >&2
-    echo "  $0 up" >&2
+    echo "  $0 up [ceph | cockroachdb | minio]" >&2
     echo "  $0 down" >&2
     echo "  $0 clean" >&2
     echo "  $0 ssh" >&2
-    echo "  $0 update" >&2
+    echo "  $0 update [ceph | cockroachdb | minio]" >&2
     echo "  $0 restart <pod-name-regex> (the pod name is a regex to match e.g. restart ^rook-ceph-osd)" >&2
     echo "  $0 wordpress" >&2
     echo "  $0 helm" >&2


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the addition of storage providers, add flexibility to the minikube script so you only load the storage provider docker images that are necessary.

To start minikube with all storage providers the command is the same:
```
tests/scripts/minikube.sh up
```

To start minikube with a single provider:
```
tests/scripts/minikube.sh up [ceph | minio | cockroachdb]
```

The same option works for the `update` command.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.

[skip ci]