### PR TITLE
ceph-k8s-exmpl: Add kube-registry app w/ psp conf

### DIFF
--- a/cluster/examples/kubernetes/ceph/kube-registry-psp.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry-psp.yaml
@@ -1,0 +1,66 @@
+# Example showing how to run the kube-registry application pod security policies.
+# Attempts have been made to make sure the policy, role, and binding in this example follow
+# best practices and are a minimal set of permissions; however, this is not a guarantee of a
+# minimal policy config.
+# Because the kube-registry service account is in the kube-registry.yaml file, that must be created
+# first or at the same time as this file.
+---
+# Create a pod security policy (psp) for the service account
+# that is as minimal as possible.
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kube-registry-psp
+spec:
+  fsGroup:
+    rule: RunAsAny
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - flexVolume
+  - secret
+  allowedFlexVolumes:
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+---
+# Create a role for the kube-registry that can use
+# the security policy
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: kube-registry-psp
+  namespace: kube-system
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - kube-registry-psp
+  verbs:
+  - use
+---
+# Bind the role to the kube-registry service account so that
+# all pods created by controllers in in the service account
+# can create the resources allowed by the psp
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-registry-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-registry-psp
+subjects:
+- kind: ServiceAccount
+  name: kube-registry
+  namespace: kube-system

--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -1,24 +1,44 @@
+---
+# Create a service account for the kube registry limited to the kube-system namespace
+# pod security policies can be bound to this service account if necessary
 apiVersion: v1
-kind: ReplicationController
+kind: ServiceAccount
 metadata:
-  name: kube-registry-v0
+  name: kube-registry
+  namespace: kube-system
+---
+# Create the HA registry
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-registry-v1
   namespace: kube-system
   labels:
     k8s-app: kube-registry
-    version: v0
+    version: v1
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 3
   selector:
-    k8s-app: kube-registry
-    version: v0
+    matchLabels:
+      k8s-app: kube-registry
+      version: v1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:
         k8s-app: kube-registry
-        version: v0
+        version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      # Use the registry's service account, which may or may not have pod security configs
+      serviceAccount: kube-registry
+      serviceAccountName: kube-registry
+      restartPolicy: Always
       containers:
       - name: registry
         image: registry:2


### PR DESCRIPTION
[skip ci]

Add a `psp/` subdir to the ceph kubernetes examples, and inside create a
modified kube-registry.yaml which is configured to run in a Kubernetes
cluster where pod security policies are enforced.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

This is a file I changed while working on validating my MDS work didn't result in data loss. I thought it could be useful to others.

I don't believe any of the checklist items apply to an addition of an example k8s manifest file.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] `make vendor` does not cause changes.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]