### PR TITLE
 ceph filesytem: use `fs fail` to bring down filesystem

### DIFF
--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -309,6 +309,18 @@ func FailMDS(context *clusterd.Context, clusterName string, gid int) error {
 	return nil
 }
 
+// FailFilesystem efficiently brings down the filesystem by marking the filesystem as down
+// and failing the MDSes using a single Ceph command. This works only from nautilus version
+// of Ceph onwards.
+func FailFilesystem(context *clusterd.Context, clusterName, fsName string) error {
+	args := []string{"fs", "fail", fsName}
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to fail filesystem %s: %+v", fsName, err)
+	}
+	return nil
+}
+
 // RemoveFilesystem performs software configuration steps to remove a Ceph filesystem and its
 // backing pools.
 func RemoveFilesystem(context *clusterd.Context, clusterName, fsName string) error {

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -167,7 +167,7 @@ func (c *FilesystemController) onDelete(obj interface{}) {
 		return
 	}
 
-	err = deleteFilesystem(c.context, *filesystem)
+	err = deleteFilesystem(c.context, c.clusterInfo.CephVersion, *filesystem)
 	if err != nil {
 		logger.Errorf("failed to delete filesystem %s: %+v", filesystem.Name, err)
 	}

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -220,7 +220,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 
 // downFilesystem marks the filesystem as down and the MDS' as failed
 func downFilesystem(context *clusterd.Context, clusterName, filesystemName string) error {
-	logger.Infof("Removing filesystem %s", filesystemName)
+	logger.Infof("Downing filesystem %s", filesystemName)
 
 	// mark the cephFS instance as cluster_down before removing
 	if err := client.MarkFilesystemAsDown(context, clusterName, filesystemName); err != nil {
@@ -238,6 +238,6 @@ func downFilesystem(context *clusterd.Context, clusterName, filesystemName strin
 		}
 	}
 
-	logger.Infof("Removed filesystem %s", filesystemName)
+	logger.Infof("Downed filesystem %s", filesystemName)
 	return nil
 }


### PR DESCRIPTION
A ceph filesystem was brought down by marking the filesystem as down and individually failing the MDSes. From nautilus onwards, this could be more simply and efficiently done by using `fs fail` command. See, https://github.com/ceph/ceph/commit/4c49f165ec1

Resolves: #2841
Signed-off-by: Ramana Raja <rraja@redhat.com>

// known ci issues
[skip ci]