### PR TITLE
Fix build/run when running on macos

### DIFF
--- a/images/cross/run.sh
+++ b/images/cross/run.sh
@@ -29,6 +29,6 @@ useradd -o -m -g $BUILDER_GID -u $BUILDER_UID $BUILDER_USER 2> /dev/null
 echo "$BUILDER_USER    ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 export HOME=/home/${BUILDER_USER}
 echo "127.0.0.1 $(cat /etc/hostname)" >> /etc/hosts
-[[ -S /var/run/docker.sock ]] && chown $BUILDER_UID:$BUILDER_GID /var/run/docker.sock
+[[ -S /var/run/docker.sock ]] && chmod 666 /var/run/docker.sock
 chown -R $BUILDER_UID:$BUILDER_GID $HOME
 exec chpst -u :$BUILDER_UID:$BUILDER_GID ${ARGS}


### PR DESCRIPTION
**Description of your changes:**

Doing a chown on /var/run/docker.sock when using `osfx` on docker for Mac corrupts the file. A workaround is to chown the file instead.

**Which issue is resolved by this Pull Request:**
Resolves #1986

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
