### PR TITLE
build: fix the check for dep ensure

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -170,9 +170,10 @@ go.validate: go.vet go.fmt
 go.vendor.lite: $(DEP)
 #	dep ensure blindly updates the whole vendor tree causing everything to be rebuilt. This workaround
 #	will only call dep ensure if the .lock file changes or if the vendor dir is non-existent.
-	@if [ ! -d $(GO_VENDOR_DIR) ] || [ ! $(DEP) ensure -no-vendor -dry-run &> /dev/null ]; then \
-		echo === updating vendor dependencies ;\
-		$(DEP) ensure ;\
+	@if [ ! -d $(GO_VENDOR_DIR) ]; then \
+		$(MAKE) go.vendor; \
+	elif ! $(DEP) ensure -no-vendor -dry-run &> /dev/null; then \
+		$(MAKE) go.vendor; \
 	fi
 
 .PHONY: go.vendor


### PR DESCRIPTION
**Description of your changes:**

the exit code from dep ensure --dry-run was not being checked correctly resulting a lots of false negatives. This probably explains why we've been seeing lots of issues with vendor dirs being out of date.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
