### PR TITLE
Helm chart: Improve operator performance and add CephNFS CRD

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -105,6 +105,22 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: cephnfses.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephNFS
+    listKind: CephNFSList
+    plural: cephnfses
+    singular: cephnfs
+    shortNames:
+    - nfs
+  scope: Namespaced
+  version: v1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: cephobjectstores.ceph.rook.io
 spec:
   group: ceph.rook.io

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -15,7 +15,7 @@ hyperkube:
 
 resources:
   limits:
-    cpu: 100m
+    cpu: 500m
     memory: 128Mi
   requests:
     cpu: 100m

--- a/tests/framework/installer/cassandra_installer.go
+++ b/tests/framework/installer/cassandra_installer.go
@@ -164,6 +164,6 @@ func (ci *CassandraInstaller) UninstallCassandra(systemNamespace string, namespa
 func (ci *CassandraInstaller) GatherAllCassandraLogs(systemNamespace, namespace, testName string) {
 
 	logger.Infof("Gathering all logs from Cassandra Cluster %s", namespace)
-	ci.k8sHelper.GetRookLogs("rook-cassandra-operator", Env.HostType, systemNamespace, testName)
-	ci.k8sHelper.GetRookLogs("rook-cassandra", Env.HostType, namespace, testName)
+	ci.k8sHelper.GetLogs("rook-cassandra-operator", Env.HostType, systemNamespace, testName)
+	ci.k8sHelper.GetLogs("rook-cassandra", Env.HostType, namespace, testName)
 }

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -391,6 +391,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		"cephobjectstores.ceph.rook.io",
 		"cephobjectstoreusers.ceph.rook.io",
 		"cephfilesystems.ceph.rook.io",
+		"cephnfses.ceph.rook.io",
 		"volumes.rook.io")
 	checkError(h.T(), err, "cannot delete CRDs")
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -309,7 +309,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevices(namespace, storeT
 	}
 	if !h.k8shelper.IsPodInExpectedState("rook-ceph-operator", onamespace, "Running") {
 		logger.Error("rook-ceph-operator is not running")
-		h.k8shelper.GetRookLogs("rook-ceph-operator", Env.HostType, onamespace, "test-setup")
+		h.k8shelper.GetLogs("rook-ceph-operator", Env.HostType, onamespace, "test-setup")
 		logger.Error("rook-ceph-operator is not Running, abort!")
 		return false, err
 	}
@@ -486,20 +486,21 @@ func (h *CephInstaller) cleanupDir(node, dir string) error {
 
 func (h *CephInstaller) GatherAllRookLogs(namespace, systemNamespace string, testName string) {
 	logger.Infof("Gathering all logs from Rook Cluster %s", namespace)
-	h.k8shelper.GetRookLogs("rook-ceph-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-agent", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-discover", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-mgr", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-mon", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-osd", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-osd-prepare", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-rgw", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookLogs("rook-ceph-mds", Env.HostType, namespace, testName)
-	h.k8shelper.GetRookContainerLogs("rook-ceph-mgr", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
-	h.k8shelper.GetRookContainerLogs("rook-ceph-mon", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
-	h.k8shelper.GetRookContainerLogs("rook-ceph-osd", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
-	h.k8shelper.GetRookContainerLogs("rook-ceph-rgw", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
-	h.k8shelper.GetRookContainerLogs("rook-ceph-mds", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetPreviousLogs("rook-ceph-operator", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-operator", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-agent", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-discover", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-mgr", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-mon", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-osd", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-osd-prepare", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-rgw", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-ceph-mds", Env.HostType, namespace, testName)
+	h.k8shelper.GetContainerLogs("rook-ceph-mgr", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetContainerLogs("rook-ceph-mon", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetContainerLogs("rook-ceph-osd", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetContainerLogs("rook-ceph-rgw", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
+	h.k8shelper.GetContainerLogs("rook-ceph-mds", Env.HostType, namespace, testName, opspec.ConfigInitContainerName)
 }
 
 // NewCephInstaller creates new instance of CephInstaller

--- a/tests/framework/installer/cockroachdb_installer.go
+++ b/tests/framework/installer/cockroachdb_installer.go
@@ -151,6 +151,6 @@ func (h *CockroachDBInstaller) UninstallCockroachDB(systemNamespace, namespace s
 
 func (h *CockroachDBInstaller) GatherAllCockroachDBLogs(systemNamespace, namespace, testName string) {
 	logger.Infof("Gathering all logs from cockroachdb cluster %s", namespace)
-	h.k8shelper.GetRookLogs("rook-cockroachdb-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-cockroachdb", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-cockroachdb-operator", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-cockroachdb", Env.HostType, namespace, testName)
 }

--- a/tests/framework/installer/edgefs_installer.go
+++ b/tests/framework/installer/edgefs_installer.go
@@ -153,6 +153,6 @@ func (h *EdgefsInstaller) UninstallEdgefs(systemNamespace, namespace string) {
 
 func (h *EdgefsInstaller) GatherAllEdgefsLogs(systemNamespace, namespace, testName string) {
 	logger.Infof("Gathering all logs from edgefs cluster %s", namespace)
-	h.k8shelper.GetRookLogs("rook-edgefs-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-edgefs", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-edgefs-operator", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-edgefs", Env.HostType, namespace, testName)
 }

--- a/tests/framework/installer/nfs_installer.go
+++ b/tests/framework/installer/nfs_installer.go
@@ -199,8 +199,8 @@ func (h *NFSInstaller) UninstallNFSServer(systemNamespace, namespace string) {
 // GatherAllNFSServerLogs gathers all NFS Server logs
 func (h *NFSInstaller) GatherAllNFSServerLogs(systemNamespace, namespace, testName string) {
 	logger.Infof("Gathering all logs from NFSServer %s", namespace)
-	h.k8shelper.GetRookLogs("rook-nfs-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetRookLogs("rook-nfs", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogs("rook-nfs-operator", Env.HostType, systemNamespace, testName)
+	h.k8shelper.GetLogs("rook-nfs", Env.HostType, namespace, testName)
 }
 
 // GetNFSServerClusterIP gets the nfs server cluster ip on which it serves

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1419,13 +1419,23 @@ func (k8sh *K8sHelper) IsRookInstalled(namespace string) bool {
 	return false
 }
 
-// GetRookLogs captures logs from specified rook pod and writes it to specified file
-func (k8sh *K8sHelper) GetRookLogs(podAppName string, hostType string, namespace string, testName string) {
-	k8sh.GetRookContainerLogs(podAppName, hostType, namespace, testName, "")
+// GetPreviousLogs captures logs from the previous run of the container if it exists
+func (k8sh *K8sHelper) GetPreviousLogs(podAppName string, hostType string, namespace string, testName string) {
+	k8sh.getContainerLogs(podAppName, hostType, namespace, testName, "", true)
 }
 
-func (k8sh *K8sHelper) GetRookContainerLogs(podAppName, hostType, namespace, testName, containerName string) {
-	logOpts := &v1.PodLogOptions{}
+// GetLogs captures logs from specified rook pod and writes it to specified file
+func (k8sh *K8sHelper) GetLogs(podAppName string, hostType string, namespace string, testName string) {
+	k8sh.getContainerLogs(podAppName, hostType, namespace, testName, "", false)
+}
+
+// GetLogs captures logs from a specific container in a pod
+func (k8sh *K8sHelper) GetContainerLogs(podAppName, hostType, namespace, testName, containerName string) {
+	k8sh.getContainerLogs(podAppName, hostType, namespace, testName, containerName, false)
+}
+
+func (k8sh *K8sHelper) getContainerLogs(podAppName, hostType, namespace, testName, containerName string, previousLog bool) {
+	logOpts := &v1.PodLogOptions{Previous: previousLog}
 	if containerName != "" {
 		logOpts.Container = containerName
 	}

--- a/tests/integration/base_object_test.go
+++ b/tests/integration/base_object_test.go
@@ -58,10 +58,6 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	require.Nil(s.T(), cosuErr)
 	logger.Infof("Waiting 10 seconds to ensure user was created")
 	time.Sleep(10 * time.Second)
-	userInfo, gosuErr := helper.ObjectUserClient.GetUser(namespace, storeName, userid)
-	require.Nil(s.T(), gosuErr)
-	require.Equal(s.T(), userid, userInfo.UserID)
-	require.Equal(s.T(), userdisplayname, *userInfo.DisplayName)
 	logger.Infof("Checking to see if the user secret has been created")
 	i := 0
 	for i = 0; i < 4 && helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid) == false; i++ {
@@ -69,8 +65,12 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 		time.Sleep(5 * time.Second)
 	}
 	assert.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid))
+	userInfo, gosuErr := helper.ObjectUserClient.GetUser(namespace, storeName, userid)
+	assert.Nil(s.T(), gosuErr)
+	assert.Equal(s.T(), userid, userInfo.UserID)
+	assert.Equal(s.T(), userdisplayname, *userInfo.DisplayName)
 
-	logger.Infof("Object store user created successfully")
+	logger.Infof("Done creating object store user")
 
 	/* TODO: We need bucket management tests.
 
@@ -144,8 +144,8 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 
 	logger.Infof("Delete Object Store")
 	dobsErr := helper.ObjectClient.Delete(namespace, storeName)
-	require.Nil(s.T(), dobsErr)
-	logger.Infof("Object store deleted successfully")
+	assert.Nil(s.T(), dobsErr)
+	logger.Infof("Done deleting object store")
 }
 
 // Test Object StoreCreation on Rook that was installed via helm


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two updates for the helm chart:
1. When looking into the intermittent integration test issues, a major cause of failures is that the helm chart tests frequently time out when waiting for the object or file CRs to install. The daemons don't start up in the expected time. In a local test of the helm chart I also saw that creating these CRs takes a lot longer than expected. When running inside the helm chart it takes over 3 minutes to create an object store instead of 30-45 seconds when not using the helm chart. The issue is that the helm chart limits the operator pod to 1/10 of a CPU. In general this is plenty since the operator is frequently dormant, but during an orchestration the operator should be able to burst higher. Now the operator can burst up to 1/2 of a CPU, which is sufficient for orchestration.
1. The CephNFS CRD was missing. The side effect was that this CR couldn't be created in this scenario and was writing errors to the log.

And a couple of integration test improvements:
1. Collect the previous operator log in case it was restarted.
1. Minor reordering of checks for the object user test to improve stability.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]