### PR TITLE
Add LVM type to supported disks

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,8 +10,10 @@
 - Rook Ceph block storage provisioner can now correctly create erasure coded block images. See [Advanced Example: Erasure Coded Block Storage](Documentation/block.md#advanced-example-erasure-coded-block-storage) for an example usage.
 - [Network File System (NFS)](https://github.com/nfs-ganesha/nfs-ganesha/wiki) is now supported by Rook with a new operator to deploy and manage this widely used server. NFS servers can be automatically deployed by creating an instance of the new `nfsservers.nfs.rook.io` custom resource. See the [NFS server user guide](Documentation/nfs.md) to get started with NFS.
 - The minimum version of Kubernetes supported by Rook changed from `1.7` to `1.8`.
+- LVM `dm` devices can now be used for Ceph OSDs.
 
 ## Breaking Changes
+
 - Mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.
 - Mons are now created with Deployments instead of ReplicaSets to improve the upgrade implementation.
 

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -31,7 +31,6 @@ var (
 )
 
 func GetAvailableDevices(devices []*sys.LocalDisk) []string {
-
 	var available []string
 	for _, device := range devices {
 		logger.Debugf("Evaluating device %+v", device)
@@ -55,7 +54,6 @@ func ignoreDevice(d string) bool {
 
 // Discover all the details of devices available on the local node
 func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
-
 	var disks []*sys.LocalDisk
 	devices, err := sys.ListDevices(executor)
 	if err != nil {
@@ -76,7 +74,7 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		}
 
 		diskType, ok := diskProps["TYPE"]
-		if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType) {
+		if !ok || (diskType != sys.DiskType && diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.LVMType && diskType != sys.PartType) {
 			// unsupported disk type, just continue
 			continue
 		}

--- a/pkg/clusterd/disk_test.go
+++ b/pkg/clusterd/disk_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestAvailableDisks(t *testing.T) {
-
 	// no disks discovered for a node is an error
 	disks := GetAvailableDevices([]*sys.LocalDisk{})
 	assert.Equal(t, 0, len(disks))
@@ -56,6 +55,9 @@ func TestAvailableDisks(t *testing.T) {
 	disks = GetAvailableDevices([]*sys.LocalDisk{d6})
 	assert.Equal(t, 1, len(disks))
 
+	d7 := &sys.LocalDisk{Name: "dm-4", UUID: "myuuid6", Size: 123, Rotational: true, Readonly: false, Type: sys.LVMType, HasChildren: true}
+	disks = GetAvailableDevices([]*sys.LocalDisk{d7})
+	assert.Equal(t, 1, len(disks))
 }
 
 func TestDiscoverDevices(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**
This adds `sys.LVMType` to the supported disks, so it is not ignored and can be used.

**Which issue is resolved by this Pull Request:**
Resolves #2047.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)