### PR TITLE
Set ceph version when cluster crd is updated

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -291,6 +291,11 @@ func clusterChanged(oldCluster, newCluster cephv1beta1.ClusterSpec, clusterRef *
 		changeFound = true
 	}
 
+	if oldCluster.CephVersion.Image != newCluster.CephVersion.Image {
+		logger.Infof("ceph version changing from %s to %s", oldCluster.CephVersion.Image, newCluster.CephVersion.Image)
+		changeFound = true
+	}
+
 	return changeFound
 }
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the cluster CRD is updated, the major version of the ceph image remains blank, which results in the default behavior of assuming luminous. This breaks mimic and nautilus clusters. This change will ensure the correct version of the image is detected, either by using the previously detected version if the image did not change, or by detecting the new version if it did change.

**Which issue is resolved by this Pull Request:**
Resolves #2260

@laevilgenius PTAL

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

skip ci due to known build issues
[skip ci]