### PR TITLE
Log the output of blkid to see if device should be formatted

### DIFF
--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
+	"github.com/rook/rook/pkg/util/exec"
 	"github.com/spf13/cobra"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/version"
@@ -134,6 +135,22 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 			return fmt.Errorf("Rook: Mount volume failed. Error checking if %s is a mount point: %v", globalVolumeMountPath, err)
 		}
 	}
+
+	// Testing to see if the device is formatted. There has been observed an issue on slow systems where k8s believes there is no filesystem
+	// formatted even though one does exist. K8s then proceeds to format the volume which would result in data loss. This logging is an attempt
+	// to understand why k8s believes the volume is not formatted. See https://github.com/rook/rook/issues/1553
+	log(client, fmt.Sprintf("Testing to see if device %s needs formatting...", devicePath), false)
+	executor := &exec.CommandExecutor{}
+	output, err := executor.ExecuteCommandWithOutput(false, "", "blkid", "-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", devicePath)
+	if err != nil {
+		log(client, fmt.Sprintf("Formatting test (blkid -p -s TYPE -s PTTYPE -o export %s). Device may not be formatted. err: %+v", devicePath, err), false)
+	} else {
+		log(client, fmt.Sprintf("Formatting test (blkid -p -s TYPE -s PTTYPE -o export %s). Device is already formatted", devicePath), false)
+	}
+	if len(output) > 0 {
+		log(client, fmt.Sprintf("Output: %s", output), false)
+	}
+
 	options := []string{opts.RW}
 	if notMnt {
 		err = redirectStdout(


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
It has been observed on slow systems that a volume is incorrectly formatted when k8s does not see the existing format. We need to understand this by adding logging and find why the device is incorrectly reporting status.

The same `blkid` command run by k8s is run here in rook to see if we get consistent output. @jbw976 can you think of any other logging that would be useful?

**Which issue is resolved by this Pull Request:**
Related to #1553 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
