### PR TITLE
Adding install for kubernetes-cni for integration tests

### DIFF
--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -47,7 +47,7 @@ sudo apt-get update
 wait_for_dpkg_unlock
 sleep 5
 wait_for_dpkg_unlock
-
+sudo apt-get install -y kubernetes-cni="0.6.0-00"
 sudo apt-get install -y kubelet="${KUBE_INSTALL_VERSION}"  && sudo apt-get install -y kubeadm="${KUBE_INSTALL_VERSION}"
 
 #get matching kubectl


### PR DESCRIPTION
**Description of your changes:**
This adds the kubernetes-cni package for integration tests. This is a required component and was blocking the integration testing steps. 

**Which issue is resolved by this Pull Request:**
Resolves # [2906](https://github.com/rook/rook/issues/2906)

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
