### PR TITLE
Return error when no valid nodes available to run osd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -160,6 +160,11 @@ func (c *Cluster) Start() error {
 		logger.Debugf("storage nodes: %+v", c.Storage.Nodes)
 	}
 	validNodes := k8sutil.GetValidNodes(c.Storage.Nodes, c.context.Clientset, c.placement)
+	// no valid node is ready to run an osd
+	if len(validNodes) == 0 {
+		logger.Warningf("no valid node available to run an osd in namespace %s", c.Namespace)
+		return nil
+	}
 	logger.Infof("%d of the %d storage nodes are valid", len(validNodes), len(c.Storage.Nodes))
 	c.Storage.Nodes = validNodes
 	// orchestrate individual nodes, starting with any that are still ongoing (in the case that we

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -60,6 +60,10 @@ func TestOrchestrationStatus(t *testing.T) {
 }
 
 func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatcher *watch.FakeWatcher) {
+	// if no valid osd node, don't need to check its status, return immediately
+	if len(c.Storage.Nodes) == 0 {
+		return
+	}
 	for {
 		// wait for the node's orchestration status to change to "starting"
 		cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)


### PR DESCRIPTION
We don't need to handle other osd(s) related tasks if there's no valid nodes available in the cluster to run
osd(s), output an error message to help user identify the cause of the issue.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Return immediately if no valid node(s) is ready to run osd, output an error message to help users identify the cause why an OSD is not launched.
**Which issue is resolved by this Pull Request:**
Resolves #1988

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
