### PR TITLE
Openshift update for the SCC Kind

### DIFF
--- a/Documentation/openshift.md
+++ b/Documentation/openshift.md
@@ -20,9 +20,11 @@ To orchestrate the storage platform, Rook requires the following access in the c
 
 Before starting the Rook operator or cluster, create the security context constraints needed by the Rook pods. The following yaml is found in `scc.yaml` under `/cluster/examples/kubernetes/ceph`.
 
+**NOTE** Older versions of OpenShift may require `apiVersion: v1`.
+
 ```yaml
 kind: SecurityContextConstraints
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 metadata:
   name: rook-ceph
 allowPrivilegedContainer: true

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -1,5 +1,6 @@
 kind: SecurityContextConstraints
-apiVersion: v1
+# older versions of openshift have "apiVersion: v1"
+apiVersion: security.openshift.io/v1
 metadata:
   name: rook-ceph
 allowPrivilegedContainer: true


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The SecurityContextConstraints has changed from `v1` to `security.openshift.io/v1`, as observed in my testing on openshift 1.11. Users should be moving off 1.9 with the known security issue, where the previous version `v1` had been tested to be working.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]