### PR TITLE
Update clusterName to clusterNamespace in example

### DIFF
--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -45,7 +45,7 @@ spec:
           fsType: ceph
           options:
             fsName: myfs # name of the filesystem specified in the filesystem CRD.
-            clusterName: rook-ceph # namespace where the Rook cluster is deployed
+            clusterNamespace: rook-ceph # namespace where the Rook cluster is deployed
             # by default the path is /, but you can override and mount a specific path of the filesystem by using the path attribute
             # the path must exist on the filesystem, otherwise mounting the filesystem at that path will fail
             # path: /some/path/inside/cephfs

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -147,7 +147,7 @@ spec:
       fsType: ceph
       options:
         fsName: ` + filesystemName + `
-        clusterName: ` + namespace + `
+        clusterNamespace: ` + namespace + `
   restartPolicy: Never
 `
 }


### PR DESCRIPTION
**Description of your changes:**
Update example filesystem (kube-registry.yaml) to use `clusterNamespace` since 0.8.0. If `clusterName` is used, it will cause the kubelet to not find the correct volume plugin.

**Which issue is resolved by this Pull Request:**
Ref: #1965 
