### PR TITLE
WIP: Remove host PID access for OSDs

### DIFF
--- a/Documentation/openshift.md
+++ b/Documentation/openshift.md
@@ -14,7 +14,6 @@ To orchestrate the storage platform, Rook requires the following access in the c
 - Create `hostPath` volumes, for persistence by the Ceph mon and osd pods
 - Run pods in `privileged` mode, for access to `/dev` and `hostPath` volumes
 - Host networking for the Rook agent and clusters that require host networking
-- Ceph OSDs require host PIDs for communication on the same node
 
 ## Security Context Constraints
 
@@ -33,7 +32,7 @@ allowHostDirVolumePlugin: true
 priority:
 allowedCapabilities: []
 allowHostPorts: false
-allowHostPID: true
+allowHostPID: false
 allowHostIPC: false
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []

--- a/Documentation/rbac.md
+++ b/Documentation/rbac.md
@@ -52,7 +52,7 @@ spec:
   - '*'
   allowedCapabilities:
   - '*'
-  hostPID: true
+  hostPID: false
   hostIPC: true
   hostNetwork: false
 ```

--- a/cluster/charts/rook-ceph/templates/psp.yaml
+++ b/cluster/charts/rook-ceph/templates/psp.yaml
@@ -29,7 +29,7 @@ spec:
   - '*'
   allowedCapabilities:
   - '*'
-  hostPID: true
+  hostPID: false
   hostIPC: true
   hostNetwork: true
 {{- end }}

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -9,7 +9,7 @@ allowHostDirVolumePlugin: true
 priority:
 allowedCapabilities: []
 allowHostPorts: false
-allowHostPID: true
+allowHostPID: false
 allowHostIPC: false
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -238,7 +238,6 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 					RestartPolicy:      v1.RestartPolicyAlways,
 					ServiceAccountName: serviceAccountName,
 					HostNetwork:        c.HostNetwork,
-					HostPID:            true,
 					DNSPolicy:          DNSPolicy,
 					InitContainers: []v1.Container{
 						{


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
OSDs have shared the host PID namespace due to concern of an issue that resulted in port exhaustion between osds on the same node. If this is not necessary, we should remove it.

@liewegas @leseb  Is sharing the pid namespace still necessary? This [old issue](https://github.com/ceph/ceph-container/issues/19) isn't clear on whether the underlying issue has been resolved. 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
