### PR TITLE
Remove unnecessary "-id" from OSD pod names

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -91,8 +91,8 @@ rook-ceph-mgr-a-9c44495df-ln9sq        1/1       Running     0          1m
 rook-ceph-mon-a-69fb9c78cd-58szd       1/1       Running     0          2m
 rook-ceph-mon-b-cf4ddc49c-c756f        1/1       Running     0          2m
 rook-ceph-mon-c-5b467747f4-8cbmv       1/1       Running     0          2m
-rook-ceph-osd-id-0-f6549956d-6z294     1/1       Running     0          1m
-rook-ceph-osd-id-1-5b96b56684-r7zsp    1/1       Running     0          1m
+rook-ceph-osd-0-f6549956d-6z294        1/1       Running     0          1m
+rook-ceph-osd-1-5b96b56684-r7zsp       1/1       Running     0          1m
 rook-ceph-osd-prepare-mynode-ftt57     0/1       Completed   0          1m
 ```
 

--- a/Documentation/upgrade.md
+++ b/Documentation/upgrade.md
@@ -333,12 +333,12 @@ Once they have all been started, you will see the pods running. If they do not s
 ```
 $ kubectl -n rook get pod -l app=rook-ceph-osd
 NAME                                  READY     STATUS    RESTARTS   AGE
-rook-ceph-osd-id-0-5675d6f5f8-r5b2g   1/1       Running   6          6m
-rook-ceph-osd-id-1-69cc6bd8f6-59tcn   1/1       Running   6          6m
-rook-ceph-osd-id-2-74b7cf67c5-mtl92   1/1       Running   6          6m
-rook-ceph-osd-id-3-757b845567-bk259   1/1       Running   6          6m
-rook-ceph-osd-id-4-6cccb5f7d8-wxl2w   1/1       Running   6          6m
-rook-ceph-osd-id-5-5b8598cc9f-2pnfb   1/1       Running   6          6m
+rook-ceph-osd-0-5675d6f5f8-r5b2g      1/1       Running   6          6m
+rook-ceph-osd-1-69cc6bd8f6-59tcn      1/1       Running   6          6m
+rook-ceph-osd-2-74b7cf67c5-mtl92      1/1       Running   6          6m
+rook-ceph-osd-3-757b845567-bk259      1/1       Running   6          6m
+rook-ceph-osd-4-6cccb5f7d8-wxl2w      1/1       Running   6          6m
+rook-ceph-osd-5-5b8598cc9f-2pnfb      1/1       Running   6          6m
 ```
 
 ### Ceph Manager

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -46,7 +46,7 @@ const (
 	appName                      = "rook-ceph-osd"
 	prepareAppName               = "rook-ceph-osd-prepare"
 	prepareAppNameFmt            = "rook-ceph-osd-prepare-%s"
-	osdAppNameFmt                = "rook-ceph-osd-id-%d"
+	osdAppNameFmt                = "rook-ceph-osd-%d"
 	appNameFmt                   = "rook-ceph-osd-%s"
 	osdLabelKey                  = "ceph-osd-id"
 	clusterAvailableSpaceReserve = 0.05

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -267,15 +267,15 @@ func TestDiscoverOSDs(t *testing.T) {
 	assert.Equal(t, 2, len(discovered))
 
 	assert.Equal(t, 2, len(discovered[node1]))
-	if discovered[node1][0].Name == "rook-ceph-osd-id-0" {
-		assert.Equal(t, "rook-ceph-osd-id-101", discovered[node1][1].Name)
+	if discovered[node1][0].Name == "rook-ceph-osd-0" {
+		assert.Equal(t, "rook-ceph-osd-101", discovered[node1][1].Name)
 	} else {
-		assert.Equal(t, "rook-ceph-osd-id-101", discovered[node1][0].Name)
-		assert.Equal(t, "rook-ceph-osd-id-0", discovered[node1][1].Name)
+		assert.Equal(t, "rook-ceph-osd-101", discovered[node1][0].Name)
+		assert.Equal(t, "rook-ceph-osd-0", discovered[node1][1].Name)
 	}
 
 	assert.Equal(t, 1, len(discovered[node2]))
-	assert.Equal(t, "rook-ceph-osd-id-23", discovered[node2][0].Name)
+	assert.Equal(t, "rook-ceph-osd-23", discovered[node2][0].Name)
 }
 
 func TestAddNodeFailure(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -77,7 +77,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	deployment, err := c.makeDeployment(n.Name, devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
-	assert.Equal(t, "rook-ceph-osd-id-0", deployment.Name)
+	assert.Equal(t, "rook-ceph-osd-0", deployment.Name)
 	assert.Equal(t, c.Namespace, deployment.Namespace)
 	assert.Equal(t, "mysa", deployment.Spec.Template.Spec.ServiceAccountName)
 	assert.Equal(t, int32(1), *(deployment.Spec.Replicas))
@@ -289,7 +289,7 @@ func TestHostNetwork(t *testing.T) {
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
 
-	assert.Equal(t, "rook-ceph-osd-id-0", r.ObjectMeta.Name)
+	assert.Equal(t, "rook-ceph-osd-0", r.ObjectMeta.Name)
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
 }

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -173,7 +173,7 @@ func GetPodPhaseMap(pods *v1.PodList) map[v1.PodPhase][]string {
 
 // DeleteDeployment makes a best effort at deleting a deployment and its pods, then waits for them to be deleted
 func DeleteDeployment(clientset kubernetes.Interface, namespace, name string) error {
-	logger.Infof("removing %s deployment if it exists", name)
+	logger.Debugf("removing %s deployment if it exists", name)
 	deleteAction := func(options *metav1.DeleteOptions) error {
 		return clientset.ExtensionsV1beta1().Deployments(namespace).Delete(name, options)
 	}


### PR DESCRIPTION
The -id portion of the name is unnecessary and inconsistent with the other
pod names.



<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)