### PR TITLE
Enable filestore on device scenario to run with ceph image

### DIFF
--- a/pkg/operator/k8sutil/volume.go
+++ b/pkg/operator/k8sutil/volume.go
@@ -31,6 +31,9 @@ func PathToVolumeName(path string) string {
 	// first replace all filepath separators with hyphens
 	volumeName := strings.Replace(path, string(filepath.Separator), "-", -1)
 
+	// convert underscores to hyphens
+	volumeName = strings.Replace(volumeName, "_", "-", -1)
+
 	// trim any leading/trailing hyphens
 	volumeName = strings.TrimPrefix(volumeName, "-")
 	volumeName = strings.TrimSuffix(volumeName, "-")

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -362,7 +362,7 @@ spec:
               fieldPath: metadata.namespace`
 }
 
-//GetRookCluster returns rook-cluster manifest
+//GetClusterRoles returns rook-cluster manifest
 func (m *CephManifestsMaster) GetClusterRoles(namespace, systemNamespace string) string {
 	return `apiVersion: v1
 kind: ServiceAccount

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -434,7 +434,7 @@ func (k8sh *K8sHelper) WaitForPodCount(label, namespace string, count int) error
 			return fmt.Errorf("failed to find pod with label %s. %+v", label, err)
 		}
 
-		if len(pods.Items) == count {
+		if len(pods.Items) >= count {
 			logger.Infof("found %d pods with label %s", count, label)
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD pod spec required two changes to allow for running the ceph image directly with the [decoupled version image](https://github.com/rook/rook/blob/master/design/decouple-ceph-version.md).
- `tini` is not included in the ceph image and cannot be used when running the daemon directly with the image. `ceph-osd` can be called directly in the daemon image and there is no need for `tini`.
- The "filestore on a device" scenario requires rook to mount the device before the daemon can be started, then unmount the device when completed. Therefore, an init container is used to copy the `tini` and `rook` binaries into an emptydir mount, which is then mounted to the ceph daemon container to run the osd.

**Which issue is resolved by this Pull Request:**
Resolves #2141 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
