### PR TITLE
[WIP] add csi block provisioner

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -86,6 +86,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:94ffc0947c337d618b6ff5ed9abaddc1217b090c1b3a1ae4739b35b7b25851d5"
+  name = "github.com/container-storage-interface/spec"
+  packages = ["lib/go/csi"]
+  pruneopts = "UT"
+  revision = "ed0bb0e1557548aa028307f48728767cfe8f6345"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:50f39e37fd7347733d97e4a88a3d4674ead4abc2eab15b25522f5d9dd5495dd3"
   name = "github.com/coreos/etcd"
   packages = [
@@ -288,14 +296,17 @@
   revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
-  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
+  digest = "1:9cab16c200148edbdc9f314f69bf71987085f618ec107385bd6634be21d1aae8"
   name = "github.com/golang/protobuf"
   packages = [
+    "descriptor",
     "proto",
+    "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
@@ -434,6 +445,38 @@
   pruneopts = "UT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
+
+[[projects]]
+  digest = "1:610f50d23ee3e0fa37d77fc23bf2c3b6897d2dc1c934739f13cdf551e9fc57d9"
+  name = "github.com/kubernetes-csi/csi-lib-utils"
+  packages = ["protosanitizer"]
+  pruneopts = "UT"
+  revision = "1628ab5351eafa4fc89a96862a08a891e601e03a"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:5f8a90bbf7d50b528879e283a77eabde63833f879c07b5e76d081972b3956637"
+  name = "github.com/kubernetes-csi/external-provisioner"
+  packages = [
+    "pkg/controller",
+    "pkg/features",
+  ]
+  pruneopts = "UT"
+  revision = "9a258a0accf64d688f312697db871ceaf42e6478"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:aa5b698b0274a8b8ea3ede91f4f0284ba1b3b2ff9c8525651b9b6857aafdfac1"
+  name = "github.com/kubernetes-csi/external-snapshotter"
+  packages = [
+    "pkg/apis/volumesnapshot/v1alpha1",
+    "pkg/client/clientset/versioned",
+    "pkg/client/clientset/versioned/scheme",
+    "pkg/client/clientset/versioned/typed/volumesnapshot/v1alpha1",
+  ]
+  pruneopts = "UT"
+  revision = "0d2cdd7bde5ea9d41ae47ef4184ca20ebe0435e1"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:87b8c5f48e71daa0fa2e0f1f18fbaafc797bc287f4da3bedc5ed653f3443dc11"
@@ -1260,7 +1303,6 @@
   version = "kubernetes-1.12.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:e79eeb85f6f9636d4a9f1c36f1bdab1b2684db3621d7feea1d087edab281154c"
   name = "k8s.io/csi-api"
   packages = [
@@ -1270,7 +1312,8 @@
     "pkg/client/clientset/versioned/typed/csi/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "102ae30137c98787ea40b5eb9fe236496a2407fd"
+  revision = "504ff913b8b7b6ee9cca269105b6c4a4c7923655"
+  version = "kubernetes-1.13.0-beta.1"
 
 [[projects]]
   branch = "master"
@@ -1285,14 +1328,6 @@
   ]
   pruneopts = "T"
   revision = "f8a0810f38afb8478882b3835a615aebfda39afa"
-
-[[projects]]
-  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
-  name = "k8s.io/klog"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
 
 [[projects]]
   digest = "1:bcd57f8e20b04c39d15eb74dc2708596f7e2b725c1df4282886f5f0f9b8ece18"
@@ -1406,6 +1441,8 @@
     "github.com/google/uuid",
     "github.com/icrowley/fake",
     "github.com/jbw976/go-ps",
+    "github.com/kubernetes-csi/external-provisioner/pkg/controller",
+    "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned",
     "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller",
     "github.com/rook/operator-kit",
     "github.com/spf13/cobra",
@@ -1414,6 +1451,7 @@
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
     "github.com/yanniszark/go-nodetool/nodetool",
+    "google.golang.org/grpc",
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/batch/v1",
@@ -1459,6 +1497,7 @@
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/csi-api/pkg/client/clientset/versioned",
     "k8s.io/kube-controller-manager/config/v1alpha1",
     "k8s.io/kubernetes/pkg/apis/core/v1/helper",
     "k8s.io/kubernetes/pkg/apis/storage/v1/util",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,3 +104,15 @@ ignored = [
 [[override]]
   name = "bitbucket.org/ww/goautoneg"
   source = "github.com/rancher/goautoneg"
+
+[[constraint]]
+  name = "k8s.io/csi-api"
+  version = "kubernetes-1.13.0-beta.1"
+
+[[constraint]]
+  name = "github.com/kubernetes-csi/external-provisioner"
+  version = "1.0.1"
+
+[[constraint]]
+  name = "github.com/kubernetes-csi/external-snapshotter"
+  version = "1.0.1"

--- a/cluster/examples/kubernetes/ceph/csi/example/rbd/pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/example/rbd/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-pvc-csi
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: rook-ceph-csi

--- a/cluster/examples/kubernetes/ceph/csi/example/rbd/rook-storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/example/rbd/rook-storageclass.yaml
@@ -1,0 +1,27 @@
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: rook-ceph-csi
+provisioner: rook-csi-rbdplugin 
+parameters:
+  blockPool: replicapool
+  # Specify the namespace of the rook cluster from which to create volumes.
+  # If not specified, it will use `rook` as the default namespace of the cluster.
+  # This is also the namespace where the cluster will be
+  clusterNamespace: rook-ceph
+  # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
+  fstype: xfs
+  # (Optional) Specify an existing Ceph user that will be used for mounting storage with this StorageClass.
+  #mountUser: user1
+  # (Optional) Specify an existing Kubernetes secret name containing just one key holding the Ceph user secret.
+  # The secret must exist in each namespace(s) where the storage will be consumed.
+  #mountSecret: ceph-user1-secret

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -73,6 +73,37 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      - name: csi-rbdplugin
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        image: quay.io/cephcsi/rbdplugin:v1.0.0
+        args :
+          - "--nodeid=$(NODE_ID)"
+          - "--endpoint=$(CSI_ENDPOINT)"
+          - "--v=5"
+          - "--drivername=rook-csi-rbdplugin"
+          - "--containerized=true"
+          - "--metadatastorage=k8s_configmap"
+        env:
+          - name: HOST_ROOTFS
+            value: "/rootfs" 
+          - name: NODE_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CSI_ENDPOINT
+            value: unix://var/lib/kubelet/plugins/csi-rbdplugin/csi-provisioner.sock
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+          - mountPath: /rootfs
+            name: host-rootfs            
       volumes:
       - name: rook-config
         emptyDir: {}
@@ -84,3 +115,10 @@ spec:
       - name: csi-cephfs-config
         configMap:
           name: csi-cephfs-config
+      - name: host-rootfs
+        hostPath:
+          path: /            
+      - name: socket-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/csi-rbdplugin
+          type: DirectoryOrCreate

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -185,10 +185,11 @@ func createClusterAccessSecret(clientset kubernetes.Interface, namespace string,
 
 	// store the secrets for internal usage of the rook pods
 	secrets := map[string][]byte{
-		clusterSecretName: []byte(clusterInfo.Name),
-		fsidSecretName:    []byte(clusterInfo.FSID),
-		monSecretName:     []byte(clusterInfo.MonitorSecret),
-		adminSecretName:   []byte(clusterInfo.AdminSecret),
+		clusterSecretName:  []byte(clusterInfo.Name),
+		fsidSecretName:     []byte(clusterInfo.FSID),
+		monSecretName:      []byte(clusterInfo.MonitorSecret),
+		adminSecretName:    []byte(clusterInfo.AdminSecret),
+		adminKeySecretName: []byte(clusterInfo.AdminSecret),
 	}
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -59,7 +59,7 @@ const (
 	tprName           = "mon.rook.io"
 	fsidSecretName    = "fsid"
 	monSecretName     = "mon-secret"
-	adminSecretName   = "admin-secret"
+	adminSecretName   = "admin"
 	clusterSecretName = "cluster-name"
 
 	// DefaultMonCount Default mon count for a cluster

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -53,14 +53,16 @@ const (
 	// MappingKey is the name of the mapping for the mon->node and node->port
 	MappingKey = "mapping"
 
-	appName           = "rook-ceph-mon"
-	monNodeAttr       = "mon_node"
-	monClusterAttr    = "mon_cluster"
-	tprName           = "mon.rook.io"
-	fsidSecretName    = "fsid"
-	monSecretName     = "mon-secret"
-	adminSecretName   = "admin"
-	clusterSecretName = "cluster-name"
+	appName         = "rook-ceph-mon"
+	monNodeAttr     = "mon_node"
+	monClusterAttr  = "mon_cluster"
+	tprName         = "mon.rook.io"
+	fsidSecretName  = "fsid"
+	monSecretName   = "mon-secret"
+	adminSecretName = "admin-secret"
+	// use admin as key in the secret
+	adminKeySecretName = "admin"
+	clusterSecretName  = "cluster-name"
 
 	// DefaultMonCount Default mon count for a cluster
 	DefaultMonCount = 3

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -212,7 +212,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 func validateStart(t *testing.T, c *Cluster) {
 	s, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(appName, metav1.GetOptions{})
 	assert.Nil(t, err) // there shouldn't be an error due the secret existing
-	assert.Equal(t, 4, len(s.Data))
+	assert.Equal(t, 5, len(s.Data))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start
 	_, err = c.context.Clientset.Apps().Deployments(c.Namespace).Get("rook-ceph-mon-a", metav1.GetOptions{})

--- a/pkg/operator/ceph/csi/provisioner/controller.go
+++ b/pkg/operator/ceph/csi/provisioner/controller.go
@@ -1,0 +1,123 @@
+/*
+
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+
+	"google.golang.org/grpc"
+
+	"github.com/rook/rook/pkg/clusterd"
+
+	ctrl "github.com/kubernetes-csi/external-provisioner/pkg/controller"
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
+	csiclientset "k8s.io/csi-api/pkg/client/clientset/versioned"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	csiEndpoint            = "/var/lib/kubelet/plugins/csi-rbdplugin/csi-provisioner.sock"
+	connectionTimeout      = 10 * time.Second
+	volumeNamePrefix       = "rook-pvc"
+	volumeNameUUIDLength   = -1
+	enableLeaderElection   = false
+	provisioningRetryCount = 0
+	deletionRetryCount     = 0
+	retryIntervalStart     = time.Second
+	retryIntervalMax       = 5 * time.Minute
+	workerThreads          = 100
+	operationTimeout       = 10 * time.Second
+	version                = "unknown"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "csi")
+
+func NewCSIProvisioner(context *clusterd.Context) *controller.ProvisionController {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Fatalf("Failed to create config: %v", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logger.Fatalf("Failed to create client: %v", err)
+	}
+	// snapclientset.NewForConfig creates a new Clientset for VolumesnapshotV1alpha1Client
+	snapClient, err := snapclientset.NewForConfig(config)
+	if err != nil {
+		logger.Fatalf("Failed to create snapshot client: %v", err)
+	}
+	csiAPIClient, err := csiclientset.NewForConfig(config)
+	if err != nil {
+		logger.Fatalf("Failed to create CSI API client: %v", err)
+	}
+
+	// The controller needs to know what the server version is because out-of-tree
+	// provisioners aren't officially supported until 1.5
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		logger.Fatalf("Error getting server version: %v", err)
+	}
+
+	// Provisioner will stay in Init until driver opens csi socket, once it's done
+	// controller will exit this loop and proceed normally.
+	socketDown := true
+	grpcClient := &grpc.ClientConn{}
+	for socketDown {
+		logger.Infof("connecting to CSI endpoint %s", csiEndpoint)
+		grpcClient, err = ctrl.Connect(csiEndpoint, connectionTimeout)
+		if err == nil {
+			socketDown = false
+			continue
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	// Autodetect provisioner name
+	provisioner, err := ctrl.GetDriverName(grpcClient, connectionTimeout)
+	if err != nil {
+		logger.Fatalf("Error getting CSI driver name: %s", err)
+	}
+	logger.Infof("Detected CSI driver %s", provisioner)
+
+	// Generate a unique ID for this provisioner
+	timeStamp := time.Now().UnixNano() / int64(time.Millisecond)
+	identity := strconv.FormatInt(timeStamp, 10) + "-" + strconv.Itoa(rand.Intn(10000)) + "-" + provisioner
+
+	// Create the provisioner: it implements the Provisioner interface expected by
+	// the controller
+	csiProvisioner := ctrl.NewCSIProvisioner(clientset, csiAPIClient, csiEndpoint, connectionTimeout, identity, volumeNamePrefix, volumeNameUUIDLength, grpcClient, snapClient)
+
+	rookProvisioner := newRookCSIProvisioner(context, csiProvisioner)
+	return controller.NewProvisionController(
+		clientset,
+		provisioner,
+		rookProvisioner,
+		serverVersion.GitVersion,
+		controller.LeaderElection(enableLeaderElection),
+	)
+}

--- a/pkg/operator/ceph/csi/provisioner/provisioner.go
+++ b/pkg/operator/ceph/csi/provisioner/provisioner.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"strings"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
+)
+
+const (
+	csiParameterPrefix                    = "csi.storage.k8s.io/"
+	prefixedProvisionerSecretNameKey      = csiParameterPrefix + "provisioner-secret-name"
+	prefixedProvisionerSecretNamespaceKey = csiParameterPrefix + "provisioner-secret-namespace"
+)
+
+// rookCSIProvisioner struct
+type rookCSIProvisioner struct {
+	context        *clusterd.Context
+	csiProvisioner controller.Provisioner
+}
+
+func newRookCSIProvisioner(context *clusterd.Context, csiProvisioner controller.Provisioner) controller.Provisioner {
+	return &rookCSIProvisioner{
+		context:        context,
+		csiProvisioner: csiProvisioner,
+	}
+}
+
+func (p *rookCSIProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+	// extract Rook parameters and resolve them and inject into ceph-csi options
+	params := make(map[string]string)
+	for k, v := range options.Parameters {
+		switch strings.ToLower(k) {
+		case "clusternamespace":
+			clusterInfo, _, _, _ := mon.LoadClusterInfo(p.context, v)
+			monEndpoints := make([]string, 0, len(clusterInfo.Monitors))
+			for _, monitor := range clusterInfo.Monitors {
+				monEndpoints = append(monEndpoints, monitor.Endpoint)
+			}
+			params["monitors"] = strings.Join(monEndpoints, ",")
+			params["adminid"] = "admin"
+			params["userid"] = "admin"
+			params[prefixedProvisionerSecretNamespaceKey] = v
+			params[prefixedProvisionerSecretNameKey] = v + "-mon"
+		case "blockpool":
+			params["pool"] = v
+		}
+	}
+	options.Parameters = params
+	// pass to ceph-csi provision
+	logger.Infof("provision params %#v", options.Parameters)
+	return p.csiProvisioner.Provision(options)
+}
+
+func (p *rookCSIProvisioner) Delete(volume *v1.PersistentVolume) error {
+	return p.csiProvisioner.Delete(volume)
+}
+
+func (p *rookCSIProvisioner) SupportsBlock() bool {
+	return true
+}

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -41,6 +41,6 @@ func TestStartCSI(t *testing.T) {
 		SnapshotterImage:  "image",
 	}
 	clientset := test.New(3)
-	err := StartCSIDrivers("ns", clientset)
+	err := StartCSIDrivers("ns", clientset, nil)
 	assert.Nil(t, err)
 }

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -115,7 +115,7 @@ func (o *Operator) Run() error {
 			}
 		} else {
 			csi.SetCSINamespace(namespace)
-			if err = csi.StartCSIDrivers(namespace, o.context.Clientset); err != nil {
+			if err = csi.StartCSIDrivers(namespace, o.context.Clientset, o.context); err != nil {
 				logger.Warningf("failed to start Ceph csi drivers: %v", err)
 				if csi.ExitOnError {
 					return err

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -798,6 +798,39 @@ spec:
           name: csi-rbd-config
         - mountPath: /etc/ceph-csi/cephfs
           name: csi-cephfs-config
+        - name: socket-dir
+          mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+      - name: csi-rbdplugin
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+        image: quay.io/cephcsi/rbdplugin:v1.0.0
+        args :
+          - "--nodeid=$(NODE_ID)"
+          - "--endpoint=$(CSI_ENDPOINT)"
+          - "--v=5"
+          - "--drivername=rook-csi-rbdplugin"
+          - "--containerized=true"
+          - "--metadatastorage=k8s_configmap"
+        env:
+          - name: HOST_ROOTFS
+            value: "/rootfs" 
+          - name: NODE_ID
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CSI_ENDPOINT
+            value: unix://var/lib/kubelet/plugins/csi-rbdplugin/csi-provisioner.sock
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+          - mountPath: /rootfs
+            name: host-rootfs            
       volumes:
       - name: csi-rbd-config
         configMap:
@@ -805,6 +838,13 @@ spec:
       - name: csi-cephfs-config
         configMap:
           name: csi-cephfs-config
+      - name: host-rootfs
+        hostPath:
+          path: /            
+      - name: socket-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/csi-rbdplugin
+          type: DirectoryOrCreate
 `
 }
 
@@ -983,7 +1023,7 @@ spec:
         valueFrom:
           secretKeyRef:
             name: rook-ceph-mon
-            key: admin-secret
+            key: admin
     securityContext:
       privileged: true
     volumeMounts:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1023,7 +1023,7 @@ spec:
         valueFrom:
           secretKeyRef:
             name: rook-ceph-mon
-            key: admin
+            key: admin-secret
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
**Description of your changes:**

Support Flex driver style StorageClass

**Which issue is resolved by this Pull Request:**
Resolves #2650 

To run the test:
```console
# kubectl apply -f cluster/examples/kubernetes/ceph/csi/example/rbd/rook-storageclass.yaml
cephblockpool.ceph.rook.io/replicapool created
storageclass.storage.k8s.io/rook-ceph-csi created
# kubectl apply -f cluster/examples/kubernetes/ceph/csi/example/rbd/pvc.yaml
persistentvolumeclaim/rbd-pvc-csi created
# kubectl get pvc -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: PersistentVolumeClaim
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"rbd-pvc-csi","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"rook-ceph-csi"}}
      pv.kubernetes.io/bind-completed: "yes"
      pv.kubernetes.io/bound-by-controller: "yes"
      volume.beta.kubernetes.io/storage-provisioner: rook-csi-rbdplugin
    creationTimestamp: "2019-02-27T19:52:25Z"
    finalizers:
    - kubernetes.io/pvc-protection
    name: rbd-pvc-csi
    namespace: default
    resourceVersion: "1072"
    selfLink: /api/v1/namespaces/default/persistentvolumeclaims/rbd-pvc-csi
    uid: 34760c98-3ac9-11e9-9212-54e1ad486b31
  spec:
    accessModes:
    - ReadWriteOnce
    dataSource: null
    resources:
      requests:
        storage: 1Gi
    storageClassName: rook-ceph-csi
    volumeMode: Filesystem
    volumeName: pvc-34760c98-3ac9-11e9-9212-54e1ad486b31
  status:
    accessModes:
    - ReadWriteOnce
    capacity:
      storage: 1Gi
    phase: Bound
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
