### PR TITLE
Fix the test function that deletes the replicapool

### DIFF
--- a/tests/scripts/multi-node/build-rook.sh
+++ b/tests/scripts/multi-node/build-rook.sh
@@ -24,10 +24,16 @@ function fail_if {
 
 function purge_rook_pods {
   cd "$rook_kube_templates_dir"
+  # Older rook versions use resource type "pool", newer versions
+  # use resource type "cephblockpools".
   kubectl delete -n rook-ceph pool replicapool || true
+  kubectl delete -n rook-ceph cephblockpools replicapool || true
   kubectl delete storageclass rook-ceph-block || true
   kubectl delete -f kube-registry.yaml || true
+  # Older rook versions use resource type "cluster",
+  # versions > 0.8 use resource type "cephcluster".
   kubectl delete -n rook-ceph cluster rook-ceph || true
+  kubectl delete -n rook-ceph cephcluster rook-ceph || true
   kubectl delete crd cephclusters.ceph.rook.io cephblockpools.ceph.rook.io cephobjectstores.ceph.rook.io cephobjectstoreusers.ceph.rook.io cephfilesystems.ceph.rook.io volumes.rook.io || true
   kubectl delete -n rook-ceph-system daemonset rook-ceph-agent || true
   kubectl delete -f operator.yaml || true


### PR DESCRIPTION
The command `kubectl delete -n rook-ceph pool replicapool` used to work, but currently returns the error `error: the server doesn't have a resource type "pool"`. The actual resource type is `cephblockpools`. The resource type `cluster` was also recently changed to `cephcluster`.

Since the function commands end with `|| true`, the errors are silently masked and the resources are not deleted.

This PR adds delete commands for `cephblockpools` and `cephcluster`, so that regardless of whether you're testing old or new versions of Rook the delete commands will work.

(I previously fixed the documentation in https://github.com/rook/rook/pull/2387, then I noticed that the build-rook.sh script still used the old resource name, so I fixed the script too.)

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]