### PR TITLE
No longer promote the images to alpha, beta, or stable

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -160,13 +160,6 @@ build.image.$(1).$(2).$(3):
 build.all.images: build.image.$(1).$(2).$(3)
 publish.image.$(1).$(2).$(3): ; @docker push $(1)/$(2)-$(3):$(VERSION)
 publish.all.images: publish.image.$(1).$(2).$(3)
-promote.image.$(1).$(2).$(3):
-	@docker pull $(1)/$(2)-$(3):$(VERSION)
-	@[ "$(CHANNEL)" = "master" ] || docker tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
-	@docker tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(CHANNEL)
-	@[ "$(CHANNEL)" = "master" ] || docker push $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
-	@docker push $(1)/$(2)-$(3):$(CHANNEL)
-promote.all.images: promote.image.$(1).$(2).$(3)
 clean.image.$(1).$(2).$(3):
 	@[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(VERSION))" ] || docker rmi $(1)/$(2)-$(3):$(VERSION)
 	@[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL))" ] || docker rmi $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
@@ -178,13 +171,9 @@ $(foreach r,$(REGISTRIES), $(foreach i,$(IMAGES), $(foreach a,$(IMAGE_ARCHS),$(e
 publish.manifest.image.%: publish.all.images $(MANIFEST_TOOL)
 	@$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(VERSION)
 
-promote.manifest.image.%: promote.all.images $(MANIFEST_TOOL)
-	@[ "$(CHANNEL)" = "master" ] || $(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(VERSION)-$(CHANNEL)
-	@$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(CHANNEL)
-
 build.images: build.all.images
 publish.images: $(addprefix publish.manifest.image.,$(IMAGES))
-promote.images: $(addprefix promote.manifest.image.,$(IMAGES))
+promote.images:
 clean.images: clean.all.images
 
 # ====================================================================================


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The alpha, beta, and stable tags on the docker images are not needed. We rely solely on the published image versions such as `master` and `v0.9.0`. This is a basic change to simplify the deployment so that we don't have to remove the many extra images from dockerhub after the promote.

Next step will be similar for publishing of helm charts, but i'll leave that for another day.

**Which issue is resolved by this Pull Request:**
This issue is a partial fix for #1885 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]