### PR TITLE
ceph: improve upgrade procedure

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -279,6 +279,10 @@ advised to upgrade to Mimic (v13.x.x) or Nautilus (v14.x.x) now.
 
 **IMPORTANT: This section only applies to clusters running Rook 1.0 or newer**
 
+**IMPORTANT: When an update is requested, the operator will check Ceph's status, if it is in `HEALTH_ERR` it will refuse to do the upgrade.**
+
+Rook is cautious when performing upgrades. When an upgrade is requested (the Ceph image has been updated in the CR), Rook will go through all the daemons one by one and will individually perform checks on them. It will make sure a particular daemon can be stopped before performing the upgrade, once the deployment has been updated, it checks if this is ok to continue. After each daemon is updated we wait for things to settle (monitors to be in a quorum, PGs to be clean for OSDs, up for MDSs, etc.), then only when the condition is met we move to the next daemon. We repeat this process until all the daemons have been updated.
+
 ## Ceph images
 Official Ceph container images can be found on [Docker Hub](https://hub.docker.com/r/ceph/ceph/tags/).
 These images are tagged in a few ways:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -28,6 +28,7 @@ an example usage
 - The cluster CRD option to allow multiple monitors to be scheduled on the same
   node---`spec.Mon.AllowMultiplePerNode`---is now active when a cluster is first
   created. Previously, it was ignored when a cluster was first installed.
+- Upgrades have drastically improved, Rook intelligently checks for each daemon state before and after upgrading. To learn more about the upgrade workflow see [Ceph Upgrades](Documentation/ceph-upgrade.md)
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	fakeOsdTree = `{
+		"nodes": [
+		  {
+			"id": -3,
+			"name": "minikube",
+			"type": "host",
+			"type_id": 1,
+			"pool_weights": {},
+			"children": [
+			  2,
+			  1,
+			  0
+			]
+		  },
+		  {
+			"id": -2,
+			"name": "minikube-2",
+			"type": "host",
+			"type_id": 1,
+			"pool_weights": {},
+			"children": [
+			  3,
+			  4,
+			  5
+			]
+		  }
+		]
+	  }`
+
+	fakeOSdList = `[0,1,2]`
+)
+
+func TestHostTree(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	emptyTreeResult := false
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		switch {
+		case args[0] == "osd" && args[1] == "tree":
+			if emptyTreeResult {
+				return `not a json`, nil
+			}
+			return fakeOsdTree, nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	tree, err := HostTree(&clusterd.Context{Executor: executor}, "rook")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(tree.Nodes))
+	assert.Equal(t, "minikube", tree.Nodes[0].Name)
+	assert.Equal(t, 3, len(tree.Nodes[0].Children))
+
+	emptyTreeResult = true
+	tree, err = HostTree(&clusterd.Context{Executor: executor}, "rook")
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(tree.Nodes))
+
+}
+
+func TestOsdListNum(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	emptyOsdListNumResult := false
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		switch {
+		case args[0] == "osd" && args[1] == "ls":
+			if emptyOsdListNumResult {
+				return `not a json`, nil
+			}
+			return fakeOSdList, nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+
+	list, err := OsdListNum(&clusterd.Context{Executor: executor}, "rook")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(list))
+
+	emptyOsdListNumResult = true
+	list, err = OsdListNum(&clusterd.Context{Executor: executor}, "rook")
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(list))
+}

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -236,3 +236,24 @@ func MdsActiveOrStandbyReplay(context *clusterd.Context, clusterName, fsName str
 
 	return fmt.Errorf("mds %s is %s, bad state", fsName, status.Fsmap.ByRank[mdsRank].Status)
 }
+
+// IsCephHealthy verifies Ceph is healthy, useful when performing an upgrade
+// check if it's a minor or major upgrade... too!
+func IsCephHealthy(context *clusterd.Context, clusterName string) bool {
+	cephStatus, err := Status(context, clusterName, false)
+	if err != nil {
+		logger.Errorf("failed to detect if Ceph is healthy. failed to get ceph status. %+v", err)
+		return false
+	}
+
+	return isCephHealthy(cephStatus)
+}
+
+func isCephHealthy(status CephStatus) bool {
+	s := status.Health.Status
+	if s == "HEALTH_WARN" || s == "HEALTH_OK" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -52,6 +52,7 @@ type CephStatus struct {
 	} `json:"osdmap"`
 	PgMap  PgMap  `json:"pgmap"`
 	MgrMap MgrMap `json:"mgrmap"`
+	Fsmap  Fsmap  `json:"fsmap"`
 }
 
 type HealthStatus struct {
@@ -123,6 +124,23 @@ type PgStateEntry struct {
 	Count     int    `json:"count"`
 }
 
+// Fsmap is a struct representing the filesystem map
+type Fsmap struct {
+	Epoch  int `json:"epoch"`
+	ID     int `json:"id"`
+	Up     int `json:"up"`
+	In     int `json:"in"`
+	Max    int `json:"max"`
+	ByRank []struct {
+		FilesystemID int    `json:"filesystem_id"`
+		Rank         int    `json:"rank"`
+		Name         string `json:"name"`
+		Status       string `json:"status"`
+		Gid          int    `json:"gid"`
+	} `json:"by_rank"`
+	UpStandby int `json:"up:standby"`
+}
+
 func Status(context *clusterd.Context, clusterName string, debug bool) (CephStatus, error) {
 	args := []string{"status"}
 	cmd := NewCephCommand(context, clusterName, args)
@@ -170,4 +188,51 @@ func isClusterClean(status CephStatus) error {
 	}
 
 	return fmt.Errorf("cluster is not fully clean. PGs: %+v", status.PgMap.PgsByState)
+}
+
+// getMDSRank returns the rank of a given MDS
+func getMDSRank(status CephStatus, clusterName, fsName string) (int, error) {
+	// dummy rank
+	mdsRank := -1000
+	for r := range status.Fsmap.ByRank {
+		if status.Fsmap.ByRank[r].Name == fsName {
+			mdsRank = r
+		}
+	}
+	// if the mds is not shown in the map one reason might be because it's in standby
+	// if not in standby there is something else going wron
+	if mdsRank < 0 && status.Fsmap.UpStandby < 1 {
+		// it might seem strange to log an error since this could be a warning too
+		// it is a warning until we reach the timeout, this should give enough time to the mds to transtion its state
+		// after the timeout we consider that the mds might be gone or the timeout was not long enough...
+		return mdsRank, fmt.Errorf("mds %s not found in fsmap, this likely means mdss are transitioning between active and standby states", fsName)
+	}
+
+	return mdsRank, nil
+}
+
+// MdsActiveOrStandbyReplay returns wether a given MDS is active or in standby
+func MdsActiveOrStandbyReplay(context *clusterd.Context, clusterName, fsName string) error {
+	status, err := Status(context, clusterName, false)
+	if err != nil {
+		return fmt.Errorf("failed to get ceph status. %+v", err)
+	}
+
+	mdsRank, err := getMDSRank(status, clusterName, fsName)
+	if err != nil {
+		return fmt.Errorf("%+v", err)
+	}
+
+	// this MDS is in standby so let's return immediatly
+	if mdsRank < 0 {
+		logger.Infof("mds %s is in standby, nothing to check", fsName)
+		return nil
+	}
+
+	if status.Fsmap.ByRank[mdsRank].Status == "up:active" || status.Fsmap.ByRank[mdsRank].Status == "up:standby-replay" || status.Fsmap.ByRank[mdsRank].Status == "up:standby" {
+		logger.Infof("mds %s is %s", fsName, status.Fsmap.ByRank[mdsRank].Status)
+		return nil
+	}
+
+	return fmt.Errorf("mds %s is %s, bad state", fsName, status.Fsmap.ByRank[mdsRank].Status)
 }

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -118,3 +118,20 @@ func TestGetMDSRank(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 0, mdsRankFake)
 }
+
+func TestIsCephHealthy(t *testing.T) {
+	var statusFake CephStatus
+	json.Unmarshal(statusFakeRaw, &statusFake)
+
+	statusFake.Health.Status = "HEALTH_WARN"
+	s := isCephHealthy(statusFake)
+	assert.True(t, s)
+
+	statusFake.Health.Status = "HEALTH_OK"
+	s = isCephHealthy(statusFake)
+	assert.True(t, s)
+
+	statusFake.Health.Status = "HEALTH_ERR"
+	s = isCephHealthy(statusFake)
+	assert.False(t, s)
+}

--- a/pkg/daemon/ceph/client/status_test.go
+++ b/pkg/daemon/ceph/client/status_test.go
@@ -27,6 +27,30 @@ const (
 	CephStatusResponseRaw = `{"fsid":"613975f3-3025-4802-9de1-a2280b950e75","health":{"checks":{"OSD_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 osds down"}},"OSD_HOST_DOWN":{"severity":"HEALTH_WARN","summary":{"message":"1 host (1 osds) down"}},"PG_AVAILABILITY":{"severity":"HEALTH_WARN","summary":{"message":"Reduced data availability: 101 pgs stale"}},"POOL_APP_NOT_ENABLED":{"severity":"HEALTH_WARN","summary":{"message":"application not enabled on 1 pool(s)"}}},"status":"HEALTH_WARN","overall_status":"HEALTH_WARN"},"election_epoch":12,"quorum":[0,1,2],"quorum_names":["rook-ceph-mon0","rook-ceph-mon2","rook-ceph-mon1"],"monmap":{"epoch":3,"fsid":"613975f3-3025-4802-9de1-a2280b950e75","modified":"2017-08-11 20:13:02.075679","created":"2017-08-11 20:12:35.314510","features":{"persistent":["kraken","luminous"],"optional":[]},"mons":[{"rank":0,"name":"rook-ceph-mon0","addr":"10.3.0.45:6789/0","public_addr":"10.3.0.45:6789/0"},{"rank":1,"name":"rook-ceph-mon2","addr":"10.3.0.249:6789/0","public_addr":"10.3.0.249:6789/0"},{"rank":2,"name":"rook-ceph-mon1","addr":"10.3.0.252:6789/0","public_addr":"10.3.0.252:6789/0"}]},"osdmap":{"osdmap":{"epoch":17,"num_osds":2,"num_up_osds":1,"num_in_osds":2,"full":false,"nearfull":true,"num_remapped_pgs":0}},"pgmap":{"pgs_by_state":[{"state_name":"stale+active+clean","count":101},{"state_name":"active+clean","count":99}],"num_pgs":200,"num_pools":2,"num_objects":243,"data_bytes":976793635,"bytes_used":13611479040,"bytes_avail":19825307648,"bytes_total":33436786688},"fsmap":{"epoch":1,"by_rank":[]},"mgrmap":{"epoch":3,"active_gid":14111,"active_name":"rook-ceph-mgr0","active_addr":"10.2.73.6:6800/9","available":true,"standbys":[],"modules":["restful","status"],"available_modules":["dashboard","prometheus","restful","status","zabbix"]},"servicemap":{"epoch":1,"modified":"0.000000","services":{}}}`
 )
 
+var (
+	// this JSON was generated from `ceph status -f json`, using Ceph Nautilus 14.2.1
+	// It was chopped to only show what the tests are looking for
+	statusFakeRaw = []byte(`{
+		"fsmap": {
+		  "epoch": 13,
+		  "id": 1,
+		  "up": 1,
+		  "in": 1,
+		  "max": 1,
+		  "by_rank": [
+			{
+			  "filesystem_id": 1,
+			  "rank": 0,
+			  "name": "myfs-b",
+			  "status": "up:active",
+			  "gid": 14716
+			}
+		  ],
+		  "up:standby": 1
+		}
+	  }`)
+)
+
 func TestStatusMarshal(t *testing.T) {
 	var status CephStatus
 	err := json.Unmarshal([]byte(CephStatusResponseRaw), &status)
@@ -84,4 +108,13 @@ func TestIsClusterClean(t *testing.T) {
 	status.PgMap.PgsByState[0].StateName = "notclean"
 	err = isClusterClean(status)
 	assert.NotNil(t, err)
+}
+
+func TestGetMDSRank(t *testing.T) {
+	var statusFake CephStatus
+	json.Unmarshal(statusFakeRaw, &statusFake)
+
+	mdsRankFake, err := getMDSRank(statusFake, "rook-ceph", "myfs-b")
+	assert.Nil(t, err)
+	assert.Equal(t, 0, mdsRankFake)
 }

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -18,35 +18,72 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/util"
 )
 
 // CephDaemonsVersions is a structure that can be used to parsed the output of the 'ceph versions' command
 type CephDaemonsVersions struct {
-	Mon     map[string]int `json:"mon,omitempty"`
-	Osd     map[string]int `json:"osd,omitempty"`
-	Mgr     map[string]int `json:"mgr,omitempty"`
-	Mds     map[string]int `json:"mds,omitempty"`
-	Overall map[string]int `json:"overall,omitempty"`
+	Mon       map[string]int `json:"mon,omitempty"`
+	Mgr       map[string]int `json:"mgr,omitempty"`
+	Osd       map[string]int `json:"osd,omitempty"`
+	Rgw       map[string]int `json:"rgw,omitempty"`
+	Mds       map[string]int `json:"mds,omitempty"`
+	RbdMirror map[string]int `json:"rbd-mirror,omitempty"`
+	Overall   map[string]int `json:"overall,omitempty"`
 }
 
-func getCephMonVersionString(context *clusterd.Context) (string, error) {
-	output, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "version")
+var (
+	// we don't perform any checks on these daemons
+	// they don't have any "ok-to-stop" command implemented
+	daemonNoCheck = []string{"mgr", "rgw", "rbd-mirror", "nfs"}
+)
+
+func getCephMonVersionString(context *clusterd.Context, clusterName string) (string, error) {
+	args := []string{"version"}
+	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
+
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
 	if err != nil {
-		return "", fmt.Errorf("failed to run ceph version: %+v", err)
+		return "", fmt.Errorf("failed to run 'ceph version'. %+v", err)
 	}
 	logger.Debug(output)
 
 	return output, nil
 }
 
-func getCephVersionsString(context *clusterd.Context) (string, error) {
-	output, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "versions")
+func getAllCephDaemonVersionsString(context *clusterd.Context, clusterName string) (string, error) {
+	args := []string{"versions"}
+	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
+
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
 	if err != nil {
-		return "", fmt.Errorf("failed to run ceph versions: %+v", err)
+		return "", fmt.Errorf("failed to run 'ceph versions'. %+v", err)
+	}
+	logger.Debug(output)
+
+	return output, nil
+}
+
+func getCephDaemonVersionString(context *clusterd.Context, deployment, clusterName string) (string, error) {
+	daemonName, err := findDaemonName(deployment)
+	if err != nil {
+		return "", fmt.Errorf("%+v", err)
+	}
+	daemonID := findDaemonID(deployment)
+	daemon := daemonName + "." + daemonID
+
+	args := []string{"tell", daemon, "version"}
+	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to run ceph tell. %+v", err)
 	}
 	logger.Debug(output)
 
@@ -54,10 +91,10 @@ func getCephVersionsString(context *clusterd.Context) (string, error) {
 }
 
 // GetCephMonVersion reports the Ceph version of all the monitors, or at least a majority with quorum
-func GetCephMonVersion(context *clusterd.Context) (*cephver.CephVersion, error) {
-	output, err := getCephMonVersionString(context)
+func GetCephMonVersion(context *clusterd.Context, clusterName string) (*cephver.CephVersion, error) {
+	output, err := getCephMonVersionString(context, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run ceph version: %+v", err)
+		return nil, err
 	}
 	logger.Debug(output)
 
@@ -69,11 +106,27 @@ func GetCephMonVersion(context *clusterd.Context) (*cephver.CephVersion, error) 
 	return v, nil
 }
 
-// GetCephVersions reports the Ceph version of each daemon in the cluster
-func GetCephVersions(context *clusterd.Context) (*CephDaemonsVersions, error) {
-	output, err := getCephVersionsString(context)
+// GetCephDaemonVersion reports the Ceph version of a particular daemon
+func GetCephDaemonVersion(context *clusterd.Context, deployment, clusterName string) (*cephver.CephVersion, error) {
+	output, err := getCephDaemonVersionString(context, deployment, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run ceph versions: %+v", err)
+		return nil, fmt.Errorf("failed to run ceph tell. %+v", err)
+	}
+	logger.Debug(output)
+
+	v, err := cephver.ExtractCephVersion(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract ceph version. %+v", err)
+	}
+
+	return v, nil
+}
+
+// GetAllCephDaemonVersions reports the Ceph version of each daemon in the cluster
+func GetAllCephDaemonVersions(context *clusterd.Context, clusterName string) (*CephDaemonsVersions, error) {
+	output, err := getAllCephDaemonVersionsString(context, clusterName)
+	if err != nil {
+		return nil, err
 	}
 	logger.Debug(output)
 
@@ -90,7 +143,7 @@ func GetCephVersions(context *clusterd.Context) (*CephDaemonsVersions, error) {
 func EnableMessenger2(context *clusterd.Context) error {
 	_, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "mon", "enable-msgr2")
 	if err != nil {
-		return fmt.Errorf("failed to enable msgr2 protocol: %+v", err)
+		return fmt.Errorf("failed to enable msgr2 protocol. %+v", err)
 	}
 	logger.Infof("successfully enabled msgr2 protocol")
 
@@ -104,6 +157,197 @@ func EnableNautilusOSD(context *clusterd.Context) error {
 		return fmt.Errorf("failed to disallow pre-nautilus osds and enable all new nautilus-only functionality: %+v", err)
 	}
 	logger.Infof("successfully disallowed pre-nautilus osds and enabled all new nautilus-only functionality")
+	return nil
+}
+
+// OkToStop determines if it's ok to stop an upgrade
+func OkToStop(context *clusterd.Context, namespace, deployment, clusterName string, cephVersion cephver.CephVersion) error {
+	daemonName, err := findDaemonName(deployment)
+	if err != nil {
+		logger.Warningf("%+v", err)
+		return nil
+	}
+
+	// The ok-to-stop command for mon and mds landed on 14.2.1
+	// so we return nil if that Ceph version is not satisfied
+	if !cephVersion.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
+		if daemonName != "osd" {
+			return nil
+		}
+	}
+
+	versions, err := GetAllCephDaemonVersions(context, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to get ceph daemons versions. %+v", err)
+	}
+
+	switch daemonName {
+	// Trying to handle the case where a **single** mon is deployed and an upgrade is called
+	case "mon":
+		// if len(versions.Mon) > 1, this means we have different Ceph versions for some monitor(s).
+		// This is fine, we can run the upgrade checks
+		if len(versions.Mon) == 1 {
+			// now trying to parse and find how many mons are presents
+			// if we have less than 3 mons we skip the check and do best-effort
+			// we do less than 3 because during the initial bootstrap the mon sequence is updated too
+			// so running running the check on 2/3 mon fails
+			// versions.Mon looks like this map[ceph version 15.0.0-12-g6c8fb92 (6c8fb920cb1d862f36ee852ed849a15f9a50bd68) octopus (dev):1]
+			// now looping over a single element since we can't address the key directly (we don't know its name)
+			for _, monCount := range versions.Mon {
+				if monCount < 3 {
+					logger.Infof("the cluster has less than 3 monitors, not performing upgrade check, running in best-effort")
+					return nil
+				}
+			}
+		}
+	// Trying to handle the case where a **single** osd is deployed and an upgrade is called
+	case "osd":
+		// if len(versions.Osd) > 1, this means we have different Ceph versions osd(s)
+		// This is fine, we can run the upgrade checks
+		if len(versions.Osd) == 1 {
+			// now trying to parse and find how many osds are presents
+			// if we have less than 3 osds we skip the check and do best-effort
+			for _, osdCount := range versions.Osd {
+				if osdCount < 3 {
+					logger.Infof("the cluster has less than 3 OSDs, not performing upgrade check, running in best-effort")
+					return nil
+				}
+			}
+		}
+	}
+	// we don't implement any checks for mon, rgw and rbdmirror since:
+	//  - mon: the is done in the monitor code since it ensures all the mons are always in quorum before continuing
+	//  - rgw: the pod spec has a liveness probe so if the pod successfully start
+	//  - rbdmirror: you can chain as many as you want like mdss but there is no ok-to-stop logic yet
+	err = okToStopDaemon(context, deployment, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to check if %s was ok to stop. %+v", deployment, err)
+	}
 
 	return nil
+}
+
+// OkToContinue determines if it's ok to continue an upgrade
+func OkToContinue(context *clusterd.Context, namespace, deployment string) error {
+	daemonName, err := findDaemonName(deployment)
+	if err != nil {
+		logger.Warningf("%+v", err)
+		return nil
+	}
+
+	// the mon case is handled directly in the deployment where the mon checks for quorum
+	switch daemonName {
+	case "osd":
+		err := okToContinueOSDDaemon(context, namespace)
+		if err != nil {
+			return fmt.Errorf("failed to check if %s was ok to continue. %+v", deployment, err)
+		}
+	case "mds":
+		err := okToContinueMDSDaemon(context, namespace, deployment)
+		if err != nil {
+			return fmt.Errorf("failed to check if %s was ok to continue. %+v", deployment, err)
+		}
+	}
+
+	return nil
+}
+
+func okToStopDaemon(context *clusterd.Context, deployment, clusterName string) error {
+	daemonID := findDaemonID(deployment)
+	daemonName, err := findDaemonName(deployment)
+	if err != nil {
+		logger.Warningf("%+v", err)
+		return nil
+	}
+
+	if !stringInSlice(daemonName, daemonNoCheck) {
+		args := []string{daemonName, "ok-to-stop", daemonID}
+		command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
+
+		output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+		if err != nil {
+			return fmt.Errorf("deployment %s cannot be stopped. %+v", deployment, err)
+		}
+		logger.Debugf("deployment %s is ok to be updated. %s", deployment, output)
+	}
+
+	logger.Debugf("deployment %s is ok to be updated.", deployment)
+
+	return nil
+}
+
+// okToContinueOSDDaemon determines whether it's fine to go to the next osd during an upgrade
+// This basically makes sure all the PGs have settled
+func okToContinueOSDDaemon(context *clusterd.Context, namespace string) error {
+	// Reconciliating PGs should not take too long so let's wait up to 10 minutes
+	err := util.Retry(10, 60*time.Second, func() error {
+		return IsClusterClean(context, namespace)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// okToContinueMDSDaemon determines whether it's fine to go to the next mds during an upgrade
+// mostly a placeholder function for the future but since we have standby mds this shouldn't be needed
+func okToContinueMDSDaemon(context *clusterd.Context, namespace, deployment string) error {
+	// wait for the MDS to be active again or in standby-replay
+	err := util.Retry(10, 15*time.Second, func() error {
+		return MdsActiveOrStandbyReplay(context, namespace, findFSName(deployment, namespace))
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findFSName(deployment, namespace string) string {
+	mdsID := findDaemonID(deployment)
+	fsNameTrimSuffix := strings.TrimSuffix(deployment, "-"+mdsID)
+	return strings.TrimPrefix(fsNameTrimSuffix, namespace+"-mds-")
+}
+
+func findDaemonID(deployment string) string {
+	daemonTrimPrefixSplit := strings.Split(deployment, "-")
+	return daemonTrimPrefixSplit[len(daemonTrimPrefixSplit)-1]
+}
+
+func findDaemonName(deployment string) (string, error) {
+	err := errors.New("could not find daemon name, is this a new daemon?")
+
+	if strings.Contains(deployment, "mds") {
+		return "mds", nil
+	}
+	if strings.Contains(deployment, "rgw") {
+		return "rgw", nil
+	}
+	if strings.Contains(deployment, "mon") {
+		return "mon", nil
+	}
+	if strings.Contains(deployment, "osd") {
+		return "osd", nil
+	}
+	if strings.Contains(deployment, "mgr") {
+		return "mgr", nil
+	}
+	if strings.Contains(deployment, "nfs") {
+		return "nfs", nil
+	}
+	if strings.Contains(deployment, "rbd-mirror") {
+		return "rbd-mirror", nil
+	}
+
+	return "", fmt.Errorf("%+v from deployment %s", err, deployment)
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,12 +30,11 @@ func TestGetCephMonVersionString(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		assert.Equal(t, "version", args[0])
-		assert.Equal(t, 1, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
 
-	_, err := getCephMonVersionString(context)
+	_, err := getCephMonVersionString(context, "rook-ceph")
 	assert.Nil(t, err)
 }
 
@@ -41,12 +42,26 @@ func TestGetCephMonVersionsString(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		assert.Equal(t, "versions", args[0])
-		assert.Equal(t, 1, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
 
-	_, err := getCephVersionsString(context)
+	_, err := getAllCephDaemonVersionsString(context, "rook-ceph")
+	assert.Nil(t, err)
+}
+
+func TestGetCephDaemonVersionString(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	deployment := "rook-ceph-mds-a"
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		assert.Equal(t, "tell", args[0])
+		assert.Equal(t, "mds.a", args[1])
+		assert.Equal(t, "version", args[2])
+		return "", nil
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	_, err := getCephDaemonVersionString(context, deployment, "rook-ceph")
 	assert.Nil(t, err)
 }
 
@@ -55,7 +70,6 @@ func TestEnableMessenger2(t *testing.T) {
 	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		assert.Equal(t, "mon", args[0])
 		assert.Equal(t, "enable-msgr2", args[1])
-		assert.Equal(t, 2, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
@@ -69,12 +83,100 @@ func TestEnableNautilusOSD(t *testing.T) {
 	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		assert.Equal(t, "osd", args[0])
 		assert.Equal(t, "require-osd-release", args[1])
-		assert.Equal(t, "nautilus", args[2])
-		assert.Equal(t, 3, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
 
 	err := EnableNautilusOSD(context)
 	assert.Nil(t, err)
+}
+
+func TestOkToStopDaemon(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		switch {
+		case args[0] == "create" && args[1] == "mon" && args[2] == "a":
+			assert.Equal(t, 2, len(args))
+			return "", nil
+		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	deployment := "rook-ceph-mon-a"
+	err := okToStopDaemon(context, deployment, "rook-ceph")
+	assert.Nil(t, err)
+
+	deployment = "rook-ceph-mgr-a"
+	err = okToStopDaemon(context, deployment, "rook-ceph")
+	assert.Nil(t, err)
+
+	deployment = "rook-ceph-dummy-a"
+	err = okToStopDaemon(context, deployment, "rook-ceph")
+	assert.Nil(t, err)
+}
+
+func TestFindDaemonName(t *testing.T) {
+	n, err := findDaemonName("rook-ceph-mon-a")
+	assert.Nil(t, err)
+	assert.Equal(t, "mon", n)
+	n, err = findDaemonName("rook-ceph-osd-0")
+	assert.Nil(t, err)
+	assert.Equal(t, "osd", n)
+	n, err = findDaemonName("rook-ceph-rgw-my-store-a")
+	assert.Nil(t, err)
+	assert.Equal(t, "rgw", n)
+	n, err = findDaemonName("rook-ceph-mds-myfs-a")
+	assert.Nil(t, err)
+	assert.Equal(t, "mds", n)
+	n, err = findDaemonName("rook-ceph-mgr-a")
+	assert.Nil(t, err)
+	assert.Equal(t, "mgr", n)
+	n, err = findDaemonName("rook-ceph-rbd-mirror-a")
+	assert.Nil(t, err)
+	assert.Equal(t, "rbd-mirror", n)
+	_, err = findDaemonName("rook-ceph-unknown-a")
+	assert.NotNil(t, err)
+}
+
+func TestFindDaemonID(t *testing.T) {
+	id := findDaemonID("rook-ceph-mon-a")
+	assert.Equal(t, "a", id)
+	id = findDaemonID("rook-ceph-osd-0")
+	assert.Equal(t, "0", id)
+	id = findDaemonID("rook-ceph-rgw-my-super-store-a")
+	assert.Equal(t, "a", id)
+	id = findDaemonID("rook-ceph-mds-my-wonderful-fs-a")
+	assert.Equal(t, "a", id)
+	id = findDaemonID("rook-ceph-mgr-a")
+	assert.Equal(t, "a", id)
+	id = findDaemonID("rook.ceph.mgr.a")
+	assert.NotEqual(t, "a", id)
+}
+
+func TestOkToContinue(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+
+	err := OkToContinue(context, "rook-ceph", "rook-ceph-mon-a") // mon is not checked on ok-to-continue so nil is expected
+	assert.Nil(t, err)
+}
+
+func TestOkToStop(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	context := &clusterd.Context{Executor: executor}
+	v := cephver.Nautilus
+
+	err := OkToStop(context, "rook-ceph", "rook-ceph-mon-a", "rook-ceph", v)
+	assert.Nil(t, err)
+
+	err = OkToStop(context, "rook-ceph", "rook-ceph-mds-a", "rook-ceph", v)
+	assert.Nil(t, err)
+}
+
+func TestFindFSName(t *testing.T) {
+	fsName := findFSName("rook-ceph-mds-myfs-a", "rook-ceph")
+	assert.Equal(t, "myfs", fsName)
+	fsName = findFSName("rook-ceph-mds-my-super-fs-a", "rook-ceph")
+	assert.Equal(t, "my-super-fs", fsName)
 }

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -179,4 +180,25 @@ func TestFindFSName(t *testing.T) {
 	assert.Equal(t, "myfs", fsName)
 	fsName = findFSName("rook-ceph-mds-my-super-fs-a", "rook-ceph")
 	assert.Equal(t, "my-super-fs", fsName)
+}
+
+func TestDaemonMapEntry(t *testing.T) {
+	dummyVersionsRaw := []byte(`
+	{
+		"mon": {
+			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
+			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+		}
+	}`)
+
+	var dummyVersions CephDaemonsVersions
+	err := json.Unmarshal([]byte(dummyVersionsRaw), &dummyVersions)
+	assert.Nil(t, err)
+
+	m, err := daemonMapEntry(&dummyVersions, "mon")
+	assert.Nil(t, err)
+	assert.Equal(t, dummyVersions.Mon, m)
+
+	m, err = daemonMapEntry(&dummyVersions, "dummy")
+	assert.NotNil(t, err)
 }

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -202,3 +202,81 @@ func TestDaemonMapEntry(t *testing.T) {
 	m, err = daemonMapEntry(&dummyVersions, "dummy")
 	assert.NotNil(t, err)
 }
+
+func TestBuildHostListFromTree(t *testing.T) {
+	dummyOsdTreeRaw := []byte(`
+	{
+		"nodes": [
+		  {
+			"id": -3,
+			"name": "r1",
+			"type": "rack",
+			"type_id": 3,
+			"children": [
+			  -4
+			]
+		  },
+		  {
+			"id": -4,
+			"name": "ceph-nano-oooooo",
+			"type": "host",
+			"type_id": 1,
+			"pool_weights": {},
+			"children": [
+			  0
+			]
+		  },
+		  {
+			"id": 0,
+			"name": "osd.0",
+			"type": "osd",
+			"type_id": 0,
+			"crush_weight": 0.009796,
+			"depth": 2,
+			"pool_weights": {},
+			"exists": 1,
+			"status": "up",
+			"reweight": 1,
+			"primary_affinity": 1
+		  },
+		  {
+			"id": -1,
+			"name": "default",
+			"type": "root",
+			"type_id": 10,
+			"children": [
+			  -2
+			]
+		  },
+		  {
+			"id": -2,
+			"name": "ceph-nano-nau-faa32aebf00b",
+			"type": "host",
+			"type_id": 1,
+			"pool_weights": {},
+			"children": []
+		  }
+		],
+		"stray": [
+		  {
+			"id": 1,
+			"name": "osd.1",
+			"type": "osd",
+			"type_id": 0,
+			"crush_weight": 0,
+			"depth": 0,
+			"exists": 1,
+			"status": "down",
+			"reweight": 0,
+			"primary_affinity": 1
+		  }
+		]
+	  }`)
+
+	var dummyTree OsdTree
+	err := json.Unmarshal([]byte(dummyOsdTreeRaw), &dummyTree)
+	assert.Nil(t, err)
+
+	osdHosts := buildHostListFromTree(dummyTree)
+	assert.Equal(t, 2, len(osdHosts.Nodes))
+}

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster to manage a Ceph cluster.
+package cluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
+
+	// 1st test
+	fakeImageVersion := cephver.Nautilus
+	fakeRunningVersions := []byte(`
+	{
+		"mon": {
+			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
+			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+		}
+	}`)
+	var dummyRunningVersions client.CephDaemonsVersions
+	err := json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions)
+	assert.NoError(t, err)
+
+	m, err := diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions)
+	assert.Error(t, err) // Overall is absent
+	assert.False(t, m)
+
+	// 2nd test - more than 1 version means we should upgrade
+	fakeRunningVersions = []byte(`
+	{
+		"overall": {
+			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
+			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+		}
+	}`)
+	var dummyRunningVersions2 client.CephDaemonsVersions
+	err = json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions2)
+	assert.NoError(t, err)
+
+	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions2)
+	assert.NoError(t, err)
+	assert.True(t, m)
+
+	// 3nd test - spec version is lower than running cluster? what's going on?
+	fakeRunningVersions = []byte(`
+		{
+			"overall": {
+				"ceph version 15.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) octopus (stable)": 2
+			}
+		}`)
+	var dummyRunningVersions3 client.CephDaemonsVersions
+	err = json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions3)
+	assert.NoError(t, err)
+
+	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions3)
+	assert.Error(t, err)
+	assert.True(t, m)
+
+	// 4 test - spec version is higher than running cluster --> we upgrade
+	fakeImageVersion = cephver.Nautilus
+	fakeRunningVersions = []byte(`
+	{
+		"overall": {
+			"ceph version 13.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) mimic (stable)": 2
+		}
+	}`)
+	var dummyRunningVersions4 client.CephDaemonsVersions
+	err = json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions4)
+	assert.NoError(t, err)
+
+	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions4)
+	assert.NoError(t, err)
+	assert.True(t, m)
+
+	// 5 test - spec version and running cluster versions are identical --> we upgrade
+	fakeImageVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 2}
+	fakeRunningVersions = []byte(`
+		{
+			"overall": {
+				"ceph version 14.2.2 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+			}
+		}`)
+	var dummyRunningVersions5 client.CephDaemonsVersions
+	err = json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions5)
+	assert.NoError(t, err)
+
+	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions5)
+	assert.NoError(t, err)
+	assert.False(t, m)
+}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -852,7 +852,7 @@ func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
 }
 
 func printOverallCephVersion(context *clusterd.Context, namespace string) {
-	versions, err := client.GetCephVersions(context, namespace)
+	versions, err := client.GetAllCephDaemonVersions(context, namespace)
 	if err != nil {
 		logger.Errorf("failed to get ceph daemons versions. %+v", err)
 		return

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -152,7 +153,19 @@ func (c *Cluster) Start() error {
 				return fmt.Errorf("failed to create mgr deployment %s. %+v", resourceName, err)
 			}
 			logger.Infof("deployment for mgr %s already exists. updating if needed", resourceName)
-			if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
+			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
+			daemon := "mgr"
+			var cephVersionToUse cephver.CephVersion
+			currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
+			if err != nil {
+				logger.Warningf("failed to retrieve current ceph %s version. %+v", daemon, err)
+				logger.Debug("could not detect ceph version during update, this is likely an initial bootstrap, proceeding with c.clusterInfo.CephVersion")
+				cephVersionToUse = c.clusterInfo.CephVersion
+			} else {
+				logger.Debugf("current cluster version for mgrs before upgrading is: %+v", currentCephVersion)
+				cephVersionToUse = currentCephVersion
+			}
+			if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
 				return fmt.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
 			}
 		}

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -154,7 +154,7 @@ func (c *Cluster) Start() error {
 			}
 			logger.Infof("deployment for mgr %s already exists. updating if needed", resourceName)
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-			daemon := "mgr"
+			daemon := string(config.MgrType)
 			var cephVersionToUse cephver.CephVersion
 			currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
 			if err != nil {
@@ -165,7 +165,7 @@ func (c *Cluster) Start() error {
 				logger.Debugf("current cluster version for mgrs before upgrading is: %+v", currentCephVersion)
 				cephVersionToUse = currentCephVersion
 			}
-			if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
+			if err := updateDeploymentAndWait(c.context, d, c.Namespace, daemon, mgrConfig.DaemonID, cephVersionToUse); err != nil {
 				return fmt.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
 			}
 		}

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -106,7 +107,7 @@ func New(
 	}
 }
 
-var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
 // Start begins the process of running a cluster of Ceph mgrs.
 func (c *Cluster) Start() error {
@@ -151,7 +152,7 @@ func (c *Cluster) Start() error {
 				return fmt.Errorf("failed to create mgr deployment %s. %+v", resourceName, err)
 			}
 			logger.Infof("deployment for mgr %s already exists. updating if needed", resourceName)
-			if _, err := updateDeploymentAndWait(c.context, d, c.Namespace); err != nil {
+			if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
 				return fmt.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
 			}
 		}

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -121,8 +121,8 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 	return clusterInfo, maxMonID, monMapping, nil
 }
 
-// writeConnectionConfig save monitor connection config to disk
-func writeConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo) error {
+// WriteConnectionConfig save monitor connection config to disk
+func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo) error {
 	// write the latest config to the config dir
 	if err := cephconfig.GenerateAdminConnectionConfig(context, clusterInfo); err != nil {
 		return fmt.Errorf("failed to write connection config. %+v", err)

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -297,7 +297,7 @@ func (c *Cluster) removeMon(daemonName string) error {
 	}
 
 	// make sure to rewrite the config so NO new connections are made to the removed mon
-	if err := writeConnectionConfig(c.context, c.clusterInfo); err != nil {
+	if err := WriteConnectionConfig(c.context, c.clusterInfo); err != nil {
 		return fmt.Errorf("failed to write connection config after failing over mon %s. %+v", daemonName, err)
 	}
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -627,7 +627,20 @@ func (c *Cluster) startMon(m *monConfig, hostname string) error {
 			return fmt.Errorf("failed to create mon deployment %s. %+v", m.ResourceName, err)
 		}
 		logger.Infof("deployment for mon %s already exists. updating if needed", m.ResourceName)
-		if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
+
+		// Always invoke ceph version before an upgrade so we are sure to be up-to-date
+		daemon := "mon"
+		var cephVersionToUse cephver.CephVersion
+		currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
+		if err != nil {
+			logger.Warningf("failed to retrieve current ceph %s version. %+v", daemon, err)
+			logger.Debug("could not detect ceph version during update, this is likely an initial bootstrap, proceeding with c.clusterInfo.CephVersion")
+			cephVersionToUse = c.clusterInfo.CephVersion
+		} else {
+			logger.Debugf("current cluster version for monitors before upgrading is: %+v", currentCephVersion)
+			cephVersionToUse = currentCephVersion
+		}
+		if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
 			return fmt.Errorf("failed to update mon deployment %s. %+v", m.ResourceName, err)
 		}
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -629,18 +629,18 @@ func (c *Cluster) startMon(m *monConfig, hostname string) error {
 		logger.Infof("deployment for mon %s already exists. updating if needed", m.ResourceName)
 
 		// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-		daemon := "mon"
+		daemonType := string(config.MonType)
 		var cephVersionToUse cephver.CephVersion
-		currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
+		currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemonType)
 		if err != nil {
-			logger.Warningf("failed to retrieve current ceph %s version. %+v", daemon, err)
+			logger.Warningf("failed to retrieve current ceph %s version. %+v", daemonType, err)
 			logger.Debug("could not detect ceph version during update, this is likely an initial bootstrap, proceeding with c.clusterInfo.CephVersion")
 			cephVersionToUse = c.clusterInfo.CephVersion
 		} else {
 			logger.Debugf("current cluster version for monitors before upgrading is: %+v", currentCephVersion)
 			cephVersionToUse = currentCephVersion
 		}
-		if err := updateDeploymentAndWait(c.context, d, c.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
+		if err := updateDeploymentAndWait(c.context, d, c.Namespace, daemonType, m.DaemonName, cephVersionToUse); err != nil {
 			return fmt.Errorf("failed to update mon deployment %s. %+v", m.ResourceName, err)
 		}
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -272,7 +272,7 @@ func (c *Cluster) ensureMonsRunning(mons []*monConfig, i, targetCount int, requi
 	}
 
 	// make sure we have the connection info generated so connections can happen
-	if err := writeConnectionConfig(c.context, c.clusterInfo); err != nil {
+	if err := WriteConnectionConfig(c.context, c.clusterInfo); err != nil {
 		return err
 	}
 
@@ -608,7 +608,7 @@ func (c *Cluster) saveMonConfig() error {
 	config.GetStore(c.context, c.Namespace, &c.ownerRef).CreateOrUpdate(c.clusterInfo)
 
 	// write the latest config to the config dir
-	if err := writeConnectionConfig(c.context, c.clusterInfo); err != nil {
+	if err := WriteConnectionConfig(c.context, c.clusterInfo); err != nil {
 		return fmt.Errorf("failed to write connection config for new mons. %+v", err)
 	}
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -217,19 +217,19 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 }
 
 // UpdateCephDeploymentAndWait verifies a deployment can be stopped or continued
-func UpdateCephDeploymentAndWait(context *clusterd.Context, deployment *apps.Deployment, namespace, clusterName string, cephVersion cephver.CephVersion) error {
+func UpdateCephDeploymentAndWait(context *clusterd.Context, deployment *apps.Deployment, namespace, daemonType, daemonName string, cephVersion cephver.CephVersion) error {
 	callback := func(action string) error {
 		logger.Infof("checking if we can %s the deployment %s", action, deployment.Name)
 
 		if action == "stop" {
-			err := client.OkToStop(context, namespace, deployment.Name, clusterName, cephVersion)
+			err := client.OkToStop(context, namespace, deployment.Name, daemonType, daemonName, cephVersion)
 			if err != nil {
 				return fmt.Errorf("failed to check if we can %s the deployment %s: %+v", action, deployment.Name, err)
 			}
 		}
 
 		if action == "continue" {
-			err := client.OkToContinue(context, namespace, deployment.Name)
+			err := client.OkToContinue(context, namespace, deployment.Name, daemonType, daemonName)
 			if err != nil {
 				return fmt.Errorf("failed to check if we can %s the deployment %s: %+v", action, deployment.Name, err)
 			}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -200,19 +200,16 @@ func (c *Cluster) Start() error {
 			logger.Warningf("failed to get ceph daemons versions; this likely means there are no osds yet. %+v", err)
 		} else {
 			// If length is one, this clearly indicates that all the osds are running the same version
-			logger.Infof("len of version.Osd is %d", len(versions.Osd))
 			// If this is the first time we are creating a cluster length will be 0
 			// On an initial OSD boostrap, by the time we reach this code, the OSDs haven't registered yet
 			// Basically, this task is happening too quickly and OSD pods are not running yet.
 			// That's not an issue since it's an initial bootstrap and not an update.
 			if len(versions.Osd) == 1 {
 				for v := range versions.Osd {
-					logger.Infof("v is %s", v)
 					osdVersion, err := cephver.ExtractCephVersion(v)
 					if err != nil {
 						return fmt.Errorf("failed to extract ceph version. %+v", err)
 					}
-					logger.Infof("osdVersion is: %v", osdVersion)
 					// if the version of these OSDs is Nautilus then we run the command
 					if osdVersion.IsAtLeastNautilus() {
 						client.EnableNautilusOSD(c.context)

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -30,6 +30,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -323,7 +324,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 			}
 			logger.Infof("deployment for osd %d already exists. updating if needed", osd.ID)
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-			daemon := "osd"
+			daemon := string(opconfig.OsdType)
 			var cephVersionToUse cephver.CephVersion
 			currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
 			if err != nil {
@@ -334,7 +335,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 				logger.Debugf("current cluster version for osds before upgrading is: %+v", currentCephVersion)
 				cephVersionToUse = currentCephVersion
 			}
-			if err = updateDeploymentAndWait(c.context, dp, c.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
+			if err = updateDeploymentAndWait(c.context, dp, c.Namespace, daemon, strconv.Itoa(osd.ID), cephVersionToUse); err != nil {
 				config.addError(fmt.Sprintf("failed to update osd deployment %d. %+v", osd.ID, err))
 			}
 		}

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -124,7 +124,7 @@ func (m *Mirroring) Start() error {
 			logger.Infof("deployment for rbd-mirror %s already exists. updating if needed", resourceName)
 
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-			daemon := "mirror"
+			daemon := string(config.RbdMirrorType)
 			var cephVersionToUse cephver.CephVersion
 			currentCephVersion, err := client.LeastUptodateDaemonVersion(m.context, m.ClusterInfo.Name, daemon)
 			if err != nil {
@@ -136,7 +136,7 @@ func (m *Mirroring) Start() error {
 				logger.Debugf("current cluster version for rbd mirrors before upgrading is: %+v", currentCephVersion)
 				cephVersionToUse = currentCephVersion
 			}
-			if err := updateDeploymentAndWait(m.context, d, m.Namespace, m.ClusterInfo.Name, cephVersionToUse); err != nil {
+			if err := updateDeploymentAndWait(m.context, d, m.Namespace, daemon, daemonConf.DaemonID, cephVersionToUse); err != nil {
 				// fail could be an issue updating label selector (immutable), so try del and recreate
 				logger.Debugf("updateDeploymentAndWait failed for rbd-mirror %s. Attempting del-and-recreate. %+v", resourceName, err)
 				err = m.context.Clientset.AppsV1().Deployments(m.Namespace).Delete(d.Name, &metav1.DeleteOptions{})

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -24,10 +24,12 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -120,7 +122,21 @@ func (m *Mirroring) Start() error {
 				return fmt.Errorf("failed to create %s deployment. %+v", resourceName, err)
 			}
 			logger.Infof("deployment for rbd-mirror %s already exists. updating if needed", resourceName)
-			if err := updateDeploymentAndWait(m.context, d, m.Namespace, m.ClusterInfo.Name, m.ClusterInfo.CephVersion); err != nil {
+
+			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
+			daemon := "mirror"
+			var cephVersionToUse cephver.CephVersion
+			currentCephVersion, err := client.LeastUptodateDaemonVersion(m.context, m.ClusterInfo.Name, daemon)
+			if err != nil {
+				logger.Warningf("failed to retrieve current ceph %s version. %+v", daemon, err)
+				logger.Debug("could not detect ceph version during update, this is likely an initial bootstrap, proceeding with m.ClusterInfo.CephVersion")
+				cephVersionToUse = m.ClusterInfo.CephVersion
+
+			} else {
+				logger.Debugf("current cluster version for rbd mirrors before upgrading is: %+v", currentCephVersion)
+				cephVersionToUse = currentCephVersion
+			}
+			if err := updateDeploymentAndWait(m.context, d, m.Namespace, m.ClusterInfo.Name, cephVersionToUse); err != nil {
 				// fail could be an issue updating label selector (immutable), so try del and recreate
 				logger.Debugf("updateDeploymentAndWait failed for rbd-mirror %s. Attempting del-and-recreate. %+v", resourceName, err)
 				err = m.context.Clientset.AppsV1().Deployments(m.Namespace).Delete(d.Name, &metav1.DeleteOptions{})

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -157,7 +157,7 @@ func (c *Cluster) Start() error {
 		// deployment from reaching ready state
 		if createErr != nil && errors.IsAlreadyExists(createErr) {
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-			daemon := "mds"
+			daemon := string(config.MdsType)
 			var cephVersionToUse cephver.CephVersion
 			currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
 			if err != nil {
@@ -169,7 +169,7 @@ func (c *Cluster) Start() error {
 				logger.Debugf("current cluster version for mdss before upgrading is: %+v", currentCephVersion)
 				cephVersionToUse = currentCephVersion
 			}
-			if err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
+			if err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace, daemon, daemonLetterID, cephVersionToUse); err != nil {
 				return fmt.Errorf("failed to update mds deployment %s. %+v", d.Name, err)
 			}
 		}

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -94,7 +95,7 @@ func NewCluster(
 }
 
 // UpdateDeploymentAndWait can be overridden for unit tests. Do not alter this for runtime operation.
-var UpdateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+var UpdateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
 // Start starts or updates a Ceph mds cluster in Kubernetes.
 func (c *Cluster) Start() error {
@@ -155,7 +156,7 @@ func (c *Cluster) Start() error {
 		// keyring must be generated before update-and-wait since no keyring will prevent the
 		// deployment from reaching ready state
 		if createErr != nil && errors.IsAlreadyExists(createErr) {
-			if _, err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace); err != nil {
+			if err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
 				return fmt.Errorf("failed to update mds deployment %s. %+v", d.Name, err)
 			}
 		}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -36,7 +36,7 @@ const (
 	ganeshaRadosGraceCmd = "ganesha-rados-grace"
 )
 
-var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+var updateDeploymentAndWait = opmon.UpdateCephDeploymentAndWait
 
 // Create the ganesha server
 func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
@@ -68,7 +68,7 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 				return fmt.Errorf("failed to create ganesha deployment. %+v", err)
 			}
 			logger.Infof("ganesha deployment %s already exists. updating if needed", deployment.Name)
-			if _, err := updateDeploymentAndWait(c.context, deployment, n.Namespace); err != nil {
+			if err := updateDeploymentAndWait(c.context, deployment, n.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
 				return fmt.Errorf("failed to update ganesha deployment %s. %+v", deployment.Name, err)
 			}
 		} else {

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -69,7 +69,7 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 			}
 			logger.Infof("ganesha deployment %s already exists. updating if needed", deployment.Name)
 			// We don't invoke ceph versions here since nfs do not show up in the service map (yet?)
-			if err := updateDeploymentAndWait(c.context, deployment, n.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
+			if err := updateDeploymentAndWait(c.context, deployment, n.Namespace, "nfs", name, c.clusterInfo.CephVersion); err != nil {
 				return fmt.Errorf("failed to update ganesha deployment %s. %+v", deployment.Name, err)
 			}
 		} else {

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -68,6 +68,7 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 				return fmt.Errorf("failed to create ganesha deployment. %+v", err)
 			}
 			logger.Infof("ganesha deployment %s already exists. updating if needed", deployment.Name)
+			// We don't invoke ceph versions here since nfs do not show up in the service map (yet?)
 			if err := updateDeploymentAndWait(c.context, deployment, n.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
 				return fmt.Errorf("failed to update ganesha deployment %s. %+v", deployment.Name, err)
 			}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -52,29 +53,12 @@ const (
 	oldRgwKeyName = "client.radosgw.gateway"
 )
 
-// Start the rgw manager
-func (c *clusterConfig) createStore() error {
-	return c.createOrUpdate(false)
-}
+var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 
-func (c *clusterConfig) updateStore() error {
-	return c.createOrUpdate(true)
-}
-
-func (c *clusterConfig) createOrUpdate(update bool) error {
+func (c *clusterConfig) createOrUpdate() error {
 	// validate the object store settings
 	if err := validateStore(c.context, c.store); err != nil {
 		return fmt.Errorf("invalid object store %s arguments. %+v", c.store.Name, err)
-	}
-
-	// check if the object store already exists
-	exists, err := c.storeExists()
-	if err == nil && exists {
-		if !update {
-			logger.Infof("object store %s exists in namespace %s", c.store.Name, c.store.Namespace)
-			return c.startRGWPods(update)
-		}
-		logger.Infof("object store %s exists in namespace %s. checking for updates", c.store.Name, c.store.Namespace)
 	}
 
 	logger.Infof("creating object store %s in namespace %s", c.store.Name, c.store.Namespace)
@@ -92,7 +76,7 @@ func (c *clusterConfig) createOrUpdate(update bool) error {
 		return fmt.Errorf("failed to create pools. %+v", err)
 	}
 
-	if err := c.startRGWPods(update); err != nil {
+	if err := c.startRGWPods(); err != nil {
 		return fmt.Errorf("failed to start pods. %+v", err)
 	}
 
@@ -100,7 +84,7 @@ func (c *clusterConfig) createOrUpdate(update bool) error {
 	return nil
 }
 
-func (c *clusterConfig) startRGWPods(update bool) error {
+func (c *clusterConfig) startRGWPods() error {
 	// backward compatibility, triggered during updates
 	if c.store.Spec.Gateway.AllNodes {
 		// log we don't support that anymore
@@ -117,6 +101,8 @@ func (c *clusterConfig) startRGWPods(update bool) error {
 	// start a new deployment and scale up
 	desiredRgwInstances := int(c.store.Spec.Gateway.Instances)
 	for i := 0; i < desiredRgwInstances; i++ {
+		var err error
+
 		daemonLetterID := k8sutil.IndexToName(i)
 		// Each rgw is id'ed by <store_name>-<letterID>
 		daemonName := fmt.Sprintf("%s-%s", c.store.Name, daemonLetterID)
@@ -128,13 +114,22 @@ func (c *clusterConfig) startRGWPods(update bool) error {
 			DaemonID:     daemonName,
 		}
 
-		deployment, err := c.startDeployment(rgwConfig)
-		if err != nil {
-			return err
+		deployment := c.startDeployment(rgwConfig)
+		logger.Infof("object store %s deployment %s started", c.store.Name, deployment.Name)
+		createdDeployment, createErr := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Create(deployment)
+		if createErr != nil {
+			if !errors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("failed to create rgw deployment. %+v", createErr)
+			}
+			logger.Infof("object store %s deployment %s already exists. updating if needed", c.store.Name, deployment.Name)
+			createdDeployment, err = c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Get(deployment.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get existing rgw deployment %s for update: %+v", deployment.Name, err)
+			}
 		}
 
 		resourceControllerOwnerRef := &metav1.OwnerReference{
-			UID:        deployment.UID,
+			UID:        createdDeployment.UID,
 			APIVersion: "v1",
 			Kind:       "deployment",
 			Name:       rgwConfig.ResourceName,
@@ -148,6 +143,12 @@ func (c *clusterConfig) startRGWPods(update bool) error {
 		}
 
 		// Generate the mime.types file after the rep. controller as well for the same reason as keyring
+		if createErr != nil && errors.IsAlreadyExists(createErr) {
+			if err := updateDeploymentAndWait(c.context, deployment, c.store.Namespace, c.clusterInfo.Name, c.clusterInfo.CephVersion); err != nil {
+				return fmt.Errorf("failed to update object store %s deployment %s. %+v", c.store.Name, deployment.Name, err)
+			}
+		}
+
 		if err := c.generateMimeTypes(resourceControllerOwnerRef); err != nil {
 			return fmt.Errorf("failed to generate the rgw mime.types config. %+v", err)
 		}
@@ -239,16 +240,6 @@ func (c *clusterConfig) deleteLegacyDaemons() {
 // Delete the object store.
 // WARNING: This is a very destructive action that deletes all metadata and data pools.
 func (c *clusterConfig) deleteStore() error {
-	// check if the object store exists
-	exists, err := c.storeExists()
-	if err != nil {
-		return fmt.Errorf("failed to detect if there is an object store to delete. %+v", err)
-	}
-	if !exists {
-		logger.Infof("Object store %s does not exist in namespace %s", c.store.Name, c.store.Namespace)
-		return nil
-	}
-
 	logger.Infof("Deleting object store %s from namespace %s", c.store.Name, c.store.Namespace)
 
 	var gracePeriod int64
@@ -256,7 +247,7 @@ func (c *clusterConfig) deleteStore() error {
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
 
 	// Delete the rgw service
-	err = c.context.Clientset.CoreV1().Services(c.store.Namespace).Delete(c.instanceName(), options)
+	err := c.context.Clientset.CoreV1().Services(c.store.Namespace).Delete(c.instanceName(), options)
 	if err != nil && !errors.IsNotFound(err) {
 		logger.Warningf("failed to delete rgw service. %+v", err)
 	}
@@ -297,32 +288,6 @@ func (c *clusterConfig) deleteStore() error {
 
 	logger.Infof("Completed deleting object store %s", c.store.Name)
 	return nil
-}
-
-// Check if the object store exists depending on either the deployment or the daemonset
-func (c *clusterConfig) storeExists() (bool, error) {
-	d, err := k8sutil.GetDeployments(c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
-	// k8sutil.GetDeployments can return an empty list!
-	if err == nil && len(d.Items) != 0 {
-		// the deployment was found
-		return true, nil
-	}
-	if err != nil && !errors.IsNotFound(err) {
-		return false, err
-	}
-
-	dd, err := k8sutil.GetDaemonsets(c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
-	// k8sutil.GetDaemonsets can return an empty list!
-	if err == nil && len(dd.Items) != 0 {
-		//  the daemonset was found
-		return true, nil
-	}
-	if err != nil && !errors.IsNotFound(err) {
-		return false, err
-	}
-
-	// neither one was found
-	return false, nil
 }
 
 func (c *clusterConfig) instanceName() string {

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -146,7 +146,7 @@ func (c *clusterConfig) startRGWPods() error {
 		// Generate the mime.types file after the rep. controller as well for the same reason as keyring
 		if createErr != nil && errors.IsAlreadyExists(createErr) {
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
-			daemon := "rgw"
+			daemon := string(config.RgwType)
 			var cephVersionToUse cephver.CephVersion
 			currentCephVersion, err := client.LeastUptodateDaemonVersion(c.context, c.clusterInfo.Name, daemon)
 			if err != nil {
@@ -158,7 +158,7 @@ func (c *clusterConfig) startRGWPods() error {
 				logger.Debugf("current cluster version for rgws before upgrading is: %+v", currentCephVersion)
 				cephVersionToUse = currentCephVersion
 			}
-			if err := updateDeploymentAndWait(c.context, deployment, c.store.Namespace, c.clusterInfo.Name, cephVersionToUse); err != nil {
+			if err := updateDeploymentAndWait(c.context, deployment, c.store.Namespace, daemon, daemonLetterID, cephVersionToUse); err != nil {
 				return fmt.Errorf("failed to update object store %s deployment %s. %+v", c.store.Name, deployment.Name, err)
 			}
 		}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -114,7 +114,7 @@ func (c *clusterConfig) startRGWPods() error {
 			DaemonID:     daemonName,
 		}
 
-		deployment := c.startDeployment(rgwConfig)
+		deployment := c.createDeployment(rgwConfig)
 		logger.Infof("object store %s deployment %s started", c.store.Name, deployment.Name)
 		createdDeployment, createErr := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Create(deployment)
 		if createErr != nil {

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -53,14 +53,10 @@ func TestStartRGW(t *testing.T) {
 
 	// start a basic cluster
 	c := &clusterConfig{info, context, store, version, cephv1.CephVersionSpec{}, false, []metav1.OwnerReference{}, data}
-	err := c.createStore()
+	err := c.startRGWPods()
 	assert.Nil(t, err)
 
 	validateStart(t, c, clientset)
-
-	// starting again should update the pods with the new settings
-	err = c.updateStore()
-	assert.Nil(t, err)
 }
 
 func validateStart(t *testing.T, c *clusterConfig, clientset *fake.Clientset) {
@@ -68,10 +64,6 @@ func validateStart(t *testing.T, c *clusterConfig, clientset *fake.Clientset) {
 	r, err := clientset.AppsV1().Deployments(c.store.Namespace).Get(rgwName, metav1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, rgwName, r.Name)
-
-	s, err := clientset.CoreV1().Services(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.Equal(t, c.instanceName(), s.Name)
 }
 
 func TestCreateObjectStore(t *testing.T) {
@@ -103,7 +95,7 @@ func TestCreateObjectStore(t *testing.T) {
 
 	// create the pools
 	c := &clusterConfig{info, context, store, "1.2.3.4", cephv1.CephVersionSpec{}, false, []metav1.OwnerReference{}, data}
-	err := c.createStore()
+	err := c.createOrUpdate()
 	assert.Nil(t, err)
 }
 

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (c *clusterConfig) startDeployment(rgwConfig *rgwConfig) (*apps.Deployment, error) {
+func (c *clusterConfig) startDeployment(rgwConfig *rgwConfig) *apps.Deployment {
 	replicas := int32(1)
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -53,31 +53,7 @@ func (c *clusterConfig) startDeployment(rgwConfig *rgwConfig) (*apps.Deployment,
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRefs(&d.ObjectMeta, c.ownerRefs)
 
-	logger.Debugf("starting rgw deployment: %+v", d)
-	deployment, err := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Get(d.Name, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, fmt.Errorf("failed to see if rgw deployment %s already exists. %+v", d.Name, err)
-	} else if err == nil {
-		// deployment exists
-		var uErr error
-		deployment, uErr = c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Update(d)
-		if uErr != nil {
-			// may fail to update when labels have changed on the deployment and thus the label selector
-			// in this case we can try to delete the deployment and recreate
-			dErr := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Delete(d.Name, &metav1.DeleteOptions{})
-			if dErr != nil {
-				return nil, fmt.Errorf("failed to delete existing rgw deployment %s as part of update attempt. %+v", d.Name, dErr)
-			}
-		} else {
-			return deployment, uErr
-		}
-	}
-	// err != nil && isNotFound  or  err == nil && update failed, causing earlier dep to be deleted
-	deployment, err = c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Create(d)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create rgw deployment %s: %+v", c.instanceName(), err)
-	}
-	return deployment, err
+	return d
 }
 
 func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) v1.PodTemplateSpec {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (c *clusterConfig) startDeployment(rgwConfig *rgwConfig) *apps.Deployment {
+func (c *clusterConfig) createDeployment(rgwConfig *rgwConfig) *apps.Deployment {
 	replicas := int32(1)
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package version
 
 import (
@@ -149,4 +165,59 @@ func (v *CephVersion) IsAtLeastNautilus() bool {
 // IsAtLeastMimic check that the Ceph version is at least Mimic
 func (v *CephVersion) IsAtLeastMimic() bool {
 	return v.IsAtLeast(Mimic)
+}
+
+// IsIdentical checks if Ceph versions are identical
+func IsIdentical(a, b CephVersion) bool {
+	if a.Major == b.Major {
+		if a.Minor == b.Minor {
+			if a.Extra == b.Extra {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// IsSuperior checks if a given version if superior to another one
+func IsSuperior(a, b CephVersion) bool {
+	if a.Major > b.Major {
+		return true
+	}
+	if a.Major == b.Major {
+		if a.Minor > b.Minor {
+			return true
+		}
+	}
+	if a.Major == b.Major {
+		if a.Minor == b.Minor {
+			if a.Extra > b.Extra {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// IsInferior checks if a given version if inferior to another one
+func IsInferior(a, b CephVersion) bool {
+	if a.Major < b.Major {
+		return true
+	}
+	if a.Major == b.Major {
+		if a.Minor < b.Minor {
+			return true
+		}
+	}
+	if a.Major == b.Major {
+		if a.Minor == b.Minor {
+			if a.Extra < b.Extra {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package version
 
 import (
@@ -163,4 +179,25 @@ func TestVersionAtLeastX(t *testing.T) {
 	assert.False(t, Luminous.IsAtLeastNautilus())
 	assert.False(t, Mimic.IsAtLeastNautilus())
 	assert.False(t, Nautilus.IsAtLeastOctopus())
+}
+
+func TestIsIdentical(t *testing.T) {
+	assert.True(t, IsIdentical(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
+	assert.False(t, IsIdentical(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
+}
+
+func TestIsSuperior(t *testing.T) {
+	assert.False(t, IsSuperior(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
+	assert.False(t, IsSuperior(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{14, 2, 2}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{15, 1, 3}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{15, 2, 1}))
+}
+
+func TestIsInferior(t *testing.T) {
+	assert.False(t, IsInferior(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
+	assert.False(t, IsInferior(CephVersion{15, 2, 2}, CephVersion{14, 2, 2}))
+	assert.True(t, IsInferior(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
+	assert.True(t, IsInferior(CephVersion{15, 1, 3}, CephVersion{15, 2, 2}))
+	assert.True(t, IsInferior(CephVersion{15, 2, 1}, CephVersion{15, 2, 2}))
 }

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -131,7 +131,13 @@ func (c *Cluster) Start(rookImage string) error {
 			return fmt.Errorf("failed to create %s deployment. %+v", appName, err)
 		}
 		logger.Infof("deployment for mgr %s already exists. updating if needed", appName)
-		if _, err := k8sutil.UpdateDeploymentAndWait(c.context, deployment, c.Namespace); err != nil {
+
+		// placeholder for a verify callback
+		// see comments on k8sutil.UpdateDeploymentAndWait's definition to understand its purpose
+		callback := func(action string) error {
+			return nil
+		}
+		if _, err := k8sutil.UpdateDeploymentAndWait(c.context, deployment, c.Namespace, callback); err != nil {
 			return fmt.Errorf("failed to update mgr deployment %s. %+v", appName, err)
 		}
 	} else {

--- a/pkg/operator/k8sutil/test/deployment.go
+++ b/pkg/operator/k8sutil/test/deployment.go
@@ -2,8 +2,8 @@ package test
 
 import (
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	apps "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // UpdateDeploymentAndWaitStub returns a stub replacement for the UpdateDeploymentAndWait function
@@ -15,13 +15,13 @@ import (
 // returns a pointer to this slice which the calling func may use to verify the expected contents of
 // deploymentsUpdated based on expected behavior.
 func UpdateDeploymentAndWaitStub() (
-	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*apps.Deployment, error),
+	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace, clusterName string, cephVersion version.CephVersion) error,
 	deploymentsUpdated *[]*apps.Deployment,
 ) {
 	deploymentsUpdated = &[]*apps.Deployment{}
-	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*apps.Deployment, error) {
+	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace, clusterName string, cephVersion version.CephVersion) error {
 		*deploymentsUpdated = append(*deploymentsUpdated, deployment)
-		return &apps.Deployment{ObjectMeta: metav1.ObjectMeta{UID: "stub-deployment-uid"}}, nil
+		return nil
 	}
 	return stubFunc, deploymentsUpdated
 }

--- a/pkg/operator/k8sutil/test/deployment.go
+++ b/pkg/operator/k8sutil/test/deployment.go
@@ -15,11 +15,11 @@ import (
 // returns a pointer to this slice which the calling func may use to verify the expected contents of
 // deploymentsUpdated based on expected behavior.
 func UpdateDeploymentAndWaitStub() (
-	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace, clusterName string, cephVersion version.CephVersion) error,
+	stubFunc func(context *clusterd.Context, deployment *apps.Deployment, namespace, daemonType, daemonName string, cephVersion version.CephVersion) error,
 	deploymentsUpdated *[]*apps.Deployment,
 ) {
 	deploymentsUpdated = &[]*apps.Deployment{}
-	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace, clusterName string, cephVersion version.CephVersion) error {
+	stubFunc = func(context *clusterd.Context, deployment *apps.Deployment, namespace, daemonType, daemonName string, cephVersion version.CephVersion) error {
 		*deploymentsUpdated = append(*deploymentsUpdated, deployment)
 		return nil
 	}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -365,6 +365,9 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 			h.checkCephHealthStatus(namespace)
 		}
 
+		// Gather logs after status checks
+		h.GatherAllRookLogs(namespace, SystemNamespace(namespace), h.T().Name())
+
 		roles := h.Manifests.GetClusterRoles(namespace, systemNamespace)
 		_, err = h.k8shelper.KubectlWithStdin(roles, deleteFromStdinArgs...)
 

--- a/tests/integration/base_deploy_test.go
+++ b/tests/integration/base_deploy_test.go
@@ -140,6 +140,5 @@ func (op *TestCluster) SetInstallData(version string) {}
 
 // TearDownRook is a wrapper for tearDown after Suite
 func (op *TestCluster) Teardown() {
-	op.installer.GatherAllRookLogs(op.namespace, installer.SystemNamespace(op.namespace), op.installer.T().Name())
 	op.installer.UninstallRook(op.namespace)
 }


### PR DESCRIPTION
**Description of your changes:**

When a cluster is updated with a different image version, this triggers
a serialized restart of all the pods. Prior to this commit, no safety
check were performed and rook was hoping for the best outcome.

Now before doing restarting a daemon we check it can be restarted. Once
it's restarted we also check we can pursue with the rest of the
platform. For instance, with monitors we check that they are in quorum,
for OSD we check that PGs are clean and for MDS we make sure they are
  active.

Fixes: https://github.com/rook/rook/issues/2889
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves  https://github.com/rook/rook/issues/2889

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]
Known issue.