### PR TITLE
minio: add necessary update verb in minio RBAC

### DIFF
--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -33,6 +33,7 @@ rules:
   - get
   - watch
   - create
+  - update
 - apiGroups:
   - apps
   resources:
@@ -40,6 +41,7 @@ rules:
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - minio.rook.io
   resources:


### PR DESCRIPTION
**Description of your changes:** Adds the missing `update` verb to the minio RBAC which is now needed since the minio operator does updates in its reconcile loop

**Which issue is resolved by this Pull Request:**
Resolves #3043 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]