### PR TITLE
Fix Helm Chart `DISCOVER_TOLERATION` binding

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
 {{- if .Values.discover }}
 {{- if .Values.discover.toleration }}
         - name: DISCOVER_TOLERATION
-          value: {{ .Values.agent.toleration }}
+          value: {{ .Values.discover.toleration }}
 {{- end }}
 {{- if .Values.discover.tolerationKey }}
         - name: DISCOVER_TOLERATION_KEY


### PR DESCRIPTION
Bind `DISCOVER_TOLERATION` env variable to `.Values.discover.toleration` (instead of `agent`)

Signed-off-by: Olivier Cloirec <5033885+clook@users.noreply.github.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Bind `DISCOVER_TOLERATION` env variable to `.Values.discover.toleration` (instead of `agent`)

**Which issue is resolved by this Pull Request:**
Resolves #2927

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
