### PR TITLE
Document the RBD module prerequisite for Rook Ceph

### DIFF
--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -20,6 +20,10 @@ Rook requires privileges to manage the storage in your cluster. See the details 
 The Rook agent requires setup as a Flex volume plugin to manage the storage attachments in your cluster.
 See the [Flex Volume Configuration](flexvolume.md) topic to configure your Kubernetes deployment to load the Rook volume plugin.
 
+## Kernel with RBD module
+
+Rook Ceph requires a Linux kernel built with the RBD module. Many distributions of Linux have this module but some don't, e.g. the GKE Container-Optimised OS (COS) does not have RBD. You can test your Kubernetes nodes by running `modprobe rbd`. If it says 'not found', you may have to [rebuild your kernel](https://rook.io/docs/rook/master/common-issues.html#rook-agent-rbd-module-missing-error) or choose a different Linux distribution.
+
 ## Kernel modules directory configuration
 
 Normally, on Linux, kernel modules can be found in `/lib/modules`. However, there are some distributions that put them elsewhere. In that case the environment variable `LIB_MODULES_DIR_PATH` can be used to override the default. Also see the documentation in [helm-operator](helm-operator.md) on the parameter `agent.libModulesDirPath`. One notable distribution where this setting is useful would be [NixOS](https://nixos.org).


### PR DESCRIPTION
The RBD module is an important prerequisite for Rook. It is mentioned as a possible problem on the Common Issues page, but that is the ambulance at the bottom of the cliff 😄. We should mention the perquisite for new users, tell them how to check, and note any major Kubernetes-as-a-service providers that do not have the RBD module.
https://rook.io/docs/rook/master/common-issues.html#rook-agent-rbd-module-missing-error

Resolves:
#2448 
[skip ci]