### PR TITLE
Wait for mon pods to start before checking for quorum

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -572,6 +572,17 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterName string, mons [
 			<-time.After(time.Duration(sleepTime) * time.Second)
 		}
 
+		// wait for the mon pods to be running
+		running, err := k8sutil.PodsRunningWithLabel(context.Clientset, clusterName, "app="+appName)
+		if err != nil {
+			logger.Infof("failed to query mon pod status, trying again. %+v", err)
+			continue
+		}
+		if running != len(mons) {
+			logger.Infof("%d/%d mon pods are running. waiting for pods to start", running, len(mons))
+			continue
+		}
+
 		// get the mon_status response that contains info about all monitors in the mon map and
 		// their quorum status
 		monStatusResp, err := client.GetMonStatus(context, clusterName, false)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -153,6 +153,21 @@ func MakeRookImage(version string) string {
 	return version
 }
 
+func PodsRunningWithLabel(clientset kubernetes.Interface, namespace, label string) (int, error) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: label})
+	if err != nil {
+		return 0, err
+	}
+
+	running := 0
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == v1.PodRunning {
+			running++
+		}
+	}
+	return running, nil
+}
+
 // GetPodPhaseMap takes a list of pods and returns a map of pod phases to the names of pods that are in that phase
 func GetPodPhaseMap(pods *v1.PodList) map[v1.PodPhase][]string {
 	podPhaseMap := map[v1.PodPhase][]string{} // status to list of pod names with that phase


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When a mon is created, the operator should wait until the pod is running before it checks to quorum. [This test](https://jenkins.rook.io/blue/organizations/jenkins/rook%2Frook/detail/master/769/pipeline) failed on 1.9 due to the operator hanging on the query before the mon started. This will also benefit the operator in production.

@galexrt this was separated from PR #2127.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
