### PR TITLE
use exec over executor to remove unnecessary console logging

### DIFF
--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 	"net/rpc"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
-	"github.com/rook/rook/pkg/util/exec"
 	"github.com/spf13/cobra"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/version"
@@ -140,8 +140,8 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 	// formatted even though one does exist. K8s then proceeds to format the volume which would result in data loss. This logging is an attempt
 	// to understand why k8s believes the volume is not formatted. See https://github.com/rook/rook/issues/1553
 	log(client, fmt.Sprintf("Testing to see if device %s needs formatting...", devicePath), false)
-	executor := &exec.CommandExecutor{}
-	output, err := executor.ExecuteCommandWithOutput(false, "", "blkid", "-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", devicePath)
+	cmd := exec.Command("blkid", "-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", devicePath)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log(client, fmt.Sprintf("Formatting test (blkid -p -s TYPE -s PTTYPE -o export %s). Device may not be formatted. err: %+v", devicePath, err), false)
 	} else {


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
as seen [here](https://github.com/rook/rook/blob/master/pkg/util/exec/exec.go#L230), extra console logging causes trouble for flex driver
**Which issue is resolved by this Pull Request:**
Resolves #2149 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
