### PR TITLE
ceph: check num mon for hostnetworking

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,17 +1,17 @@
 # Major Themes
 
-
 ## Action Required
-
 
 ## Notable Features
 
-### Minio Object Stores:
+### Minio Object Stores
+
     - Now have an additional label named `objectstore` with the name of the Object Store, to allow better selection for Services.
     - Use `Readiness` and `Liveness` probes.
     - Updated automatically on Object Store CRD changes.
 
 ### Ceph
+
 - A `CephNFS` CRD will start NFS daemon(s) for exporting CephFS volumes or RGW buckets. See the [NFS documentation](Documentation/ceph-nfs-crd.md).
 - Selinux labeling for mounts can now be toggled with the [ROOK_ENABLE_SELINUX_RELABELING](https://github.com/rook/rook/issues/2417) environment variable.
 - Recursive chown for mounts can now be toggled with the [ROOK_ENABLE_FSGROUP](https://github.com/rook/rook/issues/2254) environment variable.
@@ -21,12 +21,13 @@
 ## Breaking Changes
 
 - Rook no longer supports Kubernetes `1.8` and `1.9`.
+- Rook no longer supports running more than one monitor on the same node when `hostNetwork` and `allowMultiplePerNode` are `true`.
 
 ### Ceph
+
 - Rook will no longer create a directory-based osd in the `dataDirHostPath` if no directories or
   devices are specified or if there are no disks on the host.
 
 ## Known Issues
-
 
 ## Deprecations


### PR DESCRIPTION
We now refuse to start more than one monitor on the same machine if
hostnetworking is enabled.
Supporting this creates a lot more complexity from the rook side. Also
having 3 monitors running on the same machine is not a production setup.

This means multi-cluster support on the same machine
is not possible anymore when hostnetworking is enabled.

Resolves: https://github.com/rook/rook/issues/2604
Signed-off-by: Sébastien Han <seb@redhat.com>