### PR TITLE
ceph: dashboard/prom should bind to anyaddr

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -103,9 +103,14 @@ func (v *CephVersion) isRelease(other CephVersion) bool {
 	return v.Major == other.Major
 }
 
-// IsLuminous checks if the Ceph version if Luminous
+// IsLuminous checks if the Ceph version is Luminous
 func (v *CephVersion) IsLuminous() bool {
 	return v.isRelease(Luminous)
+}
+
+// IsMimic checks if the Ceph version is Mimic
+func (v *CephVersion) IsMimic() bool {
+	return v.isRelease(Mimic)
 }
 
 // IsAtLeast checks a given Ceph version is at least a given one

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -117,6 +117,12 @@ func TestIsReleaseX(t *testing.T) {
 	assert.True(t, Luminous.IsLuminous())
 	assert.False(t, Mimic.IsLuminous())
 	assert.False(t, Nautilus.IsLuminous())
+	assert.False(t, Octopus.IsLuminous())
+
+	assert.False(t, Luminous.IsMimic())
+	assert.True(t, Mimic.IsMimic())
+	assert.False(t, Nautilus.IsMimic())
+	assert.False(t, Octopus.IsMimic())
 }
 
 func TestVersionAtLeast(t *testing.T) {


### PR DESCRIPTION
this reverts binding to the pod IP which was added to deal with a bug in
cherrypy when binding to the default anyaddr "::". this has been
resolved in ceph, so we can eliminate this workaround.

fixes: #2492
