### PR TITLE
DNM: Remove partially-created pool/crushrule/ecprofile on failure

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -185,6 +185,13 @@ func givePoolAppTag(context *clusterd.Context, clusterName string, poolName stri
 }
 
 func CreateECPoolForApp(context *clusterd.Context, clusterName string, newPool CephStoragePoolDetails, appName string, enableECOverwrite bool, erasureCodedConfig model.ErasureCodedPoolConfig) error {
+
+	// check for existence, skip all this if it's already there
+	_, err := GetPoolDetails(context, clusterName, newPool.Name)
+	if err == nil {
+		logger.Infof("pool %s already exists, not creating", newPool.Name)
+		return nil
+	}
 	args := []string{"osd", "pool", "create", newPool.Name, strconv.Itoa(newPool.Number), "erasure", newPool.ErasureCodeProfile}
 
 	buf, err := ExecuteCephCommand(context, clusterName, args)


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Fixes current partial-failure-on-creation problem with cephfs, and pools in general:  replicated pools can fail to create the pool but leave the crush rule behind, and EC pools can similarly leave the EC profile; failures between data pool and metadata pool can leave the other behind.  

Fixes #2144.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
