### PR TITLE
ceph/osd: mount /run/udev for lvs speedup

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -217,6 +217,17 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 			args = append(args, "--default-log-to-file", "false")
 		}
 
+		// mount /run/udev in the container so ceph-volume (via `lvs`)
+		// can access the udev database
+		volumes = append(volumes, v1.Volume{
+			Name: "run-udev",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}})
+
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      "run-udev",
+			MountPath: "/run/udev"})
+
 	} else {
 		// other osds can launch the osd daemon directly
 		command = []string{"ceph-osd"}


### PR DESCRIPTION
When Ceph OSD spins up with ceph-volume `lvs` is run which can cause
significant delays without mounting /run/udev from the host.

Before:

```
[root@rook-ceph-osd-0-858f49b5-md4t9 /]# time lvs
  WARNING: Failed to connect to lvmetad. Falling back to device scanning.
  WARNING: Device /dev/sda not initialized in udev database even after waiting 10000000 microseconds.
...
  LV                                            VG                                        Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  osd-data-729c1fb6-440f-434c-be49-f199fa59f1c0 ceph-3bf7823b-6db3-42b6-bf8f-c36301e85238 -wi-ao---- <10.00g

real    1m30.545s
```

After:

```
[root@rook-ceph-osd-0-d8c4698b8-5vqnk /]# time lvs
  WARNING: Failed to connect to lvmetad. Falling back to device scanning.
  LV                                            VG                                        Attr       LSize   Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  osd-data-6c7249cc-cbd1-4f3b-9027-03725886bb30 ceph-9808319f-8567-4930-803a-41f70e537c1f -wi-ao---- <10.00g

real    0m0.043s
```

// for known CI issues
[skip ci]