### PR TITLE
Ceph Dashboard Documentation: retrieve dashboard password in a cleaner way

### DIFF
--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -46,7 +46,7 @@ After you connect to the dashboard you will need to login for secure access. Roo
 `admin` and generates a secret called `rook-ceph-dashboard-admin-password` in the namespace where rook is running.
 To retrieve the generated password, you can run the following:
 ```
-kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o yaml | grep "password:" | awk '{print $2}' | base64 --decode
+kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['data']['password']}" | base64 --decode && echo
 ```
 
 ## Configure the Dashboard


### PR DESCRIPTION
Update the Ceph dashboard documentation to retrieve dashboard password in a cleaner way

**Which issue is resolved by this Pull Request:**

- no issue created

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]