### PR TITLE
ceph mon: update tests with new spec test lib

### DIFF
--- a/pkg/operator/ceph/test/podspec.go
+++ b/pkg/operator/ceph/test/podspec.go
@@ -68,6 +68,9 @@ func (ps *PodSpecTester) AssertVolumesMeetCephRequirements(
 	daemonType config.DaemonType, daemonID string,
 ) {
 	keyringSecretName := fmt.Sprintf("rook-ceph-%s-%s-keyring", daemonType, daemonID)
+	if daemonType == config.MonType {
+		keyringSecretName = "rook-ceph-mons-keyring" // mons share a keyring
+	}
 	requiredVols := []string{"ceph-daemon-data", "rook-ceph-config", keyringSecretName}
 	vols := []string{}
 
@@ -114,6 +117,11 @@ func (ps *PodSpecTester) AssertVolumesAndMountsMatch() {
 	pod.TestMountsMatchVolumes(ps.t)
 }
 
+// AssertRestartPolicyAlways asserts that the pod spec is set to always restart on failure.
+func (ps *PodSpecTester) AssertRestartPolicyAlways() {
+	assert.Equal(ps.t, v1.RestartPolicyAlways, ps.spec.RestartPolicy)
+}
+
 // RunFullSuite runs all assertion tests for the PodSpec under test and its sub-resources.
 func (ps *PodSpecTester) RunFullSuite(
 	daemonType config.DaemonType,
@@ -121,6 +129,7 @@ func (ps *PodSpecTester) RunFullSuite(
 ) {
 	ps.AssertVolumesAndMountsMatch()
 	ps.AssertVolumesMeetCephRequirements(daemonType, resourceName)
+	ps.AssertRestartPolicyAlways()
 	ps.Containers().RunFullSuite(cephImage, cpuResourceLimit, memoryResourceRequest)
 }
 


### PR DESCRIPTION
Use the new spec test lib with the mon as well.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
