### PR TITLE
enable cross building for images/nfs

### DIFF
--- a/images/nfs/Makefile
+++ b/images/nfs/Makefile
@@ -38,12 +38,20 @@ OLD_IMAGE_ID := $(shell docker images -q $(NFS_IMAGE))
 CURRENT_IMAGE_ID := $$(docker images -q $(NFS_IMAGE))
 IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/nfs.tar.gz
 
-do.build:
+do.build.multiarch:
 	@echo === docker build $(NFS_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp start.sh $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@cd $(TEMP) && $(SED_CMD) 's|NFS_BASEIMAGE|$(NFS_BASEIMAGE)|g' Dockerfile
+	@if [ $(GOARCH) == arm64 ]; then \
+		docker run --rm --privileged multiarch/qemu-user-static:register --reset; \
+		wget -O $(TEMP)/qemu-aarch64-static \
+			https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-aarch64-static; \
+                        chmod a+x $(TEMP)/qemu-aarch64-static; \
+		sed -i '/FROM/a\COPY qemu-aarch64-static /usr/bin/' $(TEMP)/Dockerfile; \
+		sed -i '/ENTRYPOINT/i\RUN rm /usr/bin/qemu-aarch64-static -f' $(TEMP)/Dockerfile; \
+	fi;
 	@docker build $(BUILD_ARGS) \
 		-t $(NFS_IMAGE) \
 		$(TEMP)
@@ -54,3 +62,15 @@ do.build:
 		docker save $(NFS_IMAGE) | gzip -c > $(IMAGE_FILENAME); \
 	fi
 	@rm -fr $(TEMP)
+
+do.build:
+	@if [ $(GOARCH) == arm64 ]; then \
+		docker_major="$$(docker version -f "{{.Server.Version}}" | cut -d. -f1)"; \
+		if [ $${docker_major} -lt 18 ]; then \
+			echo "Docker version for NFS multi-arch building, need at least 18.00."; \
+		else \
+			${MAKE} do.build.multiarch;\
+		fi; \
+	else \
+		${MAKE} do.build.multiarch;\
+	fi;


### PR DESCRIPTION
Fix bug: can't use the command of 'make build.all' to
build images/nfs for Arm64 platform

How to test it: test the command of 'make build.all' on X86 platform

Signed-off-by: Bin Lu <bin.lu@arm.com>

**Description of your changes:**
Adding multi-arch building support on x86 platform

**Which issue is resolved by this Pull Request:**
Resolves #2276

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] make vendor does not cause changes.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
