### PR TITLE
Add CONTAINER_IMAGE env var to the ceph daemon pods

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -147,7 +147,7 @@ func (c *Cluster) makeSetServerAddrInitContainer(mgrConfig *mgrConfig, mgrModule
 			keyring.VolumeMount().Admin(),
 		),
 		Env: append(
-			opspec.DaemonEnvVars(),
+			opspec.DaemonEnvVars(c.cephVersion.Image),
 			k8sutil.PodIPEnvVar(podIPEnvVar),
 		),
 		Resources: c.resources,
@@ -184,7 +184,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 				Protocol:      v1.ProtocolTCP,
 			},
 		},
-		Env:       opspec.DaemonEnvVars(),
+		Env:       opspec.DaemonEnvVars(c.cephVersion.Image),
 		Resources: c.resources,
 	}
 	return container

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -146,7 +146,7 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) v1.Container {
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
 		SecurityContext: podSecurityContext(),
 		// filesystem creation does not require ports to be exposed
-		Env:       opspec.DaemonEnvVars(),
+		Env:       opspec.DaemonEnvVars(c.cephVersion.Image),
 		Resources: c.resources,
 	}
 }
@@ -175,7 +175,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			},
 		},
 		Env: append(
-			opspec.DaemonEnvVars(),
+			opspec.DaemonEnvVars(c.cephVersion.Image),
 			k8sutil.PodIPEnvVar(podIPEnvVar),
 		),
 		Resources: c.resources,

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -90,7 +90,7 @@ func testPodSpec(t *testing.T, monID string) {
 	isPrivileged := false
 	// All ceph images have the same image, basic envs, and the same volume mounts
 	cephImage := "ceph/ceph:myceph"
-	envVars := len(spec.DaemonEnvVars())
+	envVars := len(spec.DaemonEnvVars(c.cephVersion.Image))
 	cephVolumeMountNames := []string{
 		"rook-ceph-config",
 		"rook-ceph-mons-keyring",
@@ -119,7 +119,7 @@ func testPodSpec(t *testing.T, monID string) {
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())
 
 	// main mon daemon container
-	monDaemonEnvs := len(spec.DaemonEnvVars()) + 1
+	monDaemonEnvs := len(spec.DaemonEnvVars(c.cephVersion.Image)) + 1
 	monDaemonContDef := test_opceph.ContainerTestDefinition{
 		Image: &cephImage,
 		Command: []string{

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -126,7 +126,7 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 		tiniEnvVar,
 	}
-	envVars = append(envVars, k8sutil.ClusterDaemonEnvVars()...)
+	envVars = append(envVars, k8sutil.ClusterDaemonEnvVars(c.cephVersion.Image)...)
 	envVars = append(envVars, []v1.EnvVar{
 		{Name: "ROOK_OSD_UUID", Value: osd.UUID},
 		{Name: "ROOK_OSD_ID", Value: osdID},

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -204,7 +204,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	assert.Equal(t, "/var/lib/rook", cont.VolumeMounts[0].MountPath)
 	assert.Equal(t, "/etc/ceph", cont.VolumeMounts[1].MountPath)
 
-	assert.Equal(t, (7 + len(k8sutil.ClusterDaemonEnvVars())), len(cont.Env))
+	assert.Equal(t, (7 + len(k8sutil.ClusterDaemonEnvVars(c.cephVersion.Image))), len(cont.Env))
 
 	require.Equal(t, 2, len(podSpec.InitContainers))
 	initCont = podSpec.InitContainers[0]

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -107,7 +107,7 @@ func (m *Mirroring) makeMirroringDaemonContainer(daemonName string) v1.Container
 		},
 		Image:        m.cephVersion.Image,
 		VolumeMounts: opspec.CephVolumeMounts(),
-		Env:          k8sutil.ClusterDaemonEnvVars(),
+		Env:          k8sutil.ClusterDaemonEnvVars(m.cephVersion.Image),
 		Resources:    m.resources,
 	}
 	return container

--- a/pkg/operator/ceph/file/spec.go
+++ b/pkg/operator/ceph/file/spec.go
@@ -90,7 +90,7 @@ func (c *cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 		Image:        c.cephVersion.Image,
 		VolumeMounts: opspec.DaemonVolumeMounts(mdsConfig.DataPathMap, mdsConfig.ResourceName),
 		Env: append(
-			opspec.DaemonEnvVars(),
+			opspec.DaemonEnvVars(c.cephVersion.Image),
 		),
 		Resources: c.fs.Spec.MetadataServer.Resources,
 	}

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -176,7 +176,7 @@ func (c *CephNFSController) daemonContainer(n cephv1.CephNFS, name string, binar
 			binariesMount,
 		),
 		Env: append(
-			k8sutil.ClusterDaemonEnvVars(),
+			k8sutil.ClusterDaemonEnvVars(c.cephVersion.Image),
 			v1.EnvVar{Name: "ROOK_CEPH_NFS_NAME", Value: name},
 		),
 		Resources: n.Spec.Server.Resources,

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -192,7 +192,7 @@ func (c *config) makeDaemonContainer() v1.Container {
 			fmt.Sprintf("--rgw-mime-types-file=%s", rgwdaemon.GetMimeTypesPath(k8sutil.DataDir)),
 		},
 		VolumeMounts: opspec.CephVolumeMounts(),
-		Env:          k8sutil.ClusterDaemonEnvVars(),
+		Env:          k8sutil.ClusterDaemonEnvVars(c.cephVersion.Image),
 		Resources:    c.store.Spec.Gateway.Resources,
 	}
 

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -80,7 +80,7 @@ func TestPodSpecs(t *testing.T) {
 	assert.Equal(t, "--name=client.radosgw.gateway", cont.Args[1])
 	assert.Equal(t, "--rgw-mime-types-file=/var/lib/rook/rgw/mime.types", cont.Args[2])
 
-	assert.Equal(t, len(k8sutil.ClusterDaemonEnvVars()), len(cont.Env))
+	assert.Equal(t, len(k8sutil.ClusterDaemonEnvVars("ceph/ceph:v14")), len(cont.Env))
 
 	assert.Equal(t, "100", cont.Resources.Limits.Cpu().String())
 	assert.Equal(t, "1337", cont.Resources.Requests.Memory().String())

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -112,9 +112,9 @@ func ContainerEnvVarReference(envVarName string) string {
 }
 
 // DaemonEnvVars returns the container environment variables used by all Ceph daemons.
-func DaemonEnvVars() []v1.EnvVar {
+func DaemonEnvVars(image string) []v1.EnvVar {
 	return append(
-		k8sutil.ClusterDaemonEnvVars(),
+		k8sutil.ClusterDaemonEnvVars(image),
 		config.StoredMonHostEnvVars()...,
 	)
 }

--- a/pkg/operator/ceph/test/containers.go
+++ b/pkg/operator/ceph/test/containers.go
@@ -27,7 +27,7 @@ import (
 )
 
 var requiredEnvVars = []string{
-	"POD_NAME", "POD_NAMESPACE", "NODE_NAME",
+	"CONTAINER_IMAGE", "POD_NAME", "POD_NAMESPACE", "NODE_NAME",
 	"ROOK_CEPH_MON_HOST", "ROOK_CEPH_MON_INITIAL_MEMBERS",
 }
 
@@ -86,6 +86,9 @@ func (ct *ContainersTester) AssertEnvVarsContainCephRequirements() {
 		for _, e := range c.Env {
 			// For the required env vars, make sure they are sourced as expected
 			switch e.Name {
+			case "CONTAINER_IMAGE":
+				assert.Equal(ct.t, c.Image, e.Value,
+					"CONTAINER_IMAGE env var does not have the appropriate source:", e)
 			case "POD_NAME":
 				assert.Equal(ct.t, "metadata.name", e.ValueFrom.FieldRef.FieldPath,
 					"POD_NAME env var does not have the appropriate source:", e)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -297,8 +297,9 @@ func deleteResourceAndWait(namespace, name, resourceType string,
 }
 
 // Environment variables used by storage cluster daemons
-func ClusterDaemonEnvVars() []v1.EnvVar {
+func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 	return []v1.EnvVar{
+		{Name: "CONTAINER_IMAGE", Value: image},
 		{Name: "POD_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
 		{Name: "POD_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
 		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mgr orchestrator modules need the container image to run the ceph image for blinking the lights when a disk is down. By setting the container image name as an env var on the pod, the orchestrator can detect the image. For consistency across the daemons it is set on all the daemons, even though only the mgr would consume it.
@liewegas @leseb 

Now all the daemon pods have these env vars generated:
```
    Environment:
      CONTAINER_IMAGE:  ceph/ceph:v13
      POD_NAME:         rook-ceph-mon-a-85689bdf8f-nw5pl (v1:metadata.name)
      POD_NAMESPACE:    rook-ceph (v1:metadata.namespace)
      NODE_NAME:        (v1:spec.nodeName)
```

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
