### PR TITLE
ceph: use "rbd info" to get image info after creating it

### DIFF
--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -33,9 +33,10 @@ const (
 )
 
 type CephBlockImage struct {
-	Name   string `json:"image"`
-	Size   uint64 `json:"size"`
-	Format int    `json:"format"`
+	Name     string `json:"image"`
+	Size     uint64 `json:"size"`
+	Format   int    `json:"format"`
+	InfoName string `json:"name"`
 }
 
 func ListImages(context *clusterd.Context, clusterName, poolName string) ([]CephBlockImage, error) {
@@ -61,6 +62,24 @@ func ListImages(context *clusterd.Context, clusterName, poolName string) ([]Ceph
 	}
 
 	return images, nil
+}
+
+func getImageInfo(context *clusterd.Context, clusterName, name, poolName string) (*CephBlockImage, error) {
+	imageSpec := getImageSpec(name, poolName)
+	args := []string{"info", imageSpec}
+	buf, err := ExecuteRBDCommand(context, clusterName, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image %s info: %+v", imageSpec, err)
+	}
+
+	var image CephBlockImage
+	if err = json.Unmarshal(buf, &image); err != nil {
+		return nil, fmt.Errorf("unmarshal failed: %+v. raw buffer response: %s", err, string(buf))
+	}
+
+	image.Name = image.InfoName
+
+	return &image, nil
 }
 
 // CreateImage creates a block storage image.
@@ -98,17 +117,12 @@ func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoo
 	}
 
 	// now that the image is created, retrieve it
-	images, err := ListImages(context, clusterName, poolName)
+	image, err := getImageInfo(context, clusterName, name, poolName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list images after successfully creating image %s: %v", name, err)
-	}
-	for i := range images {
-		if images[i].Name == name {
-			return &images[i], nil
-		}
+		return nil, fmt.Errorf("failed to get image %s info after successfully creating it: %v", name, err)
 	}
 
-	return nil, fmt.Errorf("failed to find image %s after creating it", name)
+	return image, nil
 }
 
 func DeleteImage(context *clusterd.Context, clusterName, name, poolName string) error {

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -57,8 +57,10 @@ func TestCreateImage(t *testing.T) {
 			createCalled = true
 			assert.Equal(t, expectedSizeArg, args[3])
 			return "", nil
-		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
-			return `[{"image":"image1","size":1048576,"format":2}]`, nil
+		case command == "rbd" && args[0] == "info":
+			assert.Equal(t, "pool1/image1", args[1])
+			return `{"name":"image1","size":1048576,"objects":1,"order":20,"object_size":1048576,"block_name_prefix":"pool1_data.229226b8b4567",` +
+				`"format":2,"features":["layering"],"op_features":[],"flags":[],"create_timestamp":"Fri Oct  5 19:46:20 2018"}`, nil
 		}
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
@@ -93,6 +95,9 @@ func TestCreateImage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, image)
 	assert.True(t, createCalled)
+	assert.Equal(t, "image1", image.Name)
+	assert.Equal(t, uint64(sizeMB), image.Size)
+	assert.Equal(t, 2, image.Format)
 	createCalled = false
 
 	// (1 MB + 1 byte) --> 2 MB

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -54,8 +54,10 @@ func TestProvisionImage(t *testing.T) {
 				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
 			}
 
-			if command == "rbd" && args[0] == "ls" && args[1] == "-l" {
-				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
+			if command == "rbd" && args[0] == "info" {
+				assert.Equal(t, "testpool/pvc-uid-1-1", args[1])
+				return `{"name":"pvc-uid-1-1","size":1048576,"objects":1,"order":20,"object_size":1048576,"block_name_prefix":"testpool_data.229226b8b4567",` +
+					`"format":2,"features":["layering"],"op_features":[],"flags":[],"create_timestamp":"Fri Oct  5 19:46:20 2018"}`, nil
 			}
 			return "", nil
 		},
@@ -118,8 +120,10 @@ func TestReclaimPolicyForProvisionedImages(t *testing.T) {
 				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
 			}
 
-			if command == "rbd" && args[0] == "ls" && args[1] == "-l" {
-				return `[{"image":"pvc-uid-1-1","size":1048576,"format":2}]`, nil
+			if command == "rbd" && args[0] == "info" {
+				assert.Equal(t, "testpool/pvc-uid-1-1", args[1])
+				return `{"name":"pvc-uid-1-1","size":1048576,"objects":1,"order":20,"object_size":1048576,"block_name_prefix":"testpool_data.229226b8b4567",` +
+					`"format":2,"features":["layering"],"op_features":[],"flags":[],"create_timestamp":"Fri Oct  5 19:46:20 2018"}`, nil
 			}
 			return "", nil
 		},


### PR DESCRIPTION
**Description of your changes:**
As described in #2248, executing `rbd ls` to get an image's info after creating it takes a long time when having 1000+ images. This PR uses [`rbd info {pool-name}/{image-name}`](http://docs.ceph.com/docs/mimic/rbd/rados-rbd-cmds/#retrieving-image-information) instead.

**Which issue is resolved by this Pull Request:**
Resolves #2248 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]