### PR TITLE
Backport: OSD init container to initialize config at startup

### DIFF
--- a/Documentation/upgrade-patch.md
+++ b/Documentation/upgrade-patch.md
@@ -1,0 +1,93 @@
+---
+title: Patch Upgrades
+weight: 61
+indent: true
+---
+
+# 0.8 Patch Upgrades
+
+The changes in patch releases are scoped to the minimal changes necessary and are expected to be straight forward to upgrade.
+This guide will walk you through the manual steps to upgrade the software in a Rook cluster from an 0.8 version to another patched version of 0.8.
+For example, upgrade from `v0.8.0` to `v0.8.1`.
+
+After each component is upgraded, it is important to verify that the cluster returns to a healthy and fully functional state.
+
+## Considerations
+With this manual upgrade guide, there are a few notes to consider:
+* **WARNING:** Upgrading a Rook cluster is a manual process in its very early stages.  There may be unexpected issues or obstacles that damage the integrity and health of your storage cluster, including data loss.
+* This guide assumes that your Rook operator and its agents are running in the `rook-ceph-system` namespace. It also assumes that your Rook cluster is in the `rook-ceph` namespace.  If any of these components is in a different namespace, search/replace all instances of `-n rook-ceph-system` and `-n rook-ceph` in this guide with `-n <your namespace>`.
+
+## Prerequisites
+In order to successfully upgrade a Rook cluster, the following prerequisites must be met:
+* The cluster should be in a healthy state with full functionality.
+Review the [health verification section](upgrade.md#health-verification) in the main upgrade guide in order to verify your cluster is in a good starting state.
+* All pods consuming Rook storage should be created, running, and in a steady state.  No Rook persistent volumes should be in the act of being created or deleted.
+
+## Upgrade Process
+The general flow of the upgrade process will be to upgrade the version of a Rook pod, verify the pod is running with the new version, then verify that the overall cluster health is still in a good state.
+
+In this guide, we will be upgrading a live Rook cluster running `v0.8.0` to version `v0.8.1`.
+
+### Operator
+The operator controls upgrading all the components and is generally the first component to be updated.
+The operator can be updated by setting the deployment version.
+
+```bash
+kubectl -n rook-ceph-system set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v0.8.1
+```
+
+The operator pod will automatically be restarted by Kubernetes with the new version.
+
+Once you've verified the operator is `Running` and on the new version, verify the health of the cluster is still OK.
+Instructions for verifying cluster health can be found in the [health verification section](upgrade.md#health-verification).
+
+### System Daemons
+The pods in the rook-ceph-system namespace will all be updated automatically when the operator is updated. After the operator is updated, you will see the `rook-ceph-agent` and `rook-discover` pods restarted on the new version.
+
+### Monitors
+There are multiple monitor pods to upgrade and they are each individually managed by their own replica set.
+**For each** monitor's replica set, you will need to update the pod template spec's image version field to `rook/ceph:v0.8.1`.
+For example, we can update the replica set for `mon0` with:
+```bash
+kubectl -n rook-ceph set image replicaset/rook-ceph-mon0 rook-ceph-mon=rook/ceph:v0.8.1
+```
+
+Once the replica set has been updated, we need to manually terminate the old pod which will trigger the replica set to create a new pod using the new version.
+```bash
+kubectl -n rook-ceph delete pod -l mon=rook-ceph-mon0
+```
+
+At this point, it's very important to ensure that all monitors are `OK` and `in quorum`.
+Refer to the [status output section](upgrade.md#status-output) for instructions.
+If all of the monitors (and the cluster health overall) look good, then we can move on and repeat the same upgrade steps for the next monitor until all are completed.
+
+### Object Storage Daemons (OSDs)
+The automatic upgrade of OSD pods has been implemented by the operator. Within a minute of starting the operator on the new version, you should see the osd pods automatically started on the new version.
+Going forward, if there is any change needed to the OSD deployment as determined by the operator, the OSD pods will automatically be updated and restarted.
+For example, the OSDs will be automatically updated when:
+- The version of the operator container changes
+- The `resources` or `placement` elements are changed in the cluster CRD
+
+One by one, as each of the OSDs are updated the operator will wait for the OSD pod to be running again before continuing with the next OSD.
+In some scenarios, the operator will need to be restarted in order to apply the changes to the OSD deployment specs.
+
+### Ceph Manager
+To update the Ceph mgrs, edit the deployment image version:
+```bash
+kubectl -n rook-ceph set image deploy/rook-ceph-mgr-a rook-ceph-mgr-a=rook/ceph:v0.8.1
+```
+
+#### Object Storage (RGW)
+If you have object storage installed, edit the RGW deployment to use the new image version:
+```bash
+kubectl -n rook-ceph set image deploy/rook-ceph-rgw-my-store rook-ceph-rgw-my-store=rook/ceph:v0.8.1
+```
+
+#### Shared File System (MDS)
+If you have a shared file system installed, edit the MDS deployment to use the new image version:
+```bash
+kubectl -n rook-ceph set image deploy/rook-ceph-mds-myfs rook-ceph-mds-myfs=rook/ceph:v0.8.1
+```
+
+## Completion
+At this point, your Rook cluster should be fully upgraded to running version `rook/ceph:v0.8.1` and the cluster should be healthy according to the steps in the [health verification section](upgrade.md#health-verification).

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -22,6 +22,10 @@ For a guide to upgrade previous versions of Rook, please refer to the version of
 - [Upgrade 0.6 to 0.7](https://rook.io/docs/rook/v0.7/upgrade.html)
 - [Upgrade 0.5 to 0.6](https://rook.io/docs/rook/v0.6/upgrade.html)
 
+### Patch Release Upgrades
+The changes in patch releases are scoped to the minimal changes necessary and are expected to be straight forward to upgrade.
+For upgrades of 0.8 patch releases such as `0.8.0` to `0.8.1`, see the [patch release upgrade guide](upgrade-patch.md).
+
 ## Considerations
 With this manual upgrade guide, there are a few notes to consider:
 * **WARNING:** Upgrading a Rook cluster is a manual process in its very early stages.  There may be unexpected issues or obstacles that damage the integrity and health of your storage cluster, including data loss.  Only proceed with this guide if you are comfortable with that.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -646,6 +646,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4129cd2d02e1a52fb9e459f644e5b0224e363d5b713bdc01f883224db7c88908"
+  inputs-digest = "00879b3ac37e0db13a2ed7f984da41dcfc3b51b10def991871058926db327d5d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -23,6 +23,7 @@
 - One OSD will run per pod to increase the reliability and maintainability of the OSDs. No longer will restarting an OSD pod mean that all OSDs on that node will go down. See the [design doc](design/dedicated-osd-pod.md).
 - Added `nodeSelector` to Rook Ceph operator Helm chart.
 - Ceph is updated to Luminous 12.2.7.
+- Ceph OSDs will be automatically updated by the operator when there is a change to the operator version or when the OSD configuration changes. See the [OSD upgrade notes](Documentation/upgrade-patch.md#object-storage-daemons-osds).
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -58,11 +58,10 @@ type OsdAgent struct {
 	kv                *k8sutil.ConfigMapKVStore
 	configCounter     int32
 	osdsCompleted     chan struct{}
-	prepareOnly       bool
 }
 
 func NewAgent(context *clusterd.Context, devices string, usingDeviceFilter bool, metadataDevice, directories string, forceFormat bool,
-	location string, storeConfig config.StoreConfig, cluster *mon.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore, prepareOnly bool) *OsdAgent {
+	location string, storeConfig config.StoreConfig, cluster *mon.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore) *OsdAgent {
 
 	return &OsdAgent{
 		devices:           devices,
@@ -77,7 +76,6 @@ func NewAgent(context *clusterd.Context, devices string, usingDeviceFilter bool,
 		kv:                kv,
 		procMan:           proc.New(context.Executor),
 		osdProc:           make(map[int]*proc.MonitoredProc),
-		prepareOnly:       prepareOnly,
 	}
 }
 
@@ -425,13 +423,13 @@ func (a *OsdAgent) prepareOSD(context *clusterd.Context, cfg *osdConfig) (*oposd
 		}
 
 		// osd_data_dir/ready does not exist yet, create/initialize the OSD
-		err := initializeOSD(cfg, context, a.cluster, a.location, a.prepareOnly)
+		err := initializeOSD(cfg, context, a.cluster, a.location)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize OSD at %s: %+v", cfg.rootPath, err)
 		}
 	} else {
 		// update the osd config file
-		err := writeConfigFile(cfg, context, a.cluster, a.location, a.prepareOnly)
+		err := writeConfigFile(cfg, context, a.cluster, a.location)
 		if err != nil {
 			logger.Warningf("failed to update config file. %+v", err)
 		}

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -353,7 +353,7 @@ func createTestAgent(t *testing.T, devices, configDir, nodeName string, storeCon
 	cluster := &mon.ClusterInfo{Name: "myclust"}
 	context := &clusterd.Context{ConfigDir: configDir, Executor: executor, Clientset: testop.New(1)}
 	agent := NewAgent(context, devices, false, "", "", forceFormat, location, *storeConfig,
-		cluster, nodeName, mockKVStore(), false /* prepareOnly */)
+		cluster, nodeName, mockKVStore())
 
 	return agent, executor, context
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -66,11 +66,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 	// set the crush location in the osd config file
 	cephConfig := mon.CreateDefaultCephConfig(context, agent.cluster, path.Join(context.ConfigDir, agent.cluster.Name))
 	cephConfig.GlobalConfig.CrushLocation = agent.location
-	// don't set public or cluster addr if prepare only
-	if agent.prepareOnly {
-		cephConfig.PublicAddr = ""
-		cephConfig.ClusterAddr = ""
-	}
+
 	// write the latest config to the config dir
 	if err := mon.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig); err != nil {
 		return fmt.Errorf("failed to write connection config. %+v", err)

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -231,10 +231,11 @@ func (c *Cluster) handleStatusConfigMapStatus(nodeName string, config *provision
 
 	logger.Infof("osd orchestration status for node %s is %s", nodeName, status.Status)
 	if status.Status == OrchestrationStatusCompleted {
-		if !configOSDs || c.startOSDDaemon(nodeName, config, configMap, status) {
-			// upon success provisioning or removing OSDs on the node, remove the status configmap
-			c.kv.ClearStore(fmt.Sprintf(orchestrationStatusMapName, nodeName))
+		if configOSDs {
+			c.startOSDDaemonsOnNode(nodeName, config, configMap, status)
 		}
+		// remove the status configmap that indicated the progress
+		c.kv.ClearStore(fmt.Sprintf(orchestrationStatusMapName, nodeName))
 		return true
 	}
 

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func UpdateDeploymentAndWait(context *clusterd.Context, deployment *v1beta1.Deployment, namespace string) error {
+	original, err := context.Clientset.Extensions().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get deployment %s. %+v", deployment.Name, err)
+	}
+
+	logger.Infof("updating deployment %s", deployment.Name)
+	if _, err := context.Clientset.Extensions().Deployments(namespace).Update(deployment); err != nil {
+		return fmt.Errorf("failed to update deployment %s. %+v", deployment.Name, err)
+	}
+
+	// wait for the deployment to be restarted
+	sleepTime := 2
+	attempts := 30
+	if original.Spec.ProgressDeadlineSeconds != nil {
+		// make the attempts double the progress deadline since the pod is both stopping and starting
+		attempts = 2 * (int(*original.Spec.ProgressDeadlineSeconds) / sleepTime)
+	}
+	for i := 0; i < attempts; i++ {
+		// check for the status of the deployment
+		d, err := context.Clientset.Extensions().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get deployment %s. %+v", deployment.Name, err)
+		}
+		if d.Status.ObservedGeneration != original.Status.ObservedGeneration && d.Status.UpdatedReplicas > 0 && d.Status.ReadyReplicas > 0 {
+			logger.Infof("finished waiting for updated deployment %s", d.Name)
+			return nil
+		}
+
+		logger.Debugf("deployment %s status=%v", d.Name, d.Status)
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+
+	return fmt.Errorf("gave up waiting for deployment %s to update", deployment.Name)
+}

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -89,13 +89,16 @@ func NodeEnvVar() v1.EnvVar {
 }
 
 // ConfigDirEnvVar config dir env var
-func ConfigDirEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: "ROOK_CONFIG_DIR", Value: DataDir}
+func ConfigDirEnvVar(dataDir string) v1.EnvVar {
+	return v1.EnvVar{Name: "ROOK_CONFIG_DIR", Value: dataDir}
 }
 
 func GetContainerImage(pod *v1.Pod, name string) (string, error) {
+	return GetSpecContainerImage(pod.Spec, name)
+}
 
-	image, err := GetMatchingContainer(pod.Spec.Containers, name)
+func GetSpecContainerImage(spec v1.PodSpec, name string) (string, error) {
+	image, err := GetMatchingContainer(spec.Containers, name)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>
(cherry picked from commit 1d928ecd3678d487c854a21b83929a604b7eeb02)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport: The osd pod now has an init container for generating the ceph.conf every time the pod starts up. This is needed in case the mons failover or the ceph-config-override configmap changes

**Which issue is resolved by this Pull Request:**
Resolves #1919 #1939 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
