### PR TITLE
images: remove comment about ceph mimic image

### DIFF
--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# the latest mimic release is the base image
+# see Makefile for the BASEIMAGE definition
 FROM BASEIMAGE
 
 ARG ARCH


### PR DESCRIPTION
Commit 91cc62676d95783dfff7190993f3261d73def6ab changed our base ceph
version from Mimic to Nautilus.

Update the comment in the Dockerfile to reflect this change.

[skip ci]