### PR TITLE
don't print console logs during flex driver call

### DIFF
--- a/cmd/rookflex/cmd/unmount.go
+++ b/cmd/rookflex/cmd/unmount.go
@@ -19,9 +19,9 @@ package cmd
 import (
 	"fmt"
 	"net/rpc"
+	"os/exec"
 
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
-	"github.com/rook/rook/pkg/util/exec"
 	"github.com/spf13/cobra"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume/util"
@@ -33,7 +33,6 @@ var (
 		Short: "Unmounts the pod volume",
 		RunE:  handleUnmount,
 	}
-	executor = &exec.CommandExecutor{}
 )
 
 func init() {
@@ -53,7 +52,8 @@ func handleUnmount(cmd *cobra.Command, args []string) error {
 	mounter := getMounter()
 
 	// Check if it's a cephfs
-	err = executor.ExecuteCommand(false, "", "df", "--type", cephFS, mountDir)
+	command := exec.Command("df", "--type", cephFS, mountDir)
+	err = command.Run()
 	if err == nil {
 		return unmountCephFS(client, mounter, mountDir)
 	}


### PR DESCRIPTION

**Description of your changes:**

flex volume driver calls capture console messages as replies. Don't log command during driver calls.

**Which issue is resolved by this Pull Request:**
Resolves #2165 

/assign @travisn 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
