### PR TITLE
Fix code block indention in openshift doc

### DIFF
--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -58,7 +58,6 @@ spec:
 
 ## Settings Explanation
 
-
 Cluster Settings:
 
 * `version`: The version of Cassandra to use. It is used as the image tag to pull.

--- a/Documentation/openshift.md
+++ b/Documentation/openshift.md
@@ -90,7 +90,7 @@ There is an environment variable that needs to be set in the operator spec that 
 
 ```yaml
 - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
-    value: "true"
+  value: "true"
 ```
 
 ### Cluster Settings
@@ -102,7 +102,7 @@ The cluster settings in `cluster.yaml` are largely isolated from the differences
 In OpenShift, ports less than 1024 cannot be bound. In the [object store CRD](ceph-object.md), ensure the port is modified to meet this requirement.
 ```yaml
 gateway:
-    port: 8080
+  port: 8080
 ```
 
 You can expose a different port such as `80` by creating a service.


### PR DESCRIPTION
**Description of your changes:**
Fixes indention in openshift doc.
Haven't found too many more while searching through some other pages.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]