### PR TITLE
Fix Rook NFS image cross-build issue on AArch64

### DIFF
--- a/images/nfs/Dockerfile
+++ b/images/nfs/Dockerfile
@@ -14,7 +14,7 @@
 
 #Portions of this file came from https://github.com/kubernetes-incubator/external-storage/blob/master/nfs/deploy/docker/Dockerfile, which uses the same license.
 
-FROM fedora:26
+FROM NFS_BASEIMAGE
 
 # Build ganesha from source, installing deps and removing them in one line.
 # Why?

--- a/images/nfs/Makefile
+++ b/images/nfs/Makefile
@@ -19,6 +19,14 @@ include ../image.mk
 
 NFS_IMAGE = $(BUILD_REGISTRY)/nfs-$(GOARCH)
 
+NFS_BASE ?= fedora:26
+
+ifeq ($(GOARCH),amd64)
+NFS_BASEIMAGE = $(NFS_BASE)
+else ifeq ($(GOARCH),arm64)
+NFS_BASEIMAGE = arm64v8/$(NFS_BASE)
+endif
+
 TEMP := $(shell mktemp -d)
 
 # ====================================================================================
@@ -35,6 +43,7 @@ do.build:
 	@cp Dockerfile $(TEMP)
 	@cp start.sh $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
+	@cd $(TEMP) && $(SED_CMD) 's|NFS_BASEIMAGE|$(NFS_BASEIMAGE)|g' Dockerfile
 	@docker build $(BUILD_ARGS) \
 		-t $(NFS_IMAGE) \
 		$(TEMP)


### PR DESCRIPTION
We need to pull the base image for `arm64`, not for `amd64`. This PR adds prefix `arm64v8` to`fedora:26` for pull the right image.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add prefix of `arm64v8` to the base image to pull the right image when cross-building `nfs-arm64`.
**Which issue is resolved by this Pull Request:**
Resolves #2110

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
