### PR TITLE
Revert "log the output of blkid to see if device should be formatted"

### DIFF
--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
-	"github.com/rook/rook/pkg/util/exec"
 	"github.com/spf13/cobra"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/version"
@@ -135,22 +134,6 @@ func mountDevice(client *rpc.Client, mounter *k8smount.SafeFormatAndMount, devic
 			return fmt.Errorf("Rook: Mount volume failed. Error checking if %s is a mount point: %v", globalVolumeMountPath, err)
 		}
 	}
-
-	// Testing to see if the device is formatted. There has been observed an issue on slow systems where k8s believes there is no filesystem
-	// formatted even though one does exist. K8s then proceeds to format the volume which would result in data loss. This logging is an attempt
-	// to understand why k8s believes the volume is not formatted. See https://github.com/rook/rook/issues/1553
-	log(client, fmt.Sprintf("Testing to see if device %s needs formatting...", devicePath), false)
-	executor := &exec.CommandExecutor{}
-	output, err := executor.ExecuteCommandWithOutput(false, "", "blkid", "-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", devicePath)
-	if err != nil {
-		log(client, fmt.Sprintf("Formatting test (blkid -p -s TYPE -s PTTYPE -o export %s). Device may not be formatted. err: %+v", devicePath, err), false)
-	} else {
-		log(client, fmt.Sprintf("Formatting test (blkid -p -s TYPE -s PTTYPE -o export %s). Device is already formatted", devicePath), false)
-	}
-	if len(output) > 0 {
-		log(client, fmt.Sprintf("Output: %s", output), false)
-	}
-
 	options := []string{opts.RW}
 	if notMnt {
 		err = redirectStdout(


### PR DESCRIPTION
**Description of your changes:**
as seen here, extra console logging causes trouble for flex driver
This reverts commit c67542829b0f4042bb2ef57e8ed96efedbc91656.


**Which issue is resolved by this Pull Request:**
Resolves #2149 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

skipping ci only because three builds in a row have failed for random issues and the fix is verified
[skip ci]