### PR TITLE
Set objectstore type properly in ceph.conf

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -135,6 +135,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 	configEnvVars := append(c.getConfigEnvVars(storeConfig, dataDir, nodeName, location), []v1.EnvVar{
 		tiniEnvVar,
 		{Name: "ROOK_OSD_ID", Value: osdID},
+		{Name: "ROOK_OSD_STORE_TYPE", Value: storeType},
 	}...)
 
 	if !osd.IsDirectory {


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
(Replaces #2539 due to CI issues)
The osd objectstore setting is always showing as filestore in the ceph.conf in osd pods, even if the osd has been configured for bluestore. This may not actually have any side effects, but this will ensure that the correct setting is in the conf file.

Which issue is resolved by this Pull Request:
Related to #2536

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]