### PR TITLE
ceph udev monitor / hotpluggin

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -23,6 +23,9 @@
 - The number of mons can be increased automatically when new nodes come online. See the [preferredCount](https://rook.io/docs/rook/master/ceph-cluster-crd.html#mon-settings) setting in the cluster CRD documentation.
 - New Kubernetes nodes or nodes which are not tainted `NoSchedule` anymore get added automatically to the existing rook cluster if `useAllNodes` is set. [Issue #2208](https://github.com/rook/rook/issues/2208)
 - Pod's logs can be written on the filesystem as of Ceph Nautilus 14.2.1 on demand (see [common issues](https://rook.io/docs/rook/master/common-issues.html#activate-ceph-log-on-file))
+- Orchestration is automatically triggered when addition or removal of storage
+  devices is detected. This should remove the requirement of restarting the
+  operator to detect new devices.
 
 ## Breaking Changes
 

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -18,11 +18,14 @@ limitations under the License.
 package discover
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"reflect"
+	"regexp"
 	"syscall"
 	"time"
 
@@ -47,6 +50,7 @@ var (
 	lastDevice      string
 	cmName          string
 	cm              *v1.ConfigMap
+	udevEventPeriod = time.Duration(5) * time.Second
 )
 
 func Run(context *clusterd.Context, probeInterval time.Duration) error {
@@ -64,6 +68,10 @@ func Run(context *clusterd.Context, probeInterval time.Duration) error {
 		logger.Infof("failed to update device configmap: %v", err)
 		return err
 	}
+
+	udevEvents := make(chan string)
+	go udevBlockMonitor(udevEvents, udevEventPeriod)
+
 	for {
 		select {
 		case <-sigc:
@@ -71,7 +79,115 @@ func Run(context *clusterd.Context, probeInterval time.Duration) error {
 			return nil
 		case <-time.After(probeInterval):
 			updateDeviceCM(context)
+		case _, ok := <-udevEvents:
+			if ok {
+				logger.Info("trigger probe from udev event")
+				updateDeviceCM(context)
+			} else {
+				logger.Warningf("disabling udev monitoring")
+				udevEvents = nil
+			}
 		}
+	}
+}
+
+func matchUdevEvent(text string, matches, exclusions []string) (bool, error) {
+	for _, match := range matches {
+		matched, err := regexp.MatchString(match, text)
+		if err != nil {
+			return false, fmt.Errorf("failed to search string: %v", err)
+		}
+		if matched {
+			hasExclusion := false
+			for _, exclusion := range exclusions {
+				matched, err = regexp.MatchString(exclusion, text)
+				if err != nil {
+					return false, fmt.Errorf("failed to search string: %v", err)
+				}
+				if matched {
+					hasExclusion = true
+					break
+				}
+			}
+			if !hasExclusion {
+				logger.Infof("udevadm monitor: matched event: %s", text)
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// Scans `udevadm monitor` output for block sub-system events. Each line of
+// output matching a set of substrings is sent to the provided channel. An event
+// is returned if it passes any matches tests, and passes all exclusion tests.
+func rawUdevBlockMonitor(c chan string, matches, exclusions []string) {
+	defer close(c)
+
+	// stdbuf -oL performs line bufferred output
+	cmd := exec.Command("stdbuf", "-oL", "udevadm", "monitor", "-u", "-k", "-s", "block")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		logger.Warningf("Cannot open udevadm stdout: %v", err)
+		return
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		logger.Warningf("Cannot start udevadm monitoring: %v", err)
+		return
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		text := scanner.Text()
+		logger.Debugf("udevadm monitor: %s", text)
+		match, err := matchUdevEvent(text, matches, exclusions)
+		if err != nil {
+			logger.Warningf("udevadm filtering failed: %v", err)
+			return
+		}
+		if match {
+			c <- text
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Warningf("udevadm monitor scanner error: %v", err)
+	}
+
+	logger.Info("udevadm monitor finished")
+}
+
+// Monitors udev for block device changes, and collapses these events such that
+// only one event is emitted per period in order to deal with flapping.
+func udevBlockMonitor(c chan string, period time.Duration) {
+	defer close(c)
+
+	// return any add or remove events, but none that match device mapper
+	// events. string matching is case-insensitve
+	events := make(chan string)
+	go rawUdevBlockMonitor(events, []string{"(?i)add", "(?i)remove"}, []string{"(?i)dm-[0-9]+"})
+
+	for {
+		event, ok := <-events
+		if !ok {
+			return
+		}
+		timeout := time.NewTimer(period)
+		for {
+			select {
+			case <-timeout.C:
+				break
+			case _, ok := <-events:
+				if !ok {
+					return
+				}
+				continue
+			}
+			break
+		}
+		c <- event
 	}
 }
 


### PR DESCRIPTION
Respond to new block devices promptly by running an orchestration round.

1. watch the device configmap and trigger new orchestration on change
2. monitor udev for block device changes and run a device probe (which may update the config map)

fixes: #1435 

// known CI issues
[skip ci]