### PR TITLE
Retry file operations after upgrade in integration test

### DIFF
--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -135,9 +135,9 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 
 	// Test writing and reading from the pod with cephfs mounted that was created before the upgrade.
 	postFilename := "post-upgrade-file"
-	assert.Nil(s.T(), s.k8sh.ReadFromPod(s.namespace, filePodName, preFilename, message))
-	assert.Nil(s.T(), s.k8sh.WriteToPod(s.namespace, filePodName, postFilename, message))
-	assert.Nil(s.T(), s.k8sh.ReadFromPod(s.namespace, filePodName, postFilename, message))
+	assert.Nil(s.T(), s.k8sh.ReadFromPodRetry(s.namespace, filePodName, preFilename, message, 3))
+	assert.Nil(s.T(), s.k8sh.WriteToPodRetry(s.namespace, filePodName, postFilename, message, 3))
+	assert.Nil(s.T(), s.k8sh.ReadFromPodRetry(s.namespace, filePodName, postFilename, message, 3))
 
 	// Test writing and reading from the pod with rbd mounted that was created before the upgrade.
 	// There is some unreliability right after the upgrade when there is only one osd, so we will retry if needed


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The upgrade integration test has failed several times in the last few days when reading/writing to the pod with the filesystem mount after upgrading from 0.8 to master. This will retry the read/write to help stabilize the tests.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
