### PR TITLE
Fix client.admin's default MDS capabilities

### DIFF
--- a/pkg/daemon/ceph/mon/config.go
+++ b/pkg/daemon/ceph/mon/config.go
@@ -41,7 +41,7 @@ const (
 	[client.admin]
 		key = %s
 		auid = 0
-		caps mds = "allow"
+		caps mds = "allow *"
 		caps mon = "allow *"
 		caps osd = "allow *"
 		caps mgr = "allow *"


### PR DESCRIPTION
The "allow" format has been deprecated for several years, and does not allow people to do "ceph tell mds..." commands.

Signed-off-by: John Spray <john.spray@redhat.com>