### PR TITLE
Correct the usage information of rookflex volume plugin

### DIFF
--- a/cmd/rookflex/cmd/root.go
+++ b/cmd/rookflex/cmd/root.go
@@ -35,7 +35,7 @@ const (
 )
 
 var RootCmd = &cobra.Command{
-	Use:           "rook",
+	Use:           "rookflex",
 	Short:         "Rook Flex volume plugin",
 	SilenceErrors: true,
 	SilenceUsage:  true,


### PR DESCRIPTION
As the `rookflex` volume plugin, the root command should be `rookflex` instead of `rook`, else we'll get below confusing message:

```
...bin/#./rookflex help
Rook Flex volume plugin

Usage:
  rook [command]

Available Commands:
  help        Help about any command
  init        Initialize the volume plugin
  mount       Mounts the volume to the pod volume
  unmount     Unmounts the pod volume
```
Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]