### PR TITLE
Make integration tests more resilient to crd deletion failure

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -82,6 +82,11 @@ func (h *CephInstaller) CreateCephCRDs() error {
 			return err
 		}
 
+		// ensure all the cluster CRDs are removed
+		if err = h.k8shelper.PurgeClusters(); err != nil {
+			logger.Warningf("could not purge cluster crds. %+v", err)
+		}
+
 		// remove the finalizer from the cluster CRD
 		if _, err := h.k8shelper.Kubectl("patch", "crd", "clusters.ceph.rook.io", "-p", `{"metadata":{"finalizers": []}}`, "--type=merge"); err != nil {
 			logger.Warningf("could not remove finalizer from cluster crd. %+v", err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two changes to help the tests be more resilient to random failures:
- The CRD instances are sometimes not purged even though the definitions were purged. The tests now ensure the instances are purged when the definitions are purged
- When a mon is created, the operator should wait until the pod is running before it checks to quorum. [This test](https://jenkins.rook.io/blue/organizations/jenkins/rook%2Frook/detail/master/769/pipeline) failed on 1.9 due to the operator hanging on the query before the mon started. This will also benefit the operator in production.

**Which issue is resolved by this Pull Request:**
Resolves #2118

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
