### PR TITLE
ceph mds: allow mds deployment scale-down

### DIFF
--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -125,15 +125,11 @@ func UpdateDeploymentAndWait(context *clusterd.Context, deployment *extensions.D
 // GetDeployments returns a list of deployment names labels matching a given selector
 // example of a label selector might be "app=rook-ceph-mon, mon!=b"
 // more: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-func GetDeployments(clientset kubernetes.Interface, namespace, labelSelector string) ([]string, error) {
+func GetDeployments(clientset kubernetes.Interface, namespace, labelSelector string) (*extensions.DeploymentList, error) {
 	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
 	deployments, err := clientset.Extensions().Deployments(namespace).List(listOptions)
 	if err != nil {
-		return []string{}, fmt.Errorf("failed to list deployments with labelSelector %s: %v", labelSelector, err)
+		return nil, fmt.Errorf("failed to list deployments with labelSelector %s: %v", labelSelector, err)
 	}
-	dNames := []string{}
-	for _, d := range deployments.Items {
-		dNames = append(dNames, d.GetName())
-	}
-	return dNames, nil
+	return deployments, nil
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -35,7 +35,7 @@ type CephManifests interface {
 	GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string
 	GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string
 	GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string
-	GetFilesystem(namepace, name string) string
+	GetFilesystem(namepace, name string, activeCount int) string
 	GetObjectStore(namespace, name string, replicaCount, port int) string
 }
 
@@ -572,7 +572,8 @@ func (m *CephManifestsMaster) GetBlockPoolStorageClass(namespace string, poolNam
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 }
 
-func (m *CephManifestsMaster) GetFilesystem(namespace, name string) string {
+// GetFilesystem returns the manifest to create a Rook filesystem resource with the given config.
+func (m *CephManifestsMaster) GetFilesystem(namespace, name string, activeCount int) string {
 	return `apiVersion: ceph.rook.io/v1beta1
 kind: Filesystem
 metadata:
@@ -586,7 +587,7 @@ spec:
   - replicated:
       size: 1
   metadataServer:
-    activeCount: 2
+    activeCount: ` + strconv.Itoa(activeCount) + `
     activeStandby: true`
 }
 

--- a/tests/framework/installer/ceph_manifests_v0.8.go
+++ b/tests/framework/installer/ceph_manifests_v0.8.go
@@ -533,7 +533,8 @@ func (m *CephManifestsV0_8) GetBlockPoolStorageClass(namespace string, poolName 
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"), m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 }
 
-func (m *CephManifestsV0_8) GetFilesystem(namespace, name string) string {
+// GetFilesystem returns the manifest to create a Rook filesystem resource with the given config.
+func (m *CephManifestsV0_8) GetFilesystem(namespace, name string, activeCount int) string {
 	return `apiVersion: ceph.rook.io/v1beta1
 kind: Filesystem
 metadata:
@@ -547,7 +548,7 @@ spec:
   - replicated:
       size: 1
   metadataServer:
-    activeCount: 2
+    activeCount: ` + strconv.Itoa(activeCount) + `
     activeStandby: true`
 }
 

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -43,6 +43,7 @@ func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	createFilesystem(helper, k8sh, s, namespace, filesystemName)
 	createFilesystemConsumerPod(helper, k8sh, s, namespace, filesystemName)
 	writeAndReadToFilesystem(helper, k8sh, s, namespace, "test_file")
+	downscaleMetadataServers(helper, k8sh, s, namespace, filesystemName)
 	cleanupFilesystemConsumer(helper, k8sh, s, namespace, filesystemName)
 }
 
@@ -67,6 +68,12 @@ func writeAndReadToFilesystem(helper *clients.TestClient, k8sh *utils.K8sHelper,
 	require.Nil(s.T(), err)
 
 	err = k8sh.ReadFromPod(namespace, filePodName, filename, message)
+	require.Nil(s.T(), err)
+}
+
+func downscaleMetadataServers(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace, fsName string) {
+	logger.Infof("downscaling file system metadata servers")
+	err := helper.FSClient.ScaleDown(fsName, namespace)
 	require.Nil(s.T(), err)
 }
 


### PR DESCRIPTION
fix #2193

Fix regression introduced by PR allowing MDS config creation in init
container. This allows the new deployment-based mds clusters to scale
down where currently they can only remain constant or scale up.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
