### PR TITLE
Feedback Desired: WIP: DNM: Ceph mgr: decouple Rook/Ceph versions w/ init container

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -64,7 +64,7 @@ spec:
   # set the amount of mons to be started
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -49,6 +49,24 @@ subjects:
   name: rook-ceph-cluster
   namespace: rook-ceph
 ---
+# Set psp for Rook's main Ceph namespace
+# TODO: Is this still necessary?
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-default-psp
+  labels:
+      operator: rook
+      storage-backend: ceph
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: rook-ceph
+---
 apiVersion: ceph.rook.io/v1beta1
 kind: Cluster
 metadata:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -58,7 +58,7 @@ spec:
   # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
-  dataDirHostPath: /var/lib/rook
+  dataDirHostPath: /home/ses/var/lib/rook
   # The service account under which to run the daemon pods in this cluster if the default account is not sufficient (OSDs)
   serviceAccount: rook-ceph-cluster
   # set the amount of mons to be started

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -270,6 +270,23 @@ subjects:
   name: rook-ceph-system
   namespace: rook-ceph-system
 ---
+# Set psp for Rook's system namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-system-psp
+  labels:
+      operator: rook
+      storage-backend: ceph
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
 # The deployment for the rook operator
 apiVersion: apps/v1beta1
 kind: Deployment

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -306,7 +306,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:master
+        image: admin:5000/ceph-amd64
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -308,8 +308,8 @@ spec:
         # - name: AGENT_TOLERATION_KEY
         #  value: "<KeyOfTheTaintToTolerate>"
         # Set the path where the Rook agent can find the flex volumes
-        # - name: FLEXVOLUME_DIR_PATH
-        #  value: "<PathToFlexVolumes>"
+        - name: FLEXVOLUME_DIR_PATH
+          value: "/var/lib/kubelet/plugins/volume/exec/"
         # Rook Discover toleration. Will tolerate all taints with all keys.
         # Choose between NoSchedule, PreferNoSchedule and NoExecute:
         # - name: DISCOVER_TOLERATION

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph-toolbox:master
+        image: admin:5000/ceph-toolbox-amd64
         imagePullPolicy: IfNotPresent
         env:
           - name: ROOK_ADMIN_SECRET

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -31,7 +31,7 @@ var (
 )
 
 var mgrCmd = &cobra.Command{
-	Use:    "mgr",
+	Use:    "mgr-init",
 	Short:  "Generates mgr config",
 	Hidden: true,
 }
@@ -45,11 +45,10 @@ func init() {
 
 	flags.SetFlagsFromEnv(mgrCmd.Flags(), rook.RookEnvVarPrefix)
 
-	mgrCmd.RunE = startMgr
+	mgrCmd.RunE = initializeMgr
 }
 
-// Rename to prepareMgr or something similar?
-func startMgr(cmd *cobra.Command, args []string) error {
+func initializeMgr(cmd *cobra.Command, args []string) error {
 	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret"}
 	if err := flags.VerifyRequiredFlags(mgrCmd, required); err != nil {
 		return err
@@ -72,7 +71,7 @@ func startMgr(cmd *cobra.Command, args []string) error {
 		ClusterInfo: &clusterInfo,
 	}
 
-	err := mgr.Run(createContext(), config)
+	err := mgr.Initialize(createContext(), config)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -32,7 +32,7 @@ var (
 
 var mgrCmd = &cobra.Command{
 	Use:    "mgr",
-	Short:  "Generates mgr config and runs the mgr daemon",
+	Short:  "Generates mgr config",
 	Hidden: true,
 }
 

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -24,8 +24,10 @@ import (
 )
 
 var (
-	mgrName    string
-	mgrKeyring string
+	mgrName        string
+	mgrKeyring     string
+	mgrKeyringPath string
+	mgrConfDir     string
 )
 
 var mgrCmd = &cobra.Command{
@@ -37,6 +39,8 @@ var mgrCmd = &cobra.Command{
 func init() {
 	mgrCmd.Flags().StringVar(&mgrName, "mgr-name", "", "the mgr name")
 	mgrCmd.Flags().StringVar(&mgrKeyring, "mgr-keyring", "", "the mgr keyring")
+	mgrCmd.Flags().StringVar(&mgrKeyringPath, "mgr-keyring-path", "", "path to the mgr keyring")
+	mgrCmd.Flags().StringVar(&mgrConfDir, "mgr-conf-dir", "", "dir where the mgr's config is stored")
 	addCephFlags(mgrCmd)
 
 	flags.SetFlagsFromEnv(mgrCmd.Flags(), rook.RookEnvVarPrefix)
@@ -44,6 +48,7 @@ func init() {
 	mgrCmd.RunE = startMgr
 }
 
+// Rename to prepareMgr or something similar?
 func startMgr(cmd *cobra.Command, args []string) error {
 	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret"}
 	if err := flags.VerifyRequiredFlags(mgrCmd, required); err != nil {
@@ -62,6 +67,8 @@ func startMgr(cmd *cobra.Command, args []string) error {
 	config := &mgr.Config{
 		Name:        mgrName,
 		Keyring:     mgrKeyring,
+		KeyringPath: mgrKeyringPath,
+		ConfDir:     mgrConfDir,
 		ClusterInfo: &clusterInfo,
 	}
 

--- a/pkg/daemon/ceph/ceph/ceph.go
+++ b/pkg/daemon/ceph/ceph/ceph.go
@@ -1,0 +1,28 @@
+/*
+Daemon package ceph provides shared information that is applicable to all daemons in a Ceph cluster.
+*/
+
+package ceph
+
+import (
+	"path"
+)
+
+const (
+	// DefaultConfigDir is the default dir where Ceph stores its configs
+	DefaultConfigDir = "/etc/ceph"
+	// DefaultConfigFile is the default name of the file where Ceph stores its configs
+	DefaultConfigFile = "ceph.conf"
+	// DefaultKeyringFile is the default name of the file where Ceph stores its keyring info
+	DefaultKeyringFile = "keyring"
+)
+
+// DefaultConfigFilePath returns the full path to Ceph's default config file
+func DefaultConfigFilePath() string {
+	return path.Join(DefaultConfigDir, DefaultConfigFile)
+}
+
+// DefaultKeyringFilePath returns the full path to Ceph's default keyring file
+func DefaultKeyringFilePath() string {
+	return path.Join(DefaultConfigDir, DefaultKeyringFile)
+}

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -59,6 +59,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	keyringPath := config.KeyringPath
 	confDir := config.ConfDir
 	username := fmt.Sprintf("mgr.%s", config.Name)
+	// In Ceph's config, set the 'mgr data' key to the config dir Rook uses
 	settings := map[string]string{
 		"mgr data": confDir,
 	}

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -34,10 +34,6 @@ var (
 `
 )
 
-// const (
-// 	cephmgr = "ceph-mgr"
-// )
-
 type Config struct {
 	ClusterInfo *mon.ClusterInfo
 	Name        string // name of this mgr
@@ -48,22 +44,17 @@ type Config struct {
 
 // Rename this to 'Prepare' or something similar? Or is 'Run' a go-ism?
 func Run(context *clusterd.Context, config *Config) error {
-	//logger.Infof("Starting MGR %s with keyring %s", config.Name, config.Keyring)
 	logger.Infof("Preparing MGR %s with keyring %s", config.Name, config.Keyring)
-	// init container
+
 	if err := generateConfigFiles(context, config); err != nil {
 		return fmt.Errorf("failed to generate mgr config files. %+v", err)
 	}
-
-	// if err := startMgr(context, config); err != nil {
-	// 	return fmt.Errorf("failed to run mgr. %+v", err)
-	// }
 
 	logger.Infof("MGR preparation complete")
 	return nil
 }
 
-// Do in init container
+// Generate configuration files for the Ceph mgr
 func generateConfigFiles(context *clusterd.Context, config *Config) error {
 
 	keyringPath := config.KeyringPath // getMgrKeyringPath(context.ConfigDir, config.Name)
@@ -85,38 +76,8 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 
 	err = mon.WriteKeyring(keyringPath, config.Keyring, keyringEval)
 	if err != nil {
-		return fmt.Errorf("failed to create mds keyring. %+v", err)
+		return fmt.Errorf("failed to create mds keyring. %+v", err) // TODO: is 'mds' right here?
 	}
 
 	return nil
 }
-
-// // This should be what is put into the running container
-// // ceph-mgr --foreground --cluster=<config.ClusterInfo.Name> --conf=<configFile>
-// //          --keyring=<keyringPath> --id <config.Name>
-// func startMgr(context *clusterd.Context, config *Config) error {
-
-// 	// start the mgr daemon in the foreground with the given config
-// 	logger.Infof("starting ceph-mgr")
-
-// 	if err := context.Executor.ExecuteCommand(false, cephmgr, cephmgr, args...); err != nil {
-// 		return fmt.Errorf("failed to start mgr: %+v", err)
-// 	}
-// 	return nil
-// }
-
-//
-// We don't want to duplicate the below code items from the operator; pass these in as vars somehow
-//
-
-// func getMgrConfDir(dir, name string) string {
-// 	return path.Join(dir, fmt.Sprintf("mgr-%s", name))
-// }
-
-// func getMgrConfFilePath(dir, name, clusterName string) string {
-// 	return path.Join(getMgrConfDir(dir, name), fmt.Sprintf("%s.config", clusterName))
-// }
-
-// func getMgrKeyringPath(dir, name string) string {
-// 	return path.Join(getMgrConfDir(dir, name), "keyring")
-// }

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -42,8 +42,8 @@ type Config struct {
 	ConfDir     string // dir where this mgr's config is stored
 }
 
-// Rename this to 'Prepare' or something similar? Or is 'Run' a go-ism?
-func Run(context *clusterd.Context, config *Config) error {
+// Initialize generates configuration files for running the Ceph mgr daemon
+func Initialize(context *clusterd.Context, config *Config) error {
 	logger.Infof("Preparing MGR %s with keyring %s", config.Name, config.Keyring)
 
 	if err := generateConfigFiles(context, config); err != nil {
@@ -54,16 +54,16 @@ func Run(context *clusterd.Context, config *Config) error {
 	return nil
 }
 
-// Generate configuration files for the Ceph mgr
 func generateConfigFiles(context *clusterd.Context, config *Config) error {
 
-	keyringPath := config.KeyringPath // getMgrKeyringPath(context.ConfigDir, config.Name)
-	confDir := config.ConfDir         // getMgrConfDir(context.ConfigDir, config.Name)
+	keyringPath := config.KeyringPath
+	confDir := config.ConfDir
 	username := fmt.Sprintf("mgr.%s", config.Name)
 	settings := map[string]string{
 		"mgr data": confDir,
 	}
 	logger.Infof("Conf files: dir=%s keyring=%s", confDir, keyringPath)
+	// I feel like `GenerateConfigFile` doesn't belong in mon but in a higher-level ceph module
 	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, confDir,
 		username, keyringPath, nil, settings)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -19,6 +19,7 @@ package mgr
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 
 	"github.com/coreos/pkg/capnslog"
@@ -28,10 +29,12 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/ceph"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mgr")
@@ -94,6 +97,7 @@ func (c *Cluster) Start() error {
 		}
 
 		// start the deployment
+		// Why do we start multiple deployments instead of starting one deployment with replicas?
 		deployment := c.makeDeployment(name, daemonName)
 		if _, err := c.context.Clientset.ExtensionsV1beta1().Deployments(c.Namespace).Create(deployment); err != nil {
 			if !errors.IsAlreadyExists(err) {
@@ -202,6 +206,21 @@ func (c *Cluster) makeDashboardService(name string) *v1.Service {
 
 func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment {
 
+	// operator must figure this out
+	clusterInfo, _, _, _ := opmon.LoadClusterInfo(c.context, c.Namespace)
+	// TODO: Swallow any errors for now. Will need to handle this and return an error condition in
+	//   makeDeployment before finalizing this work
+	// if err != nil {
+	// 	return fmt.Errorf("failed to load cluster information from clusters namespace %s: %+v", c.Namespace, err)
+	// }
+
+	confFile := getMgrConfFilePath(c.context.ConfigDir, daemonName, clusterInfo.Name)
+	util.WriteFileToLog(logger, confFile)
+
+	// operator must figure this out too
+	keyringPath := getMgrKeyringPath(c.context.ConfigDir, daemonName)
+	util.WriteFileToLog(logger, keyringPath)
+
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -210,12 +229,13 @@ func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment
 				"prometheus.io/port": strconv.Itoa(metricsPort)},
 		},
 		Spec: v1.PodSpec{
-			Containers:     []v1.Container{c.mgrContainer(name, daemonName)},
-			InitContainers: []v1.Container{c.mgrInitContainer(name, daemonName)},
+			Containers:     []v1.Container{c.mgrContainer(name, clusterInfo.Name, confFile, keyringPath)},
+			InitContainers: []v1.Container{c.mgrInitContainer(name, daemonName, keyringPath, getMgrConfDir(c.context.ConfigDir, daemonName))},
 			RestartPolicy:  v1.RestartPolicyAlways,
 			Volumes: []v1.Volume{
 				{Name: k8sutil.DataDirVolume, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 				k8sutil.ConfigOverrideVolume(),
+				{Name: "ceph-default-config-dir", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			},
 			HostNetwork: c.HostNetwork,
 		},
@@ -237,31 +257,38 @@ func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment
 	return d
 }
 
-func (c *Cluster) mgrContainer(name, daemonName string) v1.Container {
-
+func (c *Cluster) mgrContainer(name, clusterName, confFilePath, keyringPath string) v1.Container {
 	return v1.Container{
-		Args: []string{
-			"ceph",
-			"mgr",
-			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
+		Command: []string{
+			"/usr/bin/ceph-mgr",
 		},
-		Name:  name,
+		Args: []string{
+			"--foreground",
+			fmt.Sprintf("--cluster=%s", clusterName),
+			fmt.Sprintf("--conf=%s", confFilePath),
+			fmt.Sprintf("--keyring=%s", keyringPath),
+		},
+		// There is no need to name containers in the pod 'rook-ceph-mgr-<name>'. 'mgr' and
+		//   'mgr-init' should be sufficient, and then it's easier to get specific mgr container
+		//   logs from any mgr pod since the containers inside will have deterministic names
+		Name:  "mgr",
 		Image: k8sutil.MakeRookImage(c.Version),
 		VolumeMounts: []v1.VolumeMount{
 			{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
 			k8sutil.ConfigOverrideMount(),
+			{Name: "ceph-default-config-dir", MountPath: ceph.DefaultConfigDir}
 		},
-		Env: []v1.EnvVar{
-			{Name: "ROOK_MGR_NAME", Value: daemonName},
-			{Name: "ROOK_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
-			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
-			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
-			opmon.ClusterNameEnvVar(c.Namespace),
-			opmon.EndpointEnvVar(),
-			opmon.SecretEnvVar(),
-			opmon.AdminSecretEnvVar(),
-			k8sutil.ConfigOverrideEnvVar(),
-		},
+		// Env: []v1.EnvVar{
+		// 	// {Name: "ROOK_MGR_NAME", Value: daemonName},
+		// 	// {Name: "ROOK_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
+		// 	k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+		// 	k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
+		// 	// opmon.ClusterNameEnvVar(c.Namespace),
+		// 	// opmon.EndpointEnvVar(),
+		// 	// opmon.SecretEnvVar(),
+		// 	// opmon.AdminSecretEnvVar(),
+		// 	// k8sutil.ConfigOverrideEnvVar(), // <-- What does this do? It seems unused
+		// },
 		Resources: c.resources,
 		Ports: []v1.ContainerPort{
 			{
@@ -283,19 +310,29 @@ func (c *Cluster) mgrContainer(name, daemonName string) v1.Container {
 	}
 }
 
-func (c *Cluster) mgrInitContainer(name, daemonName string) v1.Container {
+func (c *Cluster) mgrInitContainer(name, daemonName, keyringPath, confDir string) v1.Container {
 	return v1.Container{
-		Command: []string{"/usr/bin/env"},
-		Args:    []string{},
-		Name:    fmt.Sprintf("%s-init", name),
-		Image:   k8sutil.MakeRookImage(c.Version),
+		Args: []string{
+			"ceph",
+			"mgr",
+			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
+		},
+		Name:  "mgr-init",
+		Image: k8sutil.MakeRookImage(c.Version),
 		VolumeMounts: []v1.VolumeMount{
 			{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
 			k8sutil.ConfigOverrideMount(),
+			// Also mount Ceph's default config dir (/etc/ceph) so that when the Rook binary
+			// initializes the configuration and keyring and copies it to /etc/ceph, the data will
+			// be persisted to the running container as well.
+			// Is this going to overwrite any critical files installed by default into /etc/ceph?
+			{Name: "ceph-default-config-dir", MountPath: ceph.DefaultConfigDir}
 		},
 		Env: []v1.EnvVar{
 			{Name: "ROOK_MGR_NAME", Value: daemonName},
 			{Name: "ROOK_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
+			{Name: "ROOK_MGR_KEYRING_PATH", Value: keyringPath},
+			{Name: "ROOK_MGR_CONF_DIR", Value: confDir},
 			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 			opmon.ClusterNameEnvVar(c.Namespace),
@@ -305,23 +342,23 @@ func (c *Cluster) mgrInitContainer(name, daemonName string) v1.Container {
 			k8sutil.ConfigOverrideEnvVar(),
 		},
 		Resources: c.resources,
-		Ports: []v1.ContainerPort{
-			{
-				Name:          "mgr",
-				ContainerPort: int32(6800),
-				Protocol:      v1.ProtocolTCP,
-			},
-			{
-				Name:          "http-metrics",
-				ContainerPort: int32(metricsPort),
-				Protocol:      v1.ProtocolTCP,
-			},
-			{
-				Name:          "dashboard",
-				ContainerPort: int32(dashboardPort),
-				Protocol:      v1.ProtocolTCP,
-			},
-		},
+		// Ports: []v1.ContainerPort{
+		// 	{
+		// 		Name:          "mgr",
+		// 		ContainerPort: int32(6800),
+		// 		Protocol:      v1.ProtocolTCP,
+		// 	},
+		// 	{
+		// 		Name:          "http-metrics",
+		// 		ContainerPort: int32(metricsPort),
+		// 		Protocol:      v1.ProtocolTCP,
+		// 	},
+		// 	{
+		// 		Name:          "dashboard",
+		// 		ContainerPort: int32(dashboardPort),
+		// 		Protocol:      v1.ProtocolTCP,
+		// 	},
+		// },
 	}
 }
 
@@ -414,4 +451,19 @@ func createKeyring(context *clusterd.Context, clusterName, name string) (string,
 	}
 
 	return keyring, nil
+}
+
+// get the manager config directory for a manager daemon
+func getMgrConfDir(rookConfigDir, mgrDaemonName string) string {
+	return path.Join(rookConfigDir, fmt.Sprintf("mgr-%s", mgrDaemonName))
+}
+
+// get the full path of the manager config file for a manager daemon
+func getMgrConfFilePath(rookConfigDir, mgrDaemonName, clusterName string) string {
+	return path.Join(getMgrConfDir(rookConfigDir, mgrDaemonName), fmt.Sprintf("%s.config", clusterName))
+}
+
+// get the full path of the manager keyring file for a manager daemon
+func getMgrKeyringPath(rookConfigDir, mgrDaemonName string) string {
+	return path.Join(getMgrConfDir(rookConfigDir, mgrDaemonName), "keyring")
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -205,8 +205,6 @@ func (c *Cluster) makeDashboardService(name string) *v1.Service {
 }
 
 func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment {
-
-	// operator must figure this out
 	clusterInfo, _, _, _ := opmon.LoadClusterInfo(c.context, c.Namespace)
 	// TODO: Swallow any errors for now. Will need to handle this and return an error condition in
 	//   makeDeployment before finalizing this work
@@ -217,7 +215,6 @@ func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment
 	confFile := getMgrConfFilePath(c.context.ConfigDir, daemonName, clusterInfo.Name)
 	util.WriteFileToLog(logger, confFile)
 
-	// operator must figure this out too
 	keyringPath := getMgrKeyringPath(c.context.ConfigDir, daemonName)
 	util.WriteFileToLog(logger, keyringPath)
 
@@ -278,6 +275,8 @@ func (c *Cluster) mgrContainer(name, clusterName, confFilePath, keyringPath stri
 			k8sutil.ConfigOverrideMount(),
 			{Name: "ceph-default-config-dir", MountPath: ceph.DefaultConfigDir}
 		},
+		// TODO: Should all/some of the below be kept so the env vars can give useful info to
+		//       admins poking through running containers?
 		// Env: []v1.EnvVar{
 		// 	// {Name: "ROOK_MGR_NAME", Value: daemonName},
 		// 	// {Name: "ROOK_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
@@ -342,23 +341,6 @@ func (c *Cluster) mgrInitContainer(name, daemonName, keyringPath, confDir string
 			k8sutil.ConfigOverrideEnvVar(),
 		},
 		Resources: c.resources,
-		// Ports: []v1.ContainerPort{
-		// 	{
-		// 		Name:          "mgr",
-		// 		ContainerPort: int32(6800),
-		// 		Protocol:      v1.ProtocolTCP,
-		// 	},
-		// 	{
-		// 		Name:          "http-metrics",
-		// 		ContainerPort: int32(metricsPort),
-		// 		Protocol:      v1.ProtocolTCP,
-		// 	},
-		// 	{
-		// 		Name:          "dashboard",
-		// 		ContainerPort: int32(dashboardPort),
-		// 		Protocol:      v1.ProtocolTCP,
-		// 	},
-		// },
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -116,9 +116,10 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, "rook/rook:myversion", cont.Image)
 	assert.Equal(t, 2, len(cont.VolumeMounts))
 
-	assert.Equal(t, "ceph", cont.Args[0])
-	assert.Equal(t, "mgr", cont.Args[1])
-	assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[2])
+	// TODO: tests for init container and fix tests for container
+	// assert.Equal(t, "ceph", cont.Args[0])
+	// assert.Equal(t, "mgr", cont.Args[1])
+	// assert.Equal(t, "--config-dir=/var/lib/rook", cont.Args[2])
 
 	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())

--- a/pkg/operator/ceph/cluster/mon/util.go
+++ b/pkg/operator/ceph/cluster/mon/util.go
@@ -40,16 +40,16 @@ import (
 )
 
 // LoadClusterInfo constructs or loads a clusterinfo and returns it along with the maxMonID
-func LoadClusterInfo(context *clusterd.Context, namespace string) (*mon.ClusterInfo, int, *Mapping, error) {
+func LoadClusterInfo(context *clusterd.Context, namespace string) (clusterInfo *mon.ClusterInfo, maxMonID int, monMapping *Mapping, bool error) {
 	return CreateOrLoadClusterInfo(context, namespace, nil)
 }
 
 // CreateOrLoadClusterInfo constructs or loads a clusterinfo and returns it along with the maxMonID
-func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerRef *metav1.OwnerReference) (*mon.ClusterInfo, int, *Mapping, error) {
+func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerRef *metav1.OwnerReference) (clusterInfo *mon.ClusterInfo, maxMonID int, monMapping *Mapping, bool error) {
 
-	var clusterInfo *mon.ClusterInfo
-	maxMonID := -1
-	monMapping := &Mapping{
+	//var clusterInfo *mon.ClusterInfo
+	maxMonID = -1
+	monMapping = &Mapping{
 		Node: map[string]*NodeInfo{},
 		Port: map[string]int32{},
 	}


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

Rough but working work in progress. I have approximated what a decoupling of Rook and Ceph in the mgr by splitting the mgr daemon into 2 parts: (1) an init container in which the Rook binary configures the pod environment to run a ceph mgr, and (2) a main container in which `ceph-mgr` is called directly with appropriate arguments. This is a first stab, and I have focused more on "making it work" than on making the best design decisions; however, I did add/edit godoc comments for code I referenced while making these changes, and I (re)named some parameters to make the code itself more self explanatory. There are also still many old bits of code commented out and/or comments to myself which of course need removed.

If you have ideas for functional improvements, I'd love to hear them. Please feel free to comment as I continue my WIP.

-----

**Questions I have:**
- There are some questions and TODO items in comments that I will collect here on Monday for us to talk about more easily.
- In `cmd/rook/ceph/mgr.go` should `startMgr` be renamed to `prepareMgr` or similar?
- Is it okay to name containers in mgr pod `mgr` and `mgr-init`
- Will mounting an empty dir to `/etc/ceph` in the init container overwrite any important config files that are either installed there or placed there by Rook?
- In `pkg/daemon/ceph/mgr/daemon.go`, should `Run` be renamed to `Prepare` or similar? Or is `Run` a go-ism?
- I personally think that some of the functionality in `pkg/daemon/ceph/mon` should go into a shared `pkg/daemon/ceph/ceph` dir (as I have done a little bit) since a lot is shared by many daemons. This may be less needed in the future since some mon config items will be moving to the operator. Thoughts?
- Why do we start multiple mgr deployments instead of starting one deployment with replicas?
- In `pkg/operator/ceph/cluster/mgr/mgr.go` `mgrContainer`, should all/some env vars be kept for admins who want to see the info from running containers?
- Can the `Cluster` struct in `pkg/operator/ceph/cluster/mgr/mgr.go` be renamed to `MgrCluster`? (And extend this idea to other daemons). I've found it confusing to have so many different `Cluster` items.
- Same thought as above with some different config structs.

-----

**TODO Items:**
- [ ] Remove `skip ci` tag in this PR when ready for CI
- [ ] Update / add tests
- [ ] Wait until `ceph/ceph:<vers>` images available, and use those? _not strictly required_
- [ ] Add error handling to `pkg/operator/ceph/cluster/mgr/mgr.go` `makeDeployment`
- [ ] In `pkg/daemon/ceph/mgr/daemon.go`, is the "failed to create mds keyring" error text correct? I'm pretty sure this should be "mgr keyring".

-----

**Note:** Ignore the commits marked 'k8s', as these are just the changes I've made to run Rook in my environment.

**Which issue is resolved by this Pull Request:**
N/A. Exploratory implementation of design doc from #2014 for Ceph mgr daemon

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
