### PR TITLE
Set fsgroup on the top level of the mount

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -53,6 +53,7 @@ type AttachOptions struct {
 	MountSecret      string `json:"mountSecret"`
 	RW               string `json:"kubernetes.io/readwrite"`
 	FsType           string `json:"kubernetes.io/fsType"`
+	FsGroup          string `json:"kubernetes.io/fsGroup"`
 	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"` // only available on 1.7
 	Pod              string `json:"kubernetes.io/pod.name"`
 	PodID            string `json:"kubernetes.io/pod.uid"`


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With #2540 we have the ability to disable setting the fsGroup on K8s 1.13 and newer. This is particularly needed when there are large volumes that will take time to recursively set on all files. This PR revives #2259 to still set the fsGroup on the top level of the mount.

**Which issue is resolved by this Pull Request:**
Resolves #2254

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
