### PR TITLE
Add golang 1.11 version support

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -49,7 +49,7 @@ GO_TEST_FLAGS ?=
 # ====================================================================================
 # Setup go environment
 
-GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10
+GO_SUPPORTED_VERSIONS ?= 1.7|1.8|1.9|1.10|1.11
 
 GO_PACKAGES := $(foreach t,$(GO_SUBDIRS),$(GO_PROJECT)/$(t)/...)
 GO_INTEGRATION_TEST_PACKAGES := $(foreach t,$(GO_INTEGRATION_TESTS_SUBDIRS),$(GO_PROJECT)/$(t)/integration)


### PR DESCRIPTION
Now the golang version 1.11 has been released by the official website[1], so let's add support for this version, else we'll get below build error when using golang 1.11:

```
build/makelib/golang.mk:103: *** unsupported go version. Please
make install one of the following supported version: '1.7|1.8|1.9|1.10'.  Stop.
```

[1] https://golang.org/dl/

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Bump the golang version to 1.11
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
