### PR TITLE
Retry orchestrator initialization if command is unrecognized

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -42,7 +42,7 @@ const (
 	passwordLength                 = 10
 	passwordKeyName                = "password"
 	certAlreadyConfiguredErrorCode = 5
-	invalidArgErrorCode            = 22
+	invalidArgErrorCode            = int(syscall.EINVAL)
 )
 
 var (


### PR DESCRIPTION
It takes a little time between a mgr module being enabled and its commands being recognized. This adds a retry loop similar to the one in the dashboard setup code so that the orchestrator setup works correctly. There is also a minor cleanup patch to more properly define invalidArgErrorCode in terms of the syscall.EINVAL constant.