### PR TITLE
Fixed k8s object names

### DIFF
--- a/Documentation/edgefs-nfs-crd.md
+++ b/Documentation/edgefs-nfs-crd.md
@@ -108,10 +108,10 @@ Now cluster is setup, services can be now created and attached to CSI provisione
 4. Create NFS service objects for tenants
 
 ```
-efscli service create nfs nfsCola
-efscli service serve nfsCola Hawaii/Cola/bk1
-efscli service create nfs nfsPepsi
-efscli service serve nfsPepsi Hawaii/Pepsi/bk1
+efscli service create nfs nfs-cola
+efscli service serve nfs-cola Hawaii/Cola/bk1
+efscli service create nfs nfs-pepsi
+efscli service serve nfs-pepsi Hawaii/Pepsi/bk1
 ```
 
 5. Create NFS CRDs
@@ -120,7 +120,7 @@ efscli service serve nfsPepsi Hawaii/Pepsi/bk1
 apiVersion: edgefs.rook.io/v1alpha1
 kind: NFS
 metadata:
-  name: nfsCola
+  name: nfs-cola
   namespace: rook-edgefs
 spec:
   instances: 1
@@ -130,7 +130,7 @@ spec:
 apiVersion: edgefs.rook.io/v1alpha1
 kind: NFS
 metadata:
-  name: nfsPepsi
+  name: nfs-pepsi
   namespace: rook-edgefs
 spec:
   instances: 1

--- a/Documentation/edgefs-s3-crd.md
+++ b/Documentation/edgefs-s3-crd.md
@@ -113,17 +113,17 @@ Now cluster is setup, services can be now created.
 4. Create S3 services objects for tenants
 
 ```
-efscli service create s3 s3Cola
-efscli service serve s3Cola Hawaii/Cola
-efscli service create s3 s3Pepsi
-efscli service serve s3Pepsi Hawaii/Pepsi/bk1
+efscli service create s3 s3-cola
+efscli service serve s3-cola Hawaii/Cola
+efscli service create s3 s3-pepsi
+efscli service serve s3-pepsi Hawaii/Pepsi/bk1
 ```
 
 In case of s3type set to `s3`, do not forget to configure default domain name:
 
 ```
-efscli service config s3Cola X-Domain cola.com
-efscli service config s3Pepsi X-Domain pepsi.com
+efscli service config s3-cola X-Domain cola.com
+efscli service config s3-pepsi X-Domain pepsi.com
 ```
 
 5. Create S3 CRDs
@@ -132,7 +132,7 @@ efscli service config s3Pepsi X-Domain pepsi.com
 apiVersion: edgefs.rook.io/v1alpha1
 kind: S3
 metadata:
-  name: s3Cola
+  name: s3-cola
   namespace: rook-edgefs
 spec:
   instances: 1
@@ -142,7 +142,7 @@ spec:
 apiVersion: edgefs.rook.io/v1alpha1
 kind: S3
 metadata:
-  name: s3Pepsi
+  name: s3-pepsi
   namespace: rook-edgefs
 spec:
   instances: 1

--- a/Documentation/edgefs-s3x-crd.md
+++ b/Documentation/edgefs-s3x-crd.md
@@ -115,10 +115,10 @@ Now cluster is setup, services can be now created.
 4. Create Edge-X S3 services objects for tenants
 
 ```
-efscli service create s3x s3xCola
-efscli service serve s3xCola Hawaii/Cola
-efscli service create s3x s3xPepsi
-efscli service serve s3xPepsi Hawaii/Pepsi/bk1
+efscli service create s3x s3x-cola
+efscli service serve s3x-cola Hawaii/Cola
+efscli service create s3x s3x-pepsi
+efscli service serve s3x-pepsi Hawaii/Pepsi/bk1
 ```
 
 5. Create S3X CRDs
@@ -127,7 +127,7 @@ efscli service serve s3xPepsi Hawaii/Pepsi/bk1
 apiVersion: edgefs.rook.io/v1alpha1
 kind: S3X
 metadata:
-  name: s3xCola
+  name: s3x-cola
   namespace: rook-edgefs
 spec:
   instances: 1
@@ -137,7 +137,7 @@ spec:
 apiVersion: edgefs.rook.io/v1alpha1
 kind: S3X
 metadata:
-  name: s3xPepsi
+  name: s3x-pepsi
   namespace: rook-edgefs
 spec:
   instances: 1


### PR DESCRIPTION
Uppercase symbols are not allowed in k8s objects

Signed-off-by: Dmitry Mishin <dmitry.mishin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Modified the documentation examples to have proper k8s names

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]