### PR TITLE
Roundup the size of the RBD volume image

### DIFF
--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -71,7 +71,10 @@ func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoo
 		size = ImageMinSize
 	}
 
-	sizeMB := int(size / 1024 / 1024)
+	// Roundup the size of the volume image since we only create images on 1MB bundaries and we should never create an image
+	// size that's smaller than the requested one, e.g, requested 1048698 bytes should be 2MB while not be truncated to 1MB
+	sizeMB := int((size + ImageMinSize - 1) / ImageMinSize)
+
 	imageSpec := getImageSpec(name, poolName)
 
 	args := []string{"create", imageSpec, "--size", strconv.Itoa(sizeMB)}


### PR DESCRIPTION
Current code will truncate the generated RBD volume image in some cases, this PR will round up the size to make sure the final RBD image can accommodate the actual data if any.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
