### PR TITLE
ceph: filesystem: deprecate flags and updates for Nautilus

### DIFF
--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -108,6 +108,17 @@ func GetFilesystem(context *clusterd.Context, clusterName string, fsName string)
 	return &fs, nil
 }
 
+// AllowStandbyReplay gets detailed status information about a Ceph filesystem.
+func AllowStandbyReplay(context *clusterd.Context, clusterName string, fsName string, allowStandbyReplay bool) error {
+	args := []string{"fs", "set", fsName, "allow_standby_replay", strconv.FormatBool(allowStandbyReplay)}
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to set allow_standby_replay to filesystem %s: %+v", fsName, err)
+	}
+
+	return nil
+}
+
 // CreateFilesystem performs software configuration steps for Ceph to provide a new filesystem.
 func CreateFilesystem(context *clusterd.Context, clusterName, name, metadataPool string, dataPools []string) error {
 	if len(dataPools) == 0 {

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -73,6 +73,15 @@ func createFilesystem(
 		return fmt.Errorf("failed to get filesystem %s: %+v", fs.Name, err)
 	}
 
+	// As of Nautilus, allow_standby_replay is a fs property so we need to apply it
+	if cephv1.VersionAtLeast(clusterInfo.CephVersionName, cephv1.Nautilus) {
+		if fs.Spec.MetadataServer.ActiveStandby {
+			if err = client.AllowStandbyReplay(context, fs.Namespace, fs.Name, fs.Spec.MetadataServer.ActiveStandby); err != nil {
+				return fmt.Errorf("failed to set allow_standby_replay to filesystem %s: %v", fs.Name, err)
+			}
+		}
+	}
+
 	// set the number of active mds instances
 	if fs.Spec.MetadataServer.ActiveCount > 1 {
 		if err = client.SetNumMDSRanks(context, fs.Namespace, fs.Name, fs.Spec.MetadataServer.ActiveCount); err != nil {


### PR DESCRIPTION
The MDS mds_standby_for_*, mon_force_standby_active, and mds_standby_replay
configuration options have been obsoleted. Instead, the operator may now set
the new "allow_standby_replay" flag on the CephFS file system. This setting
causes standbys to become standby-replay for any available rank in the file
system.

Closes: https://github.com/rook/rook/issues/2768
Signed-off-by: Sébastien Han <seb@redhat.com>