### PR TITLE
ceph: add support octopus version detection

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -17,9 +17,14 @@ const (
 )
 
 var (
+	// Luminous Ceph version
 	Luminous = CephVersion{12, 0, 0}
-	Mimic    = CephVersion{13, 0, 0}
+	// Mimic Ceph version
+	Mimic = CephVersion{13, 0, 0}
+	// Nautilus Ceph version
 	Nautilus = CephVersion{14, 0, 0}
+	// Octopus Ceph version
+	Octopus = CephVersion{15, 0, 0}
 
 	// supportedVersions are production-ready versions that rook supports
 	supportedVersions   = []CephVersion{Luminous, Mimic}
@@ -36,8 +41,11 @@ func (v *CephVersion) String() string {
 		v.Major, v.Minor, v.Extra, v.ReleaseName())
 }
 
+// ReleaseName is the name of the Ceph release
 func (v *CephVersion) ReleaseName() string {
 	switch v.Major {
+	case Octopus.Major:
+		return "octopus"
 	case Nautilus.Major:
 		return "nautilus"
 	case Mimic.Major:
@@ -107,6 +115,11 @@ func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 		return false
 	}
 	return true
+}
+
+// IsAtLeastOctopus check that the Ceph version is at least Octopus
+func (v *CephVersion) IsAtLeastOctopus() bool {
+	return v.IsAtLeast(Octopus)
 }
 
 func (v *CephVersion) IsAtLeastNautilus() bool {


### PR DESCRIPTION
Now we are able to detect a Ceph Octopus version.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
