### PR TITLE
build: remove support for quay.io

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,7 +146,7 @@ Every PR and every merge to master triggers the CI process in [Jenkins](http://j
 The Jenkins CI will build, run unit tests, run integration tests and Publish artifacts- On every commit to PR and master.
 If any of the CI stages fail, then the process is aborted and no artifacts are published.
 On every successful build Artifacts are pushed to a [s3 bucket](https://release.rook.io/). On every successful master build,
-images are uploaded to quay and docker hub in addition.
+images are uploaded to docker hub in addition.
 
 During Integration tests phase, all End to End Integration tests under [/tests/integration](/tests/integration) are run.
 It may take a while to run all Integration tests. Based on nature of the PR, it may not be required to run full regression

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,13 +99,11 @@ pipeline {
             }
             environment {
                 DOCKER = credentials('rook-docker-hub')
-                QUAY = credentials('rook-quay-io')
                 AWS = credentials('rook-jenkins-aws')
                 GIT = credentials('rook-github')
             }
             steps {
                 sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
-                sh 'docker login -u="${QUAY_USR}" -p="${QUAY_PSW}" quay.io'
                 sh 'build/run make -j\$(nproc) -C build/release build BRANCH_NAME=${BRANCH_NAME} GIT_API_TOKEN=${GIT_PSW}'
                 sh 'build/run make -j\$(nproc) -C build/release publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_PSW}'
                 sh '[ "${BRANCH_NAME}" != "master" ] || build/run make -j\$(nproc) -C build/release promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}'

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,11 +3,14 @@
 ## Action Required
 
 ## Notable Features
+
 - The `fsType` default for StorageClass examples are now using XFS to bring it in line with Ceph recommendations.
 - Ceph is updated from Luminous 12.2.5 to 12.2.7.
 - Ceph OSDs will be automatically updated by the operator when there is a change to the operator version or when the OSD configuration changes. See the [OSD upgrade notes](Documentation/upgrade-patch.md#object-storage-daemons-osds).
 
 ## Breaking Changes
+
+- The Rook container images are no longer published to quay.io, they are published only to Docker Hub.  All manifests have referenced Docker Hub for multiple releases now, so we do not expect any directly affected users from this change.
 
 ## Known Issues
 

--- a/build/release/Jenkinsfile.promote
+++ b/build/release/Jenkinsfile.promote
@@ -17,12 +17,10 @@ pipeline {
         stage('Promote Release') {
             environment {
                 DOCKER = credentials('rook-docker-hub')
-                QUAY = credentials('rook-quay-io')
                 AWS = credentials('rook-jenkins-aws')
             }
             steps {
                 sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
-                sh 'docker login -u="${QUAY_USR}" -p="${QUAY_PSW}" quay.io'
                 sh "build/run make -j\$(nproc) -C build/release promote BRANCH_NAME=${BRANCH_NAME} VERSION=${params.version} CHANNEL=${params.channel} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}"
             }
         }

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -56,8 +56,7 @@ override BRANCH_NAME := pr/$(BRANCH_NAME)
 endif
 
 DOCKER_REGISTRY ?= rook
-QUAY_REGISTRY ?= quay.io/rook
-REGISTRIES ?= $(DOCKER_REGISTRY) $(QUAY_REGISTRY)
+REGISTRIES ?= $(DOCKER_REGISTRY)
 IMAGE_ARCHS := $(subst linux_,,$(filter linux_%,$(PLATFORMS)))
 IMAGE_PLATFORMS := $(subst _,/,$(subst $(SPACE),$(COMMA),$(filter linux_%,$(PLATFORMS))))
 

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -91,7 +91,7 @@ Binaries go to an S3 bucket `rook-release` (and https://release.rook.io) and hav
 
 ## Containers
 
-Containers go to docker hub and quay.io where we have the following repos:
+Containers go to docker hub where we have the following repos:
 
 ```
 rook/ceph


### PR DESCRIPTION
**Description of your changes:** This PR removes support for quay.io, the Rook container images will only be published to docker hub going forward.

**Which issue is resolved by this Pull Request:**
Resolves #2049 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
