### PR TITLE
Use truncated node name for missed sections

### DIFF
--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -175,7 +175,6 @@ func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOs
 			osds = append(osds, *osd)
 		}
 	}
-
 	logger.Infof("%d/%d osd devices succeeded on this node", succeeded, len(scheme.Entries))
 	return osds, nil
 }
@@ -379,7 +378,6 @@ func refreshDeviceInfo(name string, nameToUUID map[string]string, scheme *config
 }
 
 func (a *OsdAgent) prepareOSD(context *clusterd.Context, cfg *osdConfig) (*oposd.OSDInfo, error) {
-
 	cfg.rootPath = getOSDRootDir(cfg.configRoot, cfg.id)
 
 	// if the osd is using filestore on a device and it's previously been formatted/partitioned,
@@ -456,6 +454,7 @@ func prepareOSDRoot(cfg *osdConfig) (newOSD bool, err error) {
 	newOSD = isOSDDataNotExist(cfg.rootPath)
 	if !newOSD {
 		// osd is not new (it's ready), nothing to prepare
+		logger.Infof("osd with path %s is not new, nothing to prepare", cfg.rootPath)
 		return newOSD, nil
 	}
 

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -38,7 +38,6 @@ var (
 )
 
 func RunFilestoreOnDevice(context *clusterd.Context, mountSourcePath, mountPath string, cephArgs []string) error {
-
 	// start the OSD daemon in the foreground with the given config
 	logger.Infof("starting filestore osd on a device")
 
@@ -57,7 +56,6 @@ func RunFilestoreOnDevice(context *clusterd.Context, mountSourcePath, mountPath 
 }
 
 func Provision(context *clusterd.Context, agent *OsdAgent) error {
-
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
 	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
@@ -94,7 +92,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 		return fmt.Errorf("failed to get removed devices: %+v", err)
 	}
 
-	// determine the set of directories that can/should be used for OSDs, with the default dir if no devices were specified.  save off the node's crush name if needed.
+	// determine the set of directories that can/should be used for OSDs, with the default dir if no devices were specified. save off the node's crush name if needed.
 	devicesSpecified := len(agent.devices) > 0
 	dirs, removedDirs, err := getDataDirs(context, agent.kv, agent.directories, devicesSpecified, agent.nodeName)
 	if err != nil {
@@ -150,7 +148,6 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 }
 
 func getAvailableDevices(context *clusterd.Context, desiredDevices string, metadataDevice string, usingDeviceFilter bool) (*DeviceOsdMapping, error) {
-
 	var deviceList []string
 	if !usingDeviceFilter {
 		deviceList = strings.Split(desiredDevices, ",")

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -40,7 +40,7 @@ var (
 	AppName         = "rook-discover"
 	NodeAttr        = "rook.io/node"
 	LocalDiskCMData = "devices"
-	LocalDiskCMName = "local-device-"
+	LocalDiskCMName = "local-device-%s"
 	nodeName        string
 	namespace       string
 	lastDevice      string
@@ -55,7 +55,7 @@ func Run(context *clusterd.Context, probeInterval time.Duration) error {
 	logger.Infof("device discovery interval is %s", probeInterval.String())
 	nodeName = os.Getenv(k8sutil.NodeNameEnvVar)
 	namespace = os.Getenv(k8sutil.PodNamespaceEnvVar)
-	cmName = LocalDiskCMName + nodeName
+	cmName = k8sutil.TruncateNodeName(LocalDiskCMName, nodeName)
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGTERM)
 	err := updateDeviceCM(context)

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -75,10 +75,11 @@ func UpdateNodeStatus(kv *k8sutil.ConfigMapKVStore, node string, status Orchestr
 	// update the status map with the given status now
 	s, _ := json.Marshal(status)
 	if err := kv.SetValueWithLabels(
-		fmt.Sprintf(orchestrationStatusMapName, node),
+		k8sutil.TruncateNodeName(orchestrationStatusMapName, node),
 		orchestrationStatusKey,
 		string(s),
-		labels); err != nil {
+		labels,
+	); err != nil {
 		return fmt.Errorf("failed to set node %s status. %+v", node, err)
 	}
 	return nil

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -299,7 +299,7 @@ func FreeDevices(context *clusterd.Context, nodeName, clusterName string) error 
 		return nil
 	}
 	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
-	cmName := fmt.Sprintf(deviceInUseCMName, clusterName, nodeName)
+	cmName := k8sutil.TruncateNodeName(fmt.Sprintf(deviceInUseCMName, clusterName, "%s"), nodeName)
 	// delete configmap
 	err := context.Clientset.CoreV1().ConfigMaps(namespace).Delete(cmName, &metav1.DeleteOptions{})
 	if err != nil && !kserrors.IsNotFound(err) {
@@ -409,7 +409,7 @@ func GetAvailableDevices(context *clusterd.Context, nodeName, clusterName string
 
 		cm := &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf(deviceInUseCMName, clusterName, nodeName),
+				Name:      k8sutil.TruncateNodeName(fmt.Sprintf(deviceInUseCMName, clusterName, "%s"), nodeName),
 				Namespace: namespace,
 				Labels: map[string]string{
 					k8sutil.AppAttr:         deviceInUseAppName,

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -303,8 +303,8 @@ func CheckIfDeviceAvailable(executor exec.Executor, name string) (bool, string, 
 	return ownPartitions, devFS, nil
 }
 
+// RookOwnsPartitions check if all partitions in list are owned by Rook
 func RookOwnsPartitions(partitions []Partition) bool {
-
 	// if there are partitions, they must all have the rook osd label
 	ownPartitions := true
 	for _, p := range partitions {

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -61,7 +61,7 @@ const (
 	//TestMountPath is the path inside a test pod where storage is mounted
 	TestMountPath = "/tmp/testrook"
 	//hostnameTestPrefix is a prefix added to the node hostname
-	hostnameTestPrefix = "testprefix-"
+	hostnameTestPrefix = "test-prefix-this-is-a-very-long-hostname-"
 )
 
 //CreateK8sHelper creates a instance of k8sHelper


### PR DESCRIPTION
**Description of your changes:**
This fixes additional "problematic sections" as a user affected by this problem reported that running just the bash snippet didn't fix it for him, but running a Rook version based on release-0.8 branch with those fixes in worked for him when doing the upgrade.

I would add the bash snippet/issue link to the release notes when a backport for v0.8 has been decided.

**Which issue is resolved by this Pull Request:**
Resolves #2272.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)