### PR TITLE
Upgrade Integration test is masking failure of mons forming quorum after upgrade

### DIFF
--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -68,7 +68,7 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 
 		if matches == len(deployments.Items) && matches > 0 {
 			logger.Infof("all %d %s deployments are on image %s", matches, label, desiredImage)
-			break
+			return nil
 		}
 
 		if len(deployments.Items) == 0 {
@@ -78,7 +78,7 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 		}
 		time.Sleep(time.Duration(sleepTime) * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to wait for image %s in label %s", desiredImage, label)
 }
 
 // UpdateDeploymentAndWait updates a deployment and waits until it is running to return. It will


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The upgrade test has been failing silently recently in master. This change is to flush out some of the issues that will cause it to fail instead of silently failing.
- Return failure if the expected version isn't found in the pod spec (instead of silently failing)
- The version is no longer found in the pod spec to check mon version
- The rook-ceph-system role was created in the wrong namespace on upgrade

@BlaineEXE Locally I'm seeing that the upgrade test is failing due to the `mon_host` not existing in the `rook-ceph-config` secret after the upgrade. Let's see if the CI catches this issue now as well, then I could use some help investigating this.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
