### PR TITLE
docs: Improve HA docker registry example

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -95,13 +95,17 @@ spec:
       containers:
       - name: registry
         image: registry:2
+        imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
+        # Configuration reference: https://docs.docker.com/registry/configuration/
         - name: REGISTRY_HTTP_ADDR
           value: :5000
+        - name: REGISTRY_HTTP_SECRET
+          value: "Ple4seCh4ngeThisN0tAVerySecretV4lue"
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: /var/lib/registry
         volumeMounts:
@@ -111,6 +115,14 @@ spec:
         - containerPort: 5000
           name: registry
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: registry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: registry
       volumes:
       - name: image-store
         flexVolume:

--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -22,13 +22,17 @@ spec:
       containers:
       - name: registry
         image: registry:2
+        imagePullPolicy: Always
         resources:
           limits:
             cpu: 100m
             memory: 100Mi
         env:
+        # Configuration reference: https://docs.docker.com/registry/configuration/
         - name: REGISTRY_HTTP_ADDR
           value: :5000
+        - name: REGISTRY_HTTP_SECRET
+          value: "Ple4seCh4ngeThisN0tAVerySecretV4lue"
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: /var/lib/registry
         volumeMounts:
@@ -38,6 +42,14 @@ spec:
         - containerPort: 5000
           name: registry
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: registry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: registry
       volumes:
       - name: image-store
         flexVolume:


### PR DESCRIPTION
Signed-off-by: k911 <konradobal@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
HA Docker Registry without explicitly set `REGISTRY_HTTP_SECRET`, behind any load-balancing thing (e.g. kubernetes service), does not work correctly, because if omitted, value is generated randomly and thus diffrent on different pods. As outcome I was unable to push image to such registry.

https://github.com/docker/docker.github.io/blob/master/registry/deploying.md#load-balancing-considerations

I've also added:
-  link to configuration reference (can be useful)
-  `imagePullPolicy: Always` because IMO, not doing this, without setting explicit version, can cause inconsistency in cluster
- liveness/readinessProbes for stability

I also wanted to change `ReplicationController` to `Deployment` but I've seen this PR #2169 .

**Which issue is resolved by this Pull Request:**
-

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
