### PR TITLE
Allow mons to scale up or down

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -67,6 +67,13 @@ This feature is only available when `useAllNodes` has been set to `false`.
 - `count`: set the number of mons to be started. The number should be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
 - `allowMultiplePerNode`: enable (`true`) or disable (`false`) the placement of multiple mons on one node. Default is `false`.
 
+If these settings are changed in the CRD the operator will update the number of mons during a periodic check of the mon health, which by default is every 45 seconds.
+
+To change the defaults that the operator uses to determine the mon health and whether to failover a mon, the following environment variables can be changed in [operator.yaml](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/operator.yaml). The intervals should be small enough that you have confidence the mons will maintain quorum, while also being
+log enough to ignore network blips where mons are failed over too often.
+- ROOK_MON_HEALTHCHECK_INTERVAL: The frequency with which to check if mons are in quorum (default is 45 seconds)
+- ROOK_MON_OUT_TIMEOUT: The interval to wait before marking a mon as "out" and starting a new mon to replace it in the quroum (default is 5 minutes)
+
 ### Node Settings
 In addition to the cluster level settings specified above, each individual node can also specify configuration to override the cluster level settings and defaults.
 If a node does not specify any configuration then it will inherit the cluster level settings.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,7 @@
 - K8s client-go updated from version 1.8.2 to 1.11.3
 - The toolbox manifest now creates a deployment based on the `rook/ceph` image instead of creating a pod on a specialized `rook/ceph-toolbox` image.
 - The frequency of discovering devices on a node is reduced to 60 minutes by default, and is configurable with the setting `ROOK_DISCOVER_DEVICES_INTERVAL` in operator.yaml.
+- The number of mons can be changed by updating the `mon.count` in the cluster CRD.
 
 ## Breaking Changes
 - Ceph mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.

--- a/pkg/daemon/ceph/client/test/mon.go
+++ b/pkg/daemon/ceph/client/test/mon.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/daemon/ceph/config"
 )
 
 func MonInQuorumResponse() string {
@@ -30,6 +31,22 @@ func MonInQuorumResponse() string {
 			Rank:    0,
 			Address: "1.2.3.1",
 		},
+	}
+	serialized, _ := json.Marshal(resp)
+	return string(serialized)
+}
+
+func MonInQuorumResponseFromMons(mons map[string]*config.MonInfo) string {
+	resp := client.MonStatusResponse{Quorum: []int{}}
+	i := 0
+	for name := range mons {
+		resp.MonMap.Mons = append(resp.MonMap.Mons, client.MonMapEntry{
+			Name:    name,
+			Rank:    i,
+			Address: fmt.Sprintf("1.2.3.%d", i),
+		})
+		resp.Quorum = append(resp.Quorum, i)
+		i++
 	}
 	serialized, _ := json.Marshal(resp)
 	return string(serialized)

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -289,8 +289,13 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 		c.removeFinalizer(newClust)
 		return
 	}
+	cluster, ok := c.clusterMap[newClust.Namespace]
+	if !ok {
+		logger.Errorf("Cannot update cluster %s that does not exist", newClust.Namespace)
+		return
+	}
 
-	if !clusterChanged(oldClust.Spec, newClust.Spec) {
+	if !clusterChanged(oldClust.Spec, newClust.Spec, cluster) {
 		logger.Infof("update event for cluster %s is not supported", newClust.Namespace)
 		return
 	}
@@ -299,11 +304,6 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 	logger.Debugf("old cluster: %+v", oldClust.Spec)
 	logger.Debugf("new cluster: %+v", newClust.Spec)
 
-	cluster, ok := c.clusterMap[newClust.Namespace]
-	if !ok {
-		logger.Errorf("Cannot update cluster %s that does not exist", newClust.Namespace)
-		return
-	}
 	cluster.Spec = &newClust.Spec
 
 	// attempt to update the cluster.  note this is done outside of wait.Poll because that function

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
@@ -75,8 +76,9 @@ type Cluster struct {
 	Namespace            string
 	Keyring              string
 	Version              string
-	Size                 int
+	Count                int
 	AllowMultiplePerNode bool
+	MonCountMutex        sync.Mutex
 	Port                 int32
 	clusterInfo          *cephconfig.ClusterInfo
 	placement            rookalpha.Placement
@@ -126,7 +128,7 @@ func New(context *clusterd.Context, namespace, dataDirHostPath, version string, 
 		dataDirHostPath:      dataDirHostPath,
 		Namespace:            namespace,
 		Version:              version,
-		Size:                 mon.Count,
+		Count:                mon.Count,
 		AllowMultiplePerNode: mon.AllowMultiplePerNode,
 		maxMonID:             -1,
 		waitForStart:         true,
@@ -157,7 +159,7 @@ func (c *Cluster) Start() error {
 
 func (c *Cluster) startMons() error {
 	// init the mons config
-	mons := c.initMonConfig(c.Size)
+	mons := c.initMonConfig(c.Count)
 
 	// Assign the pods to nodes
 	if err := c.assignMons(mons); err != nil {
@@ -165,13 +167,13 @@ func (c *Cluster) startMons() error {
 	}
 
 	// Start one monitor at a time
-	for i := 0; i < c.Size; i++ {
+	for i := 0; i < c.Count; i++ {
 		logger.Infof("ensuring mon %s (%s) is started", mons[i].ResourceName, mons[i].DaemonName)
 		endIndex := len(c.clusterInfo.Monitors)
-		if endIndex < c.Size {
+		if endIndex < c.Count {
 			endIndex++
 		}
-		logger.Infof("looping to start mons. i=%d, endIndex=%d, c.Size=%d", i, endIndex, c.Size)
+		logger.Infof("looping to start mons. i=%d, endIndex=%d, c.Size=%d", i, endIndex, c.Count)
 
 		// Init the mon IPs
 		if err := c.initMonIPs(mons[0:endIndex]); err != nil {
@@ -380,12 +382,13 @@ func (c *Cluster) startDeployments(mons []*monConfig, index int) error {
 		return fmt.Errorf("cannot start 0 mons")
 	}
 
-	// Start the last mon in the list. The others have already been started by a previous call.
-	m := mons[index]
-	node, _ := c.mapping.Node[m.DaemonName]
-	err := c.startMon(m, node.Hostname)
-	if err != nil {
-		return fmt.Errorf("failed to create mon %s. %+v", m.DaemonName, err)
+	// Ensure each of the mons have been created. If already created, it will be a no-op.
+	for i := 0; i < len(mons); i++ {
+		node, _ := c.mapping.Node[mons[i].DaemonName]
+		err := c.startMon(mons[i], node.Hostname)
+		if err != nil {
+			return fmt.Errorf("failed to create mon %s. %+v", mons[i].DaemonName, err)
+		}
 	}
 
 	logger.Infof("mons created: %d", len(mons))
@@ -555,7 +558,7 @@ func (c *Cluster) startMon(m *monConfig, hostname string) error {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create mon %s. %+v", m.ResourceName, err)
 		}
-		logger.Infof("mon %s already exists", m.ResourceName)
+		logger.Debugf("mon %s already exists", m.ResourceName)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -171,6 +171,7 @@ func (c *Cluster) startMons() error {
 		if endIndex < c.Size {
 			endIndex++
 		}
+		logger.Infof("looping to start mons. i=%d, endIndex=%d, c.Size=%d", i, endIndex, c.Size)
 
 		// Init the mon IPs
 		if err := c.initMonIPs(mons[0:endIndex]); err != nil {
@@ -319,16 +320,16 @@ func (c *Cluster) assignMons(mons []*monConfig) error {
 		return fmt.Errorf("failed to get available nodes for mons. %+v", err)
 	}
 
-	// if all nodes already have mons return error as we don't place two mons on one node
-	if len(availableNodes) == 0 {
-		return fmt.Errorf("no nodes available for mon placement")
-	}
-
 	nodeIndex := 0
 	for _, m := range mons {
 		if _, ok := c.mapping.Node[m.DaemonName]; ok {
 			logger.Debugf("mon %s already assigned to a node, no need to assign", m.DaemonName)
 			continue
+		}
+
+		// if we need to place a new mon and don't have any more nodes available, we fail to add the mon
+		if len(availableNodes) == 0 {
+			return fmt.Errorf("no nodes available for mon placement")
 		}
 
 		// pick one of the available nodes where the mon will be assigned

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -69,7 +69,7 @@ func newCluster(context *clusterd.Context, namespace string, hostNetwork bool, r
 		context:              context,
 		Namespace:            namespace,
 		Version:              "myversion",
-		Size:                 3,
+		Count:                3,
 		AllowMultiplePerNode: true,
 		maxMonID:             -1,
 		waitForStart:         false,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The number of mons in the cluster can be changed by updating the `mon.count` in the cluster CRD. For example:
- When changed from 3 to 5, the operator will start two more mons.
- When changed from 5 to 3, the operator will remove two mons.

The mons will be added or removed by the periodic health check of the mons (every 45s by default). Since the CRD is applied in a different goroutine from the health check, there is a mutex to protect updating the number of mons. Note that once there are two or more mons, the operator cannot reduce the mon count below two because a quorum of two cannot remove a member.

**Which issue is resolved by this Pull Request:**
Resolves #1636 #2130

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]