### PR TITLE
Grant access for ceph-mgr to access the configmaps in the system namespace

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -118,6 +118,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - nodes
   - nodes/proxy
   verbs:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -314,6 +314,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - nodes
   - nodes/proxy
   verbs:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -376,6 +376,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - nodes
   - nodes/proxy
   verbs:

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -353,6 +353,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - nodes
   - nodes/proxy
   verbs:


### PR DESCRIPTION
…espace

Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The creation of the ceph-mgr service account a few days ago missed granting access for ceph-mgr to the configmaps in the rook-ceph-system namespace. This is needed for the inventory to look at available devices. @jtlayton 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// skip ci due to flaky builds
[skip ci]