### PR TITLE
Drop minimum version for ceph csi to 1.12

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -53,7 +53,7 @@ var (
 
 const (
 	KubeMinMajor = "1"
-	KubeMinMinor = "13"
+	KubeMinMinor = "12"
 
 	// image names
 	DefaultRBDPluginImage    = "quay.io/cephcsi/rbdplugin:v1.0.0"


### PR DESCRIPTION
…n test

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Allows to deploy ceph csi on k8s 1.12 as it s actually supported and expected to work

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
