### PR TITLE
ceph: Update deployments on rook img update

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,6 +20,7 @@
 - The number of mons can be changed by updating the `mon.count` in the cluster CRD.
 - RBD Mirroring is enabled by Rook. By setting the number of [rbd mirroring workers](Documentation/ceph-cluster-crd.md#cluster-settings), the daemon(s) will be started by rook. To configure the pools or images to be mirrored, use the Rook toolbox to run the [rbd mirror](http://docs.ceph.com/docs/mimic/rbd/rbd-mirroring/) configuration tool.
 - Object Store User creation via CRD for Ceph clusters.
+- Ceph MON, MGR, MDS, and RGW deployments (or DaemonSets) will be updated/upgraded automatically with updates to the Rook operator.
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -82,6 +82,8 @@ func New(context *clusterd.Context, namespace, rookVersion string, cephVersion c
 	}
 }
 
+var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+
 // Start begins the process of running a cluster of Ceph mgrs.
 func (c *Cluster) Start() error {
 	logger.Infof("start running mgr")
@@ -120,7 +122,7 @@ func (c *Cluster) Start() error {
 				return fmt.Errorf("failed to create mgr deployment %s. %+v", resourceName, err)
 			}
 			logger.Infof("deployment for mgr %s already exists. updating if needed", resourceName)
-			if err := k8sutil.UpdateDeploymentAndWait(c.context, d, c.Namespace); err != nil {
+			if err := updateDeploymentAndWait(c.context, d, c.Namespace); err != nil {
 				return fmt.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
 			}
 		}

--- a/pkg/operator/ceph/file/mds.go
+++ b/pkg/operator/ceph/file/mds.go
@@ -97,6 +97,8 @@ func (c *cluster) deleteLegacyMdsDeployment() bool {
 	return true
 }
 
+var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+
 func (c *cluster) start() error {
 	// If attempt was made to prepare daemons for upgrade, make sure that an attempt is made to
 	// bring fs state back to desired when this method returns with any error or success.
@@ -147,7 +149,7 @@ func (c *cluster) start() error {
 			// TODO: need to prepare for upgrade here each time. Also, before a given deployment is
 			// terminated, I think we should somehow make sure that it isn't running the single
 			// active daemon. If it is, then we should have another daemon take over as active. @Jan?
-			if err := k8sutil.UpdateDeploymentAndWait(c.context, d, c.fs.Namespace); err != nil {
+			if err := updateDeploymentAndWait(c.context, d, c.fs.Namespace); err != nil {
 				return fmt.Errorf("failed to update mds deployment %s. %+v", mdsConfig.ResourceName, err)
 			}
 		}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -116,26 +116,10 @@ func (c *config) startRGWPods(update bool) error {
 	}
 
 	// start the deployment or daemonset
-	var rgwType string
-	var err error
 	if c.store.Spec.Gateway.AllNodes {
-		rgwType = "daemonset"
-		err = c.startDaemonset()
-	} else {
-		rgwType = "deployment"
-		err = c.startDeployment()
+		return c.startDaemonset()
 	}
-
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create rgw %store. %+v", rgwType, err)
-		}
-		logger.Infof("rgw %s already exists", rgwType)
-	} else {
-		logger.Infof("rgw %s started", rgwType)
-	}
-
-	return nil
+	return c.startDeployment()
 }
 
 // Delete the object store.

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -52,8 +52,6 @@ func (c *config) startDeployment() error {
 		logger.Infof("deployment for rgw %s already exists. updating if needed", c.instanceName())
 		// There may be a *lot* of rgws, and they are stateless, so don't bother waiting until the
 		// entire deployment is updated to move on.
-		// TODO: is the above statement safe to assume?
-		// TODO: Are there any steps for RGW that need to happen before the daemons upgrade?
 		_, err := c.context.Clientset.Extensions().Deployments(c.store.Namespace).Update(d)
 		if err != nil {
 			return fmt.Errorf("failed to update rgw deployment %s. %+v", c.instanceName(), err)

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -34,21 +34,38 @@ import (
 
 func (c *config) startDeployment() error {
 
-	deployment := &extensions.Deployment{
+	d := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.instanceName(),
 			Namespace: c.store.Namespace,
 		},
 		Spec: extensions.DeploymentSpec{Template: c.makeRGWPodSpec(), Replicas: &c.store.Spec.Gateway.Instances},
 	}
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &deployment.ObjectMeta, c.ownerRefs)
-	_, err := c.context.Clientset.ExtensionsV1beta1().Deployments(c.store.Namespace).Create(deployment)
-	return err
+	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
+
+	logger.Debugf("starting mds deployment: %+v", d)
+	_, err := c.context.Clientset.ExtensionsV1beta1().Deployments(c.store.Namespace).Create(d)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create rgw deployment %s: %+v", c.instanceName(), err)
+		}
+		logger.Infof("deployment for rgw %s already exists. updating if needed", c.instanceName())
+		// There may be a *lot* of rgws, and they are stateless, so don't bother waiting until the
+		// entire deployment is updated to move on.
+		// TODO: is the above statement safe to assume?
+		// TODO: Are there any steps for RGW that need to happen before the daemons upgrade?
+		_, err := c.context.Clientset.Extensions().Deployments(c.store.Namespace).Update(d)
+		if err != nil {
+			return fmt.Errorf("failed to update rgw deployment %s. %+v", c.instanceName(), err)
+		}
+	}
+
+	return nil
 }
 
 func (c *config) startDaemonset() error {
 
-	daemonset := &extensions.DaemonSet{
+	d := &extensions.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      c.instanceName(),
 			Namespace: c.store.Namespace,
@@ -60,10 +77,26 @@ func (c *config) startDaemonset() error {
 			Template: c.makeRGWPodSpec(),
 		},
 	}
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &daemonset.ObjectMeta, c.ownerRefs)
+	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
-	_, err := c.context.Clientset.ExtensionsV1beta1().DaemonSets(c.store.Namespace).Create(daemonset)
-	return err
+	logger.Debugf("starting rgw daemonset: %+v", d)
+	_, err := c.context.Clientset.ExtensionsV1beta1().DaemonSets(c.store.Namespace).Create(d)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create rgw daemonset %s: %+v", c.instanceName(), err)
+		}
+		logger.Infof("daemonset for rgw %s already exists. updating if needed", c.instanceName())
+		// There may be a *lot* of rgws, and they are stateless, so don't bother waiting until the
+		// entire daemonset is updated to move on.
+		// TODO: is the above statement safe to assume?
+		// TODO: Are there any steps for RGW that need to happen before the daemons upgrade?
+		_, err := c.context.Clientset.Extensions().DaemonSets(c.store.Namespace).Update(d)
+		if err != nil {
+			return fmt.Errorf("failed to update rgw daemonset %s. %+v", c.instanceName(), err)
+		}
+	}
+
+	return nil
 }
 
 func (c *config) makeRGWPodSpec() v1.PodTemplateSpec {

--- a/pkg/operator/k8sutil/test/deployment.go
+++ b/pkg/operator/k8sutil/test/deployment.go
@@ -1,0 +1,40 @@
+package test
+
+import (
+	"github.com/rook/rook/pkg/clusterd"
+	extensions "k8s.io/api/extensions/v1beta1"
+)
+
+// UpdateDeploymentAndWaitStub returns a stub replacement for the UpdateDeploymentAndWait function
+// for unit tests which always returns success (nil). The generated simple clientset doesn't seem to
+// handle the Deployment.Update method as expected. The deployment is instead zero-ed out when the
+// deployment is updated with an unchanged version, which breaks unit tests.
+// In order to still test the UpdateDeploymentAndWait function, the stub function returned will
+// append a copy of the deployment used as input to the list of deployments updated. The function
+// returns a pointer to this slice which the calling func may use to verify the expected contents of
+// deploymentsUpdated based on expected behavior.
+func UpdateDeploymentAndWaitStub() (
+	stubFunc func(context *clusterd.Context, deployment *extensions.Deployment, namespace string) error,
+	deploymentsUpdated *[]*extensions.Deployment,
+) {
+	deploymentsUpdated = &[]*extensions.Deployment{}
+	stubFunc = func(context *clusterd.Context, deployment *extensions.Deployment, namespace string) error {
+		*deploymentsUpdated = append(*deploymentsUpdated, deployment)
+		return nil
+	}
+	return stubFunc, deploymentsUpdated
+}
+
+// DeploymentNamesUpdated converts a deploymentsUpdated slice into a string slice of deployment names
+func DeploymentNamesUpdated(deploymentsUpdated *[]*extensions.Deployment) []string {
+	ns := []string{}
+	for _, d := range *deploymentsUpdated {
+		ns = append(ns, d.GetName())
+	}
+	return ns
+}
+
+// ClearDeploymentsUpdated clears the deploymentsUpdated list
+func ClearDeploymentsUpdated(deploymentsUpdated *[]*extensions.Deployment) {
+	*deploymentsUpdated = []*extensions.Deployment{}
+}


### PR DESCRIPTION
Use the `UpdateDeploymentAndWait` method used by the osd operator to
update the deployments for ~mons,~ mgrs, mdses, and rgws when the Rook
orchestrator image is updated.

**Note:** mons deferred to v0.9.1 release because (1) the mons will still update properly from v0.8.x -> v0.9.0 due to the legacy replicaset handling code and (2) the mons require some nontrivial changes to incorporate `UpdateDeploymentAndWait`. Mon issue: #2331 

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com

**Which issue is resolved by this Pull Request:**
Resolves 997? #997 is sufficiently broad that I'm not sure I would say that this resolves it or not. It seems to me like an ongoing goal where this is the first (main) step.

I still have some TODO items for myself on this PR:
- [x] Check that each mon is in quorum before continuing to start/update the next mon. Also figure out the best way to check whether the mon upgrade has been successful factoring in that cluster healthy does not necessarily equate to the mons being okay and vise versa.
- [x] Prep mdses for upgrade before starting the upgrade, and do checking to make sure the mds being upgraded isn't the active one, which would result in mds downtime. TBH, this can probably be left for later since we are kind of up against a time constraint with the 0.9 release impending.
- [x] Check to see if there are any rgw steps needed when upgrading the rgw daemons. Perhaps @theanalyst could say whether it is safe to just stop a rgw daemon and then start up a replacement in its place without performing any steps to ready Ceph for the upgrade.
- [x] Documentation, which is a lot shorter to say than it will be to update. Perhaps that is a separate PR?

**Checklist:**
- [x] ~Documentation has been updated, if necessary.~ Planned for separate PR
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
