### PR TITLE
Align the size of the PV to the actual one

### DIFF
--- a/pkg/operator/ceph/provisioner/provisioner.go
+++ b/pkg/operator/ceph/provisioner/provisioner.go
@@ -28,12 +28,14 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/ceph/provisioner/controller"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
 	attacherImageKey              = "attacherImage"
 	storageClassBetaAnnotationKey = "volume.beta.kubernetes.io/storage-class"
+	sizeMB                        = 1048576 // 1 MB
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-provisioner")
@@ -93,8 +95,17 @@ func (p *RookVolumeProvisioner) Provision(options controller.VolumeOptions) (*v1
 		return nil, err
 	}
 
-	if err = p.createVolume(imageName, cfg.pool, cfg.dataPool, cfg.clusterNamespace, requestBytes); err != nil {
+	blockImage, err := p.createVolume(imageName, cfg.pool, cfg.dataPool, cfg.clusterNamespace, requestBytes)
+	if err != nil {
 		return nil, err
+	}
+
+	// since we can guarantee the size of the volume image generated have to be in `MB` boundary, so we can
+	// convert it to `MB` unit safely here
+	s := fmt.Sprintf("%dMi", blockImage.Size/sizeMB)
+	quantity, err := resource.ParseQuantity(s)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse '%v': %v", s, err)
 	}
 
 	driverName, err := flexvolume.RookDriverName(p.context)
@@ -111,7 +122,7 @@ func (p *RookVolumeProvisioner) Provision(options controller.VolumeOptions) (*v1
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   options.PVC.Spec.AccessModes,
 			Capacity: v1.ResourceList{
-				v1.ResourceName(v1.ResourceStorage): capacity,
+				v1.ResourceName(v1.ResourceStorage): quantity,
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				FlexVolume: &v1.FlexVolumeSource{
@@ -133,18 +144,18 @@ func (p *RookVolumeProvisioner) Provision(options controller.VolumeOptions) (*v1
 }
 
 // createVolume creates a rook block volume.
-func (p *RookVolumeProvisioner) createVolume(image, pool, dataPool string, clusterNamespace string, size int64) error {
+func (p *RookVolumeProvisioner) createVolume(image, pool, dataPool string, clusterNamespace string, size int64) (*ceph.CephBlockImage, error) {
 	if image == "" || pool == "" || clusterNamespace == "" || size == 0 {
-		return fmt.Errorf("image missing required fields (image=%s, pool=%s, clusterNamespace=%s, size=%d)", image, pool, clusterNamespace, size)
+		return nil, fmt.Errorf("image missing required fields (image=%s, pool=%s, clusterNamespace=%s, size=%d)", image, pool, clusterNamespace, size)
 	}
 
 	createdImage, err := ceph.CreateImage(p.context, clusterNamespace, image, pool, dataPool, uint64(size))
 	if err != nil {
-		return fmt.Errorf("Failed to create rook block image %s/%s: %v", pool, image, err)
+		return nil, fmt.Errorf("Failed to create rook block image %s/%s: %v", pool, image, err)
 	}
-	logger.Infof("Rook block image created: %s", createdImage.Name)
+	logger.Infof("Rook block image created: %s, size = %d", createdImage.Name, createdImage.Size)
 
-	return nil
+	return createdImage, nil
 }
 
 // Delete removes the storage asset that was created by Provision represented


### PR DESCRIPTION
We maybe roundup the requested size to the next `MB` boundary in some cases when creating the volume, thus we need to make sure the size of the PV generated is consistent with the actual one.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Align the actual size of the PV to the one when creating the volume. For example:
```
--- a/cluster/examples/kubernetes/wordpress.yaml
+++ b/cluster/examples/kubernetes/wordpress.yaml
@@ -24,7 +24,7 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 1048698
```
Before this PR, the `kubectl get pvc` will output:
```
NAME          STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
wp-pv-claim   Bound     pvc-3bdc36a3-af5f-11e8-9bfb-a08cf87f2858   1048698    RWO            rook-ceph-block   18m
```
Actually, the size of the volume image has been roundup to `2MB` when creating it, so with this PR, the `kubectl get pvc` will output like this:
```
NAME          STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
wp-pv-claim   Bound     pvc-3312426d-affe-11e8-a94b-a08cf87f2858   2Mi        RWO            rook-ceph-block   11s
``` 
The latter should be the expected behavior.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
