### PR TITLE
ceph: share host ipc namespace with provision pod

### DIFF
--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -10,7 +10,7 @@ priority:
 allowedCapabilities: []
 allowHostPorts: false
 allowHostPID: true
-allowHostIPC: false
+allowHostIPC: true
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []
 defaultAddCapabilities: []

--- a/design/ceph-volume-provisioning.md
+++ b/design/ceph-volume-provisioning.md
@@ -51,7 +51,7 @@ nodes or devices.
   storage:
     config:
       # whether to encrypt the contents of the OSD with dmcrypt
-      encryptDevice: true
+      encryptedDevice: "true"
       # how many OSDs should be configured on each device. only recommended to be greater than 1 for NVME devices
       osdsPerDevice: 1
       # the class name for the OSD(s) on devices

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -205,6 +205,9 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 		ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 	}
 
+	// needed for luksOpen synchronization when devices are encrypted
+	hostIPC := storeConfig.EncryptedDevice
+
 	DNSPolicy := v1.DNSClusterFirst
 	if c.HostNetwork {
 		DNSPolicy = v1.DNSClusterFirstWithHostNet
@@ -246,6 +249,7 @@ func (c *Cluster) makeDeployment(nodeName string, devices []rookalpha.Device, se
 					ServiceAccountName: serviceAccountName,
 					HostNetwork:        c.HostNetwork,
 					HostPID:            true,
+					HostIPC:            hostIPC,
 					DNSPolicy:          DNSPolicy,
 					InitContainers: []v1.Container{
 						{
@@ -344,6 +348,10 @@ func (c *Cluster) provisionPodTemplateSpec(devices []rookalpha.Device, selection
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.placement.ApplyToPodSpec(&podSpec)
+
+	// ceph-volume --dmcrypt uses cryptsetup that synchronizes with udev on
+	// host through semaphore
+	podSpec.HostIPC = storeConfig.EncryptedDevice
 
 	return &v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
this is needed as cryptsetup in the pod and udev on the host coordinate
via a semaphore that must be visible in both contexts. note that additionally the host needs to have dmcrypt compiled with udev synchronization, which at least one minikube version does not have.

the similar fix for containers in ceph-ansible also needed ipc host sharing on the osd container to properly handle reboots, but this did not appear to be needed for rook which is probably related the avoidance of systemd units for various things.

there are two things I want to do before merging this which shouldn't take long:

1. write up some docs for the dmcrypt cluster crd setting
2. change the crd setting to accept a real boolean instead of string "true"

In the mean time I pushed a built image with this change to

https://hub.docker.com/r/noahdesu/ceph-rook-amd64:dmcrypt

and if someone would test in a non-minikube environment that would be greatly appreciated, including the case of rebooting the physical host running the osd pods.

the relevant settings

```
   storage: # cluster level storage configuration and selection
     useAllNodes: true
-    useAllDevices: false
+    useAllDevices: true
     deviceFilter:
     location:
     config:
+      encryptedDevice: "true"
```