### PR TITLE
Ceph: Improve erasure coded filesystem docs

### DIFF
--- a/Documentation/filesystem.md
+++ b/Documentation/filesystem.md
@@ -3,7 +3,6 @@ title: Shared File System
 weight: 26
 indent: true
 ---
-
 # Shared File System
 
 A shared file system can be mounted with read/write permission from multiple pods. This may be useful for applications which can be clustered using a shared filesystem.
@@ -16,7 +15,7 @@ This guide assumes you have created a Rook cluster as explained in the main [Kub
 
 ### Multiple File Systems Not Supported
 
-By default only one shared file system can be created with Rook. Multiple file system support in Ceph is still considered experimental and can be enabled with the environment variable `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` defined in `rook-operator.yaml`.
+By default only one shared file system can be created with Rook. Multiple file system support in Ceph is still considered experimental and can be enabled with the environment variable `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` defined in `operator.yaml`.
 
 Please refer to [cephfs experimental features](http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster) page for more information.
 
@@ -37,9 +36,8 @@ spec:
     replicated:
       size: 3
   dataPools:
-    - erasureCoded:
-       dataChunks: 2
-       codingChunks: 1
+    - replicated:
+        size: 3
   metadataServer:
     activeCount: 1
     activeStandby: true
@@ -145,3 +143,6 @@ To delete the filesystem components and backing data, delete the Filesystem CRD.
 ```
 kubectl -n rook-ceph delete Filesystem myfs
 ```
+### Advanced Example: Erasure Coded Filesystem
+
+The Ceph filesystem example can be found here: [Ceph Shared File System - Samples - Erasure Coded](ceph-filesystem-crd.md#erasure-coded).

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -230,7 +230,7 @@ kubectl delete clusterrolebindings rook-operator
 
 Now we need to create the new Ceph specific operator.
 
-**IMPORTANT:** Ensure that you are using the latest manifests from the `release-0.8` branch.  If you have custom configuration options set in your old `rook-operator.yaml` manifest, you will need to set those values in the new Ceph operator manifest below.
+**IMPORTANT:** Ensure that you are using the latest manifests from the `release-0.8` branch.  If you have custom configuration options set in your old `operator.yaml` manifest, you will need to set those values in the new Ceph operator manifest below.
 
 Navigate to the new Ceph manifests directory, apply your custom configuration options if you are using any, and then create the new Ceph operator with the command below.
 Note that the new operator by default uses by `rook-ceph-system` namespace, but we will use `sed` to edit it in place to use `rook-system` instead for backwards compatibility with your existing cluster.

--- a/cluster/examples/kubernetes/ceph/ec-filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/ec-filesystem.yaml
@@ -1,19 +1,20 @@
 apiVersion: ceph.rook.io/v1beta1
 kind: Filesystem
 metadata:
-  name: myfs
+  name: myfs-ec
   namespace: rook-ceph
 spec:
   # The metadata pool spec
   metadataPool:
     replicated:
-      # Increase the replication size if you have more than one osd
-      size: 1
+      # You need at least three OSDs on different nodes for this config to work
+      size: 3
   # The list of data pool specs
   dataPools:
-    - failureDomain: osd
-      replicated:
-        size: 1
+    # You need at least three `bluestore` OSDs on different nodes for this config to work
+    - erasureCoded:
+        dataChunks: 2
+        codingChunks: 1
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/design/multiple-storage-types-support.md
+++ b/design/multiple-storage-types-support.md
@@ -65,7 +65,7 @@ Controllers would all watch the same custom resource types via a `SharedInformer
 Even though all controllers are watching, only the applicable controller responds to and handles an event.
 For example, the user runs `kubectl create cluster.yaml` to create a `cluster.rook.io` instance that has Ceph specific properties.
 All controllers will receive the created event via the `SharedInformer`, but only the Ceph controller will queue and handle it.
-We can consider only loading the controllers the user specifically asks for, perhaps via an environment variable in `rook-operator.yaml`.
+We can consider only loading the controllers the user specifically asks for, perhaps via an environment variable in `operator.yaml`.
 
 Note that this architecture can be used with either API aggregation or CRDs.
 

--- a/tests/scripts/multi-node/build-rook.sh
+++ b/tests/scripts/multi-node/build-rook.sh
@@ -96,7 +96,7 @@ function run_rook {
 function edit_rook_cluster_template {
   cd "$rook_kube_templates_dir"
   sed -i 's|image: .*$|image: 172.17.8.1:5000/rook/ceph:latest|' operator.yaml
-  echo "rook-operator.yml has been edited with the new image '172.17.8.1:5000/rook/ceph:latest'"
+  echo "operator.yml has been edited with the new image '172.17.8.1:5000/rook/ceph:latest'"
   cd -
 }
 


### PR DESCRIPTION
**Description of your changes:**
This adds an "Advanced example" to the Ceph filesystem docs. Also the `erasureCoded` example is "removed" from the default example and moved to the mentioned "advanced example".

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]