### PR TITLE
add ceph dashboard port/ssl options

### DIFF
--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -51,13 +51,23 @@ kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o yaml | grep "pas
 
 ## Configure the Dashboard
 
-If you are accessing the dashboard via a reverse proxy, you may wish to serve it under a URL prefix.
-To get the dashboard to use hyperlinks that include your prefix, you can set the `urlPrefix` setting:
+The following dashboard configuration settings are supported:
+
 ```yaml
   spec:
     dashboard:
       urlPrefix: /ceph-dashboard
+      port: 8443
 ```
+
+* `urlPrefix` If you are accessing the dashboard via a reverse proxy, you may
+  wish to serve it under a URL prefix.  To get the dashboard to use hyperlinks
+  that include your prefix, you can set the `urlPrefix` setting.
+
+* `port` The port that the dashboard is served on may be changed from the
+  default using the `port` setting. The corresponding K8s service exposing the
+  port will automatically be updated.
+
 
 ## Viewing the Dashboard External to the Cluster
 

--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -58,6 +58,7 @@ The following dashboard configuration settings are supported:
     dashboard:
       urlPrefix: /ceph-dashboard
       port: 8443
+      ssl: true
 ```
 
 * `urlPrefix` If you are accessing the dashboard via a reverse proxy, you may
@@ -68,6 +69,10 @@ The following dashboard configuration settings are supported:
   default using the `port` setting. The corresponding K8s service exposing the
   port will automatically be updated.
 
+* `ssl` The dashboard may be served without SSL (useful for when you deploy the
+  dashboard behind a proxy already served using SSL) by setting the `ssl` option
+  to be false. Note that the ssl setting will be ignored in Luminous as well as
+  Mimic 13.2.2 or older where it is not supported
 
 ## Viewing the Dashboard External to the Cluster
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,6 +11,8 @@
     - Use `Readiness` and `Liveness` probes.
     - Updated automatically on Object Store CRD changes.
 
+- Added the dashboard `port` configuration setting.
+
 ## Breaking Changes
 
 - Rook no longer supports Kubernetes `1.8` and `1.9`.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,6 +12,7 @@
     - Updated automatically on Object Store CRD changes.
 
 - Added the dashboard `port` configuration setting.
+- Added the dashboard `ssl` configuration setting.
 
 ## Breaking Changes
 

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -32,6 +32,10 @@ spec:
                   type: boolean
                 urlPrefix:
                   type: string
+                port:
+                  type: integer
+                  minimum: 0
+                  maximum: 65535
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -181,6 +181,8 @@ spec:
     # urlPrefix: /ceph-dashboard
     # serve the dashboard at the given port.
     # port: 8443
+    # serve the dashboard using SSL
+    # ssl: true
   network:
     # toggle to use hostNetwork
     hostNetwork: false

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -179,6 +179,8 @@ spec:
     enabled: true
     # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
     # urlPrefix: /ceph-dashboard
+    # serve the dashboard at the given port.
+    # port: 8443
   network:
     # toggle to use hostNetwork
     hostNetwork: false

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -36,6 +36,8 @@ spec:
                   type: boolean
                 urlPrefix:
                   type: string
+                port:
+                  type: integer
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -96,6 +96,8 @@ type DashboardSpec struct {
 	UrlPrefix string `json:"urlPrefix,omitempty"`
 	// The dashboard webserver port
 	Port int `json:"port,omitempty"`
+	// Whether SSL should be used
+	SSL *bool `json:"ssl,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -94,6 +94,8 @@ type DashboardSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// A prefix for all URLs to use the dashboard with a reverse proxy
 	UrlPrefix string `json:"urlPrefix,omitempty"`
+	// The dashboard webserver port
+	Port int `json:"port,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -264,6 +265,22 @@ func clusterChanged(oldCluster, newCluster cephv1.ClusterSpec, clusterRef *clust
 
 	if oldCluster.Dashboard.Port != newCluster.Dashboard.Port {
 		logger.Infof("dashboard port has changed from \"%d\" to \"%d\"", oldCluster.Dashboard.Port, newCluster.Dashboard.Port)
+		changeFound = true
+	}
+
+	if (oldCluster.Dashboard.SSL == nil && newCluster.Dashboard.SSL != nil) ||
+		(oldCluster.Dashboard.SSL != nil && newCluster.Dashboard.SSL == nil) ||
+		(oldCluster.Dashboard.SSL != nil && newCluster.Dashboard.SSL != nil &&
+			*oldCluster.Dashboard.SSL != *newCluster.Dashboard.SSL) {
+		oldSSL := "<default>"
+		if oldCluster.Dashboard.SSL != nil {
+			oldSSL = strconv.FormatBool(*oldCluster.Dashboard.SSL)
+		}
+		newSSL := "<default>"
+		if newCluster.Dashboard.SSL != nil {
+			newSSL = strconv.FormatBool(*newCluster.Dashboard.SSL)
+		}
+		logger.Infof("dashboard ssl option has changed from \"%s\" to \"%s\"", oldSSL, newSSL)
 		changeFound = true
 	}
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -262,6 +262,11 @@ func clusterChanged(oldCluster, newCluster cephv1.ClusterSpec, clusterRef *clust
 		changeFound = true
 	}
 
+	if oldCluster.Dashboard.Port != newCluster.Dashboard.Port {
+		logger.Infof("dashboard port has changed from \"%d\" to \"%d\"", oldCluster.Dashboard.Port, newCluster.Dashboard.Port)
+		changeFound = true
+	}
+
 	if oldCluster.Mon.Count != newCluster.Mon.Count {
 		logger.Infof("number of mons have changed from %d to %d. The health check will update the mons...", oldCluster.Mon.Count, newCluster.Mon.Count)
 		clusterRef.mons.MonCountMutex.Lock()

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -103,9 +103,10 @@ func TestStartSecureDashboard(t *testing.T) {
 	dashboardInitWaitTime = 0
 	err := c.configureDashboard(dashboardPortHttp)
 	assert.Nil(t, err)
-	// the dashboard is enabled, then disabled and enabled again to restart it with the cert
-	assert.Equal(t, 2, enables)
-	assert.Equal(t, 1, disables)
+	// the dashboard is enabled, then disabled and enabled again to restart
+	// it with the cert, and another restart when setting the dashboard port
+	assert.Equal(t, 3, enables)
+	assert.Equal(t, 2, disables)
 	assert.Equal(t, 2, moduleRetries)
 
 	svc, err := c.context.Clientset.CoreV1().Services(c.Namespace).Get("rook-ceph-mgr-dashboard", metav1.GetOptions{})
@@ -116,8 +117,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	c.dashboard.Enabled = false
 	err = c.configureDashboard(dashboardPortHttp)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, enables)
-	assert.Equal(t, 2, disables)
+	assert.Equal(t, 3, enables)
+	assert.Equal(t, 3, disables)
 
 	svc, err = c.context.Clientset.CoreV1().Services(c.Namespace).Get("rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	assert.NotNil(t, err)

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -90,9 +90,17 @@ var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
 func (c *Cluster) Start() error {
 	logger.Infof("start running mgr")
 
-	dashboardPort := dashboardPortHttps
-	if c.cephVersion.Name == cephv1.Luminous {
-		dashboardPort = dashboardPortHttp
+	var dashboardPort int
+	if c.dashboard.Port == 0 {
+		// select default ports
+		if c.cephVersion.Name == cephv1.Luminous {
+			dashboardPort = dashboardPortHttp
+		} else {
+			dashboardPort = dashboardPortHttps
+		}
+	} else {
+		// crd validates port >= 0
+		dashboardPort = c.dashboard.Port
 	}
 
 	for i := 0; i < c.Replicas; i++ {


### PR DESCRIPTION
adds support for a dashboard `port` option and `ssl` option.

**Which issue is resolved by this Pull Request:**
Resolves: #2433, maybe #2412