### PR TITLE
Backport: Set mgr privs for access to the rbd mirroring settings

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -112,7 +112,7 @@ func (c *Cluster) Start() error {
 		daemonName := mgrNames[i]
 		resourceName := fmt.Sprintf("%s-%s", appName, daemonName)
 		username := fmt.Sprintf("mgr.%s", daemonName)
-		access := []string{"mon", "allow profile mgr", "mds", "allow *", "osd", "allow *"}
+		access := []string{"mon", "allow *", "mds", "allow *", "osd", "allow *"}
 		cfg := opspec.KeyringConfig{Namespace: c.Namespace, ResourceName: resourceName, DaemonName: daemonName, OwnerRef: c.ownerRef, Username: username, Access: access}
 		if err := opspec.CreateKeyring(c.context, cfg); err != nil {
 			return fmt.Errorf("failed to create %s keyring. %+v", resourceName, err)


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>
(cherry picked from commit 9afbe36ae698787245ad2eaa61bf923fc5c74047)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport the change to the mgr privileges to prevent the dashboard from crashing.

**Which issue is resolved by this Pull Request:**
Resolves #2404 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]