### PR TITLE
ceph: fix upgrade for monitor listening on 6790 port

### DIFF
--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -168,9 +168,14 @@ func (s *Store) createOrUpdateMonHostSecrets(clusterInfo *cephconfig.ClusterInfo
 		msgr2Endpoint := net.JoinHostPort(monIP, monPorts[0])
 		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
 
-		if clusterInfo.CephVersion.IsAtLeastNautilus() {
+		// That's likely a fresh deployment
+		if clusterInfo.CephVersion.IsAtLeastNautilus() && currentMonPort == 6789 {
 			hosts[i] = "[v2:" + msgr2Endpoint + ",v1:" + msgr1Endpoint + "]"
+		} else if clusterInfo.CephVersion.IsAtLeastNautilus() && currentMonPort != 6789 {
+			// That's likely an upgrade from a Rook 0.9.x Mimic deployment
+			hosts[i] = "v1:" + msgr1Endpoint
 		} else {
+			// That's before Nautilus
 			hosts[i] = msgr1Endpoint
 		}
 


### PR DESCRIPTION
This commits fixes the upgrade for cluster running on 0.9.x and thus
have monitors listening on 6790.

The only downside is that the new messengers 2 protocol can not be
enabled because Ceph expects monitors to listen on 6789.
In order to enable messengers 2 your monitors will have to failover so
they can pick up both 6789 and 3300 ports, then and only then messenger
2 can be enabled.

Fixes: https://github.com/rook/rook/issues/3048 and
https://github.com/rook/rook/issues/3049
Signed-off-by: Sébastien Han <seb@redhat.com>