### PR TITLE
ceph: remove mon_max_pg_per_osd setting from cfg

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,8 @@
     - Now have an additional label named `objectstore` with the name of the Object Store, to allow better selection for Services.
     - Use `Readiness` and `Liveness` probes.
     - Updated automatically on Object Store CRD changes.
+- Ceph:
+    - `mon_max_pgs_per_osd` is risky for Rook to set by default and has been removed from the Ceph config
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -42,6 +42,7 @@ const (
 
 // GlobalConfig represents the [global] sections of Ceph's config file.
 type GlobalConfig struct {
+	// mon_max_pg_per_osd setting is potentially dangerous; do not include here
 	EnableExperimental       string `ini:"enable experimental unrecoverable data corrupting features,omitempty"`
 	FSID                     string `ini:"fsid,omitempty"`
 	RunDir                   string `ini:"run dir,omitempty"`
@@ -55,7 +56,6 @@ type GlobalConfig struct {
 	ClusterNetwork           string `ini:"cluster network,omitempty"`
 	MonKeyValueDb            string `ini:"mon keyvaluedb"`
 	MonAllowPoolDelete       bool   `ini:"mon_allow_pool_delete"`
-	MaxPgsPerOsd             int    `ini:"mon_max_pg_per_osd"`
 	DebugLogDefaultLevel     int    `ini:"debug default"`
 	DebugLogRadosLevel       int    `ini:"debug rados"`
 	DebugLogMonLevel         int    `ini:"debug mon"`
@@ -209,7 +209,6 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 			ClusterNetwork:         context.NetworkInfo.ClusterNetwork,
 			MonKeyValueDb:          "rocksdb",
 			MonAllowPoolDelete:     true,
-			MaxPgsPerOsd:           1000,
 			DebugLogDefaultLevel:   cephLogLevel,
 			DebugLogRadosLevel:     cephLogLevel,
 			DebugLogMonLevel:       cephLogLevel,


### PR DESCRIPTION
This setting is potentially dangerous, as it could hide misconfiguration
errors from users.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
