### PR TITLE
This prevents a liquid template error during jekyll build

### DIFF
--- a/Documentation/edgefs-csi.md
+++ b/Documentation/edgefs-csi.md
@@ -363,6 +363,8 @@ Please submit an issue at: [Issues](https://github.com/Nexenta/edgefs-csi/issues
 
 - Show termination message in case driver failed to run:
 
+  <!-- {% raw %} -->
   ```bash
   kubectl get pod edgefs-iscsi-csi-controller-0 -o go-template="{{range .status.containerStatuses}}{{.lastState.terminated.message}}{{end}}"
   ```
+  <!-- {% endraw %} -->


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Adding a raw tag wrapper tells liquid to ignore this section and compile
this text without trying to interpret it. Otherwise an error is thrown
during builds

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]