### PR TITLE
ceph: use Nautilus for operator image

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -19,7 +19,7 @@ include ../image.mk
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
-CEPH_VERSION = v13.2.2-20181023
+CEPH_VERSION = v14.2.0-20190319
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 
 TEMP := $(shell mktemp -d)


### PR DESCRIPTION
Now that Nautilus is available, use it as the base for the operator
image.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
