### PR TITLE
Fix indentation for Rancher Flexvolume docs

### DIFF
--- a/Documentation/flexvolume.md
+++ b/Documentation/flexvolume.md
@@ -52,12 +52,12 @@ this can be done in the `extra_binds` section of the kubelet cluster config.
 Configure the Rancher deployed kubelet by updating the `cluster.yml` file kubelet section:
 
 ```yaml
-kubelet:
- image: ""
- extra_args:
-  volume-plugin-dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
- extra_binds:
- - /usr/libexec/kubernetes/kubelet-plugins/volume/exec:/usr/libexec/kubernetes/kubelet-plugins/volume/exec
+services:
+  kubelet:
+    extra_args:
+      volume-plugin-dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+    extra_binds:
+      - /usr/libexec/kubernetes/kubelet-plugins/volume/exec:/usr/libexec/kubernetes/kubelet-plugins/volume/exec
 ```
 
 If you're using [rke](https://github.com/rancher/rke), run `rke up`, this will update and restart your kubernetes cluster system components, in this case the kubelet docker instance(s)
@@ -71,7 +71,7 @@ the Rook operator will need to be reconfigured, to do this continue with [config
 
 ### Google Kubernetes Engine (GKE)
 Google's Kubernetes Engine uses a non-standard FlexVolume plugin directory: `/home/kubernetes/flexvolume`
-The kubelet on GKE is already configured to use that directory. 
+The kubelet on GKE is already configured to use that directory.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 


### PR DESCRIPTION
**Description of your changes:**
Fix indentation as described in #2662 and https://rancher.com/docs/rke/v0.1.x/en/config-options/services/services-extras/.

Also as this is a docs change, I'd like to backport to v0.9 branch.

**Which issue is resolved by this Pull Request:**
Resolves #2662 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]