### PR TITLE
PVC create resiliency

### DIFF
--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -18,13 +18,14 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
+	"syscall"
 
 	"strconv"
 
 	"regexp"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -85,9 +86,15 @@ func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoo
 	}
 
 	buf, err := ExecuteRBDCommandNoFormat(context, clusterName, args)
-	if err != nil && !strings.Contains(string(buf), fmt.Sprintf("%s already exists", name)) {
-		return nil, fmt.Errorf("failed to create image %s in pool %s of size %d: %+v. output: %s",
-			name, poolName, size, err, string(buf))
+	if err != nil {
+		cmdErr, ok := err.(*exec.CommandError)
+		if ok && cmdErr.ExitStatus() == int(syscall.EEXIST) {
+			// Image with the same name already exists in the given rbd pool. Continuing with the link to PV.
+			logger.Warningf("Requested image %s exists in pool %s. Continuing", name, poolName)
+		} else {
+			return nil, fmt.Errorf("failed to create image %s in pool %s of size %d: %+v. output: %s",
+				name, poolName, size, err, string(buf))
+		}
 	}
 
 	// now that the image is created, retrieve it

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -18,6 +18,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"strconv"
 
@@ -84,7 +85,7 @@ func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoo
 	}
 
 	buf, err := ExecuteRBDCommandNoFormat(context, clusterName, args)
-	if err != nil {
+	if err != nil && !strings.Contains(string(buf), fmt.Sprintf("%s already exists", name)) {
 		return nil, fmt.Errorf("failed to create image %s in pool %s of size %d: %+v. output: %s",
 			name, poolName, size, err, string(buf))
 	}


### PR DESCRIPTION
While creating a PVC, if the operator dies between successfully creating a rbd
image and associating it with a PV, that PVC will never be completed. A
restarted operator will also fail to complete the task as the requested rbd
image already exists. With the assumption that a PVC UID will always be unique,
this patch will try to use the existing volume and complete the PVC request.

Resolves: #2072

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
