### PR TITLE
Simplify Ceph CSI setup

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -37,14 +37,6 @@ kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/rbd/
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/cephfs/
 ```
 
-### Create CSI driver deployment templates and persist them in configmaps
-
-```console
-kubectl create configmap csi-cephfs-config -n rook-ceph --from-file=cluster/examples/kubernetes/ceph/csi/template/cephfs
-
-kubectl create configmap csi-rbd-config -n rook-ceph --from-file=cluster/examples/kubernetes/ceph/csi/template/rbd
-```
-
 ### Start Rook Ceph Operator
 
 ```console

--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -32,7 +32,8 @@ cluster.
 kubectl get ns
 kubectl create namespace rook-ceph
 # create rbac. Since rook operator is not permitted to create rbac rules,
-these rules have to be created outside of operator
+# these rules have to be created outside of operator
+kubectl create -f cluster/examples/kubernetes/ceph/common.yaml
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/rbd/
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/cephfs/
 ```

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -34,10 +34,6 @@ spec:
           name: rook-config
         - mountPath: /etc/ceph
           name: default-config-dir
-        - mountPath: /etc/ceph-csi/rbd
-          name: csi-rbd-config
-        - mountPath: /etc/ceph-csi/cephfs
-          name: csi-cephfs-config
         env:
         - name: ROOK_CURRENT_NAMESPACE_ONLY
           value: "true"
@@ -78,9 +74,3 @@ spec:
         emptyDir: {}
       - name: default-config-dir
         emptyDir: {}
-      - name: csi-rbd-config
-        configMap:
-          name: csi-rbd-config
-      - name: csi-cephfs-config
-        configMap:
-          name: csi-cephfs-config

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -43,8 +43,8 @@ func init() {
 	operatorCmd.Flags().DurationVar(&mon.HealthCheckInterval, "mon-healthcheck-interval", mon.HealthCheckInterval, "mon health check interval (duration)")
 	operatorCmd.Flags().DurationVar(&mon.MonOutTimeout, "mon-out-timeout", mon.MonOutTimeout, "mon out timeout (duration)")
 
-	operatorCmd.Flags().BoolVar(&csi.EnableRBD, "csi-enable-rbd", false, "whether enable ceph-csi rbd driver")
-	operatorCmd.Flags().BoolVar(&csi.EnableCephFS, "csi-enable-cephfs", false, "whether enable ceph-csi cephfs driver")
+	operatorCmd.Flags().BoolVar(&csi.EnableRBD, "csi-enable-rbd", false, "enable ceph-csi rbd support")
+	operatorCmd.Flags().BoolVar(&csi.EnableCephFS, "csi-enable-cephfs", false, "enable ceph-csi cephfs support")
 	// csi images
 	operatorCmd.Flags().StringVar(&csi.CSIParam.RBDPluginImage, "csi-rbd-image", csi.DefaultRBDPluginImage, "ceph-csi rbd plugin image")
 	operatorCmd.Flags().StringVar(&csi.CSIParam.CephFSPluginImage, "csi-cephfs-image", csi.DefaultCephFSPluginImage, "ceph-csi cephfs plugin image")

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -23,6 +23,7 @@ RUN curl --fail -sSL -o /tini https://github.com/krallin/tini/releases/download/
     chmod +x /tini
 
 COPY rook rookflex toolbox.sh /usr/local/bin/
+COPY ceph-csi /etc/ceph-csi
 
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
 CMD [""]

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -33,6 +33,7 @@ do.build:
 	@cp toolbox.sh $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
+	@cp -r ../../cluster/examples/kubernetes/ceph/csi/template $(TEMP)/ceph-csi
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -73,10 +73,7 @@ const (
 )
 
 func CSIEnabled() bool {
-	if EnableRBD || EnableCephFS {
-		return true
-	}
-	return false
+	return EnableRBD || EnableCephFS
 }
 
 func SetCSINamespace(namespace string) {


### PR DESCRIPTION
**Description of your changes:**

This PR implements some of lthe lowest hanging fruit for improvements in the intergration of ceph csi mentioned in PR #2857.
It simplifies the globally enabling CSI and reduces the delta between the configuration of Rook when deploying for flex vs deploying for CSI.

Still TODO: updating docs to match


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known ci issues
[skip ci]