### PR TITLE
Image build/release: do not save image for builds; save only for release

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -153,7 +153,11 @@ promote.output:
 
 # 1: registry 2: image, 3: arch
 define repo.targets
-build.image.$(1).$(2).$(3): ; @docker tag $(BUILD_REGISTRY)/$(2)-$(3) $(1)/$(2)-$(3):$(VERSION)
+build.image.$(1).$(2).$(3):
+	@docker tag $(BUILD_REGISTRY)/$(2)-$(3) $(1)/$(2)-$(3):$(VERSION)
+	@# Save image as _output/images/linux_<arch>/<image>.tar.gz (no builds for darwin or windows)
+	@mkdir -p $(OUTPUT_DIR)/images/linux_$(3)
+	@docker save $(BUILD_REGISTRY)/$(2)-$(3) | gzip -c > $(OUTPUT_DIR)/images/linux_$(3)/$(2).tar.gz
 build.all.images: build.image.$(1).$(2).$(3)
 publish.image.$(1).$(2).$(3): ; @docker push $(1)/$(2)-$(3):$(VERSION)
 publish.all.images: publish.image.$(1).$(2).$(3)

--- a/images/ceph-toolbox/Makefile
+++ b/images/ceph-toolbox/Makefile
@@ -35,21 +35,9 @@ toolbox-base-image:
 		-t $(TOOLBOX_BASE_IMAGE) \
 		$(TEMP)
 
-# since this is a leaf image we avoid leaving around a lot of dangling images
-# by removing the last build of the final toolbox image
-OLD_IMAGE_ID := $(shell docker images -q $(TOOLBOX_IMAGE))
-CURRENT_IMAGE_ID := $$(docker images -q $(TOOLBOX_IMAGE))
-IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/ceph-toolbox.tar.gz
-
 do.build: toolbox-base-image
 	@echo === docker build $(TOOLBOX_IMAGE)
 	@cp -a . $(TEMP)
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(TOOLBOX_BASE_IMAGE)|g' Dockerfile
 	@docker build $(BUILD_ARGS) -t $(TOOLBOX_IMAGE) $(TEMP)
-	@[ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] && [ -n "$(OLD_IMAGE_ID)" ] && docker rmi $(OLD_IMAGE_ID) || true
-	@if [ ! -e "$(IMAGE_FILENAME)" ] || [ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] || [ -z "$(OLD_IMAGE_ID)" ]; then \
-		echo === saving image $(TOOLBOX_IMAGE); \
-		mkdir -p $(IMAGE_OUTPUT_DIR); \
-		docker save $(TOOLBOX_IMAGE) | gzip -c > $(IMAGE_FILENAME); \
-	fi
 	@rm -fr $(TEMP)

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -27,12 +27,6 @@ TEMP := $(shell mktemp -d)
 # ====================================================================================
 # Build Rook
 
-# since this is a leaf image we avoid leaving around a lot of dangling images
-# by removing the last build of the final ceph image
-OLD_IMAGE_ID := $(shell docker images -q $(CEPH_IMAGE))
-CURRENT_IMAGE_ID := $$(docker images -q $(CEPH_IMAGE))
-IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/ceph.tar.gz
-
 do.build:
 	@echo === docker build $(CEPH_IMAGE)
 	@cp Dockerfile $(TEMP)
@@ -44,10 +38,4 @@ do.build:
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
 		-t $(CEPH_IMAGE) \
 		$(TEMP)
-	@[ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] && [ -n "$(OLD_IMAGE_ID)" ] && docker rmi $(OLD_IMAGE_ID) || true
-	@if [ ! -e "$(IMAGE_FILENAME)" ] || [ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] || [ -n "$(OLD_IMAGE_ID)" ]; then \
-		echo === saving image $(CEPH_IMAGE); \
-		mkdir -p $(IMAGE_OUTPUT_DIR); \
-		docker save $(CEPH_IMAGE) | gzip -c > $(IMAGE_FILENAME); \
-	fi
 	@rm -fr $(TEMP)

--- a/images/cockroachdb/Makefile
+++ b/images/cockroachdb/Makefile
@@ -24,12 +24,6 @@ TEMP := $(shell mktemp -d)
 # ====================================================================================
 # Build Rook CockroachDB
 
-# since this is a leaf image we avoid leaving around a lot of dangling images
-# by removing the last build of the final cockroachdb image
-OLD_IMAGE_ID := $(shell docker images -q $(COCKROACHDB_IMAGE))
-CURRENT_IMAGE_ID := $$(docker images -q $(COCKROACHDB_IMAGE))
-IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/cockroachdb.tar.gz
-
 do.build:
 	@echo === docker build $(COCKROACHDB_IMAGE)
 	@cp Dockerfile $(TEMP)
@@ -37,10 +31,4 @@ do.build:
 	@docker build $(BUILD_ARGS) \
 		-t $(COCKROACHDB_IMAGE) \
 		$(TEMP)
-	@[ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] && [ -n "$(OLD_IMAGE_ID)" ] && docker rmi $(OLD_IMAGE_ID) || true
-	@if [ ! -e "$(IMAGE_FILENAME)" ] || [ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] || [ -n "$(OLD_IMAGE_ID)" ]; then \
-		echo === saving image $(COCKROACHDB_IMAGE); \
-		mkdir -p $(IMAGE_OUTPUT_DIR); \
-		docker save $(COCKROACHDB_IMAGE) | gzip -c > $(IMAGE_FILENAME); \
-	fi
 	@rm -fr $(TEMP)

--- a/images/minio/Makefile
+++ b/images/minio/Makefile
@@ -24,12 +24,6 @@ TEMP := $(shell mktemp -d)
 # ====================================================================================
 # Build Rook
 
-# since this is a leaf image we avoid leaving around a lot of dangling images
-# by removing the last build of the final minio image
-OLD_IMAGE_ID := $(shell docker images -q $(MINIO_IMAGE))
-CURRENT_IMAGE_ID := $$(docker images -q $(MINIO_IMAGE))
-IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/minio.tar.gz
-
 do.build:
 	@echo === docker build $(MINIO_IMAGE)
 	@cp Dockerfile $(TEMP)
@@ -38,10 +32,4 @@ do.build:
 		--build-arg ARCH=$(GOARCH) \
 		-t $(MINIO_IMAGE) \
 		$(TEMP)
-	@[ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] && [ -n "$(OLD_IMAGE_ID)" ] && docker rmi $(OLD_IMAGE_ID) || true
-	@if [ ! -e "$(IMAGE_FILENAME)" ] || [ "$(OLD_IMAGE_ID)" != "$(CURRENT_IMAGE_ID)" ] || [ -n "$(OLD_IMAGE_ID)" ]; then \
-		echo === saving image $(MINIO_IMAGE); \
-		mkdir -p $(IMAGE_OUTPUT_DIR); \
-		docker save $(MINIO_IMAGE) | gzip -c > $(IMAGE_FILENAME); \
-	fi
 	@rm -fr $(TEMP)


### PR DESCRIPTION
**Description of your changes:**

Add an option `SKIP_IMAGE_SAVE` to the Ceph image makefiles with the
intent that a developer can set this variable to `1` or some other
nonzero value to skip the lengthy image saving part of the Rook build.
This will allow Ceph developers to iterate more quickly on dev builds.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
