### PR TITLE
Added minio_objectstore label to Minio objects

### DIFF
--- a/Documentation/minio-object-store-crd.md
+++ b/Documentation/minio-object-store-crd.md
@@ -46,7 +46,7 @@ spec:
     podAffinity:
     podAnyAffinity:
   credentials:
-    name: access-keys
+    name: minio-my-store-access-keys
     namespace: rook-minio
   clusterDomain:
 ```

--- a/Documentation/minio-object-store.md
+++ b/Documentation/minio-object-store.md
@@ -56,7 +56,7 @@ kubectl -n rook-minio get objectstores.minio.rook.io
 To check if all the desired replicas are running, you should see the same number of entries from the following command as the replica count that was specified in `object-store.yaml`:
 
 ```console
-kubectl -n rook-minio get pod -l app=minio
+kubectl -n rook-minio get pod -l app=minio,objectstore=my-store
 ```
 
 ## Accessing the Object Store
@@ -65,7 +65,7 @@ Minio comes with an embedded web based object browser. In the example, the objec
 which port has been assigned to the service via:
 
 ```console
-kubectl -n rook-minio get service minio-service -o jsonpath='{.spec.ports[0].nodePort}'
+kubectl -n rook-minio get service minio-my-store -o jsonpath='{.spec.ports[0].nodePort}'
 ```
 
 If you are using [Minikube](https://github.com/kubernetes/minikube), you can get your cluster IP via
@@ -73,7 +73,7 @@ If you are using [Minikube](https://github.com/kubernetes/minikube), you can get
 The full address of the Minio service when using Minikube can be obtained with the following:
 
 ```console
-echo http://$(minikube ip):$(kubectl -n rook-minio get service minio-service -o jsonpath='{.spec.ports[0].nodePort}')
+echo http://$(minikube ip):$(kubectl -n rook-minio get service minio-my-store -o jsonpath='{.spec.ports[0].nodePort}')
 ```
 
 Copy and paste the full address and port into an internet browser and you will be taken to the Minio web console login page, as shown in the screenshot below:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,7 +6,10 @@
 
 ## Notable Features
 
-- Minio Object Storage now use `Readiness` and `Liveness` probes.
+- Minio Object Stores:
+    - Now have an additional label named `objectstore` with the name of the Object Store, to allow better selection for Services.
+    - Use `Readiness` and `Liveness` probes.
+    - Updated automatically on Object Store CRD changes.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/minio/object-store.yaml
+++ b/cluster/examples/kubernetes/minio/object-store.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: access-keys
+  name: minio-my-store-access-keys
   namespace: rook-minio
 type: Opaque
 data:
@@ -51,14 +51,14 @@ spec:
     podAffinity:
     podAnyAffinity:
   credentials:
-    name: access-keys
+    name: minio-my-store-access-keys
     namespace: rook-minio
   clusterDomain:
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: minio-service
+  name: minio-my-store
   namespace: rook-minio
 spec:
   type: NodePort

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -45,6 +45,7 @@ const (
 	customResourceNamePlural    = "objectstores"
 	minioCtrName                = "minio"
 	minioLabel                  = "minio"
+	minioObjectStoreLabel       = "objectstore"
 	minioPVCName                = "minio-pvc"
 	minioServerSuffixFmt        = "%s.svc.%s" // namespace.svc.clusterDomain, e.g., default.svc.cluster.local
 	minioPort                   = int32(9000)
@@ -96,7 +97,7 @@ func (c *Controller) makeMinioHeadlessService(name, namespace string, spec minio
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    map[string]string{k8sutil.AppAttr: minioLabel},
+			Labels:    getMinioLabels(name),
 		},
 		Spec: v1.ServiceSpec{
 			Selector:  map[string]string{k8sutil.AppAttr: minioLabel},
@@ -173,7 +174,7 @@ func (c *Controller) makeMinioPodSpec(name, namespace string, ctrName string, ct
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    map[string]string{k8sutil.AppAttr: minioLabel},
+			Labels:    getMinioLabels(name),
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
@@ -260,12 +261,12 @@ func (c *Controller) makeMinioStatefulSet(name, namespace string, spec miniov1al
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    map[string]string{k8sutil.AppAttr: minioLabel},
+			Labels:    getMinioLabels(name),
 		},
 		Spec: v1beta2.StatefulSetSpec{
 			Replicas: &nodeCount,
 			Selector: &meta_v1.LabelSelector{
-				MatchLabels: map[string]string{k8sutil.AppAttr: minioLabel},
+				MatchLabels: getMinioLabels(name),
 			},
 			Template:             podSpec,
 			VolumeClaimTemplates: spec.Storage.VolumeClaimTemplates,
@@ -336,4 +337,11 @@ func (c *Controller) onDelete(obj interface{}) {
 
 func getPVCDataDir(pvcName string) string {
 	return fmt.Sprintf(objectStoreDataDirTemplate, pvcName)
+}
+
+func getMinioLabels(name string) map[string]string {
+	return map[string]string{
+		k8sutil.AppAttr:       minioLabel,
+		minioObjectStoreLabel: name,
+	}
 }


### PR DESCRIPTION
**Description of your changes:**
Added minio_objectstore label to Minio objects

This allows multiple object stores to be in the same namespace and
to be selected separately from each other.

**Which issue is resolved by this Pull Request:**
Resolves #1861.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)