### PR TITLE
Added PersistentVolumeClaimTemplates to storage selection

### DIFF
--- a/pkg/apis/rook.io/v1alpha2/storage.go
+++ b/pkg/apis/rook.io/v1alpha2/storage.go
@@ -90,6 +90,10 @@ func (s *StorageScopeSpec) resolveNodeSelection(node *Node) {
 	if len(node.Selection.Directories) == 0 {
 		node.Selection.Directories = s.Directories
 	}
+
+	if len(node.Selection.VolumeClaimTemplates) == 0 {
+		node.Selection.VolumeClaimTemplates = s.VolumeClaimTemplates
+	}
 }
 
 func (s *StorageScopeSpec) resolveNodeConfig(node *Node) {
@@ -105,6 +109,7 @@ func (s *StorageScopeSpec) resolveNodeConfig(node *Node) {
 	}
 }
 
+// GetUseAllDevices return if all devices should be used.
 func (s *Selection) GetUseAllDevices() bool {
 	return s.UseAllDevices != nil && *(s.UseAllDevices)
 }

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -60,13 +60,14 @@ type Directory struct {
 type Selection struct {
 	// Whether to consume all the storage devices found on a machine
 	UseAllDevices *bool `json:"useAllDevices,omitempty"`
-
 	// A regular expression to allow more fine-grained selection of devices on nodes across the cluster
 	DeviceFilter string `json:"deviceFilter,omitempty"`
-
+	// List of devices to use as storage devices
 	Devices []Device `json:"devices,omitempty"`
-
+	// List of host directories to use as storage
 	Directories []Directory `json:"directories,omitempty"`
+	// PersistentVolumeClaims to use as storage
+	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 }
 
 type PlacementSpec map[string]Placement


### PR DESCRIPTION
**Description of your changes:**
As @jbw976 requested, I moved the change to the Rook alpha storage selection API out of #2132 so that we have that change already in.

The PR does not contain documentation as no actual implementation for Ceph, Minio and so on is done in this PR.
The implementation for using PVC templates (and adding documentation for that) will be done #2132.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)