### PR TITLE
Fixes for running Ceph, CockroachDB, Minio demos

### DIFF
--- a/Documentation/minio-object-store-crd.md
+++ b/Documentation/minio-object-store-crd.md
@@ -23,11 +23,11 @@ spec:
     nodeAffinity:
     podAffinity:
     podAnyAffinity:
-  port: 9000
   credentials:
     name: access-keys
     namespace: rook-minio
   storageAmount: "10G"
+  clusterDomain:
 ```
 
 ## Cluster Settings
@@ -36,9 +36,9 @@ spec:
 
 The settings below are specific to Minio object stores:
 
-* `port`: The internal port exposed internal to the cluster by the Minio service.
 * `credentials`: This accepts the `name` and `namespace` strings of an existing Secret to specify the access credentials for the object store.
 * `storageAmount`: The size of the volume that will be mounted at the data directory.
+* `clusterDomain`: The local cluster domain for this cluster. This should be set if an alternative cluster domain is in use.  If not set, then the default of cluster.local will be assumed.  This field is needed to workaround https://github.com/minio/minio/issues/6775, and is expected to be removed in the future.
 
 ### Storage Scope
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -794,7 +794,7 @@
   version = "v8.0.0"
 
 [[projects]]
-  digest = "1:f9b4cdfba254d53ac1f5b7e6391dff5dc6d15c82e867179041f4aae4cfd17cf1"
+  digest = "1:3b9c82e73290987c719062ba514f47cc95a7b1e10d9868b1e083e48044c0820b"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -807,13 +807,13 @@
     "cmd/client-gen/types",
     "pkg/util",
   ]
-  pruneopts = "UT"
+  pruneopts = "T"
   revision = "8c97d6ab64da020f8b151e9d3ed8af3172f5c390"
   version = "kubernetes-1.11.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:06920413ee44b5a5a23a8b682a39578532fd30474949cd631183650d6149b914"
+  digest = "1:f58422ce44ba581f34423e12c951061d139fa3518441b0e791b1f57a6494d603"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -822,7 +822,7 @@
     "parser",
     "types",
   ]
-  pruneopts = "UT"
+  pruneopts = "T"
   revision = "4242d8e6c5dba56827bb7bcf14ad11cda38f3991"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,17 @@ ignored = [
   go-tests = true
   unused-packages = true
 
+  # we need "unused packages" for code generator related repos because
+  # the dependencies cannot all be captured in golang source code
+  # e.g., codegen.sh depends on generate-groups.sh
+  [[prune.project]]
+    name = "k8s.io/code-generator"
+    unused-packages = false
+
+  [[prune.project]]
+    name = "k8s.io/gengo"
+    unused-packages = false
+
 #
 # Kubernetes projects below should all be updated as a set 
 # as they are versioned together.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,8 +5,8 @@
 ## Notable Features
 
 - Different versions of Ceph can be orchestrated by Rook. Both Luminous and Mimic are now supported, with Nautilus coming soon.
-The version of Ceph is specified in the cluster CRD with the cephVersion.image property. For example, to run Mimic you could use image `ceph/ceph:v13.2.2-20181023`
-or any other image found on the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags).
+  The version of Ceph is specified in the cluster CRD with the cephVersion.image property. For example, to run Mimic you could use image `ceph/ceph:v13.2.2-20181023`
+  or any other image found on the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags).
 - The `fsType` default for StorageClass examples are now using XFS to bring it in line with Ceph recommendations.
 - Ceph OSDs will be automatically updated by the operator when there is a change to the operator version or when the OSD configuration changes. See the [OSD upgrade notes](Documentation/upgrade-patch.md#object-storage-daemons-osds).
 - Rook Ceph block storage provisioner can now correctly create erasure coded block images. See [Advanced Example: Erasure Coded Block Storage](Documentation/block.md#advanced-example-erasure-coded-block-storage) for an example usage.
@@ -19,14 +19,17 @@ or any other image found on the [Ceph DockerHub](https://hub.docker.com/r/ceph/c
 - The number of mons can be changed by updating the `mon.count` in the cluster CRD.
 
 ## Breaking Changes
+
 - Ceph mons are [named consistently](https://github.com/rook/rook/issues/1751) with other daemons with the letters a, b, c, etc.
 - Ceph mons are now created with Deployments instead of ReplicaSets to improve the upgrade implementation.
 - Ceph mon, mgr, mds, and rgw container names in pods have changed with the refactors to initialize the
   daemon environments via pod **InitContainers** and run the Ceph daemons directly from the
   container entrypoint.
-
 - The Rook container images are no longer published to quay.io, they are published only to Docker Hub.  All manifests have referenced Docker Hub for multiple releases now, so we do not expect any directly affected users from this change.
 - Rook no longer supports kubernetes `1.7`. Users running Kubernetes `1.7` on their clusters are recommended to upgrade to Kubernetes `1.8` or higher. If you are using `kubeadm`, you can follow this [guide](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade-1-8/) to from Kubernetes `1.7` to `1.8`. If you are using `kops` or `kubespray` for managing your Kubernetes cluster, just follow the respective projects' `upgrade` guide.
+- Minio no longer exposes a configurable port for each distributed server instance to use.
+  This was an internal only port that should not need to be configured by the user.
+  All connections from users and clients are expected to come in through the [configurable Service instance](cluster/examples/kubernetes/minio/object-store.yaml#37).
 
 ## Known Issues
 

--- a/cluster/examples/kubernetes/minio/object-store.yaml
+++ b/cluster/examples/kubernetes/minio/object-store.yaml
@@ -28,11 +28,11 @@ spec:
     nodeAffinity:
     podAffinity:
     podAnyAffinity:
-  port: 9000
   credentials:
     name: access-keys
     namespace: rook-minio
   storageAmount: "10G"
+  clusterDomain:
 ---
 apiVersion: v1
 kind: Service

--- a/images/minio/Dockerfile
+++ b/images/minio/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM minio/minio:RELEASE.2018-04-19T22-54-58Z
+FROM minio/minio:RELEASE.2018-10-25T01-27-03Z
 
 COPY rook /usr/local/bin/
 

--- a/pkg/apis/minio.rook.io/v1alpha1/types.go
+++ b/pkg/apis/minio.rook.io/v1alpha1/types.go
@@ -22,6 +22,11 @@ import (
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 )
 
+const (
+	// ClusterDomainDefault is the default local cluster domain
+	ClusterDomainDefault = "cluster.local"
+)
+
 // ***************************************************************************
 // IMPORTANT FOR CODE GENERATION
 // If the types in this file are updated, you will need to run
@@ -55,12 +60,17 @@ type ObjectStoreSpec struct {
 	// tolerations).
 	Placement rook.PlacementSpec `json:"placement,omitempty"`
 
-	// Port of operation for the Minio object store.
-	Port int32 `json:"port"`
-
 	// Minio cluster credential configuration.
 	Credentials v1.SecretReference `json:"credentials"`
 
 	// The amount of storage that will be available in the object store.
 	StorageSize string `json:"storageAmount"`
+
+	// ClusterDomain is the local cluster domain for this cluster. This should be set if an
+	// alternative cluster domain is in use.  If not set, then the default of cluster.local will
+	// be assumed.
+	//
+	// This field is needed to workaround https://github.com/minio/minio/issues/6775, and is
+	// expected to be removed in the future.
+	ClusterDomain string `json:"clusterDomain,omitempty"`
 }

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -93,8 +93,9 @@ function check_context() {
 
 function copy_images() {
     if [[ "$1" == "" || "$1" == "ceph" ]]; then
-      echo "copying ceph image"
+      echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
+      copy_image_to_cluster ceph/ceph:v13 ceph/ceph:v13
     fi
 
     if [[ "$1" == "" || "$1" == "cockroachdb" ]]; then
@@ -155,6 +156,10 @@ case "${1:-}" in
     copy_image_to_cluster mysql:5.6 mysql:5.6
     copy_image_to_cluster wordpress:4.6.1-apache wordpress:4.6.1-apache
     ;;
+  cockroachdb-loadgen)
+    echo "copying the cockroachdb loadgen images"
+    copy_image_to_cluster cockroachdb/loadgen-kv:0.1 cockroachdb/loadgen-kv:0.1
+    ;;
   helm)
     echo " copying rook image for helm"
     helm_tag="$(cat _output/version)"
@@ -173,5 +178,6 @@ case "${1:-}" in
     echo "  $0 update [ceph | cockroachdb | minio | nfs]" >&2
     echo "  $0 restart <pod-name-regex> (the pod name is a regex to match e.g. restart ^rook-ceph-osd)" >&2
     echo "  $0 wordpress" >&2
+    echo "  $0 cockroachdb-loadgen" >&2
     echo "  $0 helm" >&2
 esac


### PR DESCRIPTION
**Description of your changes:**

- Add cluster domain to minio spec
- Remove port configuration from minio spec
- Include unused packages for codegen repos
- Update Minio version to pick up latest fixes
- Helper to load cockroachdb demo images into minikube

**Which issue is resolved by this Pull Request:**

Resolves #2258 
Resolves #2264 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
