### PR TITLE
ceph: add 'rook-version' label to controllers

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -108,6 +108,7 @@ func (c *cluster) detectCephVersion(image string, timeout time.Duration) (*cephv
 			},
 		},
 	}
+	k8sutil.AddRookVersionLabelToJob(job)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
 
 	// run the job to detect the version

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -86,6 +86,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
 			},
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(d)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
 	return d
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -56,6 +56,7 @@ func (c *Cluster) makeDeployment(monConfig *monConfig, hostname string) *apps.De
 			Labels:    c.getLabels(monConfig.DaemonName),
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(d)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
 
 	pod := c.makeMonPod(monConfig, hostname)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -72,6 +72,7 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 			Template: *podSpec,
 		},
 	}
+	k8sutil.AddRookVersionLabelToJob(job)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
 	return job, nil
 }
@@ -296,6 +297,7 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 			Replicas: &replicaCount,
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(deployment)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &deployment.ObjectMeta, &c.ownerRef)
 	c.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	return deployment, nil

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -61,6 +61,7 @@ func (m *Mirroring) makeDeployment(daemonConfig *daemonConfig) *apps.Deployment 
 			Replicas: &replicas,
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(d)
 	k8sutil.SetOwnerRef(m.context.Clientset, m.Namespace, &d.ObjectMeta, &m.ownerRef)
 	return d
 }

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -77,6 +77,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 			},
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.fs.Namespace, &d.ObjectMeta, c.ownerRefs)
 	return d
 }

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -47,6 +47,7 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 			},
 		},
 	}
+	k8sutil.AddRookVersionLabelToDeployment(d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw deployment: %+v", d)
@@ -93,6 +94,7 @@ func (c *clusterConfig) startDaemonset() (*apps.DaemonSet, error) {
 			Template: c.makeRGWPodSpec(),
 		},
 	}
+	k8sutil.AddRookVersionLabelToDaemonSet(d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw daemonset: %+v", d)

--- a/pkg/operator/k8sutil/daemonset.go
+++ b/pkg/operator/k8sutil/daemonset.go
@@ -19,6 +19,7 @@ package k8sutil
 import (
 	"fmt"
 
+	"k8s.io/api/apps/v1"
 	apps "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,4 +50,16 @@ func DeleteDaemonset(clientset kubernetes.Interface, namespace, name string) err
 		return err
 	}
 	return deleteResourceAndWait(namespace, name, "daemonset", deleteAction, getAction)
+}
+
+// AddRookVersionLabelToDaemonSet adds or updates a label reporting the Rook version which last
+// modified a DaemonSet.
+func AddRookVersionLabelToDaemonSet(d *v1.DaemonSet) {
+	if d == nil {
+		return
+	}
+	if d.Labels == nil {
+		d.Labels = map[string]string{}
+	}
+	addRookVersionLabel(d.Labels)
 }

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -146,3 +146,15 @@ func WaitForDeploymentImage(clientset kubernetes.Interface, namespace, label, co
 	}
 	return fmt.Errorf("failed to wait for image %s in label %s", desiredImage, label)
 }
+
+// AddRookVersionLabelToDeployment adds or updates a label reporting the Rook version which last
+// modified a deployment.
+func AddRookVersionLabelToDeployment(d *v1.Deployment) {
+	if d == nil {
+		return
+	}
+	if d.Labels == nil {
+		d.Labels = map[string]string{}
+	}
+	addRookVersionLabel(d.Labels)
+}

--- a/pkg/operator/k8sutil/job.go
+++ b/pkg/operator/k8sutil/job.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/api/batch/v1"
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,4 +107,16 @@ func DeleteBatchJob(clientset kubernetes.Interface, namespace, name string, wait
 
 	logger.Warningf("gave up waiting for batch job %s to be deleted", name)
 	return nil
+}
+
+// AddRookVersionLabelToJob adds or updates a label reporting the Rook version which last
+// modified a Job.
+func AddRookVersionLabelToJob(j *v1.Job) {
+	if j == nil {
+		return
+	}
+	if j.Labels == nil {
+		j.Labels = map[string]string{}
+	}
+	addRookVersionLabel(j.Labels)
 }

--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	rookversion "github.com/rook/rook/pkg/version"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -50,6 +51,10 @@ const (
 	PodNamespaceEnvVar = "POD_NAMESPACE"
 	// NodeNameEnvVar is the env variable for getting the node via downward api
 	NodeNameEnvVar = "NODE_NAME"
+
+	// RookVersionLabelKey is the key used for reporting the Rook version which last created or
+	// modified a resource.
+	RookVersionLabelKey = "rook-version"
 )
 
 // GetK8SVersion gets the version of the running K8S cluster
@@ -127,4 +132,12 @@ func deleteResourceAndWait(namespace, name, resourceType string,
 	}
 
 	return fmt.Errorf("gave up waiting for %s pods to be terminated", name)
+}
+
+// Add the rook version to the labels. This should *not* be used on pod specifications, because this
+// will result in the deployment/daemonset/ect. recreating all of its pods even if an update
+// wouldn't otherwise be required. Upgrading unnecessarily increases risk for loss of data
+// reliability, even if only briefly.
+func addRookVersionLabel(labels map[string]string) {
+	labels[RookVersionLabelKey] = rookversion.Version
 }


### PR DESCRIPTION
[skip ci] to merge due to random build failures.

Add a `rook-version` label to all controller resources used by Ceph:
deployments, daemonsets, and jobs. Labels are added to controller
resources only and not to the pod templates within because changing pod
templates causes updates due to the label change. The controller
resources themselves are not updated with the label addition and
therefore don't cause an unnecessary upgrade.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

While this *is* a feature, this will be very helpful for the v1.0 upgrade docs since there isn't a good way to explain to users how to know when Rook is done upgrading/updating their cluster. With this, it will be possible to write a one-liner that will allow them to see the Rook version associated with all controller resources.

**Checklist:**
- [ ] ~Documentation has been updated, if necessary.~ Docs will be updated in #2965
- [ ] ~Pending release notes updated with breaking and/or notable changes, if necessary.~ Unnecessary?
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
