### PR TITLE
Fix role issue for election

### DIFF
--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -32,4 +32,12 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - create
+  - update
 {{- end }}


### PR DESCRIPTION
**Description of your changes:**
Operator needs more right to elect the leader.

**Which issue is resolved by this Pull Request:**
Resolves #
E0214 08:23:18.224430       7 leaderelection.go:252] error retrieving resource lock rook-ceph-system/ceph.rook.io-block: endpoints "ceph.rook.io-block" is forbidden: User "system:serviceaccount:rook-ceph-system:rook-ceph-system" cannot get endpoints in the namespace "rook-ceph-system"

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)