### PR TITLE
Add nautilus to the list of supported Ceph versions

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,6 +12,7 @@
 
 ### Ceph
 
+- Ceph Nautilus (`v14`) is now supported by Rook.
 - A `CephNFS` CRD will start NFS daemon(s) for exporting CephFS volumes or RGW buckets. See the [NFS documentation](Documentation/ceph-nfs-crd.md).
 - Selinux labeling for mounts can now be toggled with the [ROOK_ENABLE_SELINUX_RELABELING](https://github.com/rook/rook/issues/2417) environment variable.
 - Recursive chown for mounts can now be toggled with the [ROOK_ENABLE_FSGROUP](https://github.com/rook/rook/issues/2254) environment variable.

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -27,8 +27,8 @@ var (
 	Octopus = CephVersion{15, 0, 0}
 
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions   = []CephVersion{Luminous, Mimic}
-	unsupportedVersions = []CephVersion{Nautilus}
+	supportedVersions   = []CephVersion{Luminous, Mimic, Nautilus}
+	unsupportedVersions = []CephVersion{Octopus}
 	// allVersions includes all supportedVersions as well as unreleased versions that are being tested with rook
 	allVersions = append(supportedVersions, unsupportedVersions...)
 

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -2,8 +2,9 @@ package version
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToString(t *testing.T) {
@@ -116,12 +117,19 @@ func TestVersionAtLeast(t *testing.T) {
 	assert.True(t, Luminous.IsAtLeast(Luminous))
 	assert.False(t, Luminous.IsAtLeast(Mimic))
 	assert.False(t, Luminous.IsAtLeast(Nautilus))
+	assert.False(t, Luminous.IsAtLeast(Octopus))
 	assert.True(t, Mimic.IsAtLeast(Luminous))
 	assert.True(t, Mimic.IsAtLeast(Mimic))
 	assert.False(t, Mimic.IsAtLeast(Nautilus))
+	assert.False(t, Mimic.IsAtLeast(Octopus))
 	assert.True(t, Nautilus.IsAtLeast(Luminous))
 	assert.True(t, Nautilus.IsAtLeast(Mimic))
 	assert.True(t, Nautilus.IsAtLeast(Nautilus))
+	assert.False(t, Nautilus.IsAtLeast(Octopus))
+	assert.True(t, Octopus.IsAtLeast(Luminous))
+	assert.True(t, Octopus.IsAtLeast(Mimic))
+	assert.True(t, Octopus.IsAtLeast(Nautilus))
+	assert.True(t, Octopus.IsAtLeast(Octopus))
 
 	assert.True(t, (&CephVersion{1, 0, 0}).IsAtLeast(CephVersion{0, 0, 0}))
 	assert.False(t, (&CephVersion{0, 0, 0}).IsAtLeast(CephVersion{1, 0, 0}))
@@ -133,10 +141,14 @@ func TestVersionAtLeast(t *testing.T) {
 }
 
 func TestVersionAtLeastX(t *testing.T) {
+	assert.True(t, Octopus.IsAtLeastOctopus())
+	assert.True(t, Octopus.IsAtLeastNautilus())
+	assert.True(t, Octopus.IsAtLeastMimic())
 	assert.True(t, Nautilus.IsAtLeastNautilus())
 	assert.True(t, Nautilus.IsAtLeastMimic())
 	assert.True(t, Mimic.IsAtLeastMimic())
 	assert.False(t, Luminous.IsAtLeastMimic())
 	assert.False(t, Luminous.IsAtLeastNautilus())
 	assert.False(t, Mimic.IsAtLeastNautilus())
+	assert.False(t, Nautilus.IsAtLeastOctopus())
 }

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -52,7 +52,7 @@ const (
 var (
 	LuminousVersion = cephv1.CephVersionSpec{Image: luminousTestImage}
 	MimicVersion    = cephv1.CephVersionSpec{Image: mimicTestImage}
-	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage, AllowUnsupported: true}
+	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage}
 )
 
 // CephInstaller wraps installing and uninstalling rook on a platform


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the release of Ceph Nautilus (v14), Rook needs to add official support for Nautilus for the 1.0 release.  

This PR is initially simply moving Nautilus to the list of supported versions. Testing still needs to be done to verify if there are any remaining functionality missing.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
