### PR TITLE
fix operator app label

### DIFF
--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -33,7 +33,7 @@ Kubernetes status is the first line of investigating when something goes wrong w
   - `kubectl get pod -n rook-ceph -o wide`
   - `kubectl get pod -n rook-ceph-system -o wide`
 - Logs for Rook pods
-  - Logs for the operator: `kubectl logs -n rook-ceph-system -l app=rook-operator`
+  - Logs for the operator: `kubectl logs -n rook-ceph-system -l app=rook-ceph-operator`
   - Logs for a specific pod: `kubectl logs -n rook-ceph <pod-name>`, or a pod using a label such as mon1: `kubectl logs -n rook-ceph -l mon=rook-ceph-mon1`
   - Logs on a specific node to find why a PVC is failing to mount:
     - Rook agent errors around the attach/detach: `kubectl logs -n rook-ceph-system <rook-ceph-agent-pod>`


### PR DESCRIPTION
**Description of your changes:**

In our 0.9 rook deployment, the `app` label assigned to the operator is `rook-ceph-operator` which was incorrectly speficied in the documentation:

```
$ kubectl describe pod/rook-ceph-operator-765bcd58b-6rr2q | grep app=
Labels:             app=rook-ceph-operator
```

Here's where the app label is defined:

https://github.com/rook/rook/blob/84ad5afb6b7cfd0028853568519ce4ecf491b561/cluster/charts/rook-ceph/templates/deployment.yaml#L17

**Which issue is resolved by this Pull Request:**

I didn't bother opening an issue for such a minor problem.

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary. (N/A)
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary. (N/A)
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary. (N/A)
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]