### PR TITLE
RFC: Add images based on openSUSE Leap

### DIFF
--- a/images/ceph-toolbox/Dockerfile.base.suse
+++ b/images/ceph-toolbox/Dockerfile.base.suse
@@ -1,0 +1,34 @@
+FROM BASEIMAGE
+SHELL ["/bin/bash","-c"]
+
+MAINTAINER Sebastian Wagner "sebastian.wagner@suse.com"
+
+RUN ( \
+    zypper --non-interactive --gpg-auto-import-keys \
+        install --no-recommends --auto-agree-with-licenses --replacefiles --details \
+            binutils \
+            curl \
+            fio \
+            gdb \
+            iperf \
+            jq \
+            kmod \
+            less \
+            man \
+            ncat \
+            net-tools \
+            nmap \
+            vim \
+        && \
+    zypper --non-interactive --gpg-auto-import-keys clean --all \
+) || ( retval=$? && echo ' = zypper log = ' && cat /var/log/zypper.log && exit $retval )
+
+ARG ARCH
+ARG TINI_VERSION
+
+# Run tini as PID 1 and avoid signal handling issues
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "-g", "--"]
+CMD ["/bin/bash"]

--- a/images/ceph-toolbox/Makefile
+++ b/images/ceph-toolbox/Makefile
@@ -21,19 +21,28 @@ CACHE_IMAGES = $(TOOLBOX_BASE_IMAGE)
 CEPH_VERSION = $(shell cat ../ceph/ceph_version)
 BASEIMAGE = $(CEPH_VERSION)-$(PLATFORM_ARCH)
 
+TEMP_BASE := $(shell mktemp -d)
 TEMP := $(shell mktemp -d)
+
+$(TEMP_BASE)/Dockerfile: Dockerfile.base Dockerfile.base.suse
+	@if [[ "$(BASEIMAGE)" =~ .*suse* ]] ; \
+	then \
+		echo DOCKER_HOST=$$DOCKER_HOST ; \
+		cp Dockerfile.base.suse $(TEMP_BASE)/Dockerfile ; \
+	else \
+		cp Dockerfile.base $(TEMP_BASE)/Dockerfile ; \
+	fi \
 
 # Split into base image and main image so that the base image may be cached on
 # the CI servers to speed up rebuilds.
-toolbox-base-image:
+toolbox-base-image: $(TEMP_BASE)/Dockerfile
 	@echo === docker build $(TOOLBOX_BASE_IMAGE)
-	@cp Dockerfile.base $(TEMP)/Dockerfile
-	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+	@cd $(TEMP_BASE) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@docker build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
 		-t $(TOOLBOX_BASE_IMAGE) \
-		$(TEMP)
+		$(TEMP_BASE)
 
 do.build: toolbox-base-image
 	@echo === docker build $(TOOLBOX_IMAGE)

--- a/images/ceph/Dockerfile.suse
+++ b/images/ceph/Dockerfile.suse
@@ -1,0 +1,25 @@
+FROM BASEIMAGE
+MAINTAINER Sebastian Wagner "sebastian.wagner@suse.com"
+
+RUN ( \
+    echo 'zypper install' && \
+    zypper --non-interactive --gpg-auto-import-keys \
+        install --no-recommends --auto-agree-with-licenses --replacefiles --details \
+            ncat \
+            net-tools \
+            nmap \
+        && \
+    zypper --non-interactive --gpg-auto-import-keys clean --all \
+) || ( retval=$? && echo ' = zypper log = ' && cat /var/log/zypper.log && exit $retval )
+
+ARG ARCH
+ARG TINI_VERSION
+
+# Run tini as PID 1 and avoid signal handling issues
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini
+RUN chmod +x /tini
+
+ADD rook rookflex /usr/local/bin/
+
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
+CMD [""]

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -27,9 +27,16 @@ TEMP := $(shell mktemp -d)
 # ====================================================================================
 # Build Rook
 
-do.build:
-	@echo === docker build $(CEPH_IMAGE)
-	@cp Dockerfile $(TEMP)
+$(TEMP)/Dockerfile: Dockerfile Dockerfile.suse
+	@if [[ "$(BASEIMAGE)" =~ .*suse* ]] ; \
+	then \
+		cp Dockerfile.suse $(TEMP)/Dockerfile ; \
+	else \
+		cp Dockerfile $(TEMP)/Dockerfile ; \
+	fi \
+
+do.build: $(TEMP)/Dockerfile
+	@echo === docker build $(CEPH_IMAGE) in $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile


### PR DESCRIPTION
Please forgive my ignorance, this is my first PR to Rook. 

**Description of your changes:**

Added special `.suse` Dockerfiles for SUSE specific commands.

I've only tested them with openSUSE Leap 15 with Mimic using these changes and using this base image https://github.com/ceph/ceph-container/pull/1183 :

```diff
diff --git a/cluster/examples/kubernetes/ceph/dashboard-external.yaml b/cluster/examples/kubernetes/ceph/dashboard-external.yaml
index 70c4d25a..4ee0c10d 100644
--- a/cluster/examples/kubernetes/ceph/dashboard-external.yaml
+++ b/cluster/examples/kubernetes/ceph/dashboard-external.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   ports:
   - name: dashboard
-    port: 7000
+    port: 8443
     protocol: TCP
-    targetPort: 7000
+    targetPort: 8443
   selector:
     app: rook-ceph-mgr
     rook_cluster: rook-ceph
diff --git a/images/ceph/ceph_version b/images/ceph/ceph_version
index 23d15c34..b1d991fe 100644
--- a/images/ceph/ceph_version
+++ b/images/ceph/ceph_version
@@ -1 +1 @@
-ceph/daemon-base:v3.0.7-stable-3.0-luminous-centos-7
\ No newline at end of file
+ceph/daemon-base:master-mimic-opensuse__leap-15
\ No newline at end of file
```
Relate to: #1536

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
