### PR TITLE
Add k8s 1.14 to the integration test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,10 +86,11 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
-                        "aws_1.10.x": "v1.10.11",
-                        "aws_1.11.x": "v1.11.5",
-                        "aws_1.12.x": "v1.12.3",
-                        "gce_1.13.x": "v1.13.1"
+                        "aws_1.10.x": "v1.10.12",
+                        "aws_1.11.x": "v1.11.8",
+                        "aws_1.12.x": "v1.12.6",
+                        "aws_1.13.x": "v1.13.4",
+                        "aws_1.14.x": "v1.14.1"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -34,8 +34,8 @@ install() {
         # shellcheck disable=SC2021
         dist=$(echo "${dist}" | tr "[A-Z]" "[a-z]")
         mkdir -p "${temp}"
-        wget "https://storage.googleapis.com/kubernetes-helm/helm-v2.6.0-${dist}-${arch}.tar.gz" -O "${temp}/helm-v2.6.0-${dist}-${arch}.tar.gz"
-        tar -C "${temp}" -zxvf "${temp}/helm-v2.6.0-${dist}-${arch}.tar.gz"
+        wget "https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-${dist}-${arch}.tar.gz" -O "${temp}/helm.tar.gz"
+        tar -C "${temp}" -zxvf "${temp}/helm.tar.gz"
         HELM="${temp}/${dist}-${arch}/helm"
     fi
 

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -120,7 +120,7 @@ function copy_images() {
 }
 
 # configure minikube
-KUBE_VERSION=${KUBE_VERSION:-"v1.13.1"}
+KUBE_VERSION=${KUBE_VERSION:-"v1.14.1"}
 MEMORY=${MEMORY:-"3000"}
 
 case "${1:-}" in


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Since k8s 1.14 was released recently, this will now add k8s v1.14.0 to the integration test matrix. At the same time, the other supported versions are updated in the CI to a more recent version.

**Which issue is resolved by this Pull Request:**
Resolves #2918 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]