### PR TITLE
Enable CI system logs in artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,8 +83,8 @@ pipeline {
                     finally{
                         sh "build/run go get -u -f  github.com/jstemmer/go-junit-report"
                         for (kv in mapToList(data)) {
-                            unstash "${kv[0]}_${kv[1]}_result"
-                            sh "cat _output/tests/${kv[0]}_${kv[1]}_integrationTests.log | _output/go-junit-report > _output/tests/${kv[0]}_${kv[1]}_integrationTests.xml"
+                            unstash "${kv[1]}_result"
+                            sh "cat _output/tests/${kv[1]}_integrationTests.log | _output/go-junit-report > _output/tests/${kv[1]}_integrationTests.xml"
                         }
                     }
                 }
@@ -155,11 +155,13 @@ def RunIntegrationTest(k, v) {
                     }
                     finally{
                         sh "journalctl -u kubelet > _output/tests/kubelet_${v}.log"
+                        sh "journalctl > _output/tests/system_journalctl_${v}.log"
+                        sh "dmesg > _output/tests/system_dmesg_${v}.log"
                         sh '''#!/bin/bash
                               export KUBECONFIG=$HOME/admin.conf
                               tests/scripts/helm.sh clean || true'''
-                        sh "mv _output/tests/integrationTests.log _output/tests/${k}_${v}_integrationTests.log"
-                        stash name: "${k}_${v}_result",includes : "_output/tests/${k}_${v}_integrationTests.log,_output/tests/kubelet_${v}.log"
+                        sh "mv _output/tests/integrationTests.log _output/tests/${v}_integrationTests.log"
+                        stash name: "${v}_result",includes : "_output/tests/${v}_integrationTests.log"
                     }
                 }
             }


### PR DESCRIPTION
This is a temporary patch to help us figure out what is causing the random
issues on concurrent builds and re-using an instance.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

Resolves # NA

- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
