### PR TITLE
Ceph: refactor daemon includes to <dmn>daemon for grokkability

### DIFF
--- a/cmd/rook/ceph/mds.go
+++ b/cmd/rook/ceph/mds.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/rook/rook/cmd/rook/rook"
-	"github.com/rook/rook/pkg/daemon/ceph/mds"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mdsdaemon "github.com/rook/rook/pkg/daemon/ceph/mds"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
@@ -66,15 +66,15 @@ func startMDS(cmd *cobra.Command, args []string) error {
 
 	id := extractMdsID(podName)
 
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	config := &mds.Config{
+	clusterInfo.Monitors = mondaemon.ParseMonEndpoints(cfg.monEndpoints)
+	config := &mdsdaemon.Config{
 		FilesystemID:  filesystemID,
 		ID:            id,
 		ActiveStandby: activeStandby,
 		ClusterInfo:   &clusterInfo,
 	}
 
-	err := mds.Run(createContext(), config)
+	err := mdsdaemon.Run(createContext(), config)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -18,8 +18,8 @@ package ceph
 
 import (
 	"github.com/rook/rook/cmd/rook/rook"
-	"github.com/rook/rook/pkg/daemon/ceph/mgr"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mgrdaemon "github.com/rook/rook/pkg/daemon/ceph/mgr"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
@@ -59,14 +59,14 @@ func startMgr(cmd *cobra.Command, args []string) error {
 
 	rook.LogStartupInfo(mgrCmd.Flags())
 
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	config := &mgr.Config{
+	clusterInfo.Monitors = mondaemon.ParseMonEndpoints(cfg.monEndpoints)
+	config := &mgrdaemon.Config{
 		Name:        mgrName,
 		Keyring:     mgrKeyring,
 		ClusterInfo: &clusterInfo,
 	}
 
-	err := mgr.Run(createContext(), config)
+	err := mgrdaemon.Run(createContext(), config)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/mon.go
+++ b/cmd/rook/ceph/mon.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-ini/ini"
 	"github.com/rook/rook/cmd/rook/rook"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
@@ -68,20 +68,20 @@ func startMon(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("missing mon port")
 	}
 
-	if err := compareMonSecret(clusterInfo.MonitorSecret, mon.GetMonRunDirPath(cfg.dataDir, monName)); err != nil {
+	if err := compareMonSecret(clusterInfo.MonitorSecret, mondaemon.GetMonRunDirPath(cfg.dataDir, monName)); err != nil {
 		rook.TerminateFatal(err)
 	}
 
 	// at first start the local monitor needs to be added to the list of mons
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
+	clusterInfo.Monitors = mondaemon.ParseMonEndpoints(cfg.monEndpoints)
 	clusterInfo.Monitors[monName] = cephconfig.NewMonInfo(monName, cfg.NetworkInfo().PublicAddr, monPort)
 
-	monCfg := &mon.Config{
+	monCfg := &mondaemon.Config{
 		Name:    monName,
 		Cluster: &clusterInfo,
 		Port:    monPort,
 	}
-	err := mon.Run(createContext(), monCfg)
+	err := mondaemon.Run(createContext(), monCfg)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/rgw.go
+++ b/cmd/rook/ceph/rgw.go
@@ -21,8 +21,8 @@ import (
 	"os"
 
 	"github.com/rook/rook/cmd/rook/rook"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
-	"github.com/rook/rook/pkg/daemon/ceph/rgw"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
+	rgwdaemon "github.com/rook/rook/pkg/daemon/ceph/rgw"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
@@ -74,8 +74,8 @@ func startRGW(cmd *cobra.Command, args []string) error {
 
 	rook.LogStartupInfo(rgwCmd.Flags())
 
-	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
-	config := &rgw.Config{
+	clusterInfo.Monitors = mondaemon.ParseMonEndpoints(cfg.monEndpoints)
+	config := &rgwdaemon.Config{
 		ClusterInfo:     &clusterInfo,
 		Name:            rgwName,
 		Keyring:         rgwKeyring,
@@ -85,7 +85,7 @@ func startRGW(cmd *cobra.Command, args []string) error {
 		CertificatePath: rgwCert,
 	}
 
-	err := rgw.Run(createContext(), config)
+	err := rgwdaemon.Run(createContext(), config)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -300,7 +300,7 @@ func (c *Cluster) removeMon(daemonName string) error {
 		delete(c.mapping.Node, daemonName)
 		// if node->port "mapping" has been created, decrease or delete it
 		if port, ok := c.mapping.Port[nodeName]; ok {
-			if port == mon.DefaultPort {
+			if port == mondaemon.DefaultPort {
 				delete(c.mapping.Port, nodeName)
 			}
 			// don't clean up if a node port is higher than the default port, other

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
-	cephmon "github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +64,7 @@ func TestCheckHealth(t *testing.T) {
 		Name:    "node0",
 		Address: "",
 	}
-	c.mapping.Port["node0"] = cephmon.DefaultPort
+	c.mapping.Port["node0"] = mondaemon.DefaultPort
 	c.maxMonID = 4
 
 	err := c.checkHealth()
@@ -109,7 +109,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 	c.mapping.Node["b"] = &NodeInfo{
 		Name: "node0",
 	}
-	c.mapping.Port["node0"] = cephmon.DefaultPort
+	c.mapping.Port["node0"] = mondaemon.DefaultPort
 	c.maxMonID = 4
 
 	c.saveMonConfig()

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
 	"k8s.io/api/core/v1"
@@ -187,7 +187,7 @@ func (c *Cluster) startMons() error {
 		}
 	}
 
-	logger.Debugf("mon endpoints used are: %s", mon.FlattenMonEndpoints(c.clusterInfo.Monitors))
+	logger.Debugf("mon endpoints used are: %s", mondaemon.FlattenMonEndpoints(c.clusterInfo.Monitors))
 	return nil
 }
 
@@ -215,7 +215,7 @@ func (c *Cluster) initMonConfig(size int) []*monConfig {
 
 	// initialize the mon pod info for mons that have been previously created
 	for _, monitor := range c.clusterInfo.Monitors {
-		mons = append(mons, &monConfig{ResourceName: resourceName(monitor.Name), DaemonName: monitor.Name, Port: int32(mon.DefaultPort)})
+		mons = append(mons, &monConfig{ResourceName: resourceName(monitor.Name), DaemonName: monitor.Name, Port: int32(mondaemon.DefaultPort)})
 	}
 
 	// initialize mon info if we don't have enough mons (at first startup)
@@ -229,7 +229,7 @@ func (c *Cluster) initMonConfig(size int) []*monConfig {
 
 func newMonConfig(monID int) *monConfig {
 	daemonName := indexToName(monID)
-	return &monConfig{ResourceName: resourceName(daemonName), DaemonName: daemonName, Port: int32(mon.DefaultPort)}
+	return &monConfig{ResourceName: resourceName(daemonName), DaemonName: daemonName, Port: int32(mondaemon.DefaultPort)}
 }
 
 // Ensure the mon name has the rook-ceph-mon prefix
@@ -420,7 +420,7 @@ func (c *Cluster) saveMonConfig() error {
 	}
 
 	configMap.Data = map[string]string{
-		EndpointDataKey: mon.FlattenMonEndpoints(c.clusterInfo.Monitors),
+		EndpointDataKey: mondaemon.FlattenMonEndpoints(c.clusterInfo.Monitors),
 		MaxMonIDKey:     strconv.Itoa(c.maxMonID),
 		MappingKey:      string(monMapping),
 	}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
-	cephmon "github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	cephtest "github.com/rook/rook/pkg/daemon/ceph/test"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -456,12 +456,12 @@ func TestHostNetworkPortIncrease(t *testing.T) {
 		{
 			ResourceName: "rook-ceph-mon-a",
 			DaemonName:   "a",
-			Port:         cephmon.DefaultPort,
+			Port:         mondaemon.DefaultPort,
 		},
 		{
 			ResourceName: "rook-ceph-mon-b",
 			DaemonName:   "b",
-			Port:         cephmon.DefaultPort,
+			Port:         mondaemon.DefaultPort,
 		},
 	}
 	c.maxMonID = 1
@@ -476,7 +476,7 @@ func TestHostNetworkPortIncrease(t *testing.T) {
 	assert.Equal(t, node.Name, c.mapping.Node["b"].Name)
 
 	sEndpoint := strings.Split(c.clusterInfo.Monitors["a"].Endpoint, ":")
-	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort), sEndpoint[1])
+	assert.Equal(t, strconv.Itoa(mondaemon.DefaultPort), sEndpoint[1])
 	sEndpoint = strings.Split(c.clusterInfo.Monitors["b"].Endpoint, ":")
-	assert.Equal(t, strconv.Itoa(cephmon.DefaultPort+1), sEndpoint[1])
+	assert.Equal(t, strconv.Itoa(mondaemon.DefaultPort+1), sEndpoint[1])
 }

--- a/pkg/operator/ceph/cluster/mon/util.go
+++ b/pkg/operator/ceph/cluster/mon/util.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	"github.com/rook/rook/pkg/daemon/ceph/mon"
+	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
@@ -127,7 +127,7 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string
 
 	// Parse the monitor List
 	if info, ok := cm.Data[EndpointDataKey]; ok {
-		monEndpointMap = mon.ParseMonEndpoints(info)
+		monEndpointMap = mondaemon.ParseMonEndpoints(info)
 	}
 
 	// Parse the max monitor id

--- a/pkg/operator/ceph/file/mds.go
+++ b/pkg/operator/ceph/file/mds.go
@@ -24,7 +24,7 @@ import (
 	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	cephmds "github.com/rook/rook/pkg/daemon/ceph/mds"
+	mdsdaemon "github.com/rook/rook/pkg/daemon/ceph/mds"
 	"github.com/rook/rook/pkg/daemon/ceph/model"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
@@ -50,7 +50,7 @@ func CreateFilesystem(context *clusterd.Context, fs cephv1beta1.Filesystem, vers
 	for _, p := range fs.Spec.DataPools {
 		dataPools = append(dataPools, p.ToModel(""))
 	}
-	f := cephmds.NewFS(fs.Name, fs.Spec.MetadataPool.ToModel(""), dataPools, fs.Spec.MetadataServer.ActiveCount)
+	f := mdsdaemon.NewFS(fs.Name, fs.Spec.MetadataPool.ToModel(""), dataPools, fs.Spec.MetadataServer.ActiveCount)
 	if err := f.CreateFilesystem(context, fs.Namespace); err != nil {
 		return fmt.Errorf("failed to create file system %s: %+v", fs.Name, err)
 	}
@@ -90,7 +90,7 @@ func DeleteFilesystem(context *clusterd.Context, fs cephv1beta1.Filesystem) erro
 	}
 
 	// Delete the ceph file system and pools
-	if err := cephmds.DeleteFilesystem(context, fs.Namespace, fs.Name); err != nil {
+	if err := mdsdaemon.DeleteFilesystem(context, fs.Namespace, fs.Name); err != nil {
 		return fmt.Errorf("failed to delete file system %s: %+v", fs.Name, err)
 	}
 

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -24,7 +24,7 @@ import (
 	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	cephrgw "github.com/rook/rook/pkg/daemon/ceph/rgw"
+	rgwdaemon "github.com/rook/rook/pkg/daemon/ceph/rgw"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -82,8 +82,8 @@ func createOrUpdate(context *clusterd.Context, store cephv1beta1.ObjectStore, ve
 	}
 
 	// create the ceph artifacts for the object store
-	objContext := cephrgw.NewContext(context, store.Name, store.Namespace)
-	err = cephrgw.CreateObjectStore(objContext, *store.Spec.MetadataPool.ToModel(""), *store.Spec.DataPool.ToModel(""), serviceIP, store.Spec.Gateway.Port)
+	objContext := rgwdaemon.NewContext(context, store.Name, store.Namespace)
+	err = rgwdaemon.CreateObjectStore(objContext, *store.Spec.MetadataPool.ToModel(""), *store.Spec.DataPool.ToModel(""), serviceIP, store.Spec.Gateway.Port)
 	if err != nil {
 		return fmt.Errorf("failed to create pools. %+v", err)
 	}
@@ -175,8 +175,8 @@ func DeleteStore(context *clusterd.Context, store cephv1beta1.ObjectStore) error
 	}
 
 	// Delete the realm and pools
-	objContext := cephrgw.NewContext(context, store.Name, store.Namespace)
-	err = cephrgw.DeleteObjectStore(objContext)
+	objContext := rgwdaemon.NewContext(context, store.Name, store.Namespace)
+	err = rgwdaemon.DeleteObjectStore(objContext)
 	if err != nil {
 		return fmt.Errorf("failed to delete the realm and pools. %+v", err)
 	}

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"errors"
 
-	"github.com/rook/rook/pkg/daemon/ceph/rgw"
+	rgwdaemon "github.com/rook/rook/pkg/daemon/ceph/rgw"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
@@ -167,7 +167,7 @@ func objectTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, na
 	helper.ObjectClient.DeleteUser(storeName, userid)*/
 }
 
-func getBucket(bucketname string, bucketList []rgw.ObjectBucket) (rgw.ObjectBucket, error) {
+func getBucket(bucketname string, bucketList []rgwdaemon.ObjectBucket) (rgwdaemon.ObjectBucket, error) {
 
 	for _, bucket := range bucketList {
 		if bucket.Name == bucketname {
@@ -175,10 +175,10 @@ func getBucket(bucketname string, bucketList []rgw.ObjectBucket) (rgw.ObjectBuck
 		}
 	}
 
-	return rgw.ObjectBucket{}, errors.New("Bucket not found")
+	return rgwdaemon.ObjectBucket{}, errors.New("Bucket not found")
 }
 
-func getBucketSizeAndObjects(bucketname string, bucketList []rgw.ObjectBucket) (uint64, uint64, error) {
+func getBucketSizeAndObjects(bucketname string, bucketList []rgwdaemon.ObjectBucket) (uint64, uint64, error) {
 	bkt, err := getBucket(bucketname, bucketList)
 	if err != nil {
 		return 0, 0, errors.New("Bucket not found")


### PR DESCRIPTION
FYI: This branch is built on top of #2081

**Description of your changes:**
As discussed in https://github.com/rook/rook/pull/2081#issuecomment-418785257, 
to help with code readability, include daemons from `pkg/daemon/ceph`
as `<dmn>daemon "github.com/rook/rook/pkg/daemon/ceph/<dmn>`. This will
make it easier to understand code lines without needing to scroll up to
check the includes, as there are mon/mds/mgr/osd/rgw packages for
daemons as well as operator and cmd.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
