### PR TITLE
ceph: fix for masked upgrade failures and getting integrations running again

### DIFF
--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -59,7 +59,6 @@ func AuthGetKey(context *clusterd.Context, clusterName, name string) (string, er
 
 // AuthGetOrCreateKey gets or creates the key for the given user.
 func AuthGetOrCreateKey(context *clusterd.Context, clusterName, name string, caps []string) (string, error) {
-
 	args := append([]string{"auth", "get-or-create-key", name}, caps...)
 	buf, err := ExecuteCephCommand(context, clusterName, args)
 	if err != nil {
@@ -67,6 +66,16 @@ func AuthGetOrCreateKey(context *clusterd.Context, clusterName, name string, cap
 	}
 
 	return parseAuthKey(buf)
+}
+
+// AuthUpdateCaps updates the capabilities for the given user.
+func AuthUpdateCaps(context *clusterd.Context, clusterName, name string, caps []string) error {
+	args := append([]string{"auth", "caps", name}, caps...)
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to update caps for %s. %+v", name, err)
+	}
+	return err
 }
 
 // AuthDelete will delete the given user.

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -324,7 +324,7 @@ func (c *Cluster) removeMon(daemonName string) error {
 		delete(c.mapping.Node, daemonName)
 		// if node->port "mapping" has been created, decrease or delete it
 		if port, ok := c.mapping.Port[nodeName]; ok {
-			if port == DefaultPort {
+			if port == DefaultMsgr1Port {
 				delete(c.mapping.Port, nodeName)
 			}
 			// don't clean up if a node port is higher than the default port, other

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestCheckHealth(t *testing.T) {
+
 	var deploymentsUpdated *[]*apps.Deployment
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
@@ -64,7 +65,7 @@ func TestCheckHealth(t *testing.T) {
 		Name:    "node0",
 		Address: "",
 	}
-	c.mapping.Port["node0"] = DefaultPort
+	c.mapping.Port["node0"] = DefaultMsgr1Port
 	c.maxMonID = 4
 
 	err := c.checkHealth()
@@ -117,7 +118,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 	c.mapping.Node["b"] = &NodeInfo{
 		Name: "node0",
 	}
-	c.mapping.Port["node0"] = DefaultPort
+	c.mapping.Port["node0"] = DefaultMsgr1Port
 	c.maxMonID = 4
 
 	c.saveMonConfig()

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -66,16 +66,20 @@ const (
 	DefaultMonCount = 3
 	// MaxMonCount Maximum allowed mon count for a cluster
 	MaxMonCount = 9
-	// Msgr2port is the listening port of the messenger v2 protocol
-	Msgr2port int32 = 3300
+
+	// DefaultMsgr1Port is the default port Ceph mons use to communicate amongst themselves prior
+	// to Ceph Nautilus.
+	DefaultMsgr1Port int32 = 6789
+	// DefaultMsgr2Port is the listening port of the messenger v2 protocol introduced in Ceph
+	// Nautilus. In Nautilus and a few Ceph releases after, Ceph can use both v1 and v2 protocols.
+	DefaultMsgr2Port int32 = 3300
+
 	// minimum amount of memory in MB to run the pod
 	cephMonPodMinimumMemory uint64 = 1024
 )
 
 var (
 	logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mon")
-	// DefaultPort is the default port Ceph mons use to communicate amongst themselves.
-	DefaultPort int32 = 6789
 )
 
 // Cluster represents the Rook and environment configuration settings needed to set up Ceph mons.
@@ -317,7 +321,7 @@ func (c *Cluster) newMonConfig(monID int) *monConfig {
 	return &monConfig{
 		ResourceName: resourceName(daemonName),
 		DaemonName:   daemonName,
-		Port:         DefaultPort,
+		Port:         DefaultMsgr1Port,
 		DataPathMap: config.NewStatefulDaemonDataPathMap(
 			c.dataDirHostPath, dataDirRelativeHostPath(daemonName), config.MonType, daemonName),
 	}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -62,7 +62,7 @@ func testGenMonConfig(monID string) *monConfig {
 	return &monConfig{
 		ResourceName: "rook-ceph-" + moniker, // rook-ceph-mon-A or rook-ceph-mon#
 		DaemonName:   monID,                  // A or mon#
-		Port:         DefaultPort,
+		Port:         DefaultMsgr1Port,
 		PublicIP:     fmt.Sprintf("2.4.6.%d", index+1),
 		// dataDirHostPath assumed to be /var/lib/rook
 		DataPathMap: config.NewStatefulDaemonDataPathMap(
@@ -142,6 +142,7 @@ func TestResourceName(t *testing.T) {
 }
 
 func TestStartMonPods(t *testing.T) {
+
 	namespace := "ns"
 	context := newTestStartCluster(namespace)
 	c := newCluster(context, namespace, false, true, v1.ResourceRequirements{})
@@ -160,6 +161,7 @@ func TestStartMonPods(t *testing.T) {
 }
 
 func TestOperatorRestart(t *testing.T) {
+
 	namespace := "ns"
 	context := newTestStartCluster(namespace)
 	c := newCluster(context, namespace, false, true, v1.ResourceRequirements{})
@@ -184,6 +186,7 @@ func TestOperatorRestart(t *testing.T) {
 
 // safety check that if hostNetwork is used no changes occur on an operator restart
 func TestOperatorRestartHostNetwork(t *testing.T) {
+
 	namespace := "ns"
 	context := newTestStartCluster(namespace)
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -164,7 +164,11 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 		Args: append(
 			opspec.DaemonFlags(c.clusterInfo, monConfig.DaemonName),
 			"--foreground",
+			// If the mon is already in the monmap, when the port is left off of --public-addr,
+			// it will still advertise on the previous port b/c monmap is saved to mon database.
 			config.NewFlag("public-addr", monConfig.PublicIP),
+			// Opposite of the above, --public-bind-addr will *not* still advertise on the previous
+			// port, which makes sense because this is the pod IP, which changes with every new pod.
 			config.NewFlag("public-bind-addr", opspec.ContainerEnvVarReference(podIPEnvVar)),
 		),
 		Image:           c.spec.CephVersion.Image,

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -62,7 +62,7 @@ func (c *clusterConfig) createOrUpdate(update bool) error {
 	if err == nil && exists {
 		if !update {
 			logger.Infof("object store %s exists in namespace %s", c.store.Name, c.store.Namespace)
-			return c.startRGWPods(false)
+			return c.startRGWPods(update)
 		}
 		logger.Infof("object store %s exists in namespace %s. checking for updates", c.store.Name, c.store.Namespace)
 	}

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -50,20 +50,30 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw deployment: %+v", d)
-	deployment, err := c.context.Clientset.Apps().Deployments(c.store.Namespace).Create(d)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("failed to create rgw deployment %s: %+v", c.instanceName(), err)
-		}
-		logger.Infof("deployment for rgw %s already exists. updating if needed", c.instanceName())
-		// There may be a *lot* of rgws, and they are stateless, so don't bother waiting until the
-		// entire deployment is updated to move on.
-		deployment, err = c.context.Clientset.Apps().Deployments(c.store.Namespace).Update(d)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update rgw deployment %s. %+v", c.instanceName(), err)
+	deployment, err := c.context.Clientset.Apps().Deployments(c.store.Namespace).Get(d.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to see if rgw deployment %s already exists. %+v", d.Name, err)
+	} else if err == nil {
+		// deployment exists
+		var uErr error
+		deployment, uErr = c.context.Clientset.Apps().Deployments(c.store.Namespace).Update(d)
+		if uErr != nil {
+			// may fail to update when labels have changed on the deployment and thus the label selector
+			// in this case we can try to delete the deployment and recreate
+			dErr := c.context.Clientset.Apps().Deployments(c.store.Namespace).Delete(d.Name, &metav1.DeleteOptions{})
+			if dErr != nil {
+				return nil, fmt.Errorf("failed to delete existing rgw deployment %s as part of update attempt. %+v", d.Name, dErr)
+			}
+		} else {
+			return deployment, uErr
 		}
 	}
-	return deployment, nil
+	// err != nil && isNotFound  or  err == nil && update failed, causing earlier dep to be deleted
+	deployment, err = c.context.Clientset.Apps().Deployments(c.store.Namespace).Create(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rgw deployment %s: %+v", c.instanceName(), err)
+	}
+	return deployment, err
 }
 
 func (c *clusterConfig) startDaemonset() (*apps.DaemonSet, error) {

--- a/pkg/operator/k8sutil/daemonset.go
+++ b/pkg/operator/k8sutil/daemonset.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+
+	apps "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CreateDaemonSet creates
+func CreateDaemonSet(name, namespace string, clientset kubernetes.Interface, ds *apps.DaemonSet) error {
+	_, err := clientset.Apps().DaemonSets(namespace).Create(ds)
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			_, err = clientset.Apps().DaemonSets(namespace).Update(ds)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to start %s daemonset: %v\n%v", name, err, ds)
+		}
+	}
+	return err
+}
+
+// DeleteDaemonset makes a best effort at deleting a daemonset and its pods, then waits for them to be deleted
+func DeleteDaemonset(clientset kubernetes.Interface, namespace, name string) error {
+	deleteAction := func(options *metav1.DeleteOptions) error {
+		return clientset.Apps().DaemonSets(namespace).Delete(name, options)
+	}
+	getAction := func() error {
+		_, err := clientset.Apps().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		return err
+	}
+	return deleteResourceAndWait(namespace, name, "daemonset", deleteAction, getAction)
+}

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -68,7 +68,7 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 
 		if matches == len(deployments.Items) && matches > 0 {
 			logger.Infof("all %d %s deployments are on image %s", matches, label, desiredImage)
-			break
+			return nil
 		}
 
 		if len(deployments.Items) == 0 {
@@ -78,7 +78,7 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 		}
 		time.Sleep(time.Duration(sleepTime) * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to wait for image %s in label %s", desiredImage, label)
 }
 
 // UpdateDeploymentAndWait updates a deployment and waits until it is running to return. It will

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -45,43 +45,6 @@ func GetDeploymentSpecImage(clientset kubernetes.Interface, d apps.Deployment, c
 	return image, nil
 }
 
-func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, container string, initContainer bool, desiredImage string) error {
-
-	sleepTime := 3
-	attempts := 30
-	for i := 0; i < attempts; i++ {
-		deployments, err := clientset.Apps().Deployments(namespace).List(metav1.ListOptions{LabelSelector: label})
-		if err != nil {
-			return fmt.Errorf("failed to list deployments with label %s. %v", label, err)
-		}
-
-		matches := 0
-		for _, d := range deployments.Items {
-			image, err := GetDeploymentSpecImage(clientset, d, container, initContainer)
-			if err != nil {
-				logger.Infof("failed to get image for deployment %s. %+v", d.Name, err)
-				continue
-			}
-			if image == desiredImage {
-				matches++
-			}
-		}
-
-		if matches == len(deployments.Items) && matches > 0 {
-			logger.Infof("all %d %s deployments are on image %s", matches, label, desiredImage)
-			return nil
-		}
-
-		if len(deployments.Items) == 0 {
-			logger.Infof("waiting for at least one deployment to start to see the version")
-		} else {
-			logger.Infof("%d/%d %s deployments match image %s", matches, len(deployments.Items), label, desiredImage)
-		}
-		time.Sleep(time.Duration(sleepTime) * time.Second)
-	}
-	return fmt.Errorf("failed to wait for image %s in label %s", desiredImage, label)
-}
-
 // UpdateDeploymentAndWait updates a deployment and waits until it is running to return. It will
 // error if the deployment does not exist to be updated or if it takes too long.
 func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deployment, namespace string) (*v1.Deployment, error) {

--- a/pkg/operator/k8sutil/name.go
+++ b/pkg/operator/k8sutil/name.go
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package k8sutil
 
 import "fmt"

--- a/pkg/operator/k8sutil/replicaset.go
+++ b/pkg/operator/k8sutil/replicaset.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeleteReplicaSet makes a best effort at deleting a deployment and its pods, then waits for them to be deleted
+func DeleteReplicaSet(clientset kubernetes.Interface, namespace, name string) error {
+	deleteAction := func(options *metav1.DeleteOptions) error {
+		return clientset.Apps().ReplicaSets(namespace).Delete(name, options)
+	}
+	getAction := func() error {
+		_, err := clientset.Apps().ReplicaSets(namespace).Get(name, metav1.GetOptions{})
+		return err
+	}
+	return deleteResourceAndWait(namespace, name, "replicaset", deleteAction, getAction)
+}

--- a/pkg/operator/k8sutil/service.go
+++ b/pkg/operator/k8sutil/service.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CreateOrUpdateService creates a service or updates the service declaratively if it already exists.
+func CreateOrUpdateService(
+	clientset kubernetes.Interface, namespace string, serviceDefinition *v1.Service,
+) (*v1.Service, error) {
+	name := serviceDefinition.Name
+	logger.Debugf("creating service %s", name)
+	s, err := clientset.CoreV1().Services(namespace).Create(serviceDefinition)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("failed to create service %s. %+v", name, err)
+		}
+		s, err = UpdateService(clientset, namespace, serviceDefinition)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update service %s. %+v", name, err)
+		}
+	}
+	return s, err
+}
+
+// UpdateService updates a service declaratively. If the service does not exist this is considered
+// an error condition.
+func UpdateService(
+	clientset kubernetes.Interface, namespace string, serviceDefinition *v1.Service,
+) (*v1.Service, error) {
+	name := serviceDefinition.Name
+	logger.Debug("updating service %s")
+	existing, err := clientset.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get existing service %s in order to update. %+v", name, err)
+	}
+	// ClusterIP is immutable for k8s services and cannot be left empty in k8s v1 API
+	serviceDefinition.Spec.ClusterIP = existing.Spec.ClusterIP
+	// ResourceVersion required to update services in k8s v1 API to prevent race conditions
+	serviceDefinition.ResourceVersion = existing.ResourceVersion
+	return clientset.CoreV1().Services(namespace).Update(serviceDefinition)
+}

--- a/pkg/operator/k8sutil/statefulset.go
+++ b/pkg/operator/k8sutil/statefulset.go
@@ -47,20 +47,6 @@ func makeHeadlessSvc(name, namespace string, label map[string]string, clientset 
 	return svc, nil
 }
 
-// create a apps.daemonset
-func CreateDaemonSet(name, namespace string, clientset kubernetes.Interface, ds *apps.DaemonSet) error {
-	_, err := clientset.Apps().DaemonSets(namespace).Create(ds)
-	if err != nil {
-		if k8serrors.IsAlreadyExists(err) {
-			_, err = clientset.Apps().DaemonSets(namespace).Update(ds)
-		}
-		if err != nil {
-			return fmt.Errorf("failed to start %s daemonset: %v\n%v", name, err, ds)
-		}
-	}
-	return err
-}
-
 // create a apps.statefulset and a headless svc
 func CreateStatefulSet(name, namespace, appName string, clientset kubernetes.Interface, ss *apps.StatefulSet) (*corev1.Service, error) {
 	label := ss.GetLabels()

--- a/pkg/operator/test/deployment.go
+++ b/pkg/operator/test/deployment.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WaitForDeploymentImage waits for all deployments with the given labels are running.
+func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, container string, initContainer bool, desiredImage string) error {
+
+	sleepTime := 3
+	attempts := 120
+	for i := 0; i < attempts; i++ {
+		deployments, err := clientset.Apps().Deployments(namespace).List(metav1.ListOptions{LabelSelector: label})
+		if err != nil {
+			return fmt.Errorf("failed to list deployments with label %s. %v", label, err)
+		}
+
+		matches := 0
+		for _, d := range deployments.Items {
+			image, err := k8sutil.GetDeploymentSpecImage(clientset, d, container, initContainer)
+			if err != nil {
+				logger.Infof("failed to get image for deployment %s. %+v", d.Name, err)
+				continue
+			}
+			if image == desiredImage {
+				matches++
+			}
+		}
+
+		if matches == len(deployments.Items) && matches > 0 {
+			logger.Infof("all %d %s deployments are on image %s", matches, label, desiredImage)
+			return nil
+		}
+
+		if len(deployments.Items) == 0 {
+			logger.Infof("waiting for at least one deployment to start to see the version")
+		} else {
+			logger.Infof("%d/%d %s deployments match image %s", matches, len(deployments.Items), label, desiredImage)
+		}
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+	return fmt.Errorf("failed to wait for image %s in label %s", desiredImage, label)
+}

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -22,6 +22,7 @@ import (
 
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
@@ -126,7 +127,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	require.Nil(s.T(), err)
 
 	// wait for the osd pods to be updated
-	err = k8sutil.WaitForDeploymentImage(s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd", opspec.ConfigInitContainerName, true, "rook/ceph:master")
+	err = optest.WaitForDeploymentImage(s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd", opspec.ConfigInitContainerName, true, "rook/ceph:master")
 	require.Nil(s.T(), err)
 
 	err = s.k8sh.WaitForLabeledPodsToRun("app=rook-ceph-osd", s.namespace)


### PR DESCRIPTION
**Description of your changes:**
     
The Ceph mon flag `--public-bind-addr` does not keep the same port as
    the previous daemon run when the port is left off the flag's value. A
    port is undesired since that could interfere with Nautilus' msgr2
    protocol, so instead configure the mon's services to forward the default
    bind port on pods (6789) to the mon endpoint's port. The endpoint port
    will be 6789 for new mons, but it may be 6790 for legacy clusters.
    
Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #2854 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
