### PR TITLE
Backport of flexvolume doc changes (#2759 and #2762)

### DIFF
--- a/Documentation/flexvolume.md
+++ b/Documentation/flexvolume.md
@@ -7,11 +7,14 @@ indent: true
 Rook uses [FlexVolume](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md) to integrate with Kubernetes for performing storage operations. In some operating systems where Kubernetes is deployed, the [default Flexvolume plugin directory](https://github.com/kubernetes/community/blob/master/contributors/devel/flexvolume.md#prerequisites) (the directory where FlexVolume drivers are installed) is **read-only**.
 This is the case for Kubernetes deployments on:
 
+* [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/services/kubernetes-service/)
 * [Atomic](https://www.projectatomic.io/)
 * [ContainerLinux](https://coreos.com/os/docs/latest/) (previously named CoreOS)
-* [OpenShift](https://www.openshift.com/)
-* [Rancher](http://rancher.com/)
 * [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
+* [OpenShift](https://www.openshift.com/)
+* [OpenStack Magnum](https://wiki.openstack.org/wiki/Magnum)
+* [Rancher](http://rancher.com/)
+* [Tectonic](https://coreos.com/tectonic/)
 
 Especially in these environments, the kubelet needs to be told to use a different FlexVolume plugin directory that is accessible and read/write (`rw`).
 These steps need to be carried out on **all nodes** in your cluster.
@@ -19,11 +22,18 @@ These steps need to be carried out on **all nodes** in your cluster.
 Please refer to the section that is applicable to your environment/platform, it contains more information on FlexVolume on your platform.
 
 ## Platform specific FlexVolume path
+
 ### Not a listed platform
 If you are not using a platform that is listed above and the path `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` is read/write, you don't need to configure anything.
 That is because `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` is the kubelet default FlexVolume path and Rook assumes the default FlexVolume path if not set differently.
 
 If running `mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/` should give you an error about read-only filesystem, you need to use the [most common read/write FlexVolume path](#most-common-readwrite-flexvolume-path) and configure it on the Rook operator and kubelet.
+
+Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
+
+### Azure Kubernetes Service (AKS)
+Azure Kubernetes Service (AKS) uses a non-standard FlexVolume plugin directory: `/etc/kubernetes/volumeplugins`.
+The kubelet on AKS is already configured to use that directory by default.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
@@ -37,8 +47,27 @@ The kubelet's systemD unit file can be located at: `/etc/systemd/system/kubelet.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
+### Custom containerized kubelet
+Use the [most common read/write FlexVolume path](#most-common-readwrite-flexvolume-path) for the next steps.
+
+If your kubelet is running as a (Docker, rkt, etc) container you need to make sure that this directory from the host is reachable by the kubelet inside the container.
+
+Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
+
+### Google Kubernetes Engine (GKE)
+Google Kubernetes Engine (GKE) uses a non-standard FlexVolume plugin directory: `/home/kubernetes/flexvolume`.
+The kubelet on GKE is already configured to use that directory.
+
+Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
+
 ### OpenShift
 To find out which FlexVolume directory path you need to set on the Rook operator, please look at the OpenShift docs of the version you are using, [latest OpenShift Flexvolume docs](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_flex_volume.html#flexvolume-installation) (they also contain the FlexVolume path for Atomic).
+
+Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
+
+### OpenStack Magnum
+OpenStack Magnum is using Atomic, which uses a non-standard FlexVolume plugin directory at:  `/var/lib/kubelet/volumeplugins`.
+The kubelet in OpenStack Magnum is already configured to use that directory.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
@@ -69,22 +98,9 @@ FlexVolume path for the Rook operator.
 If the default path as above is used no further configuration is required, otherwise if a different path is used
 the Rook operator will need to be reconfigured, to do this continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
-### Google Kubernetes Engine (GKE)
-Google's Kubernetes Engine uses a non-standard FlexVolume plugin directory: `/home/kubernetes/flexvolume`
-The kubelet on GKE is already configured to use that directory.
-
-Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
-
 ### Tectonic
 Follow [these instructions](tectonic.md) to configure the Flexvolume plugin for Rook on Tectonic during ContainerLinux node ignition file provisioning.
 If you want to use Rook with an already provisioned Tectonic cluster, please refer to the [ContainerLinux](#containerlinux) section.
-
-Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
-
-### Custom containerized kubelet
-Use the [most common read/write FlexVolume path](#most-common-readwrite-flexvolume-path) for the next steps.
-
-If your kubelet is running as a (Docker, rkt, etc) container you need to make sure that this directory from the host is reachable by the kubelet inside the container.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 
@@ -98,6 +114,7 @@ This path is commonly used for FlexVolume because `/var/lib/kubelet` is read wri
 ### Configuring the Rook operator
 You must provide the above found FlexVolume path when deploying the [rook-operator](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/operator.yaml) by setting the environment variable `FLEXVOLUME_DIR_PATH`.
 For example:
+
 ```yaml
 env:
 [...]
@@ -109,9 +126,11 @@ env:
 
 ### Configuring the Kubernetes kubelet
 You need to add the flexvolume flag with the path to all nodes's kubelet in the Kubernetes cluster:
+
 ```
 --volume-plugin-dir=PATH_TO_FLEXVOLUME
 ```
+
 (Where the `PATH_TO_FLEXVOLUME` is the above found FlexVolume path)
 
 The location where you can set the kubelet FlexVolume path (flag) depends on your platform.

--- a/Documentation/flexvolume.md
+++ b/Documentation/flexvolume.md
@@ -52,12 +52,12 @@ this can be done in the `extra_binds` section of the kubelet cluster config.
 Configure the Rancher deployed kubelet by updating the `cluster.yml` file kubelet section:
 
 ```yaml
-kubelet:
- image: ""
- extra_args:
-  volume-plugin-dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-  extra_binds:
-  - /usr/libexec/kubernetes/kubelet-plugins/volume/exec:/usr/libexec/kubernetes/kubelet-plugins/volume/exec
+services:
+  kubelet:
+    extra_args:
+      volume-plugin-dir: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+    extra_binds:
+      - /usr/libexec/kubernetes/kubelet-plugins/volume/exec:/usr/libexec/kubernetes/kubelet-plugins/volume/exec
 ```
 
 If you're using [rke](https://github.com/rancher/rke), run `rke up`, this will update and restart your kubernetes cluster system components, in this case the kubelet docker instance(s)
@@ -71,7 +71,7 @@ the Rook operator will need to be reconfigured, to do this continue with [config
 
 ### Google Kubernetes Engine (GKE)
 Google's Kubernetes Engine uses a non-standard FlexVolume plugin directory: `/home/kubernetes/flexvolume`
-The kubelet on GKE is already configured to use that directory. 
+The kubelet on GKE is already configured to use that directory.
 
 Continue with [configuring the FlexVolume path](#configuring-the-flexvolume-path) to configure Rook to use the FlexVolume path.
 


### PR DESCRIPTION
**Description of your changes:**
Backport of the two changes to the flexvolume docs change.

**Which issue is resolved by this Pull Request:**
Backport of #2759 and #2762.
Both commits are different than in the PR as there were merge conflicts.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]