### PR TITLE
ceph: enhance server to search for rookflex

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/rpc"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -69,9 +70,7 @@ func NewFlexvolumeServer(context *clusterd.Context, controller *Controller) *Fle
 
 // Start configures the flexvolume driver on the host and starts the unix domain socket server to communicate with the driver
 func (s *FlexvolumeServer) Start(driverVendor, driverName string) error {
-	// first install the flexvolume driver
-	// /usr/local/bin/rookflex
-	driverFile := path.Join(usrBinDir, flexvolumeDriverFileName)
+	driverFile := path.Join(getRookFlexBinaryPath(), flexvolumeDriverFileName)
 	// /flexmnt/rook.io~rook-system
 	flexVolumeDriverDir := fmt.Sprintf(flexMountPath, driverVendor, driverName)
 
@@ -284,4 +283,13 @@ func getFlexDriverInfo(flexDriverPath string) (vendor, driver string, err error)
 	}
 
 	return "", "", fmt.Errorf("failed to find flex driver info from path %s", flexDriverPath)
+}
+
+// getRookFlexBinaryPath returns the path of rook flex volume driver
+func getRookFlexBinaryPath() string {
+	p, err := exec.LookPath(flexvolumeDriverFileName)
+	if err != nil {
+		return usrBinDir
+	}
+	return path.Dir(p)
 }


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This commit enables server to search for `rookflex` binary instead of assuming it to be present in `/usr/local/bin/`.

**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/rook/rook/issues/2486

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]