### PR TITLE
rookflex: Use `clusterName` if available for backwards compatibility

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -42,6 +42,8 @@ import (
 const (
 	// ClusterNamespaceKey key for cluster namespace option.
 	ClusterNamespaceKey = "clusterNamespace"
+	// ClusterNameKey key for cluster name option (deprecated).
+	ClusterNameKey = "clusterName"
 	// StorageClassKey key for storage class name option.
 	StorageClassKey = "storageClass"
 	// PoolKey key for pool name option.

--- a/pkg/operator/ceph/provisioner/provisioner.go
+++ b/pkg/operator/ceph/provisioner/provisioner.go
@@ -169,8 +169,17 @@ func (p *RookVolumeProvisioner) Delete(volume *v1.PersistentVolume) error {
 		return fmt.Errorf("Failed to delete rook block image %s: %v", volume.Name, "PersistentVolume has no image defined for the FlexVolume")
 	}
 	name := volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ImageKey]
-	clusterns := volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ClusterNamespaceKey]
 	pool := volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.PoolKey]
+	var clusterns string
+	if _, ok := volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ClusterNamespaceKey]; ok {
+		clusterns = volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ClusterNamespaceKey]
+	} else if _, ok := volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ClusterNameKey]; ok {
+		// Fallback to `clusterName` as it was used in Rook version earlier v0.8
+		clusterns = volume.Spec.PersistentVolumeSource.FlexVolume.Options[flexvolume.ClusterNameKey]
+	}
+	if clusterns == "" {
+		return fmt.Errorf("Failed to delete rook block image %s/%s: no clusterNamespace or (deprecated) clusterName option given", pool, volume.Name)
+	}
 	err := ceph.DeleteImage(p.context, clusterns, name, pool)
 	if err != nil {
 		return fmt.Errorf("Failed to delete rook block image %s/%s: %v", pool, volume.Name, err)


### PR DESCRIPTION
**Description of your changes:**
This fixes issues for users trying to delete volumes and failing because
they only have `clusterNames` set on them in Rook earlier v0.8.

**Which issue is resolved by this Pull Request:**
Resolves #2373

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
