### PR TITLE
Tests: skip rbd volumes for osds

### DIFF
--- a/tests/framework/installer/install_helper.go
+++ b/tests/framework/installer/install_helper.go
@@ -569,6 +569,10 @@ func IsAdditionalDeviceAvailableOnCluster() bool {
 			logger.Infof("skipping device %s since it has file system %s", device, fs)
 			continue
 		}
+		if strings.HasPrefix(device, "rbd") {
+			logger.Infof("skipping unexpected rbd device: %s", device)
+			continue
+		}
 		logger.Infof("available device: %s", device)
 		disks++
 	}

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -19,10 +19,10 @@ install() {
     helm_ready=$(kubectl get pods -l app=helm -n kube-system -o jsonpath='{.items[0].status.phase}')
     INC=0
     until [[ "${helm_ready}" == "Running" || $INC -gt 20 ]]; do
-        echo "."
         sleep 10
         ((++INC))
         helm_ready=$(kubectl get pods -l app=helm -n kube-system -o jsonpath='{.items[0].status.phase}')
+        echo "helm pod status: $(helm_ready)"
     done
 
     if [ "${helm_ready}" != "Running" ]; then


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
At least two builds (such as [this](https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/master/runs/714/nodes/41/steps/60/log/?start=0)) in the last 12 hours have failed waiting for OSDs to start because the test framework thought an rbd device was available to consume on an osd, but then Rook refuses to actually start the osds on rbd, which is expected. This is manifest with the message in the test log:
```
installer: available device: rbd1
```

Another error in the same build was that [helm failed to install](https://jenkins.rook.io/blue/organizations/jenkins/rook%2Frook/detail/master/714/pipeline/43). It's not clear yet why 200 seconds was not sufficient to wait for the helm pod to initialize (normally it takes less than 20 seconds for the whole script), but this adds some logging. 

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
