### PR TITLE
Backport: Fix for enabling tls on rados gateway s3 api:

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -25,7 +25,7 @@ import (
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -164,11 +164,6 @@ func (c *config) makeConfigInitContainer() v1.Container {
 	}
 
 	if c.store.Spec.Gateway.SSLCertificateRef != "" {
-		// Add a volume mount for the ssl certificate
-		mount := v1.VolumeMount{Name: certVolumeName, MountPath: certMountPath, ReadOnly: true}
-		container.VolumeMounts = append(container.VolumeMounts, mount)
-
-		// Pass the flag for using the ssl cert
 		path := path.Join(certMountPath, certFilename)
 		container.Args = append(container.Args, fmt.Sprintf("--rgw-cert=%s", path))
 	}
@@ -193,6 +188,12 @@ func (c *config) makeDaemonContainer() v1.Container {
 		VolumeMounts: opspec.CephVolumeMounts(),
 		Env:          k8sutil.ClusterDaemonEnvVars(),
 		Resources:    c.store.Spec.Gateway.Resources,
+	}
+
+	if c.store.Spec.Gateway.SSLCertificateRef != "" {
+		// Add a volume mount for the ssl certificate
+		mount := v1.VolumeMount{Name: certVolumeName, MountPath: certMountPath, ReadOnly: true}
+		container.VolumeMounts = append(container.VolumeMounts, mount)
 	}
 
 	return container


### PR DESCRIPTION
this mounts secret as volume to rgw container
this adds certificate path to init container

Signed-off-by: Jack Lauritsen <jack.lauritsen@teradata.com>
(cherry picked from commit ea3e0fca26acf1578bf5e6b0dc4b67a1f94bae1c)

**Description of your changes:**
when CephObjectStore has a value for sslCertificateRef, this mounts secret as volume to rgw container and retains the certificate path for the init-container.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/2435

**Checklist:**
- [X] Documentation has been updated, if necessary.
        not required, not changes from expected functionality
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
        not required previous release does not call out any issue with tls on s3
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)