### PR TITLE
Fix TL;DR section to mention wait after operator create so that user …

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -25,6 +25,8 @@ If you're feeling lucky, a simple Rook cluster can be created with the following
 ```
 cd cluster/examples/kubernetes/ceph
 kubectl create -f operator.yaml
+  # verify the rook-ceph-operator, rook-ceph-agent, and rook-discover pods are in the `Running` state before proceeding
+  kubectl -n rook-ceph-system get pod
 kubectl create -f cluster.yaml
 ```
 


### PR DESCRIPTION
Fix TL;DR section to mention wait after operator create so that user will not try copy/paste and
be unlucky.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]