### PR TITLE
Add `ceph-version` labels to Ceph application controllers

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -27,6 +27,9 @@
   devices is detected. This should remove the requirement of restarting the
   operator to detect new devices.
 - Rook will now set `noout` on the CephClusters that have osd Nodes tainted `NoSchedule`
+- `rook-version` and `ceph-version` labels are now applied to Ceph daemon Deployments, DaemonSets,
+  Jobs, and StatefulSets. These identify the Rook version which last modified the resource and the
+  Ceph version which Rook has detected in the pod(s) being run by the resource.
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -94,6 +94,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
 		podSpec.ObjectMeta.Annotations = prometheusAnnotations
 		d.ObjectMeta.Annotations = prometheusAnnotations
 	}
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
 	return d
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -57,6 +57,7 @@ func (c *Cluster) makeDeployment(monConfig *monConfig, hostname string) *apps.De
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&d.ObjectMeta)
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
 
 	pod := c.makeMonPod(monConfig, hostname)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -74,6 +74,7 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 		},
 	}
 	k8sutil.AddRookVersionLabelToJob(job)
+	opspec.AddCephVersionLabelToJob(c.clusterInfo.CephVersion, job)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
 	return job, nil
 }
@@ -324,6 +325,8 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 	k8sutil.AddRookVersionLabelToDeployment(deployment)
 	c.annotations.ApplyToObjectMeta(&deployment.ObjectMeta)
 	c.annotations.ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &deployment.ObjectMeta, &c.ownerRef)
 	c.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	return deployment, nil

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -63,6 +63,7 @@ func (m *Mirroring) makeDeployment(daemonConfig *daemonConfig) *apps.Deployment 
 		},
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
+	opspec.AddCephVersionLabelToDeployment(m.ClusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(m.context.Clientset, m.Namespace, &d.ObjectMeta, &m.ownerRef)
 	return d
 }

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -79,6 +79,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.fs.Namespace, &d.ObjectMeta, c.ownerRefs)
 	return d
 }

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -49,6 +49,7 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	c.store.Spec.Gateway.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
+	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw deployment: %+v", d)
@@ -96,6 +97,7 @@ func (c *clusterConfig) startDaemonset() (*apps.DaemonSet, error) {
 		},
 	}
 	k8sutil.AddRookVersionLabelToDaemonSet(d)
+	opspec.AddCephVersionLabelToDaemonSet(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw daemonset: %+v", d)

--- a/pkg/operator/ceph/spec/label.go
+++ b/pkg/operator/ceph/spec/label.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/operator/ceph/version"
+	apps "k8s.io/api/apps/v1"
+	batch "k8s.io/api/batch/v1"
+)
+
+const (
+	// CephVersionLabelKey is the key used for reporting the Ceph version which Rook has detected is
+	// configured for the labeled resource.
+	CephVersionLabelKey = "ceph-version"
+)
+
+// Add the Ceph version to the given labels.  This should *not* be used on pod specifications,
+// because this will result in the deployment/daemonset/ect. recreating all of its pods even if an
+// update wouldn't otherwise be required. Upgrading unnecessarily increases risk for loss of data
+// reliability, even if only briefly.
+func addCephVersionLabel(cephVersion version.CephVersion, labels map[string]string) {
+	// cephVersion.String() returns a string with a space in it, and labels in k8s are limited to
+	// alphanum characters plus '-', '_', '.'
+	labels[CephVersionLabelKey] = fmt.Sprintf("%d.%d.%d",
+		cephVersion.Major, cephVersion.Minor, cephVersion.Extra)
+}
+
+// AddCephVersionLabelToDeployment adds a label reporting the Ceph version which Rook has detected is
+// running in the Deployment's pods.
+func AddCephVersionLabelToDeployment(cephVersion version.CephVersion, d *apps.Deployment) {
+	if d == nil {
+		return
+	}
+	if d.Labels == nil {
+		d.Labels = map[string]string{}
+	}
+	addCephVersionLabel(cephVersion, d.Labels)
+}
+
+// AddCephVersionLabelToDaemonSet adds a label reporting the Ceph version which Rook has detected is
+// running in the DaemonSet's pods.
+func AddCephVersionLabelToDaemonSet(cephVersion version.CephVersion, d *apps.DaemonSet) {
+	if d == nil {
+		return
+	}
+	if d.Labels == nil {
+		d.Labels = map[string]string{}
+	}
+	addCephVersionLabel(cephVersion, d.Labels)
+}
+
+// AddCephVersionLabelToJob adds a label reporting the Ceph version which Rook has detected is
+// running in the Job's pods.
+func AddCephVersionLabelToJob(cephVersion version.CephVersion, j *batch.Job) {
+	if j == nil {
+		return
+	}
+	if j.Labels == nil {
+		j.Labels = map[string]string{}
+	}
+	addCephVersionLabel(cephVersion, j.Labels)
+}


### PR DESCRIPTION
Add 'rook-version' label to Ceph mon services, as it could be useful
there during upgrades as well.

Add a 'ceph-version' label to application controllers in the same manner
as the prior 'rook-version' label to help with upgrades.

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]