### PR TITLE
Use separate roles for Minio operator

### DIFF
--- a/cluster/examples/kubernetes/minio/object-store.yaml
+++ b/cluster/examples/kubernetes/minio/object-store.yaml
@@ -3,6 +3,20 @@ kind: Namespace
 metadata:
   name: rook-minio
 ---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-minio-cluster-mgmt
+  namespace: rook-minio
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-minio-mgmt
+subjects:
+- kind: ServiceAccount
+  name: rook-minio-system
+  namespace: rook-minio-operator
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -17,15 +17,20 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-minio-operator
+  namespace: rook-minio-system
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-minio-operator
+  name: rook-minio-mgmt
 rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
   - secrets
   - pods
   - services
@@ -40,6 +45,11 @@ rules:
   verbs:
   - get
   - create
+---
+kind: Role
+metadata:
+  name: rook-minio-global
+rules:
 - apiGroups:
   - minio.rook.io
   resources:
@@ -53,21 +63,16 @@ rules:
   verbs:
   - "*"
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: rook-minio-operator
-  namespace: rook-minio-system
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: rook-minio-operator
+  name: rook-minio-global
   namespace: rook-minio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: rook-minio-operator
+  kind: Role
+  name: rook-minio-global
+  namespace: rook-minio-system
 subjects:
 - kind: ServiceAccount
   name: rook-minio-operator


### PR DESCRIPTION
**Description of your changes:**
Use two separate roles for the minio operator and remove the permission to create `namespaces` from the operator.

This is currently untested.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)