### PR TITLE
Ceph: Refactor daemon/mon module's config and keyring generation into cephconfig module

### DIFF
--- a/cmd/rook/ceph/agent.go
+++ b/cmd/rook/ceph/agent.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/ceph.go
+++ b/cmd/rook/ceph/ceph.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (
@@ -21,7 +22,7 @@ import (
 
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/flags"
@@ -35,7 +36,7 @@ var Cmd = &cobra.Command{
 
 var (
 	cfg         = &config{}
-	clusterInfo mon.ClusterInfo
+	clusterInfo cephconfig.ClusterInfo
 	logger      = capnslog.NewPackageLogger("github.com/rook/rook", "cephcmd")
 )
 

--- a/cmd/rook/ceph/mds.go
+++ b/cmd/rook/ceph/mds.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/mds_test.go
+++ b/cmd/rook/ceph/mds_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/mon.go
+++ b/cmd/rook/ceph/mon.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (
@@ -22,6 +23,7 @@ import (
 
 	"github.com/go-ini/ini"
 	"github.com/rook/rook/cmd/rook/rook"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
@@ -72,7 +74,7 @@ func startMon(cmd *cobra.Command, args []string) error {
 
 	// at first start the local monitor needs to be added to the list of mons
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	clusterInfo.Monitors[monName] = mon.ToCephMon(monName, cfg.NetworkInfo().PublicAddr, monPort)
+	clusterInfo.Monitors[monName] = cephconfig.NewMonInfo(monName, cfg.NetworkInfo().PublicAddr, monPort)
 
 	monCfg := &mon.Config{
 		Name:    monName,

--- a/cmd/rook/ceph/mon_test.go
+++ b/cmd/rook/ceph/mon_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/cmd/rook/ceph/rgw.go
+++ b/cmd/rook/ceph/rgw.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ceph
 
 import (
@@ -25,7 +26,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
-	cephmon "github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/util"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/util/sys"
@@ -190,7 +191,7 @@ func getClusterInfo(context *clusterd.Context, clusterNamespace string) (string,
 		return "", "", err
 	}
 
-	keyring := fmt.Sprintf(cephmon.AdminKeyringTemplate, clusterInfo.AdminSecret)
+	keyring := cephconfig.AdminKeyring(clusterInfo)
 	if err := ioutil.WriteFile(keyringFile.Name(), []byte(keyring), 0644); err != nil {
 		return "", "", fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringFile.Name(), err)
 	}

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config provides methods for creating and formatting Ceph configuration files for daemons.
+package config
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/go-ini/ini"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephconfig")
+
+const (
+	// DefaultConfigDir is the default dir where Ceph stores its configs
+	DefaultConfigDir = "/etc/ceph"
+	// DefaultConfigFile is the default name of the file where Ceph stores its configs
+	DefaultConfigFile = "ceph.conf"
+	// DefaultKeyringFile is the default name of the file where Ceph stores its keyring info
+	DefaultKeyringFile = "keyring"
+)
+
+// GlobalConfig represents the [global] sections of Ceph's config file.
+type GlobalConfig struct {
+	EnableExperimental       string `ini:"enable experimental unrecoverable data corrupting features,omitempty"`
+	FSID                     string `ini:"fsid,omitempty"`
+	RunDir                   string `ini:"run dir,omitempty"`
+	MonMembers               string `ini:"mon initial members,omitempty"`
+	MonHost                  string `ini:"mon host"`
+	LogFile                  string `ini:"log file,omitempty"`
+	MonClusterLogFile        string `ini:"mon cluster log file,omitempty"`
+	PublicAddr               string `ini:"public addr,omitempty"`
+	PublicNetwork            string `ini:"public network,omitempty"`
+	ClusterAddr              string `ini:"cluster addr,omitempty"`
+	ClusterNetwork           string `ini:"cluster network,omitempty"`
+	MonKeyValueDb            string `ini:"mon keyvaluedb"`
+	MonAllowPoolDelete       bool   `ini:"mon_allow_pool_delete"`
+	MaxPgsPerOsd             int    `ini:"mon_max_pg_per_osd"`
+	DebugLogDefaultLevel     int    `ini:"debug default"`
+	DebugLogRadosLevel       int    `ini:"debug rados"`
+	DebugLogMonLevel         int    `ini:"debug mon"`
+	DebugLogOSDLevel         int    `ini:"debug osd"`
+	DebugLogBluestoreLevel   int    `ini:"debug bluestore"`
+	DebugLogFilestoreLevel   int    `ini:"debug filestore"`
+	DebugLogJournalLevel     int    `ini:"debug journal"`
+	DebugLogLevelDBLevel     int    `ini:"debug leveldb"`
+	FileStoreOmapBackend     string `ini:"filestore_omap_backend"`
+	OsdPgBits                int    `ini:"osd pg bits,omitempty"`
+	OsdPgpBits               int    `ini:"osd pgp bits,omitempty"`
+	OsdPoolDefaultSize       int    `ini:"osd pool default size,omitempty"`
+	OsdPoolDefaultMinSize    int    `ini:"osd pool default min size,omitempty"`
+	OsdPoolDefaultPgNum      int    `ini:"osd pool default pg num,omitempty"`
+	OsdPoolDefaultPgpNum     int    `ini:"osd pool default pgp num,omitempty"`
+	OsdMaxObjectNameLen      int    `ini:"osd max object name len,omitempty"`
+	OsdMaxObjectNamespaceLen int    `ini:"osd max object namespace len,omitempty"`
+	OsdObjectStore           string `ini:"osd objectstore,omitempty"`
+	CrushLocation            string `ini:"crush location,omitempty"`
+	RbdDefaultFeatures       int    `ini:"rbd_default_features,omitempty"`
+	FatalSignalHandlers      string `ini:"fatal signal handlers"`
+}
+
+// CephConfig represents an entire Ceph config including all sections.
+type CephConfig struct {
+	*GlobalConfig `ini:"global,omitempty"`
+}
+
+// DefaultConfigFilePath returns the full path to Ceph's default config file
+func DefaultConfigFilePath() string {
+	return path.Join(DefaultConfigDir, DefaultConfigFile)
+}
+
+// DefaultKeyringFilePath returns the full path to Ceph's default keyring file
+func DefaultKeyringFilePath() string {
+	return path.Join(DefaultConfigDir, DefaultKeyringFile)
+}
+
+// GetConfFilePath gets the path of a given cluster's config file
+func GetConfFilePath(root, clusterName string) string {
+	return fmt.Sprintf("%s/%s.config", root, clusterName)
+}
+
+// GenerateAdminConnectionConfig calls GenerateAdminConnectionConfigWithSettings with no settings
+// overridden.
+func GenerateAdminConnectionConfig(context *clusterd.Context, cluster *ClusterInfo) error {
+	return GenerateAdminConnectionConfigWithSettings(context, cluster, nil)
+}
+
+// GenerateAdminConnectionConfigWithSettings generates a Ceph config and keyring which will allow
+// the daemon to connect as an admin. Default config file settings can be overridden by specifying
+// some subset of settings.
+func GenerateAdminConnectionConfigWithSettings(context *clusterd.Context, cluster *ClusterInfo, settings *CephConfig) error {
+	root := path.Join(context.ConfigDir, cluster.Name)
+	keyringPath := path.Join(root, fmt.Sprintf("%s.keyring", client.AdminUsername))
+	err := writeKeyring(AdminKeyring(cluster), keyringPath)
+	if err != nil {
+		return fmt.Errorf("failed to write keyring to %s. %+v", root, err)
+	}
+
+	if _, err = GenerateConfigFile(context, cluster, root, client.AdminUsername, keyringPath, settings, nil); err != nil {
+		return fmt.Errorf("failed to write config to %s. %+v", root, err)
+	}
+	logger.Infof("generated admin config in %s", root)
+	return nil
+}
+
+// GenerateConfigFile generates and writes a config file to disk.
+func GenerateConfigFile(context *clusterd.Context,
+	cluster *ClusterInfo,
+	pathRoot, user, keyringPath string,
+	globalConfig *CephConfig,
+	clientSettings map[string]string) (string, error) {
+
+	// create the config directory
+	if err := os.MkdirAll(pathRoot, 0744); err != nil {
+		logger.Warningf("failed to create config directory at %s: %+v", pathRoot, err)
+	}
+
+	configFile, err := createGlobalConfigFileSection(context, cluster, pathRoot, globalConfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to create global config section, %+v", err)
+	}
+
+	qualifiedUser := getQualifiedUser(user)
+	if err := addClientConfigFileSection(configFile, qualifiedUser, keyringPath, clientSettings); err != nil {
+		return "", fmt.Errorf("failed to add admin client config section, %+v", err)
+	}
+
+	// if there's a config file override path given, process the given config file
+	if context.ConfigFileOverride != "" {
+		err := configFile.Append(context.ConfigFileOverride)
+		if err != nil {
+			// log the config file override failure as a warning, but proceed without it
+			logger.Warningf("failed to add config file override from '%s': %+v", context.ConfigFileOverride, err)
+		}
+	}
+
+	// write the entire config to disk
+	filePath := GetConfFilePath(pathRoot, cluster.Name)
+	logger.Infof("writing config file %s", filePath)
+	if err := configFile.SaveTo(filePath); err != nil {
+		return "", fmt.Errorf("failed to save config file %s. %+v", filePath, err)
+	}
+
+	// copy the config to /etc/ceph/ceph.conf
+	defaultPath := DefaultConfigFilePath()
+	logger.Infof("copying config to %s", defaultPath)
+	if err := configFile.SaveTo(defaultPath); err != nil {
+		logger.Warningf("failed to save config file %s. %+v", defaultPath, err)
+	}
+
+	return filePath, nil
+}
+
+// prepends "client." if a user namespace is not already specified
+func getQualifiedUser(user string) string {
+	if strings.Index(user, ".") == -1 {
+		return fmt.Sprintf("client.%s", user)
+	}
+
+	return user
+}
+
+// CreateDefaultCephConfig creates a default ceph config file.
+func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, runDir string) *CephConfig {
+	// extract a list of just the monitor names, which will populate the "mon initial members"
+	// global config field
+	monMembers := make([]string, len(cluster.Monitors))
+	monHosts := make([]string, len(cluster.Monitors))
+	i := 0
+	for _, monitor := range cluster.Monitors {
+		monMembers[i] = monitor.Name
+		monHosts[i] = monitor.Endpoint
+		i++
+	}
+
+	cephLogLevel := logLevelToCephLogLevel(context.LogLevel)
+
+	return &CephConfig{
+		GlobalConfig: &GlobalConfig{
+			FSID:                   cluster.FSID,
+			RunDir:                 runDir,
+			MonMembers:             strings.Join(monMembers, " "),
+			MonHost:                strings.Join(monHosts, ","),
+			LogFile:                "/dev/stdout",
+			MonClusterLogFile:      "/dev/stdout",
+			PublicAddr:             context.NetworkInfo.PublicAddr,
+			PublicNetwork:          context.NetworkInfo.PublicNetwork,
+			ClusterAddr:            context.NetworkInfo.ClusterAddr,
+			ClusterNetwork:         context.NetworkInfo.ClusterNetwork,
+			MonKeyValueDb:          "rocksdb",
+			MonAllowPoolDelete:     true,
+			MaxPgsPerOsd:           1000,
+			DebugLogDefaultLevel:   cephLogLevel,
+			DebugLogRadosLevel:     cephLogLevel,
+			DebugLogMonLevel:       cephLogLevel,
+			DebugLogOSDLevel:       cephLogLevel,
+			DebugLogBluestoreLevel: cephLogLevel,
+			DebugLogFilestoreLevel: cephLogLevel,
+			DebugLogJournalLevel:   cephLogLevel,
+			DebugLogLevelDBLevel:   cephLogLevel,
+			FileStoreOmapBackend:   "rocksdb",
+			OsdPgBits:              11,
+			OsdPgpBits:             11,
+			OsdPoolDefaultSize:     1,
+			OsdPoolDefaultMinSize:  1,
+			OsdPoolDefaultPgNum:    100,
+			OsdPoolDefaultPgpNum:   100,
+			RbdDefaultFeatures:     3,
+			FatalSignalHandlers:    "false",
+		},
+	}
+}
+
+// create a config file with global settings configured, and return an ini file
+func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterInfo, runDir string, userConfig *CephConfig) (*ini.File, error) {
+
+	var ceph *CephConfig
+
+	if userConfig != nil {
+		// use the user config since it was provided
+		ceph = userConfig
+	} else {
+		ceph = CreateDefaultCephConfig(context, cluster, runDir)
+	}
+
+	configFile := ini.Empty()
+	err := ini.ReflectFrom(configFile, ceph)
+	return configFile, err
+}
+
+// add client config to the ini file
+func addClientConfigFileSection(configFile *ini.File, clientName, keyringPath string, settings map[string]string) error {
+	s, err := configFile.NewSection(clientName)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.NewKey("keyring", keyringPath); err != nil {
+		return err
+	}
+
+	for key, val := range settings {
+		if _, err := s.NewKey(key, val); err != nil {
+			return fmt.Errorf("failed to add key %s. %v", key, err)
+		}
+	}
+
+	return nil
+}
+
+// convert a Rook log level to a corresponding Ceph log level
+func logLevelToCephLogLevel(logLevel capnslog.LogLevel) int {
+	switch logLevel {
+	case capnslog.CRITICAL:
+	case capnslog.ERROR:
+	case capnslog.WARNING:
+		return -1
+	case capnslog.NOTICE:
+	case capnslog.INFO:
+		return 0
+	case capnslog.DEBUG:
+		return 10
+	case capnslog.TRACE:
+		return 100
+	}
+
+	return 0
+}

--- a/pkg/daemon/ceph/config/config_test.go
+++ b/pkg/daemon/ceph/config/config_test.go
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package mon
+
+package config
 
 import (
 	"io/ioutil"
@@ -34,7 +35,7 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 		MonitorSecret: "monsecret",
 		AdminSecret:   "adminsecret",
 		Name:          "foo-cluster",
-		Monitors: map[string]*CephMonitorConfig{
+		Monitors: map[string]*MonInfo{
 			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6790"},
 			"node1": {Name: "mon1", Endpoint: "10.0.0.2:6790"},
 		},
@@ -96,7 +97,7 @@ debug bluestore = 1234`
 		MonitorSecret: "monsecret",
 		AdminSecret:   "adminsecret",
 		Name:          "foo-cluster",
-		Monitors: map[string]*CephMonitorConfig{
+		Monitors: map[string]*MonInfo{
 			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6790"},
 		},
 	}
@@ -115,7 +116,7 @@ debug bluestore = 1234`
 	verifyConfigValue(t, actualConf, "global", "debug bluestore", "1234")
 }
 
-func verifyConfig(t *testing.T, cephConfig *cephConfig, expectedMonMembers string, loggingLevel int) {
+func verifyConfig(t *testing.T, cephConfig *CephConfig, expectedMonMembers string, loggingLevel int) {
 
 	for _, expectedMon := range strings.Split(expectedMonMembers, " ") {
 		contained := false

--- a/pkg/daemon/ceph/config/info.go
+++ b/pkg/daemon/ceph/config/info.go
@@ -1,34 +1,43 @@
 /*
 Copyright 2016 The Rook Authors. All rights reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
 	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package mon
+
+package config
 
 import (
 	"fmt"
-	"strings"
+	"net"
 )
 
+// ClusterInfo is a collection of information about a particular Ceph cluster. Rook uses information
+// about the cluster to configure daemons to connect to the desired cluster.
 type ClusterInfo struct {
 	FSID          string
 	MonitorSecret string
 	AdminSecret   string
 	Name          string
-	Monitors      map[string]*CephMonitorConfig
+	Monitors      map[string]*MonInfo
 }
 
-func (c *ClusterInfo) MonEndpoints() string {
-	var endpoints []string
-	for _, mon := range c.Monitors {
-		endpoints = append(endpoints, fmt.Sprintf("%s-%s", mon.Name, mon.Endpoint))
-	}
-	return strings.Join(endpoints, ",")
+// MonInfo is a collection of information about a Ceph mon.
+type MonInfo struct {
+	Name     string `json:"name"`
+	Endpoint string `json:"endpoint"`
+}
+
+// NewMonInfo returns a new Ceph mon info struct from the given inputs.
+func NewMonInfo(name, ip string, port int32) *MonInfo {
+	return &MonInfo{Name: name, Endpoint: net.JoinHostPort(ip, fmt.Sprintf("%d", port))}
 }

--- a/pkg/daemon/ceph/config/keyring.go
+++ b/pkg/daemon/ceph/config/keyring.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+)
+
+const (
+	// AdminKeyringTemplate is a string template of Ceph keyring settings which allow connection
+	// as admin. The key value must be filled in by the admin auth key for the cluster.
+	AdminKeyringTemplate = `
+	[client.admin]
+		key = %s
+		auid = 0
+		caps mds = "allow *"
+		caps mon = "allow *"
+		caps osd = "allow *"
+		caps mgr = "allow *"
+	`
+)
+
+// AdminKeyring returns the filled-out admin keyring
+func AdminKeyring(c *ClusterInfo) string {
+	return fmt.Sprintf(AdminKeyringTemplate, c.AdminSecret)
+}
+
+// WriteKeyring calls the generate contents function with auth key as an argument then saves the
+// output of the generateContents function to disk at the keyring path
+// TODO: Kludgey; can keyring files be generated w/ go-ini package or using the '-o' option to
+// 'ceph auth get-or-create ...'?
+func WriteKeyring(keyringPath, authKey string, generateContents func(string) string) error {
+	contents := generateContents(authKey)
+	return writeKeyring(contents, keyringPath)
+}
+
+// CreateKeyring creates a keyring for access to the cluster with the desired set of privileges
+// and writes it to disk at the keyring path
+func CreateKeyring(context *clusterd.Context, clusterName, username, keyringPath string, access []string, generateContents func(string) string) error {
+	_, err := os.Stat(keyringPath)
+	if err == nil {
+		// no error, the file exists, bail out with no error
+		logger.Debugf("keyring already exists at %s", keyringPath)
+		return nil
+	} else if !os.IsNotExist(err) {
+		// some other error besides "does not exist", bail out with error
+		return fmt.Errorf("failed to stat %s: %+v", keyringPath, err)
+	}
+
+	// get-or-create-key for the user account
+	key, err := client.AuthGetOrCreateKey(context, clusterName, username, access)
+	if err != nil {
+		return fmt.Errorf("failed to get or create auth key for %s. %+v", username, err)
+	}
+
+	return WriteKeyring(keyringPath, key, generateContents)
+}
+
+// writes the keyring to disk
+// TODO: Write keyring only to the default ceph config location since we are in a container
+func writeKeyring(keyring, keyringPath string) error {
+	// save the keyring to the given path
+	if err := os.MkdirAll(filepath.Dir(keyringPath), 0744); err != nil {
+		return fmt.Errorf("failed to create keyring directory for %s: %+v", keyringPath, err)
+	}
+	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0644); err != nil {
+		return fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringPath, err)
+	}
+
+	// Save the keyring to the default path. This allows the user to any pod to easily execute Ceph commands.
+	// It is recommended to connect to the operator pod rather than monitors and OSDs since the operator always has the latest configuration files.
+	// The mon and OSD pods will only re-create the config files when the pod is restarted. If a monitor fails over, the config
+	// in the other mon and osd pods may be out of date. This could cause your ceph commands to timeout connecting to invalid mons.
+	// Note that the running mon and osd daemons are not affected by this issue because of their live connection to the mon quorum.
+	// If you have multiple Rook clusters, it is preferred to connect to the Rook toolbox for a specific cluster. Otherwise, your ceph commands
+	// may connect to the wrong cluster.
+	if err := os.MkdirAll(DefaultConfigDir, 0744); err != nil {
+		logger.Warningf("failed to create default directory %s: %+v", DefaultConfigDir, err)
+		return nil
+	}
+	defaultPath := DefaultKeyringFilePath()
+	if err := ioutil.WriteFile(defaultPath, []byte(keyring), 0644); err != nil {
+		logger.Warningf("failed to copy keyring to %s: %+v", defaultPath, err)
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/daemon/ceph/mds/daemon.go
+++ b/pkg/daemon/ceph/mds/daemon.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mds
 
 import (
@@ -23,7 +24,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/util"
 )
 
@@ -43,7 +44,7 @@ type Config struct {
 	FilesystemID  string
 	ID            string
 	ActiveStandby bool
-	ClusterInfo   *mon.ClusterInfo
+	ClusterInfo   *cephconfig.ClusterInfo
 }
 
 func Run(context *clusterd.Context, config *Config) error {
@@ -63,7 +64,7 @@ func Run(context *clusterd.Context, config *Config) error {
 
 func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	// write the latest config to the config dir
-	if err := mon.GenerateAdminConnectionConfig(context, config.ClusterInfo); err != nil {
+	if err := cephconfig.GenerateAdminConnectionConfig(context, config.ClusterInfo); err != nil {
 		return fmt.Errorf("failed to write connection config. %+v", err)
 	}
 
@@ -80,7 +81,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	}
 
 	keyringPath := getMDSKeyringPath(context.ConfigDir)
-	_, err = mon.GenerateConfigFile(context, config.ClusterInfo, getMDSConfDir(context.ConfigDir),
+	_, err = cephconfig.GenerateConfigFile(context, config.ClusterInfo, getMDSConfDir(context.ConfigDir),
 		fmt.Sprintf("mds.%s", config.ID), keyringPath, nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create mds config file. %+v", err)
@@ -91,7 +92,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		return r
 	}
 
-	err = mon.WriteKeyring(keyringPath, keyring, keyringEval)
+	err = cephconfig.WriteKeyring(keyringPath, keyring, keyringEval)
 	if err != nil {
 		return fmt.Errorf("failed to create mds keyring. %+v", err)
 	}

--- a/pkg/daemon/ceph/mgr/daemon.go
+++ b/pkg/daemon/ceph/mgr/daemon.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mgr
 
 import (
@@ -21,7 +22,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/util"
 )
 
@@ -41,7 +42,7 @@ const (
 )
 
 type Config struct {
-	ClusterInfo *mon.ClusterInfo
+	ClusterInfo *cephconfig.ClusterInfo
 	Name        string
 	Keyring     string
 }
@@ -68,7 +69,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		"mgr data": confDir,
 	}
 	logger.Infof("Conf files: dir=%s keyring=%s", confDir, keyringPath)
-	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, confDir,
+	_, err := cephconfig.GenerateConfigFile(context, config.ClusterInfo, confDir,
 		username, keyringPath, nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create config file. %+v", err)
@@ -78,7 +79,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		return fmt.Sprintf(keyringTemplate, config.Name, key)
 	}
 
-	err = mon.WriteKeyring(keyringPath, config.Keyring, keyringEval)
+	err = cephconfig.WriteKeyring(keyringPath, config.Keyring, keyringEval)
 	if err != nil {
 		return fmt.Errorf("failed to create mds keyring. %+v", err)
 	}

--- a/pkg/daemon/ceph/mon/config.go
+++ b/pkg/daemon/ceph/mon/config.go
@@ -13,92 +13,34 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mon
 
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
-	"github.com/go-ini/ini"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+)
+
+const (
+	// The final string field is for the admin keyring
+	monitorKeyringTemplate = `
+	[mon.]
+		key = %s
+		caps mon = "allow *"
+
+	%s`
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephmon")
 
-const (
-	MonitorKeyringTemplate = `
-	[mon.]
-		key = %s
-		caps mon = "allow *"` + AdminKeyringTemplate
-
-	AdminKeyringTemplate = `
-	[client.admin]
-		key = %s
-		auid = 0
-		caps mds = "allow *"
-		caps mon = "allow *"
-		caps osd = "allow *"
-		caps mgr = "allow *"
-	`
-	defaultConfigDir   = "/etc/ceph"
-	defaultConfigFile  = "ceph.conf"
-	defaultKeyringFile = "keyring"
-)
-
-type CephMonitorConfig struct {
-	Name     string `json:"name"`
-	Endpoint string `json:"endpoint"`
-}
-
-type cephConfig struct {
-	*GlobalConfig `ini:"global,omitempty"`
-}
-
-type GlobalConfig struct {
-	EnableExperimental       string `ini:"enable experimental unrecoverable data corrupting features,omitempty"`
-	FSID                     string `ini:"fsid,omitempty"`
-	RunDir                   string `ini:"run dir,omitempty"`
-	MonMembers               string `ini:"mon initial members,omitempty"`
-	MonHost                  string `ini:"mon host"`
-	LogFile                  string `ini:"log file,omitempty"`
-	MonClusterLogFile        string `ini:"mon cluster log file,omitempty"`
-	PublicAddr               string `ini:"public addr,omitempty"`
-	PublicNetwork            string `ini:"public network,omitempty"`
-	ClusterAddr              string `ini:"cluster addr,omitempty"`
-	ClusterNetwork           string `ini:"cluster network,omitempty"`
-	MonKeyValueDb            string `ini:"mon keyvaluedb"`
-	MonAllowPoolDelete       bool   `ini:"mon_allow_pool_delete"`
-	MaxPgsPerOsd             int    `ini:"mon_max_pg_per_osd"`
-	DebugLogDefaultLevel     int    `ini:"debug default"`
-	DebugLogRadosLevel       int    `ini:"debug rados"`
-	DebugLogMonLevel         int    `ini:"debug mon"`
-	DebugLogOSDLevel         int    `ini:"debug osd"`
-	DebugLogBluestoreLevel   int    `ini:"debug bluestore"`
-	DebugLogFilestoreLevel   int    `ini:"debug filestore"`
-	DebugLogJournalLevel     int    `ini:"debug journal"`
-	DebugLogLevelDBLevel     int    `ini:"debug leveldb"`
-	FileStoreOmapBackend     string `ini:"filestore_omap_backend"`
-	OsdPgBits                int    `ini:"osd pg bits,omitempty"`
-	OsdPgpBits               int    `ini:"osd pgp bits,omitempty"`
-	OsdPoolDefaultSize       int    `ini:"osd pool default size,omitempty"`
-	OsdPoolDefaultMinSize    int    `ini:"osd pool default min size,omitempty"`
-	OsdPoolDefaultPgNum      int    `ini:"osd pool default pg num,omitempty"`
-	OsdPoolDefaultPgpNum     int    `ini:"osd pool default pgp num,omitempty"`
-	OsdMaxObjectNameLen      int    `ini:"osd max object name len,omitempty"`
-	OsdMaxObjectNamespaceLen int    `ini:"osd max object namespace len,omitempty"`
-	OsdObjectStore           string `ini:"osd objectstore,omitempty"`
-	CrushLocation            string `ini:"crush location,omitempty"`
-	RbdDefaultFeatures       int    `ini:"rbd_default_features,omitempty"`
-	FatalSignalHandlers      string `ini:"fatal signal handlers"`
-}
-
-// get the path of a given monitor's run dir
+// GetMonRunDirPath returns the path of a given monitor's run dir
 func GetMonRunDirPath(configDir, monName string) string {
 	if strings.Index(monName, "mon") == -1 {
 		// if the mon name doesn't have "mon" in it, include it in the directory
@@ -109,7 +51,7 @@ func GetMonRunDirPath(configDir, monName string) string {
 
 // get the path of a given monitor's keyring
 func getMonKeyringPath(configDir, monName string) string {
-	return filepath.Join(GetMonRunDirPath(configDir, monName), defaultKeyringFile)
+	return filepath.Join(GetMonRunDirPath(configDir, monName), cephconfig.DefaultKeyringFile)
 }
 
 // get the path of a given monitor's data dir
@@ -117,266 +59,15 @@ func getMonDataDirPath(configDir, monName string) string {
 	return filepath.Join(GetMonRunDirPath(configDir, monName), "data")
 }
 
-// get the path of a given monitor's config file
-func GetConfFilePath(root, clusterName string) string {
-	return fmt.Sprintf("%s/%s.config", root, clusterName)
-}
-
-func GenerateAdminConnectionConfig(context *clusterd.Context, cluster *ClusterInfo) error {
-	return GenerateAdminConnectionConfigWithSettings(context, cluster, nil)
-}
-
-func GenerateAdminConnectionConfigWithSettings(context *clusterd.Context, cluster *ClusterInfo, settings *cephConfig) error {
-	root := path.Join(context.ConfigDir, cluster.Name)
-	keyring := fmt.Sprintf(AdminKeyringTemplate, cluster.AdminSecret)
-	keyringPath := path.Join(root, fmt.Sprintf("%s.keyring", client.AdminUsername))
-	err := writeKeyring(keyring, keyringPath)
-	if err != nil {
-		return fmt.Errorf("failed to write keyring to %s. %+v", root, err)
-	}
-
-	if _, err = GenerateConfigFile(context, cluster, root, client.AdminUsername, keyringPath, settings, nil); err != nil {
-		return fmt.Errorf("failed to write config to %s. %+v", root, err)
-	}
-	logger.Infof("generated admin config in %s", root)
-	return nil
-}
-
-func writeMonKeyring(context *clusterd.Context, c *ClusterInfo, name string) error {
+func writeMonKeyring(context *clusterd.Context, c *cephconfig.ClusterInfo, name string) error {
 	keyringPath := getMonKeyringPath(context.ConfigDir, name)
-	keyring := fmt.Sprintf(MonitorKeyringTemplate, c.MonitorSecret, c.AdminSecret)
-	return writeKeyring(keyring, keyringPath)
-}
-
-// writes the monitor keyring to disk
-func writeKeyring(keyring, keyringPath string) error {
-	// save the keyring to the given path
-	if err := os.MkdirAll(filepath.Dir(keyringPath), 0744); err != nil {
-		return fmt.Errorf("failed to create keyring directory for %s: %+v", keyringPath, err)
-	}
-	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0644); err != nil {
-		return fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringPath, err)
-	}
-
-	// Save the keyring to the default path. This allows the user to any pod to easily execute Ceph commands.
-	// It is recommended to connect to the operator pod rather than monitors and OSDs since the operator always has the latest configuration files.
-	// The mon and OSD pods will only re-create the config files when the pod is restarted. If a monitor fails over, the config
-	// in the other mon and osd pods may be out of date. This could cause your ceph commands to timeout connecting to invalid mons.
-	// Note that the running mon and osd daemons are not affected by this issue because of their live connection to the mon quorum.
-	// If you have multiple Rook clusters, it is preferred to connect to the Rook toolbox for a specific cluster. Otherwise, your ceph commands
-	// may connect to the wrong cluster.
-	if err := os.MkdirAll(defaultConfigDir, 0744); err != nil {
-		logger.Warningf("failed to create default directory %s: %+v", defaultConfigDir, err)
-		return nil
-	}
-	defaultPath := path.Join(defaultConfigDir, defaultKeyringFile)
-	if err := ioutil.WriteFile(defaultPath, []byte(keyring), 0644); err != nil {
-		logger.Warningf("failed to copy keyring to %s: %+v", defaultPath, err)
-		return nil
-	}
-
-	return nil
-}
-
-func WriteKeyring(keyringPath, keyring string, generateContents func(string) string) error {
-	// write the keyring to disk
-	contents := generateContents(keyring)
-	return writeKeyring(contents, keyringPath)
+	keyring := fmt.Sprintf(monitorKeyringTemplate, c.MonitorSecret, cephconfig.AdminKeyring(c))
+	return cephconfig.WriteKeyring(keyringPath, "", func(_ string) string { return keyring })
 }
 
 // generates and writes the monitor config file to disk
-func GenerateConnectionConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoot, user, keyringPath string) (string, error) {
-	return GenerateConfigFile(context, cluster, pathRoot, user, keyringPath, nil, nil)
-}
-
-// generates and writes the monitor config file to disk
-func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoot, user, keyringPath string,
-	globalConfig *cephConfig, clientSettings map[string]string) (string, error) {
-
-	if pathRoot == "" {
-		pathRoot = GetMonRunDirPath(context.ConfigDir, getFirstMonitor(cluster))
-	}
-
-	// create the config directory
-	if err := os.MkdirAll(pathRoot, 0744); err != nil {
-		logger.Warningf("failed to create config directory at %s: %+v", pathRoot, err)
-	}
-
-	configFile, err := createGlobalConfigFileSection(context, cluster, pathRoot, globalConfig)
-	if err != nil {
-		return "", fmt.Errorf("failed to create global config section, %+v", err)
-	}
-
-	if err := addClientConfigFileSection(configFile, getQualifiedUser(user), keyringPath, clientSettings); err != nil {
-		return "", fmt.Errorf("failed to add admin client config section, %+v", err)
-	}
-
-	// if there's a config file override path given, process the given config file
-	if context.ConfigFileOverride != "" {
-		err := configFile.Append(context.ConfigFileOverride)
-		if err != nil {
-			// log the config file override failure as a warning, but proceed without it
-			logger.Warningf("failed to add config file override from '%s': %+v", context.ConfigFileOverride, err)
-		}
-	}
-
-	// write the entire config to disk
-	filePath := GetConfFilePath(pathRoot, cluster.Name)
-	logger.Infof("writing config file %s", filePath)
-	if err := configFile.SaveTo(filePath); err != nil {
-		return "", fmt.Errorf("failed to save config file %s. %+v", filePath, err)
-	}
-
-	// copy the config to /etc/ceph/ceph.conf
-	defaultPath := path.Join(defaultConfigDir, defaultConfigFile)
-	logger.Infof("copying config to %s", defaultPath)
-	if err := configFile.SaveTo(defaultPath); err != nil {
-		logger.Warningf("failed to save config file %s. %+v", defaultPath, err)
-	}
-
-	return filePath, nil
-}
-
-// create a keyring for access to the cluster, with the desired set of privileges
-func CreateKeyring(context *clusterd.Context, clusterName, username, keyringPath string, access []string, generateContents func(string) string) error {
-	_, err := os.Stat(keyringPath)
-	if err == nil {
-		// no error, the file exists, bail out with no error
-		logger.Debugf("keyring already exists at %s", keyringPath)
-		return nil
-	} else if !os.IsNotExist(err) {
-		// some other error besides "does not exist", bail out with error
-		return fmt.Errorf("failed to stat %s: %+v", keyringPath, err)
-	}
-
-	// get-or-create-key for the user account
-	key, err := client.AuthGetOrCreateKey(context, clusterName, username, access)
-	if err != nil {
-		return fmt.Errorf("failed to get or create auth key for %s. %+v", username, err)
-	}
-
-	return WriteKeyring(keyringPath, key, generateContents)
-}
-
-// prepends "client." if a user namespace is not already specified
-func getQualifiedUser(user string) string {
-	if strings.Index(user, ".") == -1 {
-		return fmt.Sprintf("client.%s", user)
-	}
-
-	return user
-}
-
-func getFirstMonitor(cluster *ClusterInfo) string {
-	// Get the first monitor
-	for _, m := range cluster.Monitors {
-		return m.Name
-	}
-
-	return ""
-}
-
-func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, runDir string) *cephConfig {
-	// extract a list of just the monitor names, which will populate the "mon initial members"
-	// global config field
-	monMembers := make([]string, len(cluster.Monitors))
-	monHosts := make([]string, len(cluster.Monitors))
-	i := 0
-	for _, monitor := range cluster.Monitors {
-		monMembers[i] = monitor.Name
-		monHosts[i] = monitor.Endpoint
-		i++
-	}
-
-	cephLogLevel := logLevelToCephLogLevel(context.LogLevel)
-
-	return &cephConfig{
-		GlobalConfig: &GlobalConfig{
-			FSID:                   cluster.FSID,
-			RunDir:                 runDir,
-			MonMembers:             strings.Join(monMembers, " "),
-			MonHost:                strings.Join(monHosts, ","),
-			LogFile:                "/dev/stdout",
-			MonClusterLogFile:      "/dev/stdout",
-			PublicAddr:             context.NetworkInfo.PublicAddr,
-			PublicNetwork:          context.NetworkInfo.PublicNetwork,
-			ClusterAddr:            context.NetworkInfo.ClusterAddr,
-			ClusterNetwork:         context.NetworkInfo.ClusterNetwork,
-			MonKeyValueDb:          "rocksdb",
-			MonAllowPoolDelete:     true,
-			MaxPgsPerOsd:           1000,
-			DebugLogDefaultLevel:   cephLogLevel,
-			DebugLogRadosLevel:     cephLogLevel,
-			DebugLogMonLevel:       cephLogLevel,
-			DebugLogOSDLevel:       cephLogLevel,
-			DebugLogBluestoreLevel: cephLogLevel,
-			DebugLogFilestoreLevel: cephLogLevel,
-			DebugLogJournalLevel:   cephLogLevel,
-			DebugLogLevelDBLevel:   cephLogLevel,
-			FileStoreOmapBackend:   "rocksdb",
-			OsdPgBits:              11,
-			OsdPgpBits:             11,
-			OsdPoolDefaultSize:     1,
-			OsdPoolDefaultMinSize:  1,
-			OsdPoolDefaultPgNum:    100,
-			OsdPoolDefaultPgpNum:   100,
-			RbdDefaultFeatures:     3,
-			FatalSignalHandlers:    "false",
-		},
-	}
-}
-
-func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterInfo, runDir string, userConfig *cephConfig) (*ini.File, error) {
-
-	var ceph *cephConfig
-
-	if userConfig != nil {
-		// use the user config since it was provided
-		ceph = userConfig
-	} else {
-		ceph = CreateDefaultCephConfig(context, cluster, runDir)
-	}
-
-	configFile := ini.Empty()
-	err := ini.ReflectFrom(configFile, ceph)
-	return configFile, err
-}
-
-func addClientConfigFileSection(configFile *ini.File, clientName, keyringPath string, settings map[string]string) error {
-	s, err := configFile.NewSection(clientName)
-	if err != nil {
-		return err
-	}
-
-	if _, err := s.NewKey("keyring", keyringPath); err != nil {
-		return err
-	}
-
-	for key, val := range settings {
-		if _, err := s.NewKey(key, val); err != nil {
-			return fmt.Errorf("failed to add key %s. %v", key, err)
-		}
-	}
-
-	return nil
-}
-
-func logLevelToCephLogLevel(logLevel capnslog.LogLevel) int {
-	switch logLevel {
-	case capnslog.CRITICAL:
-	case capnslog.ERROR:
-	case capnslog.WARNING:
-		return -1
-	case capnslog.NOTICE:
-	case capnslog.INFO:
-		return 0
-	case capnslog.DEBUG:
-		return 10
-	case capnslog.TRACE:
-		return 100
-	}
-
-	return 0
+func generateConnectionConfigFile(context *clusterd.Context, cluster *cephconfig.ClusterInfo, pathRoot, user, keyringPath string) (string, error) {
+	return cephconfig.GenerateConfigFile(context, cluster, pathRoot, user, keyringPath, nil, nil)
 }
 
 // writes the monitor backend file to disk
@@ -388,7 +79,7 @@ func writeBackendFile(monDataDir, backend string) error {
 	return nil
 }
 
-func generateMonMap(context *clusterd.Context, cluster *ClusterInfo, folder string) (string, error) {
+func generateMonMap(context *clusterd.Context, cluster *cephconfig.ClusterInfo, folder string) (string, error) {
 	path := path.Join(folder, "monmap")
 	args := []string{path, "--create", "--clobber", "--fsid", cluster.FSID}
 	for _, mon := range cluster.Monitors {

--- a/pkg/daemon/ceph/mon/daemon_test.go
+++ b/pkg/daemon/ceph/mon/daemon_test.go
@@ -18,13 +18,14 @@ package mon
 import (
 	"testing"
 
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMonFlattening(t *testing.T) {
 
 	// single endpoint
-	mons := map[string]*CephMonitorConfig{
+	mons := map[string]*cephconfig.MonInfo{
 		"foo": {Name: "foo", Endpoint: "1.2.3.4:5000"},
 	}
 	flattened := FlattenMonEndpoints(mons)
@@ -35,7 +36,7 @@ func TestMonFlattening(t *testing.T) {
 	assert.Equal(t, "1.2.3.4:5000", parsed["foo"].Endpoint)
 
 	// multiple endpoints
-	mons["bar"] = &CephMonitorConfig{Name: "bar", Endpoint: "2.3.4.5:6000"}
+	mons["bar"] = &cephconfig.MonInfo{Name: "bar", Endpoint: "2.3.4.5:6000"}
 	flattened = FlattenMonEndpoints(mons)
 	parsed = ParseMonEndpoints(flattened)
 	assert.Equal(t, 2, len(parsed))

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (
@@ -27,7 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -44,7 +45,7 @@ const (
 )
 
 type OsdAgent struct {
-	cluster           *mon.ClusterInfo
+	cluster           *cephconfig.ClusterInfo
 	nodeName          string
 	forceFormat       bool
 	location          string
@@ -61,7 +62,7 @@ type OsdAgent struct {
 }
 
 func NewAgent(context *clusterd.Context, devices string, usingDeviceFilter bool, metadataDevice, directories string, forceFormat bool,
-	location string, storeConfig config.StoreConfig, cluster *mon.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore) *OsdAgent {
+	location string, storeConfig config.StoreConfig, cluster *cephconfig.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore) *OsdAgent {
 
 	return &OsdAgent{
 		devices:           devices,

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (
@@ -27,7 +28,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/test"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -350,7 +351,7 @@ func createTestAgent(t *testing.T, devices, configDir, nodeName string, storeCon
 			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
 		},
 	}
-	cluster := &mon.ClusterInfo{Name: "myclust"}
+	cluster := &cephconfig.ClusterInfo{Name: "myclust"}
 	context := &clusterd.Context{ConfigDir: configDir, Executor: executor, Clientset: testop.New(1)}
 	agent := NewAgent(context, devices, false, "", "", forceFormat, location, *storeConfig,
 		cluster, nodeName, mockKVStore())
@@ -382,7 +383,7 @@ func TestGetPartitionPerfScheme(t *testing.T) {
 		{Name: "sdb", Size: 107374182400}, // 100 GB
 		{Name: "sdc", Size: 44158681088},  // 1 MB (starting offset) + 2 * (576 MB + 20 GB) = 41.125 GB
 	}
-	clusterInfo := &mon.ClusterInfo{Name: "myclust"}
+	clusterInfo := &cephconfig.ClusterInfo{Name: "myclust"}
 	a.cluster = clusterInfo
 
 	// mock monitor command to return an osd ID when the client registers/creates an osd

--- a/pkg/daemon/ceph/osd/config.go
+++ b/pkg/daemon/ceph/osd/config.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (
@@ -22,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 )
 
 const (
@@ -72,5 +73,5 @@ func createOSDBootstrapKeyring(context *clusterd.Context, clusterName string) er
 		return fmt.Sprintf(bootstrapOSDKeyringTemplate, key)
 	}
 
-	return mon.CreateKeyring(context, clusterName, username, keyringPath, access, keyringEval)
+	return cephconfig.CreateKeyring(context, clusterName, username, keyringPath, access, keyringEval)
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (
@@ -24,7 +25,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -64,11 +65,11 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 	}
 
 	// set the crush location in the osd config file
-	cephConfig := mon.CreateDefaultCephConfig(context, agent.cluster, path.Join(context.ConfigDir, agent.cluster.Name))
+	cephConfig := cephconfig.CreateDefaultCephConfig(context, agent.cluster, path.Join(context.ConfigDir, agent.cluster.Name))
 	cephConfig.GlobalConfig.CrushLocation = agent.location
 
 	// write the latest config to the config dir
-	if err := mon.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig); err != nil {
+	if err := cephconfig.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig); err != nil {
 		return fmt.Errorf("failed to write connection config. %+v", err)
 	}
 

--- a/pkg/daemon/ceph/osd/filesystem.go
+++ b/pkg/daemon/ceph/osd/filesystem.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (
@@ -22,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/util"
 )
@@ -58,7 +59,7 @@ func createOSDFileSystem(context *clusterd.Context, clusterName string, config *
 		"--mkfs",
 		fmt.Sprintf("--id=%d", config.id),
 		fmt.Sprintf("--cluster=%s", clusterName),
-		fmt.Sprintf("--conf=%s", mon.GetConfFilePath(config.rootPath, clusterName)),
+		fmt.Sprintf("--conf=%s", cephconfig.GetConfFilePath(config.rootPath, clusterName)),
 		fmt.Sprintf("--osd-data=%s", config.rootPath),
 		fmt.Sprintf("--osd-uuid=%s", config.uuid.String()),
 		fmt.Sprintf("--monmap=%s", monMapTmpPath),
@@ -146,7 +147,7 @@ func backupOSDFileSystem(config *osdConfig, clusterName string) error {
 
 	filter := util.CreateSet([]string{
 		// filter out the rook.config file since it's always regenerated
-		filepath.Base(mon.GetConfFilePath(config.rootPath, clusterName)),
+		filepath.Base(cephconfig.GetConfFilePath(config.rootPath, clusterName)),
 		// filter out the keyring since we recreate it with "auth get-or-create" and we don't want
 		// to store a secret in a non secret resource
 		keyringFileName,

--- a/pkg/daemon/ceph/rgw/admin.go
+++ b/pkg/daemon/ceph/rgw/admin.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/rgw/agent.go
+++ b/pkg/daemon/ceph/rgw/agent.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 const (

--- a/pkg/daemon/ceph/rgw/bucket.go
+++ b/pkg/daemon/ceph/rgw/bucket.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/rgw/daemon.go
+++ b/pkg/daemon/ceph/rgw/daemon.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (
@@ -25,7 +26,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/util"
 )
 
@@ -38,7 +39,7 @@ type Config struct {
 	SecurePort      int
 	Keyring         string
 	CertificatePath string
-	ClusterInfo     *mon.ClusterInfo
+	ClusterInfo     *cephconfig.ClusterInfo
 }
 
 func Run(context *clusterd.Context, config *Config) error {
@@ -93,7 +94,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 		"rgw_zone":                       config.Name,
 		"rgw_zonegroup":                  config.Name,
 	}
-	_, err := mon.GenerateConfigFile(context, config.ClusterInfo, getRGWConfDir(context.ConfigDir),
+	_, err := cephconfig.GenerateConfigFile(context, config.ClusterInfo, getRGWConfDir(context.ConfigDir),
 		"client.radosgw.gateway", getRGWKeyringPath(context.ConfigDir), nil, settings)
 	if err != nil {
 		return fmt.Errorf("failed to create config file. %+v", err)
@@ -104,7 +105,7 @@ func generateConfigFiles(context *clusterd.Context, config *Config) error {
 	}
 
 	// create rgw config
-	err = mon.WriteKeyring(getRGWKeyringPath(context.ConfigDir), config.Keyring, keyringEval)
+	err = cephconfig.WriteKeyring(getRGWKeyringPath(context.ConfigDir), config.Keyring, keyringEval)
 	if err != nil {
 		return fmt.Errorf("failed to save keyring. %+v", err)
 	}

--- a/pkg/daemon/ceph/rgw/daemon_test.go
+++ b/pkg/daemon/ceph/rgw/daemon_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/rgw/mime.go
+++ b/pkg/daemon/ceph/rgw/mime.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 const mimeTypes = `

--- a/pkg/daemon/ceph/rgw/objectstore.go
+++ b/pkg/daemon/ceph/rgw/objectstore.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/rgw/objectstore_test.go
+++ b/pkg/daemon/ceph/rgw/objectstore_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/rgw/user.go
+++ b/pkg/daemon/ceph/rgw/user.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package rgw
 
 import (

--- a/pkg/daemon/ceph/util/util_test.go
+++ b/pkg/daemon/ceph/util/util_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cluster
 
 import (

--- a/pkg/operator/ceph/cluster/migration_test.go
+++ b/pkg/operator/ceph/cluster/migration_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cluster
 
 import (

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -77,7 +78,7 @@ func (c *Cluster) checkHealth() error {
 	}
 	logger.Debugf("Mon status: %+v", status)
 
-	// Source of thruth of which mons should exist is our *clusterInfo*
+	// Source of truth of which mons should exist is our *clusterInfo*
 	monsNotFound := map[string]interface{}{}
 	for _, mon := range c.clusterInfo.Monitors {
 		monsNotFound[mon.Name] = struct{}{}
@@ -92,7 +93,7 @@ func (c *Cluster) checkHealth() error {
 		if _, ok := monsNotFound[mon.Name]; ok {
 			delete(monsNotFound, mon.Name)
 		} else {
-			// when the mon isn't in the clusterInfo, but is in qorum and there are
+			// when the mon isn't in the clusterInfo, but is in quorum and there are
 			//enough mons, remove it else remove it on the next run
 			if inQuorum && len(status.MonMap.Mons) > c.Size {
 				logger.Warningf("mon %s not in source of truth but in quorum, removing", mon.Name)
@@ -258,7 +259,7 @@ func (c *Cluster) failoverMon(name string) error {
 	} else {
 		m.PublicIP = serviceIP
 	}
-	c.clusterInfo.Monitors[m.DaemonName] = mon.ToCephMon(m.DaemonName, m.PublicIP, m.Port)
+	c.clusterInfo.Monitors[m.DaemonName] = cephconfig.NewMonInfo(m.DaemonName, m.PublicIP, m.Port)
 
 	// Start the deployment
 	if err = c.startDeployments(mConf, len(mConf)-1); err != nil {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mon
 
 import (

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mon
 
 import (

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mon
 
 import (

--- a/pkg/operator/ceph/cluster/mon/util_test.go
+++ b/pkg/operator/ceph/cluster/mon/util_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mon
 
 import (

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package object
 
 import (

--- a/pkg/operator/ceph/operator_test.go
+++ b/pkg/operator/ceph/operator_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package operator
 
 import (

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package pool
 
 import (

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+
 package provisioner
 
 import (

--- a/pkg/operator/test/info.go
+++ b/pkg/operator/test/info.go
@@ -20,22 +20,22 @@ package test
 import (
 	"fmt"
 
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 )
 
 // CreateConfigDir creates a test cluster
-func CreateConfigDir(monCount int) *mon.ClusterInfo {
-	c := &mon.ClusterInfo{
+func CreateConfigDir(monCount int) *cephconfig.ClusterInfo {
+	c := &cephconfig.ClusterInfo{
 		FSID:          "12345",
 		Name:          "default",
 		MonitorSecret: "monsecret",
 		AdminSecret:   "adminsecret",
-		Monitors:      map[string]*mon.CephMonitorConfig{},
+		Monitors:      map[string]*cephconfig.MonInfo{},
 	}
 	mons := []string{"a", "b", "c", "d", "e"}
 	for i := 0; i < monCount; i++ {
 		id := mons[i]
-		c.Monitors[id] = &mon.CephMonitorConfig{
+		c.Monitors[id] = &cephconfig.MonInfo{
 			Name:     id,
 			Endpoint: fmt.Sprintf("1.2.3.%d:6790", i+1),
 		}

--- a/pkg/test/info.go
+++ b/pkg/test/info.go
@@ -20,21 +20,21 @@ package test
 import (
 	"fmt"
 
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 )
 
 // CreateConfigDir creates a test cluster
-func CreateConfigDir(mons int) *mon.ClusterInfo {
-	c := &mon.ClusterInfo{
+func CreateConfigDir(mons int) *cephconfig.ClusterInfo {
+	c := &cephconfig.ClusterInfo{
 		FSID:          "12345",
 		Name:          "default",
 		MonitorSecret: "monsecret",
 		AdminSecret:   "adminsecret",
-		Monitors:      map[string]*mon.CephMonitorConfig{},
+		Monitors:      map[string]*cephconfig.MonInfo{},
 	}
 	for i := 1; i <= mons; i++ {
 		id := fmt.Sprintf("mon%d", i)
-		c.Monitors[id] = &mon.CephMonitorConfig{
+		c.Monitors[id] = &cephconfig.MonInfo{
 			Name:     id,
 			Endpoint: fmt.Sprintf("1.2.3.%d:6790", i),
 		}


### PR DESCRIPTION
**Description of your changes:**

This PR currently exists so that I can make notes here:
 * The below lines in `GenerateConfigFile` aren't used, because no other file calls the method with a `pathRoot` parameter which is an empty string.
```go
if pathRoot == "" {
		pathRoot = getMonRunDirPath(context.ConfigDir, getFirstMonitor(cluster))
	}
```
 * `CephMonitorConfig struct` has been moved to `pkg/daemon/ceph/cephconfig/info.go`. When I left this in the `mon` package, I got circular dependency issues. I think it makes sense that this item goes with config since that is the context in which it is used. It has also been renamed to `MonInfo` since its usage more closely matches info (it is part of the `ClusterInfo` struct) than a config, and the context "ceph" is inferred from the package.
 * I think it might make sense to do this in a different PR, but I feel that the way `WriteKeyring` is currently implemented with the `generateContents` function passed to it is awkward. I have a couple ideas in mind for improvements: (1) Use the go-ini module to write all parts of the keyring so there is no manually-typed template string, or (2) use `ceph auth get-or-create`'s `-o` option to write the keyring it generates to the disk into the file. I think I prefer option 2 since it relies on functionality provided by Ceph and can reduce a small amount of complexity in Rook. The downside is that the file will only be written to one location unless Rook does a `cp`. Bassam mentioned some work to use the default Ceph config dirs inside containers, so this seems in line with that; the `-o` option would specify `/etc/ceph/keyring`, and that should be about all that is needed.
 * I found the function name `ToCephMon` ambiguous. I think this would be more appropriately be named `NewCephMonitorConfig`. Is this something that seems reasonable to change in this PR?
 * There was only one usage of the method `MonEndpoints`, and it was in a debug print. Changed to be a usage of `FlattenMonEndpoints` which does the same thing except with `=` in place of `-`.

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
