### PR TITLE
Added ROOK_HOSTPATH_REQUIRES_PRIVILEGED as value to Helm Chart

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -103,28 +103,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter                 | Description                                                     | Default                                                |
-| ------------------------- | --------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`        | Image                                                           | `rook/ceph`                                            |
-| `image.tag`               | Image tag                                                       | `master`                                               |
-| `image.pullPolicy`        | Image pull policy                                               | `IfNotPresent`                                         |
-| `rbacEnable`              | If true, create & use RBAC resources                            | `true`                                                 |
-| `pspEnable`               | If true, create & use PSP resources                             | `true`                                                 |
-| `resources`               | Pod resource requests & limits                                  | `{}`                                                   |
-| `annotations`             | Pod annotations                                                 | `{}`                                                   |
-| `logLevel`                | Global log level                                                | `INFO`                                                 |
-| `nodeSelector`            | Kubernetes `nodeSelector` to add to the Deployment.             | <none>                                                 |
-| `tolerations`             | List of Kubernetes `tolerations` to add to the Deployment.      | `[]`                                                   |
-| `agent.flexVolumeDirPath` | Path where the Rook agent discovers the flex volume plugins (*) | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
-| `agent.libModulesDirPath` | Path where the Rook agent should look for kernel modules (*)    | `/lib/modules`                                         |
-| `agent.mounts`            | Additional paths to be mounted in the agent container           | <none>                                                 |
-| `agent.mountSecurityMode` | Mount Security Mode for the agent.                              | `Any`                                                  |
-| `agent.toleration`        | Toleration for the agent pods                                   | <none>                                                 |
-| `agent.tolerationKey`     | The specific key of the taint to tolerate                       | <none>                                                 |
-| `discover.toleration`     | Toleration for the discover pods                                | <none>                                                 |
-| `discover.tolerationKey`  | The specific key of the taint to tolerate                       | <none>                                                 |
-| `mon.healthCheckInterval` | The frequency for the operator to check the mon health          | `45s`                                                  |
-| `mon.monOutTimeout`       | The time to wait before failing over an unhealthy mon           | `300s`                                                 |
+| Parameter                    | Description                                                                                             | Default                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `image.repository`           | Image                                                                                                   | `rook/ceph`                                            |
+| `image.tag`                  | Image tag                                                                                               | `master`                                               |
+| `image.pullPolicy`           | Image pull policy                                                                                       | `IfNotPresent`                                         |
+| `rbacEnable`                 | If true, create & use RBAC resources                                                                    | `true`                                                 |
+| `pspEnable`                  | If true, create & use PSP resources                                                                     | `true`                                                 |
+| `resources`                  | Pod resource requests & limits                                                                          | `{}`                                                   |
+| `annotations`                | Pod annotations                                                                                         | `{}`                                                   |
+| `logLevel`                   | Global log level                                                                                        | `INFO`                                                 |
+| `nodeSelector`               | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
+| `tolerations`                | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
+| `hostpathRequiresPrivileged` | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
+| `agent.flexVolumeDirPath`    | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
+| `agent.libModulesDirPath`    | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |
+| `agent.mounts`               | Additional paths to be mounted in the agent container                                                   | <none>                                                 |
+| `agent.mountSecurityMode`    | Mount Security Mode for the agent.                                                                      | `Any`                                                  |
+| `agent.toleration`           | Toleration for the agent pods                                                                           | <none>                                                 |
+| `agent.tolerationKey`        | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `discover.toleration`        | Toleration for the discover pods                                                                        | <none>                                                 |
+| `discover.tolerationKey`     | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `mon.healthCheckInterval`    | The frequency for the operator to check the mon health                                                  | `45s`                                                  |
+| `mon.monOutTimeout`          | The time to wait before failing over an unhealthy mon                                                   | `300s`                                                 |
 
 &ast; For information on what to set `agent.flexVolumeDirPath` to, please refer to the [Rook flexvolume documentation](flexvolume.md)
 &ast; `agent.mounts` should have this format `mountname1=/host/path:/container/path,mountname2=/host/path2:/container/path2`

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           value: {{ .Values.discover.tolerationKey }}
 {{- end }}
 {{- end }}
+{{- if .Values.hostpathRequiresPrivileged }}
+        - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
+          value: {{ .Values.hostpathRequiresPrivileged }}
+{{- end }}
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
         - name: ROOK_ENABLE_SELINUX_RELABELING

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -72,3 +72,7 @@ pspEnable: true
 # Disable it here if you have similar issues.
 # For more details see https://github.com/rook/rook/issues/2417
 enableSelinuxRelabeling: true
+
+# Writing to the hostPath is required for the Ceph mon and osd pods. Given the restricted permissions in OpenShift with SELinux,
+# the pod must be running privileged in order to write to the hostPath volume, this must be set to true then.
+hostpathRequiresPrivileged: false


### PR DESCRIPTION
**Description of your changes:**
This adds a Helm chart value to set `ROOK_HOSTPATH_REQUIRES_PRIVILEGED` env var on the operator.

**Which issue is resolved by this Pull Request:**
Resolves #2735.


**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)