### PR TITLE
ceph/rgw: Use init container to concate tls cert and key

### DIFF
--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -35,10 +35,12 @@ caps mon = "allow rw"
 caps osd = "allow rwx"
 `
 
-	certVolumeName = "rook-ceph-rgw-cert"
-	certDir        = "/etc/ceph/private"
-	certKeyName    = "cert"
-	certFilename   = "rgw-cert.pem"
+	certSecretVolumeName = "rook-ceph-rgw-cert-secrets"
+	certSecretDir        = "/certs"
+	certVolumeName       = "rook-ceph-rgw-cert"
+	certDir              = "/etc/ceph/private"
+	certKeyName          = "cert"
+	certFilename         = "rgw-cert.pem"
 )
 
 // TODO: these should be set in the mon's central kv store for mimic+

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -162,14 +162,14 @@ func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 
 	logger.Infof("applying object store %s changes", newStore.Name)
 	cfg := clusterConfig{
-		c.clusterInfo,
-		c.context,
-		*newStore,
-		c.rookImage,
-		c.cephVersion,
-		c.hostNetwork,
-		c.storeOwners(newStore),
-		cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, newStore.Name, c.clusterInfo.Name, c.dataDirHostPath),
+		clusterInfo: c.clusterInfo,
+		context:     c.context,
+		store:       *newStore,
+		rookVersion: c.rookImage,
+		cephVersion: c.cephVersion,
+		hostNetwork: c.hostNetwork,
+		ownerRefs:   c.storeOwners(newStore),
+		DataPathMap: cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, newStore.Name, c.clusterInfo.Name, c.dataDirHostPath),
 	}
 	if err = cfg.updateStore(); err != nil {
 		logger.Errorf("failed to create (modify) object store %s. %+v", newStore.Name, err)

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -52,7 +52,16 @@ func TestStartRGW(t *testing.T) {
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "my-fs", "rook-ceph", "/var/lib/rook/")
 
 	// start a basic cluster
-	c := &clusterConfig{info, context, store, version, cephv1.CephVersionSpec{}, false, []metav1.OwnerReference{}, data}
+	c := &clusterConfig{
+		clusterInfo: info,
+		context:     context,
+		store:       store,
+		rookVersion: version,
+		cephVersion: cephv1.CephVersionSpec{},
+		hostNetwork: false,
+		ownerRefs:   []metav1.OwnerReference{},
+		DataPathMap: data,
+	}
 	err := c.createStore()
 	assert.Nil(t, err)
 
@@ -116,7 +125,16 @@ func TestCreateObjectStore(t *testing.T) {
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "my-fs", "rook-ceph", "/var/lib/rook/")
 
 	// create the pools
-	c := &clusterConfig{info, context, store, "1.2.3.4", cephv1.CephVersionSpec{}, false, []metav1.OwnerReference{}, data}
+	c := &clusterConfig{
+		clusterInfo: info,
+		context:     context,
+		store:       store,
+		rookVersion: "1.2.3.4",
+		cephVersion: cephv1.CephVersionSpec{},
+		hostNetwork: false,
+		ownerRefs:   []metav1.OwnerReference{},
+		DataPathMap: data,
+	}
 	err := c.createStore()
 	assert.Nil(t, err)
 }

--- a/pkg/operator/ceph/test/podspec.go
+++ b/pkg/operator/ceph/test/podspec.go
@@ -86,10 +86,15 @@ func (ps *PodSpecTester) AssertVolumesMeetCephRequirements(
 				// mons and osds MUST be host path
 				assert.NotNil(ps.t, v.VolumeSource.HostPath,
 					string(daemonType)+" daemon should be host path:", v)
-			case config.MgrType, config.MdsType, config.RgwType:
-				// mgrs, mdses, and rgws MUST be host path
+			case config.MgrType, config.MdsType:
+				// mgrs and mdses MUST be host path
 				assert.NotNil(ps.t, v.VolumeSource.EmptyDir,
 					string(daemonType)+" daemon should be empty dir:", v)
+			case config.RgwType:
+				// rgws use host path and empty dir when a certificate ref is given
+				if v.VolumeSource.EmptyDir == nil && v.VolumeSource.HostPath == nil {
+					assert.Fail(ps.t, string(daemonType)+" daemon should have empty dir and host path:", v)
+				}
 			}
 		case "rook-ceph-config":
 			assert.Equal(ps.t, "rook-ceph-config", v.VolumeSource.ConfigMap.LocalObjectReference.Name,


### PR DESCRIPTION
**Description of your changes:**

This uses a init container to concat `tls.crt` and `tls.key` coming from a Secret which is created after the `kubernetes.io/tls` "type", if they exist.
Otherwise it just copies the cert to the `emptyDir` volume for the cert file used by the RGW.

Just throwing this out here as this is the "quickest" fix I can think of besides maybe allowing cert and key to be given separately to the Ceph RGW.

**Which issue is resolved by this Pull Request:**
Resolves #2079

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
