### PR TITLE
Allow filesystem specifications without pools

### DIFF
--- a/pkg/apis/ceph.rook.io/v1beta1/types.go
+++ b/pkg/apis/ceph.rook.io/v1beta1/types.go
@@ -191,10 +191,10 @@ type FilesystemList struct {
 // FilesystemSpec represents the spec of a file system
 type FilesystemSpec struct {
 	// The metadata pool settings
-	MetadataPool PoolSpec `json:"metadataPool"`
+	MetadataPool PoolSpec `json:"metadataPool,omitempty"`
 
 	// The data pool settings
-	DataPools []PoolSpec `json:"dataPools"`
+	DataPools []PoolSpec `json:"dataPools,omitempty"`
 
 	// The mds pod info
 	MetadataServer MetadataServerSpec `json:"metadataServer"`

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -109,7 +109,7 @@ func GetFilesystem(context *clusterd.Context, clusterName string, fsName string)
 }
 
 // CreateFilesystem performs software configuration steps for Ceph to provide a new filesystem.
-func CreateFilesystem(context *clusterd.Context, clusterName, name, metadataPool string, dataPools []string, activeMDSCount int32) error {
+func CreateFilesystem(context *clusterd.Context, clusterName, name, metadataPool string, dataPools []string) error {
 	if len(dataPools) == 0 {
 		return fmt.Errorf("at least one data pool is required")
 	}
@@ -141,13 +141,6 @@ func CreateFilesystem(context *clusterd.Context, clusterName, name, metadataPool
 		_, err = ExecuteCephCommand(context, clusterName, args)
 		if err != nil {
 			logger.Errorf("failed to add pool %s to file system %s. %+v", poolName, name, err)
-		}
-	}
-
-	// set the number of active mds instances
-	if activeMDSCount > 1 {
-		if err = SetNumMDSRanks(context, clusterName, name, activeMDSCount); err != nil {
-			logger.Warningf("failed setting active mds count to %d. %+v", activeMDSCount, err)
 		}
 	}
 

--- a/pkg/daemon/ceph/mds/filesystem.go
+++ b/pkg/daemon/ceph/mds/filesystem.go
@@ -105,7 +105,7 @@ func (f *Filesystem) CreateFilesystem(context *clusterd.Context, clusterName str
 	}
 
 	// create the filesystem
-	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames, f.activeMDSCount); err != nil {
+	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/ceph/mds/filesystem.go
+++ b/pkg/daemon/ceph/mds/filesystem.go
@@ -113,8 +113,8 @@ func (f *Filesystem) CreateFilesystem(context *clusterd.Context, clusterName str
 	return nil
 }
 
-// DeleteFilesystem removes the filesystem in Ceph and removes the Ceph file daemons.
-func DeleteFilesystem(context *clusterd.Context, clusterName, filesystemName string) error {
+// DownFilesystem marks the filesystem as down and the MDS' as failed
+func DownFilesystem(context *clusterd.Context, clusterName, filesystemName string) error {
 	logger.Infof("Removing file system %s", filesystemName)
 
 	// mark the cephFS instance as cluster_down before removing
@@ -131,11 +131,6 @@ func DeleteFilesystem(context *clusterd.Context, clusterName, filesystemName str
 		if err := client.FailMDS(context, clusterName, mdsInfo.GID); err != nil {
 			return err
 		}
-	}
-
-	// Permanently remove the file system
-	if err := client.RemoveFilesystem(context, clusterName, filesystemName); err != nil {
-		return err
 	}
 
 	logger.Infof("Removed file system %s", filesystemName)

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -55,6 +55,13 @@ func createFilesystem(
 		return fmt.Errorf("failed to get file system %s: %+v", fs.Name, err)
 	}
 
+	// set the number of active mds instances
+	if fs.Spec.MetadataServer.ActiveCount > 1 {
+		if err = client.SetNumMDSRanks(context, fs.Namespace, fs.Name, fs.Spec.MetadataServer.ActiveCount); err != nil {
+			logger.Warningf("failed setting active mds count to %d. %+v", fs.Spec.MetadataServer.ActiveCount, err)
+		}
+	}
+
 	logger.Infof("start running mdses for file system %s", fs.Name)
 	c := newCluster(context, rookVersion, cephVersion, hostNetwork, fs, filesystem, ownerRefs)
 	if err := c.start(); err != nil {


### PR DESCRIPTION
I opened issue #2313 yesterday and decided to take a stab at it. This patchset seems to do the right thing. If no dataPool is specified then this just has the daemon just verify that the filesystem already exists and then spin up the MDS daemons for it.