### PR TITLE
WIP: Set fsGroup only at the top level of the filesystem mount

### DIFF
--- a/cmd/rookflex/cmd/init.go
+++ b/cmd/rookflex/cmd/init.go
@@ -41,8 +41,9 @@ func initPlugin(cmd *cobra.Command, args []string) error {
 		Status: flexvolume.StatusSuccess,
 		Capabilities: &flexvolume.DriverCapabilities{
 			Attach: false,
-			// Required for cephfs (ReadWriteMany)
+			// applying the selinux relabel and fsgroup is too expensive recursively, especially for shared file system
 			SELinuxRelabel: false,
+			FSGroup:        false,
 		},
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(&status); err != nil {

--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -48,6 +48,7 @@ type AttachOptions struct {
 	Path             string `json:"path"` // Path within the CephFS to mount
 	RW               string `json:"kubernetes.io/readwrite"`
 	FsType           string `json:"kubernetes.io/fsType"`
+	FsGroup          string `json:"kubernetes.io/fsGroup"`
 	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
 	Pod              string `json:"kubernetes.io/pod.name"`
 	PodID            string `json:"kubernetes.io/pod.uid"`


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Kubernetes will set the fsGroup recursively on the entire filesystem at the time of mount if the fsGroup property is set in the security context. This can be a very long operation to walk the filesystem when there are millions of files. 

The changes included here are:
- Disable the fsGroup capability on the rook flex driver so k8s will skip applying the fsGroup
- After mounting the shared filesystem, rook will set the fsgroup only on the top-level mount. If a subpath of the filesystem is specified, it will be set on the subpath.

Some questions remaining.
- Disabling the fsGroup capability applies to both block and file since it is for the flex driver as a whole. 
- Do we need a setting on the operator for whether to disable the recursive fsGroup behavior?
- If it's disabled, does Rook need settings to control whether rook sets the fsGroup for block, file, or both?

@dimm0 @rootfs thoughts on this?

**Which issue is resolved by this Pull Request:**
Resolves #2254

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
