### PR TITLE
Convert remaining extensions to apps api

### DIFF
--- a/tests/integration/mon_test.go
+++ b/tests/integration/mon_test.go
@@ -30,7 +30,7 @@ func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Mon Failover Smoke Test")
 
 	opts := metav1.ListOptions{LabelSelector: "app=rook-ceph-mon"}
-	deployments, err := suite.k8sh.Clientset.Extensions().Deployments(suite.namespace).List(opts)
+	deployments, err := suite.k8sh.Clientset.Apps().Deployments(suite.namespace).List(opts)
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), 3, len(deployments.Items))
 
@@ -38,12 +38,12 @@ func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Killing mon %s", monToKill)
 	propagation := metav1.DeletePropagationForeground
 	delOptions := &metav1.DeleteOptions{PropagationPolicy: &propagation}
-	err = suite.k8sh.Clientset.Extensions().Deployments(suite.namespace).Delete(monToKill, delOptions)
+	err = suite.k8sh.Clientset.Apps().Deployments(suite.namespace).Delete(monToKill, delOptions)
 	require.Nil(suite.T(), err)
 
 	// Wait for the health check to start a new monitor
 	for i := 0; i < 10; i++ {
-		deployments, err := suite.k8sh.Clientset.Extensions().Deployments(suite.namespace).List(opts)
+		deployments, err := suite.k8sh.Clientset.Apps().Deployments(suite.namespace).List(opts)
 		require.Nil(suite.T(), err)
 
 		// Make sure the old mon is not still alive


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
There were some lingering changes needed to switch to the apps api from the extensions, a follow up from #2611. This fixes the master build that is modifying the Gopkg.lock file to add back in the extensions which were intended to be removed.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
