### PR TITLE
Delay starting the Rook system daemons until a CephCluster CR is created

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,7 @@ an example usage
 - Rgw is now configured with the Beast backend as of the Nautilus release
 - OSD: newly updated cluster from 0.9 to 1.0.3 and thus Ceph Nautilus will have their OSDs allowing new features for Nautilus
 - Rgw instances have their own key and thus are properly reflected in the Ceph status
+- The Rook Agent pods are now started when the CephCluster is created rather than immediately when the operator is started.
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -103,9 +103,13 @@ func TestClusterDelete(t *testing.T) {
 
 		},
 	}
+	callback := func() error {
+		logger.Infof("test success callback")
+		return nil
+	}
 
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, "", volumeAttachmentController)
+	controller := NewClusterController(context, "", volumeAttachmentController, callback)
 	clusterToDelete := &cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 
@@ -177,7 +181,10 @@ func TestRemoveFinalizer(t *testing.T) {
 		Clientset:     clientset,
 		RookClientset: rookfake.NewSimpleClientset(),
 	}
-	controller := NewClusterController(context, "", &attachment.MockAttachment{})
+	callback := func() error {
+		return fmt.Errorf("test failed callback")
+	}
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, callback)
 
 	// *****************************************
 	// start with a current version ceph cluster

--- a/pkg/operator/ceph/cluster/migration_test.go
+++ b/pkg/operator/ceph/cluster/migration_test.go
@@ -77,7 +77,7 @@ func TestMigrateClusterObject(t *testing.T) {
 		Clientset:     clientset,
 		RookClientset: rookfake.NewSimpleClientset(legacyCluster),
 	}
-	controller := NewClusterController(context, "", &attachment.MockAttachment{})
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, nil)
 
 	// convert the legacy cluster object in memory and assert that a migration is needed
 	convertedCluster, migrationNeeded, err := getClusterObject(legacyCluster)
@@ -105,7 +105,7 @@ func TestOnUpdateLegacyClusterMigration(t *testing.T) {
 		// in the API during an onUpdate event
 		RookClientset: rookfake.NewSimpleClientset(newLegacyCluster),
 	}
-	controller := NewClusterController(context, "", &attachment.MockAttachment{})
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, nil)
 
 	// call the onUpdate event with the old/new legacy cluster pair
 	controller.onUpdate(oldLegacyCluster, newLegacyCluster)
@@ -136,7 +136,7 @@ func TestOnUpdateLegacyClusterDeleted(t *testing.T) {
 		// in the API during an onUpdate event
 		RookClientset: rookfake.NewSimpleClientset(newLegacyCluster),
 	}
-	controller := NewClusterController(context, "", &attachment.MockAttachment{})
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, nil)
 
 	// call the onUpdate event with the old/new legacy cluster pair, since the object has a deletion timestamp and a finalizer, this
 	// onUpdate event is actually saying that the legacy cluster has been deleted (probably from a completed migration)

--- a/tests/integration/multi_cluster_test.go
+++ b/tests/integration/multi_cluster_test.go
@@ -149,9 +149,6 @@ func (o MCTestOperations) Setup() {
 	require.True(o.T(), o.kh.IsPodInExpectedState("rook-ceph-operator", o.systemNamespace, "Running"),
 		"Make sure rook-operator is in running state")
 
-	require.True(o.T(), o.kh.IsPodInExpectedState("rook-ceph-agent", o.systemNamespace, "Running"),
-		"Make sure rook-ceph-agent is in running state")
-
 	require.True(o.T(), o.kh.IsPodInExpectedState("rook-discover", o.systemNamespace, "Running"),
 		"Make sure rook-discover is in running state")
 
@@ -165,8 +162,11 @@ func (o MCTestOperations) Setup() {
 	go o.startCluster(o.namespace2, "filestore", errCh2)
 	require.NoError(o.T(), <-errCh1)
 	require.NoError(o.T(), <-errCh2)
-	logger.Infof("finished starting clusters")
 
+	require.True(o.T(), o.kh.IsPodInExpectedState("rook-ceph-agent", o.systemNamespace, "Running"),
+		"Make sure rook-ceph-agent is in running state")
+
+	logger.Infof("finished starting clusters")
 }
 
 // TearDownRook is a wrapper for tearDown after suite


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the operator first starts, the only operation needed is to watch for new cephcluster CRs to be created. The agent, discover pods, and the volume provisioning can all be delayed
starting until the first cluster is created.

@leseb This was the first commit in the branch for external clusters, I've separated it now since it wasn't directly related to that feature.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]