### PR TITLE
docs: add instruction for amending commit to include sign-off message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ commit message:
 $ git commit -s -m 'This is my commit message'
 ```
 
+If you have already made a commit and forgot to include the sign-off, you can amend your last commit
+to add the sign-off with the following command, which can then be force pushed.
+
+```
+git commit --amend -s
+```
+
 We use a [DCO bot](https://github.com/apps/dco) to enforce the DCO on each pull
 request and branch commits.
 


### PR DESCRIPTION
**Description of your changes:** This PR updates the contribution documentation to include a command for amending a previous commit to include the sign-off message.  This commonly happens for first time contributors to the repo.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.

[skip ci]
