### PR TITLE
ceph: update env vars for ceph-mgr containers

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -70,7 +70,9 @@ func TestPodSpec(t *testing.T) {
 		config.MgrType, "a", appName, "ns")
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
-	podTemplate.Spec().Containers().RequireAdditionalEnvVars("TEST")
+	podTemplate.Spec().Containers().RequireAdditionalEnvVars(
+		"ROOK_OPERATOR_NAMESPACE", "ROOK_CEPH_CLUSTER_CRD_VERSION", "ROOK_VERSION",
+		"ROOK_CEPH_CLUSTER_CRD_NAME")
 	podTemplate.RunFullSuite(config.MgrType, "a", appName, "ns", "ceph/ceph:myceph",
 		"200", "100", "500", "250" /* resources */)
 

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -70,6 +70,7 @@ func TestPodSpec(t *testing.T) {
 		config.MgrType, "a", appName, "ns")
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
+	podTemplate.Spec().Containers().RequireAdditionalEnvVars("TEST")
 	podTemplate.RunFullSuite(config.MgrType, "a", appName, "ns", "ceph/ceph:myceph",
 		"200", "100", "500", "250" /* resources */)
 

--- a/pkg/operator/ceph/test/containers.go
+++ b/pkg/operator/ceph/test/containers.go
@@ -77,6 +77,13 @@ func (ct *ContainersTester) AssertArgsContainCephRequirements() {
 	}
 }
 
+// RequireAdditionalEnvVars adds a list of environment variable names to the list of required
+// variables for a single unit test (it does not persist between different tests).
+// Usage: myPodTemplateSpecTester.Spec().Containers().RequireAdditionalEnvVars("I_AM", "REQUIRED")
+func (*ContainersTester) RequireAdditionalEnvVars(varNames ...string) {
+	requiredEnvVars = append(requiredEnvVars, varNames...)
+}
+
 // AssertEnvVarsContainCephRequirements asserts that all Ceph containers under test have the
 // environment variables required for all Ceph containers.
 func (ct *ContainersTester) AssertEnvVarsContainCephRequirements() {


### PR DESCRIPTION


Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
pass env vars with rook-ceph-system namespace and API version to
ceph-mgr containers to remove hardcoded values from rook orchestrator in
ceph-mgr

**Which issue is resolved by this Pull Request:**
Resolves #2843 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
