### PR TITLE
Add missing semicolon to k8-vagrant-multi-node.sh file to fix syntax error

### DIFF
--- a/tests/scripts/k8s-vagrant-multi-node.sh
+++ b/tests/scripts/k8s-vagrant-multi-node.sh
@@ -13,7 +13,7 @@ function init() {
         # checkout latest tag of the repo initially after clone
         git -C "${REPO_DIR}" checkout "$(git describe --tags `git rev-list --tags --max-count=1`)"
     else
-        git -C "${REPO_DIR}" pull || { echo "git pull failed with exit code $?. continuing as the repo is already there ..." }
+        git -C "${REPO_DIR}" pull || { echo "git pull failed with exit code $?. continuing as the repo is already there ..."; }
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: Santosh Pillai sapillai@redhat.com

**Description of your changes:**
"test/scripts/k8-vagrant-multi-node.sh up ceph" was giving syntax error. Removed the braces around OR statement in the git pull command. 

**Which issue is resolved by this Pull Request:**
Resolves #3034

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]