### PR TITLE
Update ceph-upgrade.md

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -361,7 +361,7 @@ Ceph image field in the cluster CRD (`spec:cephVersion:image`).
 # kubectl -n $ROOK_SYSTEM_NAMESPACE replace -f cluster.yaml
 NEW_CEPH_IMAGE='ceph/ceph:v13.2.2-20181023'
 CLUSTER_NAME="$ROOK_NAMESPACE"  # change if your cluster name is not the Rook namespace
-kubectl patch CephCluster $CLUSTER_NAME --type=merge \
+kubectl -n $ROOK_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge \
   -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```
 


### PR DESCRIPTION
[skip ci]

In the upgrading to mimic example the namespace parameter is missing from the kubectl patch command

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
