### PR TITLE
Allow multiple operators in one cluster

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-ceph-cluster-mgmt
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-cluster-mgmt
   labels:
     operator: rook
     storage-backend: ceph
@@ -42,7 +42,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-ceph-global
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-global
   labels:
     operator: rook
     storage-backend: ceph
@@ -111,7 +111,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: rook-ceph-mgr-cluster
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-mgr-cluster
   labels:
     operator: rook
     storage-backend: ceph
@@ -131,7 +131,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-ceph-agent-mount
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-agent-mount
   labels:
     operator: rook
     storage-backend: ceph
@@ -148,7 +148,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: rook-ceph-system-psp-user
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-system-psp-user
   labels:
     operator: rook
     storage-backend: ceph
@@ -159,7 +159,7 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - 00-rook-ceph-operator
+  - 00-{{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-operator
   verbs:
   - use
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: rook-ceph-global
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-global
   labels:
     operator: rook
     storage-backend: ceph
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rook-ceph-global
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-global
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
@@ -21,7 +21,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: rook-ceph-system-psp-users
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-system-psp-users
   labels:
     operator: rook
     storage-backend: ceph
@@ -29,7 +29,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rook-ceph-system-psp-user
+  name: {{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-system-psp-user
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system

--- a/cluster/charts/rook-ceph/templates/psp.yaml
+++ b/cluster/charts/rook-ceph/templates/psp.yaml
@@ -14,7 +14,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: 00-rook-ceph-operator
+  name: 00-{{ if .Values.multipleOperators }}{{.Release.Name }}-{{ end }}rook-ceph-operator
 spec:
   fsGroup:
     rule: RunAsAny

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -47,6 +47,10 @@ rbacEnable: true
 ##
 pspEnable: true
 
+## If true, prefix all cluster resources to allow multiple operators run concurrently
+##
+multipleOperators: true
+
 ## Rook Agent configuration
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute
 ## tolerationKey: Set this to the specific key of the taint to tolerate


### PR DESCRIPTION
Deploy clusterroles, clusterrolebindings und psp under they're own namespace.

**Description of your changes:**

I regularly deploy new rook versions in they're own namespace. The current helm chart deploys cluster resources which share names with other operators then. This change allows prefixing all the cluster resources with the chart release name so cleanup won't affect other versions.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
