### PR TITLE
Set mgr daemon name in server_addr config setting path

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -135,7 +135,7 @@ func (c *Cluster) makeSetServerAddrInitContainer(mgrConfig *mgrConfig, mgrModule
 	} else {
 		cfgSetArgs = append(cfgSetArgs, fmt.Sprintf("mgr.%s", mgrConfig.DaemonID))
 	}
-	cfgPath := fmt.Sprintf("mgr/%s/server_addr", mgrModule)
+	cfgPath := fmt.Sprintf("mgr/%s/%s/server_addr", mgrModule, mgrConfig.DaemonID)
 	cfgSetArgs = append(cfgSetArgs, cfgPath, opspec.ContainerEnvVarReference(podIPEnvVar))
 	if c.clusterInfo.CephVersion.IsAtLeastNautilus() {
 		cfgSetArgs = append(cfgSetArgs, "--force")


### PR DESCRIPTION
Fix this issue: https://github.com/rook/rook/issues/1796 ; set mgr Replicas=2 for HA, two mgrs run normally : the active mgr pod accesses metrics normally, the standby mgr pod accesses metrics return empty.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
my test environment:
rook version: master
ceph version: v13
mgr Cluster.Replicas: 2

after my change, ceph config as shown below:
[root@ceph-wangxiao-test1 diamond]# ceph config dump
WHO   MASK LEVEL   OPTION                       VALUE                                                        RO 
  mgr      unknown mgr/dashboard/a/server_addr  10.107.1.232                                                 *  
  mgr      unknown mgr/dashboard/b/server_addr  10.107.1.235                                                 *  
  mgr      unknown mgr/dashboard/password       $2b$12$sGpzA2lnTAXD.n9CFIH2juASKAzJfyKfsCDBfERjq4IjwQB5q/Gim *  
  mgr      unknown mgr/dashboard/server_port    8443                                                         *  
  mgr      unknown mgr/dashboard/ssl            true                                                         *  
  mgr      unknown mgr/dashboard/url_prefix     /ceph-dashboard                                              *  
  mgr      unknown mgr/dashboard/username       admin                                                        *  
  mgr      unknown mgr/prometheus/a/server_addr 10.107.1.232                                                 *  
  mgr      unknown mgr/prometheus/b/server_addr 10.107.1.235                                                 *  

Before my changes, set mgr config:
[root@ceph-wangxiao-test1 diamond]# ceph config set mgr.a mgr/prometheus/server_addr 10.107.1.232 
[root@ceph-wangxiao-test1 diamond]# ceph config set mgr.b mgr/prometheus/server_addr 10.107.1.235 

But get the value of server_addr for each mgr is the same,  as shown below.
[root@ceph-wangxiao-test1 diamond]# ceph config get mgr.a mgr/prometheus/server_addr
10.107.1.235
[root@ceph-wangxiao-test1 diamond]# ceph config get mgr.b mgr/prometheus/server_addr
10.107.1.235

[root@ceph-wangxiao-test1 diamond]# ceph config dump
WHO   MASK LEVEL   OPTION                       VALUE                                                        RO 
  mgr      unknown mgr/dashboard/a/server_addr  10.107.1.232                                                 *  
  mgr      unknown mgr/dashboard/b/server_addr  10.107.1.235                                                 *  
  mgr      unknown mgr/dashboard/password       $2b$12$sGpzA2lnTAXD.n9CFIH2juASKAzJfyKfsCDBfERjq4IjwQB5q/Gim *  
  mgr      unknown mgr/dashboard/server_port    8443                                                         *  
  mgr      unknown mgr/dashboard/ssl            true                                                         *  
  mgr      unknown mgr/dashboard/url_prefix     /ceph-dashboard                                              *  
  mgr      unknown mgr/dashboard/username       admin                                                        *  
  mgr      unknown mgr/prometheus/a/server_addr 10.107.1.232                                                 *  
  mgr      unknown mgr/prometheus/b/server_addr 10.107.1.235                                                 *  
  mgr      unknown mgr/prometheus/server_addr   10.107.1.232                                                 *  
  mgr      unknown mgr/prometheus/server_addr   10.107.1.235          


I have posted all my findings and the solution  on the issue https://github.com/rook/rook/issues/1796 . The main meaning is: Before modification, the server_addr obtained by the two mgrs startup modules is the same (ceph config get mgr.id mgr/<module>/server_addr ), causing one of the two mgrs start modules failed due to IP error; so I change the makeSetServerAddrInitContainer function of pkg/operator/ceph/cluster/mgr/spec.go.  After modification, the two mgrs get the correct server_addr respectively(ceph config get mgr.id mgr/<module>/<mgr.id>/server_addr ), and the two mgrs start normally.

And my changes are also compatible with ceph:v12 ( ceph config-key set mgr/<module>/<mgr.id>/server_addr   <value>  )

For ceph:v12, the mgr config as shown below:
[root@ceph-wangxiao-test1 ~]# ceph config-key dump
{
    "mgr/dashboard/server_addr": "10.107.1.248",
    "mgr/dashboard/server_port": "8443",
    "mgr/dashboard/ssl": "true",
    "mgr/dashboard/url_prefix": "/ceph-dashboard",
    "mgr/prometheus/server_addr": "10.107.1.248"
}
when two mgrs runs, one of two mgrs can get the wrong server_addr. 

So it should be set to look like this：
[root@ceph-wangxiao-test1 ceph]# ceph config-key dump
{
    "mgr/dashboard/a/server_addr": "10.107.1.235",
    "mgr/dashboard/b/server_addr": "10.107.1.248",
    "mgr/dashboard/server_port": "8443",
    "mgr/dashboard/ssl": "true",
    "mgr/dashboard/url_prefix": "/ceph-dashboard",
    "mgr/prometheus/a/server_addr": "10.107.1.235",
    "mgr/prometheus/b/server_addr": "10.107.1.248"
}

**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/rook/rook/issues/1796

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issue
[skip ci]