### PR TITLE
Add mergify engine

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - label!=DNM
+      - '#approved-reviews-by>=2'
+      - 'continuous-integration/jenkins/pr-head'
+      - 'DCO'
+    actions:
+      merge:
+        strict: false
+      dismiss_reviews: {}
+      delete_head_branch: {}


### PR DESCRIPTION
The mergify engine will help us merging PRs without special permissions
on the repo. Being part of the organization is enough. So if someone
from the orgs approuves a PR, it can be merged. That person does not
need to be a maintainer and/or admin of the github org.

The goal is to make smoother progress on merging PRs without being
blocked waiting for a maintainer to merge it.

This basically:

* allow a smoother merge experience
* remove the maintainer bottleneck is the person is away
* release pressure off the maintainers

We can go deeper with who is taken into account for a merge, see https://doc.mergify.io/conditions.html#attribute-list

Signed-off-by: Sébastien Han <seb@redhat.com>

[skip ci]