### PR TITLE
Fix MergeResourceRequirements() func

### DIFF
--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -33,28 +33,36 @@ var (
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {
 	// if the first has a value not set check if second has and set it in first
 	if _, ok := first.Limits[v1.ResourceCPU]; !ok {
-		if first.Limits == nil {
-			first.Limits = v1.ResourceList{}
+		if _, ok = second.Limits[v1.ResourceCPU]; ok {
+			if first.Limits == nil {
+				first.Limits = v1.ResourceList{}
+			}
+			first.Limits[v1.ResourceCPU] = second.Limits[v1.ResourceCPU]
 		}
-		first.Limits[v1.ResourceCPU] = second.Limits[v1.ResourceCPU]
 	}
 	if _, ok := first.Limits[v1.ResourceMemory]; !ok {
-		if first.Limits == nil {
-			first.Limits = v1.ResourceList{}
+		if _, ok = second.Limits[v1.ResourceMemory]; ok {
+			if first.Limits == nil {
+				first.Limits = v1.ResourceList{}
+			}
+			first.Limits[v1.ResourceMemory] = second.Limits[v1.ResourceMemory]
 		}
-		first.Limits[v1.ResourceMemory] = second.Limits[v1.ResourceMemory]
 	}
 	if _, ok := first.Requests[v1.ResourceCPU]; !ok {
-		if first.Requests == nil {
-			first.Requests = v1.ResourceList{}
+		if _, ok = second.Requests[v1.ResourceCPU]; ok {
+			if first.Requests == nil {
+				first.Requests = v1.ResourceList{}
+			}
+			first.Requests[v1.ResourceCPU] = second.Requests[v1.ResourceCPU]
 		}
-		first.Requests[v1.ResourceCPU] = second.Requests[v1.ResourceCPU]
 	}
 	if _, ok := first.Requests[v1.ResourceMemory]; !ok {
-		if first.Requests == nil {
-			first.Requests = v1.ResourceList{}
+		if _, ok = second.Requests[v1.ResourceMemory]; ok {
+			if first.Requests == nil {
+				first.Requests = v1.ResourceList{}
+			}
+			first.Requests[v1.ResourceMemory] = second.Requests[v1.ResourceMemory]
 		}
-		first.Requests[v1.ResourceMemory] = second.Requests[v1.ResourceMemory]
 	}
 	return first
 }

--- a/pkg/operator/k8sutil/resources_test.go
+++ b/pkg/operator/k8sutil/resources_test.go
@@ -35,10 +35,9 @@ func TestMergeResourceRequirements(t *testing.T) {
 	first := v1.ResourceRequirements{}
 	second := v1.ResourceRequirements{}
 	result := MergeResourceRequirements(first, second)
-	// both are 2 because when first has one value unset it gets set from second
-	// even when it is empty/nil
-	assert.Equal(t, 2, len(result.Limits))
-	assert.Equal(t, 2, len(result.Requests))
+	// Both are 0 because first and second don't have a value set, so there is nothing to merge
+	assert.Equal(t, 0, len(result.Limits))
+	assert.Equal(t, 0, len(result.Requests))
 
 	first = v1.ResourceRequirements{}
 	second = v1.ResourceRequirements{
@@ -50,8 +49,8 @@ func TestMergeResourceRequirements(t *testing.T) {
 		},
 	}
 	result = MergeResourceRequirements(first, second)
-	assert.Equal(t, 2, len(result.Limits))
-	assert.Equal(t, 2, len(result.Requests))
+	assert.Equal(t, 1, len(result.Limits))
+	assert.Equal(t, 1, len(result.Requests))
 	assert.Equal(t, "100", result.Limits.Cpu().String())
 	assert.Equal(t, "1337", result.Requests.Memory().String())
 
@@ -65,11 +64,12 @@ func TestMergeResourceRequirements(t *testing.T) {
 			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
 		},
 		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
 			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 		},
 	}
 	result = MergeResourceRequirements(first, second)
-	assert.Equal(t, 2, len(result.Limits))
+	assert.Equal(t, 1, len(result.Limits))
 	assert.Equal(t, 2, len(result.Requests))
 	assert.Equal(t, "42", result.Limits.Cpu().String())
 	assert.Equal(t, "1337", result.Requests.Memory().String())


### PR DESCRIPTION
**Description of your changes:**
Resources are now correctly merged when "not set".
Example:
```
requests:
  cpu: 500m
```
will result in only `cpu` be set and not `memory` being set to `0` because it is not set in this case.

Slack message of error because of this issue: https://rook-io.slack.com/archives/C46Q5UC05/p1538818496000100

TL;DR Now it actually does what the comment says:
> if the first has a value not set check if second has and set it in first

Before we didn't check `second` if it has the value(s) set.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
