### PR TITLE
WIP: Ceph: Update mon start and update procedures

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -136,7 +136,6 @@ func (s *Section) Merge(overrides *Section) {
 		// this condition should never exist except in case of some kind of mem corruption
 		logger.Errorf("override config key %s could not be applied. possible struct corruption of overrides: %+v", k, overrides)
 	}
-
 }
 
 // Merge modifies the Config in-place, adding Sections from the overrides config, and overriding


### PR DESCRIPTION
[skip ci]

**Description of your changes:**
Very early work in progress of changes to update the way mons start and update. The major thing is that all mons have their addresses and ids in the `mon_host` list before the first mons are started. Then they are started. This will also necessitate some changes to the logic for mon upgrades, so part of my goal is to clean up the mon init/update code a fair bit and make sure it follows best practices for keeping mons healthy through deployments and upgrades.

**Which issue is resolved by this Pull Request:**
Resolves #2331 
Resolves #2321 

**Manual tests:**
- [ ] Upgrade Rook
- [x] Add mons
- [ ] Remove mons
- [x] Upgrade Ceph
- [ ] Delete operator pod before mons reach quorum
- [ ] Single monitor 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
