### PR TITLE
Backport: Added missing RBAC in quickstart Cluster definition

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -61,11 +61,64 @@ make sure you set the `dataDirHostPath` property. For more settings, see the doc
 Save the cluster spec as `cluster.yaml`:
 
 ```yaml
+#################################################################################
+# This example first defines some necessary namespace and RBAC security objects.
+# The actual Ceph Cluster CRD example can be found at the bottom of this example.
+#################################################################################
 apiVersion: v1
 kind: Namespace
 metadata:
   name: rook-ceph
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: [ "get", "list", "watch", "create", "update", "delete" ]
+---
+# Allow the operator to create resources in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster-mgmt
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
+# Allow the pods in this namespace to work with configmaps
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cluster
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+---
+#################################################################################
+# The Ceph Cluster CRD example
+#################################################################################
 apiVersion: ceph.rook.io/v1beta1
 kind: Cluster
 metadata:

--- a/Documentation/openshift.md
+++ b/Documentation/openshift.md
@@ -24,7 +24,7 @@ Before starting the Rook operator or cluster, create the security context constr
 kind: SecurityContextConstraints
 apiVersion: v1
 metadata:
-  name: rook
+  name: rook-ceph
 allowPrivilegedContainer: true
 allowHostNetwork: true
 allowHostDirVolumePlugin: true

--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -55,15 +55,15 @@ spec:
 
 **Hint**: Allowing `hostNetwork` usage is required when using `hostNetwork: true` in the Cluster `CustomResourceDefinition`!
 You are then also required to allow the usage of `hostPorts` in the `PodSecurityPolicy`. The given port range is a minimal
-working recommendation for rook:
+working recommendation for a Rook Ceph cluster:
  ```yaml
- hostPorts:
-   # CEPH ports
-   - min: 6789
-     max: 7300
-   # rook-api port
-   - min: 8124
-     max: 8124
+   hostPorts:
+     # Ceph ports
+     - min: 6789
+       max: 7300
+     # Ceph MGR Prometheus Metrics
+     - min: 9283
+       max: 9283
 ```
 
 ##### ClusterRole and ClusterRoleBinding
@@ -119,7 +119,7 @@ Create these two `RoleBindings` in the Namespace you plan to deploy your Rook Cl
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook
+  name: rook-ceph
 ---
 # Allow the default serviceAccount to use the priviliged PSP
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -1,7 +1,7 @@
 kind: SecurityContextConstraints
 apiVersion: v1
 metadata:
-  name: rook
+  name: rook-ceph
 allowPrivilegedContainer: true
 allowHostNetwork: true
 allowHostDirVolumePlugin: true

--- a/design/resource-constraints.md
+++ b/design/resource-constraints.md
@@ -72,12 +72,12 @@ The requests/limits configured are as an example and not to be used in productio
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook
+  name: rook-ceph
 ---
 apiVersion: rook.io/v1alpha1
 kind: Cluster
 metadata:
-  name: rook
+  name: rook-ceph
   namespace: rook-ceph
 spec:
   dataDirHostPath: /var/lib/rook


### PR DESCRIPTION
**Description of your changes:**
Backport #2035.

**Which issue is resolved by this Pull Request:**
Resolves #2035.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)