### PR TITLE
Ceph mgr: initialize mgr config in init container

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,14 +10,14 @@
 - Rook Ceph block storage provisioner can now correctly create erasure coded block images. See [Advanced Example: Erasure Coded Block Storage](Documentation/block.md#advanced-example-erasure-coded-block-storage) for an example usage.
 - [Network File System (NFS)](https://github.com/nfs-ganesha/nfs-ganesha/wiki) is now supported by Rook with a new operator to deploy and manage this widely used server. NFS servers can be automatically deployed by creating an instance of the new `nfsservers.nfs.rook.io` custom resource. See the [NFS server user guide](Documentation/nfs.md) to get started with NFS.
 - The minimum version of Kubernetes supported by Rook changed from `1.7` to `1.8`.
-- `reclaimPolicy` parameter of `StorageClass` definition is now supported. 
+- `reclaimPolicy` parameter of `StorageClass` definition is now supported.
 
 ## Breaking Changes
 - Ceph mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.
 - Ceph mons are now created with Deployments instead of ReplicaSets to improve the upgrade implementation.
-- Ceph mon container names in pods have changed with the
+- Ceph mon and mgr container names in pods have changed with the
   [refactor](https://github.com/rook/rook/pull/2095) to initialize the mon daemon environment via
-  pod **InitContainers** and run the `ceph-mon` daemon directly from the container entrypoint.
+  pod **InitContainers** and run the Ceph daemons directly from the container entrypoint.
 
 - The Rook container images are no longer published to quay.io, they are published only to Docker Hub.  All manifests have referenced Docker Hub for multiple releases now, so we do not expect any directly affected users from this change.
 - Rook no longer supports kubernetes `1.7`. Users running Kubernetes `1.7` on their clusters are recommended to upgrade to Kubernetes `1.8` or higher. If you are using `kubeadm`, you can follow this [guide](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/) to from Kubernetes `1.7` to `1.8`. If you are using `kops` or `kubespray` for managing your Kubernetes cluster, just follow the respective projects' `upgrade` guide.

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -30,23 +30,25 @@ var (
 )
 
 var mgrCmd = &cobra.Command{
-	Use:    "mgr",
-	Short:  "Generates mgr config and runs the mgr daemon",
+	Use:    mgrdaemon.InitCommand,
+	Short:  "Generates mgr config",
 	Hidden: true,
 }
 
 func init() {
-	mgrCmd.Flags().StringVar(&mgrName, "mgr-name", "", "the mgr name")
+	mgrCmd.Flags().StringVar(&mgrName, "mgr-name", "", "name of the mgr")
 	mgrCmd.Flags().StringVar(&mgrKeyring, "mgr-keyring", "", "the mgr keyring")
 	addCephFlags(mgrCmd)
 
 	flags.SetFlagsFromEnv(mgrCmd.Flags(), rook.RookEnvVarPrefix)
 
-	mgrCmd.RunE = startMgr
+	mgrCmd.RunE = initMgr
 }
 
-func startMgr(cmd *cobra.Command, args []string) error {
-	required := []string{"mon-endpoints", "cluster-name", "mon-secret", "admin-secret"}
+func initMgr(cmd *cobra.Command, args []string) error {
+	required := []string{
+		"mgr-name", "mgr-keyring",
+		"mon-endpoints", "cluster-name", "mon-secret", "admin-secret"}
 	if err := flags.VerifyRequiredFlags(mgrCmd, required); err != nil {
 		return err
 	}
@@ -66,7 +68,7 @@ func startMgr(cmd *cobra.Command, args []string) error {
 		ClusterInfo: &clusterInfo,
 	}
 
-	err := mgrdaemon.Run(createContext(), config)
+	err := mgrdaemon.Initialize(createContext(), config)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/cmd/rook/ceph/mon.go
+++ b/cmd/rook/ceph/mon.go
@@ -31,7 +31,7 @@ import (
 
 var monCmd = &cobra.Command{
 	Use:    mondaemon.InitCommand,
-	Short:  "Generates mon config and runs the mon daemon",
+	Short:  "Generates mon config",
 	Hidden: true,
 }
 

--- a/pkg/daemon/ceph/config/info.go
+++ b/pkg/daemon/ceph/config/info.go
@@ -19,6 +19,9 @@ package config
 import (
 	"fmt"
 	"net"
+	"strings"
+
+	"github.com/coreos/pkg/capnslog"
 )
 
 // ClusterInfo is a collection of information about a particular Ceph cluster. Rook uses information
@@ -40,4 +43,24 @@ type MonInfo struct {
 // NewMonInfo returns a new Ceph mon info struct from the given inputs.
 func NewMonInfo(name, ip string, port int32) *MonInfo {
 	return &MonInfo{Name: name, Endpoint: net.JoinHostPort(ip, fmt.Sprintf("%d", port))}
+}
+
+// Log writes the cluster info struct to the logger
+func (c *ClusterInfo) Log(logger *capnslog.PackageLogger) {
+	mons := []string{}
+	for _, m := range c.Monitors {
+		mons = append(mons, fmt.Sprintf("{Name: %s, Endpoint: %s}", m.Name, m.Endpoint))
+	}
+	monsec := ""
+	if c.MonitorSecret != "" {
+		monsec = "<hidden>"
+	}
+	admsec := ""
+	if c.AdminSecret != "" {
+		admsec = "<hidden>"
+	}
+	s := fmt.Sprintf(
+		"ClusterInfo: {FSID: %s, MonitorSecret: %s, AdminSecret: %s, Name: %s, Monitors: %s}",
+		c.FSID, monsec, admsec, c.Name, strings.Join(mons, " "))
+	logger.Info(s)
 }

--- a/pkg/daemon/ceph/config/pod.go
+++ b/pkg/daemon/ceph/config/pod.go
@@ -19,17 +19,18 @@ package config
 import "k8s.io/api/core/v1"
 
 const (
-	defaultConfigMountName = "ceph-default-config-dir"
+	// DefaultConfigMountName is the name of the volume mount used to mount the default Ceph config
+	DefaultConfigMountName = "ceph-default-config-dir"
 )
 
 // DefaultConfigVolume returns an empty volume used to store Ceph's config at the default path
 // in containers.
 func DefaultConfigVolume() v1.Volume {
-	return v1.Volume{Name: defaultConfigMountName,
+	return v1.Volume{Name: DefaultConfigMountName,
 		VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
 }
 
 // DefaultConfigMount returns a volume mount to Ceph's default config path.
 func DefaultConfigMount() v1.VolumeMount {
-	return v1.VolumeMount{Name: defaultConfigMountName, MountPath: DefaultConfigDir}
+	return v1.VolumeMount{Name: DefaultConfigMountName, MountPath: DefaultConfigDir}
 }

--- a/pkg/daemon/ceph/mon/init.go
+++ b/pkg/daemon/ceph/mon/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	"github.com/rook/rook/pkg/util"
 )
 
 const (
@@ -44,10 +45,14 @@ type Config struct {
 
 // Initialize generates configuration files for a Ceph mon
 func Initialize(context *clusterd.Context, config *Config) error {
+	logger.Infof("Creating config for MON %s with port %d", config.Name, config.Port)
+	config.Cluster.Log(logger)
 	err := generateConfigFiles(context, config)
 	if err != nil {
 		return fmt.Errorf("failed to generate mon config files. %+v", err)
 	}
+
+	util.WriteFileToLog(logger, cephconfig.DefaultConfigFilePath())
 
 	return err
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -19,17 +19,14 @@ package mgr
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,7 +44,7 @@ const (
 
 var mgrNames = []string{"a", "b"}
 
-// Cluster is the ceph mgr manager
+// Cluster represents the Rook and environment configuration settings needed to set up Ceph mgrs.
 type Cluster struct {
 	Namespace   string
 	Version     string
@@ -59,6 +56,12 @@ type Cluster struct {
 	resources   v1.ResourceRequirements
 	ownerRef    metav1.OwnerReference
 	dashboard   cephv1beta1.DashboardSpec
+}
+
+// mgrConfig for a single mgr
+type mgrConfig struct {
+	ResourceName string // the name rook gives to mgr resources in k8s metadata
+	DaemonName   string // the name of the Ceph daemon ("a", "b", ...)
 }
 
 // New creates an instance of the mgr
@@ -78,7 +81,7 @@ func New(context *clusterd.Context, namespace, version string, placement rookalp
 	}
 }
 
-// Start the mgr instance
+// Start begins the process of running a cluster of Ceph mgrs.
 func (c *Cluster) Start() error {
 	logger.Infof("start running mgr")
 
@@ -87,21 +90,27 @@ func (c *Cluster) Start() error {
 			logger.Errorf("cannot have more than %d mgrs", len(mgrNames))
 			break
 		}
+
 		daemonName := mgrNames[i]
-		name := fmt.Sprintf("%s-%s", appName, daemonName)
-		if err := c.createKeyring(c.Namespace, name, daemonName); err != nil {
-			return fmt.Errorf("failed to create %s keyring. %+v", name, err)
+		resourceName := fmt.Sprintf("%s-%s", appName, daemonName)
+		if err := c.createKeyring(c.Namespace, resourceName, daemonName); err != nil {
+			return fmt.Errorf("failed to create %s keyring. %+v", resourceName, err)
+		}
+
+		mgrConfig := &mgrConfig{
+			DaemonName:   daemonName,
+			ResourceName: resourceName,
 		}
 
 		// start the deployment
-		deployment := c.makeDeployment(name, daemonName)
+		deployment := c.makeDeployment(mgrConfig)
 		if _, err := c.context.Clientset.ExtensionsV1beta1().Deployments(c.Namespace).Create(deployment); err != nil {
 			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create %s deployment. %+v", name, err)
+				return fmt.Errorf("failed to create %s deployment. %+v", resourceName, err)
 			}
-			logger.Infof("%s deployment already exists", name)
+			logger.Infof("%s deployment already exists", resourceName)
 		} else {
-			logger.Infof("%s deployment started", name)
+			logger.Infof("%s deployment started", resourceName)
 		}
 	}
 
@@ -198,101 +207,6 @@ func (c *Cluster) makeDashboardService(name string) *v1.Service {
 	}
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
 	return svc
-}
-
-func (c *Cluster) makeDeployment(name, daemonName string) *extensions.Deployment {
-
-	podSpec := v1.PodTemplateSpec{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: c.getDaemonLabels(daemonName),
-			Annotations: map[string]string{"prometheus.io/scrape": "true",
-				"prometheus.io/port": strconv.Itoa(metricsPort)},
-		},
-		Spec: v1.PodSpec{
-			Containers:    []v1.Container{c.mgrContainer(name, daemonName)},
-			RestartPolicy: v1.RestartPolicyAlways,
-			Volumes: []v1.Volume{
-				{Name: k8sutil.DataDirVolume, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
-				k8sutil.ConfigOverrideVolume(),
-			},
-			HostNetwork: c.HostNetwork,
-		},
-	}
-	if c.HostNetwork {
-		podSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
-	}
-	c.placement.ApplyToPodSpec(&podSpec.Spec)
-
-	replicas := int32(1)
-	d := &extensions.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: c.Namespace,
-		},
-		Spec: extensions.DeploymentSpec{Template: podSpec, Replicas: &replicas},
-	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
-	return d
-}
-
-func (c *Cluster) mgrContainer(name, daemonName string) v1.Container {
-
-	return v1.Container{
-		Args: []string{
-			"ceph",
-			"mgr",
-			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
-		},
-		Name:  name,
-		Image: k8sutil.MakeRookImage(c.Version),
-		VolumeMounts: []v1.VolumeMount{
-			{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
-			k8sutil.ConfigOverrideMount(),
-		},
-		Env: []v1.EnvVar{
-			{Name: "ROOK_MGR_NAME", Value: daemonName},
-			{Name: "ROOK_MGR_KEYRING", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: name}, Key: keyringName}}},
-			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
-			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
-			opmon.ClusterNameEnvVar(c.Namespace),
-			opmon.EndpointEnvVar(),
-			opmon.SecretEnvVar(),
-			opmon.AdminSecretEnvVar(),
-			k8sutil.ConfigOverrideEnvVar(),
-		},
-		Resources: c.resources,
-		Ports: []v1.ContainerPort{
-			{
-				Name:          "mgr",
-				ContainerPort: int32(6800),
-				Protocol:      v1.ProtocolTCP,
-			},
-			{
-				Name:          "http-metrics",
-				ContainerPort: int32(metricsPort),
-				Protocol:      v1.ProtocolTCP,
-			},
-			{
-				Name:          "dashboard",
-				ContainerPort: int32(dashboardPort),
-				Protocol:      v1.ProtocolTCP,
-			},
-		},
-	}
-}
-
-func (c *Cluster) getLabels() map[string]string {
-	return map[string]string{
-		k8sutil.AppAttr:     appName,
-		k8sutil.ClusterAttr: c.Namespace,
-	}
-}
-
-func (c *Cluster) getDaemonLabels(daemonName string) map[string]string {
-	labels := c.getLabels()
-	labels["instance"] = daemonName
-	return labels
 }
 
 func (c *Cluster) createKeyring(clusterName, name, daemonName string) error {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgr
+
+import (
+	"fmt"
+	"strconv"
+
+	mgrdaemon "github.com/rook/rook/pkg/daemon/ceph/mgr"
+	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	mgrDaemonCommand = "ceph-mgr"
+)
+
+func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *extensions.Deployment {
+	podSpec := v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   mgrConfig.ResourceName,
+			Labels: c.getDaemonLabels(mgrConfig.DaemonName),
+			Annotations: map[string]string{"prometheus.io/scrape": "true",
+				"prometheus.io/port": strconv.Itoa(metricsPort)},
+		},
+		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				// Config file init performed by Rook
+				c.makeConfigInitContainer(mgrConfig),
+			},
+			Containers: []v1.Container{
+				c.makeMgrDaemonContainer(mgrConfig),
+			},
+			RestartPolicy: v1.RestartPolicyAlways,
+			Volumes:       opspec.PodVolumes(""),
+			HostNetwork:   c.HostNetwork,
+		},
+	}
+	if c.HostNetwork {
+		podSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	}
+	c.placement.ApplyToPodSpec(&podSpec.Spec)
+
+	replicas := int32(1)
+	d := &extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mgrConfig.ResourceName,
+			Namespace: c.Namespace,
+		},
+		Spec: extensions.DeploymentSpec{Template: podSpec, Replicas: &replicas},
+	}
+	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
+	return d
+}
+
+func (c *Cluster) makeConfigInitContainer(mgrConfig *mgrConfig) v1.Container {
+	return v1.Container{
+		Name: opspec.ConfigInitContainerName,
+		Args: []string{
+			"ceph",
+			mgrdaemon.InitCommand,
+			fmt.Sprintf("--config-dir=%s", k8sutil.DataDir),
+			fmt.Sprintf("--mgr-name=%s", mgrConfig.DaemonName),
+		},
+		Image: k8sutil.MakeRookImage(c.Version),
+		Env: []v1.EnvVar{
+			{Name: "ROOK_MGR_KEYRING",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{Name: mgrConfig.ResourceName},
+						Key:                  keyringName,
+					}}},
+			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
+			opmon.ClusterNameEnvVar(c.Namespace),
+			opmon.EndpointEnvVar(),
+			opmon.SecretEnvVar(),
+			opmon.AdminSecretEnvVar(),
+			k8sutil.ConfigOverrideEnvVar(),
+		},
+		VolumeMounts: opspec.RookVolumeMounts(),
+		// config file creation does not require ports to be open
+		Resources: c.resources,
+	}
+}
+
+func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
+	return v1.Container{
+		Name: "mgr",
+		Command: []string{
+			mgrDaemonCommand,
+		},
+		Args: []string{
+			"--foreground",
+			"--id", mgrConfig.DaemonName,
+		},
+		Image:        k8sutil.MakeRookImage(c.Version),
+		VolumeMounts: opspec.CephVolumeMounts(),
+		Ports: []v1.ContainerPort{
+			{
+				Name:          "mgr",
+				ContainerPort: int32(6800),
+				Protocol:      v1.ProtocolTCP,
+			},
+			{
+				Name:          "http-metrics",
+				ContainerPort: int32(metricsPort),
+				Protocol:      v1.ProtocolTCP,
+			},
+			{
+				Name:          "dashboard",
+				ContainerPort: int32(dashboardPort),
+				Protocol:      v1.ProtocolTCP,
+			},
+		},
+		Resources: c.resources,
+	}
+}
+
+func (c *Cluster) getLabels() map[string]string {
+	return map[string]string{
+		k8sutil.AppAttr:     appName,
+		k8sutil.ClusterAttr: c.Namespace,
+	}
+}
+
+func (c *Cluster) getDaemonLabels(daemonName string) map[string]string {
+	labels := c.getLabels()
+	labels["instance"] = daemonName
+	return labels
+}

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mgr
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/clusterd"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	mgrdaemon "github.com/rook/rook/pkg/daemon/ceph/mgr"
+	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	optest "github.com/rook/rook/pkg/operator/test"
+	testop "github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodSpec(t *testing.T) {
+	c := New(
+		&clusterd.Context{Clientset: testop.New(1)},
+		"ns",
+		"rook/rook:myversion",
+		rookalpha.Placement{},
+		false,
+		cephv1beta1.DashboardSpec{},
+		v1.ResourceRequirements{
+			Limits: v1.ResourceList{
+				v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+			},
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+			},
+		},
+		metav1.OwnerReference{},
+	)
+
+	mgrTestConfig := mgrConfig{
+		DaemonName:   "a",
+		ResourceName: "mgr-a",
+	}
+
+	d := c.makeDeployment(&mgrTestConfig)
+
+	assert.NotNil(t, d)
+	assert.Equal(t, "mgr-a", d.Name)
+	assert.Equal(t, "mgr-a", d.ObjectMeta.Name)
+	assert.Equal(t, 0, len(d.ObjectMeta.Annotations))
+
+	pod := d.Spec.Template
+	assert.Equal(t, appName, pod.ObjectMeta.Labels["app"])
+	assert.Equal(t, c.Namespace, pod.ObjectMeta.Labels["rook_cluster"])
+	assert.Equal(t, 2, len(pod.ObjectMeta.Annotations))
+	assert.Equal(t, "true", pod.ObjectMeta.Annotations["prometheus.io/scrape"])
+	assert.Equal(t, strconv.Itoa(metricsPort), pod.ObjectMeta.Annotations["prometheus.io/port"])
+	assert.Equal(t, v1.RestartPolicyAlways, pod.Spec.RestartPolicy)
+	assert.Nil(t, optest.VolumeExists("rook-data", pod.Spec.Volumes))
+	assert.Nil(t, optest.VolumeExists(cephconfig.DefaultConfigMountName, pod.Spec.Volumes))
+	assert.Nil(t, optest.VolumeExists(k8sutil.ConfigOverrideName, pod.Spec.Volumes))
+
+	assert.Equal(t, 1, len(pod.Spec.InitContainers))
+	assert.Equal(t, 1, len(pod.Spec.Containers))
+
+	configImage := "rook/rook:myversion"
+	configEnvs := 8
+	configContainerDefinition := cephtest.ContainerTestDefinition{
+		Image:   &configImage,
+		Command: []string{}, // no command
+		Args: [][]string{
+			{"ceph"},
+			{mgrdaemon.InitCommand},
+			{"--config-dir=/var/lib/rook"},
+			{fmt.Sprintf("--mgr-name=%s", mgrTestConfig.DaemonName)}},
+		InOrderArgs: map[int]string{
+			0: "ceph",                 // ceph must be first arg
+			1: mgrdaemon.InitCommand}, // mgr init command must be second arg
+		VolumeMountNames: []string{
+			"rook-data",
+			cephconfig.DefaultConfigMountName,
+			k8sutil.ConfigOverrideName},
+		EnvCount:     &configEnvs,
+		Ports:        []v1.ContainerPort{},
+		IsPrivileged: nil, // not set in spec
+	}
+	cont := &pod.Spec.InitContainers[0]
+	configContainerDefinition.TestContainer(t, "config init", cont, logger)
+	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
+	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
+
+	daemonImage := "rook/rook:myversion"
+	daemonEnvs := 0
+	daemonContainerDefinition := cephtest.ContainerTestDefinition{
+		Image: &daemonImage,
+		Command: []string{
+			"ceph-mgr"},
+		Args: [][]string{
+			{"--foreground"},
+			{"--id", mgrTestConfig.DaemonName}},
+		VolumeMountNames: []string{
+			"rook-data",
+			cephconfig.DefaultConfigMountName},
+		EnvCount: &daemonEnvs,
+		Ports: []v1.ContainerPort{
+			{ContainerPort: int32(6800),
+				Protocol: v1.ProtocolTCP},
+			{ContainerPort: int32(metricsPort),
+				Protocol: v1.ProtocolTCP},
+			{ContainerPort: int32(dashboardPort),
+				Protocol: v1.ProtocolTCP}},
+		IsPrivileged: nil, // not set in spec
+	}
+	cont = &pod.Spec.Containers[0]
+	daemonContainerDefinition.TestContainer(t, "main mon daemon", cont, logger)
+	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
+	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
+
+	// Verify that all the mounts have volumes and that there are no extraneous volumes
+	volsMountsTestDef := optest.VolumesAndMountsTestDefinition{
+		VolumesSpec: &optest.VolumesSpec{Moniker: "mon pod volumes", Volumes: pod.Spec.Volumes},
+		MountsSpecItems: []*optest.MountsSpec{
+			{Moniker: "mgr config init mounts", Mounts: pod.Spec.InitContainers[0].VolumeMounts},
+			{Moniker: "mgr daemon mounts", Mounts: pod.Spec.Containers[0].VolumeMounts}},
+	}
+	volsMountsTestDef.TestMountsMatchVolumes(t)
+}
+
+func TestServiceSpec(t *testing.T) {
+	c := New(&clusterd.Context{}, "ns", "myversion", rookalpha.Placement{}, false, cephv1beta1.DashboardSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{})
+
+	s := c.makeMetricsService("rook-mgr")
+	assert.NotNil(t, s)
+	assert.Equal(t, "rook-mgr", s.Name)
+	assert.Equal(t, 1, len(s.Spec.Ports))
+}
+
+func TestHostNetwork(t *testing.T) {
+	c := New(
+		&clusterd.Context{Clientset: testop.New(1)},
+		"ns",
+		"myversion",
+		rookalpha.Placement{},
+		true,
+		cephv1beta1.DashboardSpec{},
+		v1.ResourceRequirements{},
+		metav1.OwnerReference{},
+	)
+
+	mgrTestConfig := mgrConfig{
+		DaemonName:   "a",
+		ResourceName: "mgr-a",
+	}
+
+	d := c.makeDeployment(&mgrTestConfig)
+	assert.NotNil(t, d)
+
+	assert.Equal(t, true, d.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, v1.DNSClusterFirstWithHostNet, d.Spec.Template.Spec.DNSPolicy)
+}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -69,7 +69,7 @@ const (
 	MaxMonCount = 9
 )
 
-// Cluster represents the Rook configuration settings for Ceph mons.
+// Cluster represents the Rook and environment configuration settings needed to set up Ceph mons.
 type Cluster struct {
 	context              *clusterd.Context
 	Namespace            string

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -200,7 +200,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	assert.Equal(t, "2", cm.Data[MaxMonIDKey])
 }
 
-func TestMonInQuourm(t *testing.T) {
+func TestMonInQuorum(t *testing.T) {
 	entry := client.MonMapEntry{Name: "foo", Rank: 23}
 	quorum := []int{}
 	// Nothing in quorum

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 
-	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	mondaemon "github.com/rook/rook/pkg/daemon/ceph/mon"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -198,14 +197,7 @@ func (c *Cluster) makeMonmapInitContainer(monConfig *monConfig, containerName st
 func (c *Cluster) cephMonCommonArgs(monConfig *monConfig) []string {
 	return []string{
 		"--name", fmt.Sprintf("mon.%s", monConfig.DaemonName),
-		"--cluster", c.clusterInfo.Name,
 		"--mon-data", mondaemon.GetMonDataDirPath(c.context.ConfigDir, monConfig.DaemonName),
-		// It's safe to use the default path for the config b/c 'GenerateConfigFile'
-		// also writes a copy of the config to the default path
-		"--conf", cephconfig.DefaultConfigFilePath(),
-		// It's similarly safe to use the default path for the keyring b/c
-		// 'CreateKeyring' also writes a copy of the keyring to the default path
-		"--keyring", cephconfig.DefaultKeyringFilePath(),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -153,7 +153,7 @@ func testPodSpec(t *testing.T, dataDir string) {
 	monFsContDev := test_opceph.ContainerTestDefinition{
 		Image: &cephImage,
 		Command: []string{
-			"/usr/bin/ceph-mon"},
+			"ceph-mon"},
 		Args: append(
 			monCommonExpectedArgs(name, c),
 			[]string{"--mkfs"},
@@ -172,7 +172,7 @@ func testPodSpec(t *testing.T, dataDir string) {
 	monDaemonContDev := test_opceph.ContainerTestDefinition{
 		Image: &cephImage,
 		Command: []string{
-			"/usr/bin/ceph-mon"},
+			"ceph-mon"},
 		Args: append(
 			monCommonExpectedArgs(name, c),
 			[]string{"--foreground"},

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package spec provides Kubernetes controller/pod/container spec items used for many Ceph daemons
+package spec
+
+import (
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+)
+
+const (
+	// ConfigInitContainerName is the name which is given to the config initialization container
+	// in all Ceph pods.
+	ConfigInitContainerName = "config-init"
+)
+
+// PodVolumes returns the common list of Kubernetes volumes for use in Ceph pods.
+func PodVolumes(dataDirHostPath string) []v1.Volume {
+	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
+	if dataDirHostPath != "" {
+		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: dataDirHostPath}}
+	}
+	return []v1.Volume{
+		{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
+		cephconfig.DefaultConfigVolume(),
+		k8sutil.ConfigOverrideVolume(),
+	}
+}
+
+// CephVolumeMounts returns the common list of Kubernetes volume mounts for Ceph containers.
+func CephVolumeMounts() []v1.VolumeMount {
+	return []v1.VolumeMount{
+		{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
+		cephconfig.DefaultConfigMount(),
+		// Rook doesn't run in ceph containers, so it doesn't need the config override mounted
+
+	}
+}
+
+// RookVolumeMounts returns the common list of Kubernetes volume mounts for Rook containers.
+func RookVolumeMounts() []v1.VolumeMount {
+	return append(
+		CephVolumeMounts(),
+		k8sutil.ConfigOverrideMount(),
+	)
+}

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -29,7 +29,7 @@ const (
 	ConfigInitContainerName = "config-init"
 )
 
-// PodVolumes returns the common list of Kubernetes volumes for use in Ceph pods.
+// PodVolumes fills in the volumes parameter with the common list of Kubernetes volumes for use in Ceph pods.
 func PodVolumes(dataDirHostPath string) []v1.Volume {
 	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if dataDirHostPath != "" {
@@ -48,7 +48,6 @@ func CephVolumeMounts() []v1.VolumeMount {
 		{Name: k8sutil.DataDirVolume, MountPath: k8sutil.DataDir},
 		cephconfig.DefaultConfigMount(),
 		// Rook doesn't run in ceph containers, so it doesn't need the config override mounted
-
 	}
 }
 

--- a/pkg/operator/ceph/spec/spec_test.go
+++ b/pkg/operator/ceph/spec/spec_test.go
@@ -24,21 +24,12 @@ import (
 )
 
 func TestPodVolumes(t *testing.T) {
-	type args struct {
-		dataDirHostPath string
+	if err := test.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes("")); err != nil {
+		t.Errorf("PodVolumes(\"\") - data dir source is not EmptyDir: %s", err.Error())
 	}
-	t.Run("Empty string dataDirHostPath is EmptyDir volume", func(t *testing.T) {
-		err := test.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes(""))
-		if err != nil {
-			t.Errorf("PodVolumes(\"\") - dataDirHostPath is not EmptyDir: %s", err.Error())
-		}
-	})
-	t.Run("Specified dataDirHostPath is HostPath volume", func(t *testing.T) {
-		err := test.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes("/dev/sdb"))
-		if err != nil {
-			t.Errorf("PodVolumes(\"/dev/sdb\") - dataDirHostPath is not HostPath: %s", err.Error())
-		}
-	})
+	if err := test.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes("/dev/sdb")); err != nil {
+		t.Errorf("PodVolumes(\"/dev/sdb\") - data dir source is not HostPath: %s", err.Error())
+	}
 }
 
 func TestMountsMatchVolumes(t *testing.T) {

--- a/pkg/operator/ceph/spec/spec_test.go
+++ b/pkg/operator/ceph/spec/spec_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"github.com/rook/rook/pkg/operator/testlib"
+	"github.com/rook/rook/pkg/operator/test"
 )
 
 func TestPodVolumes(t *testing.T) {
@@ -28,13 +28,13 @@ func TestPodVolumes(t *testing.T) {
 		dataDirHostPath string
 	}
 	t.Run("Empty string dataDirHostPath is EmptyDir volume", func(t *testing.T) {
-		err := testlib.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes(""))
+		err := test.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes(""))
 		if err != nil {
 			t.Errorf("PodVolumes(\"\") - dataDirHostPath is not EmptyDir: %s", err.Error())
 		}
 	})
 	t.Run("Specified dataDirHostPath is HostPath volume", func(t *testing.T) {
-		err := testlib.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes("/dev/sdb"))
+		err := test.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes("/dev/sdb"))
 		if err != nil {
 			t.Errorf("PodVolumes(\"/dev/sdb\") - dataDirHostPath is not HostPath: %s", err.Error())
 		}
@@ -42,19 +42,12 @@ func TestPodVolumes(t *testing.T) {
 }
 
 func TestMountsMatchVolumes(t *testing.T) {
-	volsSpec := testlib.VolumesSpec{
-		Moniker: "PodVolumes(\"/dev/sdc\")",
-		Volumes: PodVolumes("/dev/sdc"),
+	volsMountsTestDef := test.VolumesAndMountsTestDefinition{
+		VolumesSpec: &test.VolumesSpec{
+			Moniker: "PodVolumes(\"/dev/sdc\")", Volumes: PodVolumes("/dev/sdc")},
+		MountsSpecItems: []*test.MountsSpec{
+			{Moniker: "CephVolumeMounts()", Mounts: CephVolumeMounts()},
+			{Moniker: "RookVolumeMounts()", Mounts: RookVolumeMounts()}},
 	}
-	mountsSpecItems := []testlib.MountsSpec{
-		{
-			Moniker: "CephVolumeMounts()",
-			Mounts:  CephVolumeMounts(),
-		},
-		{
-			Moniker: "RookVolumeMounts()",
-			Mounts:  RookVolumeMounts(),
-		},
-	}
-	testlib.TestMountsMatchVolumes(t, volsSpec, mountsSpecItems...)
+	volsMountsTestDef.TestMountsMatchVolumes(t)
 }

--- a/pkg/operator/ceph/spec/spec_test.go
+++ b/pkg/operator/ceph/spec/spec_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/testlib"
+)
+
+func TestPodVolumes(t *testing.T) {
+	type args struct {
+		dataDirHostPath string
+	}
+	t.Run("Empty string dataDirHostPath is EmptyDir volume", func(t *testing.T) {
+		err := testlib.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes(""))
+		if err != nil {
+			t.Errorf("PodVolumes(\"\") - dataDirHostPath is not EmptyDir: %s", err.Error())
+		}
+	})
+	t.Run("Specified dataDirHostPath is HostPath volume", func(t *testing.T) {
+		err := testlib.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes("/dev/sdb"))
+		if err != nil {
+			t.Errorf("PodVolumes(\"/dev/sdb\") - dataDirHostPath is not HostPath: %s", err.Error())
+		}
+	})
+}
+
+func TestMountsMatchVolumes(t *testing.T) {
+	volsSpec := testlib.VolumesSpec{
+		Moniker: "PodVolumes(\"/dev/sdc\")",
+		Volumes: PodVolumes("/dev/sdc"),
+	}
+	mountsSpecItems := []testlib.MountsSpec{
+		{
+			Moniker: "CephVolumeMounts()",
+			Mounts:  CephVolumeMounts(),
+		},
+		{
+			Moniker: "RookVolumeMounts()",
+			Mounts:  RookVolumeMounts(),
+		},
+	}
+	testlib.TestMountsMatchVolumes(t, volsSpec, mountsSpecItems...)
+}

--- a/pkg/operator/ceph/test/container.go
+++ b/pkg/operator/ceph/test/container.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	optest "github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+)
+
+// ContainerTestDefinition defines which k8s container values to test and what those values should
+// be. Any definition item may be nil, and a nil value will prevent the item from being tested in
+// the container test.
+type ContainerTestDefinition struct {
+	// Image is the name of the container image
+	Image *string
+	// Command is the container command
+	Command []string
+	// Args is a list of expected arguments in the same format as the expected arguments from
+	// the ArgumentsMatchExpected() function.
+	Args [][]string
+	// InOrderArgs is a map of argument position (int) to the argument itself (string). If the
+	// "third" arg must be exactly the third argument this should be: InOrderArgs[2]="third"
+	InOrderArgs map[int]string
+	// VolumeMountNames is a list of volume mount names which must be mounted in the container
+	VolumeMountNames []string
+	// EnvCount is the number of 'Env' variables the container should define
+	EnvCount *int
+	// Ports is a list of ports the container must define. This list is in order, and each port's
+	// 'ContainerPort' and 'Protocol' are tested for equality.
+	// Note: port's in general aren't order-dependent, but there is not yet a method to test for
+	//       the existence of a port in a list of ports without caring about order.
+	Ports []v1.ContainerPort
+	// IsPrivileged tests if the container is privileged (true) or unprivileged (false)
+	IsPrivileged *bool
+}
+
+// TestContainer tests that a container matches the container test definition. Moniker is a name
+// given to the container for identifying it in tests. Cont is the container to be tested.
+// Logger is the logger to output logs to.
+func (d *ContainerTestDefinition) TestContainer(
+	t *testing.T,
+	moniker string,
+	cont *v1.Container,
+	logger *capnslog.PackageLogger,
+) {
+
+	if d.Image != nil {
+		assert.Equal(t, *d.Image, cont.Image)
+	}
+	logCommandWithArgs(moniker, cont.Command, cont.Args, logger)
+	if d.Command != nil {
+		assert.Equal(t, len(d.Command), len(cont.Command))
+		assert.Equal(t, strings.Join(d.Command, " "), strings.Join(cont.Command, " "))
+	}
+	if d.Args != nil {
+		assert.Nil(t, optest.ArgumentsMatchExpected(cont.Args, d.Args))
+	}
+	if d.InOrderArgs != nil {
+		for argNum, arg := range d.InOrderArgs {
+			assert.Equal(t, cont.Args[argNum], arg)
+		}
+	}
+	if d.VolumeMountNames != nil {
+		assert.Equal(t, len(d.VolumeMountNames), len(cont.VolumeMounts))
+		for _, n := range d.VolumeMountNames {
+			assert.Nil(t, optest.VolumeMountExists(n, cont.VolumeMounts))
+		}
+	}
+	if d.EnvCount != nil {
+		assert.Equal(t, *d.EnvCount, len(cont.Env))
+	}
+	if d.Ports != nil {
+		assert.Equal(t, len(d.Ports), len(cont.Ports))
+		for i, p := range d.Ports {
+			assert.Equal(t, p.ContainerPort, cont.Ports[i].ContainerPort)
+			assert.Equal(t, p.Protocol, cont.Ports[i].Protocol)
+		}
+	}
+	if d.IsPrivileged != nil {
+		assert.Equal(t, *d.IsPrivileged, *cont.SecurityContext.Privileged)
+	}
+}
+
+// logCommandWithArgs writes a command and its arguments to the logger with a moniker to identify it
+func logCommandWithArgs(moniker string, command, args []string, logger *capnslog.PackageLogger) {
+	logger.Infof("%s command : %s %s", moniker, strings.Join(command, " "), strings.Join(args, " "))
+}

--- a/pkg/operator/ceph/test/container.go
+++ b/pkg/operator/ceph/test/container.go
@@ -1,3 +1,21 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test provides common resources useful for testing many Ceph daemons. This includes
+// functions for testing that resources match what is expected.
 package test
 
 import (

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package test for the operator tests.
 package test
 
 import (

--- a/pkg/operator/test/info.go
+++ b/pkg/operator/test/info.go
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package test for the operator tests
+// Package test provides common resources useful for testing many operators. This includes functions
+// for creating fake/mock resources and functions for testing that resources match what is expected.
 package test
 
 import (

--- a/pkg/operator/test/spec.go
+++ b/pkg/operator/test/spec.go
@@ -1,7 +1,19 @@
-// Package testlib provides common methods for testing code which applies to many Ceph daemons.
-//
-// Methods beginning with "TestSpec" can be used to test that Kubernetes resource specs (pods, etc.)
-// are configured correctly.
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (

--- a/pkg/operator/test/spec.go
+++ b/pkg/operator/test/spec.go
@@ -1,0 +1,58 @@
+// Package testlib provides common methods for testing code which applies to many Ceph daemons.
+//
+// Methods beginning with "TestSpec" can be used to test that Kubernetes resource specs (pods, etc.)
+// are configured correctly.
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coreos/pkg/capnslog"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "ceph-op-testlib")
+
+// ArgumentsMatchExpected returns a descriptive error if any of the expected arguments do not exist.
+// This supports arguments in which flags appear multiple times with different values but does not
+// support multiple instances of the same flag-value. This test is designed to fail if the list
+// of actual arguments contains extra arguments not specified in the expected args.
+// The expected arguments are given as an array of string arrays. This is to support flags which
+// may have multiple values. Examples:
+// expectedArgs := [][]string{
+//     {"-h"},                              // test for a short flag
+//     {"-vvv"},                            // test for a short flag with value(s) specified
+//     {"-d", "3"},                         // test for a short flag with a value specified
+//     {"--verbose"},                       // test for a --bool flag
+//     {"--name=alex"},                     // test for a --flag=value flag
+//     {"--name", "sam"},                   // test for a --flag with a value after a space
+//     {"--full-name", "sam", "goodhuman"}, // test for a --flag with 2 values separated by spaces
+// }
+func ArgumentsMatchExpected(actualArgs []string, expectedArgs [][]string) error {
+	// join all args into a big space-separated arg string so we can use string search on it
+	// this is simpler than a bunch of nested for loops and if statements with continues in them
+	fullArgString := strings.Join(actualArgs, " ")
+	logger.Info("testing that actual args: %s\nmatch expected args:%v", fullArgString, actualArgs)
+	for _, arg := range expectedArgs {
+		// We join each individual argument together the same was as the big string
+		validArgMatcher := strings.Join(arg, " ")
+		if validArgMatcher == "" {
+			return fmt.Errorf("Expected argument %v evaluated to empty string; ArgumentsMatchExpected() doesn't know what to do", arg)
+		}
+		matches := strings.Count(fullArgString, validArgMatcher)
+		if matches > 1 {
+			return fmt.Errorf("More than one instance of flag '%s' in: %s; ArgumentsMatchExpected() doesn't know what to do",
+				validArgMatcher, fullArgString)
+		} else if matches == 1 {
+			// Remove the instance of the valid match so we can't match to it any more
+			fullArgString = strings.Replace(fullArgString, validArgMatcher, "", 1)
+		} else { // zero matches
+			return fmt.Errorf("Expected argument '%s' missing in: %s\n(It's possible the same arg is in expectedArgs twice.)",
+				validArgMatcher, strings.Join(actualArgs, " "))
+		}
+	}
+	if remainingArgs := strings.Trim(fullArgString, " "); remainingArgs != "" {
+		return fmt.Errorf("The actual arguments have additional args specified: %s", remainingArgs)
+	}
+	return nil
+}

--- a/pkg/operator/test/spec_test.go
+++ b/pkg/operator/test/spec_test.go
@@ -1,0 +1,61 @@
+// Package testlib provides common methods for testing code which applies to many Ceph daemons.
+//
+// Methods beginning with "TestSpec" can be used to test that Kubernetes resource specs (pods, etc.)
+// are configured correctly.
+package test
+
+import "testing"
+
+// Test the tests!
+
+// make one expected arg
+func oneExp(s ...string) [][]string {
+	return [][]string{s}
+}
+
+// make actual args
+func act(s ...string) []string {
+	return s
+}
+
+func TestArgumentsMatchExpected(t *testing.T) {
+	type args struct {
+		expectedArgs [][]string
+		actualArgs   []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"-f ; ok", args{oneExp("-h"), act("-h")}, false},
+		{"--flag=val ; ok", args{oneExp("--show=all"), act("--show=all")}, false},
+		{"--flag val ; ok", args{oneExp("--show", "all"), act("--show", "all")}, false},
+		{"-fval notfound", args{oneExp("-Ohere"), act("-ohere")}, true},
+		{"--flag val ; no flag", args{oneExp("--debug", "3"), act("--iterations", "3")}, true},
+		{"--flag val ; no val", args{oneExp("--debug", "3"), act("--debug", "4")}, true},
+		{"--flag val ; out of order", args{oneExp("-d", "3"), act("3", "-d")}, true},
+		{"empty expected arg", args{oneExp(""), act("-h")}, true},
+		{"empty actual", args{oneExp("-h"), act("")}, true},
+		{"extra actuals", args{oneExp("-h"), act("-h", "-v")}, true},
+		{"complicated ; ok", args{
+			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
+			[]string{"-h", "-vvv", "-d", "3", "--name=kit", "--name", "sammy"}}, false},
+		{"complicated ; missing", args{
+			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
+			[]string{"-h", "-vvv", "-d", "3", "--name", "sammy"}}, true},
+		{"complicated ; extra actuals", args{
+			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
+			[]string{"-h", "-vvv", "--i-am=extra", "-d", "3", "--name", "sammy"}}, true},
+		{"complicated ; double instance", args{
+			[][]string{{"-h"}, {"-vvv"}, {"-d", "3"}, {"--name=kit"}, {"--name", "sammy"}},
+			[]string{"-h", "-vvv", "-vvv", "-d", "3", "--name", "sammy"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ArgumentsMatchExpected(tt.args.actualArgs, tt.args.expectedArgs); (err != nil) != tt.wantErr {
+				t.Errorf("ArgumentsMatchExpected() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/operator/test/spec_test.go
+++ b/pkg/operator/test/spec_test.go
@@ -1,7 +1,19 @@
-// Package testlib provides common methods for testing code which applies to many Ceph daemons.
-//
-// Methods beginning with "TestSpec" can be used to test that Kubernetes resource specs (pods, etc.)
-// are configured correctly.
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import "testing"

--- a/pkg/operator/test/volumes.go
+++ b/pkg/operator/test/volumes.go
@@ -1,0 +1,210 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+)
+
+/*
+ * Simple Volume and VolumeMount Tests
+ */
+
+// VolumeExists returns a descriptive error if the volume does not exist.
+func VolumeExists(volumeName string, volumes []v1.Volume) error {
+	_, err := getVolume(volumeName, volumes)
+	return err
+}
+
+// VolumeIsEmptyDir returns a descriptive error if the volume does not exist or is not an empty dir
+func VolumeIsEmptyDir(volumeName string, volumes []v1.Volume) error {
+	volume, err := getVolume(volumeName, volumes)
+	if err == nil && volume.VolumeSource.EmptyDir == nil {
+		return fmt.Errorf("volume %s is not EmptyDir: %s", volumeName, HumanReadableVolume(volume))
+	}
+	if err == nil && volume.VolumeSource.HostPath != nil {
+		return fmt.Errorf("volume %s is both EmptyDir and HostPath: %s", volumeName, HumanReadableVolume(volume))
+	}
+	return err
+}
+
+// VolumeIsHostPath returns a descriptive error if the volume does not exist, is not a HostPath
+// volume, or if the volume's path is not as expected.
+func VolumeIsHostPath(volumeName, path string, volumes []v1.Volume) error {
+	volume, err := getVolume(volumeName, volumes)
+	if err == nil && volume.VolumeSource.HostPath == nil {
+		return fmt.Errorf("volume %s is not HostPath: %s", volumeName, HumanReadableVolume(volume))
+	}
+	if err == nil && volume.VolumeSource.HostPath.Path != path {
+		return fmt.Errorf("volume %s is HostPath but has wrong path: %s", volumeName, HumanReadableVolume(volume))
+	}
+	if err == nil && volume.VolumeSource.EmptyDir != nil {
+		return fmt.Errorf("volume %s is both HostPath and EmptyDir: %s", volumeName, HumanReadableVolume(volume))
+	}
+	return err
+}
+
+// VolumeMountExists returns returns a descriptive error if the volume mount does not exist.
+func VolumeMountExists(mountName string, mounts []v1.VolumeMount) error {
+	_, err := getMount(mountName, mounts)
+	return err
+}
+
+/*
+ * Human-readable representations of Volumes and VolumeMounts
+ */
+
+// HumanReadableVolumes returns a string representation of a list of Kubernetes volumes which is
+// more compact and human readable than the default string go prints.
+func HumanReadableVolumes(volumes []v1.Volume) string {
+	stringVols := []string{}
+	for _, volume := range volumes {
+		stringVols = append(stringVols, HumanReadableVolume(&volume))
+	}
+	return fmt.Sprintf("%v", stringVols)
+}
+
+// HumanReadableVolume returns a string representation of a Kubernetes volume which is more compact
+// and human readable than the default string go prints.
+func HumanReadableVolume(v *v1.Volume) string {
+	sourceString := "something went wrong parsing the volume source in HumanReadableVolume()"
+	if v.VolumeSource.EmptyDir != nil {
+		sourceString = "EmptyDir"
+	} else if v.VolumeSource.HostPath != nil {
+		sourceString = v.VolumeSource.HostPath.Path
+	} else {
+		// If can't convert the vol source to something human readable, just output something useful
+		sourceString = fmt.Sprintf("%v", v.VolumeSource)
+	}
+	return fmt.Sprintf("{%s : %s}", v.Name, sourceString)
+}
+
+// HumanReadableVolumeMounts returns a string representation of a list of Kubernetes volume mounts which
+// is more compact and human readable than the default string go prints.
+func HumanReadableVolumeMounts(mounts []v1.VolumeMount) string {
+	stringMounts := []string{}
+	for _, mount := range mounts {
+		stringMounts = append(stringMounts, HumanReadableVolumeMount(&mount))
+	}
+	return fmt.Sprintf("%v", stringMounts)
+}
+
+// HumanReadableVolumeMount returns a string representation of a Kubernetes volume mount which is more
+// compact and human readable than the default string go prints.
+func HumanReadableVolumeMount(m *v1.VolumeMount) string {
+	return fmt.Sprintf("{%s : %s}", m.Name, m.MountPath)
+}
+
+/*
+ * Fully-implemented test for matching Volumes and VolumeMounts
+ */
+
+// VolumesSpec is a struct which includes a list of Kubernetes volumes as well as additional
+// metadata about the volume list for better identification during tests.
+type VolumesSpec struct {
+	// Moniker is a name given to the list to help identify it
+	Moniker string
+	Volumes []v1.Volume
+}
+
+// MountsSpec is a struct which includes a list of Kubernetes volume mounts as well as additional
+// metadata about the volume mount list for better identification during tests.
+type MountsSpec struct {
+	// Moniker is a name given to the list to help identify it
+	Moniker string
+	Mounts  []v1.VolumeMount
+}
+
+// VolumesAndMountsTestDefinition defines which volumes and mounts to test and what those values
+// should be. The test is intended to be defined with VolumesSpec defined as a pod's volumes, and
+// the list of MountsSpec items defined as the volume mounts from every container in the pod.
+type VolumesAndMountsTestDefinition struct {
+	VolumesSpec     *VolumesSpec
+	MountsSpecItems []*MountsSpec
+}
+
+// TestMountsMatchVolumes tests two things:
+// (1) That each volume mount in each every MountsSpec has a corresponding volume to source it
+//     in the VolumesSpec
+// (2) That there are no extraneous volumes defined in the VolumesSpec that do not have a
+//     corresponding volume mount in any of the MountsSpec items
+func (d *VolumesAndMountsTestDefinition) TestMountsMatchVolumes(t *testing.T) {
+	// Run a test for each MountsSpec item to verify that all the volume mounts within each item
+	// have a corresponding volume in VolumesSpec to source it
+	for _, mountsSpec := range d.MountsSpecItems {
+		t.Run(
+			fmt.Sprintf("%s mounts match volumes in %s", mountsSpec.Moniker, d.VolumesSpec.Moniker),
+			func(t *testing.T) {
+				for _, mount := range mountsSpec.Mounts {
+					assert.Nil(t, VolumeExists(mount.Name, d.VolumesSpec.Volumes),
+						"%s volume mount %s does not have a corresponding %s volume to source it: %s",
+						mountsSpec.Moniker, HumanReadableVolumeMount(&mount),
+						d.VolumesSpec.Moniker, HumanReadableVolumes(d.VolumesSpec.Volumes))
+				}
+			},
+		)
+	}
+
+	// Test that each volume in VolumesSpec has a usage in at least one of the volume mounts in at
+	// least one of the MountsSpecs items
+	t.Run(
+		fmt.Sprintf("No extraneous %s volumes exist", d.VolumesSpec.Moniker),
+		func(t *testing.T) {
+			for _, volume := range d.VolumesSpec.Volumes {
+				assert.Nil(t, mountExistsInMountsSpecItems(volume.Name, d.MountsSpecItems),
+					"%s volume %s is not used by any volume mount: %v",
+					d.VolumesSpec.Moniker, HumanReadableVolume(&volume),
+					humanReadableMountsSpecItems(d.MountsSpecItems))
+			}
+		},
+	)
+}
+
+/*
+ * Helpers
+ */
+
+func mountExistsInMountsSpecItems(name string, mountsSpecItems []*MountsSpec) error {
+	for _, mountsSpec := range mountsSpecItems {
+		if err := VolumeMountExists(name, mountsSpec.Mounts); err == nil {
+			return nil // successfully found that the mount exists at least once
+		}
+	}
+	return fmt.Errorf("") // not in any mounts; calling func will output a better error
+}
+
+func humanReadableMountsSpecItems(mountsSpecItems []*MountsSpec) (humanReadable string) {
+	for _, mountsSpec := range mountsSpecItems {
+		humanReadable = fmt.Sprintf("%s%s - %s\n", humanReadable,
+			mountsSpec.Moniker, HumanReadableVolumeMounts(mountsSpec.Mounts),
+		)
+	}
+	return
+}
+
+const (
+	volNotFound = "Volume Was Not Found by getVolume()"
+	mntNotFound = "VolumeMount Was Not Found by getMount()"
+)
+
+func getVolume(volumeName string, volumes []v1.Volume) (*v1.Volume, error) {
+	for _, volume := range volumes {
+		if volume.Name == volumeName {
+			return &volume, nil
+		}
+	}
+	return &v1.Volume{Name: volNotFound},
+		fmt.Errorf("volume %s does not exist in %s", volumeName, HumanReadableVolumes(volumes))
+}
+
+func getMount(mountName string, mounts []v1.VolumeMount) (*v1.VolumeMount, error) {
+	for _, mount := range mounts {
+		if mount.Name == mountName {
+			return &mount, nil
+		}
+	}
+	return &v1.VolumeMount{Name: mntNotFound},
+		fmt.Errorf("volume mount %s does not exist in %s", mountName, HumanReadableVolumeMounts(mounts))
+}

--- a/pkg/operator/test/volumes.go
+++ b/pkg/operator/test/volumes.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (

--- a/pkg/operator/test/volumes_test.go
+++ b/pkg/operator/test/volumes_test.go
@@ -1,0 +1,120 @@
+package test
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestVolumeExists(t *testing.T) {
+	vols := []v1.Volume{{Name: "a"}, {Name: "b"}, {Name: "d"}}
+	type args struct {
+		volumeName string
+		volumes    []v1.Volume
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"exists", args{"d", vols}, false},
+		{"dne", args{"c", vols}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VolumeExists(tt.args.volumeName, tt.args.volumes); (err != nil) != tt.wantErr {
+				t.Errorf("VolumeExists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func vols(v ...v1.Volume) []v1.Volume {
+	return v
+}
+func TestVolumeIsEmptyDir(t *testing.T) {
+	emptyVolume := v1.Volume{Name: "e", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	emptyAndHostVolume := v1.Volume{Name: "e&hp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	emptyAndHostVolume.VolumeSource.HostPath = &v1.HostPathVolumeSource{Path: "/dev/sdx"}
+	hostVolume := v1.Volume{Name: "h", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev/vdh"}}}
+	type args struct {
+		volumeName string
+		volumes    []v1.Volume
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"is EmptyDir", args{"e", vols(emptyVolume)}, false},
+		{"is HostPath", args{"h", vols(hostVolume)}, true},
+		{"EmptyDir and HostPath", args{"e&hp", vols(emptyAndHostVolume)}, true},
+		{"not found", args{"e", vols(hostVolume)}, true},
+		{"many ; ok", args{"e", vols(emptyVolume, hostVolume, emptyAndHostVolume)}, false},
+		{"many ; nf", args{"e", vols(hostVolume, emptyAndHostVolume)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VolumeIsEmptyDir(tt.args.volumeName, tt.args.volumes); (err != nil) != tt.wantErr {
+				t.Errorf("VolumeIsEmptyDir() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVolumeIsHostPath(t *testing.T) {
+	emptyVolume := v1.Volume{Name: "e", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	emptyAndHostVolume := v1.Volume{Name: "e&hp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	emptyAndHostVolume.VolumeSource.HostPath = &v1.HostPathVolumeSource{Path: "/dev/sdx"}
+	hostVolume := v1.Volume{Name: "h", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev/vdh"}}}
+	type args struct {
+		volumeName string
+		path       string
+		volumes    []v1.Volume
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"is EmptyDir", args{"e", "/dev/sdx", vols(emptyVolume)}, true},
+		{"is HostPath", args{"h", "/dev/vdh", vols(hostVolume)}, false},
+		{"wrong HostPath", args{"h", "/dev/sdx", vols(hostVolume)}, true},
+		{"EmptyDir and HostPath", args{"e&hp", "/dev/sdx", vols(emptyAndHostVolume)}, true},
+		{"not found", args{"e", "/dev/sdx", vols(hostVolume)}, true},
+		{"many ; ok", args{"h", "/dev/vdh", vols(emptyVolume, hostVolume, emptyAndHostVolume)}, false},
+		{"many ; nf", args{"h", "/dev/vdh", vols(emptyVolume, emptyAndHostVolume)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VolumeIsHostPath(tt.args.volumeName, tt.args.path, tt.args.volumes); (err != nil) != tt.wantErr {
+				t.Errorf("VolumeIsHostPath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVolumeMountExists(t *testing.T) {
+	mounts := []v1.VolumeMount{{Name: "a"}, {Name: "b"}, {Name: "d"}}
+	type args struct {
+		mountName string
+		mounts    []v1.VolumeMount
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"exists", args{"d", mounts}, false},
+		{"dne", args{"c", mounts}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VolumeMountExists(tt.args.mountName, tt.args.mounts); (err != nil) != tt.wantErr {
+				t.Errorf("VolumeMountExists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Don't test human readables since they aren't critical to function

--- a/pkg/operator/test/volumes_test.go
+++ b/pkg/operator/test/volumes_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package test
 
 import (


### PR DESCRIPTION
The initial (still very WIP) part of these changes include changes to mon and config as well to pull out duplicated and nearly-duplicated code between these 2 and the mgr into shared packages. The first changes have focused on some shared test methods.

**Description of your changes:**
Progress toward issue #2003.
Includes design from design doc PR #1578

**Which issue is resolved by this Pull Request:**
Progress toward issue #2003.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
- [x] Update commit messages
