### PR TITLE
Publish the build independent from the integration test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,7 @@
 
 pipeline {
    parameters {
-         booleanParam(defaultValue: true, description: 'Execute pipeline?', name: 'shouldBuild')
-         booleanParam(defaultValue: false, description: 'Run Only Smoke Test', name: 'smokeOnly')
-
+         booleanParam(defaultValue: false, description: 'Skip Integration Tests?', name: 'skipIntegrationTests')
       }
     agent { label 'ec2-stateful' }
 
@@ -57,10 +55,30 @@ pipeline {
             }
         }
 
-       stage('Integration Tests') {
+        stage('Publish if Master') {
             when {
                 expression {
-                    return env.shouldBuild != "false" && env.shouldTest != "false"
+                    return env.BRANCH_NAME == "master"
+                }
+            }
+            environment {
+                DOCKER = credentials('rook-docker-hub')
+                AWS = credentials('rook-jenkins-aws')
+                GIT = credentials('rook-github')
+            }
+            steps {
+                sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
+                sh 'build/run make -j\$(nproc) -C build/release build BRANCH_NAME=${BRANCH_NAME} GIT_API_TOKEN=${GIT_PSW}'
+                sh 'build/run make -j\$(nproc) -C build/release publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_PSW}'
+                // automatically promote the master builds
+                sh 'build/run make -j\$(nproc) -C build/release promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}'
+            }
+        }
+
+        stage('Integration Tests') {
+            when {
+                expression {
+                    return env.shouldBuild != "false" && env.shouldTest != "false" && !params.skipIntegrationTests
                 }
             }
             steps{
@@ -91,10 +109,11 @@ pipeline {
                 }
             }
         }
-        stage('Publish') {
+
+        stage('Publish if Release') {
             when {
                 expression {
-                    return env.shouldBuild != "false" && env.shouldTest != "false"
+                    return env.BRANCH_NAME.contains("release-")
                 }
             }
             environment {
@@ -106,7 +125,6 @@ pipeline {
                 sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
                 sh 'build/run make -j\$(nproc) -C build/release build BRANCH_NAME=${BRANCH_NAME} GIT_API_TOKEN=${GIT_PSW}'
                 sh 'build/run make -j\$(nproc) -C build/release publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_PSW}'
-                sh '[ "${BRANCH_NAME}" != "master" ] || build/run make -j\$(nproc) -C build/release promote BRANCH_NAME=master CHANNEL=master AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}'
             }
         }
     }
@@ -205,7 +223,7 @@ def notifySlack(String buildStatus) {
     // Override default values based on build status
     if (buildStatus != 'SUCCESS') {
         // Send notifications to channel on non success builds only
-        if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.contains("release")){
+        if (env.BRANCH_NAME == "master" || env.BRANCH_NAME.contains("release-")){
             slackSend (color: colorCode, message: summary)
         }
     }


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This change will cause master and release builds to be published before the integration tests are run. There are some positive and negative aspects to this:

PROS:
- Published builds match what has been merged
- Random integration test failures don't block the publishing of the build

CONS:
- If there is a significant failure shown by the integration tests, the build will be published anyway

I wouldn't be surprised if there is much debate around this, but the reality of the situation is that the random failures in integration tests are too painful not to do this. It doesn't mean we deprioritize fixing the integration test issues, but this will help us ensure our published images match what has been merged to the repo. I'm not worried about the integration tests finding significant issues after the merge, because they would have already been vetted **before** the merge.

As an example, we haven't had a successful master build for 6 days, but there was a breaking change three days ago that requires a new build. See #2329.

**Which issue is resolved by this Pull Request:**
Resolves #2329 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
