### PR TITLE
Remove unused volume manager parameters

### DIFF
--- a/pkg/daemon/ceph/agent/agent.go
+++ b/pkg/daemon/ceph/agent/agent.go
@@ -63,7 +63,6 @@ func (a *Agent) Run() error {
 	flexvolumeServer := flexvolume.NewFlexvolumeServer(
 		a.context,
 		flexvolumeController,
-		volumeManager,
 	)
 
 	err = rpc.Register(flexvolumeController)
@@ -95,8 +94,7 @@ func (a *Agent) Run() error {
 	clusterController := cluster.NewClusterController(
 		a.context,
 		flexvolumeController,
-		volumeAttachmentController,
-		volumeManager)
+		volumeAttachmentController)
 	stopChan := make(chan struct{})
 	clusterController.StartWatch(v1.NamespaceAll, stopChan)
 

--- a/pkg/daemon/ceph/agent/cluster/controller.go
+++ b/pkg/daemon/ceph/agent/cluster/controller.go
@@ -52,7 +52,7 @@ type ClusterController struct {
 
 // NewClusterController creates a new instance of a ClusterController
 func NewClusterController(context *clusterd.Context, flexvolumeController flexvolume.VolumeController,
-	volumeAttachment attachment.Attachment, manager flexvolume.VolumeManager) *ClusterController {
+	volumeAttachment attachment.Attachment) *ClusterController {
 
 	return &ClusterController{
 		context:              context,

--- a/pkg/daemon/ceph/agent/cluster/controller_test.go
+++ b/pkg/daemon/ceph/agent/cluster/controller_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
-	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/manager"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,7 +76,6 @@ func TestClusterDeleteSingleAttachment(t *testing.T) {
 	deleteAttachmentCalled := false
 	removeAttachmentCalled := false
 
-	flexvolumeManager := &manager.FakeVolumeManager{}
 	volumeAttachmentController := &attachment.MockAttachment{
 		MockList: func(namespace string) (*rookv1alpha2.VolumeList, error) {
 			return existingVolAttachList, nil
@@ -107,7 +105,7 @@ func TestClusterDeleteSingleAttachment(t *testing.T) {
 		},
 	}
 
-	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController, flexvolumeManager)
+	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController)
 
 	// tell the cluster controller that a cluster has been deleted.  the controller will perform the cleanup
 	// async, but block and wait for it all to complete before returning to us, so there should be no races
@@ -160,7 +158,6 @@ func TestClusterDeleteAttachedToOtherNode(t *testing.T) {
 
 	getAttachInfoCalled := false
 
-	flexvolumeManager := &manager.FakeVolumeManager{}
 	volumeAttachmentController := &attachment.MockAttachment{
 		MockList: func(namespace string) (*rookv1alpha2.VolumeList, error) {
 			return existingVolAttachList, nil
@@ -173,7 +170,7 @@ func TestClusterDeleteAttachedToOtherNode(t *testing.T) {
 		},
 	}
 
-	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController, flexvolumeManager)
+	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController)
 
 	// delete the cluster, nothing should happen
 	clusterToDelete := &cephv1beta1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
@@ -226,8 +223,6 @@ func TestClusterDeleteMultiAttachmentRace(t *testing.T) {
 		},
 	}
 
-	flexvolumeManager := &manager.FakeVolumeManager{}
-
 	var lock sync.Mutex
 
 	deleteCount := 0
@@ -274,7 +269,7 @@ func TestClusterDeleteMultiAttachmentRace(t *testing.T) {
 	}
 
 	// kick off the cluster deletion process
-	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController, flexvolumeManager)
+	controller := NewClusterController(context, flexvolumeController, volumeAttachmentController)
 	clusterToDelete := &cephv1beta1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleClusterDelete(clusterToDelete, time.Millisecond)
 

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -55,7 +55,7 @@ type FlexvolumeServer struct {
 }
 
 // NewFlexvolumeServer creates an Flexvolume server
-func NewFlexvolumeServer(context *clusterd.Context, controller *Controller, manager VolumeManager) *FlexvolumeServer {
+func NewFlexvolumeServer(context *clusterd.Context, controller *Controller) *FlexvolumeServer {
 	return &FlexvolumeServer{
 		context:    context,
 		controller: controller,


### PR DESCRIPTION
We don't use volume manager argument in NewClusterController() and NewFlexvolumeServer() functions, so remove the volume manager argument from those functions prototype.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
