### PR TITLE
reset resource version if watch channel closed

### DIFF
--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -134,7 +134,6 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 	}
 
 	// check the status map to see if the node is already completed before we start watching
-	remainingNodes := util.NewSet()
 	statuses, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).List(opts)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -143,33 +142,37 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 		}
 		// the status map doesn't exist yet, watching below is still an OK thing to do
 	}
+	originalNodes := 0
+	remainingNodes := util.NewSet()
+	checkStatus := func() {
+		remainingNodes = util.NewSet()
+		// check the nodes to see which ones are already completed
+		originalNodes = len(statuses.Items)
+		for _, configMap := range statuses.Items {
+			node, ok := configMap.Labels[nodeLabelKey]
+			if !ok {
+				logger.Infof("missing node label on configmap %s", configMap.Name)
+				continue
+			}
 
-	// check the nodes to see which ones are already completed
-	originalNodes := len(statuses.Items)
-	for _, configMap := range statuses.Items {
-		node, ok := configMap.Labels[nodeLabelKey]
-		if !ok {
-			logger.Infof("missing node label on configmap %s", configMap.Name)
-			continue
+			completed := c.handleStatusConfigMapStatus(node, config, &configMap, configOSDs)
+			if !completed {
+				remainingNodes.Add(node)
+			}
 		}
-
-		completed := c.handleStatusConfigMapStatus(node, config, &configMap, configOSDs)
-		if !completed {
-			remainingNodes.Add(node)
-		}
+	}
+	checkStatus()
+	if remainingNodes.Count() == 0 {
+		return true
 	}
 
 	// start watching for changes on the orchestration status map
 	opts.ResourceVersion = statuses.ResourceVersion
 
-	if remainingNodes.Count() == 0 {
-		return true
-	}
-
-	opts.Watch = true
 	currentTimeoutMinutes := 0
 	for {
 		logger.Infof("%d/%d node(s) completed osd provisioning, resource version %v", (originalNodes - remainingNodes.Count()), originalNodes, opts.ResourceVersion)
+		opts.Watch = true
 		w, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Watch(opts)
 		if err != nil {
 			logger.Warningf("failed to start watch on osd status, trying again. %+v", err)
@@ -187,9 +190,18 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 					w.Stop()
 					<-time.After(100 * time.Millisecond)
 					opts.ResourceVersion = ""
-					st, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).List(opts)
+					opts.Watch = false
+					statuses, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).List(opts)
 					if err == nil {
-						opts.ResourceVersion = st.ResourceVersion
+						logger.Infof("checking listing status")
+						checkStatus()
+						if remainingNodes.Count() == 0 {
+							logger.Infof("%d/%d node(s) completed osd provisioning", originalNodes, originalNodes)
+							return true
+						}
+						opts.ResourceVersion = statuses.ResourceVersion
+					} else {
+						logger.Infof("failed to list status: %v", err)
 					}
 					break ResultLoop
 				}


### PR DESCRIPTION
**Description of your changes:**

per @travisn @deads2k, when the watch channel is closed, relist the configmap and use the newer resource version

(this is to kick off the CI against 0.8 branch, patch will go to master branch)

**Which issue is resolved by this Pull Request:**
Resolves #2043

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
