### PR TITLE
Allow specifying custom Ceph user and secret name for mounting

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -9,6 +9,7 @@ indent: true
 These examples show how to perform advanced configuration tasks on your Rook
 storage cluster.
 
+- [Use custom Ceph user and secret for mounting](#use-custom-ceph-user-and-secret-for-mounting)
 - [Log Collection](#log-collection)
 - [OSD Information](#osd-information)
 - [Separate Storage Groups](#separate-storage-groups)
@@ -26,6 +27,112 @@ the Ceph client suite is from a [Rook Toolbox container](toolbox.md).
 The Kubernetes based examples assume Rook OSD pods are in the `rook-ceph` namespace.
 If you run them in a different namespace, modify `kubectl -n rook-ceph [...]` to fit
 your situation.
+
+## Use custom Ceph user and secret for mounting
+
+**NOTE** For extensive info about creating Ceph users, consult the Ceph documentation: http://docs.ceph.com/docs/mimic/rados/operations/user-management/#add-a-user.
+Using a custom Ceph user and secret can be done for filesystem and block storage.
+
+Create a custom user in Ceph with read-write access in the `/bar` directory on CephFS (For Ceph Mimic or newer, use `data=POOL_NAME` instead of `pool=POOL_NAME`):
+
+```
+ceph auth get-or-create-key client.user1 mon 'allow r' osd 'allow rw tag cephfs pool=YOUR_FS_DATA_POOL' mds 'allow r, allow rw path=/bar'
+```
+
+The command will return a Ceph secret key, this key should be added as a secret in Kubernetes like this:
+
+```
+kubectl create secret generic ceph-user1-secret --from-literal=key=YOUR_CEPH_KEY
+```
+
+**NOTE** This secret with the same name must be created in each namespace where the StorageClass will be used.
+In addition to this Secret you must create a RoleBinding to allow the Rook Ceph agent to get the secret from each namespace.
+The RoleBinding is optional if you are using a ClusterRoleBinding for the Rook Ceph agent secret access.
+A ClusterRole which contains the permissions which are needed and used for the Bindings are shown as an example after the next step.
+
+On a StorageClass `parameters` and/or flexvolume Volume entry `options` set the following options:
+
+```
+mountUser: user1
+mountSecret: ceph-user1-secret
+```
+
+If you want the Rook Ceph agent to require a `mountUser` and `mountSecret` to be set in StorageClasses using Rook, you must set the environment variable `AGENT_MOUNT_SECURITY_MODE` to `Restricted` on the Rook Ceph operator Deployment.
+
+For more information on using the Ceph feature to limit access to CephFS paths, see [Ceph Documentation - Path Restriction](http://docs.ceph.com/docs/mimic/cephfs/client-auth/#path-restriction).
+
+### ClusterRole
+
+**NOTE**: When you are using the Helm chart to install the Rook Ceph operator and have set `mountSecurityMode` to e.g., `Restricted`,  then the below ClusterRole has already been created for you.
+
+**This ClusterRole is needed no matter if you want to use a RoleBinding per namespace or a ClusterRoleBinding.**
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-agent-mount
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+```
+
+### RoleBinding
+
+**NOTE**: You either need a RoleBinding in each namespace in which a mount secret resides in or create a ClusterRoleBinding with which the Rook Ceph agent
+has access to Kubernetes secrets in all namespaces.
+
+Create the RoleBinding shown here in each namespace the Rook Ceph agent should read secrets for mounting.
+The RoleBinding `subjects`' `namespace` must be the one the Rook Ceph agent runs in (default `rook-ceph-system`).
+
+Replace `namespace: name-of-namespace-with-mountsecret` according to the name of all namespaces a `mountSecret` can be in.
+```yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-agent-mount
+  namespace: name-of-namespace-with-mountsecret
+  labels:
+    operator: rook
+    storage-backend: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-agent-mount
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+```
+
+### ClusterRoleBinding
+
+This ClusterRoleBinding only needs to be created once, as it covers the whole cluster.
+
+```yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-agent-mount
+  labels:
+    operator: rook
+    storage-backend: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-agent-mount
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+```
 
 ## Log Collection
 

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -110,6 +110,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `agent.flexVolumeDirPath` | Path where the Rook agent discovers the flex volume plugins (*) | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
 | `agent.libModulesDirPath` | Path where the Rook agent should look for kernel modules (*)    | `/lib/modules`                                         |
 | `agent.mounts`            | Additional paths to be mounted in the agent container           | <none>                                                 |
+| `agent.mountSecurityMode` | Mount Security Mode for the agent.                              | `Any`                                                  |
 | `agent.toleration`        | Toleration for the agent pods                                   | <none>                                                 |
 | `agent.tolerationKey`     | The specific key of the taint to tolerate                       | <none>                                                 |
 | `discover.toleration`     | Toleration for the discover pods                                | <none>                                                 |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ def RunIntegrationTest(k, v) {
                                   export PATH="/tmp/rook-tests-scripts-helm/linux-amd64:$PATH" \
                                       KUBECONFIG=$HOME/admin.conf
                                   kubectl config view
-                                  _output/tests/linux_amd64/integration -test.v -test.timeout 600s -test.run SmokeSuite --host_type '''+"${k}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
+                                  _output/tests/linux_amd64/integration -test.v -test.timeout 1800s -test.run SmokeSuite --host_type '''+"${k}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
                         }
                         else {
                         echo "Running full regression"
@@ -154,7 +154,7 @@ def RunIntegrationTest(k, v) {
                               export PATH="/tmp/rook-tests-scripts-helm/linux-amd64:$PATH" \
                                   KUBECONFIG=$HOME/admin.conf
                               kubectl config view
-                              _output/tests/linux_amd64/integration -test.v -test.timeout 2400s --host_type '''+"${k}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
+                              _output/tests/linux_amd64/integration -test.v -test.timeout 7200s --host_type '''+"${k}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
                          }
                     }
                     finally{

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -138,16 +138,16 @@ go.install:
 go.test.unit: $(GOJUNIT)
 	@echo === go test unit-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
-	@CGO_ENABLED=0 $(GOHOST) test -v -i -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES)
-	@CGO_ENABLED=0 $(GOHOST) test -v -cover $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) 2>&1 | tee $(GO_TEST_OUTPUT)/unit-tests.log
+	CGO_ENABLED=0 $(GOHOST) test -v -i -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES)
+	CGO_ENABLED=0 $(GOHOST) test -v -cover $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_PACKAGES) 2>&1 | tee $(GO_TEST_OUTPUT)/unit-tests.log
 	@cat $(GO_TEST_OUTPUT)/unit-tests.log | $(GOJUNIT) -set-exit-code > $(GO_TEST_OUTPUT)/unit-tests.xml
 
 .PHONY:
 go.test.integration: $(GOJUNIT)
 	@echo === go test integration-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
-	@CGO_ENABLED=0 $(GOHOST) test -v -i $(GO_STATIC_FLAGS) $(GO_INTEGRATION_TEST_PACKAGES)
-	@CGO_ENABLED=0 $(GOHOST) test -v $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_INTEGRATION_TEST_PACKAGES) $(TEST_FILTER_PARAM) 2>&1 | tee $(GO_TEST_OUTPUT)/integration-tests.log
+	CGO_ENABLED=0 $(GOHOST) test -v -i $(GO_STATIC_FLAGS) $(GO_INTEGRATION_TEST_PACKAGES)
+	CGO_ENABLED=0 $(GOHOST) test -v -timeout 7200s $(GO_TEST_FLAGS) $(GO_STATIC_FLAGS) $(GO_INTEGRATION_TEST_PACKAGES) $(TEST_FILTER_PARAM) 2>&1 | tee $(GO_TEST_OUTPUT)/integration-tests.log
 	@cat $(GO_TEST_OUTPUT)/integration-tests.log | $(GOJUNIT) -set-exit-code > $(GO_TEST_OUTPUT)/integration-tests.xml
 
 .PHONY: go.lint

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -111,6 +111,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
 rules:
 - apiGroups:
   - ""
@@ -121,6 +124,23 @@ rules:
   - get
   - list
   - watch
+{{- if ((.Values.agent) and .Values.agent.mountSecurityMode) and ne .Values.agent.mountSecurityMode "Any" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-agent-mount
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+{{- end }}
 {{- if .Values.pspEnable }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         - name: AGENT_TOLERATION_KEY
           value: {{ .Values.agent.tolerationKey }}
 {{- end }}
+{{- if .Values.agent.mountSecurityMode }}
+        - name: AGENT_MOUNT_SECURITY_MODE
+          value: {{ .Values.agent.mountSecurityMode }}
+{{- end }}
 {{- if .Values.agent.flexVolumeDirPath }}
         - name: FLEXVOLUME_DIR_PATH
           value: {{ .Values.agent.flexVolumeDirPath }}

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -55,6 +55,7 @@ pspEnable: true
 # agent:
 #   toleration: NoSchedule
 #   tolerationKey: key
+#   mountSecurityMode: Any
 ## For information on FlexVolume path, please refer to https://rook.io/docs/rook/master/flexvolume.html
 #   flexVolumeDirPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
 #   libModulesDirPath: /lib/modules

--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -49,3 +49,8 @@ spec:
             # by default the path is /, but you can override and mount a specific path of the filesystem by using the path attribute
             # the path must exist on the filesystem, otherwise mounting the filesystem at that path will fail
             # path: /some/path/inside/cephfs
+            # (Optional) Specify an existing Ceph user that will be used for mounting storage with this StorageClass.
+            #mountUser: user1
+            # (Optional) Specify an existing Kubernetes secret name containing just one key holding the Ceph user secret.
+            # The secret must exist in each namespace(s) where the storage will be consumed.
+            #mountSecret: ceph-user1-secret

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -293,6 +293,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
 rules:
 - apiGroups:
   - ""
@@ -383,10 +386,17 @@ spec:
         # Rook Agent toleration. Will tolerate all taints with all keys.
         # Choose between NoSchedule, PreferNoSchedule and NoExecute:
         # - name: AGENT_TOLERATION
-        #  value: "NoSchedule"
+        #   value: "NoSchedule"
         # (Optional) Rook Agent toleration key. Set this to the key of the taint you want to tolerate
         # - name: AGENT_TOLERATION_KEY
-        #  value: "<KeyOfTheTaintToTolerate>"
+        #   value: "<KeyOfTheTaintToTolerate>"
+        # (Optional) Rook Agent mount security mode. Can by `Any` or `Restricted`.
+        # `Any` uses Ceph admin credentials by default/fallback.
+        # For using `Restricted` you must have a Ceph secret in each namespace storage should be consumed from and
+        # set `mountUser` to the Ceph user, `mountSecret` to the Kubernetes secret name.
+        # to the namespace in which the `mountSecret` Kubernetes secret namespace.
+        # - name: AGENT_MOUNT_SECURITY_MODE
+        #   value: "Any"
         # Set the path where the Rook agent can find the flex volumes
         # - name: FLEXVOLUME_DIR_PATH
         #  value: "<PathToFlexVolumes>"
@@ -399,7 +409,7 @@ spec:
         # Rook Discover toleration. Will tolerate all taints with all keys.
         # Choose between NoSchedule, PreferNoSchedule and NoExecute:
         # - name: DISCOVER_TOLERATION
-        #  value: "NoSchedule"
+        #   value: "NoSchedule"
         # (Optional) Rook Discover toleration key. Set this to the key of the taint you want to tolerate
         # - name: DISCOVER_TOLERATION_KEY
         #  value: "<KeyOfTheTaintToTolerate>"

--- a/cluster/examples/kubernetes/ceph/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass.yaml
@@ -20,3 +20,8 @@ parameters:
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
   fstype: xfs
+  # (Optional) Specify an existing Ceph user that will be used for mounting storage with this StorageClass.
+  #mountUser: user1
+  # (Optional) Specify an existing Kubernetes secret name containing just one key holding the Ceph user secret.
+  # The secret must exist in each namespace(s) where the storage will be consumed.
+  #mountSecret: ceph-user1-secret

--- a/cmd/rook/ceph/agent.go
+++ b/cmd/rook/ceph/agent.go
@@ -40,7 +40,6 @@ func init() {
 }
 
 func startAgent(cmd *cobra.Command, args []string) error {
-
 	rook.SetLogLevel()
 
 	rook.LogStartupInfo(agentCmd.Flags())
@@ -50,7 +49,7 @@ func startAgent(cmd *cobra.Command, args []string) error {
 		rook.TerminateFatal(fmt.Errorf("failed to get k8s client. %+v", err))
 	}
 
-	logger.Info("starting rook ceph agent")
+	logger.Infof("starting rook ceph agent")
 	context := &clusterd.Context{
 		Executor:              &exec.CommandExecutor{},
 		ConfigDir:             k8sutil.DataDir,

--- a/cmd/rookflex/cmd/root.go
+++ b/cmd/rookflex/cmd/root.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cmd
 
 import (
@@ -34,15 +35,12 @@ const (
 	cephFS = "ceph"
 )
 
+// RootCmd the rookflex volume plugin cobra root command
 var RootCmd = &cobra.Command{
 	Use:           "rookflex",
 	Short:         "Rook Flex volume plugin",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func Execute() {
-	RootCmd.Execute()
 }
 
 func getRPCClient() (*rpc.Client, error) {

--- a/pkg/daemon/ceph/agent/cluster/controller.go
+++ b/pkg/daemon/ceph/agent/cluster/controller.go
@@ -63,7 +63,6 @@ func NewClusterController(context *clusterd.Context, flexvolumeController flexvo
 
 // StartWatch will start the watching of cluster events by this controller
 func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) error {
-
 	resourceHandlerFuncs := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: c.onDelete,
 	}

--- a/pkg/daemon/ceph/agent/flexvolume/manager/fake.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/fake.go
@@ -21,7 +21,7 @@ import "fmt"
 // FakeVolumeManager represents a fake (mocked) implementation of the VolumeManager interface for testing.
 type FakeVolumeManager struct {
 	FakeInit   func() error
-	FakeAttach func(image, pool, clusterName string) (string, error)
+	FakeAttach func(image, pool, id, key, clusterName string) (string, error)
 	FakeDetach func(image, pool, clusterName string, force bool) error
 }
 
@@ -34,15 +34,15 @@ func (f *FakeVolumeManager) Init() error {
 }
 
 // Attach a volume image to the node
-func (f *FakeVolumeManager) Attach(image, pool, clusterName string) (string, error) {
+func (f *FakeVolumeManager) Attach(image, pool, id, key, clusterName string) (string, error) {
 	if f.FakeAttach != nil {
-		return f.FakeAttach(image, pool, clusterName)
+		return f.FakeAttach(image, pool, id, key, clusterName)
 	}
 	return fmt.Sprintf("/%s/%s/%s", image, pool, clusterName), nil
 }
 
 // Detach a volume image from a node
-func (f *FakeVolumeManager) Detach(image, pool, clusterName string, force bool) error {
+func (f *FakeVolumeManager) Detach(image, pool, id, key, clusterName string, force bool) error {
 	if f.FakeDetach != nil {
 		return f.FakeDetach(image, pool, clusterName, force)
 	}

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -66,7 +66,6 @@ func NewFlexvolumeServer(context *clusterd.Context, controller *Controller) *Fle
 
 // Start configures the flexvolume driver on the host and starts the unix domain socket server to communicate with the driver
 func (s *FlexvolumeServer) Start(driverVendor, driverName string) error {
-
 	// first install the flexvolume driver
 	// /usr/local/bin/rookflex
 	driverFile := path.Join(usrBinDir, flexvolumeDriverFileName)
@@ -112,7 +111,7 @@ func (s *FlexvolumeServer) Start(driverVendor, driverName string) error {
 	return nil
 }
 
-// Stop the unix domain socket server and deletes the socket file
+// StopAll Stop the unix domain socket server and deletes the socket file
 func (s *FlexvolumeServer) StopAll() {
 	logger.Infof("Stopping %d unix socket rpc server(s).", len(s.listeners))
 	for unixSocketFile, listener := range s.listeners {
@@ -129,6 +128,7 @@ func (s *FlexvolumeServer) StopAll() {
 	s.listeners = make(map[string]net.Listener)
 }
 
+// RookDriverName return the Kubernetes version appropriate Rook driver name
 func RookDriverName(context *clusterd.Context) (string, error) {
 	kubeVersion, err := k8sutil.GetK8SVersion(context.Clientset)
 	if err != nil {

--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -17,15 +17,17 @@ limitations under the License.
 package flexvolume
 
 const (
-	ReadOnly  = "ro"
+	// ReadOnly mount mode
+	ReadOnly = "ro"
+	// ReadWrite mount mode
 	ReadWrite = "rw"
 )
 
 // VolumeManager handles flexvolume plugin storage operations
 type VolumeManager interface {
 	Init() error
-	Attach(image, pool, clusterName string) (string, error)
-	Detach(image, pool, clusterName string, force bool) error
+	Attach(image, pool, id, key, clusterName string) (string, error)
+	Detach(image, pool, id, key, clusterName string, force bool) error
 }
 
 type VolumeController interface {
@@ -46,6 +48,8 @@ type AttachOptions struct {
 	MountDir         string `json:"mountDir"`
 	FsName           string `json:"fsName"`
 	Path             string `json:"path"` // Path within the CephFS to mount
+	MountUser        string `json:"mountUser"`
+	MountSecret      string `json:"mountSecret"`
 	RW               string `json:"kubernetes.io/readwrite"`
 	FsType           string `json:"kubernetes.io/fsType"`
 	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7

--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -138,12 +138,12 @@ func DeleteImage(context *clusterd.Context, clusterName, name, poolName string) 
 }
 
 // MapImage maps an RBD image using admin cephfx and returns the device path
-func MapImage(context *clusterd.Context, imageName, poolName, clusterName, keyring, monitors string) error {
+func MapImage(context *clusterd.Context, imageName, poolName, id, keyring, clusterName, monitors string) error {
 	imageSpec := getImageSpec(imageName, poolName)
 	args := []string{
 		"map",
 		imageSpec,
-		"--id", "admin",
+		fmt.Sprintf("--id=%s", id),
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--keyring=%s", keyring),
 		"-m", monitors,
@@ -159,12 +159,12 @@ func MapImage(context *clusterd.Context, imageName, poolName, clusterName, keyri
 }
 
 // UnMapImage unmap an RBD image from the node
-func UnMapImage(context *clusterd.Context, imageName, poolName, clusterName, keyring, monitors string, force bool) error {
+func UnMapImage(context *clusterd.Context, imageName, poolName, id, keyring, clusterName, monitors string, force bool) error {
 	deviceImage := getImageSpec(imageName, poolName)
 	args := []string{
 		"unmap",
 		deviceImage,
-		"--id", "admin",
+		fmt.Sprintf("--id=%s", id),
 		fmt.Sprintf("--cluster=%s", clusterName),
 		fmt.Sprintf("--keyring=%s", keyring),
 		"-m", monitors,

--- a/pkg/daemon/ceph/config/keyring.go
+++ b/pkg/daemon/ceph/config/keyring.go
@@ -86,23 +86,5 @@ func writeKeyring(keyring, keyringPath string) error {
 	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0644); err != nil {
 		return fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringPath, err)
 	}
-
-	// Save the keyring to the default path. This allows the user to any pod to easily execute Ceph commands.
-	// It is recommended to connect to the operator pod rather than monitors and OSDs since the operator always has the latest configuration files.
-	// The mon and OSD pods will only re-create the config files when the pod is restarted. If a monitor fails over, the config
-	// in the other mon and osd pods may be out of date. This could cause your ceph commands to timeout connecting to invalid mons.
-	// Note that the running mon and osd daemons are not affected by this issue because of their live connection to the mon quorum.
-	// If you have multiple Rook clusters, it is preferred to connect to the Rook toolbox for a specific cluster. Otherwise, your ceph commands
-	// may connect to the wrong cluster.
-	if err := os.MkdirAll(DefaultConfigDir, 0744); err != nil {
-		logger.Warningf("failed to create default directory %s: %+v", DefaultConfigDir, err)
-		return nil
-	}
-	defaultPath := DefaultKeyringFilePath()
-	if err := ioutil.WriteFile(defaultPath, []byte(keyring), 0644); err != nil {
-		logger.Warningf("failed to copy keyring to %s: %+v", defaultPath, err)
-		return nil
-	}
-
 	return nil
 }

--- a/pkg/operator/ceph/agent/agent_test.go
+++ b/pkg/operator/ceph/agent/agent_test.go
@@ -73,7 +73,7 @@ func TestStartAgentDaemonset(t *testing.T) {
 	volumeMounts := agentDS.Spec.Template.Spec.Containers[0].VolumeMounts
 	assert.Equal(t, 4, len(volumeMounts))
 	envs := agentDS.Spec.Template.Spec.Containers[0].Env
-	assert.Equal(t, 2, len(envs))
+	assert.Equal(t, 3, len(envs))
 	image := agentDS.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, "rook/rook:myversion", image)
 	assert.Nil(t, agentDS.Spec.Template.Spec.Tolerations)

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,7 +118,7 @@ go test -v -timeout 1800s -run SmokeSuite github.com/rook/rook/tests/integration
 
 #### To run specific tests inside a suite:
 ```
-go test -v -timeout 1800s -run SmokeSuite github.com/rook/rook/tests/integration -testify.m TestRookClusterInstallation_smokeTest
+go test -v -timeout 1800s -run SmokeSuite github.com/rook/rook/tests/integration -testify.m TestRookClusterInstallation_SmokeTest
 ```
 
 ##### To run specific without installing rook

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rook/rook/tests/framework/utils"
 )
 
-//BlockOperation is wrapper for k8s rook block operations
+// BlockOperation is wrapper for k8s rook block operations
 type BlockOperation struct {
 	k8sClient *utils.K8sHelper
 	manifests installer.CephManifests

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//PoolOperation is a wrapper for rook pool operations
+// PoolOperation is a wrapper for rook pool operations
 type PoolOperation struct {
 	k8sh      *utils.K8sHelper
 	manifests installer.CephManifests

--- a/tests/framework/clients/read_write.go
+++ b/tests/framework/clients/read_write.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//ReadWriteOperation is a wrapper for k8s rook file operations
+// ReadWriteOperation is a wrapper for k8s rook file operations
 type ReadWriteOperation struct {
 	k8sh *utils.K8sHelper
 }

--- a/tests/framework/clients/test_client.go
+++ b/tests/framework/clients/test_client.go
@@ -28,7 +28,7 @@ var (
 	versionCmd = []string{"rook", "version"}
 )
 
-//TestClient is a wrapper for test client, containing interfaces for all rook operations
+// TestClient is a wrapper for test client, containing interfaces for all rook operations
 type TestClient struct {
 	BlockClient      *BlockOperation
 	FSClient         *FilesystemOperation
@@ -42,9 +42,8 @@ const (
 	unableToCheckRookStatusMsg = "Unable to check rook status - please check of rook is up and running"
 )
 
-//CreateTestClient creates new instance of test client for a platform
+// CreateTestClient creates new instance of test client for a platform
 func CreateTestClient(k8sHelper *utils.K8sHelper, manifests installer.CephManifests) *TestClient {
-
 	return &TestClient{
 		CreateBlockOperation(k8sHelper, manifests),
 		CreateFilesystemOperation(k8sHelper, manifests),
@@ -55,7 +54,7 @@ func CreateTestClient(k8sHelper *utils.K8sHelper, manifests installer.CephManife
 	}
 }
 
-//Status returns rook status details
+// Status returns rook status details
 func (c TestClient) Status(namespace string) (client.CephStatus, error) {
 	context := c.k8sh.MakeContext()
 	status, err := client.Status(context, namespace)

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -53,7 +53,7 @@ var (
 	MimicVersion    = cephv1beta1.CephVersionSpec{Image: mimicTestImage, Name: cephv1beta1.Mimic}
 )
 
-//CephInstaller wraps installing and uninstalling rook on a platform
+// CephInstaller wraps installing and uninstalling rook on a platform
 type CephInstaller struct {
 	Manifests        CephManifests
 	k8shelper        *utils.K8sHelper
@@ -108,13 +108,13 @@ func (h *CephInstaller) CreateCephCRDs() error {
 	return err
 }
 
-//CreateCephOperator creates rook-operator via kubectl
+// CreateCephOperator creates rook-operator via kubectl
 func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 	logger.Infof("Starting Rook Operator")
-	//creating clusterrolebinding for kubeadm env.
+	// creating clusterrolebinding for kubeadm env.
 	h.k8shelper.CreateAnonSystemClusterBinding()
 
-	//creating rook resources
+	// creating rook resources
 	if err = h.CreateCephCRDs(); err != nil {
 		return err
 	}
@@ -140,9 +140,9 @@ func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 	return nil
 }
 
-//CreateK8sRookOperatorViaHelm creates rook operator via Helm chart named local/rook present in local repo
+// CreateK8sRookOperatorViaHelm creates rook operator via Helm chart named local/rook present in local repo
 func (h *CephInstaller) CreateK8sRookOperatorViaHelm(namespace string) error {
-	//creating clusterrolebinding for kubeadm env.
+	// creating clusterrolebinding for kubeadm env.
 	h.k8shelper.CreateAnonSystemClusterBinding()
 
 	helmTag, err := h.helmHelper.GetLocalRookHelmChartVersion(helmChartName)
@@ -164,7 +164,7 @@ func (h *CephInstaller) CreateK8sRookOperatorViaHelm(namespace string) error {
 	return nil
 }
 
-//CreateK8sRookToolbox creates rook-ceph-tools via kubectl
+// CreateK8sRookToolbox creates rook-ceph-tools via kubectl
 func (h *CephInstaller) CreateK8sRookToolbox(namespace string) (err error) {
 	logger.Infof("Starting Rook toolbox")
 
@@ -191,7 +191,7 @@ func (h *CephInstaller) CreateK8sRookCluster(namespace, systemNamespace string, 
 		LuminousVersion)
 }
 
-//CreateK8sRookCluster creates rook cluster via kubectl
+// CreateK8sRookCluster creates rook cluster via kubectl
 func (h *CephInstaller) CreateK8sRookClusterWithHostPathAndDevices(namespace, systemNamespace, storeType string,
 	useAllDevices bool, mon cephv1beta1.MonSpec, startWithAllNodes bool, rbdMirrorWorkers int, cephVersion cephv1beta1.CephVersionSpec) error {
 
@@ -276,12 +276,12 @@ func (h *CephInstaller) GetNodeHostnames() ([]string, error) {
 	return names, nil
 }
 
-//InstallRookOnK8sWithHostPathAndDevices installs rook on k8s
+// InstallRookOnK8sWithHostPathAndDevices installs rook on k8s
 func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeType string,
 	helmInstalled, useDevices bool, mon cephv1beta1.MonSpec, startWithAllNodes bool, rbdMirrorWorkers int) (bool, error) {
 
 	var err error
-	//flag used for local debuggin purpose, when rook is pre-installed
+	// flag used for local debuggin purpose, when rook is pre-installed
 	if Env.SkipInstallRook {
 		return true, nil
 	}
@@ -291,7 +291,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 	logger.Infof("Installing rook on k8s %s", k8sversion)
 
 	onamespace := namespace
-	//Create rook operator
+	// Create rook operator
 	if helmInstalled {
 		err = h.CreateK8sRookOperatorViaHelm(namespace)
 		if err != nil {
@@ -324,7 +324,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 		useDevices = IsAdditionalDeviceAvailableOnCluster()
 	}
 
-	//Create rook cluster
+	// Create rook cluster
 	err = h.CreateK8sRookClusterWithHostPathAndDevices(namespace, onamespace, storeType,
 		useDevices, cephv1beta1.MonSpec{Count: mon.Count, AllowMultiplePerNode: mon.AllowMultiplePerNode}, startWithAllNodes,
 		rbdMirrorWorkers,
@@ -334,7 +334,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 		return false, err
 	}
 
-	//Create rook client
+	// Create rook client
 	err = h.CreateK8sRookToolbox(namespace)
 	if err != nil {
 		logger.Errorf("Rook toolbox in cluster %s not installed, error -> %v", namespace, err)
@@ -344,14 +344,14 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 	return true, nil
 }
 
-//UninstallRookFromK8s uninstalls rook from k8s
+// UninstallRookFromK8s uninstalls rook from k8s
 func (h *CephInstaller) UninstallRook(helmInstalled bool, namespace string) {
 	h.UninstallRookFromMultipleNS(helmInstalled, SystemNamespace(namespace), namespace)
 }
 
-//UninstallRookFromK8s uninstalls rook from multiple namespaces in k8s
+// UninstallRookFromK8s uninstalls rook from multiple namespaces in k8s
 func (h *CephInstaller) UninstallRookFromMultipleNS(helmInstalled bool, systemNamespace string, namespaces ...string) {
-	//flag used for local debugging purpose, when rook is pre-installed
+	// flag used for local debugging purpose, when rook is pre-installed
 	if Env.SkipInstallRook {
 		return
 	}
@@ -366,7 +366,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(helmInstalled bool, systemNa
 		checkError(h.T(), err, fmt.Sprintf("cannot remove cluster %s", namespace))
 
 		crdCheckerFunc := func() error {
-			_, err := h.k8shelper.RookClientset.RookV1alpha1().Clusters(namespace).Get(namespace, metav1.GetOptions{})
+			_, err := h.k8shelper.RookClientset.CephV1beta1().Clusters(namespace).Get(namespace, metav1.GetOptions{})
 			return err
 		}
 		err = h.k8shelper.WaitForCustomResourceDeletion(namespace, crdCheckerFunc)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -51,7 +51,7 @@ type ClusterSettings struct {
 	CephVersion      cephv1beta1.CephVersionSpec
 }
 
-//CephManifestsMaster wraps rook yaml definitions
+// CephManifestsMaster wraps rook yaml definitions
 type CephManifestsMaster struct {
 	imageTag string
 }
@@ -155,9 +155,8 @@ spec:
   version: v1alpha2`
 }
 
-//GetRookOperator returns rook Operator  manifest
+// GetRookOperator returns rook Operator manifest
 func (m *CephManifestsMaster) GetRookOperator(namespace string) string {
-
 	return `kind: Namespace
 apiVersion: v1
 metadata:
@@ -314,6 +313,22 @@ rules:
   - list
   - watch
 ---
+# Aspects of Rook Ceph Agent that require access to secrets
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-agent-mount
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -398,7 +413,7 @@ spec:
               fieldPath: metadata.namespace`
 }
 
-//GetClusterRoles returns rook-cluster manifest
+// GetClusterRoles returns rook-cluster manifest
 func (m *CephManifestsMaster) GetClusterRoles(namespace, systemNamespace string) string {
 	return `apiVersion: v1
 kind: ServiceAccount
@@ -550,7 +565,7 @@ subjects:
 `
 }
 
-//GetRookCluster returns rook-cluster manifest
+// GetRookCluster returns rook-cluster manifest
 func (m *CephManifestsMaster) GetRookCluster(settings *ClusterSettings) string {
 	return `apiVersion: ceph.rook.io/v1beta1
 kind: Cluster
@@ -583,7 +598,7 @@ spec:
       journalSizeMB: "1024"`
 }
 
-//GetRookToolBox returns rook-toolbox manifest
+// GetRookToolBox returns rook-toolbox manifest
 func (m *CephManifestsMaster) GetRookToolBox(namespace string) string {
 	return `apiVersion: v1
 kind: Pod
@@ -634,7 +649,7 @@ spec:
           path: mon-endpoints`
 }
 
-//GetCleanupPod gets a cleanup Pod manifest
+// GetCleanupPod gets a cleanup Pod manifest
 func (m *CephManifestsMaster) GetCleanupPod(node, removalDir string) string {
 	return `apiVersion: batch/v1
 kind: Job

--- a/tests/framework/installer/ceph_manifests_v0.8.go
+++ b/tests/framework/installer/ceph_manifests_v0.8.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 )
 
-//CephManifestsV0_8 wraps rook yaml definitions
+// CephManifestsV0_8 wraps rook yaml definitions
 type CephManifestsV0_8 struct {
 	imageTag string
 }
@@ -99,7 +99,7 @@ spec:
   version: v1alpha2`
 }
 
-//GetRookOperator returns rook Operator  manifest
+// GetRookOperator returns rook Operator  manifest
 func (m *CephManifestsV0_8) GetRookOperator(namespace string) string {
 
 	return `kind: Namespace
@@ -326,7 +326,7 @@ spec:
               fieldPath: metadata.namespace`
 }
 
-//GetRookCluster returns rook-cluster manifest
+// GetRookCluster returns rook-cluster manifest
 func (m *CephManifestsV0_8) GetClusterRoles(namespace, systemNamespace string) string {
 	return `apiVersion: v1
 kind: ServiceAccount
@@ -375,7 +375,7 @@ subjects:
   namespace: ` + namespace
 }
 
-//GetRookCluster returns rook-cluster manifest
+// GetRookCluster returns rook-cluster manifest
 func (m *CephManifestsV0_8) GetRookCluster(settings *ClusterSettings) string {
 	return `apiVersion: ceph.rook.io/v1beta1
 kind: Cluster
@@ -404,7 +404,7 @@ spec:
       journalSizeMB: "1024"`
 }
 
-//GetRookToolBox returns rook-toolbox manifest
+// GetRookToolBox returns rook-toolbox manifest
 func (m *CephManifestsV0_8) GetRookToolBox(namespace string) string {
 	return `apiVersion: v1
 kind: Pod
@@ -453,7 +453,7 @@ spec:
           path: mon-endpoints`
 }
 
-//GetCleanupPod gets a cleanup Pod manifest
+// GetCleanupPod gets a cleanup Pod manifest
 func (m *CephManifestsV0_8) GetCleanupPod(node, removalDir string) string {
 	return `apiVersion: batch/v1
 kind: Job

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -20,7 +20,7 @@ import (
 	"flag"
 )
 
-//EnvironmentManifest contains information about system under test
+// EnvironmentManifest contains information about system under test
 type EnvironmentManifest struct {
 	HostType           string
 	Helm               string

--- a/tests/framework/utils/exec_utils.go
+++ b/tests/framework/utils/exec_utils.go
@@ -40,7 +40,7 @@ type CommandArgs struct {
 	EnvironmentVariable []string
 }
 
-//CommandOut is a wrapper for cmd out returned after executing command args
+// CommandOut is a wrapper for cmd out returned after executing command args
 type CommandOut struct {
 	StdOut   string
 	StdErr   string
@@ -48,7 +48,7 @@ type CommandOut struct {
 	Err      error
 }
 
-//ExecuteCommand executes a os command with stdin and returns output
+// ExecuteCommand executes a os command with stdin and returns output
 func ExecuteCommand(cmdStruct CommandArgs) CommandOut {
 	logger.Infof("Running %s %v", cmdStruct.Command, cmdStruct.CmdArgs)
 

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -24,20 +24,20 @@ import (
 	"github.com/rook/rook/pkg/util/sys"
 )
 
-//HelmHelper is wrapper for running helm commands
+// HelmHelper is wrapper for running helm commands
 type HelmHelper struct {
 	executor *exec.CommandExecutor
 	HelmPath string
 }
 
-//NewHelmHelper creates a instance of HelmHelper
+// NewHelmHelper creates a instance of HelmHelper
 func NewHelmHelper(helmPath string) *HelmHelper {
 	executor := &exec.CommandExecutor{}
 	return &HelmHelper{executor: executor, HelmPath: helmPath}
 
 }
 
-//Execute is wrapper for executing helm commands
+// Execute is wrapper for executing helm commands
 func (h *HelmHelper) Execute(args ...string) (string, error) {
 	result, err := h.executor.ExecuteCommandWithOutput(false, "", h.HelmPath, args...)
 	if err != nil {
@@ -49,7 +49,7 @@ func (h *HelmHelper) Execute(args ...string) (string, error) {
 
 }
 
-//GetLocalRookHelmChartVersion returns helm chart version for a given chart
+// GetLocalRookHelmChartVersion returns helm chart version for a given chart
 func (h *HelmHelper) GetLocalRookHelmChartVersion(chartName string) (string, error) {
 	cmdArgs := []string{"search", chartName}
 	result, err := h.Execute(cmdArgs...)
@@ -73,7 +73,7 @@ func (h *HelmHelper) GetLocalRookHelmChartVersion(chartName string) (string, err
 	return version, nil
 }
 
-//InstallLocalRookHelmChart installs a give helm chart
+// InstallLocalRookHelmChart installs a give helm chart
 func (h *HelmHelper) InstallLocalRookHelmChart(chartName string, deployName string, chartVersion string, namespace string) error {
 	cmdArgs := []string{"install", chartName, "--name", deployName, "--version", chartVersion}
 	if namespace != "" {
@@ -99,7 +99,7 @@ func (h *HelmHelper) InstallLocalRookHelmChart(chartName string, deployName stri
 	return fmt.Errorf("cannot install helm chart with name : %v, version: %v, namespace: %v - %v, err: %v", chartName, chartVersion, namespace, result, err)
 }
 
-//DeleteLocalRookHelmChart uninstalls a give helm deploy
+// DeleteLocalRookHelmChart uninstalls a give helm deploy
 func (h *HelmHelper) DeleteLocalRookHelmChart(deployName string) error {
 	cmdArgs := []string{"delete", "--purge", deployName}
 	_, err := h.Execute(cmdArgs...)

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -44,7 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
-//K8sHelper is a helper for common kubectl commads
+// K8sHelper is a helper for common kubectl commads
 type K8sHelper struct {
 	executor         *exec.CommandExecutor
 	Clientset        *kubernetes.Clientset
@@ -54,17 +54,17 @@ type K8sHelper struct {
 }
 
 const (
-	//RetryLoop params for tests.
-	RetryLoop = 30
-	//RetryInterval param for test - wait time while in RetryLoop
+	// RetryLoop params for tests.
+	RetryLoop = 40
+	// RetryInterval param for test - wait time while in RetryLoop
 	RetryInterval = 5
-	//TestMountPath is the path inside a test pod where storage is mounted
+	// TestMountPath is the path inside a test pod where storage is mounted
 	TestMountPath = "/tmp/testrook"
 	//hostnameTestPrefix is a prefix added to the node hostname
 	hostnameTestPrefix = "test-prefix-this-is-a-very-long-hostname-"
 )
 
-//CreateK8sHelper creates a instance of k8sHelper
+// CreateK8sHelper creates a instance of k8sHelper
 func CreateK8sHelper(t func() *testing.T) (*K8sHelper, error) {
 	executor := &exec.CommandExecutor{}
 	config, err := getKubeConfig(executor)
@@ -89,7 +89,7 @@ func CreateK8sHelper(t func() *testing.T) (*K8sHelper, error) {
 
 var k8slogger = capnslog.NewPackageLogger("github.com/rook/rook", "utils")
 
-//GetK8sServerVersion returns k8s server version under test
+// GetK8sServerVersion returns k8s server version under test
 func (k8sh *K8sHelper) GetK8sServerVersion() string {
 	versionInfo, err := k8sh.Clientset.ServerVersion()
 	require.Nil(k8sh.T(), err)
@@ -115,7 +115,7 @@ func (k8sh *K8sHelper) SetDeploymentVersion(namespace, deploymentName, container
 	return err
 }
 
-//Kubectl is wrapper for executing kubectl commands
+// Kubectl is wrapper for executing kubectl commands
 func (k8sh *K8sHelper) Kubectl(args ...string) (string, error) {
 	result, err := k8sh.executor.ExecuteCommandWithTimeout(false, 15*time.Second, "kubectl", "kubectl", args...)
 	if err != nil {
@@ -158,7 +158,7 @@ func (k8sh *K8sHelper) PurgeClusters() error {
 	return nil
 }
 
-//KubectlWithStdin is wrapper for executing kubectl commands in stdin
+// KubectlWithStdin is wrapper for executing kubectl commands in stdin
 func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, error) {
 
 	cmdStruct := CommandArgs{Command: "kubectl", PipeToStdIn: stdin, CmdArgs: args}
@@ -241,7 +241,7 @@ func getKubeConfig(executor exec.Executor) (*rest.Config, error) {
 			KeyFile:  currentUser.Cluster.ClientKey,
 			CertFile: currentUser.Cluster.ClientCert,
 		}
-		//set Insecure to true if cert information is missing
+		// Set Insecure to true if cert information is missing
 		if currentUser.Cluster.ClientCert == "" {
 			config.Insecure = true
 		}
@@ -293,7 +293,7 @@ func (k8sh *K8sHelper) Exec(namespace, podName, command string, commandArgs []st
 	return result, nil
 }
 
-//ResourceOperationFromTemplate performs a kubectl action from a template file after replacing its context
+// ResourceOperationFromTemplate performs a kubectl action from a template file after replacing its context
 func (k8sh *K8sHelper) ResourceOperationFromTemplate(action string, podDefinition string, config map[string]string) (string, error) {
 
 	t := template.New("testTemplate")
@@ -318,7 +318,7 @@ func (k8sh *K8sHelper) ResourceOperationFromTemplate(action string, podDefinitio
 	return "", fmt.Errorf("Could not %s resource in args : %v  %v-- %v", action, args, podDef, err)
 }
 
-//ResourceOperation performs a kubectl action on a pod definition
+// ResourceOperation performs a kubectl action on a pod definition
 func (k8sh *K8sHelper) ResourceOperation(action string, manifest string) (string, error) {
 	args := []string{action, "-f", "-"}
 	result, err := k8sh.KubectlWithStdin(manifest, args...)
@@ -329,7 +329,7 @@ func (k8sh *K8sHelper) ResourceOperation(action string, manifest string) (string
 	return "", fmt.Errorf("Could Not create resource in args : %v -- %v", args, err)
 }
 
-//DeletePod performs a kubectl delete pod on the given pod
+// DeletePod performs a kubectl delete pod on the given pod
 func (k8sh *K8sHelper) DeletePod(namespace, name string) (string, error) {
 	args := append([]string{"--grace-period=0", "pod"}, name)
 	if namespace != "" {
@@ -338,7 +338,7 @@ func (k8sh *K8sHelper) DeletePod(namespace, name string) (string, error) {
 	return k8sh.DeleteResourceAndWait(true, args...)
 }
 
-//DeletePods performs a kubectl delete pod on the given pods
+// DeletePods performs a kubectl delete pod on the given pods
 func (k8sh *K8sHelper) DeletePods(pods ...string) (msg string, err error) {
 	for _, pod := range pods {
 		msg, err = k8sh.DeletePod("", pod)
@@ -346,12 +346,12 @@ func (k8sh *K8sHelper) DeletePods(pods ...string) (msg string, err error) {
 	return
 }
 
-//DeleteResource performs a kubectl delete on the given args
+// DeleteResource performs a kubectl delete on the given args
 func (k8sh *K8sHelper) DeleteResource(args ...string) (string, error) {
 	return k8sh.DeleteResourceAndWait(true, args...)
 }
 
-//WaitForCustomResourceDeletion waits for the CRD deletion
+// WaitForCustomResourceDeletion waits for the CRD deletion
 func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace string, checkerFunc func() error) error {
 	if !k8sh.VersionAtLeast("v1.8.0") {
 		// v1.7 has an intermittent issue with long delay to delete resources so we will skip waiting
@@ -394,7 +394,7 @@ func (k8sh *K8sHelper) DeleteResourceAndWait(wait bool, args ...string) (string,
 	return "", fmt.Errorf("Could Not delete resource in k8s -- %v", err)
 }
 
-//GetResource performs a kubectl get on give args
+// GetResource performs a kubectl get on give args
 func (k8sh *K8sHelper) GetResource(args ...string) (string, error) {
 	args = append([]string{"get"}, args...)
 	result, err := k8sh.Kubectl(args...)
@@ -427,7 +427,7 @@ func (k8sh *K8sHelper) CountPodsWithLabel(label string, namespace string) (int, 
 	return len(pods.Items), nil
 }
 
-//WaitForPodCount waits until the desired number of pods with the label are started
+// WaitForPodCount waits until the desired number of pods with the label are started
 func (k8sh *K8sHelper) WaitForPodCount(label, namespace string, count int) error {
 	options := metav1.ListOptions{LabelSelector: label}
 	inc := 0
@@ -449,6 +449,7 @@ func (k8sh *K8sHelper) WaitForPodCount(label, namespace string, count int) error
 	return fmt.Errorf("Giving up waiting for pods with label %s in namespace %s", label, namespace)
 }
 
+// IsPodWithLabelPresent return true if there is at least one Pod with the label is present.
 func (k8sh *K8sHelper) IsPodWithLabelPresent(label string, namespace string) bool {
 	count, err := k8sh.CountPodsWithLabel(label, namespace)
 	if err != nil {
@@ -457,12 +458,12 @@ func (k8sh *K8sHelper) IsPodWithLabelPresent(label string, namespace string) boo
 	return count > 0
 }
 
-//WaitForLabelWaitForLabeledPodsToRun calls WaitForLabeledPodsToRunWithRetries with the default number of retries
+// WaitForLabeledPodsToRun calls WaitForLabeledPodsToRunWithRetries with the default number of retries
 func (k8sh *K8sHelper) WaitForLabeledPodsToRun(label, namespace string) error {
 	return k8sh.WaitForLabeledPodsToRunWithRetries(label, namespace, RetryLoop)
 }
 
-//WaitForLabeledPodsToRun returns true if a Pod is running status or goes to Running status within 90s else returns false
+// WaitForLabeledPodsToRunWithRetries returns true if a Pod is running status or goes to Running status within 90s else returns false
 func (k8sh *K8sHelper) WaitForLabeledPodsToRunWithRetries(label string, namespace string, retries int) error {
 	options := metav1.ListOptions{LabelSelector: label}
 	var lastPod v1.Pod
@@ -496,7 +497,7 @@ func (k8sh *K8sHelper) WaitForLabeledPodsToRunWithRetries(label string, namespac
 	return fmt.Errorf("Giving up waiting for pod with label %s in namespace %s to be running", label, namespace)
 }
 
-//WaitUntilPodWithLabelDeleted returns true if a Pod is deleted within 90s else returns false
+// WaitUntilPodWithLabelDeleted returns true if a Pod is deleted within 90s else returns false
 func (k8sh *K8sHelper) WaitUntilPodWithLabelDeleted(label string, namespace string) bool {
 	options := metav1.ListOptions{LabelSelector: label}
 	for i := 0; i < RetryLoop; i++ {
@@ -506,6 +507,7 @@ func (k8sh *K8sHelper) WaitUntilPodWithLabelDeleted(label string, namespace stri
 			return true
 		}
 		if len(pods.Items) == 0 {
+			logger.Infof("no (more) pods with label %s in namespace %s to be deleted", label, namespace)
 			return true
 		}
 
@@ -517,6 +519,7 @@ func (k8sh *K8sHelper) WaitUntilPodWithLabelDeleted(label string, namespace stri
 	return false
 }
 
+// PrintPodStatus log out the status phase of a pod
 func (k8sh *K8sHelper) PrintPodStatus(namespace string) {
 	pods, err := k8sh.Clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {
@@ -567,7 +570,7 @@ func (k8sh *K8sHelper) PrintEventsForNamespace(namespace string) {
 	logger.Infof("DONE DUMPING events in namespace %s", namespace)
 }
 
-//IsPodRunning returns true if a Pod is running status or goes to Running status within 90s else returns false
+// IsPodRunning returns true if a Pod is running status or goes to Running status within 90s else returns false
 func (k8sh *K8sHelper) IsPodRunning(name string, namespace string) bool {
 	getOpts := metav1.GetOptions{}
 	inc := 0
@@ -587,10 +590,14 @@ func (k8sh *K8sHelper) IsPodRunning(name string, namespace string) bool {
 	return false
 }
 
-//IsPodTerminated returns true if a Pod is terminated status or goes to Terminated  status
-// within 90s else returns false\
+// IsPodTerminated wrapper around IsPodTerminatedWithOpts()
 func (k8sh *K8sHelper) IsPodTerminated(name string, namespace string) bool {
-	getOpts := metav1.GetOptions{}
+	return k8sh.IsPodTerminatedWithOpts(name, namespace, metav1.GetOptions{})
+}
+
+// IsPodTerminatedWithOpts returns true if a Pod is terminated status or goes to Terminated status
+// within 90s else returns false\
+func (k8sh *K8sHelper) IsPodTerminatedWithOpts(name string, namespace string, getOpts metav1.GetOptions) bool {
 	inc := 0
 	for inc < RetryLoop {
 		pod, err := k8sh.Clientset.CoreV1().Pods(namespace).Get(name, getOpts)
@@ -601,13 +608,12 @@ func (k8sh *K8sHelper) IsPodTerminated(name string, namespace string) bool {
 		k8slogger.Infof("waiting for Pod %s in namespace %s to terminate, status : %v", name, namespace, pod.Status.Phase)
 		time.Sleep(RetryInterval * time.Second)
 		inc++
-
 	}
 	k8slogger.Infof("Pod %s in namespace %s did not terminate", name, namespace)
 	return false
 }
 
-//IsServiceUp returns true if a service is up or comes up within 150s, else returns false
+// IsServiceUp returns true if a service is up or comes up within 150s, else returns false
 func (k8sh *K8sHelper) IsServiceUp(name string, namespace string) bool {
 	getOpts := metav1.GetOptions{}
 	inc := 0
@@ -620,13 +626,12 @@ func (k8sh *K8sHelper) IsServiceUp(name string, namespace string) bool {
 		k8slogger.Infof("waiting for Service %s in namespace %s ", name, namespace)
 		time.Sleep(RetryInterval * time.Second)
 		inc++
-
 	}
 	k8slogger.Infof("Giving up waiting for service: %s in namespace %s ", name, namespace)
 	return false
 }
 
-//GetService returns output from "kubectl get svc $NAME" command
+// GetService returns output from "kubectl get svc $NAME" command
 func (k8sh *K8sHelper) GetService(servicename string, namespace string) (*v1.Service, error) {
 	getOpts := metav1.GetOptions{}
 	result, err := k8sh.Clientset.CoreV1().Services(namespace).Get(servicename, getOpts)
@@ -636,7 +641,7 @@ func (k8sh *K8sHelper) GetService(servicename string, namespace string) (*v1.Ser
 	return result, nil
 }
 
-//IsCRDPresent returns true if custom resource definition is present
+// IsCRDPresent returns true if custom resource definition is present
 func (k8sh *K8sHelper) IsCRDPresent(crdName string) bool {
 
 	cmdArgs := []string{"get", "crd", crdName}
@@ -654,10 +659,12 @@ func (k8sh *K8sHelper) IsCRDPresent(crdName string) bool {
 	return false
 }
 
+// WriteToPod write file in Pod
 func (k8sh *K8sHelper) WriteToPod(namespace, podName, filename, message string) error {
 	return k8sh.WriteToPodRetry(namespace, podName, filename, message, 1)
 }
 
+// WriteToPodRetry WriteToPod in a retry loop
 func (k8sh *K8sHelper) WriteToPodRetry(namespace, podName, filename, message string, retries int) error {
 	logger.Infof("Writing file %s to pod %s", filename, podName)
 	var err error
@@ -748,7 +755,7 @@ func (k8sh *K8sHelper) GetVolumeResourceName(namespace, pvcName string) (string,
 	return pvc.Spec.VolumeName, nil
 }
 
-//IsVolumeResourcePresent returns true if Volume resource is present
+// IsVolumeResourcePresent returns true if Volume resource is present
 func (k8sh *K8sHelper) IsVolumeResourcePresent(namespace, volumeName string) bool {
 	err := k8sh.waitForVolume(namespace, volumeName, true)
 	if err != nil {
@@ -758,7 +765,7 @@ func (k8sh *K8sHelper) IsVolumeResourcePresent(namespace, volumeName string) boo
 	return true
 }
 
-//IsVolumeResourceAbsent returns true if the Volume resource is deleted/absent within 90s else returns false
+// IsVolumeResourceAbsent returns true if the Volume resource is deleted/absent within 90s else returns false
 func (k8sh *K8sHelper) IsVolumeResourceAbsent(namespace, volumeName string) bool {
 
 	err := k8sh.waitForVolume(namespace, volumeName, false)
@@ -898,7 +905,7 @@ func (k8sh *K8sHelper) GetPodNamesForApp(appName, namespace string) ([]string, e
 	return podNames, nil
 }
 
-//GetPodDetails returns details about a  pod
+// GetPodDetails returns details about a  pod
 func (k8sh *K8sHelper) GetPodDetails(podNamePattern string, namespace string) (string, error) {
 	args := []string{"get", "pods", "-l", "app=" + podNamePattern, "-o", "wide", "--no-headers=true", "-o", "name"}
 	if namespace != "" {
@@ -911,7 +918,7 @@ func (k8sh *K8sHelper) GetPodDetails(podNamePattern string, namespace string) (s
 	return strings.TrimSpace(result), nil
 }
 
-//GetPodEvents returns events about a pod
+// GetPodEvents returns events about a pod
 func (k8sh *K8sHelper) GetPodEvents(podNamePattern string, namespace string) (*v1.EventList, error) {
 	uri := fmt.Sprintf("api/v1/namespaces/%s/events?fieldSelector=involvedObject.name=%s,involvedObject.namespace=%s", namespace, podNamePattern, namespace)
 	result, err := k8sh.Clientset.CoreV1().RESTClient().Get().RequestURI(uri).DoRaw()
@@ -929,7 +936,7 @@ func (k8sh *K8sHelper) GetPodEvents(podNamePattern string, namespace string) (*v
 	return &events, nil
 }
 
-//IsPodInError returns true if a Pod is in error status with the given reason and contains the given message
+// IsPodInError returns true if a Pod is in error status with the given reason and contains the given message
 func (k8sh *K8sHelper) IsPodInError(podNamePattern, namespace, reason, containingMessage string) bool {
 	inc := 0
 	for inc < RetryLoop {
@@ -953,7 +960,7 @@ func (k8sh *K8sHelper) IsPodInError(podNamePattern, namespace, reason, containin
 	return false
 }
 
-//GetPodHostID returns HostIP address of a pod
+// GetPodHostID returns HostIP address of a pod
 func (k8sh *K8sHelper) GetPodHostID(podNamePattern string, namespace string) (string, error) {
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podNamePattern}
 	podList, err := k8sh.Clientset.CoreV1().Pods(namespace).List(listOpts)
@@ -969,7 +976,7 @@ func (k8sh *K8sHelper) GetPodHostID(podNamePattern string, namespace string) (st
 	return podList.Items[0].Status.HostIP, nil
 }
 
-//GetServiceNodePort returns nodeProt of service
+// GetServiceNodePort returns nodeProt of service
 func (k8sh *K8sHelper) GetServiceNodePort(serviceName string, namespace string) (string, error) {
 	getOpts := metav1.GetOptions{}
 	svc, err := k8sh.Clientset.CoreV1().Services(namespace).Get(serviceName, getOpts)
@@ -981,7 +988,7 @@ func (k8sh *K8sHelper) GetServiceNodePort(serviceName string, namespace string) 
 	return strconv.FormatInt(int64(np), 10), nil
 }
 
-//IsStorageClassPresent returns true if storageClass is present, if not false
+// IsStorageClassPresent returns true if storageClass is present, if not false
 func (k8sh *K8sHelper) IsStorageClassPresent(name string) error {
 	args := []string{"get", "storageclass", "-o", "jsonpath='{.items[*].metadata.name}'"}
 	result, err := k8sh.Kubectl(args...)
@@ -1006,7 +1013,7 @@ func (k8sh *K8sHelper) IsDefaultStorageClassPresent() (bool, error) {
 	return false, nil
 }
 
-//CheckPvcCount returns True if expected number pvs for a app are found
+// CheckPvcCount returns True if expected number pvs for a app are found
 func (k8sh *K8sHelper) CheckPvcCountAndStatus(podName string, namespace string, expectedPvcCount int, expectedStatus string) bool {
 	logger.Infof("wait until %d pvc for app=%s are present", expectedPvcCount, podName)
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podName}
@@ -1055,7 +1062,7 @@ func (k8sh *K8sHelper) CheckPvcCountAndStatus(podName string, namespace string, 
 	return false
 }
 
-//GetPVCStatus returns status of PVC
+// GetPVCStatus returns status of PVC
 func (k8sh *K8sHelper) GetPVCStatus(namespace string, name string) (v1.PersistentVolumeClaimPhase, error) {
 	getOpts := metav1.GetOptions{}
 
@@ -1068,7 +1075,7 @@ func (k8sh *K8sHelper) GetPVCStatus(namespace string, name string) (v1.Persisten
 
 }
 
-//GetPVCVolumeName returns volume name of PVC
+// GetPVCVolumeName returns volume name of PVC
 func (k8sh *K8sHelper) GetPVCVolumeName(namespace string, name string) (string, error) {
 	getOpts := metav1.GetOptions{}
 
@@ -1080,7 +1087,7 @@ func (k8sh *K8sHelper) GetPVCVolumeName(namespace string, name string) (string, 
 	return pvc.Spec.VolumeName, nil
 }
 
-//GetPVCAccessModes returns AccessModes on PVC
+// GetPVCAccessModes returns AccessModes on PVC
 func (k8sh *K8sHelper) GetPVCAccessModes(namespace string, name string) ([]v1.PersistentVolumeAccessMode, error) {
 	getOpts := metav1.GetOptions{}
 
@@ -1093,7 +1100,7 @@ func (k8sh *K8sHelper) GetPVCAccessModes(namespace string, name string) ([]v1.Pe
 
 }
 
-//GetPV returns PV by name
+// GetPV returns PV by name
 func (k8sh *K8sHelper) GetPV(name string) (*v1.PersistentVolume, error) {
 	getOpts := metav1.GetOptions{}
 
@@ -1104,8 +1111,8 @@ func (k8sh *K8sHelper) GetPV(name string) (*v1.PersistentVolume, error) {
 	return pv, nil
 }
 
-//IsPodInExpectedState waits for 90s for a pod to be an expected state
-//If the pod is in expected state within 90s true is returned,  if not false
+// IsPodInExpectedState waits for 90s for a pod to be an expected state
+// If the pod is in expected state within 90s true is returned,  if not false
 func (k8sh *K8sHelper) IsPodInExpectedState(podNamePattern string, namespace string, state string) bool {
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podNamePattern}
 	inc := 0
@@ -1125,7 +1132,7 @@ func (k8sh *K8sHelper) IsPodInExpectedState(podNamePattern string, namespace str
 	return false
 }
 
-//CheckPodCountAndState returns true if expected number of pods with matching name are found and are in expected state
+// CheckPodCountAndState returns true if expected number of pods with matching name are found and are in expected state
 func (k8sh *K8sHelper) CheckPodCountAndState(podName string, namespace string, minExpected int, expectedPhase string) bool {
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podName}
 	podCountCheck := false
@@ -1173,8 +1180,8 @@ func (k8sh *K8sHelper) CheckPodCountAndState(podName string, namespace string, m
 
 }
 
-//WaitUntilPodInNamespaceIsDeleted waits for 90s for a pod  in a namespace to be terminated
-//If the pod disappears within 90s true is returned,  if not false
+// WaitUntilPodInNamespaceIsDeleted waits for 90s for a pod  in a namespace to be terminated
+// If the pod disappears within 90s true is returned,  if not false
 func (k8sh *K8sHelper) WaitUntilPodInNamespaceIsDeleted(podNamePattern string, namespace string) bool {
 	inc := 0
 	for inc < RetryLoop {
@@ -1190,8 +1197,8 @@ func (k8sh *K8sHelper) WaitUntilPodInNamespaceIsDeleted(podNamePattern string, n
 	return false
 }
 
-//WaitUntilPodIsDeleted waits for 90s for a pod to be terminated
-//If the pod disappears within 90s true is returned,  if not false
+// WaitUntilPodIsDeleted waits for 90s for a pod to be terminated
+// If the pod disappears within 90s true is returned,  if not false
 func (k8sh *K8sHelper) WaitUntilPodIsDeleted(name, namespace string) bool {
 	inc := 0
 	for inc < RetryLoop {
@@ -1207,8 +1214,8 @@ func (k8sh *K8sHelper) WaitUntilPodIsDeleted(name, namespace string) bool {
 	return false
 }
 
-//WaitUntilPVCIsBound waits for a PVC to be in bound state for 90 seconds
-//if PVC goes to Bound state within 90s True is returned, if not false
+// WaitUntilPVCIsBound waits for a PVC to be in bound state for 90 seconds
+// if PVC goes to Bound state within 90s True is returned, if not false
 func (k8sh *K8sHelper) WaitUntilPVCIsBound(namespace string, pvcname string) bool {
 
 	inc := 0
@@ -1265,8 +1272,8 @@ func (k8sh *K8sHelper) DeletePvcWithLabel(namespace string, podName string) bool
 	return false
 }
 
-//WaitUntilNameSpaceIsDeleted waits for namespace to be deleted for 180s.
-//If namespace is deleted True is returned, if not false.
+// WaitUntilNameSpaceIsDeleted waits for namespace to be deleted for 180s.
+// If namespace is deleted True is returned, if not false.
 func (k8sh *K8sHelper) WaitUntilNameSpaceIsDeleted(namespace string) bool {
 	getOpts := metav1.GetOptions{}
 	inc := 0
@@ -1283,7 +1290,7 @@ func (k8sh *K8sHelper) WaitUntilNameSpaceIsDeleted(namespace string) bool {
 	return false
 }
 
-//CreateExternalRGWService creates a service for rgw access external to the cluster on a node port
+// CreateExternalRGWService creates a service for rgw access external to the cluster on a node port
 func (k8sh *K8sHelper) CreateExternalRGWService(namespace, storeName string) error {
 	svcName := "rgw-external-" + storeName
 	externalSvc := `apiVersion: v1
@@ -1320,7 +1327,7 @@ func (k8sh *K8sHelper) GetRGWServiceURL(storeName string, namespace string) (str
 	return k8sh.GetExternalRGWServiceURL(storeName, namespace)
 }
 
-//GetRGWServiceURL returns URL of ceph RGW service in the cluster
+// GetRGWServiceURL returns URL of ceph RGW service in the cluster
 func (k8sh *K8sHelper) GetInternalRGWServiceURL(storeName string, namespace string) (string, error) {
 	name := "rook-ceph-rgw-" + storeName
 	svc, err := k8sh.GetService(name, namespace)
@@ -1333,7 +1340,7 @@ func (k8sh *K8sHelper) GetInternalRGWServiceURL(storeName string, namespace stri
 	return endpoint, nil
 }
 
-//GetRGWServiceURL returns URL of ceph RGW service in the cluster
+// GetRGWServiceURL returns URL of ceph RGW service in the cluster
 func (k8sh *K8sHelper) GetExternalRGWServiceURL(storeName string, namespace string) (string, error) {
 	hostip, err := k8sh.GetPodHostID("rook-ceph-rgw", namespace)
 	if err != nil {
@@ -1391,7 +1398,7 @@ func (k8sh *K8sHelper) RestoreHostnames() ([]string, error) {
 	return nil, nil
 }
 
-//IsRookInstalled returns true is rook-ceph-mgr service is running(indicating rook is installed)
+// IsRookInstalled returns true is rook-ceph-mgr service is running(indicating rook is installed)
 func (k8sh *K8sHelper) IsRookInstalled(namespace string) bool {
 	opts := metav1.GetOptions{}
 	_, err := k8sh.Clientset.CoreV1().Services(namespace).Get("rook-ceph-mgr", opts)
@@ -1401,7 +1408,7 @@ func (k8sh *K8sHelper) IsRookInstalled(namespace string) bool {
 	return false
 }
 
-//GetRookLogs captures logs from specified rook pod and writes it to specified file
+// GetRookLogs captures logs from specified rook pod and writes it to specified file
 func (k8sh *K8sHelper) GetRookLogs(podAppName string, hostType string, namespace string, testName string) {
 	k8sh.GetRookContainerLogs(podAppName, hostType, namespace, testName, "")
 }
@@ -1462,7 +1469,7 @@ func (k8sh *K8sHelper) GetRookContainerLogs(podAppName, hostType, namespace, tes
 	}
 }
 
-//CreateAnonSystemClusterBinding Creates anon-user-access clusterrolebinding for cluster-admin role - used by kubeadm env.
+// CreateAnonSystemClusterBinding Creates anon-user-access clusterrolebinding for cluster-admin role - used by kubeadm env.
 func (k8sh *K8sHelper) CreateAnonSystemClusterBinding() {
 	args := []string{"create", "clusterrolebinding", "anon-user-access", "--clusterrole", "cluster-admin", "--user", "system:anonymous"}
 	_, err := k8sh.Kubectl(args...)

--- a/tests/framework/utils/mysql_helper.go
+++ b/tests/framework/utils/mysql_helper.go
@@ -28,7 +28,7 @@ import (
 	"github.com/icrowley/fake"
 )
 
-//MySQLHelper contains pointer to MySqlDB  and wrappers for basic object on mySql database
+// MySQLHelper contains pointer to MySqlDB  and wrappers for basic object on mySql database
 type MySQLHelper struct {
 	DB *sql.DB
 }
@@ -44,12 +44,12 @@ func CreateNewMySQLHelper(username string, password string, url string, dbname s
 	return &MySQLHelper{DB: db}
 }
 
-//CloseConnection function closes mysql connection
+// CloseConnection function closes mysql connection
 func (h *MySQLHelper) CloseConnection() {
 	h.DB.Close()
 }
 
-//PingSuccess function is used check connection to a database
+// PingSuccess function is used check connection to a database
 func (h *MySQLHelper) PingSuccess() bool {
 	inc := 0
 
@@ -66,7 +66,7 @@ func (h *MySQLHelper) PingSuccess() bool {
 	return false
 }
 
-//CreateTable func create sample Table
+// CreateTable func create sample Table
 func (h *MySQLHelper) CreateTable() sql.Result {
 	result, err := h.DB.Exec("CREATE TABLE LONGHAUL (id int NOT NULL AUTO_INCREMENT,number int,data1 varchar(10000),data2 varchar(10000),data3 varchar(10000),data4 varchar(10000),data5 varchar(10000)" +
 		", PRIMARY KEY (id) )")
@@ -76,7 +76,7 @@ func (h *MySQLHelper) CreateTable() sql.Result {
 	return result
 }
 
-//InsertRandomData Inserts random Data into the table
+// InsertRandomData Inserts random Data into the table
 func (h *MySQLHelper) InsertRandomData(dataSize int) sql.Result {
 	stmtIns, err := h.DB.Prepare("INSERT INTO LONGHAUL (number, data1, data2, data3, data4, data5) VALUES ( ?, ?, ?, ?, ? )") // ? = placeholder
 	if err != nil {
@@ -92,7 +92,7 @@ func (h *MySQLHelper) InsertRandomData(dataSize int) sql.Result {
 	return result
 }
 
-//TableRowCount gets row count of table
+// TableRowCount gets row count of table
 func (h *MySQLHelper) SelectRandomData(limit int) *sql.Rows {
 	query := fmt.Sprintf("SELECT * FROM  LONGHAUL ORDER BY RAND() LIMIT %d", limit)
 	rows, err := h.DB.Query(query)
@@ -104,7 +104,7 @@ func (h *MySQLHelper) SelectRandomData(limit int) *sql.Rows {
 	return rows
 }
 
-//TableRowCount gets row count of table
+// TableRowCount gets row count of table
 func (h *MySQLHelper) TableRowCount() (count int) {
 	rows, err := h.DB.Query("SELECT COUNT(*) as count FROM LONGHAUL")
 	if err != nil {
@@ -120,7 +120,7 @@ func (h *MySQLHelper) TableRowCount() (count int) {
 	return count
 }
 
-//TableExists checks if a table exists
+// TableExists checks if a table exists
 func (h *MySQLHelper) TableExists() bool {
 	_, err := h.DB.Query("SELECT 1 FROM LONGHAUL LIMIT 1 ")
 	if err != nil {
@@ -129,7 +129,7 @@ func (h *MySQLHelper) TableExists() bool {
 	return true
 }
 
-//DeleteRandomRow deletes a random row
+// DeleteRandomRow deletes a random row
 func (h *MySQLHelper) DeleteRandomRow() sql.Result {
 	var id int
 	rows, err := h.DB.Query("SELECT id FROM LONGHAUL ORDER BY RAND() LIMIT 1")

--- a/tests/framework/utils/s3_operations.go
+++ b/tests/framework/utils/s3_operations.go
@@ -26,7 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
-//S3Helper contains pointer to s3 client and wrappers for basic object store operations
+// S3Helper contains pointer to s3 client and wrappers for basic object store operations
 type S3Helper struct {
 	s3client *s3.S3
 }
@@ -45,16 +45,16 @@ func CreateNewS3Helper(endpoint string, keyID string, keySecret string) *S3Helpe
 		WithDisableSSL(true).
 		WithMaxRetries(20)
 
-	//create new session
+	// create new session
 	ses := session.New()
 
-	//create new s3 client connection
+	// create new s3 client connection
 	c := s3.New(ses, awsConfig)
 
 	return &S3Helper{c}
 }
 
-//CreateBucket function creates  bucket using s3 client
+// CreateBucket function creates  bucket using s3 client
 func (h *S3Helper) CreateBucket(name string) (bool, error) {
 	_, err := h.s3client.CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(name),
@@ -67,7 +67,7 @@ func (h *S3Helper) CreateBucket(name string) (bool, error) {
 	return true, nil
 }
 
-//DeleteBucket function deletes given bucket using s3 client
+// DeleteBucket function deletes given bucket using s3 client
 func (h *S3Helper) DeleteBucket(name string) (bool, error) {
 	_, err := h.s3client.DeleteBucket(&s3.DeleteBucketInput{
 		Bucket: aws.String(name),
@@ -80,7 +80,7 @@ func (h *S3Helper) DeleteBucket(name string) (bool, error) {
 	return true, nil
 }
 
-//PutObjectInBucket function puts an object in a bucket using s3 client
+// PutObjectInBucket function puts an object in a bucket using s3 client
 func (h *S3Helper) PutObjectInBucket(bucketname string, body string, key string,
 	contentType string) (bool, error) {
 	_, err := h.s3client.PutObject(&s3.PutObjectInput{
@@ -97,7 +97,7 @@ func (h *S3Helper) PutObjectInBucket(bucketname string, body string, key string,
 	return true, nil
 }
 
-//GetObjectInBucket function retrieves an object from a bucket using s3 client
+// GetObjectInBucket function retrieves an object from a bucket using s3 client
 func (h *S3Helper) GetObjectInBucket(bucketname string, key string) (string, error) {
 	result, err := h.s3client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(bucketname),
@@ -115,7 +115,7 @@ func (h *S3Helper) GetObjectInBucket(bucketname string, key string) (string, err
 	return buf.String(), nil
 }
 
-//DeleteObjectInBucket function deletes given bucket using s3 client
+// DeleteObjectInBucket function deletes given bucket using s3 client
 func (h *S3Helper) DeleteObjectInBucket(bucketname string, key string) (bool, error) {
 	_, err := h.s3client.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: aws.String(bucketname),
@@ -129,7 +129,7 @@ func (h *S3Helper) DeleteObjectInBucket(bucketname string, key string) (bool, er
 	return true, nil
 }
 
-//IsBucketPresent function returns true if a bucket is present and false if it's not present
+// IsBucketPresent function returns true if a bucket is present and false if it's not present
 func (h *S3Helper) IsBucketPresent(bucketname string) (bool, error) {
 	_, err := h.s3client.HeadBucket(&s3.HeadBucketInput{
 		Bucket: aws.String(bucketname),

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Smoke Test for Block Storage - Test check the following operations on Block Storage in order
-//Create,Mount,Write,Read,Unmount and Delete.
+// Create,Mount,Write,Read,Unmount and Delete.
 func runBlockE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
 	podName := "block-test"
 	poolName := "replicapool"
@@ -193,7 +193,7 @@ func runBlockE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s su
 func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite,
 	clusterNamespace, poolName, storageClassName, blockName, podName string) int {
 
-	//Check initial number of blocks
+	// Check initial number of blocks
 	initialBlocks, err := helper.BlockClient.List(clusterNamespace)
 	require.Nil(s.T(), err)
 	initBlockCount := len(initialBlocks)
@@ -206,7 +206,7 @@ func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, blockName))
 
-	//Make sure new block is created
+	// Make sure new block is created
 	b, _ := helper.BlockClient.List(clusterNamespace)
 	assert.Equal(s.T(), initBlockCount+1, len(b), "Make sure new block image is created")
 	poolExists, err := helper.PoolClient.CephPoolExists(clusterNamespace, poolName)
@@ -219,7 +219,7 @@ func deleteBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.
 	clusterNamespace, poolName, storageClassName, blockName, podName string, initBlockCount int) {
 
 	logger.Infof("deleteBlockLite: cleaning up after test")
-	//Delete pvc and storageclass
+	// Delete pvc and storageclass
 	err := helper.PoolClient.DeleteStorageClassAndPvc(clusterNamespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
 	assert.NoError(s.T(), err)
 
@@ -250,9 +250,9 @@ func checkPoolDeleted(helper *clients.TestClient, s suite.Suite, namespace, name
 	assert.Fail(s.T(), fmt.Sprintf("pool %s was not deleted", name))
 }
 
-func blockTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, poolname, storageclassname, blockname, podname string) {
+func blockTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, poolname, storageclassname, blockname, podName string) {
 	logger.Infof("Cleaning up block storage")
-	k8sh.DeletePod(k8sutil.DefaultNamespace, podname)
+	k8sh.DeletePod(k8sutil.DefaultNamespace, podName)
 	helper.PoolClient.DeleteStorageClassAndPvc(namespace, poolname, storageclassname, "Delete", blockname, "ReadWriteOnce")
 	cleanupDynamicBlockStorage(helper, namespace)
 }
@@ -293,7 +293,7 @@ func retryPVCheck(k8sh *utils.K8sHelper, name string, exists bool, status string
 	return false
 }
 
-//CleanUpDynamicBlockStorage is helper method to clean up bock storage created by tests
+// CleanUpDynamicBlockStorage is helper method to clean up bock storage created by tests
 func cleanupDynamicBlockStorage(helper *clients.TestClient, namespace string) {
 	// Delete storage pool, storage class and pvc
 	blockImagesList, _ := helper.BlockClient.List(namespace)
@@ -302,11 +302,11 @@ func cleanupDynamicBlockStorage(helper *clients.TestClient, namespace string) {
 	}
 }
 
-func getBlockPodDefintion(podname, blockName string, readOnly bool) string {
+func getBlockPodDefintion(podName, blockName string, readOnly bool) string {
 	return `apiVersion: v1
 kind: Pod
 metadata:
-  name: ` + podname + `
+  name: ` + podName + `
 spec:
       containers:
       - image: busybox
@@ -326,7 +326,7 @@ spec:
       restartPolicy: Never`
 }
 
-func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podname, StorageClassName string) (*v1.Service, *v1beta1.StatefulSet) {
+func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podName, StorageClassName string) (*v1.Service, *v1beta1.StatefulSet) {
 	service := &v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -361,7 +361,7 @@ func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podname
 			Kind:       "StatefulSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podname,
+			Name:      podName,
 			Namespace: namespace,
 		},
 		Spec: v1beta1.StatefulSetSpec{
@@ -382,7 +382,7 @@ func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podname
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: 80,
-									Name:          podname,
+									Name:          podName,
 								},
 							},
 							VolumeMounts: []v1.VolumeMount{

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -40,7 +40,7 @@ var (
 	logger = capnslog.NewPackageLogger("github.com/rook/rook", "integrationTest")
 )
 
-//Test to make sure all rook components are installed and Running
+// Test to make sure all rook components are installed and Running
 func checkIfRookClusterIsInstalled(s suite.Suite, k8sh *utils.K8sHelper, opNamespace, clusterNamespace string, mons int) {
 	logger.Infof("Make sure all Pods in Rook Cluster %s are running", clusterNamespace)
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-operator", opNamespace, 1, "Running"),
@@ -86,7 +86,7 @@ func HandlePanics(r interface{}, op installer.TestSuite, t func() *testing.T) {
 	}
 }
 
-//TestCluster struct for handling panic and test suite tear down
+// TestCluster struct for handling panic and test suite tear down
 type TestCluster struct {
 	installer        *installer.CephInstaller
 	kh               *utils.K8sHelper
@@ -120,7 +120,7 @@ func StartTestCluster(t func() *testing.T, namespace, storeType string, helmInst
 	return op, kh
 }
 
-//SetUpRook is a wrapper for setting up rook
+// SetUpRook is a wrapper for setting up rook
 func (op *TestCluster) Setup() {
 	isRookInstalled, err := op.installer.InstallRookOnK8sWithHostPathAndDevices(op.namespace, op.storeType,
 		op.helmInstalled, op.useDevices, cephv1beta1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers)
@@ -137,11 +137,9 @@ func (op *TestCluster) Setup() {
 }
 
 // SetInstallData updates the installer helper based on the version of Rook desired
-func (op *TestCluster) SetInstallData(version string) {
+func (op *TestCluster) SetInstallData(version string) {}
 
-}
-
-//TearDownRook is a wrapper for tearDown after Suite
+// TearDownRook is a wrapper for tearDown after Suite
 func (op *TestCluster) Teardown() {
 	if op.installer.T().Failed() {
 		op.installer.GatherAllRookLogs(op.namespace, installer.SystemNamespace(op.namespace), op.installer.T().Name())

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -133,7 +133,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Object store deleted successfully")
 }
 
-//Test Object StoreCreation on Rook that was installed via helm
+// Test Object StoreCreation on Rook that was installed via helm
 func runObjectE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, name string, replicaSize int) {
 	logger.Infof("Object Storage End To End Integration Test - Create Object Store and check if rgw service is Running")
 	logger.Infof("Running on Rook Cluster %s", namespace)
@@ -168,7 +168,6 @@ func objectTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, na
 }
 
 func getBucket(bucketname string, bucketList []rgwdaemon.ObjectBucket) (rgwdaemon.ObjectBucket, error) {
-
 	for _, bucket := range bucketList {
 		if bucket.Name == bucketname {
 			return bucket, nil

--- a/tests/integration/block_create_test.go
+++ b/tests/integration/block_create_test.go
@@ -67,7 +67,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	logger.Infof("Test creating PVC(block images) when storage class is not created")
 
-	//Create PVC
+	// Create PVC
 	claimName := "test-no-storage-class-claim"
 	poolName := "test-no-storage-class-pool"
 	storageClassName := "rook-ceph-block"
@@ -78,12 +78,12 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	checkOrderedSubstrings(s.T(), result, "persistentvolumeclaim", claimName, "created")
 	require.NoError(s.T(), err)
 
-	//check status of PVC
+	// check status of PVC
 	pvcStatus, err := s.kh.GetPVCStatus(defaultNamespace, claimName)
 	require.Nil(s.T(), err)
 	assert.Contains(s.T(), pvcStatus, "Pending", "Makes sure PVC is in Pending state")
 
-	//check block image count
+	// check block image count
 	b, _ := s.testClient.BlockClient.List(s.namespace)
 	require.Equal(s.T(), s.initBlockCount, len(b), "Make sure new block image is not created")
 }
@@ -194,13 +194,13 @@ func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 func (s *BlockCreateSuite) statefulSetDataCleanup(namespace, poolName, storageClassName, reclaimPolicy, statefulSetName, statefulPodsName string) {
 	delOpts := metav1.DeleteOptions{}
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + statefulSetName}
-	//Delete stateful set
+	// Delete stateful set
 	s.kh.Clientset.CoreV1().Services(namespace).Delete(statefulSetName, &delOpts)
 	s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
 	s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
-	//Delete all PVCs
+	// Delete all PVCs
 	s.kh.DeletePvcWithLabel(defaultNamespace, statefulSetName)
-	//Delete storageclass and pool
+	// Delete storageclass and pool
 	s.testClient.PoolClient.DeleteStorageClass(s.namespace, poolName, storageClassName, reclaimPolicy)
 }
 
@@ -222,7 +222,7 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 	reclaimPolicy := "Delete"
 	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, pvcAccessMode)
 
-	//create pool and storageclass
+	// create pool and storageclass
 	result0, err0 := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
 	checkOrderedSubstrings(s.T(), result0, poolName, "created")
 	require.NoError(s.T(), err0)
@@ -230,22 +230,22 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 	checkOrderedSubstrings(s.T(), result1, storageClassName, "created")
 	require.NoError(s.T(), err1)
 
-	//make sure storageclass is created
+	// make sure storageclass is created
 	err := s.kh.IsStorageClassPresent(storageClassName)
 	require.Nil(s.T(), err)
 
-	//create pvc
+	// create pvc
 	result2, err2 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode)
 	checkOrderedSubstrings(s.T(), result2, claimName, "created")
 	require.NoError(s.T(), err2)
 
-	//check status of PVC
+	// check status of PVC
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
 	accessModes, err := s.kh.GetPVCAccessModes(defaultNamespace, claimName)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), accessModes[0], v1.PersistentVolumeAccessMode(pvcAccessMode))
 
-	//check block image count
+	// check block image count
 	b, _ := s.testClient.BlockClient.List(s.namespace)
 	require.Equal(s.T(), s.initBlockCount+1, len(b), "Make sure new block image is created")
 

--- a/tests/integration/filesystem_mountuser_test.go
+++ b/tests/integration/filesystem_mountuser_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/tests/framework/clients"
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	fileMountUserPodName = "file-mountuser-test"
+	fileMountUser        = "filemountuser"
+	fileMountSecret      = "file-mountuser-cephkey"
+)
+
+// Smoke Test for File System Storage mountUser and mountSecret parameter - Test check the
+// following operations on Filesystem Storage in order Create,Mount,Write,Read,Unmount and Delete,
+// with a mountUser and mountSecret specified.
+func runFileMountUserE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
+	defer fileTestDataCleanUp(helper, k8sh, s, fileMountUserPodName, namespace, filesystemName)
+	logger.Infof("Running on Rook Cluster %s", namespace)
+	logger.Infof("File Storage MountUser/MountSecret End To End Integration Test - create, mount, write to, read from, and unmount")
+
+	createFilesystem(helper, k8sh, s, namespace, filesystemName)
+	createFilesystemMountCephCredentials(helper, k8sh, s, namespace, filesystemName)
+	createFilesystemMountUserConsumerPod(helper, k8sh, s, namespace, filesystemName)
+	err := writeAndReadToFilesystem(helper, k8sh, s, namespace, fileMountUserPodName, "canttouchthis")
+	require.NotNil(s.T(), err, "we should not be able to write to file canttouchthis on CephFS `/`")
+	err = writeAndReadToFilesystem(helper, k8sh, s, namespace, fileMountUserPodName, "foo/test_file")
+	require.Nil(s.T(), err, "we should be able to write to the `/foo` directory on CephFS")
+	cleanupFilesystemConsumer(helper, k8sh, s, namespace, filesystemName, fileMountUserPodName)
+	cleanupFilesystem(helper, k8sh, s, namespace, filesystemName)
+}
+
+func createFilesystemMountCephCredentials(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
+	// Create agent binding for access to Secrets
+	_, err := k8sh.ResourceOperation("apply", getFilesystemAgentMountSecretsBinding(namespace))
+	require.Nil(s.T(), err)
+	// Mount CephFS in toolbox and create /foo directory on it
+	logger.Info("Creating /foo directory on CephFS")
+	_, err = k8sh.Exec(namespace, "rook-ceph-tools", "mkdir", []string{"-p", utils.TestMountPath})
+	require.Nil(s.T(), err)
+	_, err = k8sh.Exec(namespace, "rook-ceph-tools", "bash", []string{"-c", fmt.Sprintf("mount -t ceph -o mds_namespace=%s,name=admin,secret=$(grep key /etc/ceph/keyring | awk '{print $3}') $(grep mon_host /etc/ceph/ceph.conf | awk '{print $3}'):/ %s", filesystemName, utils.TestMountPath)})
+	require.Nil(s.T(), err)
+	_, err = k8sh.Exec(namespace, "rook-ceph-tools", "mkdir", []string{"-p", fmt.Sprintf("%s/foo", utils.TestMountPath)})
+	require.Nil(s.T(), err)
+	_, err = k8sh.Exec(namespace, "rook-ceph-tools", "umount", []string{utils.TestMountPath})
+	require.Nil(s.T(), err)
+	logger.Info("Created /foo directory on CephFS")
+
+	// Create Ceph credentials which allow CephFS access to `/foo` but not `/`.
+	commandArgs := []string{
+		"-c",
+		fmt.Sprintf(
+			`ceph auth get-or-create-key client.%s mon "allow r" osd "allow rw pool=%s-data0" mds "allow r, allow rw path=/foo"`,
+			fileMountUser,
+			filesystemName,
+		),
+	}
+	logger.Infof("ceph credentials command args: %s", commandArgs[1])
+	result, err := k8sh.Exec(namespace, "rook-ceph-tools", "bash", commandArgs)
+	logger.Infof("Ceph filesystem credentials output: %s", result)
+	logger.Info("Created Ceph credentials")
+	require.Nil(s.T(), err)
+	// Save Ceph credentials to Kubernetes
+	_, err = k8sh.Clientset.Core().Secrets(namespace).Create(&v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fileMountSecret,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"mykey": []byte(result),
+		},
+	})
+	require.Nil(s.T(), err)
+	logger.Info("Created Ceph credentials Secret in Kubernetes")
+}
+
+func createFilesystemMountUserConsumerPod(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
+	mtfsErr := podWithFilesystem(k8sh, s, fileMountUserPodName, namespace, filesystemName, "create", getFilesystemMountUserTestPod)
+	require.Nil(s.T(), mtfsErr)
+	filePodRunning := k8sh.IsPodRunning(fileMountUserPodName, namespace)
+	if !filePodRunning {
+		k8sh.PrintPodDescribe(namespace, fileMountUserPodName)
+		k8sh.PrintPodStatus(namespace)
+		k8sh.PrintPodStatus(installer.SystemNamespace(namespace))
+	}
+	require.True(s.T(), filePodRunning, "make sure file-mountuser-test pod is in running state")
+	logger.Infof("File system mounted successfully")
+}
+
+func getFilesystemMountUserTestPod(podName string, namespace string, filesystemName string, driverName string) string {
+	return `apiVersion: v1
+kind: Pod
+metadata:
+  name: ` + podName + `
+  namespace: ` + namespace + `
+spec:
+  containers:
+  - name: ` + podName + `
+    image: busybox
+    command:
+        - sleep
+        - "3600"
+    imagePullPolicy: IfNotPresent
+    env:
+    volumeMounts:
+    - mountPath: "` + utils.TestMountPath + `"
+      name: ` + filesystemName + `
+  volumes:
+  - name: ` + filesystemName + `
+    flexVolume:
+      driver: ceph.rook.io/` + driverName + `
+      fsType: ceph
+      options:
+        fsName: ` + filesystemName + `
+        clusterNamespace: ` + namespace + `
+        mountUser: ` + fileMountUser + `
+        mountSecret: ` + fileMountSecret + `
+  restartPolicy: Never
+`
+}
+
+func getFilesystemAgentMountSecretsBinding(namespace string) string {
+	return `apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-agent-mount
+  labels:
+    operator: rook
+    storage-backend: ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-agent-mount
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: ` + namespace + `
+`
+}

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -73,22 +73,24 @@ func (hs *HelmSuite) TearDownSuite() {
 	hs.op.Teardown()
 }
 
-//Test to make sure all rook components are installed and Running
+// Test to make sure all rook components are installed and Running
 func (hs *HelmSuite) TestRookInstallViaHelm() {
 	checkIfRookClusterIsInstalled(hs.Suite, hs.kh, hs.namespace, hs.namespace, 1)
 }
 
-//Test BlockCreation on Rook that was installed via Helm
+// Test BlockCreation on Rook that was installed via Helm
 func (hs *HelmSuite) TestBlockStoreOnRookInstalledViaHelm() {
 	runBlockE2ETestLite(hs.helper, hs.kh, hs.Suite, hs.namespace)
 }
 
-//Test File System Creation on Rook that was installed via helm
-func (hs *HelmSuite) TestFileStoreOnRookInstalledViaHelm() {
+// Test File System Creation on Rook that was installed via helm
+// The test func name has `Z` in its name to run as the last test, this needs to
+// be done as there were some issues that the operator "disappeared".
+func (hs *HelmSuite) TestZFileStoreOnRookInstalledViaHelm() {
 	runFileE2ETestLite(hs.helper, hs.kh, hs.Suite, hs.namespace, "testfs")
 }
 
-//Test Object StoreCreation on Rook that was installed via helm
+// Test Object StoreCreation on Rook that was installed via helm
 func (hs *HelmSuite) TestObjectStoreOnRookInstalledViaHelm() {
 	runObjectE2ETestLite(hs.helper, hs.kh, hs.Suite, hs.namespace, "default", 3)
 }

--- a/tests/integration/mon_test.go
+++ b/tests/integration/mon_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Smoke Test for Mon failover - Test check the following operations for the Mon failover in order
-//Delete mon pod, Wait for new mon pod
+// Delete mon pod, Wait for new mon pod
 func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Mon Failover Smoke Test")
 

--- a/tests/integration/multi_cluster_test.go
+++ b/tests/integration/multi_cluster_test.go
@@ -61,7 +61,7 @@ type MultiClusterDeploySuite struct {
 	op         *MCTestOperations
 }
 
-//Deploy Multiple Rook clusters
+// Deploy Multiple Rook clusters
 func (mrc *MultiClusterDeploySuite) SetupSuite() {
 
 	mrc.namespace1 = "mrc-n1"
@@ -91,36 +91,36 @@ func (mrc *MultiClusterDeploySuite) TearDownSuite() {
 	mrc.op.Teardown()
 }
 
-//Test to make sure all rook components are installed and Running
+// Test to make sure all rook components are installed and Running
 func (mrc *MultiClusterDeploySuite) TestInstallingMultipleRookClusters() {
-	//Check if Rook cluster 1 is deployed successfully
+	// Check if Rook cluster 1 is deployed successfully
 	checkIfRookClusterIsInstalled(mrc.Suite, mrc.k8sh, installer.SystemNamespace(mrc.namespace1), mrc.namespace1, 1)
 	checkIfRookClusterIsHealthy(mrc.Suite, mrc.testClient, mrc.namespace1)
 
-	//Check if Rook cluster 2 is deployed successfully
+	// Check if Rook cluster 2 is deployed successfully
 	checkIfRookClusterIsInstalled(mrc.Suite, mrc.k8sh, installer.SystemNamespace(mrc.namespace1), mrc.namespace2, 1)
 	checkIfRookClusterIsHealthy(mrc.Suite, mrc.testClient, mrc.namespace2)
 }
 
-//Test Block Store Creation on multiple rook clusters
+// Test Block Store Creation on multiple rook clusters
 func (mrc *MultiClusterDeploySuite) TestBlockStoreOnMultipleRookCluster() {
 	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1)
 	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2)
 }
 
-//Test Filesystem Creation on multiple rook clusters
+// Test Filesystem Creation on multiple rook clusters
 func (mrc *MultiClusterDeploySuite) TestFileStoreOnMultiRookCluster() {
 	runFileE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, "test-fs-1")
 	runFileE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, "test-fs-2")
 }
 
-//Test Object Store Creation on multiple rook clusters
+// Test Object Store Creation on multiple rook clusters
 func (mrc *MultiClusterDeploySuite) TestObjectStoreOnMultiRookCluster() {
 	runObjectE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, "default-c1", 2)
 	runObjectE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, "default-c2", 1)
 }
 
-//MCTestOperations struct for handling panic and test suite tear down
+// MCTestOperations struct for handling panic and test suite tear down
 type MCTestOperations struct {
 	installer       *installer.CephInstaller
 	kh              *utils.K8sHelper
@@ -130,7 +130,7 @@ type MCTestOperations struct {
 	systemNamespace string
 }
 
-//NewMCTestOperations creates new instance of TestCluster struct
+// NewMCTestOperations creates new instance of TestCluster struct
 func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 string) (*MCTestOperations, *utils.K8sHelper) {
 
 	kh, err := utils.CreateK8sHelper(t)
@@ -142,7 +142,7 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 	return op, kh
 }
 
-//SetUpRook is wrapper for setting up multiple rook clusters.
+// SetUpRook is wrapper for setting up multiple rook clusters.
 func (o MCTestOperations) Setup() {
 	var err error
 	err = o.installer.CreateCephOperator(installer.SystemNamespace(o.namespace1))
@@ -171,7 +171,7 @@ func (o MCTestOperations) Setup() {
 
 }
 
-//TearDownRook is a wrapper for tearDown after suite
+// TearDownRook is a wrapper for tearDown after suite
 func (o MCTestOperations) Teardown() {
 	defer func() {
 		if r := recover(); r != nil {

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -89,15 +89,21 @@ func (suite *SmokeSuite) TearDownSuite() {
 func (suite *SmokeSuite) TestBlockStorage_SmokeTest() {
 	runBlockE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace)
 }
+
 func (suite *SmokeSuite) TestFileStorage_SmokeTest() {
 	runFileE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace, "smoke-test-fs")
 }
+
+func (suite *SmokeSuite) TestFileStorageMountUser_SmokeTest() {
+	runFileMountUserE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace, "smoke-test-fs-mountuser")
+}
+
 func (suite *SmokeSuite) TestObjectStorage_SmokeTest() {
 	runObjectE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace)
 }
 
-//Test to make sure all rook components are installed and Running
-func (suite *SmokeSuite) TestRookClusterInstallation_smokeTest() {
+// Test to make sure all rook components are installed and Running
+func (suite *SmokeSuite) TestRookClusterInstallation_SmokeTest() {
 	checkIfRookClusterIsInstalled(suite.Suite, suite.k8sh, installer.SystemNamespace(suite.namespace), suite.namespace, 3)
 }
 
@@ -106,14 +112,14 @@ func (suite *SmokeSuite) TestOperatorGetFlexvolumePath() {
 	if !v.LessThan(version.MustParseSemantic("1.9.0")) {
 		suite.T().Skip("Skipping test - known issues with k8s 1.9 (https://github.com/rook/rook/issues/1330)")
 	}
-	// get the operator pod
+	// Get the operator pod
 	sysNamespace := installer.SystemNamespace(suite.namespace)
 	listOpts := metav1.ListOptions{LabelSelector: "app=rook-ceph-operator"}
 	podList, err := suite.k8sh.Clientset.CoreV1().Pods(sysNamespace).List(listOpts)
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), 1, len(podList.Items))
 
-	// get the raw log for the operator pod
+	// Get the raw log for the operator pod
 	opPodName := podList.Items[0].Name
 	rawLog, err := suite.k8sh.Clientset.CoreV1().Pods(sysNamespace).GetLogs(opPodName, &v1.PodLogOptions{}).Do().Raw()
 	require.Nil(suite.T(), err)
@@ -122,7 +128,7 @@ func (suite *SmokeSuite) TestOperatorGetFlexvolumePath() {
 	logStmt := string(r.Find(rawLog))
 	logger.Infof("flexvolume discovery log statement: %s", logStmt)
 
-	// verify that the volume plugin dir was discovered by the operator pod and that it did not come from
+	// Verify that the volume plugin dir was discovered by the operator pod and that it did not come from
 	// an env var or the default
 	require.NotEmpty(suite.T(), logStmt)
 	assert.True(suite.T(), strings.Contains(logStmt, "discovered flexvolume dir path from source"))

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -88,7 +88,10 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	filesystemName := "upgrade-test-fs"
 	createFilesystem(s.helper, s.k8sh, s.Suite, s.namespace, filesystemName)
 	createFilesystemConsumerPod(s.helper, s.k8sh, s.Suite, s.namespace, filesystemName)
-	defer cleanupFilesystemConsumer(s.helper, s.k8sh, s.Suite, s.namespace, filesystemName)
+	defer func() {
+		cleanupFilesystemConsumer(s.helper, s.k8sh, s.Suite, s.namespace, filesystemName, filePodName)
+		cleanupFilesystem(s.helper, s.k8sh, s.Suite, s.namespace, filesystemName)
+	}()
 
 	logger.Infof("Initializing object before the upgrade")
 	objectStoreName := "upgraded-object"

--- a/tests/integration/zblock_mount_unmount_test.go
+++ b/tests/integration/zblock_mount_unmount_test.go
@@ -161,10 +161,10 @@ func (s *BlockMountUnMountSuite) TestBlockStorageMountUnMountForDifferentAccessM
 
 	logger.Infof("Test case when existing RWO PVC is mounted and unmounted on pods with various accessModes")
 	logger.Infof("Step 1.1: Mount existing ReadWriteOnce and ReadWriteMany PVC on a Pod with RW access")
-	//mount PVC with RWO access on a pod with readonly set to false
+	// mount PVC with RWO access on a pod with readonly set to false
 	_, err := s.bc.BlockMap(getBlockPodDefintion("rwo-block-rw-one", s.pvcNameRWO, false))
 	require.Nil(s.T(), err)
-	//mount PVC with RWX access on a pod with readonly set to false
+	// mount PVC with RWX access on a pod with readonly set to false
 	_, err = s.bc.BlockMap(getBlockPodDefintion("rwx-block-rw-one", s.pvcNameRWX, false))
 	require.Nil(s.T(), err)
 	crdName1, err1 := s.kh.GetVolumeResourceName(defaultNamespace, s.pvcNameRWO)
@@ -178,37 +178,37 @@ func (s *BlockMountUnMountSuite) TestBlockStorageMountUnMountForDifferentAccessM
 	assert.True(s.T(), s.kh.IsPodRunning("rwx-block-rw-one", defaultNamespace), "make sure rwx-block-rw-one pod is in running state")
 
 	logger.Infof("Step 2: Check if previously persisted data is readable from ReadWriteOnce and ReadWriteMany PVC")
-	//Read data on RWO PVC Mounted on pod with RW Access
+	// Read data on RWO PVC Mounted on pod with RW Access
 	filename1 := "bsFile1"
 	message1 := "Persisted message one"
 	err = s.kh.ReadFromPod("", "rwo-block-rw-one", filename1, message1)
 	assert.Nil(s.T(), err)
 
-	//Read data on RWX PVC Mounted on pod with RW Access
+	// Read data on RWX PVC Mounted on pod with RW Access
 	err = s.kh.ReadFromPod("", "rwx-block-rw-one", filename1, message1)
 	assert.Nil(s.T(), err)
 
 	logger.Infof("Step 3: Check if read/write works on ReadWriteOnce and ReadWriteMany PVC")
-	//Write data on RWO PVC Mounted on pod with RW Access
+	// Write data on RWO PVC Mounted on pod with RW Access
 	filename2 := "bsFile2"
 	message2 := "Persisted message two"
 	assert.Nil(s.T(), s.kh.WriteToPod("", "rwo-block-rw-one", filename2, message2))
 
-	//Read data on RWO PVC Mounted on pod with RW Access
+	// Read data on RWO PVC Mounted on pod with RW Access
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwo-block-rw-one", filename2, message2))
 
-	//Write data on RWX PVC Mounted on pod with RW Access
+	// Write data on RWX PVC Mounted on pod with RW Access
 	assert.Nil(s.T(), s.kh.WriteToPod("", "rwx-block-rw-one", filename2, message2))
 
-	//Read data on RWX PVC Mounted on pod with RW Access
+	// Read data on RWX PVC Mounted on pod with RW Access
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwx-block-rw-one", filename2, message2))
 
-	//Mount another Pod with RW access on same PVC
+	// Mount another Pod with RW access on same PVC
 	logger.Infof("Step 4: Mount existing ReadWriteOnce and ReadWriteMany PVC on a new Pod with RW access")
-	//Mount RWO PVC on a new pod with ReadOnly set to false
+	// Mount RWO PVC on a new pod with ReadOnly set to false
 	_, err = s.bc.BlockMap(getBlockPodDefintion("rwo-block-rw-two", s.pvcNameRWO, false))
 	assert.Nil(s.T(), err)
-	//Mount RWX PVC on a new pod with ReadOnly set to false
+	// Mount RWX PVC on a new pod with ReadOnly set to false
 	_, err = s.bc.BlockMap(getBlockPodDefintion("rwx-block-rw-two", s.pvcNameRWX, false))
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), s.kh.IsPodInError("rwo-block-rw-two", defaultNamespace, "FailedMount", "Volume is already attached by pod"), "make sure rwo-block-rw-two pod errors out while mounting the volume")
@@ -219,10 +219,10 @@ func (s *BlockMountUnMountSuite) TestBlockStorageMountUnMountForDifferentAccessM
 	assert.True(s.T(), s.kh.IsPodTerminated("rwx-block-rw-two", defaultNamespace), "make sure rwx-block-rw-two pod is terminated")
 
 	logger.Infof("Step 5: Mount existing ReadWriteOnce and ReadWriteMany PVC on a new Pod with RO access")
-	//Mount RWO PVC on a new pod with ReadOnly set to true
+	// Mount RWO PVC on a new pod with ReadOnly set to true
 	_, err = s.bc.BlockMap(getBlockPodDefintion("rwo-block-ro-one", s.pvcNameRWO, true))
 	assert.Nil(s.T(), err)
-	//Mount RWX PVC on a new pod with ReadOnly set to true
+	// Mount RWX PVC on a new pod with ReadOnly set to true
 	_, err = s.bc.BlockMap(getBlockPodDefintion("rwx-block-ro-one", s.pvcNameRWX, true))
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), s.kh.IsPodInError("rwo-block-ro-one", defaultNamespace, "FailedMount", "Volume is already attached by pod"), "make sure rwo-block-ro-one pod errors out while mounting the volume")
@@ -239,12 +239,12 @@ func (s *BlockMountUnMountSuite) TestBlockStorageMountUnMountForDifferentAccessM
 	assert.True(s.T(), s.kh.IsPodTerminated("rwx-block-rw-one", defaultNamespace), "make sure rwx-lock-rw-one pod is terminated")
 
 	logger.Infof("Step 7: Mount ReadWriteOnce and ReadWriteMany PVC on two different pods with ReadOnlyMany with Readonly Access")
-	//Mount RWO PVC on 2 pods with ReadOnly set to True
+	// Mount RWO PVC on 2 pods with ReadOnly set to True
 	_, err1 = s.bc.BlockMap(getBlockPodDefintion("rwo-block-ro-one", s.pvcNameRWO, true))
 	_, err2 = s.bc.BlockMap(getBlockPodDefintion("rwo-block-ro-two", s.pvcNameRWO, true))
 	assert.Nil(s.T(), err1)
 	assert.Nil(s.T(), err2)
-	//Mount RWX PVC on 2 pods with ReadOnly set to True
+	// Mount RWX PVC on 2 pods with ReadOnly set to True
 	_, err1 = s.bc.BlockMap(getBlockPodDefintion("rwx-block-ro-one", s.pvcNameRWX, true))
 	_, err2 = s.bc.BlockMap(getBlockPodDefintion("rwx-block-ro-two", s.pvcNameRWX, true))
 	assert.Nil(s.T(), err1)
@@ -255,27 +255,27 @@ func (s *BlockMountUnMountSuite) TestBlockStorageMountUnMountForDifferentAccessM
 	assert.True(s.T(), s.kh.IsPodRunning("rwx-block-ro-two", defaultNamespace), "make sure rwx-block-ro-two pod is in running state")
 
 	logger.Infof("Step 8: Read Data from both ReadyOnlyMany and ReadWriteOnce pods with ReadOnly Access")
-	//Read data from RWO PVC via both ReadOnly pods
+	// Read data from RWO PVC via both ReadOnly pods
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwo-block-ro-one", filename1, message1))
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwo-block-ro-two", filename1, message1))
 
-	//Read data from RWX PVC via both ReadOnly pods
+	// Read data from RWX PVC via both ReadOnly pods
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwx-block-ro-one", filename1, message1))
 	assert.Nil(s.T(), s.kh.ReadFromPod("", "rwx-block-ro-two", filename1, message1))
 
 	logger.Infof("Step 9: Write Data to Pod with ReadOnlyMany and ReadWriteOnce PVC  mounted with ReadOnly access")
-	//Write data to RWO PVC via pod with ReadOnly Set to true
+	// Write data to RWO PVC via pod with ReadOnly Set to true
 	message3 := "Persisted message three"
 	filename3 := "bsFile3"
 	err = s.kh.WriteToPod("", "rwo-block-ro-one", filename3, message3)
 	assert.Contains(s.T(), err.Error(), "failed to write file")
 
-	//Write data to RWx PVC via pod with ReadOnly Set to true
+	// Write data to RWx PVC via pod with ReadOnly Set to true
 	err = s.kh.WriteToPod("", "rwx-block-ro-one", filename3, message3)
 	assert.Contains(s.T(), err.Error(), "failed to write file")
 
 	logger.Infof("Step 10: UnMount Pod with ReadOnlyMany and ReadWriteOnce PVCs")
-	//UnMount RWO PVC from both ReadOnly Pods
+	// UnMount RWO PVC from both ReadOnly Pods
 	_, err = s.kh.DeletePods("rwo-block-ro-one", "rwo-block-ro-two", "rwx-block-ro-one", "rwx-block-ro-two")
 	assert.Nil(s.T(), err)
 	assert.True(s.T(), s.kh.IsPodTerminated("rwo-block-ro-one", defaultNamespace), "make sure rwo-block-ro-one pod is terminated")

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -19,7 +19,7 @@ var (
 
 // Create StorageClass and poll if needed
 func createStorageClassAndPool(t func() *testing.T, testClient *clients.TestClient, kh *utils.K8sHelper, namespace string, storageClassName string, poolName string) {
-	//create storage class
+	// Create storage class
 	if err := kh.IsStorageClassPresent(storageClassName); err != nil {
 		logger.Infof("Install pool and storage class for rook block")
 		_, err := testClient.PoolClient.Create(poolName, namespace, 3)
@@ -27,7 +27,7 @@ func createStorageClassAndPool(t func() *testing.T, testClient *clients.TestClie
 		_, err = testClient.BlockClient.CreateStorageClass(poolName, storageClassName, "Delete", namespace, false)
 		require.NoError(t(), err)
 
-		//make sure storageclass is created
+		// make sure storageclass is created
 		err = kh.IsStorageClassPresent(storageClassName)
 		require.NoError(t(), err)
 	}
@@ -37,13 +37,13 @@ func createStorageClassAndPool(t func() *testing.T, testClient *clients.TestClie
 // All the set up is if needed.
 func createPVCAndMountMysqlPod(t func() *testing.T, kh *utils.K8sHelper, storageClassName string, appName string, appLabel string, pvcName string) *utils.MySQLHelper {
 
-	//create mysql pod
+	// Create mysql pod
 	if _, err := kh.GetPVCStatus(defaultNamespace, pvcName); err != nil {
 		logger.Infof("Create PVC")
 
 		mySqlPodOperation(kh, storageClassName, appName, appLabel, pvcName, "create")
 
-		//wait till mysql pod is up
+		// Wait till mysql pod is up
 		require.True(t(), kh.IsPodInExpectedState(appLabel, "", "Running"))
 		require.True(t(), kh.WaitUntilPVCIsBound(defaultNamespace, pvcName))
 	}
@@ -51,7 +51,7 @@ func createPVCAndMountMysqlPod(t func() *testing.T, kh *utils.K8sHelper, storage
 	require.Nil(t(), err)
 	dbPort, err := kh.GetServiceNodePort(appName, "default")
 	require.Nil(t(), err)
-	//create database connection
+	// Create database connection
 	db := utils.CreateNewMySQLHelper("mysql", "mysql", dbIP+":"+dbPort, "sample")
 
 	require.True(t(), db.PingSuccess())
@@ -61,7 +61,6 @@ func createPVCAndMountMysqlPod(t func() *testing.T, kh *utils.K8sHelper, storage
 	}
 
 	return db
-
 }
 
 func mySqlPodOperation(k8sh *utils.K8sHelper, storageClassName string, appName string, appLabel string, pvcName string, action string) (string, error) {
@@ -73,7 +72,6 @@ func mySqlPodOperation(k8sh *utils.K8sHelper, storageClassName string, appName s
 	}
 
 	result, err := k8sh.ResourceOperationFromTemplate(action, GetMySqlPodDef(), config)
-
 	return result, err
 
 }
@@ -115,7 +113,7 @@ func dbOperation(db *utils.MySQLHelper, wg *sync.WaitGroup, runtime int, loadSiz
 	start := time.Now()
 	elapsed := time.Since(start).Seconds()
 	for elapsed < float64(runtime) {
-		//InsertRandomData
+		// InsertRandomData
 		db.InsertRandomData(ds)
 		db.InsertRandomData(ds)
 		db.InsertRandomData(ds)
@@ -125,7 +123,7 @@ func dbOperation(db *utils.MySQLHelper, wg *sync.WaitGroup, runtime int, loadSiz
 		db.InsertRandomData(ds)
 		db.SelectRandomData(10)
 
-		//delete Data
+		// Delete Data
 		db.DeleteRandomRow()
 		db.SelectRandomData(20)
 		elapsed = time.Since(start).Seconds()
@@ -173,7 +171,7 @@ func (o LoadTestCluster) Setup() {
 	}
 }
 
-//TearDownRook is a wrapper for tearDown after suite
+// TearDownRook is a wrapper for tearDown after suite
 func (o LoadTestCluster) Teardown() {
 	// No Clean up for load test
 }

--- a/tests/longhaul/base_object_test.go
+++ b/tests/longhaul/base_object_test.go
@@ -109,7 +109,6 @@ func bucketOperations(s3 *utils.S3Helper, bucketName string, wg *sync.WaitGroup,
 		s3.DeleteObjectInBucket(bucketName, key4)
 		elapsed = time.Since(start).Seconds()
 	}
-
 }
 
 func randomBool() bool {

--- a/tests/longhaul/block_test.go
+++ b/tests/longhaul/block_test.go
@@ -34,8 +34,8 @@ import (
 // Start Rook and set up a storage class and pool.
 // Start multiple MySql databases that are using rook provisioned block storage.
 // First block volume is persistent(mounted once) all the other volumes are mounted and unmounted per test
-//NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
-//to reuse the same cluster and volume for multiple runs or over a period of time.
+// NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
+// to reuse the same cluster and volume for multiple runs or over a period of time.
 // It is recommended to run this test with -count test param (to repeat th test n number of times)
 // along with --load_parallel_runs params(number of concurrent operations per test) and
 //--load_volumes(number of volumes that are created per test
@@ -52,8 +52,8 @@ type BlockLongHaulSuite struct {
 	testClient *clients.TestClient
 }
 
-//Test set up - does the following in order
-//create pool and storage class, create a PVC, Create a MySQL app/service that uses pvc
+// Test set up - does the following in order
+// create pool and storage class, create a PVC, Create a MySQL app/service that uses pvc
 func (s *BlockLongHaulSuite) SetupSuite() {
 	s.namespace = "longhaul-ns"
 	s.op, s.kh, s.installer = StartLoadTestCluster(s.T, s.namespace)
@@ -61,9 +61,9 @@ func (s *BlockLongHaulSuite) SetupSuite() {
 	createStorageClassAndPool(s.T, s.testClient, s.kh, s.namespace, "rook-ceph-block", "rook-pool")
 }
 
-//create a n number  ofPVC, Create a MySQL app/service that uses pvc
-//The first PVC and mysql pod are persistent i.e. they are never deleted
-//All other PVC and mounts are created and deleted/unmounted per test
+// create a n number  ofPVC, Create a MySQL app/service that uses pvc
+// The first PVC and mysql pod are persistent i.e. they are never deleted
+// All other PVC and mounts are created and deleted/unmounted per test
 func (s *BlockLongHaulSuite) TestBlockLonghaulRun() {
 	var wg sync.WaitGroup
 	wg.Add(installer.Env.LoadVolumeNumber)
@@ -93,7 +93,7 @@ func BlockVolumeOperations(s *BlockLongHaulSuite, wg *sync.WaitGroup, storageCla
 }
 
 func (s *BlockLongHaulSuite) TearDownSuite() {
-	//clean up all ephemeral block storage, index 1 is persistent block storage which is going to be used among different test runs.
+	// clean up all ephemeral block storage, index 1 is persistent block storage which is going to be used among different test runs.
 	for i := 2; i <= installer.Env.LoadVolumeNumber; i++ {
 		mySqlPodOperation(s.kh, "rook-ceph-block", "mysqlapp-ephemeral-"+strconv.Itoa(i), "mysqldbeph"+strconv.Itoa(i), "mysql-ephemeral-claim"+strconv.Itoa(i), "delete")
 	}

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -34,8 +34,8 @@ import (
 // Rook Block Storage fencing longhaul test
 // Create a PVC, mount a pod with readOnly= false and write some data and unmount pod
 // Then Mound n pods concurrently with readOnly=true and read  data.
-//NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
-//to reuse the same cluster and volume for multiple runs or over a period of time.
+// NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
+// to reuse the same cluster and volume for multiple runs or over a period of time.
 // It is recommended to run this test with -count test param (to repeat th test n number of times)
 // along with --load_parallel_runs params(number of concurrent operations per test)
 func TestBlockWithFencingLongHaul(t *testing.T) {
@@ -51,9 +51,9 @@ type BlockLongHaulSuiteWithFencing struct {
 	op         installer.TestSuite
 }
 
-//Test set up - does the following in order
-//create pool and storage class, Create a PVC and mount a pod with ReadOnly=false.
-//Write some data to the pvc and unmount the pod
+// Test set up - does the following in order
+// create pool and storage class, Create a PVC and mount a pod with ReadOnly=false.
+// Write some data to the pvc and unmount the pod
 func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 	s.namespace = "longhaul-ns"
 	s.op, s.kh, s.installer = StartLoadTestCluster(s.T, s.namespace)
@@ -74,7 +74,7 @@ func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 	}
 }
 
-//Mount n number of pods on the same PVC created earlier with readOnly=True.
+// Mount n number of pods on the same PVC created earlier with readOnly=True.
 func (s *BlockLongHaulSuiteWithFencing) TestBlockWithFencingLonghaulRun() {
 
 	var wg sync.WaitGroup

--- a/tests/longhaul/longhaul_util.go
+++ b/tests/longhaul/longhaul_util.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//utility to install and prometheus and grafana to monitor rook cluster
+// utility to install and prometheus and grafana to monitor rook cluster
 var (
 	logger = capnslog.NewPackageLogger("github.com/rook/rook", "longhaul")
 )

--- a/tests/longhaul/object_test.go
+++ b/tests/longhaul/object_test.go
@@ -33,8 +33,8 @@ import (
 // Create object store bucket and perform CURD operations.
 // This Test creates 1 to n object stores - first object store is present throughout the run,
 // but all other object stores are deleted after each run.
-//NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
-//to reuse the same cluster and volume for multiple runs or over a period of time.
+// NOTE: This tests doesn't clean up the cluster or volume after the run, the tests is designed
+// to reuse the same cluster and volume for multiple runs or over a period of time.
 // It is recommended to run this test with -count test param (to repeat th test n number of times)
 // along with --load_parallel_runs params(number of concurrent operations per test) and
 //--load_volumes(number of volumes that are created per test

--- a/tests/pipeline/Jenkinsfile.k8sSetup
+++ b/tests/pipeline/Jenkinsfile.k8sSetup
@@ -44,7 +44,7 @@ pipeline {
                }
             }
         }
-        //start 3 node k8s cluster
+        // start 3 node k8s cluster
         stage ("Set Up k8s") {
             steps{
                 script{
@@ -94,7 +94,7 @@ pipeline {
 }
 
 def setUpRookImages(){
-    //tag rook images need for testing
+    // tag rook images need for testing
     env.versionId = readFile('version').trim()
     sh'''
           #!/bin/bash

--- a/tests/pipeline/Jenkinsfile.regression
+++ b/tests/pipeline/Jenkinsfile.regression
@@ -47,7 +47,7 @@ pipeline {
                }
             }
         }
-        //Run regression
+        // Run regression
         stage ("Run Regression") {
             steps{
                 script {


### PR DESCRIPTION
**Description of your changes:**

Introduce mount security mode for basic multi tenancy

This adds three new parameters/options to StorageClass/flexvolume entry:
* `mountUser`
* `mountSecret`
* `mountSecretNamespace`

Will test in a minute or two but I'm currently "rebuilding" my vendor directory which takes quite an amount of time.

**Which issue is resolved by this Pull Request:**
Resolves #2164.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

/cc @dimm0 took me a bit longer than said in the community meeting but here it is