### PR TITLE
Remove unreliable string checks from integration tests

### DIFF
--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -64,21 +64,21 @@ func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 
 }
 
-func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode string) (string, error) {
+func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode string) error {
 	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
 }
 
-func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, reclaimPolicy, namespace string, varClusterName bool) (string, error) {
+func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, reclaimPolicy, namespace string, varClusterName bool) error {
 	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, varClusterName))
 }
 
 func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode string) error {
-	_, err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
+	err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
 	return err
 }
 
 func (b *BlockOperation) DeleteStorageClass(poolName, storageClassName, reclaimPolicy, namespace string) error {
-	_, err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
+	err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false))
 	return err
 }
 

--- a/tests/framework/clients/filesystem.go
+++ b/tests/framework/clients/filesystem.go
@@ -41,7 +41,7 @@ func CreateFilesystemOperation(k8sh *utils.K8sHelper, manifests installer.CephMa
 // Create creates a filesystem in Rook
 func (f *FilesystemOperation) Create(name, namespace string) error {
 	logger.Infof("creating the filesystem via CRD")
-	if _, err := f.k8sh.ResourceOperation("create", f.manifests.GetFilesystem(namespace, name, 2)); err != nil {
+	if err := f.k8sh.ResourceOperation("create", f.manifests.GetFilesystem(namespace, name, 2)); err != nil {
 		return err
 	}
 
@@ -58,7 +58,7 @@ func (f *FilesystemOperation) Create(name, namespace string) error {
 // ScaleDown scales down the number of active metadata servers of a filesystem in Rook
 func (f *FilesystemOperation) ScaleDown(name, namespace string) error {
 	logger.Infof("scaling down the number of filesystem active metadata servers via CRD")
-	if _, err := f.k8sh.ResourceOperation("apply", f.manifests.GetFilesystem(namespace, name, 1)); err != nil {
+	if err := f.k8sh.ResourceOperation("apply", f.manifests.GetFilesystem(namespace, name, 1)); err != nil {
 		return err
 	}
 

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -43,7 +43,7 @@ func CreateObjectOperation(k8sh *utils.K8sHelper, manifests installer.CephManife
 func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32) error {
 
 	logger.Infof("creating the object store via CRD")
-	if _, err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStore(namespace, storeName, int(replicaCount), rgwPort)); err != nil {
+	if err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStore(namespace, storeName, int(replicaCount), rgwPort)); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32
 func (o *ObjectOperation) Delete(namespace, storeName string) error {
 
 	logger.Infof("Deleting the object store via CRD")
-	if _, err := o.k8sh.DeleteResource("-n", namespace, "CephObjectStore", storeName); err != nil {
+	if err := o.k8sh.DeleteResource("-n", namespace, "CephObjectStore", storeName); err != nil {
 		return err
 	}
 

--- a/tests/framework/clients/object_user.go
+++ b/tests/framework/clients/object_user.go
@@ -60,7 +60,7 @@ func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, u
 func (o *ObjectUserOperation) Create(namespace string, userid string, displayName string, store string) error {
 
 	logger.Infof("creating the object store user via CRD")
-	if _, err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStoreUser(namespace, userid, displayName, store)); err != nil {
+	if err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStoreUser(namespace, userid, displayName, store)); err != nil {
 		return err
 	}
 	return nil
@@ -69,7 +69,7 @@ func (o *ObjectUserOperation) Create(namespace string, userid string, displayNam
 func (o *ObjectUserOperation) Delete(namespace string, userid string) error {
 
 	logger.Infof("Deleting the object store user via CRD")
-	if _, err := o.k8sh.DeleteResource("-n", namespace, "ObjectStoreUser", userid); err != nil {
+	if err := o.k8sh.DeleteResource("-n", namespace, "ObjectStoreUser", userid); err != nil {
 		return err
 	}
 	return nil

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -39,20 +39,19 @@ func CreatePoolOperation(k8sh *utils.K8sHelper, manifests installer.CephManifest
 	return &PoolOperation{k8sh, manifests}
 }
 
-func (p *PoolOperation) Create(name, namespace string, replicas int) (string, error) {
+func (p *PoolOperation) Create(name, namespace string, replicas int) error {
 	return p.createOrUpdatePool(name, namespace, "create", replicas)
 }
 
 func (p *PoolOperation) Delete(name string, namespace string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolDef(name, namespace, "1"))
-	return err
+	return p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolDef(name, namespace, "1"))
 }
 
-func (p *PoolOperation) Update(name, namespace string, replicas int) (string, error) {
+func (p *PoolOperation) Update(name, namespace string, replicas int) error {
 	return p.createOrUpdatePool(name, namespace, "apply", replicas)
 }
 
-func (p *PoolOperation) createOrUpdatePool(name, namespace, action string, replicas int) (string, error) {
+func (p *PoolOperation) createOrUpdatePool(name, namespace, action string, replicas int) error {
 	return p.k8sh.ResourceOperation(action, p.manifests.GetBlockPoolDef(name, namespace, strconv.Itoa(replicas)))
 }
 
@@ -110,25 +109,25 @@ func (p *PoolOperation) CephPoolExists(namespace, name string) (bool, error) {
 	return false, nil
 }
 
-func (p *PoolOperation) CreateStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) (string, error) {
+func (p *PoolOperation) CreateStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) error {
 	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
 }
 
 func (p *PoolOperation) DeleteStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
+	err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
 	return err
 }
 
 func (p *PoolOperation) DeleteStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
+	err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
 	return err
 }
 
 func (p *PoolOperation) DeletePvc(blockName, storageClassName, mode string) error {
-	_, err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPvcDef(blockName, storageClassName, mode))
+	err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPvcDef(blockName, storageClassName, mode))
 	return err
 }
 
-func (p *PoolOperation) CreateStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) (string, error) {
+func (p *PoolOperation) CreateStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) error {
 	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
 }

--- a/tests/framework/clients/read_write.go
+++ b/tests/framework/clients/read_write.go
@@ -38,7 +38,7 @@ func (f *ReadWriteOperation) CreateWriteClient(volName string) ([]string, error)
 	logger.Infof("creating the filesystem via replication controller")
 	writerSpec := getReplicationController(volName)
 
-	if _, err := f.k8sh.ResourceOperation("create", writerSpec); err != nil {
+	if err := f.k8sh.ResourceOperation("create", writerSpec); err != nil {
 		return nil, err
 	}
 
@@ -54,7 +54,7 @@ func (f *ReadWriteOperation) CreateWriteClient(volName string) ([]string, error)
 }
 
 // Delete Function to delete a nfs consuming pod in rook
-func (f *ReadWriteOperation) Delete() (string, error) {
+func (f *ReadWriteOperation) Delete() error {
 	return f.k8sh.DeleteResource("rc", "read-write-test")
 }
 

--- a/tests/framework/installer/cassandra_installer.go
+++ b/tests/framework/installer/cassandra_installer.go
@@ -18,10 +18,11 @@ package installer
 
 import (
 	"fmt"
+	"testing"
+
 	cassandrav1alpha1 "github.com/rook/rook/pkg/apis/cassandra.rook.io/v1alpha1"
 	"github.com/rook/rook/tests/framework/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 const (
@@ -121,7 +122,7 @@ func (ci *CassandraInstaller) DeleteCassandraCluster(namespace string) {
 
 	// Delete Cassandra Cluster
 	logger.Infof("Uninstalling Cassandra from namespace %s", namespace)
-	_, err := ci.k8sHelper.DeleteResourceAndWait(true, "-n", namespace, cassandraCRD, namespace)
+	err := ci.k8sHelper.DeleteResourceAndWait(true, "-n", namespace, cassandraCRD, namespace)
 	checkError(ci.T(), err, fmt.Sprintf("cannot remove cluster %s", namespace))
 
 	crdCheckerFunc := func() error {
@@ -132,7 +133,7 @@ func (ci *CassandraInstaller) DeleteCassandraCluster(namespace string) {
 
 	// Delete Namespace
 	logger.Infof("Deleting Cassandra Cluster namespace %s", namespace)
-	_, err = ci.k8sHelper.DeleteResourceAndWait(true, "namespace", namespace)
+	err = ci.k8sHelper.DeleteResourceAndWait(true, "namespace", namespace)
 	checkError(ci.T(), err, fmt.Sprintf("cannot delete namespace %s", namespace))
 }
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -353,7 +353,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(helmInstalled bool, systemNa
 		roles := h.Manifests.GetClusterRoles(namespace, systemNamespace)
 		_, err = h.k8shelper.KubectlWithStdin(roles, deleteFromStdinArgs...)
 
-		_, err = h.k8shelper.DeleteResourceAndWait(false, "-n", namespace, "cephcluster", namespace)
+		err = h.k8shelper.DeleteResourceAndWait(false, "-n", namespace, "cephcluster", namespace)
 		checkError(h.T(), err, fmt.Sprintf("cannot remove cluster %s", namespace))
 
 		crdCheckerFunc := func() error {
@@ -363,12 +363,12 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(helmInstalled bool, systemNa
 		err = h.k8shelper.WaitForCustomResourceDeletion(namespace, crdCheckerFunc)
 		checkError(h.T(), err, fmt.Sprintf("failed to wait for crd %s deletion", namespace))
 
-		_, err = h.k8shelper.DeleteResourceAndWait(false, "namespace", namespace)
+		err = h.k8shelper.DeleteResourceAndWait(false, "namespace", namespace)
 		checkError(h.T(), err, fmt.Sprintf("cannot delete namespace %s", namespace))
 	}
 
 	logger.Infof("removing the operator from namespace %s", systemNamespace)
-	_, err = h.k8shelper.DeleteResource(
+	err = h.k8shelper.DeleteResource(
 		"crd",
 		"cephclusters.ceph.rook.io",
 		"cephblockpools.ceph.rook.io",

--- a/tests/framework/installer/cockroachdb_installer.go
+++ b/tests/framework/installer/cockroachdb_installer.go
@@ -121,7 +121,7 @@ func (h *CockroachDBInstaller) CreateCockroachDBCluster(namespace string, count 
 func (h *CockroachDBInstaller) UninstallCockroachDB(systemNamespace, namespace string) {
 	logger.Infof("uninstalling cockroachdb from namespace %s", namespace)
 
-	_, err := h.k8shelper.DeleteResourceAndWait(false, "-n", namespace, "cluster.cockroachdb.rook.io", namespace)
+	err := h.k8shelper.DeleteResourceAndWait(false, "-n", namespace, "cluster.cockroachdb.rook.io", namespace)
 	checkError(h.T(), err, fmt.Sprintf("cannot remove cluster %s", namespace))
 
 	crdCheckerFunc := func() error {
@@ -131,11 +131,11 @@ func (h *CockroachDBInstaller) UninstallCockroachDB(systemNamespace, namespace s
 	err = h.k8shelper.WaitForCustomResourceDeletion(namespace, crdCheckerFunc)
 	checkError(h.T(), err, fmt.Sprintf("failed to wait for crd %s deletion", namespace))
 
-	_, err = h.k8shelper.DeleteResourceAndWait(false, "namespace", namespace)
+	err = h.k8shelper.DeleteResourceAndWait(false, "namespace", namespace)
 	checkError(h.T(), err, fmt.Sprintf("cannot delete namespace %s", namespace))
 
 	logger.Infof("removing the operator from namespace %s", systemNamespace)
-	_, err = h.k8shelper.DeleteResource("crd", "clusters.cockroachdb.rook.io")
+	err = h.k8shelper.DeleteResource("crd", "clusters.cockroachdb.rook.io")
 	checkError(h.T(), err, "cannot delete CRDs")
 
 	cockroachDBOperator := h.manifests.GetCockroachDBOperator(systemNamespace)

--- a/tests/framework/installer/nfs_installer.go
+++ b/tests/framework/installer/nfs_installer.go
@@ -156,19 +156,19 @@ func (h *NFSInstaller) CreateNFSServerVolume(namespace string) error {
 func (h *NFSInstaller) UninstallNFSServer(systemNamespace, namespace string) {
 	logger.Infof("uninstalling nfsserver from namespace %s", namespace)
 
-	_, err := h.k8shelper.DeleteResource("pvc", "nfs-pv-claim")
+	err := h.k8shelper.DeleteResource("pvc", "nfs-pv-claim")
 	checkError(h.T(), err, fmt.Sprintf("cannot remove nfs pvc : nfs-pv-claim"))
 
-	_, err = h.k8shelper.DeleteResource("pvc", "nfs-pv-claim-bigger")
+	err = h.k8shelper.DeleteResource("pvc", "nfs-pv-claim-bigger")
 	checkError(h.T(), err, fmt.Sprintf("cannot remove nfs pvc : nfs-pv-claim-bigger"))
 
-	_, err = h.k8shelper.DeleteResource("pv", "nfs-pv")
+	err = h.k8shelper.DeleteResource("pv", "nfs-pv")
 	checkError(h.T(), err, fmt.Sprintf("cannot remove nfs pv : nfs-pv"))
 
-	_, err = h.k8shelper.DeleteResource("pv", "nfs-pv1")
+	err = h.k8shelper.DeleteResource("pv", "nfs-pv1")
 	checkError(h.T(), err, fmt.Sprintf("cannot remove nfs pv : nfs-pv1"))
 
-	_, err = h.k8shelper.DeleteResource("-n", namespace, "nfsservers.nfs.rook.io", namespace)
+	err = h.k8shelper.DeleteResource("-n", namespace, "nfsservers.nfs.rook.io", namespace)
 	checkError(h.T(), err, fmt.Sprintf("cannot remove nfsserver %s", namespace))
 
 	crdCheckerFunc := func() error {
@@ -178,11 +178,11 @@ func (h *NFSInstaller) UninstallNFSServer(systemNamespace, namespace string) {
 	err = h.k8shelper.WaitForCustomResourceDeletion(namespace, crdCheckerFunc)
 	checkError(h.T(), err, fmt.Sprintf("failed to wait for crd %s deletion", namespace))
 
-	_, err = h.k8shelper.DeleteResource("namespace", namespace)
+	err = h.k8shelper.DeleteResource("namespace", namespace)
 	checkError(h.T(), err, fmt.Sprintf("cannot delete namespace %s", namespace))
 
 	logger.Infof("removing the operator from namespace %s", systemNamespace)
-	_, err = h.k8shelper.DeleteResource("crd", "nfsservers.nfs.rook.io")
+	err = h.k8shelper.DeleteResource("crd", "nfsservers.nfs.rook.io")
 	checkError(h.T(), err, "cannot delete CRDs")
 
 	nfsOperator := h.manifests.GetNFSServerOperator(systemNamespace)

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -56,10 +56,10 @@ func runBlockE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.
 	initBlockImages, _ := helper.BlockClient.List(namespace)
 
 	logger.Infof("step 1: Create block storage")
-	_, cbErr := helper.PoolClient.CreateStorageClassAndPvc(namespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
+	cbErr := helper.PoolClient.CreateStorageClassAndPvc(namespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
 	require.Nil(s.T(), cbErr)
 	require.True(s.T(), retryBlockImageCountCheck(helper, len(initBlockImages), 1, namespace), "Make sure a new block is created")
-	_, cbErr = helper.PoolClient.CreateStorageClassAndPvc(namespace, poolNameRetained, storageClassNameRetained, "Retain", blockNameRetained, "ReadWriteOnce")
+	cbErr = helper.PoolClient.CreateStorageClassAndPvc(namespace, poolNameRetained, storageClassNameRetained, "Retain", blockNameRetained, "ReadWriteOnce")
 	require.Nil(s.T(), cbErr)
 	require.True(s.T(), retryBlockImageCountCheck(helper, len(initBlockImages), 2, namespace), "Make sure another new block is created")
 	logger.Infof("Block Storage created successfully")
@@ -98,15 +98,15 @@ func runBlockE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.
 	logger.Infof("Block Storage successfully fenced")
 
 	logger.Infof("step 8: Delete fenced pod")
-	_, unmtErr := k8sh.DeletePod(k8sutil.DefaultNamespace, otherPod)
+	unmtErr := k8sh.DeletePod(k8sutil.DefaultNamespace, otherPod)
 	require.Nil(s.T(), unmtErr)
 	require.True(s.T(), k8sh.IsPodTerminated(otherPod, defaultNamespace), "make sure block-test2 pod is terminated")
 	logger.Infof("Fenced pod deleted successfully")
 
 	logger.Infof("step 9: Unmount block storage")
-	_, unmtErr = k8sh.DeletePod(k8sutil.DefaultNamespace, podName)
+	unmtErr = k8sh.DeletePod(k8sutil.DefaultNamespace, podName)
 	require.Nil(s.T(), unmtErr)
-	_, unmtErr = k8sh.DeletePod(k8sutil.DefaultNamespace, podNameWithPVRetained)
+	unmtErr = k8sh.DeletePod(k8sutil.DefaultNamespace, podNameWithPVRetained)
 	require.Nil(s.T(), unmtErr)
 	require.True(s.T(), k8sh.IsVolumeResourceAbsent(installer.SystemNamespace(namespace), crdName), fmt.Sprintf("make sure Volume %s is deleted", crdName))
 	require.True(s.T(), k8sh.IsVolumeResourceAbsent(installer.SystemNamespace(namespace), crdNameRetained), fmt.Sprintf("make sure Volume %s is deleted", crdNameRetained))
@@ -200,7 +200,7 @@ func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 
 	logger.Infof("step : Create Pool,StorageClass and PVC")
 
-	res1, err := helper.PoolClient.CreateStorageClassAndPvc(clusterNamespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
+	err = helper.PoolClient.CreateStorageClassAndPvc(clusterNamespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
 	require.NoError(s.T(), err)
 
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, blockName))

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -201,7 +201,6 @@ func setupBlockLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	logger.Infof("step : Create Pool,StorageClass and PVC")
 
 	res1, err := helper.PoolClient.CreateStorageClassAndPvc(clusterNamespace, poolName, storageClassName, "Delete", blockName, "ReadWriteOnce")
-	checkOrderedSubstrings(s.T(), res1, poolName, "created", storageClassName, "created", blockName, "created")
 	require.NoError(s.T(), err)
 
 	require.True(s.T(), k8sh.WaitUntilPVCIsBound(defaultNamespace, blockName))

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -79,7 +79,7 @@ func downscaleMetadataServers(helper *clients.TestClient, k8sh *utils.K8sHelper,
 
 func cleanupFilesystemConsumer(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string, podName string) {
 	logger.Infof("Delete file System consumer")
-	_, err := k8sh.DeletePod(namespace, podName)
+	err := k8sh.DeletePod(namespace, podName)
 	require.Nil(s.T(), err)
 	require.True(s.T(), k8sh.IsPodTerminated(podName, namespace), fmt.Sprintf("make sure %s pod is terminated", podName))
 	logger.Infof("File system consumer deleted")
@@ -88,7 +88,7 @@ func cleanupFilesystemConsumer(helper *clients.TestClient, k8sh *utils.K8sHelper
 // cleanupFilesystem cleans up the filesystem and checks if all mds pods are teminated before continuing
 func cleanupFilesystem(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
 	args := []string{"--grace-period=0", "-n", namespace, "deployment", "-l", fmt.Sprintf("rook_file_system=%s", filesystemName)}
-	_, err := k8sh.DeleteResourceAndWait(false, args...)
+	err := k8sh.DeleteResourceAndWait(false, args...)
 	assert.Nil(s.T(), err, "force and no wait delete of rook file system deployments failed")
 
 	logger.Infof("Deleting file system")
@@ -133,8 +133,7 @@ func podWithFilesystem(
 	driverName := installer.SystemNamespace(namespace)
 	testPodManifest := testPod(podName, namespace, filesystemName, driverName)
 	logger.Infof("creating test pod: %s", testPodManifest)
-	_, err := k8sh.ResourceOperation(action, testPodManifest)
-	if err != nil {
+	if err := k8sh.ResourceOperation(action, testPodManifest); err != nil {
 		return fmt.Errorf("failed to %s pod -- %s. %+v", action, testPodManifest, err)
 	}
 	return nil

--- a/tests/integration/block_create_test.go
+++ b/tests/integration/block_create_test.go
@@ -75,7 +75,6 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, "ReadWriteOnce")
 
 	result, err := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	checkOrderedSubstrings(s.T(), result, "persistentvolumeclaim", claimName, "created")
 	require.NoError(s.T(), err)
 
 	// check status of PVC
@@ -108,11 +107,9 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("create pool and storageclass")
 	result0, err0 := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
-	checkOrderedSubstrings(s.T(), result0, poolName, "created")
 	require.NoError(s.T(), err0)
 
 	result1, err1 := s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
-	checkOrderedSubstrings(s.T(), result1, storageClassName, "created")
 	require.NoError(s.T(), err1)
 
 	logger.Infof("make sure storageclass is created")
@@ -121,7 +118,6 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("create pvc")
 	result2, err2 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	checkOrderedSubstrings(s.T(), result2, claimName, "created")
 	require.NoError(s.T(), err2)
 
 	logger.Infof("check status of PVC")
@@ -133,7 +129,6 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 
 	logger.Infof("Create same pvc again")
 	_, err3 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	checkOrderedSubstrings(s.T(), err3.Error(), claimName, "already exists")
 
 	logger.Infof("check status of PVC")
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
@@ -224,10 +219,8 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	// create pool and storageclass
 	result0, err0 := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
-	checkOrderedSubstrings(s.T(), result0, poolName, "created")
 	require.NoError(s.T(), err0)
 	result1, err1 := s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
-	checkOrderedSubstrings(s.T(), result1, storageClassName, "created")
 	require.NoError(s.T(), err1)
 
 	// make sure storageclass is created
@@ -236,7 +229,6 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 
 	// create pvc
 	result2, err2 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode)
-	checkOrderedSubstrings(s.T(), result2, claimName, "created")
 	require.NoError(s.T(), err2)
 
 	// check status of PVC

--- a/tests/integration/block_create_test.go
+++ b/tests/integration/block_create_test.go
@@ -74,7 +74,7 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	reclaimPolicy := "Delete"
 	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, "ReadWriteOnce")
 
-	result, err := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
+	err := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
 	require.NoError(s.T(), err)
 
 	// check status of PVC
@@ -106,19 +106,19 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	s.testClient.BlockClient.List(s.namespace)
 
 	logger.Infof("create pool and storageclass")
-	result0, err0 := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
-	require.NoError(s.T(), err0)
+	err := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
+	require.NoError(s.T(), err)
 
-	result1, err1 := s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
-	require.NoError(s.T(), err1)
+	err = s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
+	require.NoError(s.T(), err)
 
 	logger.Infof("make sure storageclass is created")
-	err := s.kh.IsStorageClassPresent("rook-ceph-block")
+	err = s.kh.IsStorageClassPresent("rook-ceph-block")
 	require.Nil(s.T(), err)
 
 	logger.Infof("create pvc")
-	result2, err2 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	require.NoError(s.T(), err2)
+	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
+	require.NoError(s.T(), err)
 
 	logger.Infof("check status of PVC")
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
@@ -127,8 +127,9 @@ func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), s.initBlockCount+1, len(b1), "Make sure new block image is created")
 
-	logger.Infof("Create same pvc again")
-	_, err3 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
+	logger.Infof("Create same pvc again and expect an error")
+	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
+	assert.NotNil(s.T(), err)
 
 	logger.Infof("check status of PVC")
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
@@ -150,14 +151,14 @@ func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 	logger.Infof("Test case when block persistent volumes are scaled up and down along with StatefulSet")
 	logger.Info("Step 1: Create pool and storageClass")
 
-	_, cbErr := s.testClient.PoolClient.CreateStorageClass(s.namespace, poolName, storageClassName, reclaimPolicy)
-	assert.Nil(s.T(), cbErr)
+	err := s.testClient.PoolClient.CreateStorageClass(s.namespace, poolName, storageClassName, reclaimPolicy)
+	assert.Nil(s.T(), err)
 	logger.Info("Step 2 : Deploy statefulSet with 1X replication")
 	service, statefulset := getBlockStatefulSetAndServiceDefinition(defaultNamespace, statefulSetName, statefulPodsName, storageClassName)
-	_, err1 := s.kh.Clientset.CoreV1().Services(defaultNamespace).Create(service)
-	_, err2 := s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Create(statefulset)
-	assert.Nil(s.T(), err1)
-	assert.Nil(s.T(), err2)
+	_, err = s.kh.Clientset.CoreV1().Services(defaultNamespace).Create(service)
+	assert.Nil(s.T(), err)
+	_, err = s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Create(statefulset)
+	assert.Nil(s.T(), err)
 	require.True(s.T(), s.kh.CheckPodCountAndState(statefulSetName, defaultNamespace, 1, "Running"))
 	require.True(s.T(), s.kh.CheckPvcCountAndStatus(statefulSetName, defaultNamespace, 1, "Bound"))
 
@@ -176,12 +177,12 @@ func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 	logger.Info("Step 5 : Delete statefulSet")
 	delOpts := metav1.DeleteOptions{}
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + statefulSetName}
-	err1 = s.kh.Clientset.CoreV1().Services(defaultNamespace).Delete(statefulSetName, &delOpts)
-	err2 = s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
-	err3 := s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
-	assert.Nil(s.T(), err1)
-	assert.Nil(s.T(), err2)
-	assert.Nil(s.T(), err3)
+	err = s.kh.Clientset.CoreV1().Services(defaultNamespace).Delete(statefulSetName, &delOpts)
+	assert.Nil(s.T(), err)
+	err = s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
+	assert.Nil(s.T(), err)
+	err = s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
+	assert.Nil(s.T(), err)
 	require.True(s.T(), s.kh.WaitUntilPodWithLabelDeleted(fmt.Sprintf("app=%s", statefulSetName), defaultNamespace))
 	require.True(s.T(), s.kh.CheckPvcCountAndStatus(statefulSetName, defaultNamespace, 2, "Bound"))
 }
@@ -218,18 +219,18 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, pvcAccessMode)
 
 	// create pool and storageclass
-	result0, err0 := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
-	require.NoError(s.T(), err0)
-	result1, err1 := s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
-	require.NoError(s.T(), err1)
+	err := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
+	require.NoError(s.T(), err)
+	err = s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
+	require.NoError(s.T(), err)
 
 	// make sure storageclass is created
-	err := s.kh.IsStorageClassPresent(storageClassName)
+	err = s.kh.IsStorageClassPresent(storageClassName)
 	require.Nil(s.T(), err)
 
 	// create pvc
-	result2, err2 := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode)
-	require.NoError(s.T(), err2)
+	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode)
+	require.NoError(s.T(), err)
 
 	// check status of PVC
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))

--- a/tests/integration/ceph_csi_test.go
+++ b/tests/integration/ceph_csi_test.go
@@ -88,12 +88,10 @@ func createCephCSISecret(helper *clients.TestClient, k8sh *utils.K8sHelper, s su
 }
 
 func createCephPools(helper *clients.TestClient, s suite.Suite, namespace string) {
-	out, err := helper.PoolClient.Create(csiPoolRBD, namespace, 1)
-	logger.Infof("rbd pool create: %+v", out)
+	err := helper.PoolClient.Create(csiPoolRBD, namespace, 1)
 	require.Nil(s.T(), err)
 
-	out, err = helper.PoolClient.Create(csiPoolCephFS, namespace, 1)
-	logger.Infof("cephFS pool create: %+v", out)
+	err = helper.PoolClient.Create(csiPoolCephFS, namespace, 1)
 	require.Nil(s.T(), err)
 }
 
@@ -130,12 +128,10 @@ parameters:
     adminid: admin
     userid: admin
 `
-	out, err := k8sh.ResourceOperation("apply", rbdSC)
-	logger.Infof("create rbd storage class: %v", out)
+	err := k8sh.ResourceOperation("apply", rbdSC)
 	require.Nil(s.T(), err)
 
-	out, err = k8sh.ResourceOperation("apply", cephFSSC)
-	logger.Infof("create cephfs storage class: %v", out)
+	err = k8sh.ResourceOperation("apply", cephFSSC)
 	require.Nil(s.T(), err)
 }
 
@@ -170,7 +166,7 @@ spec:
     imagePullPolicy: IfNotPresent
     env:
     volumeMounts:
-    - mountPath: /test 
+    - mountPath: /test
       name: csivol
   volumes:
   - name: csivol
@@ -179,8 +175,7 @@ spec:
        readOnly: false
   restartPolicy: Never
 `
-	out, err := k8sh.ResourceOperation("create", pod)
-	logger.Infof("create csi rbd test pod: %v", out)
+	err := k8sh.ResourceOperation("create", pod)
 	require.Nil(s.T(), err)
 	isPodRunning := k8sh.IsPodRunning(csiTestRBDPodName, namespace)
 	if !isPodRunning {
@@ -188,7 +183,7 @@ spec:
 		k8sh.PrintPodStatus(namespace)
 	} else {
 		// cleanup the pod and pv
-		_, err = k8sh.ResourceOperation("delete", pod)
+		err = k8sh.ResourceOperation("delete", pod)
 	}
 
 	require.True(s.T(), isPodRunning, "csi rbd test pod fails to run")

--- a/tests/integration/filesystem_mountuser_test.go
+++ b/tests/integration/filesystem_mountuser_test.go
@@ -55,7 +55,7 @@ func runFileMountUserE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, 
 
 func createFilesystemMountCephCredentials(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
 	// Create agent binding for access to Secrets
-	_, err := k8sh.ResourceOperation("apply", getFilesystemAgentMountSecretsBinding(namespace))
+	err := k8sh.ResourceOperation("apply", getFilesystemAgentMountSecretsBinding(namespace))
 	require.Nil(s.T(), err)
 	// Mount CephFS in toolbox and create /foo directory on it
 	logger.Info("Creating /foo directory on CephFS")

--- a/tests/integration/multi_cluster_test.go
+++ b/tests/integration/multi_cluster_test.go
@@ -76,12 +76,12 @@ func (mrc *MultiClusterDeploySuite) createPools() {
 	// create a test pool in each cluster so that we get some PGs
 	poolName := "multi-cluster-pool1"
 	logger.Infof("Creating pool %s", poolName)
-	result, err := mrc.testClient.PoolClient.Create(poolName, mrc.namespace1, 1)
+	err := mrc.testClient.PoolClient.Create(poolName, mrc.namespace1, 1)
 	require.Nil(mrc.T(), err)
 
 	poolName = "multi-cluster-pool2"
 	logger.Infof("Creating pool %s", poolName)
-	result, err = mrc.testClient.PoolClient.Create(poolName, mrc.namespace2, 1)
+	err = mrc.testClient.PoolClient.Create(poolName, mrc.namespace2, 1)
 	require.Nil(mrc.T(), err)
 }
 

--- a/tests/integration/multi_cluster_test.go
+++ b/tests/integration/multi_cluster_test.go
@@ -77,13 +77,11 @@ func (mrc *MultiClusterDeploySuite) createPools() {
 	poolName := "multi-cluster-pool1"
 	logger.Infof("Creating pool %s", poolName)
 	result, err := mrc.testClient.PoolClient.Create(poolName, mrc.namespace1, 1)
-	checkOrderedSubstrings(mrc.T(), result, poolName, "created")
 	require.Nil(mrc.T(), err)
 
 	poolName = "multi-cluster-pool2"
 	logger.Infof("Creating pool %s", poolName)
 	result, err = mrc.testClient.PoolClient.Create(poolName, mrc.namespace2, 1)
-	checkOrderedSubstrings(mrc.T(), result, poolName, "created")
 	require.Nil(mrc.T(), err)
 }
 

--- a/tests/integration/pool_test.go
+++ b/tests/integration/pool_test.go
@@ -28,8 +28,7 @@ func (suite *SmokeSuite) TestPoolResize() {
 	logger.Infof("Pool Resize Smoke Test")
 
 	poolName := "testpool"
-	out, err := suite.helper.PoolClient.Create(poolName, suite.namespace, 1)
-	logger.Infof("poolCreate: %+v", out)
+	err := suite.helper.PoolClient.Create(poolName, suite.namespace, 1)
 	require.Nil(suite.T(), err)
 
 	poolFound := false
@@ -54,8 +53,7 @@ func (suite *SmokeSuite) TestPoolResize() {
 
 	require.Equal(suite.T(), true, poolFound, "pool not found")
 
-	_, err = suite.helper.PoolClient.Update(poolName, suite.namespace, 3)
-	logger.Infof("poolCreate (modify): %+v", out)
+	err = suite.helper.PoolClient.Update(poolName, suite.namespace, 3)
 	require.Nil(suite.T(), err)
 
 	poolFound = false

--- a/tests/integration/smoke_test.go
+++ b/tests/integration/smoke_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package integration
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -104,20 +101,4 @@ func (suite *SmokeSuite) TestObjectStorage_SmokeTest() {
 // Test to make sure all rook components are installed and Running
 func (suite *SmokeSuite) TestRookClusterInstallation_SmokeTest() {
 	checkIfRookClusterIsInstalled(suite.Suite, suite.k8sh, installer.SystemNamespace(suite.namespace), suite.namespace, 3)
-}
-
-func checkOrderedSubstrings(t *testing.T, input string, substrings ...string) {
-	if len(input) == 0 {
-		// Nothing to compare. An error was likely returned, which should be checked elsewhere.
-		return
-	}
-	original := input
-	for i, substring := range substrings {
-		if !strings.Contains(input, substring) {
-			assert.Fail(t, fmt.Sprintf("missing substring %d. original=%s", i, original))
-			return
-		}
-		index := strings.Index(input, substring)
-		input = input[index+len(substring):]
-	}
 }

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -154,22 +154,22 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 func (s *UpgradeSuite) updateClusterRoles() error {
 	systemNamespace := installer.SystemNamespace(s.namespace)
 
-	if _, err := s.k8sh.DeleteResource("ClusterRole", "rook-ceph-global"); err != nil {
+	if err := s.k8sh.DeleteResource("ClusterRole", "rook-ceph-global"); err != nil {
 		return err
 	}
-	if _, err := s.k8sh.DeleteResource("ClusterRole", "rook-ceph-cluster-mgmt"); err != nil {
+	if err := s.k8sh.DeleteResource("ClusterRole", "rook-ceph-cluster-mgmt"); err != nil {
 		return err
 	}
-	if _, err := s.k8sh.DeleteResource("-n", s.namespace, "Role", "rook-ceph-system"); err != nil {
+	if err := s.k8sh.DeleteResource("-n", s.namespace, "Role", "rook-ceph-system"); err != nil {
 		return err
 	}
-	if _, err := s.k8sh.DeleteResource("-n", s.namespace, "Role", "rook-ceph-mgr-system"); err != nil {
+	if err := s.k8sh.DeleteResource("-n", s.namespace, "Role", "rook-ceph-mgr-system"); err != nil {
 		return err
 	}
-	if _, err := s.k8sh.DeleteResource("-n", systemNamespace, "RoleBinding", "rook-ceph-mgr-system"); err != nil {
+	if err := s.k8sh.DeleteResource("-n", systemNamespace, "RoleBinding", "rook-ceph-mgr-system"); err != nil {
 		return err
 	}
-	if _, err := s.k8sh.DeleteResource("-n", s.namespace, "RoleBinding", "rook-ceph-mgr-cluster"); err != nil {
+	if err := s.k8sh.DeleteResource("-n", s.namespace, "RoleBinding", "rook-ceph-mgr-cluster"); err != nil {
 		return err
 	}
 
@@ -369,6 +369,5 @@ subjects:
   namespace: rook-ceph
 `
 	logger.Infof("creating the new resources that have been added since 0.9")
-	_, err := s.k8sh.ResourceOperation("create", newResources)
-	return err
+	return s.k8sh.ResourceOperation("create", newResources)
 }

--- a/tests/integration/zblock_mount_unmount_test.go
+++ b/tests/integration/zblock_mount_unmount_test.go
@@ -99,11 +99,11 @@ func (s *BlockMountUnMountSuite) setupPVCs() {
 	storageClassNameRWO := "rook-ceph-block-rwo"
 
 	// Create PVCs
-	_, cbErr := s.testClient.PoolClient.CreateStorageClassAndPvc(s.namespace, poolNameRWO, storageClassNameRWO, "Delete", s.pvcNameRWO, "ReadWriteOnce")
+	cbErr := s.testClient.PoolClient.CreateStorageClassAndPvc(s.namespace, poolNameRWO, storageClassNameRWO, "Delete", s.pvcNameRWO, "ReadWriteOnce")
 	require.Nil(s.T(), cbErr)
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, s.pvcNameRWO), "Make sure PVC is Bound")
 
-	_, cbErr2 := s.testClient.BlockClient.CreatePvc(s.pvcNameRWX, storageClassNameRWO, "ReadWriteMany")
+	cbErr2 := s.testClient.BlockClient.CreatePvc(s.pvcNameRWX, storageClassNameRWO, "ReadWriteMany")
 	require.Nil(s.T(), cbErr2)
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, s.pvcNameRWX), "Make sure PVC is Bound")
 

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -22,9 +22,9 @@ func createStorageClassAndPool(t func() *testing.T, testClient *clients.TestClie
 	// Create storage class
 	if err := kh.IsStorageClassPresent(storageClassName); err != nil {
 		logger.Infof("Install pool and storage class for rook block")
-		_, err := testClient.PoolClient.Create(poolName, namespace, 3)
+		err := testClient.PoolClient.Create(poolName, namespace, 3)
 		require.NoError(t(), err)
-		_, err = testClient.BlockClient.CreateStorageClass(poolName, storageClassName, "Delete", namespace, false)
+		err = testClient.BlockClient.CreateStorageClass(poolName, storageClassName, "Delete", namespace, false)
 		require.NoError(t(), err)
 
 		// make sure storageclass is created

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -61,7 +61,7 @@ func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 	createStorageClassAndPool(s.T, s.testClient, s.kh, s.namespace, "rook-ceph-block", "rook-pool")
 	if _, err := s.kh.GetPVCStatus(defaultNamespace, "block-pv-one"); err != nil {
 		logger.Infof("Creating PVC and mounting it to pod with readOnly set to false")
-		_, err = s.testClient.BlockClient.CreatePvc("block-pv-one", "rook-ceph-block", "ReadWriteOnce")
+		err = s.testClient.BlockClient.CreatePvc("block-pv-one", "rook-ceph-block", "ReadWriteOnce")
 		require.Nil(s.T(), err)
 		mountUnmountPVCOnPod(s.kh, "block-rw", "block-pv-one", "false", "create")
 		require.True(s.T(), s.kh.IsPodRunning("block-rw", defaultNamespace))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests check for the return of substrings from calls to kubectl in a number of places. On occasion these return something slightly different and cause an unnecessary failure in the integration tests. It is sufficient and complete to check the `err` from these calls to determine failure. There is no need to return strings from create, delete, or apply operations.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
