### PR TITLE
Base the rook ceph operator on Nautilus

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -19,7 +19,7 @@ include ../image.mk
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
-CEPH_VERSION = v13.2.2-20181023
+CEPH_VERSION = v14.2.0-20190319
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 
 TEMP := $(shell mktemp -d)

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -97,7 +97,6 @@ func TestCreateImage(t *testing.T) {
 	assert.True(t, createCalled)
 	assert.Equal(t, "image1", image.Name)
 	assert.Equal(t, uint64(sizeMB), image.Size)
-	assert.Equal(t, 2, image.Format)
 	createCalled = false
 
 	// (1 MB + 1 byte) --> 2 MB

--- a/tests/framework/clients/nfs.go
+++ b/tests/framework/clients/nfs.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NFSOperation is a wrapper for k8s rook file operations
+type NFSOperation struct {
+	k8sh      *utils.K8sHelper
+	manifests installer.CephManifests
+}
+
+// CreateNFSOperation Constructor to create NFSOperation - client to perform ceph nfs operations on k8s
+func CreateNFSOperation(k8sh *utils.K8sHelper, manifests installer.CephManifests) *NFSOperation {
+	return &NFSOperation{k8sh, manifests}
+}
+
+// Create creates a filesystem in Rook
+func (n *NFSOperation) Create(namespace, name, pool string, daemonCount int) error {
+
+	logger.Infof("creating the NFS daemons via CRD")
+	if err := n.k8sh.ResourceOperation("create", n.manifests.GetNFS(namespace, name, pool, daemonCount)); err != nil {
+		return err
+	}
+
+	logger.Infof("Make sure rook-ceph-nfs pod is running")
+	err := n.k8sh.WaitForLabeledPodsToRun(fmt.Sprintf("ceph_nfs=%s", name), namespace)
+	assert.Nil(n.k8sh.T(), err)
+
+	assert.True(n.k8sh.T(), n.k8sh.CheckPodCountAndState("rook-ceph-nfs", namespace, daemonCount, "Running"),
+		"Make sure all nfs daemon pods are in Running state")
+
+	return nil
+}
+
+// Delete deletes a filesystem in Rook
+func (n *NFSOperation) Delete(namespace, name string) error {
+	options := &metav1.DeleteOptions{}
+	logger.Infof("Deleting nfs %s in namespace %s", name, namespace)
+	err := n.k8sh.RookClientset.CephV1().CephNFSs(namespace).Delete(name, options)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	logger.Infof("Deleted nfs %s in namespace %s", name, namespace)
+	return nil
+}

--- a/tests/framework/clients/test_client.go
+++ b/tests/framework/clients/test_client.go
@@ -32,6 +32,7 @@ var (
 type TestClient struct {
 	BlockClient      *BlockOperation
 	FSClient         *FilesystemOperation
+	NFSClient        *NFSOperation
 	ObjectClient     *ObjectOperation
 	ObjectUserClient *ObjectUserOperation
 	PoolClient       *PoolOperation
@@ -47,6 +48,7 @@ func CreateTestClient(k8sHelper *utils.K8sHelper, manifests installer.CephManife
 	return &TestClient{
 		CreateBlockOperation(k8sHelper, manifests),
 		CreateFilesystemOperation(k8sHelper, manifests),
+		CreateNFSOperation(k8sHelper, manifests),
 		CreateObjectOperation(k8sHelper, manifests),
 		CreateObjectUserOperation(k8sHelper, manifests),
 		CreatePoolOperation(k8sHelper, manifests),

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -63,7 +63,7 @@ type CephInstaller struct {
 	helmHelper       *utils.HelmHelper
 	k8sVersion       string
 	changeHostnames  bool
-	cephVersion      cephv1.CephVersionSpec
+	CephVersion      cephv1.CephVersionSpec
 	T                func() *testing.T
 }
 
@@ -321,8 +321,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 	// Create rook cluster
 	err = h.CreateK8sRookClusterWithHostPathAndDevices(namespace, onamespace, storeType,
 		useDevices, cephv1.MonSpec{Count: mon.Count, AllowMultiplePerNode: mon.AllowMultiplePerNode}, startWithAllNodes,
-		rbdMirrorWorkers,
-		h.cephVersion)
+		rbdMirrorWorkers, h.CephVersion)
 	if err != nil {
 		logger.Errorf("Rook cluster %s not installed, error -> %v", namespace, err)
 		return false, err
@@ -483,7 +482,7 @@ func NewCephInstaller(t func() *testing.T, clientset *kubernetes.Clientset, rook
 		k8shelper:       k8shelp,
 		helmHelper:      utils.NewHelmHelper(Env.Helm),
 		k8sVersion:      version.String(),
-		cephVersion:     cephVersion,
+		CephVersion:     cephVersion,
 		changeHostnames: rookVersion != Version0_9 && k8shelp.VersionAtLeast("v1.13.0"),
 		T:               t,
 	}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -43,8 +43,8 @@ const (
 	luminousTestImage = "ceph/ceph:v12"
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
-	// test with the latest master build until nautilus is released
-	nautilusTestImage = "ceph/daemon-base:latest-master"
+	// test with the latest nautilus build
+	nautilusTestImage = "ceph/ceph:v14.2.0-20190319"
 	helmChartName     = "local/rook-ceph"
 	helmDeployName    = "rook-ceph"
 )

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -43,13 +43,16 @@ const (
 	luminousTestImage = "ceph/ceph:v12"
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
-	helmChartName  = "local/rook-ceph"
-	helmDeployName = "rook-ceph"
+	// test with the latest master build until nautilus is released
+	nautilusTestImage = "ceph/daemon-base:latest-master"
+	helmChartName     = "local/rook-ceph"
+	helmDeployName    = "rook-ceph"
 )
 
 var (
 	LuminousVersion = cephv1.CephVersionSpec{Image: luminousTestImage}
 	MimicVersion    = cephv1.CephVersionSpec{Image: mimicTestImage}
+	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage, AllowUnsupported: true}
 )
 
 // CephInstaller wraps installing and uninstalling rook on a platform

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -37,6 +37,7 @@ type CephManifests interface {
 	GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string
 	GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string
 	GetFilesystem(namepace, name string, activeCount int) string
+	GetNFS(namepace, name, pool string, daemonCount int) string
 	GetObjectStore(namespace, name string, replicaCount, port int) string
 	GetObjectStoreUser(namespace, name string, displayName string, store string) string
 }
@@ -167,6 +168,22 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephnfses.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephNFS
+    listKind: CephNFSList
+    plural: cephnfses
+    singular: cephnfs
+    shortNames:
+    - nfs
+  scope: Namespaced
+  version: v1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -1107,6 +1124,21 @@ spec:
   metadataServer:
     activeCount: ` + strconv.Itoa(activeCount) + `
     activeStandby: true`
+}
+
+// GetFilesystem returns the manifest to create a Rook Ceph NFS resource with the given config.
+func (m *CephManifestsMaster) GetNFS(namespace, name, pool string, count int) string {
+	return `apiVersion: ceph.rook.io/v1
+kind: CephNFS
+metadata:
+  name: ` + name + `
+  namespace: ` + namespace + `
+spec:
+  rados:
+    pool: ` + pool + `
+    namespace: nfs-ns
+  server:
+    active: ` + strconv.Itoa(count)
 }
 
 func (m *CephManifestsMaster) GetObjectStore(namespace, name string, replicaCount, port int) string {

--- a/tests/framework/installer/ceph_manifests_v0.9.go
+++ b/tests/framework/installer/ceph_manifests_v0.9.go
@@ -780,6 +780,10 @@ spec:
     activeStandby: true`
 }
 
+func (m *CephManifestsV0_9) GetNFS(namespace, name, pool string, count int) string {
+	panic("GetNFS not implemented")
+}
+
 func (m *CephManifestsV0_9) GetObjectStore(namespace, name string, replicaCount, port int) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephObjectStore

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -43,9 +43,21 @@ func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	createFilesystemConsumerPod(helper, k8sh, s, namespace, filesystemName)
 	err := writeAndReadToFilesystem(helper, k8sh, s, namespace, filePodName, "test_file")
 	require.Nil(s.T(), err)
+
+	testNFSDaemons(helper, k8sh, s, namespace, filesystemName)
+
 	downscaleMetadataServers(helper, k8sh, s, namespace, filesystemName)
 	cleanupFilesystemConsumer(helper, k8sh, s, namespace, filesystemName, filePodName)
 	cleanupFilesystem(helper, k8sh, s, namespace, filesystemName)
+}
+
+func testNFSDaemons(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
+	name := "my-nfs"
+	err := helper.NFSClient.Create(namespace, name, filesystemName+"-data0", 2)
+	require.Nil(s.T(), err)
+
+	err = helper.NFSClient.Delete(namespace, name)
+	assert.Nil(s.T(), err)
 }
 
 func createFilesystemConsumerPod(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {

--- a/tests/integration/helm_test.go
+++ b/tests/integration/helm_test.go
@@ -80,7 +80,7 @@ func (hs *HelmSuite) TestRookInstallViaHelm() {
 
 // Test BlockCreation on Rook that was installed via Helm
 func (hs *HelmSuite) TestBlockStoreOnRookInstalledViaHelm() {
-	runBlockE2ETestLite(hs.helper, hs.kh, hs.Suite, hs.namespace)
+	runBlockE2ETestLite(hs.helper, hs.kh, hs.Suite, hs.namespace, hs.op.installer.CephVersion)
 }
 
 // Test File System Creation on Rook that was installed via helm

--- a/tests/integration/multi_cluster_test.go
+++ b/tests/integration/multi_cluster_test.go
@@ -102,8 +102,8 @@ func (mrc *MultiClusterDeploySuite) TestInstallingMultipleRookClusters() {
 
 // Test Block Store Creation on multiple rook clusters
 func (mrc *MultiClusterDeploySuite) TestBlockStoreOnMultipleRookCluster() {
-	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1)
-	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2)
+	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, mrc.op.installer.CephVersion)
+	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, mrc.op.installer.CephVersion)
 }
 
 // Test Filesystem Creation on multiple rook clusters

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -70,7 +70,7 @@ func (suite *SmokeSuite) SetupSuite() {
 	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 1
-	suite.op, suite.k8sh = StartTestCluster(suite.T, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.MimicVersion)
+	suite.op, suite.k8sh = StartTestCluster(suite.T, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	suite.helper = clients.CreateTestClient(suite.k8sh, suite.op.installer.Manifests)
 }
 

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -77,7 +77,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	blockName := "block-claim-upgrade"
 	podName := "test-pod-upgrade"
 	logger.Infof("Initializing block before the upgrade")
-	setupBlockLite(s.helper, s.k8sh, s.Suite, s.namespace, poolName, storageClassName, blockName, podName)
+	setupBlockLite(s.helper, s.k8sh, s.Suite, s.namespace, poolName, storageClassName, blockName, podName, s.op.installer.CephVersion)
 	createPodWithBlock(s.helper, s.k8sh, s.Suite, s.namespace, blockName, podName)
 	defer blockTestDataCleanUp(s.helper, s.k8sh, s.namespace, poolName, storageClassName, blockName, podName)
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the v1.0 release we will plan on supporting nautilus. With that in mind, we should start running some integration tests on nautilus. This change moves the SmokeSuite over to nautilus, while also adding a test for starting the ceph nfs daemons with the new crds.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
