### PR TITLE
nfs: scale up/down ganesha servers with Active count

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -75,3 +75,16 @@ Each daemon will have a stock configuration with no exports defined, and that in
 The pool and namespace are configured via the spec's RADOS block. The nodeid is a value automatically assigned internally by rook. Nodeids start with "a" and go through "z", at which point they become two letters ("aa" to "az").
 
 When a server is started, it will create the included object if it does not already exist. It is possible to prepopulate the included objects prior to starting the server. The format for these objects is documented in the [NFS Ganesha](https://github.com/nfs-ganesha/nfs-ganesha/wiki) project.
+
+## Scaling the active server count
+
+It is possible to scale the size of the cluster up or down by modifying
+the spec.server.active field. Scaling the cluster size up can be done at
+will. Once the new server comes up, clients can be assigned to it
+immediately.
+
+The CRD always eliminates the highest index servers first, in reverse
+order from how they were started. Scaling down the cluster requires that
+clients be migrated from servers that will be eliminated to others. That
+process is currently a manual one and should be performed before
+reducing the size of the cluster.


### PR DESCRIPTION
Rename createCephNFS to upCephNFS and have it take a parameter with the
old active count. Rename deleteGanesha to downCephNFS and have it take a
parameter with the new desired active count. Both the existing callers
pass in "0" for the new count parameters.

Fix up the onUpdate handler for CephNFS objects, such that changes to
the active count are reflected in the number of active servers. Have it
pass in the appropriate values when scaling servers up or down.

Finally, fix downCephNFS to shut down the highest-index servers first
and counting down instead of doing them in the order they were started.
This should eventually allow us more predictable behavior when scaling
down the number of server nodes.

Signed-off-by: Jeff Layton <jlayton@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #2644 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
