### PR TITLE
Update wordpress.yaml

### DIFF
--- a/cluster/examples/kubernetes/wordpress.yaml
+++ b/cluster/examples/kubernetes/wordpress.yaml
@@ -35,6 +35,9 @@ metadata:
 spec:
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: wordpress   
   template:
     metadata:
       labels:


### PR DESCRIPTION
added missing selector to wordpress

Due to the change to `apps/v1` object api of the wordpress example Deployment, a `selector` is needed in the Deployment object.
This commit adds this missing selector.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
add "selector"
**Which issue is resolved by this Pull Request:****kubectl create -f wordpress.yaml**
error validating "wordpress.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
![image](https://user-images.githubusercontent.com/20528139/54728534-547caa80-4bb9-11e9-9ea6-d7fe79a24983.png)

Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]