### PR TITLE
Enable glog logging

### DIFF
--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -43,7 +43,7 @@ func init() {
 	operatorCmd.Flags().DurationVar(&mon.HealthCheckInterval, "mon-healthcheck-interval", mon.HealthCheckInterval, "mon health check interval (duration)")
 	operatorCmd.Flags().DurationVar(&mon.MonOutTimeout, "mon-out-timeout", mon.MonOutTimeout, "mon out timeout (duration)")
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
-
+	flags.SetLoggingFlags(operatorCmd.Flags())
 	operatorCmd.RunE = startOperator
 }
 

--- a/cmd/rook/cockroachdb/operator.go
+++ b/cmd/rook/cockroachdb/operator.go
@@ -37,6 +37,7 @@ https://github.com/rook/rook`,
 
 func init() {
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetLoggingFlags(operatorCmd.Flags())
 
 	operatorCmd.RunE = startOperator
 }

--- a/cmd/rook/minio/operator.go
+++ b/cmd/rook/minio/operator.go
@@ -39,6 +39,7 @@ var (
 
 func init() {
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetLoggingFlags(operatorCmd.Flags())
 	operatorCmd.RunE = startOperator
 }
 

--- a/cmd/rook/nfs/operator.go
+++ b/cmd/rook/nfs/operator.go
@@ -37,6 +37,7 @@ https://github.com/rook/rook`,
 
 func init() {
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetLoggingFlags(operatorCmd.Flags())
 
 	operatorCmd.RunE = startOperator
 }

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -16,7 +16,6 @@ limitations under the License.
 package rook
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -76,9 +75,6 @@ func SetLogLevel() {
 }
 
 func LogStartupInfo(cmdFlags *pflag.FlagSet) {
-	// workaround a k8s logging issue: https://github.com/kubernetes/kubernetes/issues/17162
-	flag.CommandLine.Parse([]string{})
-
 	// log the version number, arguments, and all final flag values (environment variable overrides
 	// have already been taken into account)
 	flagValues := flags.GetFlagsAndValues(cmdFlags, "secret")

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -16,6 +16,7 @@ limitations under the License.
 package flags
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -79,6 +80,14 @@ func createRequiredFlagError(name string, flags []string) error {
 	}
 
 	return fmt.Errorf("%s are required for %s", strings.Join(flags, ","), name)
+}
+
+func SetLoggingFlags(flags *pflag.FlagSet) {
+	//Add commandline flags to the flagset. We will always write to stderr
+	//and not to a file by default
+	flags.AddGoFlagSet(flag.CommandLine)
+	flags.Set("logtostderr", "true")
+	flags.Parse(nil)
 }
 
 func SetFlagsFromEnv(flags *pflag.FlagSet, prefix string) error {


### PR DESCRIPTION
Change enables glog logging and also make default flag values
configurable.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>

Resolves: #2105 

- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
