### PR TITLE
Add ENV flag for selinux labeling

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,8 @@
     - Now have an additional label named `objectstore` with the name of the Object Store, to allow better selection for Services.
     - Use `Readiness` and `Liveness` probes.
     - Updated automatically on Object Store CRD changes.
+    
+- Selinux labeling for mounts can now be toggled with the ROOK_ENABLE_SELINUX_RELABELING environment variable. This addresses https://github.com/rook/rook/issues/2417
 
 ## Breaking Changes
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
 {{- end }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
+        - name: ROOK_ENABLE_SELINUX_RELABELING
+          value: {{ .Values.enableSelinuxRelabeling | quote }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -67,3 +67,8 @@ pspEnable: true
 # discover:
 #   toleration: NoSchedule
 #   tolerationKey: key
+
+# In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
+# Disable it here if you have similiar issues.
+# For more details see https://github.com/rook/rook/issues/2417
+enableSelinuxRelabeling: true

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -452,6 +452,11 @@ spec:
         # For more details see https://github.com/rook/rook/issues/1314#issuecomment-355799641
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "false"
+        # In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
+        # Disable it here if you have similiar issues.
+        # For more details see https://github.com/rook/rook/issues/2417
+        - name: ROOK_ENABLE_SELINUX_RELABELING
+          value: "true"
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/pkg/operator/ceph/agent/agent_test.go
+++ b/pkg/operator/ceph/agent/agent_test.go
@@ -73,7 +73,7 @@ func TestStartAgentDaemonset(t *testing.T) {
 	volumeMounts := agentDS.Spec.Template.Spec.Containers[0].VolumeMounts
 	assert.Equal(t, 4, len(volumeMounts))
 	envs := agentDS.Spec.Template.Spec.Containers[0].Env
-	assert.Equal(t, 3, len(envs))
+	assert.Equal(t, 4, len(envs))
 	image := agentDS.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, "rook/rook:myversion", image)
 	assert.Nil(t, agentDS.Spec.Template.Spec.Tolerations)


### PR DESCRIPTION
**Description of your changes:**

Added an enviroment variable for disabling Selinux relabeling. It was disabled by default in https://github.com/rook/rook/pull/2219 . It is now enabled by default with the option to turn it off if needed.

**Which issue is resolved by this Pull Request:**
Resolves #2417

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
