### PR TITLE
ceph: fix mon not to be scheduled on the same node

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -176,6 +176,16 @@ func (c *Cluster) Start(clusterInfo *cephconfig.ClusterInfo, rookVersion string,
 		return nil, fmt.Errorf("failed to initialize ceph cluster info. %+v", err)
 	}
 
+	nodeList, err := c.getFullNodeList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node list. %+v", err)
+	}
+	validNodes := c.getValidNodes(nodeList.Items)
+	nodeCount := len(validNodes)
+	if !c.spec.Mon.AllowMultiplePerNode && c.spec.Mon.Count > nodeCount {
+		return nil, fmt.Errorf("the desired mon count is %d while the number of available nodes is %d despite allowMultiplePerNode is %t", c.spec.Mon.Count, nodeCount, c.spec.Mon.AllowMultiplePerNode)
+	}
+
 	targetCount, msg, err := c.getTargetMonCount()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get target mon count. %+v", err)


### PR DESCRIPTION
Signed-off-by: Ryo Nakao <nakabonne@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
I think this problem is caused by the inconsistency between `mon.Count` and the number of nodes.
When `mon.allowMultiplePerNode: false`, can be solved by overwriting `mon.Count`.

**Which issue is resolved by this Pull Request:**
Resolves #2826 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
