### PR TITLE
Support storageclass reclaimpolicy

### DIFF
--- a/Documentation/block.md
+++ b/Documentation/block.md
@@ -45,6 +45,8 @@ parameters:
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
   fstype: xfs
+# Optional, default reclaimPolicy is "Delete". Other options are: "Retain", "Recycle" as documented in https://kubernetes.io/docs/concepts/storage/storage-classes/ 
+reclaimPolicy: Retain
 ```
 
 Create the storage class.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,7 @@
 - Rook Ceph block storage provisioner can now correctly create erasure coded block images. See [Advanced Example: Erasure Coded Block Storage](Documentation/block.md#advanced-example-erasure-coded-block-storage) for an example usage.
 - [Network File System (NFS)](https://github.com/nfs-ganesha/nfs-ganesha/wiki) is now supported by Rook with a new operator to deploy and manage this widely used server. NFS servers can be automatically deployed by creating an instance of the new `nfsservers.nfs.rook.io` custom resource. See the [NFS server user guide](Documentation/nfs.md) to get started with NFS.
 - The minimum version of Kubernetes supported by Rook changed from `1.7` to `1.8`.
+- `reclaimPolicy` parameter of `StorageClass` definition is now supported. 
 
 ## Breaking Changes
 - Mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -68,8 +68,8 @@ func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode string) (st
 	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
 }
 
-func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, namespace string, varClusterName bool) (string, error) {
-	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, namespace, varClusterName))
+func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, reclaimPolicy, namespace string, varClusterName bool) (string, error) {
+	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, varClusterName))
 }
 
 func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode string) error {
@@ -77,8 +77,8 @@ func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode string) err
 	return err
 }
 
-func (b *BlockOperation) DeleteStorageClass(poolName, storageClassName, namespace string) error {
-	_, err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, namespace, false))
+func (b *BlockOperation) DeleteStorageClass(poolName, storageClassName, reclaimPolicy, namespace string) error {
+	_, err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 	return err
 }
 

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -110,20 +110,25 @@ func (p *PoolOperation) CephPoolExists(namespace, name string) (bool, error) {
 	return false, nil
 }
 
-func (p *PoolOperation) CreateStorageClassAndPvc(namespace, poolName, storageClassName, blockName, mode string) (string, error) {
-	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, blockName, mode))
+func (p *PoolOperation) CreateStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) (string, error) {
+	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
 }
 
-func (p *PoolOperation) DeleteStorageClass(namespace, poolName, storageClassName string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName))
+func (p *PoolOperation) DeleteStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) error {
+	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
 	return err
 }
 
-func (p *PoolOperation) DeleteStorageClassAndPvc(namespace, poolName, storageClassName, blockName, mode string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, blockName, mode))
+func (p *PoolOperation) DeleteStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) error {
+	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
 	return err
 }
 
-func (p *PoolOperation) CreateStorageClass(namespace, poolName, storageClassName string) (string, error) {
-	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName))
+func (p *PoolOperation) DeletePvc(blockName, storageClassName, mode string) error {
+	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPvcDef(blockName, storageClassName, mode))
+	return err
+}
+
+func (p *PoolOperation) CreateStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) (string, error) {
+	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -31,10 +31,10 @@ type CephManifests interface {
 	GetRookToolBox(namespace string) string
 	GetCleanupPod(node, removalDir string) string
 	GetBlockPoolDef(poolName string, namespace string, replicaSize string) string
-	GetBlockStorageClassDef(poolName string, storageClassName string, namespace string, varClusterName bool) string
+	GetBlockStorageClassDef(poolName string, storageClassName string, reclaimPolicy string, namespace string, varClusterName bool) string
 	GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string
-	GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, blockName string, accessMode string) string
-	GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string) string
+	GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string
+	GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string
 	GetFilesystem(namepace, name string) string
 	GetObjectStore(namespace, name string, replicaCount, port int) string
 }
@@ -530,7 +530,7 @@ spec:
     size: ` + replicaSize
 }
 
-func (m *CephManifestsMaster) GetBlockStorageClassDef(poolName string, storageClassName string, namespace string, varClusterName bool) string {
+func (m *CephManifestsMaster) GetBlockStorageClassDef(poolName string, storageClassName string, reclaimPolicy string, namespace string, varClusterName bool) string {
 	namespaceParameter := "clusterNamespace"
 	if varClusterName {
 		namespaceParameter = "clusterName"
@@ -540,6 +540,7 @@ kind: StorageClass
 metadata:
    name: ` + storageClassName + `
 provisioner: ceph.rook.io/block
+reclaimPolicy: ` + reclaimPolicy + `
 parameters:
     pool: ` + poolName + `
     ` + namespaceParameter + `: ` + namespace
@@ -560,13 +561,13 @@ spec:
       storage: 1M`
 }
 
-func (m *CephManifestsMaster) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, blockName string, accessMode string) string {
+func (m *CephManifestsMaster) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string {
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"),
-		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
+		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
 }
 
-func (m *CephManifestsMaster) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string) string {
-	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, namespace, false))
+func (m *CephManifestsMaster) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string {
+	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 }
 
 func (m *CephManifestsMaster) GetFilesystem(namespace, name string) string {

--- a/tests/framework/installer/ceph_manifests_v0.8.go
+++ b/tests/framework/installer/ceph_manifests_v0.8.go
@@ -494,7 +494,7 @@ spec:
     size: ` + replicaSize
 }
 
-func (m *CephManifestsV0_8) GetBlockStorageClassDef(poolName string, storageClassName string, namespace string, varClusterName bool) string {
+func (m *CephManifestsV0_8) GetBlockStorageClassDef(poolName string, storageClassName string, reclaimPolicy string, namespace string, varClusterName bool) string {
 	namespaceParameter := "clusterNamespace"
 	if varClusterName {
 		namespaceParameter = "clusterName"
@@ -524,13 +524,13 @@ spec:
       storage: 10M`
 }
 
-func (m *CephManifestsV0_8) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, blockName string, accessMode string) string {
+func (m *CephManifestsV0_8) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string {
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"),
-		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
+		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
 }
 
-func (m *CephManifestsV0_8) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string) string {
-	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, namespace, false))
+func (m *CephManifestsV0_8) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string {
+	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 }
 
 func (m *CephManifestsV0_8) GetFilesystem(namespace, name string) string {

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1031,6 +1031,18 @@ func (k8sh *K8sHelper) GetPVCStatus(namespace string, name string) (v1.Persisten
 
 }
 
+//GetPVCVolumeName returns volume name of PVC
+func (k8sh *K8sHelper) GetPVCVolumeName(namespace string, name string) (string, error) {
+	getOpts := metav1.GetOptions{}
+
+	pvc, err := k8sh.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(name, getOpts)
+	if err != nil {
+		return "", fmt.Errorf("PVC %s not found,err->%v", name, err)
+	}
+
+	return pvc.Spec.VolumeName, nil
+}
+
 //GetPVCAccessModes returns AccessModes on PVC
 func (k8sh *K8sHelper) GetPVCAccessModes(namespace string, name string) ([]v1.PersistentVolumeAccessMode, error) {
 	getOpts := metav1.GetOptions{}
@@ -1042,6 +1054,17 @@ func (k8sh *K8sHelper) GetPVCAccessModes(namespace string, name string) ([]v1.Pe
 
 	return pvc.Status.AccessModes, nil
 
+}
+
+//GetPV returns PV by name
+func (k8sh *K8sHelper) GetPV(name string) (*v1.PersistentVolume, error) {
+	getOpts := metav1.GetOptions{}
+
+	pv, err := k8sh.Clientset.CoreV1().PersistentVolumes().Get(name, getOpts)
+	if err != nil {
+		return nil, fmt.Errorf("PV %s not found,err->%v", name, err)
+	}
+	return pv, nil
 }
 
 //IsPodInExpectedState waits for 90s for a pod to be an expected state

--- a/tests/integration/zblock_mount_unmount_test.go
+++ b/tests/integration/zblock_mount_unmount_test.go
@@ -97,7 +97,7 @@ func (s *BlockMountUnMountSuite) setupPVCs() {
 	storageClassNameRWO := "rook-ceph-block-rwo"
 
 	// Create PVCs
-	_, cbErr := s.testClient.PoolClient.CreateStorageClassAndPvc(s.namespace, poolNameRWO, storageClassNameRWO, s.pvcNameRWO, "ReadWriteOnce")
+	_, cbErr := s.testClient.PoolClient.CreateStorageClassAndPvc(s.namespace, poolNameRWO, storageClassNameRWO, "Delete", s.pvcNameRWO, "ReadWriteOnce")
 	require.Nil(s.T(), cbErr)
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, s.pvcNameRWO), "Make sure PVC is Bound")
 
@@ -147,8 +147,8 @@ func (s *BlockMountUnMountSuite) TearDownSuite() {
 	s.kh.DeletePods(
 		"setup-block-rwo", "setup-block-rwx", "rwo-block-rw-one", "rwo-block-rw-two", "rwo-block-ro-one",
 		"rwo-block-ro-two", "rwx-block-rw-one", "rwx-block-rw-two", "rwx-block-ro-one", "rwx-block-ro-two")
-	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwo", "rook-ceph-block-rwo", s.pvcNameRWO, "ReadWriteOnce")
-	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwx", "rook-ceph-block-rwx", s.pvcNameRWX, "ReadWriteMany")
+	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwo", "rook-ceph-block-rwo", "Delete", s.pvcNameRWO, "ReadWriteOnce")
+	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwx", "rook-ceph-block-rwx", "Delete", s.pvcNameRWX, "ReadWriteMany")
 
 	cleanupDynamicBlockStorage(s.testClient, s.namespace)
 	s.op.Teardown()

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -24,7 +24,7 @@ func createStorageClassAndPool(t func() *testing.T, testClient *clients.TestClie
 		logger.Infof("Install pool and storage class for rook block")
 		_, err := testClient.PoolClient.Create(poolName, namespace, 3)
 		require.NoError(t(), err)
-		_, err = testClient.BlockClient.CreateStorageClass(poolName, storageClassName, namespace, false)
+		_, err = testClient.BlockClient.CreateStorageClass(poolName, storageClassName, "Delete", namespace, false)
 		require.NoError(t(), err)
 
 		//make sure storageclass is created


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

This adds support for processing `reclaimPolicy` attribute of a `StorageClass` and set it the `PersistentVolume` created for `PersistentVolumeClaim` using that storage class.

**Which issue is resolved by this Pull Request:**
Resolves #1259

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] `make vendor` does not cause changes.
