### PR TITLE
#2208 OSDs not automatically started when adding nodes to existing cluster

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -18,6 +18,7 @@
 - Added the dashboard `port` configuration setting.
 - Added the dashboard `ssl` configuration setting.
 - Added Ceph CSI driver deployments on Kubernetes 1.13 and above.
+- New Kubernetes nodes or nodes which are not tainted `NoSchedule` anymore get added automatically to the existing rook cluster if `useAllNodes` is set. [Issue #2208](https://github.com/rook/rook/issues/2208)
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -36,7 +37,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/rbd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	batch "k8s.io/api/batch/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,13 +54,17 @@ var (
 )
 
 type cluster struct {
-	Info      *cephconfig.ClusterInfo
-	context   *clusterd.Context
-	Namespace string
-	Spec      *cephv1.ClusterSpec
-	mons      *mon.Cluster
-	stopCh    chan struct{}
-	ownerRef  metav1.OwnerReference
+	Info                 *cephconfig.ClusterInfo
+	context              *clusterd.Context
+	Namespace            string
+	Spec                 *cephv1.ClusterSpec
+	mons                 *mon.Cluster
+	stopCh               chan struct{}
+	ownerRef             metav1.OwnerReference
+	orchestrationRunning bool
+	orchestrationPending bool
+	orchRunMux           sync.Mutex
+	orchPenMux           sync.Mutex
 }
 
 func newCluster(c *cephv1.CephCluster, context *clusterd.Context) *cluster {
@@ -67,12 +72,14 @@ func newCluster(c *cephv1.CephCluster, context *clusterd.Context) *cluster {
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's
 		// identity can be established.
-		Info:      nil,
-		Namespace: c.Namespace,
-		Spec:      &c.Spec,
-		context:   context,
-		stopCh:    make(chan struct{}),
-		ownerRef:  ClusterOwnerRef(c.Namespace, string(c.UID)),
+		Info:                 nil,
+		Namespace:            c.Namespace,
+		Spec:                 &c.Spec,
+		context:              context,
+		stopCh:               make(chan struct{}),
+		ownerRef:             ClusterOwnerRef(c.Namespace, string(c.UID)),
+		orchestrationRunning: false,
+		orchestrationPending: false,
 	}
 }
 
@@ -133,71 +140,85 @@ func (c *cluster) detectCephMajorVersion(image string, timeout time.Duration) (s
 }
 
 func (c *cluster) createInstance(rookImage string) error {
-
-	// Create a configmap for overriding ceph config settings
-	// These settings should only be modified by a user after they are initialized
-	placeholderConfig := map[string]string{
-		k8sutil.ConfigOverrideVal: "",
-	}
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: k8sutil.ConfigOverrideName,
-		},
-		Data: placeholderConfig,
-	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
-
-	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)
+	if c.checkSetOrchestrationRunning() == true {
+		logger.Debugf("As createInstance is currently running added this request as pending.")
+		c.setOrchestrationPending()
+		return nil
 	}
 
-	// Start the mon pods
-	c.mons = mon.New(c.Info, c.context, c.Namespace,
-		c.Spec.DataDirHostPath, rookImage, c.Spec.CephVersion, c.Spec.Mon,
-		cephv1.GetMonPlacement(c.Spec.Placement), c.Spec.Network.HostNetwork,
-		cephv1.GetMonResources(c.Spec.Resources), c.ownerRef)
-	clusterInfo, err := c.mons.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start the mons. %+v", err)
-	}
-	c.Info = clusterInfo // mons return the cluster's info
+	defer c.unsetOrchestrationRunning()
+	initRun := true
+	for c.checkUnsetOrchestrationPending() == true || initRun == true {
+		initRun = false
+		// Use a DeepCopy of the spec to avoid using an inconsistent data-set
+		spec := c.Spec.DeepCopy()
 
-	// The cluster Identity must be established at this point
-	if !c.Info.IsInitialized() {
-		return fmt.Errorf("the cluster identity was not established: %+v", c.Info)
+		// Create a configmap for overriding ceph config settings
+		// These settings should only be modified by a user after they are initialized
+		placeholderConfig := map[string]string{
+			k8sutil.ConfigOverrideVal: "",
+		}
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: k8sutil.ConfigOverrideName,
+			},
+			Data: placeholderConfig,
+		}
+		k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
+
+		_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
+		if err != nil && !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)
+		}
+
+		// Start the mon pods
+		c.mons = mon.New(c.Info, c.context, c.Namespace,
+			spec.DataDirHostPath, rookImage, spec.CephVersion, spec.Mon,
+			cephv1.GetMonPlacement(spec.Placement), spec.Network.HostNetwork,
+			cephv1.GetMonResources(spec.Resources), c.ownerRef)
+		clusterInfo, err := c.mons.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start the mons. %+v", err)
+		}
+		c.Info = clusterInfo // mons return the cluster's info
+
+		// The cluster Identity must be established at this point
+		if !c.Info.IsInitialized() {
+			return fmt.Errorf("the cluster identity was not established: %+v", c.Info)
+		}
+
+		err = c.createInitialCrushMap()
+		if err != nil {
+			return fmt.Errorf("failed to create initial crushmap: %+v", err)
+		}
+
+		mgrs := mgr.New(c.Info, c.context, c.Namespace, rookImage,
+			spec.CephVersion, cephv1.GetMgrPlacement(spec.Placement), spec.Network.HostNetwork,
+			spec.Dashboard, cephv1.GetMgrResources(spec.Resources), c.ownerRef)
+		err = mgrs.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start the ceph mgr. %+v", err)
+		}
+
+		// Start the OSDs
+		osds := osd.New(c.context, c.Namespace, rookImage, spec.CephVersion, spec.Storage, spec.DataDirHostPath,
+			cephv1.GetOSDPlacement(spec.Placement), spec.Network.HostNetwork, cephv1.GetOSDResources(spec.Resources), c.ownerRef)
+		err = osds.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start the osds. %+v", err)
+		}
+
+		// Start the rbd mirroring daemon(s)
+		rbdmirror := rbd.New(c.Info, c.context, c.Namespace, rookImage, spec.CephVersion, cephv1.GetRBDMirrorPlacement(spec.Placement),
+			spec.Network.HostNetwork, spec.RBDMirroring, cephv1.GetRBDMirrorResources(spec.Resources), c.ownerRef)
+		err = rbdmirror.Start()
+		if err != nil {
+			return fmt.Errorf("failed to start the rbd mirrors. %+v", err)
+		}
+
+		logger.Infof("Done creating rook instance in namespace %s", c.Namespace)
 	}
 
-	err = c.createInitialCrushMap()
-	if err != nil {
-		return fmt.Errorf("failed to create initial crushmap: %+v", err)
-	}
-
-	mgrs := mgr.New(c.Info, c.context, c.Namespace, rookImage,
-		c.Spec.CephVersion, cephv1.GetMgrPlacement(c.Spec.Placement), c.Spec.Network.HostNetwork,
-		c.Spec.Dashboard, cephv1.GetMgrResources(c.Spec.Resources), c.ownerRef)
-	err = mgrs.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start the ceph mgr. %+v", err)
-	}
-
-	// Start the OSDs
-	osds := osd.New(c.context, c.Namespace, rookImage, c.Spec.CephVersion, c.Spec.Storage, c.Spec.DataDirHostPath,
-		cephv1.GetOSDPlacement(c.Spec.Placement), c.Spec.Network.HostNetwork, cephv1.GetOSDResources(c.Spec.Resources), c.ownerRef)
-	err = osds.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start the osds. %+v", err)
-	}
-
-	// Start the rbd mirroring daemon(s)
-	rbdmirror := rbd.New(c.Info, c.context, c.Namespace, rookImage, c.Spec.CephVersion, cephv1.GetRBDMirrorPlacement(c.Spec.Placement),
-		c.Spec.Network.HostNetwork, c.Spec.RBDMirroring, cephv1.GetRBDMirrorResources(c.Spec.Resources), c.ownerRef)
-	err = rbdmirror.Start()
-	if err != nil {
-		return fmt.Errorf("failed to start the rbd mirrors. %+v", err)
-	}
-
-	logger.Infof("Done creating rook instance in namespace %s", c.Namespace)
 	return nil
 }
 
@@ -349,6 +370,52 @@ func versionSupported(version string) bool {
 		if v == version {
 			return true
 		}
+	}
+	return false
+}
+
+func (c *cluster) unsetOrchestrationRunning() {
+	c.orchRunMux.Lock()
+	c.orchestrationRunning = false
+	c.orchRunMux.Unlock()
+}
+
+func (c *cluster) setOrchestrationPending() {
+	c.orchPenMux.Lock()
+	c.orchestrationPending = true
+	c.orchPenMux.Unlock()
+}
+
+func (c *cluster) getOrchestrationRunning() bool {
+	c.orchRunMux.Lock()
+	defer c.orchRunMux.Unlock()
+	return c.orchestrationRunning
+}
+
+func (c *cluster) getOrchestrationPending() bool {
+	c.orchPenMux.Lock()
+	defer c.orchPenMux.Unlock()
+	return c.orchestrationPending
+}
+
+// make checking and setting orchestrationRunning "atomic"
+func (c *cluster) checkSetOrchestrationRunning() bool {
+	defer c.orchRunMux.Unlock()
+	c.orchRunMux.Lock()
+	if c.orchestrationRunning == false {
+		c.orchestrationRunning = true
+		return false
+	}
+	return true
+}
+
+// make checking and unsetting orchestrationPending "atomic"
+func (c *cluster) checkUnsetOrchestrationPending() bool {
+	defer c.orchPenMux.Unlock()
+	c.orchPenMux.Lock()
+	if c.orchestrationPending == true {
+		c.orchestrationPending = false
+		return true
 	}
 	return false
 }

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -143,4 +143,17 @@ func GetNodeHostNames(clientset kubernetes.Interface) (map[string]string, error)
 		nodeMap[node.Name] = node.Labels[apis.LabelHostname]
 	}
 	return nodeMap, nil
+}
+
+// GetNodeSchedulable returns a boolean if the node is tainted as Schedulable or not
+// true -> Node is schedulable
+// false -> Node is unschedulable
+func GetNodeSchedulable(node v1.Node) bool {
+	for i := range node.Spec.Taints {
+		if node.Spec.Taints[i].Effect == "NoSchedule" {
+			logger.Debugf("Node %s is unschedulable", node.Labels[apis.LabelHostname])
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Added an "Informer" to the rook-operator notification loop to get notified when either a new k8s node got added or if the NoSchedule taint got removed from a k8s node. 
Signed-off-by: Stefan Haas <shaas@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #2208 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// build is passing except known CI issues
[skip ci]