### PR TITLE
ceph: no longer create fallback osd

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,6 +22,10 @@
 
 - Rook no longer supports Kubernetes `1.8` and `1.9`.
 
+### Ceph
+- Rook will no longer create a directory-based osd in the `dataDirHostPath` if no directories or
+  devices are specified or if there are no disks on the host.
+
 ## Known Issues
 
 

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -166,7 +166,7 @@ spec:
     # After nautilus is released, Rook will be updated to support nautilus.
     # Do not set to true in production.
     allowUnsupported: false
-  # The path on the host where configuration files will be persisted. If not specified, a kubernetes emptyDir will be created (not recommended).
+  # The path on the host where configuration files will be persisted. Must be specified.
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
   dataDirHostPath: /var/lib/rook
@@ -237,8 +237,10 @@ spec:
       journalSizeMB: "1024"  # this value can be removed for environments with normal sized disks (20 GB or larger)
       osdsPerDevice: "1" # this value can be overridden at the node or device level
 # Cluster level list of directories to use for storage. These values will be set for all nodes that have no `directories` set.
-#    directories:
-#    - path: /rook/storage-dir
+    directories:
+    # By default create a osd in the dataDirHostPath directory. This should be removed for
+    # environments where nodes have disks available for Rook to use.
+    - path: /var/lib/rook
 # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
 # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
 #    nodes:

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -90,11 +90,10 @@ func TestGetDataDirs(t *testing.T) {
 	assert.Equal(t, 0, len(dirMap))
 	assert.Equal(t, 0, len(removedDirMap))
 
-	// user has no devices specified, should return default dir
+	// user has no devices specified, should NO LONGER return default dir
 	dirMap, removedDirMap, err = getDataDirs(context, kv, "", false, nodeName)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(dirMap))
-	assert.Equal(t, unassignedOSDID, dirMap[context.ConfigDir])
+	assert.Equal(t, 0, len(dirMap))
 	assert.Equal(t, 0, len(removedDirMap))
 
 	// user has no devices specified but does specify dirs, those should be returned

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -539,16 +539,5 @@ func (c *Cluster) resolveNode(nodeName string) *rookalpha.Node {
 	}
 	rookNode.Resources = k8sutil.MergeResourceRequirements(rookNode.Resources, c.resources)
 
-	// ensure no invalid dirs are specified
-	var validDirs []rookalpha.Directory
-	for _, dir := range rookNode.Directories {
-		if dir.Path == k8sutil.DataDir || dir.Path == c.dataDirHostPath {
-			logger.Warningf("skipping directory %s that would conflict with the dataDirHostPath", dir.Path)
-			continue
-		}
-		validDirs = append(validDirs, dir)
-	}
-	rookNode.Directories = validDirs
-
 	return rookNode
 }

--- a/pkg/operator/k8sutil/volume_test.go
+++ b/pkg/operator/k8sutil/volume_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package k8sutil for Kubernetes helpers.
+package k8sutil
+
+import "testing"
+
+func TestPathToVolumeName(t *testing.T) {
+	tests := []struct {
+		name string // test name
+		path string // argument
+		want string
+	}{
+		{"simple", "simple", "simple"},
+		{"preceding slash", "/preceding", "preceding"},
+		{"trailing slash", "trailing/", "trailing"},
+		{"convert to lower case", "ASDFGHJKLQWERTYUIOPZXCVBNM", "asdfghjklqwertyuiopzxcvbnm"},
+		{"preserve nums", "0123456789", "0123456789"},
+		{"preserve lower case", "qwertyuiopasdfghjklzxcvbnm", "qwertyuiopasdfghjklzxcvbnm"},
+		{"convert any non-lower-case-alphanum symbols to dash",
+			"a/.;,=[]_~!@`#$%^&*()_+-<>?:\"\\'|}{z", // symbols on U.S. keyboard
+			"a---------------------------------z"},
+		{"various currency symbols", // only those written left-to-right
+			"z£¢©®™¥€§฿₽₨₱¤₡₫ƒ₲₴₭č₾֏₣лвдине₤₺₼₥₦₱៛₹₪৳₸₩ła",
+			"z------------------------------------------a"},
+		{"full-width symbols", "q￠￥￦℃℉p", "q-----p"}, // only those written left-to-right
+		{"longer than 63 chars", // if you change the arg string, the hash on the end will change
+			"/this/is/some-path/.that/is_longer/than/$63/chars/1234567890/and/i'm/still/typing",
+			"this-is-some-path--that-i---7890-and-i-m-still-typing-c4132749"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PathToVolumeName(tt.path); got != tt.want {
+				t.Errorf("PathToVolumeName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -661,6 +661,8 @@ spec:
   storage:
     useAllNodes: true
     useAllDevices: ` + strconv.FormatBool(settings.UseAllDevices) + `
+    directories:
+    - path: ` + settings.DataDirHostPath + /* simulate legacy fallback osd behavior so existing tests still work */ `
     deviceFilter:
     location:
     config:


### PR DESCRIPTION
Rook's behavior should not be to create a default OSD in dataDirHostPath
when no devices are present on a node. Any preexisting fallback osd
should be kept as long as no dirs or disks have been specified to keep
the legacy behavior for those clusters running with these osds in place.
The legacy deletion behavior is also kept, removing the osd as soon as
any dir or device is specified other than the dataDirHostPath dir.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #2569

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
