### PR TITLE
added support for edgefs-monitoring via Prometheus

### DIFF
--- a/Documentation/edgefs-monitoring.md
+++ b/Documentation/edgefs-monitoring.md
@@ -1,0 +1,89 @@
+---
+title: Monitoring
+weight: 48
+indent: true
+---
+
+# Monitoring
+
+Each Rook EdgeFS cluster has some built in metrics collectors/exporters for monitoring with [Prometheus](https://prometheus.io/).
+If you do not have Prometheus running, follow the steps below to enable monitoring of Rook. If your cluster already
+contains a Prometheus instance, it will automatically discover Rooks scrape endpoint using the standard
+`prometheus.io/scrape` and `prometheus.io/port` annotations.
+
+
+## Prometheus Operator
+
+First the Prometheus operator needs to be started in the cluster so it can watch for our requests to start monitoring Rook and respond by deploying the correct Prometheus pods and configuration.
+A full explanation can be found in the [Prometheus operator repository on GitHub](https://github.com/coreos/prometheus-operator), but the quick instructions can be found here:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.27.0/bundle.yaml
+```
+This will start the Prometheus operator, but before moving on, wait until the operator is in the `Running` state:
+```bash
+kubectl get pod
+```
+Once the Prometheus operator is in the `Running` state, proceed to the next section.
+
+## Prometheus Instances
+
+With the Prometheus operator running, we can create a service monitor that will watch the Rook cluster and collect metrics regularly.
+From the root of your locally cloned Rook repo, go the monitoring directory:
+```bash
+cd cluster/examples/kubernetes/edgefs/monitoring
+```
+
+Create the service monitor as well as the Prometheus server pod and service:
+```bash
+kubectl create -f service-monitor.yaml
+kubectl create -f prometheus.yaml
+kubectl create -f prometheus-service.yaml
+```
+
+Ensure that the Prometheus server pod gets created and advances to the `Running` state before moving on:
+```bash
+kubectl -n rook-edgefs get pod prometheus-rook-prometheus-0
+```
+
+## Prometheus Web Console
+
+Once the Prometheus server is running, you can open a web browser and go to the URL that is output from this command:
+```bash
+echo "http://$(kubectl -n rook-edgefs -o jsonpath={.status.hostIP} get pod prometheus-rook-prometheus-0):30900"
+```
+
+You should now see the Prometheus monitoring website.
+
+![Prometheus Monitoring Website](media/prometheus-monitor.png)
+
+
+Click on `Graph` in the top navigation bar.
+
+![Prometheus Add graph](media/prometheus-graph.png)
+
+
+In the dropdown that says `insert metric at cursor`, select any metric you would like to see, for example `nedge_cluster_objects`.
+Below the `Execute` button, ensure the `Graph` tab is selected and you should now see a graph of your chosen metric over time.
+
+
+## Prometheus Consoles
+A guide to how you can write your own Prometheus consoles can be found on the official Prometheus site here: https://prometheus.io/docs/visualization/consoles/.
+
+## Grafana Dashboards
+For feedback on the dashboards please reach out to him on the [Rook.io Slack](https://slack.rook.io).
+
+> **NOTE** The dashboard only compatible with Grafana 5.0.3 or higher.
+
+The following Grafana dashboard is available:
+* [EdgeFS Cluster](https://grafana.com/dashboards/9683)
+
+## Teardown
+
+To clean up all the artifacts created by the monitoring walkthrough, copy/paste the entire block below (note that errors about resources "not found" can be ignored):
+```bash
+kubectl delete -f service-monitor.yaml
+kubectl delete -f prometheus.yaml
+kubectl delete -f prometheus-service.yaml
+kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.27.0/bundle.yaml
+```
+Then the rest of the instructions in the [Prometheus Operator docs](https://github.com/coreos/prometheus-operator#removal) can be followed to finish cleaning up.

--- a/cluster/examples/kubernetes/edgefs/monitoring/prometheus-service.yaml
+++ b/cluster/examples/kubernetes/edgefs/monitoring/prometheus-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rook-prometheus
+  namespace: rook-edgefs
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30900
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    prometheus: rook-prometheus

--- a/cluster/examples/kubernetes/edgefs/monitoring/prometheus.yaml
+++ b/cluster/examples/kubernetes/edgefs/monitoring/prometheus.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: rook-edgefs
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+  namespace: rook-edgefs
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+  namespace: rook-edgefs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: rook-edgefs
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: rook-prometheus
+  namespace: rook-edgefs
+  labels:
+    prometheus: rook-prometheus
+spec:
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      team: rook
+  resources:
+    requests:
+      memory: 400Mi

--- a/cluster/examples/kubernetes/edgefs/monitoring/service-monitor.yaml
+++ b/cluster/examples/kubernetes/edgefs/monitoring/service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rook-edgefs-mgr
+  namespace: rook-edgefs
+  labels:
+    team: rook
+spec:
+  namespaceSelector:
+    matchNames:
+      - rook-edgefs
+  selector:
+    matchLabels:
+      app: rook-edgefs-mgr
+      rook_cluster: rook-edgefs
+  endpoints:
+  - port: http-metrics
+    path: /metrics
+    interval: 5s

--- a/pkg/operator/edgefs/cluster/mgr/mgr_test.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr_test.go
@@ -87,9 +87,10 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, 1, len(d.Spec.Template.Spec.Volumes))
 
 	//check ports
-	assert.Equal(t, 2, len(d.Spec.Template.Spec.Containers[0].Ports))
-	assert.Equal(t, int32(6789), d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
-	assert.Equal(t, int32(8881), d.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort)
+	assert.Equal(t, 3, len(d.Spec.Template.Spec.Containers[0].Ports))
+	assert.Equal(t, int32(8881), d.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+	assert.Equal(t, int32(8080), d.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort)
+	assert.Equal(t, int32(4443), d.Spec.Template.Spec.Containers[0].Ports[2].ContainerPort)
 
 	assert.Equal(t, "edgefs-datadir", d.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(t, "mgr-a", d.ObjectMeta.Name)
@@ -116,7 +117,7 @@ func TestServiceSpec(t *testing.T) {
 	s := c.makeMgrService("rook-edgefs-mgr")
 	assert.NotNil(t, s)
 	assert.Equal(t, "rook-edgefs-mgr", s.Name)
-	assert.Equal(t, 2, len(s.Spec.Ports))
+	assert.Equal(t, 4, len(s.Spec.Ports))
 }
 
 func TestHostNetwork(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Dmitry Yusupov <dmitry.yusupov@nexenta.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This enables automatic prometheus scarping and fixes /metrics access. It also adds documentation on how to get it all configured. 

**Which issue is resolved by this Pull Request:**
Resolves #2401 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
