### PR TITLE
Fix colliding with builtin function

### DIFF
--- a/pkg/operator/cassandra/controller/controller.go
+++ b/pkg/operator/cassandra/controller/controller.go
@@ -280,10 +280,10 @@ func (cc *ClusterController) syncHandler(key string) error {
 
 	logger.Infof("handling cluster object: %+v", spew.Sdump(cluster))
 	// Deepcopy here to ensure nobody messes with the cache.
-	old, new := cluster, cluster.DeepCopy()
+	old, newObj := cluster, cluster.DeepCopy()
 	// If sync was successful and Status has changed, update the Cluster.
-	if err = cc.Sync(new); err == nil && !reflect.DeepEqual(old.Status, new.Status) {
-		err = util.PatchClusterStatus(new, cc.rookClient)
+	if err = cc.Sync(newObj); err == nil && !reflect.DeepEqual(old.Status, newObj.Status) {
+		err = util.PatchClusterStatus(newObj, cc.rookClient)
 	}
 
 	return err

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -123,7 +123,7 @@ func TestClusterChanged(t *testing.T) {
 			},
 		},
 	}
-	new := cephv1.ClusterSpec{
+	newClusterSpec := cephv1.ClusterSpec{
 		Storage: rookalpha.StorageScopeSpec{
 			Nodes: []rookalpha.Node{
 				{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
@@ -132,7 +132,7 @@ func TestClusterChanged(t *testing.T) {
 		},
 	}
 	c := &cluster{Spec: &cephv1.ClusterSpec{}, mons: &mon.Cluster{}}
-	assert.True(t, clusterChanged(old, new, c))
+	assert.True(t, clusterChanged(old, newClusterSpec, c))
 	assert.Equal(t, 0, c.Spec.Mon.Count)
 
 	// a node was removed, should be a change
@@ -140,28 +140,28 @@ func TestClusterChanged(t *testing.T) {
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	new.Storage.Nodes = []rookalpha.Node{
+	newClusterSpec.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.True(t, clusterChanged(old, new, c))
+	assert.True(t, clusterChanged(old, newClusterSpec, c))
 
 	// the nodes being in a different order should not be a change
 	old.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	new.Storage.Nodes = []rookalpha.Node{
+	newClusterSpec.Storage.Nodes = []rookalpha.Node{
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.False(t, clusterChanged(old, new, c))
+	assert.False(t, clusterChanged(old, newClusterSpec, c))
 	assert.Equal(t, 0, c.Spec.Mon.Count)
 
 	// If the number of mons changes, the mon count on the cluster should be updated so the health check can adjust the mons
-	new.Mon.Count = 3
-	new.Mon.AllowMultiplePerNode = true
+	newClusterSpec.Mon.Count = 3
+	newClusterSpec.Mon.AllowMultiplePerNode = true
 	assert.False(t, c.mons.AllowMultiplePerNode)
-	assert.False(t, clusterChanged(old, new, c))
+	assert.False(t, clusterChanged(old, newClusterSpec, c))
 	assert.Equal(t, 3, c.mons.Count)
 	assert.True(t, c.mons.AllowMultiplePerNode)
 }

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -36,16 +36,16 @@ import (
 func TestFilesystemChanged(t *testing.T) {
 	// no change
 	old := cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
-	new := cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
-	changed := filesystemChanged(old, new)
+	newFileSpec := cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
+	changed := filesystemChanged(old, newFileSpec)
 	assert.False(t, changed)
 
 	// changed properties
-	new = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 2, ActiveStandby: true}}
-	assert.True(t, filesystemChanged(old, new))
+	newFileSpec = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 2, ActiveStandby: true}}
+	assert.True(t, filesystemChanged(old, newFileSpec))
 
-	new = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: false}}
-	assert.True(t, filesystemChanged(old, new))
+	newFileSpec = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: false}}
+	assert.True(t, filesystemChanged(old, newFileSpec))
 }
 
 func TestGetFilesystemObject(t *testing.T) {

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -35,25 +35,25 @@ import (
 
 func TestObjectStoreChanged(t *testing.T) {
 	old := cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
-	new := cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	newObjectStoreSpec := cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
 	// nothing changed
-	assert.False(t, storeChanged(old, new))
+	assert.False(t, storeChanged(old, newObjectStoreSpec))
 
 	// there was a change
-	new = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 81, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
-	assert.True(t, storeChanged(old, new))
+	newObjectStoreSpec = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 81, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, newObjectStoreSpec))
 
-	new = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 444, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
-	assert.True(t, storeChanged(old, new))
+	newObjectStoreSpec = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 444, Instances: 1, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, newObjectStoreSpec))
 
-	new = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 2, AllNodes: false, SSLCertificateRef: ""}}
-	assert.True(t, storeChanged(old, new))
+	newObjectStoreSpec = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 2, AllNodes: false, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, newObjectStoreSpec))
 
-	new = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: true, SSLCertificateRef: ""}}
-	assert.True(t, storeChanged(old, new))
+	newObjectStoreSpec = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: true, SSLCertificateRef: ""}}
+	assert.True(t, storeChanged(old, newObjectStoreSpec))
 
-	new = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: "mysecret"}}
-	assert.True(t, storeChanged(old, new))
+	newObjectStoreSpec = cephv1.ObjectStoreSpec{Gateway: cephv1.GatewaySpec{Port: 80, SecurePort: 443, Instances: 1, AllNodes: false, SSLCertificateRef: "mysecret"}}
+	assert.True(t, storeChanged(old, newObjectStoreSpec))
 }
 
 func TestGetObjectStoreObject(t *testing.T) {

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -144,14 +144,14 @@ func TestCreatePool(t *testing.T) {
 func TestUpdatePool(t *testing.T) {
 	// the pool did not change for properties that are updatable
 	old := cephv1.PoolSpec{FailureDomain: "osd", ErasureCoded: cephv1.ErasureCodedSpec{CodingChunks: 2, DataChunks: 2}}
-	new := cephv1.PoolSpec{FailureDomain: "host", ErasureCoded: cephv1.ErasureCodedSpec{CodingChunks: 3, DataChunks: 3}}
-	changed := poolChanged(old, new)
+	newPoolSpec := cephv1.PoolSpec{FailureDomain: "host", ErasureCoded: cephv1.ErasureCodedSpec{CodingChunks: 3, DataChunks: 3}}
+	changed := poolChanged(old, newPoolSpec)
 	assert.False(t, changed)
 
 	// the pool changed for properties that are updatable
 	old = cephv1.PoolSpec{FailureDomain: "osd", Replicated: cephv1.ReplicatedSpec{Size: 1}}
-	new = cephv1.PoolSpec{FailureDomain: "osd", Replicated: cephv1.ReplicatedSpec{Size: 2}}
-	changed = poolChanged(old, new)
+	newPoolSpec = cephv1.PoolSpec{FailureDomain: "osd", Replicated: cephv1.ReplicatedSpec{Size: 2}}
+	changed = poolChanged(old, newPoolSpec)
 	assert.True(t, changed)
 }
 

--- a/pkg/operator/edgefs/cluster/controller_test.go
+++ b/pkg/operator/edgefs/cluster/controller_test.go
@@ -59,7 +59,7 @@ func TestClusterChanged(t *testing.T) {
 			},
 		},
 	}
-	new := edgefsv1alpha1.ClusterSpec{
+	newClusterSpec := edgefsv1alpha1.ClusterSpec{
 		Storage: rookalpha.StorageScopeSpec{
 			Nodes: []rookalpha.Node{
 				{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
@@ -67,28 +67,28 @@ func TestClusterChanged(t *testing.T) {
 			},
 		},
 	}
-	assert.True(t, clusterChanged(old, new))
+	assert.True(t, clusterChanged(old, newClusterSpec))
 
 	// a node was removed, should be a change
 	old.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	new.Storage.Nodes = []rookalpha.Node{
+	newClusterSpec.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.True(t, clusterChanged(old, new))
+	assert.True(t, clusterChanged(old, newClusterSpec))
 
 	// the nodes being in a different order should not be a change
 	old.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	new.Storage.Nodes = []rookalpha.Node{
+	newClusterSpec.Storage.Nodes = []rookalpha.Node{
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.False(t, clusterChanged(old, new))
+	assert.False(t, clusterChanged(old, newClusterSpec))
 }
 
 func TestRemoveFinalizer(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**
Some variable name, function name is colliding with builtin function.
Files changed:

- pkg/operator/ceph/cluster/controller_test.go
- pkg/operator/ceph/file/controller_test.go
- pkg/operator/ceph/object/controller_test.go
- pkg/operator/ceph/pool/controller_test.go
- pkg/operator/edgefs/cluster/controller_test.go

**Which issue is resolved by this Pull Request:**
N/A
