### PR TITLE
Tests: skip checking substring if empty

### DIFF
--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -130,6 +130,10 @@ func (suite *SmokeSuite) TestOperatorGetFlexvolumePath() {
 }
 
 func checkOrderedSubstrings(t *testing.T, input string, substrings ...string) {
+	if len(input) == 0 {
+		// Nothing to compare. An error was likely returned, which should be checked elsewhere.
+		return
+	}
 	original := input
 	for i, substring := range substrings {
 		assert.Contains(t, input, substring, fmt.Sprintf("missing substring %d. original=%s", i, original))


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
[This build](https://jenkins.rook.io/blue/organizations/jenkins/rook%2Frook/detail/PR-1999/7/pipeline/48) hit an error where a substring was empty and caused the tests to crash. An `err` had been returned from a previous call and isn't being checked until after calling this helper test method. So if the string is empty, the helper should just return and allow the test to fail elsewhere.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
