### PR TITLE
Set application name to "rbd" when creating a RBD pool

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -39,6 +39,7 @@ const (
 	customResourceNamePlural = "pools"
 	replicatedType           = "replicated"
 	erasureCodeType          = "erasure-coded"
+	poolApplicationNameRBD   = "rbd"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-pool")
@@ -186,7 +187,7 @@ func createPool(context *clusterd.Context, p *cephv1beta1.Pool) error {
 
 	// create the pool
 	logger.Infof("creating pool %s in namespace %s", p.Name, p.Namespace)
-	if err := ceph.CreatePoolWithProfile(context, p.Namespace, *p.Spec.ToModel(p.Name), p.Name); err != nil {
+	if err := ceph.CreatePoolWithProfile(context, p.Namespace, *p.Spec.ToModel(p.Name), poolApplicationNameRBD); err != nil {
 		return fmt.Errorf("failed to create pool %s. %+v", p.Name, err)
 	}
 


### PR DESCRIPTION
**Description of your changes:**
Set application name to "rbd" when creating a RBD pool

**Which issue is resolved by this Pull Request:**
Resolves #2011 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
