### PR TITLE
Backport: Build with arch-specific Ceph base image

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # the latest mimic release is the base image
-FROM ceph/ceph:v13
+FROM BASEIMAGE
 
 ARG ARCH
 ARG TINI_VERSION

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -19,7 +19,8 @@ include ../image.mk
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
-BASEIMAGE = ubuntu:18.04
+CEPH_VERSION = v13.2.2-20181023
+BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 
 TEMP := $(shell mktemp -d)
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>
(cherry picked from commit 8ea61fdc66341144b0e792f1ceab30d7b4a68a24)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport the fix to build the ceph operator for different architectures, in particular, arm64.

**Which issue is resolved by this Pull Request:**
Resolves #2406

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// skip build due to random failure
[skip ci]