### PR TITLE
Retry creating self signed cert if module is not ready

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -56,6 +56,7 @@ type Cluster struct {
 	dashboard   cephv1.DashboardSpec
 	cephVersion cephv1.CephVersionSpec
 	rookVersion string
+	exitCode    func(err error) (int, bool)
 }
 
 // mgrConfig for a single mgr
@@ -79,6 +80,7 @@ func New(context *clusterd.Context, namespace, rookVersion string, cephVersion c
 		HostNetwork: hostNetwork,
 		resources:   resources,
 		ownerRef:    ownerRef,
+		exitCode:    getExitCode,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
After enabling a mgr module, it takes some short period of time before the module is ready to accept commands. If the module is not yet ready, it will respond with error `22 invalid argument`. In this case, we should retry the operation until the module is ready. 

**Which issue is resolved by this Pull Request:**
Resolves #2298

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
