### PR TITLE
The NFS deployment needs serviceaccount as well for PSP

### DIFF
--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -164,6 +164,7 @@ func (c *NFSController) makeDeployment(svcname, namespace, rookImage string, nfs
 			HostIPC:       true,
 			HostNetwork:   c.hostNetwork,
 			NodeSelector:  map[string]string{namespace: "cluster"},
+			ServiceAccountName: "rook-edgefs-cluster",
 		},
 	}
 	if c.hostNetwork {


### PR DESCRIPTION
Signed-off-by: Dmitry Mishin <dmitry.mishin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The NFS pod created by operator is running under default serviceaccount, which may lack PSP permissions

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
