### PR TITLE
Fix ceph-mgr caps

### DIFF
--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -31,6 +31,8 @@ var (
 [mgr.%s]
 	key = %s
 	caps mon = "allow *"
+	caps mds = "allow *"
+	caps osd = "allow *"
 `
 )
 

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -30,7 +30,7 @@ var (
 	keyringTemplate = `
 [mgr.%s]
 	key = %s
-	caps mon = "allow *"
+	caps mon = "allow profile mgr"
 	caps mds = "allow *"
 	caps osd = "allow *"
 `


### PR DESCRIPTION
This enables using modules that expect OSD/MDS access to work, and makes Rook match how other deployment tools like ceph-deploy set up the ceph-mgr caps.