### PR TITLE
Remove hyperkube variables from helm chart and use helm crd-install hook

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephclusters.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -187,6 +189,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephfilesystems.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -261,6 +265,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephnfses.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -295,6 +301,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectstores.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -357,6 +365,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephobjectstoreusers.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -374,6 +384,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: cephblockpools.ceph.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: ceph.rook.io
   names:
@@ -388,6 +400,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: volumes.rook.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: rook.io
   names:
@@ -404,6 +418,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: objectbuckets.objectbucket.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: objectbucket.io
   versions:
@@ -426,6 +442,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: objectbucketclaims.objectbucket.io
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   versions:
     - name: v1alpha1

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -21,7 +21,7 @@ nodeSelector:
 # For more info, see https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 #  disktype: ssd
 
-# Tolerations for the rook-ceph-operator to allow it to run on nodes with particular taints
+# Tolerations for the rook-ceph-operator to allow it to run on nodes with particular taints
 tolerations: []
 
 # Whether rook watches its current namespace for CRDs or the entire cluster, defaults to false


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Description of your changes:**
These values are a leftover from earlier times where the operator would
create the CRDs and use helm install hooks to create the CRDs "first".

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] `make vendor` does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[test ceph]
[test full]