### PR TITLE
cockroachdb: add minimal rbac access for cockroachdb pod

### DIFF
--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -32,18 +32,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
-  - get
-  - list
   - create
-  - update
 - apiGroups:
   - apps
   resources:

--- a/tests/framework/installer/cockroachdb_manifests.go
+++ b/tests/framework/installer/cockroachdb_manifests.go
@@ -66,10 +66,7 @@ rules:
   resources:
   - services
   verbs:
-  - get
-  - list
   - create
-  - update
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
Signed-off-by: zhangyue <zy675793960@yeah.net>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
According to [security-model](https://github.com/rook/rook/blob/master/design/security-model.md#proposed-changes), the rbac work can split into two parts:
* rbac for cockroachdb operator, which have already done but have some privileges it don't need, fix in this PR.
* rbac for cockroachdb pod, for now it only support insecure install, so I think the default serviceAccount is enough.

**Which issue is resolved by this Pull Request:**
Resolves #1813 

