### PR TITLE
Trigger an orchestration on any crd update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -310,6 +310,19 @@
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
+  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
@@ -1390,6 +1403,7 @@
     "github.com/go-ini/ini",
     "github.com/go-sql-driver/mysql",
     "github.com/golang/glog",
+    "github.com/google/go-cmp/cmp",
     "github.com/google/uuid",
     "github.com/icrowley/fake",
     "github.com/jbw976/go-ps",

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -175,10 +175,7 @@ func (c *cluster) createInstance(rookImage string) error {
 		}
 
 		// Start the mon pods
-		clusterInfo, err := c.mons.Start(c.Info,
-			rookImage, c.Spec.CephVersion, c.Spec.Mon,
-			cephv1.GetMonPlacement(c.Spec.Placement),
-			cephv1.GetMonResources(c.Spec.Resources))
+		clusterInfo, err := c.mons.Start(c.Info, rookImage, *c.Spec)
 		if err != nil {
 			return fmt.Errorf("failed to start the mons. %+v", err)
 		}

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -68,18 +67,18 @@ type cluster struct {
 }
 
 func newCluster(c *cephv1.CephCluster, context *clusterd.Context) *cluster {
+	ownerRef := ClusterOwnerRef(c.Namespace, string(c.UID))
 	return &cluster{
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's
 		// identity can be established.
-		Info:                 nil,
-		Namespace:            c.Namespace,
-		Spec:                 &c.Spec,
-		context:              context,
-		stopCh:               make(chan struct{}),
-		ownerRef:             ClusterOwnerRef(c.Namespace, string(c.UID)),
-		orchestrationRunning: false,
-		orchestrationPending: false,
+		Info:      nil,
+		Namespace: c.Namespace,
+		Spec:      &c.Spec,
+		context:   context,
+		stopCh:    make(chan struct{}),
+		ownerRef:  ownerRef,
+		mons:      mon.New(context, c.Namespace, c.Spec.DataDirHostPath, c.Spec.Network.HostNetwork, ownerRef),
 	}
 }
 
@@ -170,18 +169,16 @@ func (c *cluster) createInstance(rookImage string) error {
 			Data: placeholderConfig,
 		}
 		k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
-
 		_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
 		if err != nil && !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)
 		}
 
 		// Start the mon pods
-		c.mons = mon.New(c.Info, c.context, c.Namespace,
-			spec.DataDirHostPath, rookImage, spec.CephVersion, spec.Mon,
-			cephv1.GetMonPlacement(spec.Placement), spec.Network.HostNetwork,
-			cephv1.GetMonResources(spec.Resources), c.ownerRef)
-		clusterInfo, err := c.mons.Start()
+		clusterInfo, err := c.mons.Start(c.Info,
+			rookImage, c.Spec.CephVersion, c.Spec.Mon,
+			cephv1.GetMonPlacement(c.Spec.Placement),
+			cephv1.GetMonResources(c.Spec.Resources))
 		if err != nil {
 			return fmt.Errorf("failed to start the mons. %+v", err)
 		}
@@ -287,78 +284,18 @@ func (c *cluster) createInitialCrushMap() error {
 }
 
 func clusterChanged(oldCluster, newCluster cephv1.ClusterSpec, clusterRef *cluster) bool {
-	changeFound := false
-	oldStorage := oldCluster.Storage
-	newStorage := newCluster.Storage
 
 	// sort the nodes by name then compare to see if there are changes
-	sort.Sort(rookv1alpha2.NodesByName(oldStorage.Nodes))
-	sort.Sort(rookv1alpha2.NodesByName(newStorage.Nodes))
-	if !reflect.DeepEqual(oldStorage.Nodes, newStorage.Nodes) {
-		logger.Infof("The list of nodes has changed")
-		changeFound = true
+	sort.Sort(rookv1alpha2.NodesByName(oldCluster.Storage.Nodes))
+	sort.Sort(rookv1alpha2.NodesByName(newCluster.Storage.Nodes))
+
+	// any change in the crd will trigger an orchestration
+	if !reflect.DeepEqual(oldCluster, newCluster) {
+		logger.Infof("The Cluster CRD has changed")
+		return true
 	}
 
-	if oldCluster.Dashboard.Enabled != newCluster.Dashboard.Enabled {
-		logger.Infof("dashboard enabled has changed from %t to %t", oldCluster.Dashboard.Enabled, newCluster.Dashboard.Enabled)
-		changeFound = true
-	}
-	if oldCluster.Dashboard.UrlPrefix != newCluster.Dashboard.UrlPrefix {
-		logger.Infof("dashboard url prefix has changed from \"%s\" to \"%s\"", oldCluster.Dashboard.UrlPrefix, newCluster.Dashboard.UrlPrefix)
-		changeFound = true
-	}
-
-	if oldCluster.Dashboard.Port != newCluster.Dashboard.Port {
-		logger.Infof("dashboard port has changed from \"%d\" to \"%d\"", oldCluster.Dashboard.Port, newCluster.Dashboard.Port)
-		changeFound = true
-	}
-
-	if (oldCluster.Dashboard.SSL == nil && newCluster.Dashboard.SSL != nil) ||
-		(oldCluster.Dashboard.SSL != nil && newCluster.Dashboard.SSL == nil) ||
-		(oldCluster.Dashboard.SSL != nil && newCluster.Dashboard.SSL != nil &&
-			*oldCluster.Dashboard.SSL != *newCluster.Dashboard.SSL) {
-		oldSSL := "<default>"
-		if oldCluster.Dashboard.SSL != nil {
-			oldSSL = strconv.FormatBool(*oldCluster.Dashboard.SSL)
-		}
-		newSSL := "<default>"
-		if newCluster.Dashboard.SSL != nil {
-			newSSL = strconv.FormatBool(*newCluster.Dashboard.SSL)
-		}
-		logger.Infof("dashboard ssl option has changed from \"%s\" to \"%s\"", oldSSL, newSSL)
-		changeFound = true
-	}
-
-	if oldCluster.Mon.Count != newCluster.Mon.Count {
-		logger.Infof("number of mons have changed from %d to %d. The health check will update the mons...", oldCluster.Mon.Count, newCluster.Mon.Count)
-		clusterRef.mons.MonCountMutex.Lock()
-		clusterRef.mons.Count = newCluster.Mon.Count
-		clusterRef.mons.MonCountMutex.Unlock()
-	}
-
-	if oldCluster.Mon.AllowMultiplePerNode != newCluster.Mon.AllowMultiplePerNode {
-		logger.Infof("allow multiple mons per node changed from %t to %t. The health check will update the mons...", oldCluster.Mon.AllowMultiplePerNode, newCluster.Mon.AllowMultiplePerNode)
-		clusterRef.mons.MonCountMutex.Lock()
-		clusterRef.mons.AllowMultiplePerNode = newCluster.Mon.AllowMultiplePerNode
-		clusterRef.mons.MonCountMutex.Unlock()
-	}
-
-	if oldCluster.RBDMirroring.Workers != newCluster.RBDMirroring.Workers {
-		logger.Infof("rbd mirrors changed from %d to %d", oldCluster.RBDMirroring.Workers, newCluster.RBDMirroring.Workers)
-		changeFound = true
-	}
-
-	if oldCluster.CephVersion.AllowUnsupported != newCluster.CephVersion.AllowUnsupported {
-		logger.Infof("ceph version allowUnsupported has changed from %t to %t", oldCluster.CephVersion.AllowUnsupported, newCluster.CephVersion.AllowUnsupported)
-		changeFound = true
-	}
-
-	if oldCluster.CephVersion.Image != newCluster.CephVersion.Image {
-		logger.Infof("ceph version changing from %s to %s", oldCluster.CephVersion.Image, newCluster.CephVersion.Image)
-		changeFound = true
-	}
-
-	return changeFound
+	return false
 }
 
 func extractCephVersion(version string) (string, error) {

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -418,7 +418,8 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	if !clusterChanged(oldClust.Spec, newClust.Spec, cluster) {
+	changed, _ := clusterChanged(oldClust.Spec, newClust.Spec, cluster)
+	if !changed {
 		logger.Infof("update event for cluster %s is not supported", newClust.Namespace)
 		return
 	}

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -160,7 +160,6 @@ func TestClusterChanged(t *testing.T) {
 	// If the number of mons changes, the cluster would be updated
 	new.Mon.Count = 3
 	new.Mon.AllowMultiplePerNode = true
-	assert.False(t, c.mons.AllowMultiplePerNode)
 	assert.True(t, clusterChanged(old, new, c))
 }
 

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -132,7 +132,9 @@ func TestClusterChanged(t *testing.T) {
 		},
 	}
 	c := &cluster{Spec: &cephv1.ClusterSpec{}, mons: &mon.Cluster{}}
-	assert.True(t, clusterChanged(old, new, c))
+	changed, diff := clusterChanged(old, new, c)
+	assert.True(t, changed)
+	assert.Equal(t, "{v1.ClusterSpec}.Storage.Nodes[?->1]:\n\t-: <non-existent>\n\t+: v1alpha2.Node{Name: \"node2\", Selection: v1alpha2.Selection{Devices: []v1alpha2.Device{{Name: \"sda\"}}}}\n", diff)
 	assert.Equal(t, 0, c.Spec.Mon.Count)
 
 	// a node was removed, should be a change
@@ -143,7 +145,9 @@ func TestClusterChanged(t *testing.T) {
 	new.Storage.Nodes = []rookalpha.Node{
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.True(t, clusterChanged(old, new, c))
+	changed, diff = clusterChanged(old, new, c)
+	assert.True(t, changed)
+	assert.Equal(t, "{v1.ClusterSpec}.Storage.Nodes[1->?]:\n\t-: v1alpha2.Node{Name: \"node2\", Selection: v1alpha2.Selection{Devices: []v1alpha2.Device{{Name: \"sda\"}}}}\n\t+: <non-existent>\n", diff)
 
 	// the nodes being in a different order should not be a change
 	old.Storage.Nodes = []rookalpha.Node{
@@ -154,13 +158,17 @@ func TestClusterChanged(t *testing.T) {
 		{Name: "node2", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 		{Name: "node1", Selection: rookalpha.Selection{Devices: []rookalpha.Device{{Name: "sda"}}}},
 	}
-	assert.False(t, clusterChanged(old, new, c))
+	changed, diff = clusterChanged(old, new, c)
+	assert.False(t, changed)
 	assert.Equal(t, 0, c.Spec.Mon.Count)
+	assert.Equal(t, "", diff)
 
 	// If the number of mons changes, the cluster would be updated
 	new.Mon.Count = 3
 	new.Mon.AllowMultiplePerNode = true
-	assert.True(t, clusterChanged(old, new, c))
+	changed, diff = clusterChanged(old, new, c)
+	assert.True(t, changed)
+	assert.Equal(t, "{v1.ClusterSpec}.Mon.Count:\n\t-: 0\n\t+: 3\n{v1.ClusterSpec}.Mon.AllowMultiplePerNode:\n\t-: false\n\t+: true\n", diff)
 }
 
 func TestRemoveFinalizer(t *testing.T) {

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -157,13 +157,11 @@ func TestClusterChanged(t *testing.T) {
 	assert.False(t, clusterChanged(old, new, c))
 	assert.Equal(t, 0, c.Spec.Mon.Count)
 
-	// If the number of mons changes, the mon count on the cluster should be updated so the health check can adjust the mons
+	// If the number of mons changes, the cluster would be updated
 	new.Mon.Count = 3
 	new.Mon.AllowMultiplePerNode = true
 	assert.False(t, c.mons.AllowMultiplePerNode)
-	assert.False(t, clusterChanged(old, new, c))
-	assert.Equal(t, 3, c.mons.Count)
-	assert.True(t, c.mons.AllowMultiplePerNode)
+	assert.True(t, clusterChanged(old, new, c))
 }
 
 func TestRemoveFinalizer(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -66,14 +66,17 @@ func (hc *HealthChecker) Check(stopCh chan struct{}) {
 }
 
 func (c *Cluster) checkHealth() error {
+	logger.Debugf("Acquiring mon lock to check mon health")
+	c.monMutex.Lock()
+	defer c.monMutex.Unlock()
+	logger.Debugf("Acquired mon lock to check mon health")
+
 	logger.Debugf("Checking health for mons (desired=%d). %+v", c.Count, c.clusterInfo)
 
 	// Use a local mon count in case the user updates the crd in another goroutine.
 	// We need to complete a health check with a consistent value.
-	c.MonCountMutex.Lock()
 	desiredMonCount := c.Count
 	allowMultiplePerNode := c.AllowMultiplePerNode
-	c.MonCountMutex.Unlock()
 
 	// connect to the mons
 	// get the status and check for quorum

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -66,17 +67,15 @@ func (hc *HealthChecker) Check(stopCh chan struct{}) {
 }
 
 func (c *Cluster) checkHealth() error {
-	logger.Debugf("Acquiring mon lock to check mon health")
-	c.monMutex.Lock()
-	defer c.monMutex.Unlock()
-	logger.Debugf("Acquired mon lock to check mon health")
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
 
-	logger.Debugf("Checking health for mons (desired=%d). %+v", c.Count, c.clusterInfo)
+	logger.Debugf("Checking health for mons (desired=%d). %+v", c.spec.Mon.Count, c.clusterInfo)
 
 	// Use a local mon count in case the user updates the crd in another goroutine.
 	// We need to complete a health check with a consistent value.
-	desiredMonCount := c.Count
-	allowMultiplePerNode := c.AllowMultiplePerNode
+	desiredMonCount := c.spec.Mon.Count
+	allowMultiplePerNode := c.spec.Mon.AllowMultiplePerNode
 
 	// connect to the mons
 	// get the status and check for quorum
@@ -224,7 +223,7 @@ func (c *Cluster) checkMonsOnValidNodes() (bool, error) {
 			return true, err
 		}
 		// check if node the mon is on is still valid
-		valid, err := k8sutil.ValidNode(*node, c.placement)
+		valid, err := k8sutil.ValidNode(*node, cephv1.GetMonPlacement(c.spec.Placement))
 		if err != nil {
 			logger.Warning("failed to validate node %s %v", node.Name, err)
 		} else if !valid {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -55,7 +55,7 @@ func TestCheckHealth(t *testing.T) {
 		Executor:  executor,
 	}
 	c := New(context, "ns", "", false, metav1.OwnerReference{})
-	setTestMonSettings(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	logger.Infof("initial mons: %v", c.clusterInfo.Monitors)
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -107,7 +107,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 		Executor:  executor,
 	}
 	c := New(context, "ns", "", false, metav1.OwnerReference{})
-	setTestMonSettings(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -179,7 +179,7 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 	}
 
 	c := New(context, "ns", "", false, metav1.OwnerReference{})
-	setTestMonSettings(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -288,7 +288,7 @@ func TestCheckMonsValid(t *testing.T) {
 		Executor:  executor,
 	}
 	c := New(context, "ns", "", false, metav1.OwnerReference{})
-	setTestMonSettings(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -375,7 +375,7 @@ func TestAddRemoveMons(t *testing.T) {
 		Executor:  executor,
 	}
 	c := New(context, "ns", "", false, metav1.OwnerReference{})
-	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
+	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -390,7 +390,7 @@ func TestAddRemoveMons(t *testing.T) {
 
 	// reducing the mon count to 3 will reduce the mon count once each time we call checkHealth
 	monQuorumResponse = clienttest.MonInQuorumResponseFromMons(c.clusterInfo.Monitors)
-	c.Count = 3
+	c.spec.Mon.Count = 3
 	err = c.checkHealth()
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(c.clusterInfo.Monitors))
@@ -409,7 +409,7 @@ func TestAddRemoveMons(t *testing.T) {
 
 	// now attempt to reduce the mons down to quorum size 1
 	monQuorumResponse = clienttest.MonInQuorumResponseFromMons(c.clusterInfo.Monitors)
-	c.Count = 1
+	c.spec.Mon.Count = 1
 	err = c.checkHealth()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(c.clusterInfo.Monitors))

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
@@ -55,9 +54,8 @@ func TestCheckHealth(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(test.CreateConfigDir(1), context, "ns", "", "myversion", cephv1.CephVersionSpec{},
-		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, rookalpha.Placement{}, false,
-		v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(context, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	logger.Infof("initial mons: %v", c.clusterInfo.Monitors)
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -108,9 +106,8 @@ func TestCheckHealthNotFound(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(test.CreateConfigDir(2), context, "ns", "", "myversion", cephv1.CephVersionSpec{},
-		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, rookalpha.Placement{}, false,
-		v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(context, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -180,9 +177,9 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(test.CreateConfigDir(2), context, "ns", "", "myversion", cephv1.CephVersionSpec{},
-		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, rookalpha.Placement{}, false,
-		v1.ResourceRequirements{}, metav1.OwnerReference{})
+
+	c := New(context, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -290,9 +287,8 @@ func TestCheckMonsValid(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(test.CreateConfigDir(1), context, "ns", "", "myversion", cephv1.CephVersionSpec{},
-		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, rookalpha.Placement{}, false,
-		v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(context, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
 
@@ -378,9 +374,8 @@ func TestAddRemoveMons(t *testing.T) {
 		ConfigDir: configDir,
 		Executor:  executor,
 	}
-	c := New(test.CreateConfigDir(0), context, "ns", "", "myversion", cephv1.CephVersionSpec{},
-		cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, rookalpha.Placement{}, false,
-		v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(context, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -77,27 +76,23 @@ const (
 
 // Cluster represents the Rook and environment configuration settings needed to set up Ceph mons.
 type Cluster struct {
-	clusterInfo          *cephconfig.ClusterInfo
-	context              *clusterd.Context
-	Namespace            string
-	Keyring              string
-	rookVersion          string
-	cephVersion          cephv1.CephVersionSpec
-	Count                int
-	AllowMultiplePerNode bool
-	monMutex             sync.Mutex
-	Port                 int32
-	placement            rookalpha.Placement
-	maxMonID             int
-	waitForStart         bool
-	dataDirHostPath      string
-	monPodRetryInterval  time.Duration
-	monPodTimeout        time.Duration
-	monTimeoutList       map[string]time.Time
-	HostNetwork          bool
-	mapping              *Mapping
-	resources            v1.ResourceRequirements
-	ownerRef             metav1.OwnerReference
+	clusterInfo         *cephconfig.ClusterInfo
+	context             *clusterd.Context
+	spec                cephv1.ClusterSpec
+	Namespace           string
+	Keyring             string
+	rookVersion         string
+	orchestrationMutex  sync.Mutex
+	Port                int32
+	HostNetwork         bool
+	maxMonID            int
+	waitForStart        bool
+	dataDirHostPath     string
+	monPodRetryInterval time.Duration
+	monPodTimeout       time.Duration
+	monTimeoutList      map[string]time.Time
+	mapping             *Mapping
+	ownerRef            metav1.OwnerReference
 }
 
 // monConfig for a single monitor
@@ -149,26 +144,19 @@ func New(context *clusterd.Context, namespace, dataDirHostPath string, hostNetwo
 }
 
 // Start begins the process of running a cluster of Ceph mons.
-func (c *Cluster) Start(clusterInfo *cephconfig.ClusterInfo, rookVersion string, cephVersion cephv1.CephVersionSpec,
-	mon cephv1.MonSpec, placement rookalpha.Placement, resources v1.ResourceRequirements) (*cephconfig.ClusterInfo, error) {
+func (c *Cluster) Start(clusterInfo *cephconfig.ClusterInfo, rookVersion string, spec cephv1.ClusterSpec) (*cephconfig.ClusterInfo, error) {
 
 	// Only one goroutine can orchestrate the mons at a time
-	logger.Infof("Acquiring lock for mon orchestration")
-	c.monMutex.Lock()
-	defer c.monMutex.Unlock()
-	logger.Infof("Acquired lock for mon orchestration")
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
 
 	c.clusterInfo = clusterInfo
-	c.Count = mon.Count
-	c.AllowMultiplePerNode = mon.AllowMultiplePerNode
-	c.placement = placement
 	c.rookVersion = rookVersion
-	c.cephVersion = cephVersion
-	c.resources = resources
+	c.spec = spec
 
 	// fail if we were instructed to deploy more than one mon on the same machine with host networking
-	if c.HostNetwork && c.AllowMultiplePerNode && c.Count > 1 {
-		return nil, fmt.Errorf("refusing to deploy %d monitors on the same host since hostNetwork is %v and allowMultiplePerNode is %v. Only one monitor per node is allowed", c.Count, c.HostNetwork, c.AllowMultiplePerNode)
+	if c.HostNetwork && c.spec.Mon.AllowMultiplePerNode && c.spec.Mon.Count > 1 {
+		return nil, fmt.Errorf("refusing to deploy %d monitors on the same host since hostNetwork is %v and allowMultiplePerNode is %v. Only one monitor per node is allowed", c.spec.Mon.Count, c.HostNetwork, c.spec.Mon.AllowMultiplePerNode)
 	}
 
 	logger.Infof("start running mons")
@@ -184,7 +172,7 @@ func (c *Cluster) Start(clusterInfo *cephconfig.ClusterInfo, rookVersion string,
 
 func (c *Cluster) startMons() error {
 	// init the mon config
-	existingCount, mons := c.initMonConfig(c.Count)
+	existingCount, mons := c.initMonConfig(c.spec.Mon.Count)
 
 	// Assign the mons to nodes
 	if err := c.assignMons(mons); err != nil {
@@ -193,7 +181,7 @@ func (c *Cluster) startMons() error {
 
 	if existingCount < len(mons) {
 		// Start the new mons one at a time
-		for i := existingCount; i < c.Count; i++ {
+		for i := existingCount; i < c.spec.Mon.Count; i++ {
 			if err := c.ensureMonsRunning(mons, i, true); err != nil {
 				return err
 			}
@@ -226,7 +214,7 @@ func (c *Cluster) ensureMonsRunning(mons []*monConfig, i int, requireAllInQuorum
 	// If we are adding a new mon, we expect one more than currently exist.
 	// If we haven't created all the desired mons already, we will be adding a new one with this iteration
 	expectedMonCount := len(c.clusterInfo.Monitors)
-	if expectedMonCount < c.Count {
+	if expectedMonCount < c.spec.Mon.Count {
 		expectedMonCount++
 	}
 
@@ -259,7 +247,7 @@ func (c *Cluster) initClusterInfo() error {
 	var err error
 	// get the cluster info from secret
 	c.clusterInfo, c.maxMonID, c.mapping, err = CreateOrLoadClusterInfo(c.context, c.Namespace, &c.ownerRef)
-	c.clusterInfo.CephVersionName = c.cephVersion.Name
+	c.clusterInfo.CephVersionName = c.spec.CephVersion.Name
 
 	if err != nil {
 		return fmt.Errorf("failed to get cluster info. %+v", err)
@@ -607,4 +595,15 @@ func monFoundInQuorum(name string, monStatusResp client.MonStatusResponse) bool 
 	}
 
 	return false
+}
+
+func (c *Cluster) acquireOrchestrationLock() {
+	logger.Debugf("Acquiring lock for mon orchestration")
+	c.orchestrationMutex.Lock()
+	logger.Debugf("Acquired lock for mon orchestration")
+}
+
+func (c *Cluster) releaseOrchestrationLock() {
+	c.orchestrationMutex.Unlock()
+	logger.Debugf("Released lock for mon orchestration")
 }

--- a/pkg/operator/ceph/cluster/mon/node.go
+++ b/pkg/operator/ceph/cluster/mon/node.go
@@ -19,6 +19,7 @@ package mon
 import (
 	"fmt"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
 	"k8s.io/api/core/v1"
@@ -35,10 +36,10 @@ func (c *Cluster) getMonNodes() ([]v1.Node, error) {
 	logger.Infof("Found %d running nodes without mons", len(availableNodes))
 
 	// if all nodes already have mons and the user has given the mon.count, add all nodes to be available
-	if c.AllowMultiplePerNode && len(availableNodes) == 0 {
+	if c.spec.Mon.AllowMultiplePerNode && len(availableNodes) == 0 {
 		logger.Infof("All nodes are running mons. Adding all %d nodes to the availability.", len(nodes.Items))
 		for _, node := range nodes.Items {
-			valid, err := k8sutil.ValidNode(node, c.placement)
+			valid, err := k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
 			if err != nil {
 				logger.Warning("failed to validate node %s %v", node.Name, err)
 			} else if valid {
@@ -70,7 +71,7 @@ func (c *Cluster) getAvailableMonNodes() ([]v1.Node, *v1.NodeList, error) {
 	availableNodes := []v1.Node{}
 	for _, node := range nodes.Items {
 		if !nodesInUse.Contains(node.Name) {
-			valid, err := k8sutil.ValidNode(node, c.placement)
+			valid, err := k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
 			if err != nil {
 				logger.Warning("failed to validate node %s %v", node.Name, err)
 			} else if valid {

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
@@ -30,9 +29,8 @@ import (
 
 func TestAvailableMonNodes(t *testing.T) {
 	clientset := test.New(1)
-	c := New(test.CreateConfigDir(0), &clusterd.Context{Clientset: clientset}, "ns", "", "myversion",
-		cephv1.CephVersionSpec{}, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
-		rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
@@ -57,9 +55,8 @@ func TestAvailableMonNodes(t *testing.T) {
 
 func TestAvailableNodesInUse(t *testing.T) {
 	clientset := test.New(3)
-	c := New(test.CreateConfigDir(0), &clusterd.Context{Clientset: clientset}, "ns", "", "myversion",
-		cephv1.CephVersionSpec{}, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
-		rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// all three nodes are available by default
 	nodes, err := c.getMonNodes()
@@ -98,9 +95,8 @@ func TestAvailableNodesInUse(t *testing.T) {
 
 func TestTaintedNodes(t *testing.T) {
 	clientset := test.New(3)
-	c := New(test.CreateConfigDir(0), &clusterd.Context{Clientset: clientset}, "ns", "", "myversion",
-		cephv1.CephVersionSpec{}, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
-		rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
@@ -132,9 +128,8 @@ func TestTaintedNodes(t *testing.T) {
 
 func TestNodeAffinity(t *testing.T) {
 	clientset := test.New(3)
-	c := New(test.CreateConfigDir(0), &clusterd.Context{Clientset: clientset}, "ns", "", "myversion",
-		cephv1.CephVersionSpec{}, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
-		rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	nodes, err := c.getMonNodes()
 	assert.Nil(t, err)
@@ -181,15 +176,14 @@ func TestHostNetworkSameNode(t *testing.T) {
 	c.clusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
-	_, err := c.Start()
+	_, err := testStart(c)
 	assert.Error(t, err)
 }
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(3)
-	c := New(test.CreateConfigDir(0), &clusterd.Context{Clientset: clientset}, "ns", "", "myversion",
-		cephv1.CephVersionSpec{}, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: false},
-		rookalpha.Placement{}, false, v1.ResourceRequirements{}, metav1.OwnerReference{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", false, metav1.OwnerReference{})
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.HostNetwork = true
 

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -53,7 +53,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	}
 
 	// If deploying Nautilus or newer we need a new port for the monitor service
-	if cephv1.VersionAtLeast(c.cephVersion.Name, cephv1.Nautilus) {
+	if cephv1.VersionAtLeast(c.spec.CephVersion.Name, cephv1.Nautilus) {
 		addServicePort(s, "msgr2", Msgr2port)
 	}
 
@@ -76,7 +76,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	// mon endpoint are not actually like, they remain with the mgrs1 format
 	// however it's interesting to show that monitors can be addressed via 2 different ports
 	// in the end the service has msgr1 and msgr2 ports configured so it's not entirely wrong
-	if cephv1.VersionAtLeast(c.cephVersion.Name, cephv1.Nautilus) {
+	if cephv1.VersionAtLeast(c.spec.CephVersion.Name, cephv1.Nautilus) {
 		logger.Infof("mon %s endpoint are [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(Msgr2port)), s.Spec.ClusterIP, mon.Port)
 	} else {
 		logger.Infof("mon %s endpoint is %s:%d", mon.DaemonName, s.Spec.ClusterIP, mon.Port)

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -98,10 +98,13 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, hostname string) *v1.Pod {
 	if c.HostNetwork {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
-	c.placement.ApplyToPodSpec(&podSpec)
+
+	// apply the pod placement if specified in the crd
 	// remove Pod (anti-)affinity because we have our own placement logic
-	c.placement.PodAffinity = nil
-	c.placement.PodAntiAffinity = nil
+	p := cephv1.GetMonPlacement(c.spec.Placement)
+	p.PodAffinity = nil
+	p.PodAntiAffinity = nil
+	p.ApplyToPodSpec(&podSpec)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,12 +145,12 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) v1.Container {
 			config.NewFlag("public-addr", monConfig.PublicIP),
 			"--mkfs",
 		),
-		Image:           c.cephVersion.Image,
+		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
 		SecurityContext: podSecurityContext(),
 		// filesystem creation does not require ports to be exposed
-		Env:       opspec.DaemonEnvVars(c.cephVersion.Image),
-		Resources: c.resources,
+		Env:       opspec.DaemonEnvVars(c.spec.CephVersion.Image),
+		Resources: cephv1.GetMonResources(c.spec.Resources),
 	}
 }
 
@@ -164,7 +167,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			config.NewFlag("public-addr", monConfig.PublicIP),
 			config.NewFlag("public-bind-addr", opspec.ContainerEnvVarReference(podIPEnvVar)),
 		),
-		Image:           c.cephVersion.Image,
+		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
 		SecurityContext: podSecurityContext(),
 		Ports: []v1.ContainerPort{
@@ -175,14 +178,14 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			},
 		},
 		Env: append(
-			opspec.DaemonEnvVars(c.cephVersion.Image),
+			opspec.DaemonEnvVars(c.spec.CephVersion.Image),
 			k8sutil.PodIPEnvVar(podIPEnvVar),
 		),
-		Resources: c.resources,
+		Resources: cephv1.GetMonResources(c.spec.Resources),
 	}
 
 	// If deploying Nautilus and newer we need a new port of the monitor container
-	if cephv1.VersionAtLeast(c.cephVersion.Name, cephv1.Nautilus) {
+	if cephv1.VersionAtLeast(c.spec.CephVersion.Name, cephv1.Nautilus) {
 		addContainerPort(container, "msgr2", 3300)
 	}
 

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -44,9 +44,10 @@ func testPodSpec(t *testing.T, monID string) {
 		false,
 		metav1.OwnerReference{},
 	)
-	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
-	c.cephVersion = cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"}
-	c.resources = v1.ResourceRequirements{
+	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
+	c.spec.CephVersion = cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"}
+	c.spec.Resources = map[string]v1.ResourceRequirements{}
+	c.spec.Resources["mon"] = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
 		},

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
@@ -39,25 +38,22 @@ func TestPodSpecs(t *testing.T) {
 func testPodSpec(t *testing.T, monID string) {
 	clientset := testop.New(1)
 	c := New(
-		testop.CreateConfigDir(0),
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
 		"/var/lib/rook",
-		"rook/rook:myversion",
-		cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"},
-		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
-		rookalpha.Placement{},
 		false,
-		v1.ResourceRequirements{
-			Limits: v1.ResourceList{
-				v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
-			},
-			Requests: v1.ResourceList{
-				v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
-			},
-		},
 		metav1.OwnerReference{},
 	)
+	setTestMonSettings(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
+	c.cephVersion = cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"}
+	c.resources = v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+		},
+	}
 	monConfig := testGenMonConfig(monID)
 
 	d := c.makeDeployment(monConfig, "node0")


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The orchestrations need to be triggered on any update to the crd. Users today restart the operator for various scenarios when the operator could take care of it automatically. If unsupported options are updated, they should just be ignored.

The subsequent change needed for this is it became apparent there was a race condition for updating the mons. There are two goroutines that are working with the mons. The first is an orchestration that is triggered by the operator at startup, or when the cluster crd is updated. The second is the health check that triggers periodically by default every 45 seconds. These goroutines must not try to make updates at the same time. A mutex is added so one will block if the other is still active. The mutex is only active for the duration of working with mons, and not an entire orchestration of mgr, osd, etc

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
