### PR TITLE
nfs: add watch_urls directive to watch a RADOS object for notifications

### DIFF
--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -84,6 +84,7 @@ RADOS_KV {
 RADOS_URLS {
 	ceph_conf = '` + cephConfigPath + `';
 	userid = ` + userID + `;
+	watch_url = '` + url + `';
 }
 
 %url	` + url + `


### PR DESCRIPTION
Ganesha recently grew the ability to watch a RADOS object for
notifications, which will cue it to reload its configuration. Add the
directive to the RADOS_URLS config block.

Signed-off-by: Jeff Layton <jlayton@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
