### PR TITLE
update mon addr in secret data that used by storage class

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -192,15 +192,15 @@ rules:
   - create
   - update
   - delete
-- apiGroups:
-  - ""
-  resources:
-  # secret access is needed for mon failover used by csi storageclass 
-  resources:
-  - secrets
-  verbs:
-  - get
-  - update  
+# uncomment the following to allow operator to update mon address in secrets
+# used by csi driver storage class
+#- apiGroups:
+#  - ""
+#  resources:
+  #- secrets
+  #verbs:
+  #- get
+  #- update  
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -193,6 +193,15 @@ rules:
   - update
   - delete
 - apiGroups:
+  - ""
+  resources:
+  # secret access is needed for mon failover used by csi storageclass 
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update  
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/pkg/daemon/ceph/mon/endpoint.go
+++ b/pkg/daemon/ceph/mon/endpoint.go
@@ -33,6 +33,22 @@ func FlattenMonEndpoints(mons map[string]*cephconfig.MonInfo) string {
 	return strings.Join(endpoints, ",")
 }
 
+// FlatternMonInfoForCSI returns a comma-delimited string of all mons in the form of
+// mon1Addr:port,mon2Addr:port
+func FlattenMonInfoForCSI(mons map[string]*cephconfig.MonInfo) string {
+	monAddr := ""
+	for _, m := range mons {
+		a := m.Endpoint
+		if len(monAddr) > 0 {
+			monAddr = monAddr + "," + a
+		} else {
+			monAddr = a
+		}
+	}
+	return monAddr
+
+}
+
 // ParseMonEndpoints parses a flattened representation of mons and endpoints in the form
 // <mon-name>=<mon-endpoint> and returns a list of Ceph mon configs.
 func ParseMonEndpoints(input string) map[string]*cephconfig.MonInfo {

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -268,8 +268,7 @@ func (c *Cluster) failoverMon(name string) error {
 	// Only increment the max mon id if the new pod started successfully
 	c.maxMonID++
 
-	err = c.removeMon(name)
-	if err != nil {
+	if err = c.removeMon(name); err != nil {
 		return fmt.Errorf("failed to remove mon %s: %v", name, err)
 	}
 
@@ -333,8 +332,8 @@ func (c *Cluster) removeMon(daemonName string) error {
 		return fmt.Errorf("failed to write connection config after failing over mon %s. %+v", daemonName, err)
 	}
 
-	monAddr := monInfoString(c.clusterInfo.Monitors)
-	if err := updateMonValuesForSC(c.context, c.Namespace, monAddr); err != nil {
+	monAddr := mondaemon.FlattenMonInfoForCSI(c.clusterInfo.Monitors)
+	if err := updateStorageClassMonEndpoints(c.context, c.Namespace, monAddr); err != nil {
 		// just log the error
 		logger.Warningf("failed to update mon value used by storage class: %v", err)
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -193,6 +193,9 @@ func (c *Cluster) startMons() error {
 		}
 	}
 
+	monAddr := monConfigString(mons)
+	updateMonValuesForSC(c.context, c.Namespace, monAddr)
+
 	logger.Debugf("mon endpoints used are: %s", mondaemon.FlattenMonEndpoints(c.clusterInfo.Monitors))
 	return nil
 }
@@ -264,7 +267,6 @@ func (c *Cluster) initMonIPs(mons []*monConfig) error {
 		}
 		c.clusterInfo.Monitors[m.DaemonName] = cephconfig.NewMonInfo(m.DaemonName, m.PublicIP, m.Port)
 	}
-
 	return nil
 }
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -193,8 +193,11 @@ func (c *Cluster) startMons() error {
 		}
 	}
 
-	monAddr := monConfigString(mons)
-	updateMonValuesForSC(c.context, c.Namespace, monAddr)
+	monAddr := flattenMonConfig(mons)
+	if err := updateStorageClassMonEndpoints(c.context, c.Namespace, monAddr); err != nil {
+		// log but don't return the error
+		logger.Warningf("updating mon endpoint for storage class failed: %v", err)
+	}
 
 	logger.Debugf("mon endpoints used are: %s", mondaemon.FlattenMonEndpoints(c.clusterInfo.Monitors))
 	return nil

--- a/pkg/operator/ceph/cluster/mon/util.go
+++ b/pkg/operator/ceph/cluster/mon/util.go
@@ -288,7 +288,7 @@ func fullNameToIndex(name string) (int, error) {
 	return id, nil
 }
 
-func monConfigString(mons []*monConfig) string {
+func flattenMonConfig(mons []*monConfig) string {
 	monAddr := ""
 	for _, m := range mons {
 		a := fmt.Sprintf("%s:%d", m.PublicIP, m.Port)
@@ -301,23 +301,9 @@ func monConfigString(mons []*monConfig) string {
 	return monAddr
 }
 
-func monInfoString(mons map[string]*cephconfig.MonInfo) string {
-	monAddr := ""
-	for _, m := range mons {
-		a := m.Endpoint
-		if len(monAddr) > 0 {
-			monAddr = monAddr + "," + a
-		} else {
-			monAddr = a
-		}
-	}
-	return monAddr
-
-}
-
 // ceph csi storage class can embed mon service in secret.
 // list all such storage classes and update their mon values
-func updateMonValuesForSC(context *clusterd.Context, clusterName string, monAddr string) error {
+func updateStorageClassMonEndpoints(context *clusterd.Context, clusterName string, monAddr string) error {
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", csiSCLabelSelector, clusterName)}
 	scs, err := context.Clientset.Storage().StorageClasses().List(listOpts)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mon/util_test.go
+++ b/pkg/operator/ceph/cluster/mon/util_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	monValueFrom = "monitors"
+)
+
+func createFakeSecret(name, ns string, clientset *fake.Clientset) error {
+	data := make(map[string][]byte, 1)
+	data[monValueFrom] = []byte("mon1:6790,mon2:6790")
+	s := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: data,
+	}
+	_, err := clientset.CoreV1().Secrets(ns).Create(s)
+	return err
+}
+
+func getFakeSecretData(name, ns, key string, clientset *fake.Clientset) (string, error) {
+	s, err := clientset.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	data, ok := s.Data[key]
+	if !ok {
+		return "", nil
+	}
+
+	return string(data), nil
+}
+
+func createFakeStorageClass(name, clusterName, secretName, secretNS string, clientset *fake.Clientset) error {
+	labels := map[string]string{
+		csiSCLabelSelector: clusterName,
+	}
+	param := map[string]string{
+		csiSCSecretParamName:   secretName,
+		csiSCSecretNSParamName: secretNS,
+		csiSCMonParamName:      monValueFrom,
+	}
+
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Provisioner: "csi-rbdplugin",
+		Parameters:  param,
+	}
+	_, err := clientset.Storage().StorageClasses().Create(sc)
+	return err
+}
+
+func TestUpdateSC(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	err := createFakeSecret("fakeSecret", "fakeNS", clientset)
+	assert.Nil(t, err)
+	err = createFakeStorageClass("fakeSC", "fakeCluster", "fakeSecret", "fakeNS", clientset)
+	assert.Nil(t, err)
+	context := &clusterd.Context{Clientset: clientset}
+	mon1 := &monConfig{
+		PublicIP: "1.2.3.4",
+		Port:     6790,
+	}
+	mon2 := &monConfig{
+		PublicIP: "5.6.7.8",
+		Port:     6790,
+	}
+
+	newMons := []*monConfig{mon1, mon2}
+	monAddr := monConfigString(newMons)
+	err = updateMonValuesForSC(context, "fakeCluster", monAddr)
+	assert.Nil(t, err)
+	val, err := getFakeSecretData("fakeSecret", "fakeNS", monValueFrom, clientset)
+	assert.Nil(t, err)
+	assert.True(t, strings.Contains(val, "1.2.3.4:6790"))
+	assert.True(t, strings.Contains(val, "5.6.7.8:6790"))
+}

--- a/pkg/operator/ceph/cluster/mon/util_test.go
+++ b/pkg/operator/ceph/cluster/mon/util_test.go
@@ -33,8 +33,9 @@ const (
 )
 
 func createFakeSecret(name, ns string, clientset *fake.Clientset) error {
-	data := make(map[string][]byte, 1)
-	data[monValueFrom] = []byte("mon1:6790,mon2:6790")
+	data := map[string][]byte{
+		monValueFrom: []byte("mon1:6790,mon2:6790"),
+	}
 	s := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -98,8 +99,8 @@ func TestUpdateSC(t *testing.T) {
 	}
 
 	newMons := []*monConfig{mon1, mon2}
-	monAddr := monConfigString(newMons)
-	err = updateMonValuesForSC(context, "fakeCluster", monAddr)
+	monAddr := flattenMonConfig(newMons)
+	err = updateStorageClassMonEndpoints(context, "fakeCluster", monAddr)
 	assert.Nil(t, err)
 	val, err := getFakeSecretData("fakeSecret", "fakeNS", monValueFrom, clientset)
 	assert.Nil(t, err)


### PR DESCRIPTION

**Description of your changes:**
following up #2059 
ceph-csi rbd driver can store monitors in secret. After monitors fail over, updating the secret allows existing PVs still accessible.


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
