### PR TITLE
ceph mds: update keyring before deployment update

### DIFF
--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -134,25 +134,30 @@ func (c *Cluster) Start() error {
 		// start the deployment
 		d := c.makeDeployment(mdsConfig)
 		logger.Debugf("starting mds: %+v", d)
-		createdDeployment, err := c.context.Clientset.AppsV1().Deployments(c.fs.Namespace).Create(d)
-		if err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create mds deployment %s: %+v", mdsConfig.ResourceName, err)
+		createdDeployment, createErr := c.context.Clientset.AppsV1().Deployments(c.fs.Namespace).Create(d)
+		if createErr != nil {
+			if !errors.IsAlreadyExists(createErr) {
+				return fmt.Errorf("failed to create mds deployment %s: %+v", mdsConfig.ResourceName, createErr)
 			}
 			logger.Infof("deployment for mds %s already exists. updating if needed", mdsConfig.ResourceName)
-			// TODO: need to prepare for upgrade here each time. Also, before a given deployment is
-			// terminated, I think we should somehow make sure that it isn't running the single
-			// active daemon. If it is, then we should have another daemon take over as active. @Jan?
-			if createdDeployment, err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace); err != nil {
-				return fmt.Errorf("failed to update mds deployment %s. %+v", mdsConfig.ResourceName, err)
+			createdDeployment, err = c.context.Clientset.AppsV1().Deployments(c.fs.Namespace).Get(d.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to get existing mds deployment %s for update: %+v", d.Name, err)
 			}
 		}
-		desiredDeployments[d.GetName()] = true // add deployment name to improvised set
-
 		// create unique key for each mds saved to k8s secret
 		if err := c.generateKeyring(mdsConfig, createdDeployment.UID); err != nil {
 			return fmt.Errorf("failed to generate keyring for %s. %+v", resourceName, err)
 		}
+		// keyring must be generated before update-and-wait since no keyring will prevent the
+		// deployment from reaching ready state
+		if createErr != nil && errors.IsAlreadyExists(createErr) {
+			if _, err = UpdateDeploymentAndWait(c.context, d, c.fs.Namespace); err != nil {
+				return fmt.Errorf("failed to update mds deployment %s. %+v", d.Name, err)
+			}
+		}
+		desiredDeployments[d.GetName()] = true // add deployment name to improvised set
+
 	}
 
 	if err := c.scaleDownDeployments(replicas, desiredDeployments); err != nil {

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -76,7 +76,7 @@ func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deploym
 			return d, nil
 		}
 
-		logger.Debugf("deployment %s status=%v", d.Name, d.Status)
+		logger.Debugf("deployment %s status=%+v", d.Name, d.Status)
 		time.Sleep(time.Duration(sleepTime) * time.Second)
 	}
 


### PR DESCRIPTION
Because the deployment update-and-wait function waits for the deployment
to be ready, and that cannot happen due to the keyring not
having been updated yet. The keyring has its
owner set to the deployment so that no special keyring handling must
be done, but it must be created after the deployment UID is known.
Change the order of operations so that the existing deployment's UID can
be retrieved if it exists and the keyring created/updated before the
update-and-wait function is called.

This order-of-operations issue currently only applies to the mds. Other
daemons whose keyrings are owned by the replication controller do not
use the update-and-wait function.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #2989

**Checklist:**
- [ ] ~Documentation has been updated, if necessary.~
- [ ] ~Pending release notes updated with breaking and/or notable changes, if necessary.~
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]