### PR TITLE
Backport: Configure OSDs when hostname is different from node name

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -98,7 +98,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | Parameter                 | Description                                                     | Default                                                |
 | ------------------------- | --------------------------------------------------------------- | ------------------------------------------------------ |
 | `image.repository`        | Image                                                           | `rook/ceph`                                            |
-| `image.tag`               | Image tag                                                       | `v0.8.2`                                               |
+| `image.tag`               | Image tag                                                       | `v0.8.3`                                               |
 | `image.pullPolicy`        | Image pull policy                                               | `IfNotPresent`                                         |
 | `rbacEnable`              | If true, create & use RBAC resources                            | `true`                                                 |
 | `pspEnable`               | If true, create & use PSP resources                             | `true`                                                 |

--- a/Documentation/toolbox.md
+++ b/Documentation/toolbox.md
@@ -25,7 +25,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: rook-ceph-tools
-    image: rook/ceph-toolbox:v0.8.2
+    image: rook/ceph-toolbox:v0.8.3
     imagePullPolicy: IfNotPresent
     env:
       - name: ROOK_ADMIN_SECRET

--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-after-reboot-check
-        image: rook/ceph-toolbox:v0.8.2
+        image: rook/ceph-toolbox:v0.8.3
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-before-reboot-check
-        image: rook/ceph-toolbox:v0.8.2
+        image: rook/ceph-toolbox:v0.8.3
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -289,7 +289,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v0.8.2
+        image: rook/ceph:v0.8.3
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -7,7 +7,7 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   containers:
   - name: rook-ceph-tools
-    image: rook/ceph-toolbox:v0.8.2
+    image: rook/ceph-toolbox:v0.8.3
     imagePullPolicy: IfNotPresent
     env:
       - name: ROOK_ADMIN_SECRET

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: rook-cockroachdb-operator
       containers:
       - name: rook-cockroachdb-operator
-        image: rook/cockroachdb:v0.8.2
+        image: rook/cockroachdb:v0.8.3
         args: ["cockroachdb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -88,7 +88,7 @@ spec:
       serviceAccountName: rook-minio-operator
       containers:
       - name: rook-minio-operator
-        image: rook/minio:v0.8.2
+        image: rook/minio:v0.8.3
         args: ["minio", "operator"]
         env:
         - name: POD_NAME

--- a/pkg/operator/ceph/cluster/osd/pod.go
+++ b/pkg/operator/ceph/cluster/osd/pod.go
@@ -50,7 +50,7 @@ const (
 func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 	selection rookalpha.Selection, resources v1.ResourceRequirements, storeConfig config.StoreConfig, metadataDevice, location string) (*batch.Job, error) {
 
-	podSpec, err := c.provisionPodTemplateSpec(devices, selection, resources, storeConfig, metadataDevice, location, v1.RestartPolicyOnFailure)
+	podSpec, err := c.provisionPodTemplateSpec(devices, selection, resources, storeConfig, metadataDevice, nodeName, location, v1.RestartPolicyOnFailure)
 	if err != nil {
 		return nil, err
 	}
@@ -124,12 +124,12 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 	osdID := strconv.Itoa(osd.ID)
 	tiniEnvVar := v1.EnvVar{Name: "TINI_SUBREAPER", Value: ""}
 	envVars := []v1.EnvVar{
-		nodeNameEnvVar(),
+		nodeNameEnvVar(nodeName),
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 		tiniEnvVar,
 	}
-	configEnvVars := append(c.getConfigEnvVars(storeConfig, dataDir, location), []v1.EnvVar{
+	configEnvVars := append(c.getConfigEnvVars(storeConfig, dataDir, nodeName, location), []v1.EnvVar{
 		tiniEnvVar,
 		{Name: "ROOK_OSD_ID", Value: osdID},
 	}...)
@@ -244,7 +244,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 }
 
 func (c *Cluster) provisionPodTemplateSpec(devices []rookalpha.Device, selection rookalpha.Selection, resources v1.ResourceRequirements,
-	storeConfig config.StoreConfig, metadataDevice, location string, restart v1.RestartPolicy) (*v1.PodTemplateSpec, error) {
+	storeConfig config.StoreConfig, metadataDevice, nodeName, location string, restart v1.RestartPolicy) (*v1.PodTemplateSpec, error) {
 	volumes := []v1.Volume{k8sutil.ConfigOverrideVolume()}
 
 	if c.dataDirHostPath != "" {
@@ -277,7 +277,7 @@ func (c *Cluster) provisionPodTemplateSpec(devices []rookalpha.Device, selection
 
 	podSpec := v1.PodSpec{
 		ServiceAccountName: c.serviceAccount,
-		Containers:         []v1.Container{c.provisionOSDContainer(devices, selection, resources, storeConfig, metadataDevice, location)},
+		Containers:         []v1.Container{c.provisionOSDContainer(devices, selection, resources, storeConfig, metadataDevice, nodeName, location)},
 		RestartPolicy:      restart,
 		Volumes:            volumes,
 		HostNetwork:        c.HostNetwork,
@@ -300,9 +300,9 @@ func (c *Cluster) provisionPodTemplateSpec(devices []rookalpha.Device, selection
 	}, nil
 }
 
-func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, location string) []v1.EnvVar {
+func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, nodeName, location string) []v1.EnvVar {
 	envVars := []v1.EnvVar{
-		nodeNameEnvVar(),
+		nodeNameEnvVar(nodeName),
 		{Name: "ROOK_CLUSTER_ID", Value: string(c.ownerRef.UID)},
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
@@ -338,9 +338,9 @@ func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, loca
 }
 
 func (c *Cluster) provisionOSDContainer(devices []rookalpha.Device, selection rookalpha.Selection, resources v1.ResourceRequirements,
-	storeConfig config.StoreConfig, metadataDevice, location string) v1.Container {
+	storeConfig config.StoreConfig, metadataDevice, nodeName, location string) v1.Container {
 
-	envVars := c.getConfigEnvVars(storeConfig, k8sutil.DataDir, location)
+	envVars := c.getConfigEnvVars(storeConfig, k8sutil.DataDir, nodeName, location)
 	devMountNeeded := false
 	privileged := false
 
@@ -418,8 +418,8 @@ func (c *Cluster) provisionOSDContainer(devices []rookalpha.Device, selection ro
 	}
 }
 
-func nodeNameEnvVar() v1.EnvVar {
-	return v1.EnvVar{Name: "ROOK_NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}}
+func nodeNameEnvVar(name string) v1.EnvVar {
+	return v1.EnvVar{Name: "ROOK_NODE_NAME", Value: name}
 }
 
 func dataDevicesEnvVar(dataDevices string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/pod_test.go
+++ b/pkg/operator/ceph/cluster/osd/pod_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{Namespace: "myosd", Version: "23"}
-	c, err := cluster.provisionPodTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "", v1.RestartPolicyAlways)
+	c, err := cluster.provisionPodTemplateSpec([]rookalpha.Device{}, rookalpha.Selection{}, v1.ResourceRequirements{}, config.StoreConfig{}, "", "node", "", v1.RestartPolicyAlways)
 	assert.NotNil(t, c)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.Spec.Containers))

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -192,6 +192,15 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 
 // ListDevices lists all devices discovered on all nodes or specific node if node name is provided.
 func ListDevices(context *clusterd.Context, namespace, nodeName string) (map[string][]sys.LocalDisk, error) {
+	// convert the host name label to the k8s node name to look up the configmap  with the devices
+	if len(nodeName) > 0 {
+		var err error
+		nodeName, err = k8sutil.GetNodeNameFromHostname(context.Clientset, nodeName)
+		if err != nil {
+			logger.Warningf("failed to get node name from hostname. %+v", err)
+		}
+	}
+
 	var devices map[string][]sys.LocalDisk
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, discoverDaemon.AppName)}
 	// wait for device discovery configmaps


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Backport the changes that allow configuring of osds when the hostname is different from the k8s node name.
- Update the release version in the yamls in anticipation of the v0.8.3 release

**Which issue is resolved by this Pull Request:**
Resolves #2148

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
