### PR TITLE
Ceph: fix upgrade to Nautilus

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rook/rook/pkg/clusterd"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+)
+
+// CephDaemonsVersions is a structure that can be used to parsed the output of the 'ceph versions' command
+type CephDaemonsVersions struct {
+	Mon     map[string]int `json:"mon,omitempty"`
+	Mgr     map[string]int `json:"mgr,omitempty"`
+	Mds     map[string]int `json:"mds,omitempty"`
+	Overall map[string]int `json:"overall,omitempty"`
+}
+
+func getCephMonVersionString(context *clusterd.Context) (string, error) {
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "version")
+	if err != nil {
+		return "", fmt.Errorf("failed to run ceph version: %+v", err)
+	}
+	logger.Debug(output)
+
+	return output, nil
+}
+
+func getCephVersionsString(context *clusterd.Context) (string, error) {
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "versions")
+	if err != nil {
+		return "", fmt.Errorf("failed to run ceph versions: %+v", err)
+	}
+	logger.Debug(output)
+
+	return output, nil
+}
+
+// GetCephMonVersion reports the Ceph version of all the monitors, or at least a majority with quorum
+func GetCephMonVersion(context *clusterd.Context) (*cephver.CephVersion, error) {
+	output, err := getCephMonVersionString(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run ceph version: %+v", err)
+	}
+	logger.Debug(output)
+
+	v, err := cephver.ExtractCephVersion(output)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract ceph version. %+v", err)
+	}
+
+	return v, nil
+}
+
+// GetCephVersions reports the Ceph version of each daemon in the cluster
+func GetCephVersions(context *clusterd.Context) (*CephDaemonsVersions, error) {
+	output, err := getCephVersionsString(context)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run ceph versions: %+v", err)
+	}
+	logger.Debug(output)
+
+	var cephVersionsResult CephDaemonsVersions
+	err = json.Unmarshal([]byte(output), &cephVersionsResult)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve ceph versions results. %+v", err)
+	}
+
+	return &cephVersionsResult, nil
+}
+
+// EnableMessenger2 enable the messenger 2 protocol on Nautilus clusters
+func EnableMessenger2(context *clusterd.Context) error {
+	_, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "mon", "enable-msgr2")
+	if err != nil {
+		return fmt.Errorf("failed to enable msgr2 protocol: %+v", err)
+	}
+	logger.Infof("successfully enabled msgr2 protocol")
+
+	return nil
+}

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCephMonVersionString(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		assert.Equal(t, "version", args[0])
+		assert.Equal(t, 1, len(args))
+		return "", nil
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	_, err := getCephMonVersionString(context)
+	assert.Nil(t, err)
+}
+
+func TestGetCephMonVersionsString(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		assert.Equal(t, "versions", args[0])
+		assert.Equal(t, 1, len(args))
+		return "", nil
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	_, err := getCephVersionsString(context)
+	assert.Nil(t, err)
+}
+
+func TestEnableMessenger2(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		assert.Equal(t, "mon", args[0])
+		assert.Equal(t, "enable-msgr2", args[1])
+		assert.Equal(t, 2, len(args))
+		return "", nil
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	err := EnableMessenger2(context)
+	assert.Nil(t, err)
+}

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -209,14 +209,8 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
 
 		monPorts := [2]string{strconv.Itoa(int(Msgr2port)), strconv.Itoa(int(currentMonPort))}
-		msgr2Endpoint := net.JoinHostPort(monIP, monPorts[0])
 		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
-
-		if cluster.CephVersion.IsAtLeastNautilus() {
-			monHosts[i] = "[v2:" + msgr2Endpoint + ",v1:" + msgr1Endpoint + "]"
-		} else {
-			monHosts[i] = msgr1Endpoint
-		}
+		monHosts[i] = msgr1Endpoint
 		i++
 	}
 


### PR DESCRIPTION
This commits allows the upgrade from Mimic to Nautilus to work by:

* removing the v2 brackets on the operator ceph config file generation,
we stick with v1 and can revert this back once we deprecate mimic there
is no rush since mons keep on listening to v1.

* enable messengers 2 when the cluster runs on Nautilus

Fixes: https://github.com/rook/rook/issues/2973
Signed-off-by: Sébastien Han <seb@redhat.com>

// known CI issues
[skip ci]