### PR TITLE
Update VERSION generation to produce a valid semantic version

### DIFF
--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -62,7 +62,7 @@ SED_CMD?=sed -i -e
 # set the version number. you should not need to do this
 # for the majority of scenarios.
 ifeq ($(origin VERSION), undefined)
-VERSION := $(shell git describe --dirty --always --tags | sed 's/-g/.g/g;s/-dirty/.dirty/g')
+VERSION := $(shell git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2' )
 endif
 export VERSION
 


### PR DESCRIPTION
### Overview
Currently, VERSION generation does not handle the case with the `-dirty` branch and no commits since the previous tag, which results in invalid semantic version, which in turn, fails `make build`.
For example, a branch with:
```
git describe --dirty --always --tags
v0.8.1-dirty
```
will result in `VERSION=v0.8.1.dirty`, which will fail `make build` with the following message:
```
make build                                                                                                                                                                 
=== helm package rook-ceph
==> Linting /home/user/go/src/github.com/rook/rook/cluster/charts/rook-ceph
Lint OK

1 chart(s) linted, no failures
Error: Invalid Semantic Version
build/makelib/helm.mk:48: recipe for target '/home/user/go/src/github.com/rook/rook/_output/charts/rook-ceph-v0.8.1.dirty.tgz' failed
make: *** [/home/user/go/src/github.com/rook/rook/_output/charts/rook-ceph-v0.8.1.dirty.tgz] Error 1
```
### Change Description
`VERSION` generation from `git describe` can be generalized as following:
 for any value produced by `git describe` replace all `-` with `.` starting with second occurrence.
For example: 
`v0.8.0-82-g8e29245e-dirty` - > `v0.8.0-82.g8e29245e.dirty`
and 
`v0.8.1-dirty` -> `v0.8.1-dirty` - i.e. no change

Resolves #1208

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
