### PR TITLE
Support metadataDevice for ceph-volume based osd

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -30,6 +30,7 @@
 - `rook-version` and `ceph-version` labels are now applied to Ceph daemon Deployments, DaemonSets,
   Jobs, and StatefulSets. These identify the Rook version which last modified the resource and the
   Ceph version which Rook has detected in the pod(s) being run by the resource.
+- OSDs provisioned by `ceph-volume` now supports `metadataDevice` and `databaseSizeMB` options.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -98,6 +98,7 @@ spec:
       # The default and recommended storeType is dynamically set to bluestore for devices and filestore for directories.
       # Set the storeType explicitly only if it is required not to use the default.
       # storeType: bluestore
+      # metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
       # databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB
       # journalSizeMB: "1024"  # uncomment if the disks are 20 GB or smaller
       # osdsPerDevice: "1" # this value can be overridden at the node or device level

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -153,8 +153,7 @@ func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOs
 	}
 	if a.metadataDevice != "" {
 		// ceph-volume still is work in progress for accepting fast devices for the metadata
-		logger.Infof("skipping ceph-volume until the fast devices can be specified for the metadata")
-		cvSupported = false
+		logger.Warningf("ceph-volume metadata support is experimental. osd provision might fail if vg on %s does not have enough space", a.metadataDevice)
 	}
 
 	var osds []oposd.OSDInfo


### PR DESCRIPTION
**Description of your changes:**

When this change, I can place block-db of multiple OSDs on a ssd, simply with what `ceph-volume lvm batch` already does.

for an osd node with 1 ssd (sdb) and 3 hdd:
```
sdb                                                                                                                     8:16   0   20G  0 disk 
├─ceph--block--dbs--f95e4aba--9900--403a--9d2c--6fbb55e71710-osd--block--db--15c7a93a--4c41--4aac--8388--d4a30eb861cf 252:1    0    6G  0 lvm  
├─ceph--block--dbs--f95e4aba--9900--403a--9d2c--6fbb55e71710-osd--block--db--732d4aa5--ce75--4c3e--a10f--d7dff89160f1 252:3    0    6G  0 lvm  
└─ceph--block--dbs--f95e4aba--9900--403a--9d2c--6fbb55e71710-osd--block--db--f8e9d19d--26e0--4b6b--bae0--8a44a2795f74 252:5    0    6G  0 lvm  
sdc                                                                                                                     8:32   0   40G  0 disk 
└─ceph--block--c9810b2b--b27c--46f0--8c4f--c0d0e5c1d670-osd--block--de166af7--11ca--4090--855c--eae30c6c6870          252:2    0   40G  0 lvm  
sdd                                                                                                                     8:48   0   40G  0 disk 
└─ceph--block--5b853881--002b--4123--bafb--dbacdbbac17c-osd--block--088724ac--aec1--41bf--9a27--f363a577200d          252:4    0   40G  0 lvm  
sde                                                                                                                     8:64   0   40G  0 disk 
└─ceph--block--b8b45004--f21f--46ee--a5f0--f060895ba2ce-osd--block--15312d00--ee09--49d7--935b--7612d3e3fd10          252:0    0   40G  0 lvm  
                                         
```

TODO:
- [ ] reject when metadataDevice specified is of the same storage class as data devices
- [ ] reject node configured with multiple devices that have different osd-per-device values
- [x] reject when there's not enough space on metadataDevice
- [x] use `ceph-volume batch --report` to produce meaningful logs to the user
- [x] support block-db-size, as databaseSizeMB

**Which issue is resolved by this Pull Request:**
Resolves #2566 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

cc/@hSATAC

// known CI issues
[skip ci]