### PR TITLE
Collect init container logs from failed integration tests

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package installer
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -26,18 +27,16 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/kubernetes/pkg/kubelet/apis"
-
-	"flag"
-
 	cephv1beta1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1beta1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/kubelet/apis"
 )
 
 const (
@@ -435,6 +434,11 @@ func (h *CephInstaller) GatherAllRookLogs(namespace, systemNamespace string, tes
 	h.k8shelper.GetRookLogs("rook-ceph-osd-prepare", Env.HostType, namespace, testName)
 	h.k8shelper.GetRookLogs("rook-ceph-rgw", Env.HostType, namespace, testName)
 	h.k8shelper.GetRookLogs("rook-ceph-mds", Env.HostType, namespace, testName)
+	h.k8shelper.GetRookContainerLogs("rook-ceph-mgr", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetRookContainerLogs("rook-ceph-mon", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetRookContainerLogs("rook-ceph-osd", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetRookContainerLogs("rook-ceph-rgw", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetRookContainerLogs("rook-ceph-mds", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
 }
 
 // NewCephInstaller creates new instance of CephInstaller

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1403,7 +1403,14 @@ func (k8sh *K8sHelper) IsRookInstalled(namespace string) bool {
 
 //GetRookLogs captures logs from specified rook pod and writes it to specified file
 func (k8sh *K8sHelper) GetRookLogs(podAppName string, hostType string, namespace string, testName string) {
+	k8sh.GetRookContainerLogs(podAppName, hostType, namespace, testName, "")
+}
+
+func (k8sh *K8sHelper) GetRookContainerLogs(podAppName, hostType, namespace, testName, containerName string) {
 	logOpts := &v1.PodLogOptions{}
+	if containerName != "" {
+		logOpts.Container = containerName
+	}
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + podAppName}
 
 	podList, err := k8sh.Clientset.CoreV1().Pods(namespace).List(listOpts)
@@ -1434,7 +1441,11 @@ func (k8sh *K8sHelper) GetRookLogs(podAppName string, hostType string, namespace
 				continue
 			}
 		}
-		fileName := fmt.Sprintf("%s_%s_%s_%s_%d.log", testName, hostType, podName, namespace, time.Now().Unix())
+		logSuffix := ""
+		if containerName != "" {
+			logSuffix = "_" + containerName
+		}
+		fileName := fmt.Sprintf("%s_%s_%s_%s%s_%d.log", testName, hostType, podName, namespace, logSuffix, time.Now().Unix())
 		fpath = path.Join(fpath, fileName)
 		file, err := os.Create(fpath)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When integration tests fail, we need access to all the rook pod logs. This change will collect the `config-init` container logs from the ceph daemon pods.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
