### PR TITLE
ceph: allow disk selection by full path (fixes #1228)

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -117,7 +117,7 @@ Below are the settings available, both at the cluster and individual node level,
   - `^s`: Selects all devices that start with `s`
   - `^[^r]`: Selects all devices that do *not* start with `r`
 - `devices`: A list of individual device names belonging to this node to include in the storage cluster.
-  - `name`: The name of the device (e.g., `sda`).
+  - `name`: The name of the device (e.g., `sda`), or full udev path (e.g. `/dev/disk/by-id/ata-ST4000DM004-XXXX` - this will not change after reboots).
   - `config`: Device-specific config settings. See the [config settings](#osd-configuration-settings) below.
 - `directories`:  A list of directory paths that will be included in the storage cluster. Note that using two directories on the same physical device can cause a negative performance impact.
   - `path`: The path on disk of the directory (e.g., `/rook/storage-dir`).
@@ -244,7 +244,7 @@ spec:
     - name: "172.17.4.201"
       devices:             # specific devices to use for storage can be specified for each node
       - name: "sdb"
-      - name: "sdc"
+      - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # both device name and explicit udev links are supported
       config:         # configuration can be specified at the node level which overrides the cluster level config
         storeType: bluestore
     - name: "172.17.4.301"

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,6 +20,8 @@
 - Added Ceph CSI driver deployments on Kubernetes 1.13 and above.
 - The number of mons can be increased automatically when new nodes come online. See the [preferredCount](https://rook.io/docs/rook/master/ceph-cluster-crd.html#mon-settings) setting in the cluster CRD documentation.
 - New Kubernetes nodes or nodes which are not tainted `NoSchedule` anymore get added automatically to the existing rook cluster if `useAllNodes` is set. [Issue #2208](https://github.com/rook/rook/issues/2208)
+- Specific devices for OSDs can now be specified using the full udev path (e.g. /dev/disk/by-id/ata-ST4000DM004-XXXX) instead of the device name
+
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -259,6 +259,7 @@ spec:
 #      - name: "nvme01" # multiple osds can be created on high performance devices
 #        config:
 #          osdsPerDevice: "5"
+#      - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # devices can be specified using full udev paths
 #      config: # configuration can be specified at the node level which overrides the cluster level config
 #        storeType: filestore
 #    - name: "172.17.4.301"

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -45,7 +45,7 @@ type Node struct {
 
 type Device struct {
 	Name     string            `json:"name,omitempty"`
-	FullPath string            // TODO: FullPath to be supported for devices
+	FullPath string            `json:"fullPath,omitempty"`
 	Config   map[string]string `json:"config"`
 }
 

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -220,6 +220,15 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 				} else if device.Name == desiredDevice.Name {
 					logger.Infof("%s found in the desired devices", device.Name)
 					matched = true
+				} else if strings.HasPrefix(desiredDevice.Name, "/dev/") {
+					devLinks := strings.Split(device.DevLinks, " ")
+					for _, link := range devLinks {
+						if link == desiredDevice.Name {
+							logger.Infof("%s found in the desired devices (matched by link: %s)", device.Name, link)
+							matched = true
+							break
+						}
+					}
 				}
 				matchedDevice = desiredDevice
 				if matched {

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -199,10 +199,10 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 
 	context := &clusterd.Context{Executor: executor}
 	context.Devices = []*sys.LocalDisk{
-		{Name: "sda"},
+		{Name: "sda", DevLinks: "/dev/disk/by-id/sda-0x0000 /dev/disk/by-path/pci-0000:00:17.0-ata-1"},
 		{Name: "sdb"},
 		{Name: "sdc"},
-		{Name: "sdd"},
+		{Name: "sdd", DevLinks: "/dev/disk/by-id/sdd-0x0000 /dev/disk/by-path/pci-0000:00:18.0-ata-1"},
 		{Name: "nvme01"},
 		{Name: "rda"},
 		{Name: "rdb"},
@@ -249,6 +249,12 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 	assert.Equal(t, -1, mapping.Entries["rda"].Data)
 	assert.Equal(t, -1, mapping.Entries["rdb"].Data)
 	assert.Equal(t, -1, mapping.Entries["nvme01"].Data)
+
+	// select a device by explicit link
+	mapping, err = getAvailableDevices(context, []DesiredDevice{{Name: "/dev/disk/by-id/sdd-0x0000"}}, "")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mapping.Entries))
+	assert.Equal(t, -1, mapping.Entries["sdd"].Data)
 }
 
 func TestGetRemovedDevices(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -449,7 +449,11 @@ func (c *Cluster) provisionOSDContainer(devices []rookalpha.Device, selection ro
 				logger.Infof("%s osds requested on device %s (node %s)", count, device.Name, nodeName)
 				countSuffix = ":" + count
 			}
-			deviceNames[i] = device.Name + countSuffix
+			deviceId := device.Name
+			if device.FullPath != "" {
+				deviceId = device.FullPath
+			}
+			deviceNames[i] = deviceId + countSuffix
 		}
 		envVars = append(envVars, dataDevicesEnvVar(strings.Join(deviceNames, ",")))
 		devMountNeeded = true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Allows selecting specific disks predictably, using `DevLinks` from `udevadm`, for example `/dev/disks/by-id/...`

**Which issue is resolved by this Pull Request:**
Resolves #1228

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
