### PR TITLE
rook-ceph: install kubernetes python module in rook-ceph image

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -16,7 +16,9 @@ FROM BASEIMAGE
 
 RUN yum --assumeyes install \
     net-tools \
-    nmap-ncat && \
+    nmap-ncat \
+    python2-pip && \
+    pip install kubernetes && \
     yum clean all && rm -rf /tmp/* /var/tmp/*
 
 ARG ARCH


### PR DESCRIPTION
ceph-mgr has an extension for rook, but it requires the kubernetes
python module. Let's install it as a matter of course when generating
rook images.

Signed-off-by: Jeff Layton <jlayton@redhat.com>