### PR TITLE
ceph: add --force to mgr settings

### DIFF
--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -20,11 +20,11 @@ func MgrDisableModule(context *clusterd.Context, clusterName, name string) error
 
 // MgrSetAllConfig applies a setting for all mgr daemons
 func MgrSetAllConfig(context *clusterd.Context, clusterName, cephVersionName, key, val string) (bool, error) {
-	return MgrSetConfig(context, clusterName, "", cephVersionName, key, val)
+	return MgrSetConfig(context, clusterName, "", cephVersionName, key, val, false)
 }
 
 // MgrSetConfig applies a setting for a single mgr daemon
-func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionName, key, val string) (bool, error) {
+func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionName, key, val string, force bool) (bool, error) {
 	var getArgs, setArgs []string
 	mgrID := fmt.Sprintf("mgr.%s", mgrName)
 	if cephVersionName == cephv1.Luminous || cephVersionName == "" {
@@ -40,6 +40,9 @@ func MgrSetConfig(context *clusterd.Context, clusterName, mgrName, cephVersionNa
 			setArgs = append(setArgs, "config", "rm", mgrID, key)
 		} else {
 			setArgs = append(setArgs, "config", "set", mgrID, key, val)
+		}
+		if force && cephv1.VersionAtLeast(cephVersionName, cephv1.Nautilus) {
+			setArgs = append(setArgs, "--force")
 		}
 	}
 

--- a/pkg/daemon/ceph/mgr/init.go
+++ b/pkg/daemon/ceph/mgr/init.go
@@ -86,7 +86,7 @@ func setServerAddr(context *clusterd.Context, config *Config) error {
 	modules := []string{"prometheus", "dashboard"}
 	for _, module := range modules {
 		settingPath := fmt.Sprintf("mgr/%s/server_addr", module)
-		if _, err := client.MgrSetConfig(context, clusterName, config.Name, config.CephVersionName, settingPath, config.ModuleServerAddr); err != nil {
+		if _, err := client.MgrSetConfig(context, clusterName, config.Name, config.CephVersionName, settingPath, config.ModuleServerAddr, true); err != nil {
 			return fmt.Errorf("setting %s server_addr failed. %+v", module, err)
 		}
 	}


### PR DESCRIPTION
This patch fixes an issue I was seeing when starting the mgr with recently-built nautilus ceph-container images. Apparently until the mgr is started, you need to add in --force when setting these values.

This fixes the problem for me, but I'm now wondering whether we need to exclude this flag on ceph versions =< mimic.