### PR TITLE
Integration test for upgrading Ceph from mimic to nautilus

### DIFF
--- a/tests/framework/clients/filesystem.go
+++ b/tests/framework/clients/filesystem.go
@@ -39,9 +39,9 @@ func CreateFilesystemOperation(k8sh *utils.K8sHelper, manifests installer.CephMa
 }
 
 // Create creates a filesystem in Rook
-func (f *FilesystemOperation) Create(name, namespace string) error {
+func (f *FilesystemOperation) Create(name, namespace string, metadataServers int) error {
 	logger.Infof("creating the filesystem via CRD")
-	if err := f.k8sh.ResourceOperation("create", f.manifests.GetFilesystem(namespace, name, 2)); err != nil {
+	if err := f.k8sh.ResourceOperation("create", f.manifests.GetFilesystem(namespace, name, metadataServers)); err != nil {
 		return err
 	}
 
@@ -49,8 +49,8 @@ func (f *FilesystemOperation) Create(name, namespace string) error {
 	err := f.k8sh.WaitForLabeledPodsToRun(fmt.Sprintf("rook_file_system=%s", name), namespace)
 	assert.Nil(f.k8sh.T(), err)
 
-	assert.True(f.k8sh.T(), f.k8sh.CheckPodCountAndState("rook-ceph-mds", namespace, 4, "Running"),
-		"Make sure there are four rook-ceph-mds pods present in Running state")
+	assert.True(f.k8sh.T(), f.k8sh.CheckPodCountAndState("rook-ceph-mds", namespace, metadataServers*2, "Running"),
+		"Make sure there are %d rook-ceph-mds pods present in Running state", (metadataServers * 2))
 
 	return nil
 }

--- a/tests/integration/base_file_test.go
+++ b/tests/integration/base_file_test.go
@@ -39,7 +39,7 @@ func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 	logger.Infof("Running on Rook Cluster %s", namespace)
 	logger.Infof("File Storage End To End Integration Test - create, mount, write to, read from, and unmount")
 
-	createFilesystem(helper, k8sh, s, namespace, filesystemName)
+	createFilesystem(helper, k8sh, s, namespace, filesystemName, 2)
 	createFilesystemConsumerPod(helper, k8sh, s, namespace, filesystemName)
 	err := writeAndReadToFilesystem(helper, k8sh, s, namespace, filePodName, "test_file")
 	require.Nil(s.T(), err)
@@ -113,13 +113,13 @@ func cleanupFilesystem(helper *clients.TestClient, k8sh *utils.K8sHelper, s suit
 func runFileE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
 	logger.Infof("File Storage End to End Integration Test - create Filesystem and make sure mds pod is running")
 	logger.Infof("Running on Rook Cluster %s", namespace)
-	createFilesystem(helper, k8sh, s, namespace, filesystemName)
+	createFilesystem(helper, k8sh, s, namespace, filesystemName, 1)
 	cleanupFilesystem(helper, k8sh, s, namespace, filesystemName)
 }
 
-func createFilesystem(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace, filesystemName string) {
+func createFilesystem(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace, filesystemName string, metadataServers int) {
 	logger.Infof("Create file System")
-	fscErr := helper.FSClient.Create(filesystemName, namespace)
+	fscErr := helper.FSClient.Create(filesystemName, namespace, metadataServers)
 	require.Nil(s.T(), fscErr)
 	logger.Infof("File system %s created", filesystemName)
 

--- a/tests/integration/ceph_csi_test.go
+++ b/tests/integration/ceph_csi_test.go
@@ -86,7 +86,7 @@ func createCephPools(helper *clients.TestClient, s suite.Suite, namespace string
 	err := helper.PoolClient.Create(csiPoolRBD, namespace, 1)
 	require.Nil(s.T(), err)
 
-	err = helper.FSClient.Create(csiPoolCephFS, namespace)
+	err = helper.FSClient.Create(csiPoolCephFS, namespace, 1)
 	require.Nil(s.T(), err)
 }
 

--- a/tests/integration/filesystem_mountuser_test.go
+++ b/tests/integration/filesystem_mountuser_test.go
@@ -42,7 +42,7 @@ func runFileMountUserE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, 
 	logger.Infof("Running on Rook Cluster %s", namespace)
 	logger.Infof("File Storage MountUser/MountSecret End To End Integration Test - create, mount, write to, read from, and unmount")
 
-	createFilesystem(helper, k8sh, s, namespace, filesystemName)
+	createFilesystem(helper, k8sh, s, namespace, filesystemName, 1)
 	createFilesystemMountCephCredentials(helper, k8sh, s, namespace, filesystemName)
 	createFilesystemMountUserConsumerPod(helper, k8sh, s, namespace, filesystemName)
 	err := writeAndReadToFilesystem(helper, k8sh, s, namespace, fileMountUserPodName, "canttouchthis")


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration test for upgrades will now upgrade from mimic to nautilus, in addition to testing the rook upgrade from the previous version of rook. 

This is dependent on the fix for #2973 which will allow the upgrade to succeed when the mons are updated to use msgr2.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
