### PR TITLE
Update ceph-quickstart.md

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -24,6 +24,7 @@ If you are using `dataDirHostPath` to persist rook data on kubernetes hosts, mak
 If you're feeling lucky, a simple Rook cluster can be created with the following kubectl commands. For the more detailed install, skip to the next section to [deploy the Rook operator](#deploy-the-rook-operator).
 ```
 cd cluster/examples/kubernetes/ceph
+kubectl create -f common.yaml
 kubectl create -f operator.yaml
 kubectl create -f cluster.yaml
 ```


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

ceph-quickstart.md was missing `kubectl create -f common.yaml`  for the release-0.9 docs.
So the missing command was added.
**Which issue is resolved by this Pull Request:**
Resolves # na 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]