### PR TITLE
backporto: ceph: share host ipc namespace with provision pod

### DIFF
--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -10,7 +10,7 @@ priority:
 allowedCapabilities: []
 allowHostPorts: false
 allowHostPID: true
-allowHostIPC: false
+allowHostIPC: true
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []
 defaultAddCapabilities: []

--- a/design/ceph-volume-provisioning.md
+++ b/design/ceph-volume-provisioning.md
@@ -51,7 +51,7 @@ nodes or devices.
   storage:
     config:
       # whether to encrypt the contents of the OSD with dmcrypt
-      encryptDevice: true
+      encryptedDevice: "true"
       # how many OSDs should be configured on each device. only recommended to be greater than 1 for NVME devices
       osdsPerDevice: 1
       # the class name for the OSD(s) on devices


### PR DESCRIPTION
this is needed as cryptsetup in the pod and udev on the host coordinate
via a semaphore that must be visible in both contexts.

note that additionally the host needs to have dmcrypt compiled with udev
synchronization, which at least one minikube version does not have.

fixes: #923

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>
(cherry picked from commit 6597531ed0b0324f48141bfdc65c8b6431abaff7)

// skip ci for random failure
[skip ci]