### PR TITLE
WIP: ceph osd: ceph-vol activate in init container

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -60,11 +60,6 @@ var filestoreDeviceCmd = &cobra.Command{
 	Short:  "Runs the ceph daemon for a filestore device",
 	Hidden: true,
 }
-var osdStartCmd = &cobra.Command{
-	Use:    "start",
-	Short:  "Starts the osd daemon", // OSDs that were provisioned by ceph-volume
-	Hidden: true,
-}
 var (
 	osdDataDeviceFilter string
 	ownerRefID          string
@@ -101,17 +96,11 @@ func addOSDFlags(command *cobra.Command) {
 	filestoreDeviceCmd.Flags().StringVar(&mountSourcePath, "source-path", "", "the source path of the device to mount")
 	filestoreDeviceCmd.Flags().StringVar(&mountPath, "mount-path", "", "the path where the device should be mounted")
 
-	// flags for running osds that were provisioned by ceph-volume
-	osdStartCmd.Flags().StringVar(&osdStringID, "osd-id", "", "the osd ID")
-	osdStartCmd.Flags().StringVar(&osdUUID, "osd-uuid", "", "the osd UUID")
-	osdStartCmd.Flags().StringVar(&osdStoreType, "osd-store-type", "", "whether the osd is bluestore or filestore")
-
 	// add the subcommands to the parent osd command
 	osdCmd.AddCommand(osdConfigCmd)
 	osdCmd.AddCommand(copyBinariesCmd)
 	osdCmd.AddCommand(provisionCmd)
 	osdCmd.AddCommand(filestoreDeviceCmd)
-	osdCmd.AddCommand(osdStartCmd)
 }
 
 func addOSDConfigFlags(command *cobra.Command) {
@@ -136,30 +125,11 @@ func init() {
 	flags.SetFlagsFromEnv(copyBinariesCmd.Flags(), rook.RookEnvVarPrefix)
 	flags.SetFlagsFromEnv(provisionCmd.Flags(), rook.RookEnvVarPrefix)
 	flags.SetFlagsFromEnv(filestoreDeviceCmd.Flags(), rook.RookEnvVarPrefix)
-	flags.SetFlagsFromEnv(osdStartCmd.Flags(), rook.RookEnvVarPrefix)
 
 	osdConfigCmd.RunE = writeOSDConfig
 	copyBinariesCmd.RunE = copyRookBinaries
 	provisionCmd.RunE = prepareOSD
 	filestoreDeviceCmd.RunE = runFilestoreDeviceOSD
-	osdStartCmd.RunE = startOSD
-}
-
-// Start the osd daemon if provisioned by ceph-volume
-func startOSD(cmd *cobra.Command, args []string) error {
-	required := []string{"osd-id", "osd-uuid", "osd-store-type"}
-	if err := flags.VerifyRequiredFlags(osdStartCmd, required); err != nil {
-		return err
-	}
-
-	commonOSDInit(osdStartCmd)
-
-	context := createContext()
-	err := osddaemon.StartOSD(context, osdStoreType, osdStringID, osdUUID, args)
-	if err != nil {
-		rook.TerminateFatal(err)
-	}
-	return nil
 }
 
 // Start the osd daemon for filestore running on a device

--- a/pkg/operator/ceph/cluster/osd/ceph-volume.go
+++ b/pkg/operator/ceph/cluster/osd/ceph-volume.go
@@ -1,0 +1,64 @@
+package osd
+
+import (
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+)
+
+type spec struct {
+	c      *Cluster
+	sc     *v1.SecurityContext
+	cfgEnv []v1.EnvVar
+}
+
+type cephVolumeSpec struct {
+	*spec
+}
+
+func newSpec(c *Cluster, sc *v1.SecurityContext, configEnvVars []v1.EnvVar) *spec {
+	return &spec{c: c, sc: sc, cfgEnv: configEnvVars}
+}
+
+func (s *spec) CephVolume() *cephVolumeSpec { return &cephVolumeSpec{spec: s} }
+
+func (s *cephVolumeSpec) Containers(
+	storeType, osdID, osdUUID, configPath string,
+	deviceVolumeMount *v1.VolumeMount,
+) (initContainers []v1.Container, runContainers []v1.Container) {
+	storeFlag := "--" + storeType
+	initContainers = []v1.Container{{
+		Args:            []string{"ceph", "osd", "init"},
+		Name:            opspec.ConfigInitContainerName,
+		Image:           k8sutil.MakeRookImage(s.c.rookVersion),
+		VolumeMounts:    opspec.RookVolumeMounts(),
+		Env:             s.cfgEnv,
+		SecurityContext: s.sc,
+	}, {
+		Command:         []string{"ceph-volume", "lvm", "activate"},
+		Args:            []string{"--no-systemd", storeFlag, osdID, osdUUID},
+		Name:            "init-ceph-volume-activate",
+		Image:           s.c.cephVersion.Image,
+		VolumeMounts:    append(opspec.CephVolumeMounts(), *deviceVolumeMount),
+		Env:             k8sutil.ClusterDaemonEnvVars(),
+		Resources:       s.c.resources,
+		SecurityContext: s.sc,
+	}}
+	runContainers = []v1.Container{{
+		Command: []string{"ceph-osd"},
+		Args: []string{
+			"--foreground",
+			"--id", osdID,
+			"--osd-uuid", osdUUID,
+			"--conf", configPath,
+			"--cluster", "ceph",
+		},
+		Name:            "osd",
+		Image:           s.c.cephVersion.Image,
+		VolumeMounts:    append(opspec.CephVolumeMounts(), *deviceVolumeMount),
+		Env:             k8sutil.ClusterDaemonEnvVars(),
+		Resources:       s.c.resources,
+		SecurityContext: s.sc,
+	}}
+	return
+}


### PR DESCRIPTION
Make some small changes to the Ceph osd daemon pod that runs daemons for
ceph-volume-provisioned osds to run the `ceph-volume lvm activate...`
command and `ceph-osd...` command directly from the container
entrypoints. This is one small step in transitioning the OSDs to be
configured as much as possible from the operator.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
