### PR TITLE
Update the rgw deployment or daemonset when the pod spec changes

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -69,7 +69,7 @@ func (c *config) createOrUpdate(update bool) error {
 	if err == nil && exists {
 		if !update {
 			logger.Infof("object store %s exists in namespace %s", c.store.Name, c.store.Namespace)
-			return nil
+			return c.startRGWPods(false)
 		}
 		logger.Infof("object store %s exists in namespace %s. checking for updates", c.store.Name, c.store.Namespace)
 	}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The rgw daemon was not being updated during the upgrade from v0.8. This change will ensure the pod spec is updated whenever the orchestration runs for the object store.

**Which issue is resolved by this Pull Request:**
Resolves #2347

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// skip ci due to flaky builds
[skip ci]