### PR TITLE
Fix quickstart link in kubernetes examples

### DIFF
--- a/cluster/examples/kubernetes/README.md
+++ b/cluster/examples/kubernetes/README.md
@@ -1,1 +1,1 @@
-For documentation on running Rook in your Kubernetes cluster see the [Kubernetes Quickstart Guide](/Documentation/quickstart.md)
+For documentation on running Rook in your Kubernetes cluster see the [Kubernetes Quickstart Guide](/Documentation/quickstart-toc.md)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

These will fix the link in the kubernetes example readme to link to the correct quickstart.

**Which issue is resolved by this Pull Request:**
none

[skip ci]