### PR TITLE
rearrange RBD resource cleanup order in ceph-csi doc

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -332,9 +332,9 @@ if you have tested snapshot, delete snapshotclass, snapshot and pvc-restore
 created to test snapshot feature
 
 ```console
-kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshotclass.yaml
-kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshot.yaml
 kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/pvc-restore.yaml
+kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshot.yaml
+kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshotclass.yaml
 ```
 
 ```console

--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -30,7 +30,6 @@ cluster.
 ```console
 # create rbac. Since rook operator is not permitted to create rbac rules,
 # these rules have to be created outside of operator
-kubectl create -f cluster/examples/kubernetes/ceph/common.yaml
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/rbd/
 kubectl apply -f cluster/examples/kubernetes/ceph/csi/rbac/cephfs/
 ```


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
* common.yaml is pre-req for deploying the ceph cluster, as ceph-csi has a pre-req to deploy rook operator and create  ceph cluster, we can  remove the common.yaml  from ceph-csi doc
* updated the resource cleanup order for the RBD

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]

@travisn @phlogistonjohn PTAL