### PR TITLE
Don't automatically use filestore on systems with all devices absent.

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -132,8 +132,8 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 
 	// determine the set of directories that can/should be used for OSDs, with the default dir if no devices were specified. save off the node's crush name if needed.
 	logger.Infof("devices = %+v", deviceOSDs)
-	devicesConfigured := len(deviceOSDs) > 0
-	dirs, removedDirs, err := getDataDirs(context, agent.kv, agent.directories, devicesConfigured, agent.nodeName)
+	devicesSpecified := len(devices) > 0
+	dirs, removedDirs, err := getDataDirs(context, agent.kv, agent.directories, devicesSpecified, agent.nodeName)
 	if err != nil {
 		return fmt.Errorf("failed to get data dirs. %+v", err)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

On setups where all specified disks are absent, we shouldn't
automatically make use of filestore. It may well be the case that the
disks still need to be installed.

There is already code in place to realise this, except that it checks
the list of OSDs that end up being configured, as opposed to the ones
that are specified in configuration.

**Which issue is resolved by this Pull Request:**
Resolves #1007

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
