### PR TITLE
remove --set-uid option from ceph-authtool calls

### DIFF
--- a/pkg/operator/ceph/cluster/mon/util.go
+++ b/pkg/operator/ceph/cluster/mon/util.go
@@ -210,7 +210,7 @@ func createNamedClusterInfo(context *clusterd.Context, clusterName string) (*cep
 	}
 
 	// generate the admin secret if one was not provided at the command line
-	args := []string{"--set-uid=0", "--cap", "mon", "'allow *'", "--cap", "osd", "'allow *'", "--cap", "mgr", "'allow *'", "--cap", "mds", "'allow'"}
+	args := []string{"--cap", "mon", "'allow *'", "--cap", "osd", "'allow *'", "--cap", "mgr", "'allow *'", "--cap", "mds", "'allow'"}
 	adminSecret, err := genSecret(context.Executor, dir, client.AdminUsername, args)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Newer versions of ceph have deprecated this option, and the commands
will fail if you try to pass it in.

Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

(skipping the build for known random issues and jenkins overload)
[skip ci]