### PR TITLE
docs: Correct typo in advanced config docs

### DIFF
--- a/Documentation/advanced-configuration.md
+++ b/Documentation/advanced-configuration.md
@@ -480,7 +480,7 @@ between each restart to ensure the cluster goes back to "active/clean" state.
 - MDS: the pods are stateless and can be restarted as needed
 
 After the pod restart, your new settings should be in effect. Note that if you create
-the ConfigMap in the `rook` namespace before the cluster is even created
+the ConfigMap in the `rook-ceph` namespace before the cluster is even created
 the daemons will pick up the settings at first launch.
 
 The only validation of the settings done by Rook is whether the settings can be merged


### PR DESCRIPTION
It appears this reference to 'rook' was inadvertently not updated
to 'rook-ceph' when multiple backend storage system support was
added.  Both the surrounding documentation and code seem to support
the idea that this is the correct value.

Signed-off-by: James E. Blair <jeblair@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]