### PR TITLE
Ceph: set nout only on specific taint. [WIP]

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -415,7 +415,7 @@ func (c *ClusterController) reconcileNodeMaintenance(updatedNode *v1.Node) {
 			}
 			allSchedulable := true
 			for _, node := range nodes {
-				if !k8sutil.GetNodeSchedulable(node) {
+				if !k8sutil.IsNodeMaintenance(node) {
 					allSchedulable = false
 					break
 				}

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -114,8 +114,25 @@ func GetNodeSchedulable(node v1.Node) bool {
 	if node.Spec.Unschedulable {
 		return false
 	}
-	for i := range node.Spec.Taints {
-		if node.Spec.Taints[i].Effect == "NoSchedule" {
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == "NoSchedule" {
+			logger.Debugf("Node %s is unschedulable", node.Labels[v1.LabelHostname])
+			return false
+		}
+	}
+	return true
+}
+
+// IsNodeMaintenance returns true iff the node is tainted with key="rook.io/maintenance" with the NoSchedule effect
+func IsNodeMaintenance(node v1.Node) bool {
+	// some unit tests set this to quickly emulate an unschedulable node; if this is set to true,
+	// we can shortcut deeper inspection for schedulability.
+	if node.Spec.Unschedulable {
+		return false
+	}
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == "NoSchedule" && taint.Key == "rook.io/maintenance" {
 			logger.Debugf("Node %s is unschedulable", node.Labels[v1.LabelHostname])
 			return false
 		}


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Set noout only if the node is tainted with key="rook.io/maintenance" with the NoSchedule effect


**Which issue is resolved by this Pull Request:**
Resolves #3014 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

**TODO:**
- [ ] Only unset noout if rook set it for this reason in the first place.