### PR TITLE
Add 'if not exists' to the command that creates a test database/table

### DIFF
--- a/tests/integration/cockroachdb_test.go
+++ b/tests/integration/cockroachdb_test.go
@@ -117,7 +117,7 @@ func (suite *CockroachDBSuite) TestCockroachDBClusterInstallation() {
 	command := "/cockroach/cockroach"
 	commandArgs := []string{
 		"sql", "--insecure", fmt.Sprintf("--host=cockroachdb-public.%s", suite.namespace), "-e",
-		`create database rookcockroachdb; use rookcockroachdb; create table testtable ( testID int ); insert into testtable values (123456789); select * from testtable;`,
+		`create database if not exists rookcockroachdb; use rookcockroachdb; create table if not exists testtable ( testID int ); insert into testtable values (123456789); select * from testtable;`,
 	}
 
 	inc := 0


### PR DESCRIPTION
Signed-off-by: Ryo Nakao <nakabonne@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

The cause for the tests mentioned in the #1870 to fail is trying to create a table that already exists.
All tests fail after outputting the following.

```
kubectl exec command /cockroach/cockroach failed on pod rook-cockroachdb-operator-7d5554bdc-npv92 in namespace cockroachdb-ns-system: Failed to run: kubectl [exec -n cockroachdb-ns-system rook-cockroachdb-operator-7d5554bdc-npv92 -- /cockroach/cockroach sql --insecure --host=cockroachdb-public.cockroachdb-ns -e create database rookcockroachdb; use rookcockroachdb; create table testtable ( testID int ); insert into testtable values (123456789); select * from testtable;] : Failed to complete 'kubectl': exit status 1. . output: Error: pq: database "rookcockroachdb" already exists
```

**Which issue is resolved by this Pull Request:**
Resolves #1870 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// these changes passed the build, skipping for known CI issues
[skip ci]