### PR TITLE
Load flex driver more slowly to avoid race condition

### DIFF
--- a/Documentation/openshift.md
+++ b/Documentation/openshift.md
@@ -45,7 +45,8 @@ fsGroup:
 supplementalGroups:
   type: RunAsAny
 allowedFlexVolumes:
-  - driver: "rook.io/rook"
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
 volumes:
   - configMap
   - downwardAPI

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -22,7 +22,8 @@ fsGroup:
 supplementalGroups:
   type: RunAsAny
 allowedFlexVolumes:
-  - driver: "rook.io/rook"
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
 volumes:
   - configMap
   - downwardAPI

--- a/pkg/daemon/ceph/agent/agent.go
+++ b/pkg/daemon/ceph/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
@@ -76,11 +77,20 @@ func (a *Agent) Run() error {
 	}
 
 	flexDriverVendors := []string{flexvolume.FlexvolumeVendor, flexvolume.FlexvolumeVendorLegacy}
-	for _, vendor := range flexDriverVendors {
+	for i, vendor := range flexDriverVendors {
+		if i > 0 {
+			// Wait before the next driver is registered. In 1.11 and newer there is a timing issue if flex drivers are registered too quickly.
+			// See https://github.com/rook/rook/issues/1501 and https://github.com/kubernetes/kubernetes/issues/60694
+			time.Sleep(500 * time.Millisecond)
+		}
+
 		err = flexvolumeServer.Start(vendor, driverName)
 		if err != nil {
 			return fmt.Errorf("failed to start flex volume server %s/%s, %+v", vendor, driverName, err)
 		}
+
+		// Wait before the next driver is registered
+		time.Sleep(500 * time.Millisecond)
 
 		// Register drivers both with the name of the namespace and the name "rook"
 		// for the volume plugins not based on the namespace.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Loading of multiple flex drivers too quickly on 1.11 causes a race condition where the driver(s) fail to load. This will throttle the flex driver loading as a workaround until we transition to a csi driver.

**Which issue is resolved by this Pull Request:**
Resolves #2064

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
