### PR TITLE
ceph osd operator: Allow explicit runAsNonRoot=false

### DIFF
--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -395,9 +395,7 @@ func (c *Cluster) provisionOSDContainer(devices []rookalpha.Device, selection ro
 		privileged = true
 	}
 	runAsUser := int64(0)
-	// don't set runAsNonRoot explicitly when it is false, Kubernetes version < 1.6.4 has
-	// an issue with this fixed in https://github.com/kubernetes/kubernetes/pull/47009
-	// runAsNonRoot := false
+	runAsNonRoot := false
 	readOnlyRootFilesystem := false
 	return v1.Container{
 		// Set the hostname so we have the pod's host in the crush map rather than the pod container name
@@ -407,11 +405,9 @@ func (c *Cluster) provisionOSDContainer(devices []rookalpha.Device, selection ro
 		VolumeMounts: volumeMounts,
 		Env:          envVars,
 		SecurityContext: &v1.SecurityContext{
-			Privileged: &privileged,
-			RunAsUser:  &runAsUser,
-			// don't set runAsNonRoot explicitly when it is false, Kubernetes version < 1.6.4 has
-			// an issue with this fixed in https://github.com/kubernetes/kubernetes/pull/47009
-			// RunAsNonRoot:           &runAsNonRoot,
+			Privileged:             &privileged,
+			RunAsUser:              &runAsUser,
+			RunAsNonRoot:           &runAsNonRoot,
 			ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 		},
 		Resources: resources,


### PR DESCRIPTION
**Description of your changes:**

Rook no longer supports Kubernetes < 1.7
Remove a workaround for k8s < 1.6.4 where `runAsNonRoot` could not be
explicitly set to false.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #1942 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
