### PR TITLE
Clean up provisioning of OSDs on devices

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -245,7 +245,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 		}
 
 		dataDevices = []osddaemon.DesiredDevice{
-			{Name: osdDataDeviceFilter, IsFilter: true},
+			{Name: osdDataDeviceFilter, IsFilter: true, OSDsPerDevice: cfg.storeConfig.OSDsPerDevice},
 		}
 	} else {
 		var err error

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -110,7 +110,7 @@ func formatDevice(context *clusterd.Context, config *osdConfig, forceFormat bool
 	}
 
 	// check if partitions belong to rook
-	ownPartitions, devFS, err := sys.CheckIfDeviceAvailable(context.Executor, dataDetails.Device)
+	_, ownPartitions, devFS, err := sys.CheckIfDeviceAvailable(context.Executor, dataDetails.Device)
 	if err != nil {
 		return nil, fmt.Errorf("failed to format device. %+v", err)
 	}
@@ -170,7 +170,7 @@ func partitionMetadata(context *clusterd.Context, info *config.MetadataDeviceInf
 	}
 
 	// check one last time to make sure it's OK for us to format this metadata device
-	ownPartitions, fs, err := sys.CheckIfDeviceAvailable(context.Executor, info.Device)
+	_, ownPartitions, fs, err := sys.CheckIfDeviceAvailable(context.Executor, info.Device)
 	if err != nil {
 		return fmt.Errorf("failed to get metadata device %s info: %+v", info.Device, err)
 	} else if fs != "" || !ownPartitions {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -76,7 +76,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 
 	batchArgs := append(baseArgs, []string{
 		osdsPerDeviceFlag,
-		strconv.Itoa(a.storeConfig.OSDsPerDevice),
+		sanitizeOSDsPerDevice(a.storeConfig.OSDsPerDevice),
 	}...)
 
 	// ceph-volume is soon implementing a parameter to specify the "fast devices", which correspond to the "metadataDevice" from the
@@ -102,7 +102,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 				immediateExecuteArgs := append(baseArgs, []string{
 					deviceArg,
 					osdsPerDeviceFlag,
-					strconv.Itoa(device.Config.OSDsPerDevice),
+					sanitizeOSDsPerDevice(device.Config.OSDsPerDevice),
 				}...)
 
 				if err := context.Executor.ExecuteCommand(false, "", cephVolumeCmd, immediateExecuteArgs...); err != nil {
@@ -123,6 +123,14 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 
 	return nil
 }
+
+func sanitizeOSDsPerDevice(count int) string {
+	if count < 1 {
+		count = 1
+	}
+	return strconv.Itoa(count)
+}
+
 func getCephVolumeSupported(context *clusterd.Context) (bool, error) {
 	_, err := context.Executor.ExecuteCommandWithOutput(false, "", cephVolumeCmd, "lvm", "batch", "--prepare")
 	if err != nil {

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -107,3 +107,10 @@ func TestParseCephVolumeResult(t *testing.T) {
 	require.NotNil(t, osds)
 	assert.Equal(t, 2, len(osds))
 }
+
+func TestSanitizeOSDsPerDevice(t *testing.T) {
+	assert.Equal(t, "1", sanitizeOSDsPerDevice(-1))
+	assert.Equal(t, "1", sanitizeOSDsPerDevice(0))
+	assert.Equal(t, "1", sanitizeOSDsPerDevice(1))
+	assert.Equal(t, "2", sanitizeOSDsPerDevice(2))
+}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -37,7 +37,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
-	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -412,7 +411,6 @@ func (c *ClusterController) onDelete(obj interface{}) {
 	if clust.Spec.Storage.AnyUseAllDevices() {
 		c.devicesInUse = false
 	}
-	discover.FreeDevicesByCluster(c.context, clust.Namespace)
 }
 
 func (c *ClusterController) handleDelete(cluster *cephv1.CephCluster, retryInterval time.Duration) error {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -76,7 +76,7 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 	return job, nil
 }
 
-func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, selection rookalpha.Selection, resources v1.ResourceRequirements,
+func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection, resources v1.ResourceRequirements,
 	storeConfig config.StoreConfig, metadataDevice, location string, osd OSDInfo) (*apps.Deployment, error) {
 
 	replicaCount := int32(1)

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -86,7 +86,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		ID: 0,
 	}
 
-	deployment, err := c.makeDeployment(n.Name, devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	deployment, err := c.makeDeployment(n.Name, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
 	assert.Equal(t, "rook-ceph-osd-0", deployment.Name)
@@ -165,7 +165,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 		IsDirectory: true,
 		DataPath:    "/my/root/path/osd1",
 	}
-	deployment, err := c.makeDeployment(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	deployment, err := c.makeDeployment(n.Name, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.NotNil(t, deployment)
 	assert.Nil(t, err)
 	// pod spec should have a volume for the given dir in the main container and the init container
@@ -192,7 +192,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 		IsDirectory: true,
 		DataPath:    "/var/lib/rook/osd1",
 	}
-	deployment, err = c.makeDeployment(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	deployment, err = c.makeDeployment(n.Name, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.NotNil(t, deployment)
 	assert.Nil(t, err)
 	// pod spec should have a volume for the given dir in the main container and the init container
@@ -300,7 +300,7 @@ func TestHostNetwork(t *testing.T) {
 	osd := OSDInfo{
 		ID: 0,
 	}
-	r, err := c.makeDeployment(n.Name, n.Devices, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
+	r, err := c.makeDeployment(n.Name, n.Selection, v1.ResourceRequirements{}, config.StoreConfig{}, "", n.Location, osd)
 	assert.NotNil(t, r)
 	assert.Nil(t, err)
 

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"time"
 
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
 	apps "k8s.io/api/apps/v1"
@@ -48,7 +47,6 @@ const (
 )
 
 type provisionConfig struct {
-	devicesToUse  map[string][]rookalpha.Device
 	errorMessages []string
 }
 

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -116,29 +116,4 @@ func TestGetAvailableDevices(t *testing.T) {
 	devices, err = GetAvailableDevices(context, nodeName, ns, d, "^sd.", false)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(devices))
-
-	err = FreeDevices(context, nodeName, ns)
-	assert.Nil(t, err)
-	// all devices freed
-	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(devices))
-	// devices should be in use now, 2nd try gets the same list
-	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "^sd.", false)
-	assert.Nil(t, err)
-	assert.Equal(t, 4, len(devices))
-
-	err = FreeDevices(context, nodeName, ns)
-	assert.Nil(t, err)
-
-	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
-	assert.Nil(t, err)
-	assert.Equal(t, 5, len(devices))
-	// devices should be in use now, 2nd try gets the same list
-	devices, err = GetAvailableDevices(context, nodeName, ns, nil, "", true)
-	assert.Nil(t, err)
-	assert.Equal(t, 5, len(devices))
-
-	err = FreeDevices(context, nodeName, ns)
-	assert.Nil(t, err)
 }

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -28,7 +28,6 @@ import (
 	opkit "github.com/rook/operator-kit"
 	edgefsv1alpha1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/edgefs/iscsi"
 	"github.com/rook/rook/pkg/operator/edgefs/isgw"
 	"github.com/rook/rook/pkg/operator/edgefs/nfs"
@@ -322,7 +321,6 @@ func (c *ClusterController) onDelete(obj interface{}) {
 	if clust.Spec.Storage.AnyUseAllDevices() {
 		c.devicesInUse = false
 	}
-	discover.FreeDevicesByCluster(c.context, clust.Namespace)
 }
 
 func (c *ClusterController) handleDelete(clust *edgefsv1alpha1.Cluster, retryInterval time.Duration) error {

--- a/tests/framework/installer/device.go
+++ b/tests/framework/installer/device.go
@@ -40,7 +40,7 @@ func IsAdditionalDeviceAvailableOnCluster() bool {
 			continue
 		}
 
-		ownPartitions, fs, err := sys.CheckIfDeviceAvailable(executor, device)
+		_, ownPartitions, fs, err := sys.CheckIfDeviceAvailable(executor, device)
 		if err != nil {
 			logger.Warningf("failed to detect device %s availability. %+v", device, err)
 			continue


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
There were several issues around OSDs that this PR will get properly working:
- The `deviceFilter` was not working at all
- All devices detected by the discovery pod were being passed to the OSD provisioning pod, thus not always honoring the desired device list that should be provisioned. Now the provisioning pod will be given the "desired" state from the crd, then apply that state depending on the actual devices detected
- Added a helper to ensure OSDsPerDevice is always valid (default of 1 instead of 0)
- In the rook-ceph-system namespace, two configmaps were being stored: one for the discovered devices, and one for the devices already configured. The latter device list was always storing everything discovered rather than what was configured, so it was broken. For now it is removed. 
  - @jtlayton Is the orchestrator plugin depending on that configmap anywhere currently for the devices in use? The configmap is called `local-device-in-use-cluster-<clusterName>-node-<nodeName>`. The first configmap that is accurate for all devices available is named `local-device-<nodeName>`

**Which issue is resolved by this Pull Request:**
Resolves #2659 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
