### PR TITLE
docs: correct prose in quickstart to match example

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -241,7 +241,7 @@ Create the cluster:
 kubectl create -f cluster.yaml
 ```
 
-Use `kubectl` to list pods in the `rook` namespace. You should be able to see the following pods once they are all running.
+Use `kubectl` to list pods in the `rook-ceph` namespace. You should be able to see the following pods once they are all running.
 The number of osd pods will depend on the number of nodes in the cluster and the number of devices and directories configured.
 
 ```bash


### PR DESCRIPTION
**Description of your changes:**

The namespace referred to by the prose text in the "Create a Rook Cluster" when creating the cluster was incorrect and did not match the example below, which was correct.

[skip ci]