### PR TITLE
nfs: rebase nfs image onto fedora 28

### DIFF
--- a/images/nfs/Dockerfile
+++ b/images/nfs/Dockerfile
@@ -22,7 +22,7 @@ FROM NFS_BASEIMAGE
 # 2. Set NFS_V4_RECOV_ROOT to /export
 # 3. Use device major/minor as fsid major/minor to work on OverlayFS
 
-RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all \
+RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch libnsl2-devel && dnf clean all \
  && curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.1.tar.gz | tar zx \
  && curl -L https://github.com/nfs-ganesha/nfs-ganesha/commit/c583534b166be198755d905c82a7687d83b458d8.patch -o /nfs-ganesha.patch \
  && curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.4.tar.gz | tar zx \

--- a/images/nfs/Makefile
+++ b/images/nfs/Makefile
@@ -19,7 +19,7 @@ include ../image.mk
 
 NFS_IMAGE = $(BUILD_REGISTRY)/nfs-$(GOARCH)
 
-NFS_BASE ?= fedora:26
+NFS_BASE ?= fedora:28
 
 ifeq ($(GOARCH),amd64)
 NFS_BASEIMAGE = $(NFS_BASE)


### PR DESCRIPTION
f26 has been EOL'ed for a while now, so we shouldn't be relying on it.

Update to fedora 28. This necessitates installing libnsl2 for ganesha,
which is not installed in the base image these days.

Long term, we should probably find some way to keep this in sync with
the Fedora release cadence, or rebase onto something more stable like
Centos.

Signed-off-by: Jeff Layton <jlayton@redhat.com>

-----8<-------

Build tested only as I don't have a great way to test this at the moment.