### PR TITLE
Reduce frequency of device discovery

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -928,7 +928,6 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/policy/v1beta1",
-    "k8s.io/api/rbac/v1beta1",
     "k8s.io/api/storage/v1",
     "k8s.io/api/storage/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -13,6 +13,7 @@
 - `reclaimPolicy` parameter of `StorageClass` definition is now supported.
 - K8s client-go updated from version 1.8.2 to 1.11.3
 - The toolbox manifest now creates a deployment based on the `rook/ceph` image instead of creating a pod on a specialized `rook/ceph-toolbox` image.
+- The frequency of discovering devices on a node is reduced to 60 minutes by default, and is configurable with the setting `ROOK_DISCOVER_DEVICES_INTERVAL` in operator.yaml.
 
 ## Breaking Changes
 - Ceph mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -333,6 +333,9 @@ spec:
         # current mon with a new mon (useful for compensating flapping network).
         - name: ROOK_MON_OUT_TIMEOUT
           value: "300s"
+        # The duration between discovering devices in the rook-discover daemonset.
+        - name: ROOK_DISCOVER_DEVICES_INTERVAL
+          value: "60m"
         # Whether to start pods as privileged that mount a host path, which includes the Ceph mon and osd pods.
         # This is necessary to workaround the anyuid issues when running on OpenShift.
         # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641

--- a/cmd/rook/discover.go
+++ b/cmd/rook/discover.go
@@ -17,22 +17,32 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	rook "github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
+	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
 
-var discoverCmd = &cobra.Command{
-	Use:    "discover",
-	Short:  "Discover devices",
-	Hidden: true,
-}
+var (
+	discoverCmd = &cobra.Command{
+		Use:    "discover",
+		Short:  "Discover devices",
+		Hidden: true,
+	}
+
+	// interval between discovering devices
+	discoverDevicesInterval time.Duration
+)
 
 func init() {
+	discoverCmd.Flags().DurationVar(&discoverDevicesInterval, "discover-interval", 60*time.Minute, "interval between discovering devices (default 60m)")
+
+	flags.SetFlagsFromEnv(discoverCmd.Flags(), rook.RookEnvVarPrefix)
 	discoverCmd.RunE = startDiscover
 }
 
@@ -55,7 +65,7 @@ func startDiscover(cmd *cobra.Command, args []string) error {
 		RookClientset:         rookClientset,
 	}
 
-	err = discover.Run(context)
+	err = discover.Run(context, discoverDevicesInterval)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -36,20 +36,23 @@ import (
 )
 
 var (
-	logger                                  = capnslog.NewPackageLogger("github.com/rook/rook", "rook-discover")
-	AppName                                 = "rook-discover"
-	NodeAttr                                = "rook.io/node"
-	LocalDiskCMData                         = "devices"
-	LocalDiskCMName                         = "local-device-"
-	probeInterval                           = 30 * time.Second
-	nodeName, namespace, lastDevice, cmName string
-	cm                                      *v1.ConfigMap
+	logger          = capnslog.NewPackageLogger("github.com/rook/rook", "rook-discover")
+	AppName         = "rook-discover"
+	NodeAttr        = "rook.io/node"
+	LocalDiskCMData = "devices"
+	LocalDiskCMName = "local-device-"
+	nodeName        string
+	namespace       string
+	lastDevice      string
+	cmName          string
+	cm              *v1.ConfigMap
 )
 
-func Run(context *clusterd.Context) error {
+func Run(context *clusterd.Context, probeInterval time.Duration) error {
 	if context == nil {
 		return fmt.Errorf("nil context")
 	}
+	logger.Infof("device discovery interval is %s", probeInterval.String())
 	nodeName = os.Getenv(k8sutil.NodeNameEnvVar)
 	namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
 	cmName = LocalDiskCMName + nodeName


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The device discovery on each node is currently performed every 30s and is not configurable. This frequency actually has a performance impact on some systems. We can reduce this frequency and also make it configurable. The operator currently doesn't take action when new devices are discovered anyway, which we will need to handle better in the future separately.

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
