### PR TITLE
Upgrade all daemons during Ceph upgrade

### DIFF
--- a/Documentation/common-issues.md
+++ b/Documentation/common-issues.md
@@ -428,7 +428,8 @@ cephosd: configuring osd devices: {"Entries":{"sdb":{"Data":-1,"Metadata":null},
 ## Solution
 After you have either updated the CRD with the correct settings, or you have cleaned the partitions or file system from your devices,
 you can trigger the operator to analyze the devices again by restarting the operator. Each time the operator starts, it
-will ensure all the desired devices are configured.
+will ensure all the desired devices are configured. The operator does automatically deploy OSDs in most scenarios, but an operator restart
+will cover any scenarios that the operator doesn't detect automatically.
 
 ```
 # Restart the operator to ensure devices are configured. A new pod will automatically be started when the current operator pod is deleted.
@@ -542,4 +543,4 @@ You don't need to restart the pod, the effect will be immediate.
 
 To disable the logging on file, simply set `log_to_file` to `false`.
 
-For Ceph Luminous/Mimic releases, `mon_cluster_log_file` and `cluster_log_file` can be set to `/var/log/ceph/XXXX` in the config override ConfigMap to enable logging. See the (Advanced Documentation)[Documentation/advanced-configuration.md#kubernetes] for information about how to use the config override ConfigMap.
+For Ceph Luminous/Mimic releases, `mon_cluster_log_file` and `cluster_log_file` can be set to `/var/log/ceph/XXXX` in the config override ConfigMap to enable logging. See the (Advanced Documentation)[advanced-configuration.md#custom-cephconf-settings] for information about how to use the config override ConfigMap.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -13,6 +13,11 @@
 ### Ceph
 
 - Ceph Nautilus (`v14`) is now supported by Rook and is the default version deployed by the examples.
+- An operator restart is no longer needed to apply changes to the cluster in the following scenarios:
+   - When a node is added to the cluster, OSDs will be automatically configured if needed.
+   - When a device is attached to a storage node, OSDs will be automatically configured if needed.
+   - Any change to the CephCluster CR will trigger updates to the cluster.
+   - Upgrading the Ceph version will update all Ceph daemons (in v0.9, mds and rgw daemons were skipped)
 - Ceph status is surfaced in the CephCluster CR and periodically updated by the operator (default is 60s). The interval can be configured with the `ROOK_CEPH_STATUS_CHECK_INTERVAL` env var.
 - A `CephNFS` CRD will start NFS daemon(s) for exporting CephFS volumes or RGW buckets. See the [NFS documentation](Documentation/ceph-nfs-crd.md).
 - Selinux labeling for mounts can now be toggled with the [ROOK_ENABLE_SELINUX_RELABELING](https://github.com/rook/rook/issues/2417) environment variable.

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -42,3 +42,13 @@ find "${scriptdir}/../../pkg/client" -name "clientset_generated.go" -exec \
     $SED 's/return \&Clientset{fakePtr, \&fakediscovery.FakeDiscovery{Fake: \&fakePtr}}/cs.discovery = \&fakediscovery.FakeDiscovery{Fake: \&cs.Fake}\
 	return cs/g' {} +
 find "${scriptdir}/../../pkg/client" -name "clientset_generated.go.bak" -delete
+
+# Code generation does not respect the plural version of the CRD name unless it simply appends "s".
+# In this case the plural for cephnfs should be cephnfses.
+find "${scriptdir}/../../pkg/client" -name "*.go" -exec \
+    $SED 's/cephnfss/cephnfses/g' {} +
+find "${scriptdir}/../../pkg/client" -name "*.go" -exec \
+    $SED 's/CephNFSs/CephNFSes/g' {} +
+find "${scriptdir}/../../pkg/client" -name "*.go" -exec \
+    $SED 's/cephNFSs/cephNFSes/g' {} +
+find "${scriptdir}/../../pkg/client" -name "*.go.bak" -delete

--- a/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/ceph.rook.io_client.go
+++ b/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/ceph.rook.io_client.go
@@ -30,7 +30,7 @@ type CephV1Interface interface {
 	CephBlockPoolsGetter
 	CephClustersGetter
 	CephFilesystemsGetter
-	CephNFSsGetter
+	CephNFSesGetter
 	CephObjectStoresGetter
 	CephObjectStoreUsersGetter
 }
@@ -52,8 +52,8 @@ func (c *CephV1Client) CephFilesystems(namespace string) CephFilesystemInterface
 	return newCephFilesystems(c, namespace)
 }
 
-func (c *CephV1Client) CephNFSs(namespace string) CephNFSInterface {
-	return newCephNFSs(c, namespace)
+func (c *CephV1Client) CephNFSes(namespace string) CephNFSInterface {
+	return newCephNFSes(c, namespace)
 }
 
 func (c *CephV1Client) CephObjectStores(namespace string) CephObjectStoreInterface {

--- a/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/cephnfs.go
+++ b/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/cephnfs.go
@@ -29,10 +29,10 @@ import (
 	rest "k8s.io/client-go/rest"
 )
 
-// CephNFSsGetter has a method to return a CephNFSInterface.
+// CephNFSesGetter has a method to return a CephNFSInterface.
 // A group's client should implement this interface.
-type CephNFSsGetter interface {
-	CephNFSs(namespace string) CephNFSInterface
+type CephNFSesGetter interface {
+	CephNFSes(namespace string) CephNFSInterface
 }
 
 // CephNFSInterface has methods to work with CephNFS resources.
@@ -48,26 +48,26 @@ type CephNFSInterface interface {
 	CephNFSExpansion
 }
 
-// cephNFSs implements CephNFSInterface
-type cephNFSs struct {
+// cephNFSes implements CephNFSInterface
+type cephNFSes struct {
 	client rest.Interface
 	ns     string
 }
 
-// newCephNFSs returns a CephNFSs
-func newCephNFSs(c *CephV1Client, namespace string) *cephNFSs {
-	return &cephNFSs{
+// newCephNFSes returns a CephNFSes
+func newCephNFSes(c *CephV1Client, namespace string) *cephNFSes {
+	return &cephNFSes{
 		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }
 
 // Get takes name of the cephNFS, and returns the corresponding cephNFS object, and an error if there is any.
-func (c *cephNFSs) Get(name string, options metav1.GetOptions) (result *v1.CephNFS, err error) {
+func (c *cephNFSes) Get(name string, options metav1.GetOptions) (result *v1.CephNFS, err error) {
 	result = &v1.CephNFS{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do().
@@ -75,8 +75,8 @@ func (c *cephNFSs) Get(name string, options metav1.GetOptions) (result *v1.CephN
 	return
 }
 
-// List takes label and field selectors, and returns the list of CephNFSs that match those selectors.
-func (c *cephNFSs) List(opts metav1.ListOptions) (result *v1.CephNFSList, err error) {
+// List takes label and field selectors, and returns the list of CephNFSes that match those selectors.
+func (c *cephNFSes) List(opts metav1.ListOptions) (result *v1.CephNFSList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -84,7 +84,7 @@ func (c *cephNFSs) List(opts metav1.ListOptions) (result *v1.CephNFSList, err er
 	result = &v1.CephNFSList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Do().
@@ -92,8 +92,8 @@ func (c *cephNFSs) List(opts metav1.ListOptions) (result *v1.CephNFSList, err er
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested cephNFSs.
-func (c *cephNFSs) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested cephNFSes.
+func (c *cephNFSes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -101,18 +101,18 @@ func (c *cephNFSs) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch()
 }
 
 // Create takes the representation of a cephNFS and creates it.  Returns the server's representation of the cephNFS, and an error, if there is any.
-func (c *cephNFSs) Create(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
+func (c *cephNFSes) Create(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
 	result = &v1.CephNFS{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		Body(cephNFS).
 		Do().
 		Into(result)
@@ -120,11 +120,11 @@ func (c *cephNFSs) Create(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
 }
 
 // Update takes the representation of a cephNFS and updates it. Returns the server's representation of the cephNFS, and an error, if there is any.
-func (c *cephNFSs) Update(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
+func (c *cephNFSes) Update(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
 	result = &v1.CephNFS{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		Name(cephNFS.Name).
 		Body(cephNFS).
 		Do().
@@ -133,10 +133,10 @@ func (c *cephNFSs) Update(cephNFS *v1.CephNFS) (result *v1.CephNFS, err error) {
 }
 
 // Delete takes name of the cephNFS and deletes it. Returns an error if one occurs.
-func (c *cephNFSs) Delete(name string, options *metav1.DeleteOptions) error {
+func (c *cephNFSes) Delete(name string, options *metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		Name(name).
 		Body(options).
 		Do().
@@ -144,14 +144,14 @@ func (c *cephNFSs) Delete(name string, options *metav1.DeleteOptions) error {
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *cephNFSs) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *cephNFSes) DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	var timeout time.Duration
 	if listOptions.TimeoutSeconds != nil {
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
@@ -160,11 +160,11 @@ func (c *cephNFSs) DeleteCollection(options *metav1.DeleteOptions, listOptions m
 }
 
 // Patch applies the patch and returns the patched cephNFS.
-func (c *cephNFSs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.CephNFS, err error) {
+func (c *cephNFSes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.CephNFS, err error) {
 	result = &v1.CephNFS{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
-		Resource("cephnfss").
+		Resource("cephnfses").
 		SubResource(subresources...).
 		Name(name).
 		Body(data).

--- a/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/fake/fake_ceph.rook.io_client.go
+++ b/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/fake/fake_ceph.rook.io_client.go
@@ -40,8 +40,8 @@ func (c *FakeCephV1) CephFilesystems(namespace string) v1.CephFilesystemInterfac
 	return &FakeCephFilesystems{c, namespace}
 }
 
-func (c *FakeCephV1) CephNFSs(namespace string) v1.CephNFSInterface {
-	return &FakeCephNFSs{c, namespace}
+func (c *FakeCephV1) CephNFSes(namespace string) v1.CephNFSInterface {
+	return &FakeCephNFSes{c, namespace}
 }
 
 func (c *FakeCephV1) CephObjectStores(namespace string) v1.CephObjectStoreInterface {

--- a/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/fake/fake_cephnfs.go
+++ b/pkg/client/clientset/versioned/typed/ceph.rook.io/v1/fake/fake_cephnfs.go
@@ -28,20 +28,20 @@ import (
 	testing "k8s.io/client-go/testing"
 )
 
-// FakeCephNFSs implements CephNFSInterface
-type FakeCephNFSs struct {
+// FakeCephNFSes implements CephNFSInterface
+type FakeCephNFSes struct {
 	Fake *FakeCephV1
 	ns   string
 }
 
-var cephnfssResource = schema.GroupVersionResource{Group: "ceph.rook.io", Version: "v1", Resource: "cephnfss"}
+var cephnfsesResource = schema.GroupVersionResource{Group: "ceph.rook.io", Version: "v1", Resource: "cephnfses"}
 
-var cephnfssKind = schema.GroupVersionKind{Group: "ceph.rook.io", Version: "v1", Kind: "CephNFS"}
+var cephnfsesKind = schema.GroupVersionKind{Group: "ceph.rook.io", Version: "v1", Kind: "CephNFS"}
 
 // Get takes name of the cephNFS, and returns the corresponding cephNFS object, and an error if there is any.
-func (c *FakeCephNFSs) Get(name string, options v1.GetOptions) (result *cephrookiov1.CephNFS, err error) {
+func (c *FakeCephNFSes) Get(name string, options v1.GetOptions) (result *cephrookiov1.CephNFS, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(cephnfssResource, c.ns, name), &cephrookiov1.CephNFS{})
+		Invokes(testing.NewGetAction(cephnfsesResource, c.ns, name), &cephrookiov1.CephNFS{})
 
 	if obj == nil {
 		return nil, err
@@ -49,10 +49,10 @@ func (c *FakeCephNFSs) Get(name string, options v1.GetOptions) (result *cephrook
 	return obj.(*cephrookiov1.CephNFS), err
 }
 
-// List takes label and field selectors, and returns the list of CephNFSs that match those selectors.
-func (c *FakeCephNFSs) List(opts v1.ListOptions) (result *cephrookiov1.CephNFSList, err error) {
+// List takes label and field selectors, and returns the list of CephNFSes that match those selectors.
+func (c *FakeCephNFSes) List(opts v1.ListOptions) (result *cephrookiov1.CephNFSList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(cephnfssResource, cephnfssKind, c.ns, opts), &cephrookiov1.CephNFSList{})
+		Invokes(testing.NewListAction(cephnfsesResource, cephnfsesKind, c.ns, opts), &cephrookiov1.CephNFSList{})
 
 	if obj == nil {
 		return nil, err
@@ -71,17 +71,17 @@ func (c *FakeCephNFSs) List(opts v1.ListOptions) (result *cephrookiov1.CephNFSLi
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested cephNFSs.
-func (c *FakeCephNFSs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested cephNFSes.
+func (c *FakeCephNFSes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(cephnfssResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchAction(cephnfsesResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a cephNFS and creates it.  Returns the server's representation of the cephNFS, and an error, if there is any.
-func (c *FakeCephNFSs) Create(cephNFS *cephrookiov1.CephNFS) (result *cephrookiov1.CephNFS, err error) {
+func (c *FakeCephNFSes) Create(cephNFS *cephrookiov1.CephNFS) (result *cephrookiov1.CephNFS, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(cephnfssResource, c.ns, cephNFS), &cephrookiov1.CephNFS{})
+		Invokes(testing.NewCreateAction(cephnfsesResource, c.ns, cephNFS), &cephrookiov1.CephNFS{})
 
 	if obj == nil {
 		return nil, err
@@ -90,9 +90,9 @@ func (c *FakeCephNFSs) Create(cephNFS *cephrookiov1.CephNFS) (result *cephrookio
 }
 
 // Update takes the representation of a cephNFS and updates it. Returns the server's representation of the cephNFS, and an error, if there is any.
-func (c *FakeCephNFSs) Update(cephNFS *cephrookiov1.CephNFS) (result *cephrookiov1.CephNFS, err error) {
+func (c *FakeCephNFSes) Update(cephNFS *cephrookiov1.CephNFS) (result *cephrookiov1.CephNFS, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(cephnfssResource, c.ns, cephNFS), &cephrookiov1.CephNFS{})
+		Invokes(testing.NewUpdateAction(cephnfsesResource, c.ns, cephNFS), &cephrookiov1.CephNFS{})
 
 	if obj == nil {
 		return nil, err
@@ -101,25 +101,25 @@ func (c *FakeCephNFSs) Update(cephNFS *cephrookiov1.CephNFS) (result *cephrookio
 }
 
 // Delete takes name of the cephNFS and deletes it. Returns an error if one occurs.
-func (c *FakeCephNFSs) Delete(name string, options *v1.DeleteOptions) error {
+func (c *FakeCephNFSes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(cephnfssResource, c.ns, name), &cephrookiov1.CephNFS{})
+		Invokes(testing.NewDeleteAction(cephnfsesResource, c.ns, name), &cephrookiov1.CephNFS{})
 
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeCephNFSs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(cephnfssResource, c.ns, listOptions)
+func (c *FakeCephNFSes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(cephnfsesResource, c.ns, listOptions)
 
 	_, err := c.Fake.Invokes(action, &cephrookiov1.CephNFSList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched cephNFS.
-func (c *FakeCephNFSs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *cephrookiov1.CephNFS, err error) {
+func (c *FakeCephNFSes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *cephrookiov1.CephNFS, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(cephnfssResource, c.ns, name, pt, data, subresources...), &cephrookiov1.CephNFS{})
+		Invokes(testing.NewPatchSubresourceAction(cephnfsesResource, c.ns, name, pt, data, subresources...), &cephrookiov1.CephNFS{})
 
 	if obj == nil {
 		return nil, err

--- a/pkg/client/informers/externalversions/ceph.rook.io/v1/cephnfs.go
+++ b/pkg/client/informers/externalversions/ceph.rook.io/v1/cephnfs.go
@@ -32,7 +32,7 @@ import (
 )
 
 // CephNFSInformer provides access to a shared informer and lister for
-// CephNFSs.
+// CephNFSes.
 type CephNFSInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() v1.CephNFSLister
@@ -61,13 +61,13 @@ func NewFilteredCephNFSInformer(client versioned.Interface, namespace string, re
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CephV1().CephNFSs(namespace).List(options)
+				return client.CephV1().CephNFSes(namespace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CephV1().CephNFSs(namespace).Watch(options)
+				return client.CephV1().CephNFSes(namespace).Watch(options)
 			},
 		},
 		&cephrookiov1.CephNFS{},

--- a/pkg/client/informers/externalversions/ceph.rook.io/v1/interface.go
+++ b/pkg/client/informers/externalversions/ceph.rook.io/v1/interface.go
@@ -30,8 +30,8 @@ type Interface interface {
 	CephClusters() CephClusterInformer
 	// CephFilesystems returns a CephFilesystemInformer.
 	CephFilesystems() CephFilesystemInformer
-	// CephNFSs returns a CephNFSInformer.
-	CephNFSs() CephNFSInformer
+	// CephNFSes returns a CephNFSInformer.
+	CephNFSes() CephNFSInformer
 	// CephObjectStores returns a CephObjectStoreInformer.
 	CephObjectStores() CephObjectStoreInformer
 	// CephObjectStoreUsers returns a CephObjectStoreUserInformer.
@@ -64,8 +64,8 @@ func (v *version) CephFilesystems() CephFilesystemInformer {
 	return &cephFilesystemInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
-// CephNFSs returns a CephNFSInformer.
-func (v *version) CephNFSs() CephNFSInformer {
+// CephNFSes returns a CephNFSInformer.
+func (v *version) CephNFSes() CephNFSInformer {
 	return &cephNFSInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -70,8 +70,8 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Ceph().V1().CephClusters().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("cephfilesystems"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Ceph().V1().CephFilesystems().Informer()}, nil
-	case v1.SchemeGroupVersion.WithResource("cephnfss"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Ceph().V1().CephNFSs().Informer()}, nil
+	case v1.SchemeGroupVersion.WithResource("cephnfses"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Ceph().V1().CephNFSes().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("cephobjectstores"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Ceph().V1().CephObjectStores().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("cephobjectstoreusers"):

--- a/pkg/client/listers/ceph.rook.io/v1/cephnfs.go
+++ b/pkg/client/listers/ceph.rook.io/v1/cephnfs.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// CephNFSLister helps list CephNFSs.
+// CephNFSLister helps list CephNFSes.
 type CephNFSLister interface {
-	// List lists all CephNFSs in the indexer.
+	// List lists all CephNFSes in the indexer.
 	List(selector labels.Selector) (ret []*v1.CephNFS, err error)
-	// CephNFSs returns an object that can list and get CephNFSs.
-	CephNFSs(namespace string) CephNFSNamespaceLister
+	// CephNFSes returns an object that can list and get CephNFSes.
+	CephNFSes(namespace string) CephNFSNamespaceLister
 	CephNFSListerExpansion
 }
 
@@ -44,7 +44,7 @@ func NewCephNFSLister(indexer cache.Indexer) CephNFSLister {
 	return &cephNFSLister{indexer: indexer}
 }
 
-// List lists all CephNFSs in the indexer.
+// List lists all CephNFSes in the indexer.
 func (s *cephNFSLister) List(selector labels.Selector) (ret []*v1.CephNFS, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CephNFS))
@@ -52,14 +52,14 @@ func (s *cephNFSLister) List(selector labels.Selector) (ret []*v1.CephNFS, err e
 	return ret, err
 }
 
-// CephNFSs returns an object that can list and get CephNFSs.
-func (s *cephNFSLister) CephNFSs(namespace string) CephNFSNamespaceLister {
+// CephNFSes returns an object that can list and get CephNFSes.
+func (s *cephNFSLister) CephNFSes(namespace string) CephNFSNamespaceLister {
 	return cephNFSNamespaceLister{indexer: s.indexer, namespace: namespace}
 }
 
-// CephNFSNamespaceLister helps list and get CephNFSs.
+// CephNFSNamespaceLister helps list and get CephNFSes.
 type CephNFSNamespaceLister interface {
-	// List lists all CephNFSs in the indexer for a given namespace.
+	// List lists all CephNFSes in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.CephNFS, err error)
 	// Get retrieves the CephNFS from the indexer for a given namespace and name.
 	Get(name string) (*v1.CephNFS, error)
@@ -73,7 +73,7 @@ type cephNFSNamespaceLister struct {
 	namespace string
 }
 
-// List lists all CephNFSs in the indexer for a given namespace.
+// List lists all CephNFSes in the indexer for a given namespace.
 func (s cephNFSNamespaceLister) List(selector labels.Selector) (ret []*v1.CephNFS, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.CephNFS))

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -306,24 +306,28 @@ func (c *ClusterController) onAdd(obj interface{}) {
 	}
 
 	// Start pool CRD watcher
-	poolController := pool.NewPoolController(c.context)
-	poolController.StartWatch(cluster.Namespace, cluster.stopCh)
+	poolController := pool.NewPoolController(c.context, cluster.Namespace)
+	poolController.StartWatch(cluster.stopCh)
 
 	// Start object store CRD watcher
-	objectStoreController := object.NewObjectStoreController(cluster.Info, c.context, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef, cluster.Spec.DataDirHostPath)
-	objectStoreController.StartWatch(cluster.Namespace, cluster.stopCh)
+	objectStoreController := object.NewObjectStoreController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef, cluster.Spec.DataDirHostPath)
+	objectStoreController.StartWatch(cluster.stopCh)
 
 	// Start object store user CRD watcher
-	objectStoreUserController := objectuser.NewObjectStoreUserController(c.context, cluster.ownerRef)
-	objectStoreUserController.StartWatch(cluster.Namespace, cluster.stopCh)
+	objectStoreUserController := objectuser.NewObjectStoreUserController(c.context, cluster.Namespace, cluster.ownerRef)
+	objectStoreUserController.StartWatch(cluster.stopCh)
 
 	// Start file system CRD watcher
-	fileController := file.NewFilesystemController(cluster.Info, c.context, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef, cluster.Spec.DataDirHostPath)
-	fileController.StartWatch(cluster.Namespace, cluster.stopCh)
+	fileController := file.NewFilesystemController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef, cluster.Spec.DataDirHostPath)
+	fileController.StartWatch(cluster.stopCh)
 
 	// Start nfs ganesha CRD watcher
-	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef)
-	ganeshaController.StartWatch(cluster.Namespace, cluster.stopCh)
+	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef)
+	ganeshaController.StartWatch(cluster.stopCh)
+
+	cluster.childControllers = []childController{
+		poolController, objectStoreController, objectStoreUserController, fileController, ganeshaController,
+	}
 
 	// Start mon health checker
 	healthChecker := mon.NewHealthChecker(cluster.mons)

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -87,7 +87,7 @@ func TestMigrateFilesystemObject(t *testing.T) {
 	}
 	clusterInfo := &cephconfig.ClusterInfo{FSID: "myfsid"}
 
-	controller := NewFilesystemController(clusterInfo, context, "", cephv1.CephVersionSpec{}, false, metav1.OwnerReference{}, "/var/lib/rook/")
+	controller := NewFilesystemController(clusterInfo, context, legacyFilesystem.Namespace, "", cephv1.CephVersionSpec{}, false, metav1.OwnerReference{}, "/var/lib/rook/")
 
 	// convert the legacy filesystem object in memory and assert that a migration is needed
 	convertedFilesystem, migrationNeeded, err := getFilesystemObject(legacyFilesystem)

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -36,6 +36,8 @@ const (
 	ganeshaRadosGraceCmd = "ganesha-rados-grace"
 )
 
+var updateDeploymentAndWait = k8sutil.UpdateDeploymentAndWait
+
 // Create the ganesha server
 func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 	if err := validateGanesha(c.context, n); err != nil {
@@ -65,7 +67,10 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 			if !errors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create ganesha deployment. %+v", err)
 			}
-			logger.Infof("ganesha deployment %s already exists", deployment.Name)
+			logger.Infof("ganesha deployment %s already exists. updating if needed", deployment.Name)
+			if _, err := updateDeploymentAndWait(c.context, deployment, n.Namespace); err != nil {
+				return fmt.Errorf("failed to update ganesha deployment %s. %+v", deployment.Name, err)
+			}
 		} else {
 			logger.Infof("ganesha deployment %s started", deployment.Name)
 		}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -76,9 +76,7 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 			return fmt.Errorf("failed to create ganesha service. %+v", err)
 		}
 
-		if err = c.addServerToDatabase(n, name); err != nil {
-			logger.Warningf("Failed to add ganesha server %s to database. It may already be added. %+v", name, err)
-		}
+		c.addServerToDatabase(n, name)
 	}
 
 	return nil
@@ -97,22 +95,20 @@ func (c *CephNFSController) addRADOSConfigFile(n cephv1.CephNFS, name string) er
 	return c.context.Executor.ExecuteCommand(false, "", "rados", "--pool", n.Spec.RADOS.Pool, "--namespace", n.Spec.RADOS.Namespace, "create", config)
 }
 
-func (c *CephNFSController) addServerToDatabase(n cephv1.CephNFS, name string) error {
+func (c *CephNFSController) addServerToDatabase(n cephv1.CephNFS, name string) {
 	logger.Infof("Adding ganesha %s to grace db", name)
 
 	if err := c.runGaneshaRadosGraceJob(n, name, "add", 10*time.Minute); err != nil {
 		logger.Errorf("failed to add %s to grace db. %+v", name, err)
 	}
-	return nil
 }
 
-func (c *CephNFSController) removeServerFromDatabase(n cephv1.CephNFS, name string) error {
+func (c *CephNFSController) removeServerFromDatabase(n cephv1.CephNFS, name string) {
 	logger.Infof("Removing ganesha %s from grace db", name)
 
 	if err := c.runGaneshaRadosGraceJob(n, name, "remove", 10*time.Minute); err != nil {
 		logger.Errorf("failed to remmove %s from grace db. %+v", name, err)
 	}
-	return nil
 }
 
 func (c *CephNFSController) runGaneshaRadosGraceJob(n cephv1.CephNFS, name, action string, timeout time.Duration) error {
@@ -219,9 +215,7 @@ func (c *CephNFSController) downCephNFS(n cephv1.CephNFS, newActive int) error {
 		name := k8sutil.IndexToName(i)
 
 		// Remove from grace db
-		if err := c.removeServerFromDatabase(n, name); err != nil {
-			logger.Warningf("failed to remove server %s from grace db. %+v", name, err)
-		}
+		c.removeServerFromDatabase(n, name)
 
 		// Delete the mds deployment
 		k8sutil.DeleteDeployment(c.context.Clientset, n.Namespace, instanceName(n, name))

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -19,6 +19,7 @@ package object
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/coreos/pkg/capnslog"
 	opkit "github.com/rook/operator-kit"
@@ -57,19 +58,22 @@ var ObjectStoreResourceRookLegacy = opkit.CustomResource{
 
 // ObjectStoreController represents a controller object for object store custom resources
 type ObjectStoreController struct {
-	clusterInfo     *daemonconfig.ClusterInfo
-	context         *clusterd.Context
-	rookImage       string
-	cephVersion     cephv1.CephVersionSpec
-	hostNetwork     bool
-	ownerRef        metav1.OwnerReference
-	dataDirHostPath string
+	clusterInfo        *daemonconfig.ClusterInfo
+	context            *clusterd.Context
+	namespace          string
+	rookImage          string
+	cephVersion        cephv1.CephVersionSpec
+	hostNetwork        bool
+	ownerRef           metav1.OwnerReference
+	dataDirHostPath    string
+	orchestrationMutex sync.Mutex
 }
 
 // NewObjectStoreController create controller for watching object store custom resources created
 func NewObjectStoreController(
 	clusterInfo *daemonconfig.ClusterInfo,
 	context *clusterd.Context,
+	namespace string,
 	rookImage string,
 	cephVersion cephv1.CephVersionSpec,
 	hostNetwork bool,
@@ -79,6 +83,7 @@ func NewObjectStoreController(
 	return &ObjectStoreController{
 		clusterInfo:     clusterInfo,
 		context:         context,
+		namespace:       namespace,
 		rookImage:       rookImage,
 		cephVersion:     cephVersion,
 		hostNetwork:     hostNetwork,
@@ -88,7 +93,7 @@ func NewObjectStoreController(
 }
 
 // StartWatch watches for instances of ObjectStore custom resources and acts on them
-func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{}) error {
+func (c *ObjectStoreController) StartWatch(stopCh chan struct{}) error {
 
 	resourceHandlerFuncs := cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onAdd,
@@ -96,12 +101,12 @@ func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{
 		DeleteFunc: c.onDelete,
 	}
 
-	logger.Infof("start watching object store resources in namespace %s", namespace)
-	watcher := opkit.NewWatcher(ObjectStoreResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
+	logger.Infof("start watching object store resources in namespace %s", c.namespace)
+	watcher := opkit.NewWatcher(ObjectStoreResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
 	go watcher.Watch(&cephv1.CephObjectStore{}, stopCh)
 
 	// watch for events on all legacy types too
-	c.watchLegacyObjectStores(namespace, stopCh, resourceHandlerFuncs)
+	c.watchLegacyObjectStores(c.namespace, stopCh, resourceHandlerFuncs)
 
 	return nil
 }
@@ -120,19 +125,10 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 		return
 	}
 
-	cfg := clusterConfig{
-		clusterInfo: c.clusterInfo,
-		context:     c.context,
-		store:       *objectstore,
-		rookVersion: c.rookImage,
-		cephVersion: c.cephVersion,
-		hostNetwork: c.hostNetwork,
-		ownerRefs:   c.storeOwners(objectstore),
-		DataPathMap: cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, objectstore.Name, c.clusterInfo.Name, c.dataDirHostPath),
-	}
-	if err = cfg.createStore(); err != nil {
-		logger.Errorf("failed to create object store %s. %+v", objectstore.Name, err)
-	}
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
+
+	c.createOrUpdateStore(true, objectstore)
 }
 
 func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
@@ -160,19 +156,31 @@ func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	logger.Infof("applying object store %s changes", newStore.Name)
-	cfg := clusterConfig{
-		c.clusterInfo,
-		c.context,
-		*newStore,
-		c.rookImage,
-		c.cephVersion,
-		c.hostNetwork,
-		c.storeOwners(newStore),
-		cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, newStore.Name, c.clusterInfo.Name, c.dataDirHostPath),
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
+
+	c.createOrUpdateStore(true, newStore)
+}
+
+func (c *ObjectStoreController) createOrUpdateStore(update bool, objectstore *cephv1.CephObjectStore) {
+	action := "create"
+	if update {
+		action = "update"
 	}
-	if err = cfg.updateStore(); err != nil {
-		logger.Errorf("failed to create (modify) object store %s. %+v", newStore.Name, err)
+
+	logger.Infof("%s object store %s", action, objectstore.Name)
+	cfg := clusterConfig{
+		clusterInfo: c.clusterInfo,
+		context:     c.context,
+		store:       *objectstore,
+		rookVersion: c.rookImage,
+		cephVersion: c.cephVersion,
+		hostNetwork: c.hostNetwork,
+		ownerRefs:   c.storeOwners(objectstore),
+		DataPathMap: cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, objectstore.Name, c.clusterInfo.Name, c.dataDirHostPath),
+	}
+	if err := cfg.createOrUpdate(update); err != nil {
+		logger.Errorf("failed to %s object store %s. %+v", action, objectstore.Name, err)
 	}
 }
 
@@ -188,9 +196,39 @@ func (c *ObjectStoreController) onDelete(obj interface{}) {
 		return
 	}
 
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
+
 	cfg := clusterConfig{context: c.context, store: *objectstore}
 	if err = cfg.deleteStore(); err != nil {
 		logger.Errorf("failed to delete object store %s. %+v", objectstore.Name, err)
+	}
+}
+
+func (c *ObjectStoreController) ParentClusterChanged(cluster cephv1.ClusterSpec, clusterInfo *daemonconfig.ClusterInfo) {
+	c.clusterInfo = clusterInfo
+	if cluster.CephVersion.Image == c.cephVersion.Image {
+		logger.Debugf("No need to update the object store after the parent cluster changed")
+		return
+	}
+
+	c.acquireOrchestrationLock()
+	defer c.releaseOrchestrationLock()
+
+	c.cephVersion = cluster.CephVersion
+	objectStores, err := c.context.RookClientset.CephV1().CephObjectStores(c.namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Errorf("failed to retrieve object stores to update the ceph version. %+v", err)
+		return
+	}
+	for _, store := range objectStores.Items {
+		logger.Infof("updating the ceph version for object store %s to %s", store.Name, c.cephVersion.Image)
+		c.createOrUpdateStore(true, &store)
+		if err != nil {
+			logger.Errorf("failed to update object store %s. %+v", store.Name, err)
+		} else {
+			logger.Infof("updated object store %s to ceph version %s", store.Name, c.cephVersion.Image)
+		}
 	}
 }
 
@@ -324,4 +362,15 @@ func convertRookLegacyObjectStore(legacyObjectStore *cephbeta.ObjectStore) *ceph
 	}
 
 	return objectStore
+}
+
+func (c *ObjectStoreController) acquireOrchestrationLock() {
+	logger.Debugf("Acquiring lock for object store orchestration")
+	c.orchestrationMutex.Lock()
+	logger.Debugf("Acquired lock for object store orchestration")
+}
+
+func (c *ObjectStoreController) releaseOrchestrationLock() {
+	c.orchestrationMutex.Unlock()
+	logger.Debugf("Released lock for object store orchestration")
 }

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -92,7 +92,7 @@ func TestMigrateObjectStoreObject(t *testing.T) {
 		RookClientset: rookfake.NewSimpleClientset(legacyObjectStore),
 	}
 	info := testop.CreateConfigDir(1)
-	controller := NewObjectStoreController(info, context, "", cephv1.CephVersionSpec{}, false, metav1.OwnerReference{}, "/var/lib/rook/")
+	controller := NewObjectStoreController(info, context, legacyObjectStore.Namespace, "", cephv1.CephVersionSpec{}, false, metav1.OwnerReference{}, "/var/lib/rook/")
 
 	// convert the legacy objectstore object in memory and assert that a migration is needed
 	convertedObjectStore, migrationNeeded, err := getObjectStoreObject(legacyObjectStore)

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -220,7 +220,7 @@ func TestMigratePoolObject(t *testing.T) {
 		Clientset:     clientset,
 		RookClientset: rookfake.NewSimpleClientset(legacyPool),
 	}
-	controller := NewPoolController(context)
+	controller := NewPoolController(context, legacyPool.Namespace)
 
 	// convert the legacy pool object in memory and assert that a migration is needed
 	convertedPool, migrationNeeded, err := getPoolObject(legacyPool)

--- a/tests/framework/clients/nfs.go
+++ b/tests/framework/clients/nfs.go
@@ -59,7 +59,7 @@ func (n *NFSOperation) Create(namespace, name, pool string, daemonCount int) err
 func (n *NFSOperation) Delete(namespace, name string) error {
 	options := &metav1.DeleteOptions{}
 	logger.Infof("Deleting nfs %s in namespace %s", name, namespace)
-	err := n.k8sh.RookClientset.CephV1().CephNFSs(namespace).Delete(name, options)
+	err := n.k8sh.RookClientset.CephV1().CephNFSes(namespace).Delete(name, options)
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CR controllers were previously all acting independently and there was not a pattern for communicating to trigger orchestrations in other controllers. In particular, the CephCluster CR is the parent of each of the other CRs. If the CephCluster is updated, the daemons started by the others CRs (mds, rgw, nfs) may need to be updated as well, for example if the Ceph version is updated. Now the daemons will be updated without requiring an operator restart.

When calling the controllers from another controller, we ensure that only a single goroutine is handling CRs at any given time to prevent contention across multiple CRs of the same type. The same locking pattern is used that the mon health check is using to coordinate with the CephCluster updates.

As an aside a couple updates were needed for the CephNFS daemon. 
- Code generation was incorrect due to the non-standard plural name of the CRD: `CephNFSes`. The code generation doesn't appear to have a way to generate the correct name, so we replace the incorrect names.
- The NFS daemons weren't being updated during a Ceph upgrade. 
@jtlayton Any concerns or special needs for the daemons when they are being restarted? Please see the last commit in the PR.

An integration test to verify the working ceph upgrade is separated to #3022.

**Which issue is resolved by this Pull Request:**
Resolves #2379

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issues
[skip ci]