### PR TITLE
Roadmap: update for recent v1.0 triage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,75 +10,90 @@ We use the [milestone](https://github.com/rook/rook/milestones) feature in Githu
 
 ## Rook 1.0
 
-* Custom resource validation, progress, status [#1539](https://github.com/rook/rook/issues/1539)
-* Durability of state (local storage support, config can be regenerated) [#1011](https://github.com/rook/rook/issues/1011) [#592](https://github.com/rook/rook/issues/592)
-* Integration testing improvements
-  * Update promotion and release channels to align with storage provider specific statuses [#1885](https://github.com/rook/rook/issues/1885)
-  * Refactor test framework and helpers to support multiple storage providers [#1788](https://github.com/rook/rook/issues/1788)
-  * Isolate and parallelize storage provider testing [#1218](https://github.com/rook/rook/issues/1218)
-  * Longhaul testing pipeline [#1847](https://github.com/rook/rook/issues/1847)
-* Support for dynamic provisioning of new storage types
-  * Dynamic bucket provisioning [#1705](https://github.com/rook/rook/issues/1705)
-  * Dynamic database provisioning [1704](https://github.com/rook/rook/issues/1704)
 * Cassandra
   * Admission webhook to reduce user error [#2363](https://github.com/rook/rook/issues/2363)
-  * Integrate prometheus monitoring [#2530](https://github.com/rook/rook/issues/2530)
-  * Integrate with Spotify Reaper to provide repairs [#2531](https://github.com/rook/rook/issues/2531)
-  * Dealing with loss of persistence: leverage cassandra's mechanisms to detect when data has been lost and stream it from other nodes [#2533](https://github.com/rook/rook/issues/2533)
-  * Minor version upgrades [#2532](https://github.com/rook/rook/issues/2532)
+  * Handle loss of persistent local data [#2533](https://github.com/rook/rook/issues/2533)
 * Ceph
-  * Ceph-CSI plug-in integration [#1385](https://github.com/rook/rook/issues/1385)
-    * Resizing volumes [#1169](https://github.com/rook/rook/issues/1169)
-  * Improved data placement and pool configuration (CRUSH maps) [#560](https://github.com/rook/rook/issues/560)
-  * OSDs
-    * Run on arbitrary PVs (local storage) as an alternative to host path [#919](https://github.com/rook/rook/issues/919)
-    * Detect new nodes for OSD configuration [#2208](https://github.com/rook/rook/issues/2208)
-    * Disk management (adding, removing, and replacing disks) [#1435](https://github.com/rook/rook/issues/1435)
-  * File
-    * NFS Ganesha CRD [#1799](https://github.com/rook/rook/issues/1799)
-    * Dynamic Volume Provisioning for CephFS [#1125](https://github.com/rook/rook/issues/1125)
-  * Object
-    * Multi-site configuration [#1584](https://github.com/rook/rook/issues/1584)
-  * Mgr and plugins
-    * Placement group balancer support (enable the mgr module)
+  * Add support for Ceph Nautilus
+  * Beta release of CSI plug-in [#1385](https://github.com/rook/rook/issues/1385)
+    * Dynamic volume resizing [#1169](https://github.com/rook/rook/issues/1169)
+  * Automatically detect new nodes [#2208](https://github.com/rook/rook/issues/2208)
+  * Disk management (adding, removing, and replacing disks) [#1435](https://github.com/rook/rook/issues/1435)
+  * Create NFS Ganesha CRD [#1799](https://github.com/rook/rook/issues/1799)
+  * Document metadata backup and disaster recovery [#592](https://github.com/rook/rook/issues/592)
 * CockroachDB
-  * Secure deployment using certificates [#1809](https://github.com/rook/rook/issues/1809)
-  * Helm chart deployment [#1810](https://github.com/rook/rook/issues/1810)
 * EdgeFS
   * Declare EdgeFS CRDs to be Beta v1 [#2506](https://github.com/rook/rook/issues/2506)
   * Automatic host validation [#2409](https://github.com/rook/rook/issues/2409)
-  * Target VDEVs
-    * Support for flexible write I/O “sync” option [#2367](https://github.com/rook/rook/issues/2367)
+  * Allow for more performance vs. availability tradeoff configuration [#2367](https://github.com/rook/rook/issues/2367)
   * Object
     * OpenStack/SWIFT CRD [#2509](https://github.com/rook/rook/issues/2509)
     * Support for S3 bucket as DNS subdomain [#2510](https://github.com/rook/rook/issues/2510)
-  * Block (iSCSI)
-    * Support Block CSI [#2507](https://github.com/rook/rook/issues/2507)
-  * Mgr
-    * Support for Prometheus Dashboard and REST APIs [#2401](https://github.com/rook/rook/issues/2401)
-    * Support for Management GUI with automated CRD wizards [#2508](https://github.com/rook/rook/issues/2508)
+  * Support Block (iSCSI) CSI [#2507](https://github.com/rook/rook/issues/2507)
+  * Support for Prometheus Dashboard and REST APIs [#2401](https://github.com/rook/rook/issues/2401)
+  * Support for Management GUI with automated CRD wizards [#2508](https://github.com/rook/rook/issues/2508)
+  * Failure domains and zoning provisioning support [#2513](https://github.com/rook/rook/issues/2513)
+  * Multi-Namespace clusters support [#2878](https://github.com/rook/rook/issues/2878)
+  * Embedded mode support [#2810](https://github.com/rook/rook/issues/2810)
 * Minio
-  * Helm chart deployment [#1814](https://github.com/rook/rook/issues/1814)
+* NFS
+
+## Initial planning for Rook 1.1
+
+* Cassandra
+  * Continue to implement Cassandra design [#2294](https://github.com/rook/rook/issues/2294)
+  * Integrate prometheus monitoring [#2530](https://github.com/rook/rook/issues/2530)
+  * Enable automated repairs [#2531](https://github.com/rook/rook/issues/2531)
+  * Minor version upgrades [#2532](https://github.com/rook/rook/issues/2532)
+* Ceph
+  * Allow Ceph disk selection by full path [#2845](https://github.com/rook/rook/pull/2845)
+  * Remove support for Ceph Luminous
+  * Stable release of Ceph-CSI plug-in (feature parity with FlexVolume)
+  * Mon placement respects failure domains [#2603](https://github.com/rook/rook/issues/2603)
+  * User-modifiable configuration at runtime [#2470](https://github.com/rook/rook/pull/2470/files)
+  * Support modified CRUSH maps [#2514](https://github.com/rook/rook/issue/2514)
+  * OSDs
+    * Run on arbitrary PVs (local storage) as an alternative to host path [#919](https://github.com/rook/rook/issues/919)
+    * Leverage node labels for CRUSH locations [#1366](https://github.com/rook/rook/issues/1366)
+  * Orchestrate multi-site replication [#1584](https://github.com/rook/rook/issues/1584)
+  * Document a safe shutdown procedure [#2517](https://github.com/rook/rook/issues/2517)
+* CockroachDB
+* EdgeFS
+* Minio
 * NFS
   * Dynamic NFS provisioning [#2062](https://github.com/rook/rook/issues/2062)
-  * Client access control [#2283](https://github.com/rook/rook/issues/2283)
 
-## Beyond 1.0
+## Future improvements
 
-* Support for multi-networking configurations to provide more secure storage configuration (Multus?)
-* Support for more dynamic clusters such as GKE [#2107](https://github.com/rook/rook/pull/2107)
+* Custom resource validation, progress, status [#1539](https://github.com/rook/rook/issues/1539)
 * Integration testing improvements
-  * Incorporate new environments [#1315](https://github.com/rook/rook/issues/1315)
-  * Incorporate more architectures [#1901](https://github.com/rook/rook/issues/1901)
+  * Update promotion and release channels to align with storage provider specific statuses [#1885](https://github.com/rook/rook/issues/1885)
+  * Speed up integration tests [#1218](https://github.com/rook/rook/issues/1218)
+  * Longhaul testing pipeline [#1847](https://github.com/rook/rook/issues/1847)
+  * Include more architectures [#1901](https://github.com/rook/rook/issues/1901)
+    and environments [#1315](https://github.com/rook/rook/issues/1315)
+                     [#1841](https://github.com/rook/rook/issues/1841) in test pipeline
+* Support for dynamic provisioning of bucket [#1705](https://github.com/rook/rook/issues/1705)
+  and database [#1704](https://github.com/rook/rook/issues/1704) storage types
+* Support for multi-networking configurations to provide more secure storage configuration. [#2621](https://github.com/rook/rook/issues/2621)
+* Upgrade Rook to a more advanced operator/controller framework [#1981](https://github.com/rook/rook/issues/1981)
+* Support disk selection by full path [#1228](https://github.com/rook/rook/issues/1228)
+* Wildcard support for disk selection spec [#1744](https://github.com/rook/rook/issues/1744)
+* Support for more dynamic clusters such as GKE [#2107](https://github.com/rook/rook/pull/2107)
 * Cassandra
   * Graduate CRDs to beta
 * Ceph
   * More complete upgrade automation
 * CockroachDB
+  * Helm chart deployment [#1810](https://github.com/rook/rook/issues/1810)
+  * Secure deployment using certificates [#1809](https://github.com/rook/rook/issues/1809)
   * Graduate CRDs to beta
 * EdgeFS
   * Graduate CRDs to v1
 * Minio
+  * Helm chart deployment [#1814](https://github.com/rook/rook/issues/1814)
+  * End-to-end integration tests [#1804](https://github.com/rook/rook/issues/1804)
   * Graduate CRDs to beta
 * NFS
+  * Client access control [#2283](https://github.com/rook/rook/issues/2283)
   * Graduate CRDs to beta


### PR DESCRIPTION
[skip ci]

**Description of your changes:**
Update roadmap with recent triage of v1.0 release.

There are 2 commits here:
 - commit 1 is a very granular, technical roadmap
 - commit 2 is more genercized, and I believe the direction we want the roadmap to go in.
Developers should be able to compare the two commits to make sure the more generalized commit doesn't remove any important information. When there is approval, these 2 PRs will be squashed. 

Who else should I add as reviewers from the various storage backend groups?

Should I include the April 1 (5th?) estimated Rook v1.0 release date?