### PR TITLE
doc: clarify Ceph pool `failureDomain` setting

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -72,6 +72,8 @@ When creating an erasure-coded pool, it is highly recommended to create the pool
 with the default of `host`. For example, if you have replication of size `3` and the failure domain is `host`, all three copies of the data will be
 placed on osds that are found on unique hosts. In that case you would be guaranteed to tolerate the failure of two hosts. If the failure domain were `osd`,
 you would be able to tolerate the loss of two devices. Similarly for erasure coding, the data and coding chunks would be spread across the requested failure domain.
+<br>**NOTE:** Neither Rook nor Ceph will prevent the user from creating a cluster where data (or chunks) cannot be replicated safely;
+it is Ceph's design to delay checking for OSDs until a write request is made, and the write will hang if there are not sufficient OSDs to satisfy the request.
 - `crushRoot`: The root in the crush map to be used by the pool. If left empty or unspecified, the default root will be used. Creating a crush hierarchy for the OSDs currently requires the Rook toolbox to run the Ceph tools described [here](http://docs.ceph.com/docs/master/rados/operations/crush-map/#modifying-the-crush-map).
 
 ### Erasure Coding


### PR DESCRIPTION
[skip ci]

Based on discussion in issue #2411, clarify Rook and Ceph's behavior
around allowing the user to create a cluster where data replication
cannot tolerate the cluster's failure domain safely.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>
