### PR TITLE
Fix the documented command to delete replicapool

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -108,7 +108,7 @@ To clean up all the artifacts created by the block demo:
 ```
 kubectl delete -f wordpress.yaml
 kubectl delete -f mysql.yaml
-kubectl delete -n rook-ceph pool replicapool
+kubectl delete -n rook-ceph cephblockpools.ceph.rook.io replicapool
 kubectl delete storageclass rook-ceph-block
 ```
 


### PR DESCRIPTION
The command `kubectl delete -n rook-ceph pool replicapool` returns the error `error: the server doesn't have a resource type "pool"`. The actual resource type is `cephblockpools.ceph.rook.io`.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]