### PR TITLE
docs: add stable channel to rook ceph helm chart docs

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -38,7 +38,15 @@ After the helm chart is installed, you will need to [create a Rook cluster](ceph
 
 The `helm install` command deploys rook on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation. It is recommended that the rook operator be installed into the `rook-ceph-system` namespace (you will install your clusters into separate namespaces).
 
-Rook currently publishes builds of the Ceph operator to the `beta`, `alpha`, and `master` channels. In the future `stable` will also be available.
+Rook currently publishes builds of the Ceph operator to the `stable`, `beta`, `alpha`, and `master` channels.
+
+### Stable
+The stable channel is the most recent release of Rook that is considered stable for the community, starting with the v0.9 release.
+
+```console
+helm repo add rook-stable https://charts.rook.io/stable
+helm install --namespace rook-ceph-system rook-stable/rook-ceph
+```
 
 ### Beta
 The beta channel is the most recent release of Rook that is considered nearly stable for the community, starting with the v0.8 release.
@@ -126,14 +134,14 @@ You can pass the settings with helm command line parameters. Specify each parame
 `--set key=value[,key=value]` argument to `helm install`. For example, the following command will install rook where RBAC is not enabled.
 
 ```console
-$ helm install --namespace rook-ceph-system --name rook-ceph rook-beta/rook-ceph --set rbacEnable=false
+$ helm install --namespace rook-ceph-system --name rook-ceph rook-stable/rook-ceph --set rbacEnable=false
 ```
 
 ### Settings File
 Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while installing the chart.
 
 ```console
-$ helm install --namespace rook-ceph-system --name rook-ceph rook-beta/rook-ceph -f values.yaml
+$ helm install --namespace rook-ceph-system --name rook-ceph rook-stable/rook-ceph -f values.yaml
 ```
 
 Here are the sample settings to get you started.


### PR DESCRIPTION
**Description of your changes:** Quick docs update to include the stable channel for the rook ceph helm chart in the docs

**Which issue is resolved by this Pull Request:**
Resolves #2340

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]