### PR TITLE
Ceph memory process tuning

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -45,12 +45,12 @@ func TestPodSpec(t *testing.T) {
 		cephv1.DashboardSpec{},
 		v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
-				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+				v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+				v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
 			},
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
-				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+				v1.ResourceMemory: *resource.NewQuantity(250.0, resource.BinarySI),
 			},
 		},
 		metav1.OwnerReference{},
@@ -71,7 +71,7 @@ func TestPodSpec(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.MgrType, "a", appName, "ns", "ceph/ceph:myceph",
-		"100", "1337", "100", "1337" /* resources */)
+		"200", "100", "500", "250" /* resources */)
 
 }
 

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -27,7 +27,7 @@ import (
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,9 +45,11 @@ func TestPodSpec(t *testing.T) {
 		cephv1.DashboardSpec{},
 		v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 			},
 			Requests: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
 				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 			},
 		},
@@ -69,7 +71,7 @@ func TestPodSpec(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.MgrType, "a", appName, "ns", "ceph/ceph:myceph",
-		"100", "1337" /* resources */)
+		"100", "1337", "100", "1337" /* resources */)
 
 }
 

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -49,10 +49,12 @@ func testPodSpec(t *testing.T, monID string) {
 	c.spec.Resources = map[string]v1.ResourceRequirements{}
 	c.spec.Resources["mon"] = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 		},
 		Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
 		},
 	}
 	monConfig := testGenMonConfig(monID)
@@ -66,5 +68,5 @@ func testPodSpec(t *testing.T, monID string) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.MonType, monID, appName, "ns", "ceph/ceph:myceph",
-		"100", "1337" /* resources */)
+		"200", "100", "1337", "500" /* resources */)
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -150,6 +150,14 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 		"--cluster", osd.Cluster,
 		"--osd-uuid", osd.UUID,
 	}
+
+	// Set osd memory target to the best appropriate value
+	if !osd.IsFileStore {
+		if !c.resources.Limits.Memory().IsZero() {
+			commonArgs = append(commonArgs, "--osd-memory-target", strconv.Itoa(int(c.resources.Limits.Memory().Value())))
+		}
+	}
+
 	if osd.IsFileStore {
 		commonArgs = append(commonArgs, fmt.Sprintf("--osd-journal=%s", osd.Journal))
 	}
@@ -190,6 +198,14 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 			"--conf", osd.Config,
 			"--cluster", "ceph",
 		}
+
+		// Set osd memory target to the best appropriate value
+		if !osd.IsFileStore {
+			if !c.resources.Limits.Memory().IsZero() {
+				args = append(args, "--osd-memory-target", strconv.Itoa(int(c.resources.Limits.Memory().Value())))
+			}
+		}
+
 	} else {
 		// other osds can launch the osd daemon directly
 		command = []string{"ceph-osd"}

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -232,10 +232,12 @@ func TestStorageSpecConfig(t *testing.T) {
 				},
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+						v1.ResourceCPU:    *resource.NewQuantity(1024.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(4096.0, resource.BinarySI),
 					},
 					Requests: v1.ResourceList{
-						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+						v1.ResourceCPU:    *resource.NewQuantity(500.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(2048.0, resource.BinarySI),
 					},
 				},
 			},
@@ -266,8 +268,10 @@ func TestStorageSpecConfig(t *testing.T) {
 	verifyEnvVar(t, container.Env, "ROOK_LOCATION", "rack=foo", true)
 	verifyEnvVar(t, container.Env, "ROOK_METADATA_DEVICE", "nvme093", true)
 
-	assert.Equal(t, "100", container.Resources.Limits.Cpu().String())
-	assert.Equal(t, "1337", container.Resources.Requests.Memory().String())
+	assert.Equal(t, "1Ki", container.Resources.Limits.Cpu().String(), "limit cpu is: %s", container.Resources.Limits.Cpu().String())
+	assert.Equal(t, "500", container.Resources.Requests.Cpu().String())
+	assert.Equal(t, "4Ki", container.Resources.Limits.Memory().String())
+	assert.Equal(t, "2Ki", container.Resources.Requests.Memory().String())
 
 	// verify that osd config can be discovered from the container and matches the original config from the spec
 	discoveredConfig := getConfigFromContainer(container)

--- a/pkg/operator/ceph/cluster/rbd/spec_test.go
+++ b/pkg/operator/ceph/cluster/rbd/spec_test.go
@@ -27,7 +27,7 @@ import (
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -44,10 +44,12 @@ func TestPodSpec(t *testing.T) {
 		cephv1.RBDMirroringSpec{Workers: 2},
 		v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+				v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+				v1.ResourceMemory: *resource.NewQuantity(600.0, resource.BinarySI),
 			},
 			Requests: v1.ResourceList{
-				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+				v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+				v1.ResourceMemory: *resource.NewQuantity(300.0, resource.BinarySI),
 			},
 		},
 		metav1.OwnerReference{},
@@ -67,5 +69,5 @@ func TestPodSpec(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.RbdMirrorType, "a", appName, "ns", "ceph/ceph:myceph",
-		"100", "1337" /* resources */)
+		"200", "100", "600", "300" /* resources */)
 }

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -34,7 +34,7 @@ import (
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -102,7 +102,7 @@ func TestCreateFilesystem(t *testing.T) {
 				ActiveCount: 1,
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(4294967296, resource.BinarySI),
 					},
 					Requests: v1.ResourceList{
 						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -44,12 +44,17 @@ func testDeploymentObject(hostNetwork bool) *apps.Deployment {
 				ActiveStandby: false,
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
-					},
-					Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
 						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 					},
-				}}}}
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+					},
+				},
+			},
+		},
+	}
 	clusterInfo := &cephconfig.ClusterInfo{FSID: "myfsid"}
 
 	c := NewCluster(
@@ -82,7 +87,7 @@ func TestPodSpecs(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.MdsType, "myfs-a", "rook-ceph-mds", "ns", "ceph/ceph:testversion",
-		"100", "1337" /* resources */)
+		"100", "1337", "100", "1337" /* resources */)
 }
 
 func TestHostNetwork(t *testing.T) {

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -44,12 +44,12 @@ func testDeploymentObject(hostNetwork bool) *apps.Deployment {
 				ActiveStandby: false,
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
-						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+						v1.ResourceCPU:    *resource.NewQuantity(500.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(4337.0, resource.BinarySI),
 					},
 					Requests: v1.ResourceList{
-						v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
-						v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+						v1.ResourceCPU:    *resource.NewQuantity(250.0, resource.BinarySI),
+						v1.ResourceMemory: *resource.NewQuantity(2169.0, resource.BinarySI),
 					},
 				},
 			},
@@ -87,7 +87,7 @@ func TestPodSpecs(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.MdsType, "myfs-a", "rook-ceph-mds", "ns", "ceph/ceph:testversion",
-		"100", "1337", "100", "1337" /* resources */)
+		"500", "250", "4337", "2169" /* resources */)
 }
 
 func TestHostNetwork(t *testing.T) {

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -34,10 +34,12 @@ func TestPodSpecs(t *testing.T) {
 	store := simpleStore()
 	store.Spec.Gateway.Resources = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 		},
 		Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
 		},
 	}
 	info := testop.CreateConfigDir(1)
@@ -56,17 +58,19 @@ func TestPodSpecs(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
-		"100", "1337" /* resources */)
+		"200", "100", "1337", "500" /* resources */)
 }
 
 func TestSSLPodSpec(t *testing.T) {
 	store := simpleStore()
 	store.Spec.Gateway.Resources = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(200.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
 		},
 		Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceMemory: *resource.NewQuantity(500.0, resource.BinarySI),
 		},
 	}
 	info := testop.CreateConfigDir(1)
@@ -88,7 +92,7 @@ func TestSSLPodSpec(t *testing.T) {
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
-		"100", "1337" /* resources */)
+		"200", "100", "1337", "500" /* resources */)
 
 	assert.True(t, s.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, s.Spec.DNSPolicy)

--- a/pkg/operator/ceph/test/containers.go
+++ b/pkg/operator/ceph/test/containers.go
@@ -161,6 +161,8 @@ func (ct *ContainersTester) AssertCephImagesMatch(image string) {
 func (ct *ContainersTester) AssertResourceSpec(cpuResourceLimit, cpuResourceRequest, memoryResourceLimit, memoryResourceRequest string) {
 	for _, c := range ct.containers {
 		assert.Equal(ct.t, cpuResourceLimit, c.Resources.Limits.Cpu().String())
+		assert.Equal(ct.t, cpuResourceRequest, c.Resources.Requests.Cpu().String())
+		assert.Equal(ct.t, memoryResourceLimit, c.Resources.Limits.Memory().String())
 		assert.Equal(ct.t, memoryResourceRequest, c.Resources.Requests.Memory().String())
 	}
 }

--- a/pkg/operator/ceph/test/podspec.go
+++ b/pkg/operator/ceph/test/podspec.go
@@ -42,7 +42,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // A PodSpecTester is a helper exposing methods for testing required Ceph specifications common for
@@ -128,12 +128,12 @@ func (ps *PodSpecTester) AssertRestartPolicyAlways() {
 // RunFullSuite runs all assertion tests for the PodSpec under test and its sub-resources.
 func (ps *PodSpecTester) RunFullSuite(
 	daemonType config.DaemonType,
-	resourceName, cephImage, cpuResourceLimit, memoryResourceRequest string,
+	resourceName, cephImage, cpuResourceLimit, cpuResourceRequest, memoryResourceLimit, memoryResourceRequest string,
 ) {
 	ps.AssertVolumesAndMountsMatch()
 	ps.AssertVolumesMeetCephRequirements(daemonType, resourceName)
 	ps.AssertRestartPolicyAlways()
-	ps.Containers().RunFullSuite(cephImage, cpuResourceLimit, memoryResourceRequest)
+	ps.Containers().RunFullSuite(cephImage, cpuResourceLimit, cpuResourceRequest, memoryResourceLimit, memoryResourceRequest)
 }
 
 func allContainers(p *v1.PodSpec) []v1.Container {

--- a/pkg/operator/ceph/test/podtemplatespec.go
+++ b/pkg/operator/ceph/test/podtemplatespec.go
@@ -48,9 +48,9 @@ func (pt *PodTemplateSpecTester) AssertLabelsContainCephRequirements(
 func (pt *PodTemplateSpecTester) RunFullSuite(
 	daemonType config.DaemonType,
 	daemonID, appName, namespace, cephImage,
-	cpuResourceLimit, memoryResourceLimit,
-	cpuResourceRequest, memoryResourceRequest string,
+	cpuResourceLimit, cpuResourceRequest,
+	memoryResourceLimit, memoryResourceRequest string,
 ) {
 	pt.AssertLabelsContainCephRequirements(daemonType, daemonID, appName, namespace)
-	pt.Spec().RunFullSuite(daemonType, daemonID, cephImage, cpuResourceLimit, memoryResourceLimit, cpuResourceRequest, memoryResourceRequest)
+	pt.Spec().RunFullSuite(daemonType, daemonID, cephImage, cpuResourceLimit, cpuResourceRequest, memoryResourceLimit, memoryResourceRequest)
 }

--- a/pkg/operator/ceph/test/podtemplatespec.go
+++ b/pkg/operator/ceph/test/podtemplatespec.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // A PodTemplateSpecTester is a helper exposing methods for testing required Ceph specifications
@@ -47,9 +47,10 @@ func (pt *PodTemplateSpecTester) AssertLabelsContainCephRequirements(
 // RunFullSuite runs all assertion tests for the PodTemplateSpec under test and its sub-resources.
 func (pt *PodTemplateSpecTester) RunFullSuite(
 	daemonType config.DaemonType,
-	daemonID, appName, namespace, cephImage string,
-	cpuResourceLimit, memoryResourceRequest string,
+	daemonID, appName, namespace, cephImage,
+	cpuResourceLimit, memoryResourceLimit,
+	cpuResourceRequest, memoryResourceRequest string,
 ) {
 	pt.AssertLabelsContainCephRequirements(daemonType, daemonID, appName, namespace)
-	pt.Spec().RunFullSuite(daemonType, daemonID, cephImage, cpuResourceLimit, memoryResourceRequest)
+	pt.Spec().RunFullSuite(daemonType, daemonID, cephImage, cpuResourceLimit, memoryResourceLimit, cpuResourceRequest, memoryResourceRequest)
 }

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -296,13 +297,29 @@ func deleteResourceAndWait(namespace, name, resourceType string,
 	return fmt.Errorf("gave up waiting for %s pods to be terminated", name)
 }
 
-// Environment variables used by storage cluster daemons
+// ClusterDaemonEnvVars Environment variables used by storage cluster daemon
 func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 	return []v1.EnvVar{
 		{Name: "CONTAINER_IMAGE", Value: image},
 		{Name: "POD_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
 		{Name: "POD_NAMESPACE", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}},
 		{Name: "NODE_NAME", ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
+
+		// If limits.memory is not set in the pod definition, Kubernetes will populate that value with the total memory available on the host
+		// If a user sets 0, all available memory on the host will be used
+		{Name: "POD_MEMORY_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{Resource: "limits.memory"}}}, // Bytes
+
+		// If requests.memory is not set in the pod definition, Kubernetes will use the formula "requests.memory = limits.memory" during pods's scheduling
+		// Kubernetes will set this variable to 0 or equal to limits.memory if set
+		{Name: "POD_MEMORY_REQUEST", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{Resource: "requests.memory"}}}, // Bytes
+
+		// If limits.cpu is not set in the pod definition, Kubernetes will set this variable to number of CPUs available on the host
+		// If a user sets 0, all CPUs will be used
+		{Name: "POD_CPU_LIMIT", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{Resource: "limits.cpu", Divisor: resource.MustParse("1")}}},
+
+		// If request.cpu is not set in the pod definition, Kubernetes will use the formula "requests.cpu = limits.cpu" during pods's scheduling
+		// Kubernetes will set this variable to 0 or equal to limits.cpu if set
+		{Name: "POD_CPU_REQUEST", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{Resource: "requests.cpu"}}},
 	}
 }
 

--- a/pkg/util/display/bytes.go
+++ b/pkg/util/display/bytes.go
@@ -13,21 +13,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package display
 
 import (
 	"fmt"
+	"math"
 )
 
 const (
+	// KiB kibibyte
 	KiB uint64 = 1024
+	// MiB mebibyte
 	MiB uint64 = KiB * 1024
+	// GiB gibibyte
 	GiB uint64 = MiB * 1024
+	// TiB tebibyte
 	TiB uint64 = GiB * 1024
+	// PiB pebibyte
 	PiB uint64 = TiB * 1024
+	// EiB exbibyte
 	EiB uint64 = PiB * 1024
 )
 
+// BytesToString converts bytes to strings
 func BytesToString(b uint64) string {
 	if b < KiB {
 		return fmt.Sprintf("%d B", b)
@@ -47,4 +56,15 @@ func BytesToString(b uint64) string {
 
 func formatStorageString(b, u uint64, unitLabel string) string {
 	return fmt.Sprintf("%.2f %s", float64(b)/float64(u), unitLabel)
+}
+
+// BToMb converts bytes to megabytes
+func BToMb(b uint64) uint64 {
+	mb := float64(b) / 1024.0 / 1024.0
+	return uint64(math.Round(mb))
+}
+
+// MbTob converts megabytes to bytes
+func MbTob(b uint64) uint64 {
+	return b * 1024 * 1024
 }

--- a/pkg/util/display/bytes_test.go
+++ b/pkg/util/display/bytes_test.go
@@ -35,4 +35,7 @@ func TestBytesToString(t *testing.T) {
 	// min and max values
 	assert.Equal(t, "0 B", BytesToString(0))
 	assert.Equal(t, "16.00 EiB", BytesToString(math.MaxUint64))
+	assert.Equal(t, uint64(50), BToMb(uint64(52428800)))
+	assert.Equal(t, uint64(52428800), MbTob(uint64(50)))
+
 }


### PR DESCRIPTION
**Description of your changes:**

So this is a simple first step moving torward a better utilisation of resources by the Ceph processes. This initial implementation simply relies on whatever the user specified in the daemon spec and acknowledge it.
The rest of the job is up to Ceph, for now we set the flag at daemon's initialisation but obviosuly the best way to handle that would be to have Ceph reading the `POD_` env variables and change its interval values.

I also have a commit that have been reluctant to push that enforces POD to run with a minimum amount of memory. I believe that's more intended for production clusters but might not please all the users.
But if you think we want something like this I can push it. It basically check of limits are enabled and fail if they are lower than what we recommend. It sounds acceptable but again not sure if everyone will be happy about it. I guess the intent is too make sure people run Ceph with the correct limits if they are looking at applying limits...

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/2712

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
