### PR TITLE
Fix ceph-csi deployment document

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -24,6 +24,8 @@ Here is a guide on how to use Rook to deploy ceph-csi drivers on a Kubernetes cl
 ### Create RBAC used by CSI drivers in the same namespace as Rook Ceph Operator
 
 ```console
+#check if rook-ceph-system namespace is already created, if not create it
+kubectl get ns
 kubectl create namespace rook-ceph-system
 # create rbac. Since rook operator is not permitted to create rbac rules, these rules have to be created outside of operator
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/rbd/


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR removes the namespace creation from the ceph-csi document
and also uses `kubectl create` instead of `kubectl apply`

**Which issue is resolved by this Pull Request:**
Resolves #2710 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]