### PR TITLE
Ensure that $ROOK_CLUSTER_NAME is set for mgr daemon

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -91,7 +91,6 @@ func (c *Cluster) makeConfigInitContainer(mgrConfig *mgrConfig) v1.Container {
 					}}},
 			k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 			k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
-			opmon.ClusterNameEnvVar(c.Namespace),
 			opmon.EndpointEnvVar(),
 			opmon.SecretEnvVar(),
 			opmon.AdminSecretEnvVar(),
@@ -104,7 +103,7 @@ func (c *Cluster) makeConfigInitContainer(mgrConfig *mgrConfig) v1.Container {
 }
 
 func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
-	return v1.Container{
+	container := v1.Container{
 		Name: "mgr",
 		Command: []string{
 			mgrDaemonCommand,
@@ -136,6 +135,8 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 		Env:       k8sutil.ClusterDaemonEnvVars(),
 		Resources: c.resources,
 	}
+	container.Env = append(container.Env, opmon.ClusterNameEnvVar(c.Namespace))
+	return container
 }
 
 func (c *Cluster) getPodLabels(daemonName string) map[string]string {

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -82,7 +82,7 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, 1, len(pod.Spec.Containers))
 
 	configImage := "rook/rook:myversion"
-	configEnvs := 8
+	configEnvs := 7
 	configContainerDefinition := cephtest.ContainerTestDefinition{
 		Image:   &configImage,
 		Command: []string{}, // no command
@@ -108,7 +108,8 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
 
 	daemonImage := "rook/rook:myversion"
-	daemonEnvs := len(k8sutil.ClusterDaemonEnvVars())
+	// +1 for $ROOK_CLUSTER_NAME
+	daemonEnvs := len(k8sutil.ClusterDaemonEnvVars()) + 1
 	daemonContainerDefinition := cephtest.ContainerTestDefinition{
 		Image: &daemonImage,
 		Command: []string{


### PR DESCRIPTION
We need this environment variable in the main container, not the init
container, as it's used by the rook ceph-mgr module.

Fixes: ca71b7a311e4 (Ceph mgr: Set up config in init container)
Signed-off-by: Jeff Layton <jlayton@redhat.com>