### PR TITLE
Fix compatible issue of Rook for golang 1.11

### DIFF
--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -143,7 +143,7 @@ func (c *FilesystemController) onUpdate(oldObj, newObj interface{}) {
 	}
 
 	// if the file system is modified, allow the file system to be created if it wasn't already
-	logger.Infof("updating filesystem %s", newFS)
+	logger.Infof("updating filesystem %s", newFS.Name)
 	err = CreateFilesystem(c.context, *newFS, c.rookImage, c.hostNetwork, c.filesystemOwners(newFS))
 	if err != nil {
 		logger.Errorf("failed to create (modify) file system %s. %+v", newFS.Name, err)

--- a/pkg/operator/ceph/provisioner/controller/controller.go
+++ b/pkg/operator/ceph/provisioner/controller/controller.go
@@ -783,9 +783,9 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 	options := VolumeOptions{
 		// TODO SHOULD be set to `Delete` unless user manually configures other reclaim policy.
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
-		PVName:     pvName,
-		PVC:        claim,
-		Parameters: parameters,
+		PVName:                        pvName,
+		PVC:                           claim,
+		Parameters:                    parameters,
 	}
 
 	ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("External provisioner is provisioning volume for claim %q", claimToClaimKey(claim)))

--- a/pkg/operator/ceph/provisioner/controller/controller_test.go
+++ b/pkg/operator/ceph/provisioner/controller/controller_test.go
@@ -560,9 +560,9 @@ func newProvisionedVolume(storageClass *storagebeta.StorageClass, claim *v1.Pers
 	// pv.Spec MUST be set to match requirements in claim.Spec, especially access mode and PV size. The provisioned volume size MUST NOT be smaller than size requested in the claim, however it MAY be larger.
 	options := VolumeOptions{
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
-		PVName:     "pvc-" + string(claim.ObjectMeta.UID),
-		PVC:        claim,
-		Parameters: storageClass.Parameters,
+		PVName:                        "pvc-" + string(claim.ObjectMeta.UID),
+		PVC:                           claim,
+		Parameters:                    storageClass.Parameters,
 	}
 	volume, _ := newTestProvisioner().Provision(options)
 

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -146,9 +146,9 @@ func TestParseClassParametersInvalidOption(t *testing.T) {
 func newVolumeOptions(storageClass *storagebeta.StorageClass, claim *v1.PersistentVolumeClaim) controller.VolumeOptions {
 	return controller.VolumeOptions{
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
-		PVName:     "pvc-" + string(claim.ObjectMeta.UID),
-		PVC:        claim,
-		Parameters: storageClass.Parameters,
+		PVName:                        "pvc-" + string(claim.ObjectMeta.UID),
+		PVC:                           claim,
+		Parameters:                    storageClass.Parameters,
 	}
 }
 

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -246,9 +246,9 @@ func (c *ClusterController) createReplicaService(cluster *cluster) error {
 				// field is broken in some versions of Kubernetes:
 				// https://github.com/kubernetes/kubernetes/issues/58662
 				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-				"prometheus.io/scrape":                                   "true",
-				"prometheus.io/path":                                     "_status/vars",
-				"prometheus.io/port":                                     strconv.Itoa(int(httpPort)),
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "_status/vars",
+				"prometheus.io/port":   strconv.Itoa(int(httpPort)),
 			},
 		},
 		Spec: v1.ServiceSpec{

--- a/pkg/util/proc/monitoredproc.go
+++ b/pkg/util/proc/monitoredproc.go
@@ -38,8 +38,8 @@ type MonitoredProc struct {
 
 func newMonitoredProc(p *ProcManager, cmd *exec.Cmd) *MonitoredProc {
 	m := &MonitoredProc{
-		parent: p,
-		cmd:    cmd,
+		parent:                   p,
+		cmd:                      cmd,
 		retrySecondsExponentBase: 2,
 	}
 	m.waitForExit = m.waitForProcessExit


### PR DESCRIPTION
When building Rook with golang 1.11 version, we'll get below 2 errors in `go vet` phase:
1. Wrong type of `newFS`:
```
pkg/operator/ceph/file/controller.go:146: PackageLogger.Infof format %s has arg newFS of wrong type *github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1.Filesystem
build/makelib/golang.mk:150: recipe for target 'go.vet' failed
make[1]: *** [go.vet] Error 2
Makefile:101: recipe for target 'build.common' failed
make: *** [build.common] Error 2
```
2. `go fmt` error against some files:
```
build/makelib/golang.mk:155: recipe for target 'go.fmt' failed
make[1]: *** [go.fmt] Error 1
Makefile:101: recipe for target 'build.common' failed
make: *** [build.common] Error 2
```
This PR is trying to fix those issue to make sure the Rook build can succeed for all the supported golang versions.

Signed-off-by: Dennis Chen <dennis.chen@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
