### PR TITLE
Docs: clarify pool replication samples

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -5,8 +5,26 @@ indent: true
 ---
 
 # Ceph Cluster CRD
-Rook allows creation and customization of storage clusters through the custom resource definitions (CRDs). The following settings are
-available for a Ceph cluster.
+Rook allows creation and customization of storage clusters through the custom resource definitions (CRDs).
+
+## Sample
+To get you started, here is a simple example of a CRD to configure a Ceph cluster with all nodes and all devices. More examples are included [later in this doc](#samples).
+
+```yaml
+apiVersion: ceph.rook.io/v1beta1
+kind: Cluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  dataDirHostPath: /var/lib/rook
+  serviceAccount: rook-ceph-cluster
+  storage:
+    useAllNodes: true
+    useAllDevices: true
+```
+
+In addition to the CRD, you will also need to create a namespace, role, and role binding as seen in the [common cluster resources](#common-cluster-resources) below.
 
 ## Settings
 Settings can be specified at the global level to apply to the cluster as a whole, while other settings can be specified at more fine-grained levels.  If any setting is unspecified, a suitable default will be used automatically.
@@ -131,9 +149,11 @@ metadata:
   namespace: rook-ceph
 spec:
   dataDirHostPath: /var/lib/rook
+  serviceAccount: rook-ceph-cluster
+  network:
+    hostNetwork: false
   dashboard:
     enabled: true
-  serviceAccount: rook-ceph-cluster
   # cluster level storage configuration and selection
   storage:
     useAllNodes: true
@@ -159,6 +179,10 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-ceph-cluster
+  network:
+    hostNetwork: false
+  dashboard:
+    enabled: true
   # cluster level storage configuration and selection
   storage:
     useAllNodes: false
@@ -196,6 +220,10 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-ceph-cluster
+  network:
+    hostNetwork: false
+  dashboard:
+    enabled: true
   # cluster level storage configuration and selection
   storage:
     useAllNodes: false
@@ -227,6 +255,10 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-ceph-cluster
+  network:
+    hostNetwork: false
+  dashboard:
+    enabled: true
   placement:
     all:
       nodeAffinity:

--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -9,8 +9,26 @@ indent: true
 Rook allows creation and customization of storage pools through the custom resource definitions (CRDs). The following settings are available
 for pools.
 
-## Sample
+## Samples
 
+### Replicated
+
+For optimal performance while adding redundancy to the system, configure the data to be copied in full to multiple locations.
+```yaml
+apiVersion: ceph.rook.io/v1beta1
+kind: Pool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+```
+
+### Erasure Coded
+
+To lower your storage capacity requirements while adding redundancy, use [erasure coding](#erasure-coding).
 ```yaml
 apiVersion: ceph.rook.io/v1beta1
 kind: Pool
@@ -18,13 +36,17 @@ metadata:
   name: ecpool
   namespace: rook-ceph
 spec:
-  replicated:
-  #  size: 3
+  failureDomain: osd
   erasureCoded:
     dataChunks: 2
     codingChunks: 1
-  crushRoot: default
 ```
+
+High performance applications typically will not use erasure coding due to the performance overhead of creating and distributing the chunks in the cluster.
+
+When creating an erasure-coded pool, it is highly recommended to create the pool when you have **bluestore OSDs** in your cluster
+(see the [OSD configuration settings](ceph-cluster-crd.md#osd-configuration-settings). Filestore OSDs have
+[limitations](http://docs.ceph.com/docs/luminous/rados/operations/erasure-code/#erasure-coding-with-overwrites) that are unsafe and lower performance.
 
 ## Pool Settings
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This splits the pool samples into two: one for replication and one for erasure coding. The sample was confusing being together with one of them commented out.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.

[skip ci]