### PR TITLE
Ceph: Set noout on cluster when storage nodes are in maintenance

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -26,6 +26,7 @@
 - Orchestration is automatically triggered when addition or removal of storage
   devices is detected. This should remove the requirement of restarting the
   operator to detect new devices.
+- Rook will now set `noout` on the CephClusters that have osd Nodes tainted `NoSchedule`
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/rook/rook/pkg/clusterd"
 )
@@ -63,6 +64,18 @@ type OSDDump struct {
 		Up  json.Number `json:"up"`
 		In  json.Number `json:"in"`
 	} `json:"osds"`
+	Flags string `json:"flags"`
+}
+
+// IsFlagSet checks if an OSD flag is set
+func (dump *OSDDump) IsFlagSet(checkFlag string) bool {
+	flags := strings.Split(dump.Flags, ",")
+	for _, flag := range flags {
+		if flag == checkFlag {
+			return true
+		}
+	}
+	return false
 }
 
 // StatusByID returns status and inCluster states for given OSD id
@@ -178,6 +191,26 @@ func EnableScrubbing(context *clusterd.Context, clusterName string) (string, err
 	}
 
 	return string(buf), nil
+}
+
+// SetNoOut sets the osd flag `noout`
+func SetNoOut(context *clusterd.Context, clusterName string) error {
+	args := []string{"osd", "set", "noout"}
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to set noout: %+v", err)
+	}
+	return nil
+}
+
+// UnsetNoOut unsets the osd flag `noout`
+func UnsetNoOut(context *clusterd.Context, clusterName string) error {
+	args := []string{"osd", "unset", "noout"}
+	_, err := ExecuteCephCommand(context, clusterName, args)
+	if err != nil {
+		return fmt.Errorf("failed to unset noout: %+v", err)
+	}
+	return nil
 }
 
 func (usage *OSDUsage) ByID(osdID int) *OSDNodeUsage {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -154,7 +154,7 @@ func TestAddRemoveNode(t *testing.T) {
 	// simulate the OSD pod having been created
 	osdPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name:   "osdPod",
-		Labels: map[string]string{k8sutil.AppAttr: appName}}}
+		Labels: map[string]string{k8sutil.AppAttr: AppName}}}
 	c.context.Clientset.CoreV1().Pods(c.Namespace).Create(osdPod)
 
 	// mock the ceph calls that will be called during remove node
@@ -274,7 +274,7 @@ func TestDiscoverOSDs(t *testing.T) {
 	clientset := fake.NewSimpleClientset(d1, d2, d3)
 	c.context.Clientset = clientset
 
-	discovered, err := c.discoverStorageNodes()
+	discovered, err := DiscoverStorageNodes(c.context, c.Namespace)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(discovered))
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -255,7 +255,7 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 			Name:      fmt.Sprintf(osdAppNameFmt, osd.ID),
 			Namespace: c.Namespace,
 			Labels: map[string]string{
-				k8sutil.AppAttr:     appName,
+				k8sutil.AppAttr:     AppName,
 				k8sutil.ClusterAttr: c.Namespace,
 				osdLabelKey:         fmt.Sprintf("%d", osd.ID),
 			},
@@ -263,7 +263,7 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 		Spec: apps.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					k8sutil.AppAttr:     appName,
+					k8sutil.AppAttr:     AppName,
 					k8sutil.ClusterAttr: c.Namespace,
 					osdLabelKey:         fmt.Sprintf("%d", osd.ID),
 				},
@@ -273,9 +273,9 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: appName,
+					Name: AppName,
 					Labels: map[string]string{
-						k8sutil.AppAttr:     appName,
+						k8sutil.AppAttr:     AppName,
 						k8sutil.ClusterAttr: c.Namespace,
 						osdLabelKey:         fmt.Sprintf("%d", osd.ID),
 					},
@@ -390,7 +390,7 @@ func (c *Cluster) provisionPodTemplateSpec(devices []rookalpha.Device, selection
 	c.placement.ApplyToPodSpec(&podSpec)
 
 	podMeta := metav1.ObjectMeta{
-		Name: appName,
+		Name: AppName,
 		Labels: map[string]string{
 			k8sutil.AppAttr:     prepareAppName,
 			k8sutil.ClusterAttr: c.Namespace,

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -113,8 +113,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, "rook-data", deployment.Spec.Template.Spec.Volumes[0].Name)
 	assert.Equal(t, "ceph-default-config-dir", deployment.Spec.Template.Spec.Volumes[1].Name)
 
-	assert.Equal(t, appName, deployment.Spec.Template.ObjectMeta.Name)
-	assert.Equal(t, appName, deployment.Spec.Template.ObjectMeta.Labels["app"])
+	assert.Equal(t, AppName, deployment.Spec.Template.ObjectMeta.Name)
+	assert.Equal(t, AppName, deployment.Spec.Template.ObjectMeta.Labels["app"])
 	assert.Equal(t, c.Namespace, deployment.Spec.Template.ObjectMeta.Labels["rook_cluster"])
 	assert.Equal(t, 0, len(deployment.Spec.Template.ObjectMeta.Annotations))
 

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -25,8 +25,8 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -66,7 +66,7 @@ func (c *Cluster) updateNodeStatus(node string, status OrchestrationStatus) erro
 
 func UpdateNodeStatus(kv *k8sutil.ConfigMapKVStore, node string, status OrchestrationStatus) error {
 	labels := map[string]string{
-		k8sutil.AppAttr:        appName,
+		k8sutil.AppAttr:        AppName,
 		orchestrationStatusKey: provisioningLabelKey,
 		nodeLabelKey:           node,
 	}
@@ -162,7 +162,7 @@ func (c *Cluster) checkNodesCompleted(selector string, config *provisionConfig, 
 
 func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bool, timeoutMinutes int) bool {
 	selector := fmt.Sprintf("%s=%s,%s=%s",
-		k8sutil.AppAttr, appName,
+		k8sutil.AppAttr, AppName,
 		orchestrationStatusKey, provisioningLabelKey,
 	)
 
@@ -277,7 +277,7 @@ func (c *Cluster) findRemovedNodes() (map[string][]*apps.Deployment, error) {
 	removedNodes := map[string][]*apps.Deployment{}
 
 	// first discover the storage nodes that are still running
-	discoveredNodes, err := c.discoverStorageNodes()
+	discoveredNodes, err := DiscoverStorageNodes(c.context, c.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("aborting search for removed nodes. failed to discover storage nodes. %+v", err)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Set noout when a kubernetes node is moved to maintenance, and unset when no nodes are in maintenance
**Which issue is resolved by this Pull Request:**
Resolves #2825

**Checklist:**
- [x] Documentation has been updated, if necessary. (Not necessary)
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.  (Not necessary)
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.  (Not necessary)
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

**TODO**
- [x] Remove unnecessary logging

// known CI issues
[skip ci]

