### PR TITLE
ceph mon: remove code to delete legacy replicasets

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -43,7 +43,6 @@ rules:
   resources:
   - deployments
   - daemonsets
-  - replicasets
   verbs:
   - get
   - list

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -242,7 +242,6 @@ rules:
   resources:
   - deployments
   - daemonsets
-  - replicasets
   verbs:
   - get
   - list

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -477,11 +477,6 @@ func (c *Cluster) saveMonConfig() error {
 var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
 
 func (c *Cluster) startMon(m *monConfig, hostname string) error {
-	// If we determine the legacy replicaset exists, delete it so we can start the new deployment in its place
-	if err := k8sutil.DeleteReplicaSet(c.context.Clientset, c.Namespace, m.ResourceName); err != nil {
-		logger.Errorf("failed to delete legacy mon replicaset. %+v", err)
-	}
-
 	d := c.makeDeployment(m, hostname)
 	logger.Debugf("Starting mon: %+v", d.Name)
 	_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(d)

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -267,7 +267,6 @@ rules:
   resources:
   - deployments
   - daemonsets
-  - replicasets
   verbs:
   - get
   - list


### PR DESCRIPTION
This code path is no longer necessary, and removing it allows removing
the `replicasets` RBAC permission for the operator.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]