### PR TITLE
WIP: DNM: flex: set rshared flag on cephfs mount point

### DIFF
--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -277,6 +277,13 @@ func mountCephFS(client *rpc.Client, opts *flexvolume.AttachOptions) error {
 				return nil
 			}
 			os.MkdirAll(opts.MountDir, 0750)
+			// Make the mountpoint shared so that mounts inside of a container, such as when
+			// kubelet is being run containerized, can be shared across the container boundary.
+			err = mounter.MakeRShared(opts.MountDir)
+			if err != nil {
+				return fmt.Errorf("failed to set RSHARED flag on mountpoint %s: %+v", opts.MountDir, err)
+
+			}
 
 			err = mounter.Interface.Mount(devicePath, opts.MountDir, cephFS, options)
 			if err != nil {


### PR DESCRIPTION
**Description of your changes:**

When kubelet is running in a container, mounting the cephfs happens in
the container and not on the host. Even if the containing kubelet
filesystem is mounted rshared, the ceph mounts aren't propagating out to
the host, so aren't being seen by the actual pods requesting them.

**Which issue is resolved by this Pull Request:**
Resolves #2371

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
