### PR TITLE
Set nautilus as the default Ceph version to deploy

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -23,7 +23,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -222,7 +222,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -254,7 +254,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -297,7 +297,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -334,7 +334,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -380,7 +380,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -418,7 +418,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.2-20181023
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -70,7 +70,7 @@ metadata:
 spec:
   cephVersion:
     # For the latest ceph images, see https://hub.docker.com/r/ceph/ceph/tags
-    image: ceph/ceph:v13.2.5-20190319
+    image: ceph/ceph:v14.2.0-20190410
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,7 +12,7 @@
 
 ### Ceph
 
-- Ceph Nautilus (`v14`) is now supported by Rook.
+- Ceph Nautilus (`v14`) is now supported by Rook and is the default version deployed by the examples.
 - Ceph status is surfaced in the CephCluster CR and periodically updated by the operator (default is 60s). The interval can be configured with the `ROOK_CEPH_STATUS_CHECK_INTERVAL` env var.
 - A `CephNFS` CRD will start NFS daemon(s) for exporting CephFS volumes or RGW buckets. See the [NFS documentation](Documentation/ceph-nfs-crd.md).
 - Selinux labeling for mounts can now be toggled with the [ROOK_ENABLE_SELINUX_RELABELING](https://github.com/rook/rook/issues/2417) environment variable.

--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.5-20190319
+    image: ceph/ceph:v14.2.0-20190410
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v13.2.5-20190319
+    image: ceph/ceph:v14.2.0-20190410
     allowUnsupported: true
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -18,11 +18,10 @@ spec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
-    # RECOMMENDATION: In production, use a specific version tag instead of the general v13 flag, which pulls the latest release and could result in different
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/ceph:v13.2.5-20190319
-    # Whether to allow unsupported versions of Ceph. Currently only luminous and mimic are supported.
-    # After nautilus is released, Rook will be updated to support nautilus.
+    image: ceph/ceph:v14.2.0-20190410
+    # Whether to allow unsupported versions of Ceph. Currently luminous, mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Do not set to true in production.
     allowUnsupported: false
   # The path on the host where configuration files will be persisted. Must be specified.


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Nautilus is now the recommended version to install with Rook. The documentation and example manifests are updated to reflect this recommendation.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]