### PR TITLE
Update all operators to use apps/v1

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -71,25 +71,23 @@ As an example, we will start the kube-registry pod with the shared file system a
 Save the following spec as `kube-registry.yaml`:
 
 ```yaml
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: kube-registry-v0
+  name: kube-registry
   namespace: kube-system
   labels:
     k8s-app: kube-registry
-    version: v0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 3
   selector:
-    k8s-app: kube-registry
-    version: v0
+    matchLabels:
+      k8s-app: kube-registry
   template:
     metadata:
       labels:
         k8s-app: kube-registry
-        version: v0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1415,7 +1415,6 @@
     "github.com/stretchr/testify/suite",
     "github.com/yanniszark/go-nodetool/nodetool",
     "k8s.io/api/apps/v1",
-    "k8s.io/api/apps/v1beta1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/policy/v1beta1",

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner.yaml
@@ -1,5 +1,5 @@
 kind: StatefulSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-cephfsplugin-provisioner
   namespace: {{ .Namespace }}  

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-cephfsplugin
   namespace: {{ .Namespace }}  

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-attacher.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-attacher.yaml
@@ -1,0 +1,35 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-rbdplugin-attacher
+  namespace: {{ .Namespace }}  
+spec:
+  serviceName: csi-rbdplugin-attacher
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-rbdplugin-attacher  
+  template:
+    metadata:
+      labels:
+        app: csi-rbdplugin-attacher
+    spec:
+      serviceAccount: rook-csi-rbd-attacher-sa
+      containers:
+        - name: csi-rbdplugin-attacher
+          image: {{ .AttacherImage }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/csi-rbdplugin/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/csi-rbdplugin
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi-rbdplugin
+            type: DirectoryOrCreate

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
@@ -1,5 +1,5 @@
 kind: StatefulSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-rbdplugin-provisioner
   namespace: {{ .Namespace }}

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-rbdplugin
   namespace: {{ .Namespace }}  

--- a/cluster/examples/kubernetes/ceph/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/kube-registry.yaml
@@ -1,22 +1,20 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: kube-registry-v0
+  name: kube-registry
   namespace: kube-system
   labels:
     k8s-app: kube-registry
-    version: v0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 3
   selector:
-    k8s-app: kube-registry
-    version: v0
+    matchLabels:
+      k8s-app: kube-registry
   template:
     metadata:
       labels:
         k8s-app: kube-registry
-        version: v0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:

--- a/cluster/examples/kubernetes/cockroachdb/loadgen-kv.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/loadgen-kv.yaml
@@ -1,9 +1,14 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example
+  name: loadgen
   namespace: rook-cockroachdb
+  labels:
+    app: loadgen
 spec:
+  selector:
+    matchLabels:
+      app: loadgen
   replicas: 1
   template:
     metadata:

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -74,12 +74,17 @@ subjects:
   name: rook-cockroachdb-operator
   namespace: rook-cockroachdb-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-cockroachdb-operator
   namespace: rook-cockroachdb-system
+  labels:
+    app: rook-cockroachdb-operator
 spec:
+  selector:
+    matchLabels:
+      app: rook-cockroachdb-operator
   replicas: 1
   template:
     metadata:

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -215,7 +215,7 @@ subjects:
   namespace: rook-edgefs-system
 ---
 # The deployment for the rook operator
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-edgefs-operator
@@ -224,6 +224,9 @@ metadata:
     operator: rook
     storage-backend: edgefs
 spec:
+  selector:
+    matchLabels:
+      app: rook-edgefs-operator
   replicas: 1
   template:
     metadata:

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -73,12 +73,17 @@ subjects:
   name: rook-minio-operator
   namespace: rook-minio-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-minio-operator
   namespace: rook-minio-system
+  labels:
+    app: rook-minio-operator
 spec:
+  selector:
+    matchLabels:
+      app: rook-minio-operator
   replicas: 1
   template:
     metadata:

--- a/cluster/examples/kubernetes/mysql.yaml
+++ b/cluster/examples/kubernetes/mysql.yaml
@@ -26,13 +26,18 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress-mysql
   labels:
     app: wordpress
+    tier: mysql
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: mysql
   strategy:
     type: Recreate
   template:

--- a/cluster/examples/kubernetes/nfs/busybox-rc.yaml
+++ b/cluster/examples/kubernetes/nfs/busybox-rc.yaml
@@ -1,16 +1,21 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
+  labels:
+    app: nfs-demo
+    role: busybox
   name: nfs-busybox
 spec:
   replicas: 2
   selector:
-    name: nfs-busybox
+    matchLabels:
+      app: nfs-demo
+      role: busybox
   template:
     metadata:
       labels:
-        name: nfs-busybox
         app: nfs-demo
+        role: busybox
     spec:
       containers:
       - image: busybox

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -73,13 +73,18 @@ subjects:
   name: rook-nfs-operator
   namespace: rook-nfs-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-nfs-operator
   namespace: rook-nfs-system
+  labels:
+    app: rook-nfs-operator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rook-nfs-operator
   template:
     metadata:
       labels:

--- a/cluster/examples/kubernetes/nfs/web-rc.yaml
+++ b/cluster/examples/kubernetes/nfs/web-rc.yaml
@@ -1,16 +1,21 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
+  labels:
+    app: nfs-demo
+    role: web-frontend
   name: nfs-web
 spec:
   replicas: 2
   selector:
-    role: web-frontend
+    matchLabels:
+      app: nfs-demo
+      role: web-frontend
   template:
     metadata:
       labels:
-        role: web-frontend
         app: nfs-demo
+        role: web-frontend
     spec:
       containers:
       - name: web

--- a/cluster/examples/kubernetes/wordpress.yaml
+++ b/cluster/examples/kubernetes/wordpress.yaml
@@ -32,7 +32,12 @@ metadata:
   name: wordpress
   labels:
     app: wordpress
+    tier: frontend
 spec:
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
   strategy:
     type: Recreate
   template:

--- a/cmd/rook/cassandra/operator.go
+++ b/cmd/rook/cassandra/operator.go
@@ -18,6 +18,8 @@ package cassandra
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/rook/rook/cmd/rook/rook"
 	rookinformers "github.com/rook/rook/pkg/client/informers/externalversions"
 	"github.com/rook/rook/pkg/operator/cassandra/constants"
@@ -29,7 +31,6 @@ import (
 	"k8s.io/apiserver/pkg/server"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/informers/internalinterfaces"
-	"time"
 )
 
 const resyncPeriod = time.Second * 30

--- a/design/decouple-ceph-version.md
+++ b/design/decouple-ceph-version.md
@@ -30,7 +30,7 @@ The full image name is an important part of the version. This allows the contain
 In this example, the Rook version is `rook/ceph:v0.8.1`.
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator

--- a/design/dynamic-provision-filesystem.md
+++ b/design/dynamic-provision-filesystem.md
@@ -16,7 +16,7 @@ Also Dynamic Provision Filesystem is a concept that has already been done in htt
 To consume a filesystem, the experience is the following:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql
@@ -70,7 +70,7 @@ spec:
 To consume it, the pod manifest is shown as follows:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql

--- a/design/nfs.md
+++ b/design/nfs.md
@@ -79,21 +79,21 @@ spec:
 ```
 The table explains each parameter
 
-| Parameter                                 | Description                              | Default                       |
-|-------------------------------------------|------------------------------------------|-------------------------------|
-| `replicas`                                | The no. of NFS daemon to start           | `1`                           |
-| `exports`                                 | Parameters for creating an export        | <none>                        |
-| `exports.name`                            | Name of the volume being shared          | <none>                        |
-| `exports.server`                          | NFS server configuration                 | <none>                        |
-| `exports.server.accessMode`               | Volume access modes(Reading and Writing) for the share          | `ReadOnly` |
-| `exports.server.squash`                   | This prevents root users connected remotely from having root privileges  | `root` |
-| `exports.server.allowedClients`           | Access configuration for clients that can consume the NFS volume         | <none> |
-| `exports.server.allowedClients.name`      | Name of the host/hosts                                                   | <none> |
-| `exports.server.allowedClients.clients`   | The host or network to which export is being shared.(could be hostname, ip address, netgroup, CIDR network address, or all) | <none> |
-| `exports.server.allowedClients.accessMode` | Reading and Writing permissions for the client*                         | `ReadOnly` |
-| `exports.server.allowedClients.squash`    | Squash option for the client*                                          | `root`     |
-| `exports.persistentVolumeClaim`      | Claim to get volume(Volume could come from hostPath, cephFS, cephRBD, googlePD, EBS etc. and these volumes will be exposed by NFS server ). | <none> |
-| `exports.persistentVolumeClaim.claimName` | Name of the PVC                                         | <none>    |
+| Parameter                                  | Description                                                                                                                                 | Default    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `replicas`                                 | The no. of NFS daemon to start                                                                                                              | `1`        |
+| `exports`                                  | Parameters for creating an export                                                                                                           | <none>     |
+| `exports.name`                             | Name of the volume being shared                                                                                                             | <none>     |
+| `exports.server`                           | NFS server configuration                                                                                                                    | <none>     |
+| `exports.server.accessMode`                | Volume access modes(Reading and Writing) for the share                                                                                      | `ReadOnly` |
+| `exports.server.squash`                    | This prevents root users connected remotely from having root privileges                                                                     | `root`     |
+| `exports.server.allowedClients`            | Access configuration for clients that can consume the NFS volume                                                                            | <none>     |
+| `exports.server.allowedClients.name`       | Name of the host/hosts                                                                                                                      | <none>     |
+| `exports.server.allowedClients.clients`    | The host or network to which export is being shared.(could be hostname, ip address, netgroup, CIDR network address, or all)                 | <none>     |
+| `exports.server.allowedClients.accessMode` | Reading and Writing permissions for the client*                                                                                             | `ReadOnly` |
+| `exports.server.allowedClients.squash`     | Squash option for the client*                                                                                                               | `root`     |
+| `exports.persistentVolumeClaim`            | Claim to get volume(Volume could come from hostPath, cephFS, cephRBD, googlePD, EBS etc. and these volumes will be exposed by NFS server ). | <none>     |
+| `exports.persistentVolumeClaim.claimName`  | Name of the PVC                                                                                                                             | <none>     |
 
 *note: if `exports.server.accessMode` and `exports.server.squash` options are mentioned, `exports.server.allowedClients.accessMode` and `exports.server.allowedClients.squash` are overridden respectively.
 
@@ -261,7 +261,7 @@ spec:
     requests:
       storage: 1Gi
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-server

--- a/pkg/operator/cassandra/controller/controller_test.go
+++ b/pkg/operator/cassandra/controller/controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	rookfake "github.com/rook/rook/pkg/client/clientset/versioned/fake"
 	rookScheme "github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	rookinformers "github.com/rook/rook/pkg/client/informers/externalversions"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"time"
 )
 
 const informerResyncPeriod = time.Millisecond

--- a/pkg/operator/ceph/agent/agent.go
+++ b/pkg/operator/ceph/agent/agent.go
@@ -240,13 +240,13 @@ func (a *Agent) createAgentDaemonSet(namespace, agentImage, serviceAccount strin
 		}
 	}
 
-	_, err = a.clientset.Apps().DaemonSets(namespace).Create(ds)
+	_, err = a.clientset.AppsV1().DaemonSets(namespace).Create(ds)
 	if err != nil {
 		if !kserrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create rook-ceph-agent daemon set. %+v", err)
 		}
 		logger.Infof("rook-ceph-agent daemonset already exists, updating ...")
-		_, err = a.clientset.Apps().DaemonSets(namespace).Update(ds)
+		_, err = a.clientset.AppsV1().DaemonSets(namespace).Update(ds)
 		if err != nil {
 			return fmt.Errorf("failed to update rook-ceph-agent daemon set. %+v", err)
 		}

--- a/pkg/operator/ceph/agent/agent_test.go
+++ b/pkg/operator/ceph/agent/agent_test.go
@@ -62,7 +62,7 @@ func TestStartAgentDaemonset(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check daemonset parameters
-	agentDS, err := clientset.Apps().DaemonSets(namespace).Get("rook-ceph-agent", metav1.GetOptions{})
+	agentDS, err := clientset.AppsV1().DaemonSets(namespace).Get("rook-ceph-agent", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, namespace, agentDS.Namespace)
 	assert.Equal(t, "rook-ceph-agent", agentDS.Name)
@@ -177,7 +177,7 @@ func TestStartAgentDaemonsetWithToleration(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check daemonset toleration
-	agentDS, err := clientset.Apps().DaemonSets(namespace).Get("rook-ceph-agent", metav1.GetOptions{})
+	agentDS, err := clientset.AppsV1().DaemonSets(namespace).Get("rook-ceph-agent", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(agentDS.Spec.Template.Spec.Tolerations))
 	assert.Equal(t, "mysa", agentDS.Spec.Template.Spec.ServiceAccountName)

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -126,7 +126,7 @@ func (c *Cluster) Start() error {
 		// start the deployment
 		d := c.makeDeployment(mgrConfig)
 		logger.Debugf("starting mgr deployment: %+v", d)
-		_, err := c.context.Clientset.Apps().Deployments(c.Namespace).Create(d)
+		_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(d)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create mgr deployment %s. %+v", resourceName, err)

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -100,7 +100,7 @@ func validateStart(t *testing.T, c *Cluster) {
 		}
 		logger.Infof("Looking for cephmgr replica %d", i)
 		daemonName := mgrNames[i]
-		_, err := c.context.Clientset.Apps().Deployments(c.Namespace).Get(fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
+		_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
 		assert.Nil(t, err)
 	}
 

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -305,7 +305,7 @@ func (c *Cluster) removeMon(daemonName string) error {
 	var gracePeriod int64
 	propagation := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-	if err := c.context.Clientset.Apps().Deployments(c.Namespace).Delete(resourceName, options); err != nil {
+	if err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Delete(resourceName, options); err != nil {
 		if errors.IsNotFound(err) {
 			logger.Infof("dead mon %s was already gone", resourceName)
 		} else {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -202,7 +202,7 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 	for i := 0; i < len(monNames); i++ {
 		monConfig := testGenMonConfig(monNames[i])
 		d := c.makeDeployment(monConfig, "node0")
-		_, err := clientset.Apps().Deployments(c.Namespace).Create(d)
+		_, err := clientset.AppsV1().Deployments(c.Namespace).Create(d)
 		assert.Nil(t, err)
 		po := c.makeMonPod(monConfig, "node0")
 		_, err = clientset.CoreV1().Pods(c.Namespace).Create(po)
@@ -246,7 +246,7 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 
 	// check if mon b has been deleted
 	var dlist *apps.DeploymentList
-	dlist, err = clientset.Apps().Deployments(c.Namespace).List(metav1.ListOptions{})
+	dlist, err = clientset.AppsV1().Deployments(c.Namespace).List(metav1.ListOptions{})
 	assert.Nil(t, err)
 	deleted := true
 	for _, d := range dlist.Items {
@@ -262,7 +262,7 @@ func TestCheckHealthTwoMonsOneNode(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check that nothing has changed
-	dlist, err = clientset.Apps().Deployments(c.Namespace).List(metav1.ListOptions{})
+	dlist, err = clientset.AppsV1().Deployments(c.Namespace).List(metav1.ListOptions{})
 	assert.Nil(t, err)
 
 	for _, d := range dlist.Items {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -485,13 +485,13 @@ func (c *Cluster) startMon(m *monConfig, hostname string) error {
 
 	d := c.makeDeployment(m, hostname)
 	logger.Debugf("Starting mon: %+v", d.Name)
-	_, err := c.context.Clientset.Apps().Deployments(c.Namespace).Create(d)
+	_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(d)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create mon %s. %+v", m.ResourceName, err)
 		}
 		logger.Debugf("deployment for mon %s already exists. updating if needed", m.ResourceName)
-		p, err := c.context.Clientset.Apps().Deployments(c.Namespace).Get(d.Name, metav1.GetOptions{})
+		p, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(d.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to update mon deployment %s. failed to inspect preexisting deployment. %+v", d.Name, err)
 		}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -218,7 +218,7 @@ func validateStart(t *testing.T, c *Cluster) {
 	assert.Equal(t, 4, len(s.Data))
 
 	// there is only one pod created. the other two won't be created since the first one doesn't start
-	_, err = c.context.Clientset.Apps().Deployments(c.Namespace).Get("rook-ceph-mon-a", metav1.GetOptions{})
+	_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get("rook-ceph-mon-a", metav1.GetOptions{})
 	assert.Nil(t, err)
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -301,7 +301,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 			continue
 		}
 
-		_, err = c.context.Clientset.Apps().Deployments(c.Namespace).Create(dp)
+		_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(dp)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				// we failed to create job, update the orchestration status for this node
@@ -421,7 +421,7 @@ func (c *Cluster) cleanupRemovedNode(config *provisionConfig, nodeName, crushNam
 func (c *Cluster) discoverStorageNodes() (map[string][]*apps.Deployment, error) {
 
 	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appName)}
-	osdDeployments, err := c.context.Clientset.Apps().Deployments(c.Namespace).List(listOpts)
+	osdDeployments, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).List(listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list osd deployment: %+v", err)
 	}

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -99,7 +99,7 @@ func (m *Mirroring) Start() error {
 
 		// Start the deployment
 		d := m.makeDeployment(daemonConf)
-		if _, err := m.context.Clientset.Apps().Deployments(m.Namespace).Create(d); err != nil {
+		if _, err := m.context.Clientset.AppsV1().Deployments(m.Namespace).Create(d); err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create %s deployment. %+v", resourceName, err)
 			}
@@ -107,11 +107,11 @@ func (m *Mirroring) Start() error {
 			if _, err := updateDeploymentAndWait(m.context, d, m.Namespace); err != nil {
 				// fail could be an issue updating label selector (immutable), so try del and recreate
 				logger.Debugf("updateDeploymentAndWait failed for rbd-mirror %s. Attempting del-and-recreate. %+v", resourceName, err)
-				err = m.context.Clientset.Apps().Deployments(m.Namespace).Delete(d.Name, &metav1.DeleteOptions{})
+				err = m.context.Clientset.AppsV1().Deployments(m.Namespace).Delete(d.Name, &metav1.DeleteOptions{})
 				if err != nil {
 					return fmt.Errorf("failed to delete rbd-mirror %s during del-and-recreate update attempt. %+v", resourceName, err)
 				}
-				if _, err := m.context.Clientset.Apps().Deployments(m.Namespace).Create(d); err != nil {
+				if _, err := m.context.Clientset.AppsV1().Deployments(m.Namespace).Create(d); err != nil {
 					return fmt.Errorf("failed to recreate rbd-mirror deployment %s during del-and-recreate update attempt. %+v", resourceName, err)
 				}
 			}
@@ -131,7 +131,7 @@ func (m *Mirroring) Start() error {
 
 func (m *Mirroring) removeExtraMirrors() error {
 	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appName)}
-	d, err := m.context.Clientset.Apps().Deployments(m.Namespace).List(opts)
+	d, err := m.context.Clientset.AppsV1().Deployments(m.Namespace).List(opts)
 	if err != nil {
 		return fmt.Errorf("failed to get mirrors. %+v", err)
 	}
@@ -157,7 +157,7 @@ func (m *Mirroring) removeExtraMirrors() error {
 			var gracePeriod int64
 			propagation := metav1.DeletePropagationForeground
 			deleteOpts := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-			if err = m.context.Clientset.Apps().Deployments(m.Namespace).Delete(deploy.Name, &deleteOpts); err != nil {
+			if err = m.context.Clientset.AppsV1().Deployments(m.Namespace).Delete(deploy.Name, &deleteOpts); err != nil {
 				logger.Warningf("failed to delete rbd-mirror %s. %+v", daemonName, err)
 			}
 

--- a/pkg/operator/ceph/cluster/rbd/mirror_test.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror_test.go
@@ -64,7 +64,7 @@ func TestRBDMirror(t *testing.T) {
 	assert.False(t, keysCreated[fullDaemonName("c")])
 
 	opts := metav1.ListOptions{}
-	d, err := clientset.Apps().Deployments(c.Namespace).List(opts)
+	d, err := clientset.AppsV1().Deployments(c.Namespace).List(opts)
 	assert.Equal(t, 2, len(d.Items))
 	for _, de := range d.Items {
 		daemonName := de.Name[len(de.Name)-1:]

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -208,11 +208,11 @@ func contains(arr []string, str string) bool {
 }
 
 func validateStart(t *testing.T, context *clusterd.Context, fs cephv1.CephFilesystem) {
-	r, err := context.Clientset.Apps().Deployments(fs.Namespace).Get("rook-ceph-mds-myfs-a", metav1.GetOptions{})
+	r, err := context.Clientset.AppsV1().Deployments(fs.Namespace).Get("rook-ceph-mds-myfs-a", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "rook-ceph-mds-myfs-a", r.Name)
 
-	r, err = context.Clientset.Apps().Deployments(fs.Namespace).Get("rook-ceph-mds-myfs-b", metav1.GetOptions{})
+	r, err = context.Clientset.AppsV1().Deployments(fs.Namespace).Get("rook-ceph-mds-myfs-b", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, "rook-ceph-mds-myfs-b", r.Name)
 }

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -134,7 +134,7 @@ func (c *Cluster) Start() error {
 		// start the deployment
 		d := c.makeDeployment(mdsConfig)
 		logger.Debugf("starting mds: %+v", d)
-		createdDeployment, err := c.context.Clientset.Apps().Deployments(c.fs.Namespace).Create(d)
+		createdDeployment, err := c.context.Clientset.AppsV1().Deployments(c.fs.Namespace).Create(d)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create mds deployment %s: %+v", mdsConfig.ResourceName, err)

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -141,7 +141,7 @@ func deleteMdsDeployment(context *clusterd.Context, namespace string, deployment
 	var gracePeriod int64
 	propagation := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-	if err := context.Clientset.Apps().Deployments(namespace).Delete(deployment.GetName(), options); err != nil {
+	if err := context.Clientset.AppsV1().Deployments(namespace).Delete(deployment.GetName(), options); err != nil {
 		errCount++
 		logger.Errorf("failed to delete mds deployment %s: %+v", deployment.GetName(), err)
 	}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -60,7 +60,7 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 
 		// start the deployment
 		deployment := c.makeDeployment(n, name, configName)
-		_, err = c.context.Clientset.Apps().Deployments(n.Namespace).Create(deployment)
+		_, err = c.context.Clientset.AppsV1().Deployments(n.Namespace).Create(deployment)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create ganesha deployment. %+v", err)

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -199,7 +199,7 @@ func (c *clusterConfig) deleteStore() error {
 
 // Check if the object store exists depending on either the deployment or the daemonset
 func (c *clusterConfig) storeExists() (bool, error) {
-	_, err := c.context.Clientset.Apps().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+	_, err := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil
@@ -208,7 +208,7 @@ func (c *clusterConfig) storeExists() (bool, error) {
 		return false, err
 	}
 
-	_, err = c.context.Clientset.Apps().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+	_, err = c.context.Clientset.AppsV1().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 	if err == nil {
 		//  the daemonset was found
 		return true, nil

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -68,18 +68,18 @@ func TestStartRGW(t *testing.T) {
 
 func validateStart(t *testing.T, c *clusterConfig, clientset *fake.Clientset, allNodes bool) {
 	if !allNodes {
-		r, err := clientset.Apps().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+		r, err := clientset.AppsV1().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, c.instanceName(), r.Name)
 
-		_, err = clientset.Apps().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+		_, err = clientset.AppsV1().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 	} else {
-		r, err := clientset.Apps().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+		r, err := clientset.AppsV1().DaemonSets(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, c.instanceName(), r.Name)
 
-		_, err = clientset.Apps().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
+		_, err = clientset.AppsV1().Deployments(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 		assert.True(t, errors.IsNotFound(err))
 	}
 

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -31,7 +31,7 @@ import (
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -312,14 +312,17 @@ func (c *ClusterController) createStatefulSet(cluster *cluster) error {
 		return err
 	}
 
-	statefulSet := &appsv1beta1.StatefulSet{
+	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: cluster.namespace,
 		},
-		Spec: appsv1beta1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			ServiceName: appName,
-			Replicas:    &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: createAppLabels(),
+			},
+			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: cluster.namespace,
@@ -327,16 +330,16 @@ func (c *ClusterController) createStatefulSet(cluster *cluster) error {
 				},
 				Spec: createPodSpec(cluster, c.containerImage, httpPort, grpcPort),
 			},
-			PodManagementPolicy: appsv1beta1.ParallelPodManagement,
-			UpdateStrategy: appsv1beta1.StatefulSetUpdateStrategy{
-				Type: appsv1beta1.RollingUpdateStatefulSetStrategyType,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 			},
 			VolumeClaimTemplates: cluster.spec.Storage.VolumeClaimTemplates,
 		},
 	}
 	k8sutil.SetOwnerRef(c.context.Clientset, cluster.namespace, &statefulSet.ObjectMeta, &cluster.ownerRef)
 
-	if _, err := c.context.Clientset.AppsV1beta1().StatefulSets(cluster.namespace).Create(statefulSet); err != nil {
+	if _, err := c.context.Clientset.AppsV1().StatefulSets(cluster.namespace).Create(statefulSet); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/pkg/operator/cockroachdb/controller_test.go
+++ b/pkg/operator/cockroachdb/controller_test.go
@@ -201,7 +201,7 @@ func TestOnAdd(t *testing.T) {
 	assert.Equal(t, int32(1), pdb.Spec.MaxUnavailable.IntVal)
 
 	// verify stateful set
-	ss, err := clientset.AppsV1beta1().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
+	ss, err := clientset.AppsV1().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.NotNil(t, ss)
 	assert.Equal(t, int32(5), *ss.Spec.Replicas)

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -170,13 +170,13 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 		}
 	}
 
-	_, err := d.clientset.Apps().DaemonSets(namespace).Create(ds)
+	_, err := d.clientset.AppsV1().DaemonSets(namespace).Create(ds)
 	if err != nil {
 		if !kserrors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create rook-discover daemon set. %+v", err)
 		}
 		logger.Infof("rook-discover daemonset already exists, updating ...")
-		_, err = d.clientset.Apps().DaemonSets(namespace).Update(ds)
+		_, err = d.clientset.AppsV1().DaemonSets(namespace).Update(ds)
 		if err != nil {
 			return fmt.Errorf("failed to update rook-discover daemon set. %+v", err)
 		}

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -50,7 +50,7 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	assert.Nil(t, err)
 
 	// check daemonset parameters
-	agentDS, err := clientset.Apps().DaemonSets(namespace).Get("rook-discover", metav1.GetOptions{})
+	agentDS, err := clientset.AppsV1().DaemonSets(namespace).Get("rook-discover", metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, namespace, agentDS.Namespace)
 	assert.Equal(t, "rook-discover", agentDS.Name)

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -123,7 +123,7 @@ func (c *Cluster) Start(rookImage string) error {
 	logger.Infof("Mgr Image is %s", rookImage)
 	// start the deployment
 	deployment := c.makeDeployment(appName, c.Namespace, rookImage, 1)
-	if _, err := c.context.Clientset.Apps().Deployments(c.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}

--- a/pkg/operator/edgefs/cluster/mgr/mgr_test.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr_test.go
@@ -63,7 +63,7 @@ func TestStartMGR(t *testing.T) {
 
 func validateStart(t *testing.T, c *Cluster) {
 
-	_, err := c.context.Clientset.Apps().Deployments(c.Namespace).Get("rook-edgefs-mgr", metav1.GetOptions{})
+	_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get("rook-edgefs-mgr", metav1.GetOptions{})
 	assert.Nil(t, err)
 
 	_, err = c.context.Clientset.CoreV1().Services(c.Namespace).Get("rook-edgefs-mgr", metav1.GetOptions{})

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -20,7 +20,7 @@ import (
 	edgefsv1alpha1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/operator/edgefs/cluster/target/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -395,17 +395,19 @@ func (c *Cluster) createPodSpec(rookImage string, dro edgefsv1alpha1.DevicesResu
 	}
 }
 
-func (c *Cluster) makeStatefulSet(replicas int32, rookImage string, dro edgefsv1alpha1.DevicesResurrectOptions) (*appsv1beta1.StatefulSet, error) {
-
-	statefulSet := &appsv1beta1.StatefulSet{
+func (c *Cluster) makeStatefulSet(replicas int32, rookImage string, dro edgefsv1alpha1.DevicesResurrectOptions) (*appsv1.StatefulSet, error) {
+	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      appName,
 			Namespace: c.Namespace,
 			Labels:    c.createAppLabels(),
 		},
-		Spec: appsv1beta1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			ServiceName: appName,
-			Replicas:    &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: c.createAppLabels(),
+			},
+			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: c.Namespace,
@@ -413,9 +415,9 @@ func (c *Cluster) makeStatefulSet(replicas int32, rookImage string, dro edgefsv1
 				},
 				Spec: c.createPodSpec(rookImage, dro),
 			},
-			PodManagementPolicy: appsv1beta1.ParallelPodManagement,
-			UpdateStrategy: appsv1beta1.StatefulSetUpdateStrategy{
-				Type: appsv1beta1.RollingUpdateStatefulSetStrategyType,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 			},
 		},
 	}

--- a/pkg/operator/edgefs/cluster/target/target.go
+++ b/pkg/operator/edgefs/cluster/target/target.go
@@ -125,7 +125,7 @@ func (c *Cluster) Start(rookImage string, nodes []rookalpha.Node, dro edgefsv1al
 	}
 
 	statefulSet, _ := c.makeStatefulSet(int32(len(nodes)), rookImage, dro)
-	if _, err := c.context.Clientset.AppsV1beta1().StatefulSets(c.Namespace).Create(statefulSet); err != nil {
+	if _, err := c.context.Clientset.AppsV1().StatefulSets(c.Namespace).Create(statefulSet); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
 		}

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -78,7 +78,7 @@ func (c *ISCSIController) CreateOrUpdate(s edgefsv1alpha1.ISCSI, update bool, ow
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, c.rookImage, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -331,7 +331,7 @@ func instanceName(svcname string) string {
 
 // Check if the ISCSI service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.ISCSI) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -89,7 +89,7 @@ func (c *ISGWController) CreateOrUpdate(s edgefsv1alpha1.ISGW, update bool, owne
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, c.rookImage, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -416,7 +416,7 @@ func instanceName(svcname string) string {
 
 // Check if the ISGW service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.ISGW) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -70,7 +70,7 @@ func (c *NFSController) CreateOrUpdate(s edgefsv1alpha1.NFS, update bool, ownerR
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, c.rookImage, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -333,7 +333,7 @@ func instanceName(svcname string) string {
 
 // Check if the NFS service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.NFS) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -109,7 +109,7 @@ func (c *S3Controller) CreateOrUpdate(s edgefsv1alpha1.S3, update bool, ownerRef
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, rookImage+":"+rookImageVer, imageArgs, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -385,7 +385,7 @@ func instanceName(svcname string) string {
 
 // Check if the S3 service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.S3) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/edgefs/s3x/s3x.go
+++ b/pkg/operator/edgefs/s3x/s3x.go
@@ -83,7 +83,7 @@ func (c *S3XController) CreateOrUpdate(s edgefsv1alpha1.S3X, update bool, ownerR
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, c.rookImage, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -355,7 +355,7 @@ func instanceName(svcname string) string {
 
 // Check if the S3X service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.S3X) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -97,7 +97,7 @@ func (c *SWIFTController) CreateOrUpdate(s edgefsv1alpha1.SWIFT, update bool, ow
 
 	// start the deployment
 	deployment := c.makeDeployment(s.Name, s.Namespace, rookImage+":"+rookImageVer, imageArgs, s.Spec)
-	if _, err := c.context.Clientset.Apps().Deployments(s.Namespace).Create(deployment); err != nil {
+	if _, err := c.context.Clientset.AppsV1().Deployments(s.Namespace).Create(deployment); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
@@ -373,7 +373,7 @@ func instanceName(svcname string) string {
 
 // Check if the SWIFT service exists
 func serviceExists(context *clusterd.Context, s edgefsv1alpha1.SWIFT) (bool, error) {
-	_, err := context.Clientset.Apps().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
+	_, err := context.Clientset.AppsV1().Deployments(s.Namespace).Get(instanceName(s.Name), metav1.GetOptions{})
 	if err == nil {
 		// the deployment was found
 		return true, nil

--- a/pkg/operator/k8sutil/daemonset.go
+++ b/pkg/operator/k8sutil/daemonset.go
@@ -27,10 +27,10 @@ import (
 
 // CreateDaemonSet creates
 func CreateDaemonSet(name, namespace string, clientset kubernetes.Interface, ds *apps.DaemonSet) error {
-	_, err := clientset.Apps().DaemonSets(namespace).Create(ds)
+	_, err := clientset.AppsV1().DaemonSets(namespace).Create(ds)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			_, err = clientset.Apps().DaemonSets(namespace).Update(ds)
+			_, err = clientset.AppsV1().DaemonSets(namespace).Update(ds)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to start %s daemonset: %v\n%v", name, err, ds)
@@ -42,10 +42,10 @@ func CreateDaemonSet(name, namespace string, clientset kubernetes.Interface, ds 
 // DeleteDaemonset makes a best effort at deleting a daemonset and its pods, then waits for them to be deleted
 func DeleteDaemonset(clientset kubernetes.Interface, namespace, name string) error {
 	deleteAction := func(options *metav1.DeleteOptions) error {
-		return clientset.Apps().DaemonSets(namespace).Delete(name, options)
+		return clientset.AppsV1().DaemonSets(namespace).Delete(name, options)
 	}
 	getAction := func() error {
-		_, err := clientset.Apps().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		_, err := clientset.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
 		return err
 	}
 	return deleteResourceAndWait(namespace, name, "daemonset", deleteAction, getAction)

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -29,7 +29,7 @@ import (
 
 // GetDeploymentImage returns the version of the image running in the pod spec for the desired container
 func GetDeploymentImage(clientset kubernetes.Interface, namespace, name, container string) (string, error) {
-	d, err := clientset.Apps().Deployments(namespace).Get(name, metav1.GetOptions{})
+	d, err := clientset.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to find deployment %s. %v", name, err)
 	}
@@ -48,13 +48,13 @@ func GetDeploymentSpecImage(clientset kubernetes.Interface, d apps.Deployment, c
 // UpdateDeploymentAndWait updates a deployment and waits until it is running to return. It will
 // error if the deployment does not exist to be updated or if it takes too long.
 func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*v1.Deployment, error) {
-	original, err := context.Clientset.Apps().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
+	original, err := context.Clientset.AppsV1().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment %s. %+v", deployment.Name, err)
 	}
 
 	logger.Infof("updating deployment %s", deployment.Name)
-	if _, err := context.Clientset.Apps().Deployments(namespace).Update(deployment); err != nil {
+	if _, err := context.Clientset.AppsV1().Deployments(namespace).Update(deployment); err != nil {
 		return nil, fmt.Errorf("failed to update deployment %s. %+v", deployment.Name, err)
 	}
 
@@ -67,7 +67,7 @@ func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deploym
 	}
 	for i := 0; i < attempts; i++ {
 		// check for the status of the deployment
-		d, err := context.Clientset.Apps().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
+		d, err := context.Clientset.AppsV1().Deployments(namespace).Get(deployment.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get deployment %s. %+v", deployment.Name, err)
 		}
@@ -88,7 +88,7 @@ func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deploym
 // more: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 func GetDeployments(clientset kubernetes.Interface, namespace, labelSelector string) (*apps.DeploymentList, error) {
 	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
-	deployments, err := clientset.Apps().Deployments(namespace).List(listOptions)
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(listOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list deployments with labelSelector %s: %v", labelSelector, err)
 	}
@@ -99,10 +99,10 @@ func GetDeployments(clientset kubernetes.Interface, namespace, labelSelector str
 func DeleteDeployment(clientset kubernetes.Interface, namespace, name string) error {
 	logger.Debugf("removing %s deployment if it exists", name)
 	deleteAction := func(options *metav1.DeleteOptions) error {
-		return clientset.Apps().Deployments(namespace).Delete(name, options)
+		return clientset.AppsV1().Deployments(namespace).Delete(name, options)
 	}
 	getAction := func() error {
-		_, err := clientset.Apps().Deployments(namespace).Get(name, metav1.GetOptions{})
+		_, err := clientset.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
 		return err
 	}
 	return deleteResourceAndWait(namespace, name, "deployment", deleteAction, getAction)
@@ -115,7 +115,7 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 	sleepTime := 3
 	attempts := 120
 	for i := 0; i < attempts; i++ {
-		deployments, err := clientset.Apps().Deployments(namespace).List(metav1.ListOptions{LabelSelector: label})
+		deployments, err := clientset.AppsV1().Deployments(namespace).List(metav1.ListOptions{LabelSelector: label})
 		if err != nil {
 			return fmt.Errorf("failed to list deployments with label %s. %v", label, err)
 		}

--- a/pkg/operator/k8sutil/replicaset.go
+++ b/pkg/operator/k8sutil/replicaset.go
@@ -24,10 +24,10 @@ import (
 // DeleteReplicaSet makes a best effort at deleting a deployment and its pods, then waits for them to be deleted
 func DeleteReplicaSet(clientset kubernetes.Interface, namespace, name string) error {
 	deleteAction := func(options *metav1.DeleteOptions) error {
-		return clientset.Apps().ReplicaSets(namespace).Delete(name, options)
+		return clientset.AppsV1().ReplicaSets(namespace).Delete(name, options)
 	}
 	getAction := func() error {
-		_, err := clientset.Apps().ReplicaSets(namespace).Get(name, metav1.GetOptions{})
+		_, err := clientset.AppsV1().ReplicaSets(namespace).Get(name, metav1.GetOptions{})
 		return err
 	}
 	return deleteResourceAndWait(namespace, name, "replicaset", deleteAction, getAction)

--- a/pkg/operator/k8sutil/statefulset.go
+++ b/pkg/operator/k8sutil/statefulset.go
@@ -55,10 +55,10 @@ func CreateStatefulSet(name, namespace, appName string, clientset kubernetes.Int
 		return nil, fmt.Errorf("failed to start %s service: %v\n%v", name, err, ss)
 	}
 
-	_, err = clientset.Apps().StatefulSets(namespace).Create(ss)
+	_, err = clientset.AppsV1().StatefulSets(namespace).Create(ss)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			_, err = clientset.Apps().StatefulSets(namespace).Update(ss)
+			_, err = clientset.AppsV1().StatefulSets(namespace).Update(ss)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to start %s statefulset: %v\n%v", name, err, ss)

--- a/pkg/operator/k8sutil/test/deployment.go
+++ b/pkg/operator/k8sutil/test/deployment.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"github.com/rook/rook/pkg/clusterd"
-	"k8s.io/api/apps/v1"
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,13 +15,13 @@ import (
 // returns a pointer to this slice which the calling func may use to verify the expected contents of
 // deploymentsUpdated based on expected behavior.
 func UpdateDeploymentAndWaitStub() (
-	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*v1.Deployment, error),
+	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*apps.Deployment, error),
 	deploymentsUpdated *[]*apps.Deployment,
 ) {
 	deploymentsUpdated = &[]*apps.Deployment{}
-	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*v1.Deployment, error) {
+	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*apps.Deployment, error) {
 		*deploymentsUpdated = append(*deploymentsUpdated, deployment)
-		return &v1.Deployment{ObjectMeta: metav1.ObjectMeta{UID: "stub-deployment-uid"}}, nil
+		return &apps.Deployment{ObjectMeta: metav1.ObjectMeta{UID: "stub-deployment-uid"}}, nil
 	}
 	return stubFunc, deploymentsUpdated
 }

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -274,11 +274,11 @@ func (c *Controller) makeMinioStatefulSet(name, namespace string, spec miniov1al
 		},
 	}
 	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &sts.ObjectMeta, &ownerRef)
-	sts, err = c.context.Clientset.Apps().StatefulSets(namespace).Create(sts)
+	sts, err = c.context.Clientset.AppsV1().StatefulSets(namespace).Create(sts)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("failed to create minio statefulset. %+v", err)
 	}
-	sts, err = c.context.Clientset.Apps().StatefulSets(namespace).Update(sts)
+	sts, err = c.context.Clientset.AppsV1().StatefulSets(namespace).Update(sts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update minio statefulset. %+v", err)
 	}

--- a/pkg/operator/minio/controller_test.go
+++ b/pkg/operator/minio/controller_test.go
@@ -110,7 +110,7 @@ func TestOnAdd(t *testing.T) {
 	assert.Equal(t, minioPort, svc.Spec.Ports[0].Port)
 
 	// verify stateful set
-	ss, err := clientset.Apps().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
+	ss, err := clientset.AppsV1().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.NotNil(t, ss)
 	assert.Equal(t, int32(6), *ss.Spec.Replicas)

--- a/pkg/operator/nfs/controller_test.go
+++ b/pkg/operator/nfs/controller_test.go
@@ -152,7 +152,7 @@ NFS_Core_Param
 	assert.Equal(t, nfsGaneshaConfig, configMap.Data[nfsConfigMapName])
 
 	// verify stateful set
-	ss, err := clientset.AppsV1beta1().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
+	ss, err := clientset.AppsV1().StatefulSets(namespace).Get(appName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.NotNil(t, ss)
 	assert.Equal(t, int32(1), *ss.Spec.Replicas)

--- a/tests/framework/clients/read_write.go
+++ b/tests/framework/clients/read_write.go
@@ -36,7 +36,7 @@ func CreateReadWriteOperation(k8sh *utils.K8sHelper) *ReadWriteOperation {
 // CreateWriteClient Function to create a nfs client in rook
 func (f *ReadWriteOperation) CreateWriteClient(volName string) ([]string, error) {
 	logger.Infof("creating the filesystem via replication controller")
-	writerSpec := getReplicationController(volName)
+	writerSpec := getDeployment(volName)
 
 	if err := f.k8sh.ResourceOperation("create", writerSpec); err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (f *ReadWriteOperation) CreateWriteClient(volName string) ([]string, error)
 
 // Delete Function to delete a nfs consuming pod in rook
 func (f *ReadWriteOperation) Delete() error {
-	return f.k8sh.DeleteResource("rc", "read-write-test")
+	return f.k8sh.DeleteResource("deployment", "read-write-test")
 }
 
 // Read Function to read from nfs mount point created by rook ,i.e. Read data from a pod that has an nfs export mounted
@@ -74,15 +74,16 @@ func (f *ReadWriteOperation) Read(name string) (string, error) {
 	return result, nil
 }
 
-func getReplicationController(volName string) string {
-	return `apiVersion: v1
-kind: ReplicationController
+func getDeployment(volName string) string {
+	return `apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: read-write-test
 spec:
   replicas: 2
   selector:
-    app: read-write-test
+    matchLabels:
+      app: read-write-test
   template:
     metadata:
       labels:

--- a/tests/framework/installer/ceph_csi_templates.go
+++ b/tests/framework/installer/ceph_csi_templates.go
@@ -19,7 +19,7 @@ package installer
 const (
 	rbdProvisionerTemplate = `
     kind: StatefulSet
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     metadata:
       name: csi-rbdplugin-provisioner
       namespace: {{ .Namespace }}
@@ -135,7 +135,7 @@ const (
 `
 	rbdPluginTemplate = `
     kind: DaemonSet
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     metadata:
       name: csi-rbdplugin
       namespace: {{ .Namespace }}
@@ -253,7 +253,7 @@ const (
     `
 	cephfsProvisionerTemplate = `
     kind: StatefulSet
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     metadata:
       name: csi-cephfsplugin-provisioner
       namespace: {{ .Namespace }}
@@ -333,7 +333,7 @@ const (
 `
 	cephfsPluginTemplate = `
     kind: DaemonSet
-    apiVersion: apps/v1beta2
+    apiVersion: apps/v1
     metadata:
       name: csi-cephfsplugin
       namespace: {{ .Namespace }}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -708,7 +708,7 @@ roleRef:
   name: cephfs-external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
@@ -718,6 +718,9 @@ metadata:
     storage-backend: ceph
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-operator
   template:
     metadata:
       labels:

--- a/tests/framework/installer/cockroachdb_manifests.go
+++ b/tests/framework/installer/cockroachdb_manifests.go
@@ -106,12 +106,17 @@ subjects:
   name: rook-cockroachdb-operator
   namespace: ` + namespace + `
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-cockroachdb-operator
   namespace: ` + namespace + `
+  labels:
+    app: rook-cockroachdb-operator
 spec:
+  selector:
+    matchLabels:
+      app: rook-cockroachdb-operator
   replicas: 1
   template:
     metadata:

--- a/tests/framework/installer/nfs_manifests.go
+++ b/tests/framework/installer/nfs_manifests.go
@@ -104,12 +104,17 @@ subjects:
   name: rook-nfs-operator
   namespace: ` + namespace + `
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-nfs-operator
   namespace: ` + namespace + `
+  labels:
+    app: rook-nfs-operator
 spec:
+  selector:
+    matchLabels:
+      app: rook-nfs-operator
   replicas: 1
   template:
     metadata:

--- a/tests/integration/base_block_test.go
+++ b/tests/integration/base_block_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -330,7 +330,7 @@ spec:
       restartPolicy: Never`
 }
 
-func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podName, StorageClassName string) (*v1.Service, *v1beta1.StatefulSet) {
+func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podName, StorageClassName string) (*v1.Service, *appsv1.StatefulSet) {
 	service := &v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -359,23 +359,28 @@ func getBlockStatefulSetAndServiceDefinition(namespace, statefulsetName, podName
 
 	var replica int32 = 1
 
-	statefulSet := &v1beta1.StatefulSet{
+	labels := map[string]string{
+		"app": statefulsetName,
+	}
+
+	statefulSet := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1beta1",
+			APIVersion: "apps/v1",
 			Kind:       "StatefulSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
 			Namespace: namespace,
 		},
-		Spec: v1beta1.StatefulSetSpec{
+		Spec: appsv1.StatefulSetSpec{
 			ServiceName: statefulsetName,
-			Replicas:    &replica,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Replicas: &replica,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": statefulsetName,
-					},
+					Labels: labels,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/tests/integration/block_create_test.go
+++ b/tests/integration/block_create_test.go
@@ -157,7 +157,7 @@ func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 	service, statefulset := getBlockStatefulSetAndServiceDefinition(defaultNamespace, statefulSetName, statefulPodsName, storageClassName)
 	_, err = s.kh.Clientset.CoreV1().Services(defaultNamespace).Create(service)
 	assert.Nil(s.T(), err)
-	_, err = s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Create(statefulset)
+	_, err = s.kh.Clientset.AppsV1().StatefulSets(defaultNamespace).Create(statefulset)
 	assert.Nil(s.T(), err)
 	require.True(s.T(), s.kh.CheckPodCountAndState(statefulSetName, defaultNamespace, 1, "Running"))
 	require.True(s.T(), s.kh.CheckPvcCountAndStatus(statefulSetName, defaultNamespace, 1, "Bound"))
@@ -179,7 +179,7 @@ func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + statefulSetName}
 	err = s.kh.Clientset.CoreV1().Services(defaultNamespace).Delete(statefulSetName, &delOpts)
 	assert.Nil(s.T(), err)
-	err = s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
+	err = s.kh.Clientset.AppsV1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
 	assert.Nil(s.T(), err)
 	err = s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
 	assert.Nil(s.T(), err)
@@ -192,7 +192,7 @@ func (s *BlockCreateSuite) statefulSetDataCleanup(namespace, poolName, storageCl
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + statefulSetName}
 	// Delete stateful set
 	s.kh.Clientset.CoreV1().Services(namespace).Delete(statefulSetName, &delOpts)
-	s.kh.Clientset.AppsV1beta1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
+	s.kh.Clientset.AppsV1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
 	s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
 	// Delete all PVCs
 	s.kh.DeletePvcWithLabel(defaultNamespace, statefulSetName)

--- a/tests/integration/mon_test.go
+++ b/tests/integration/mon_test.go
@@ -30,7 +30,7 @@ func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Mon Failover Smoke Test")
 
 	opts := metav1.ListOptions{LabelSelector: "app=rook-ceph-mon"}
-	deployments, err := suite.k8sh.Clientset.Apps().Deployments(suite.namespace).List(opts)
+	deployments, err := suite.k8sh.Clientset.AppsV1().Deployments(suite.namespace).List(opts)
 	require.Nil(suite.T(), err)
 	require.Equal(suite.T(), 3, len(deployments.Items))
 
@@ -38,12 +38,12 @@ func (suite *SmokeSuite) TestMonFailover() {
 	logger.Infof("Killing mon %s", monToKill)
 	propagation := metav1.DeletePropagationForeground
 	delOptions := &metav1.DeleteOptions{PropagationPolicy: &propagation}
-	err = suite.k8sh.Clientset.Apps().Deployments(suite.namespace).Delete(monToKill, delOptions)
+	err = suite.k8sh.Clientset.AppsV1().Deployments(suite.namespace).Delete(monToKill, delOptions)
 	require.Nil(suite.T(), err)
 
 	// Wait for the health check to start a new monitor
 	for i := 0; i < 10; i++ {
-		deployments, err := suite.k8sh.Clientset.Apps().Deployments(suite.namespace).List(opts)
+		deployments, err := suite.k8sh.Clientset.AppsV1().Deployments(suite.namespace).List(opts)
 		require.Nil(suite.T(), err)
 
 		// Make sure the old mon is not still alive

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -207,7 +207,7 @@ spec:
     requests:
       storage: 20Gi
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{.appName}}
@@ -216,6 +216,9 @@ metadata:
 spec:
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: {{.appLabel}}
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Description of your changes:**
Updated MySQL and Wordpress examples to use apps/v1

I also went ahead and fixed some indentation issues while changing the templated manifests to apps/v1.

**Which issue is resolved by this Pull Request:**
Resolves #2731.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
