### PR TITLE
Add configuration note about OpenStack Magnum flexvolume

### DIFF
--- a/Documentation/flexvolume.md
+++ b/Documentation/flexvolume.md
@@ -28,7 +28,7 @@ If running `mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/` shoul
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
 ### Atomic
-See the [OpenShift](#openshift) section.
+See the [OpenShift](#openshift) section, unless running with OpenStack Magnum, then see [OpenStack Magnum](#openstack-magnum) section.
 
 ### ContainerLinux
 Use the [Most common read/write FlexVolume path](#most-common-readwrite-flexvolume-path) for the next steps.
@@ -80,6 +80,11 @@ Follow [these instructions](tectonic.md) to configure the Flexvolume plugin for 
 If you want to use Rook with an already provisioned Tectonic cluster, please refer to the [ContainerLinux](#containerlinux) section.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
+
+### OpenStack Magnum
+OpenStack Magnum is using Atomic, which uses a non-standard FlexVolume plugin directory at:  `/var/lib/kubelet/volumeplugins`
+The kubelet in OpenStack Magnum is already configured to use that directory.
+You will need to use this value when [configuring the Rook operator](#configuring-the-rook-operator)
 
 ### Custom containerized kubelet
 Use the [most common read/write FlexVolume path](#most-common-readwrite-flexvolume-path) for the next steps.


### PR DESCRIPTION
**Description of your changes:**

OpenStack Magnum uses Atomic Host as its default deployment. The Atomic
docs for rook point to the openshift docs, which are a bit complex to
follow if one is not actually using OpenShift. For magnum, the path
/var/lib/kubelet/volumeplugins is the correct path, so it's easier to
just point to that directly rather than sending users to OpenShift docs.

**Which issue is resolved by this Pull Request:**
Resolves #2373

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]