### PR TITLE
Build with arch-specific Ceph base image

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # the latest mimic release is the base image
-FROM ceph/ceph:v13
+FROM BASEIMAGE
 
 ARG ARCH
 ARG TINI_VERSION

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -19,7 +19,8 @@ include ../image.mk
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
-BASEIMAGE = ubuntu:18.04
+CEPH_VERSION = v13.2.2-20181023
+BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 
 TEMP := $(shell mktemp -d)
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The `rook/ceph` image is always using the amd64 base image. The base image was set to `ceph/ceph:v13` and since the build machine is amd64 even while cross compiling arm, the arm base image was not used. We must specify the arch-specific base image. 

**Which issue is resolved by this Pull Request:**
Resolves #2406

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
