### PR TITLE
Increase the number of mons when nodes are added

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -84,8 +84,12 @@ This feature is only available when `useAllNodes` has been set to `false`.
 
 ### Mon Settings
 
-- `count`: set the number of mons to be started. The number should be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
-- `allowMultiplePerNode`: enable (`true`) or disable (`false`) the placement of multiple mons on one node. Default is `false`.
+- `count`: Set the number of mons to be started. The number should be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
+- `preferredCount`: If you want to increase the number of mons when the number of nodes increases, set the `preferredCount` to be larger than the `count`. For example, if your cluster
+starts with three nodes, but might grow to more than five nodes, you might want five mons running after the other nodes come online. In this case, set `count: 3` and `preferredCount: 5`.
+When the operator sees the new nodes come online, the number of mons will increase to the preferred count. If the number of nodes decreases below the `preferredCount`, the operator will
+reduce the number of mons back to `count`. If `allowMultiplePerNode: true` (for testing scenarios), the number of mons will always use `preferredCount` if set.
+- `allowMultiplePerNode`: Enable (`true`) or disable (`false`) the placement of multiple mons on one node. Default is `false`.
 
 If these settings are changed in the CRD the operator will update the number of mons during a periodic check of the mon health, which by default is every 45 seconds.
 
@@ -368,7 +372,7 @@ spec:
 ### Custom Location Information On Node Level
 For each individual node a `location` can be configured. The provided information is fed directly into the CRUSH map of Ceph. More information on CRUSH maps can be found in the [ceph docs](http://docs.ceph.com/docs/master/rados/operations/crush-map/).
 
-**HINT** When setting this prior to `CephCluster` creation, these settings take immediate effect. However, applying this to an already deployed `CephCluster` requires to remove each node from the cluster first and then re-add it with new configuration to take effect. Do this node by node to keep your data safe! You can check the result with `ceph osd tree` from the [Rook Toolbox](ceph-toolbox.md) in your setup. The OSD tree should display your location hierarchy for the nodes you already re-added. 
+**HINT** When setting this prior to `CephCluster` creation, these settings take immediate effect. However, applying this to an already deployed `CephCluster` requires to remove each node from the cluster first and then re-add it with new configuration to take effect. Do this node by node to keep your data safe! You can check the result with `ceph osd tree` from the [Rook Toolbox](ceph-toolbox.md) in your setup. The OSD tree should display your location hierarchy for the nodes you already re-added.
 
 This example assumes you have 3 unique racks in your datacenter and want to use them as failure domain
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -18,6 +18,7 @@
 - Added the dashboard `port` configuration setting.
 - Added the dashboard `ssl` configuration setting.
 - Added Ceph CSI driver deployments on Kubernetes 1.13 and above.
+- The number of mons can be increased automatically when new nodes come online. See the [preferredCount](https://rook.io/docs/rook/master/ceph-cluster-crd.html#mon-settings) setting in the cluster CRD documentation.
 - New Kubernetes nodes or nodes which are not tainted `NoSchedule` anymore get added automatically to the existing rook cluster if `useAllNodes` is set. [Issue #2208](https://github.com/rook/rook/issues/2208)
 
 ## Breaking Changes

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -49,6 +49,10 @@ spec:
                   maximum: 9
                   minimum: 1
                   type: integer
+                preferredCount:
+                  maximum: 9
+                  minimum: 0
+                  type: integer
               required:
               - count
             network:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -113,6 +113,7 @@ const (
 
 type MonSpec struct {
 	Count                int  `json:"count"`
+	PreferredCount       int  `json:"preferredCount"`
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode"`
 }
 

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -298,3 +298,55 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 
 	assert.Equal(t, "1.1.1.1", info.Address)
 }
+
+func TestTargetMonCount(t *testing.T) {
+	// only a single node and min 1
+	spec := cephv1.MonSpec{Count: 1, PreferredCount: 0, AllowMultiplePerNode: false}
+	nodes := 1
+	target, msg := calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 1, target)
+	logger.Infof(msg)
+
+	// preferred 3 mons, but only one node available
+	spec.PreferredCount = 3
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 1, target)
+	logger.Infof(msg)
+
+	// preferred 3 mons, and 3 nodes available
+	nodes = 3
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 3, target)
+	logger.Infof(msg)
+
+	// get an intermediate odd number since we have several options between the min and the node count
+	nodes = 4
+	spec.Count = 1
+	spec.PreferredCount = 5
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 3, target)
+	logger.Infof(msg)
+	nodes = 5
+	spec.PreferredCount = 6
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 5, target)
+	logger.Infof(msg)
+	nodes = 6
+	spec.PreferredCount = 7
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 5, target)
+	logger.Infof(msg)
+	nodes = 7
+	spec.PreferredCount = 7
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 7, target)
+	logger.Infof(msg)
+
+	// multiple allowed per node, so we always returned preferred
+	nodes = 1
+	spec.PreferredCount = 7
+	spec.AllowMultiplePerNode = true
+	target, msg = calcTargetMonCount(nodes, spec)
+	assert.Equal(t, 7, target)
+	logger.Infof(msg)
+}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The desired number of mons could change depending on the number of nodes in a cluster. For example, three mons would be the min number of mons in a production cluster with at least three nodes. If there are five or more nodes, the number of mons could increase to five in order to increase the failure tolerance to two nodes.

This is accomplished by a new setting in the cluster CRD preferredCount. If the number of hosts exceeds preferredCount, more mons are added to quorum. If the number of hosts drops below the preferred count, the operator would reduce the quorum size to the smaller desired count.

The implementation of increasing and decreasing mons is already implemented in the health check, so this change is mainly about calculating a dynamic number of desired mons.

**Which issue is resolved by this Pull Request:**
Resolves #2740

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
