### PR TITLE
Promote builds to master and release rather than alpha, beta, and stable

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -38,34 +38,19 @@ After the helm chart is installed, you will need to [create a Rook cluster](ceph
 
 The `helm install` command deploys rook on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation. It is recommended that the rook operator be installed into the `rook-ceph` namespace (you will install your clusters into separate namespaces).
 
-Rook currently publishes builds of the Ceph operator to the `stable`, `beta`, `alpha`, and `master` channels.
+Rook currently publishes builds of the Ceph operator to the `release` and `master` channels.
 
-### Stable
-The stable channel is the most recent release of Rook that is considered stable for the community, starting with the v0.9 release.
-
-```console
-helm repo add rook-stable https://charts.rook.io/stable
-helm install --namespace rook-ceph rook-stable/rook-ceph
-```
-
-### Beta
-The beta channel is the most recent release of Rook that is considered nearly stable for the community, starting with the v0.8 release.
+### Release
+The release channel is the most recent release of Rook that is considered stable for the community.
 
 ```console
-helm repo add rook-beta https://charts.rook.io/beta
-helm install --namespace rook-ceph rook-beta/rook-ceph
-```
-
-### Alpha
-The alpha channel is the most recent release of Rook that is considered ready for testing by the community.
-
-```console
-helm repo add rook-alpha https://charts.rook.io/alpha
-helm install --namespace rook-ceph rook-alpha/rook-ceph
+helm repo add rook-release https://charts.rook.io/release
+helm install --namespace rook-ceph rook-release/rook-ceph
 ```
 
 ### Master
-The master channel includes the latest commits, with all automated tests green. Historically it has been very stable, though there is no guarantee.
+The master channel includes the latest commits, with all automated tests green. Historically it has been very stable, though it is only recommended for testing.
+The critical point to consider is that upgrades are not supported to or from master builds.
 
 To install the helm chart from master, you will need to pass the specific version returned by the `search` command.
 ```console
@@ -135,14 +120,14 @@ You can pass the settings with helm command line parameters. Specify each parame
 `--set key=value[,key=value]` argument to `helm install`. For example, the following command will install rook where RBAC is not enabled.
 
 ```console
-$ helm install --namespace rook-ceph --name rook-ceph rook-stable/rook-ceph --set rbacEnable=false
+$ helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph --set rbacEnable=false
 ```
 
 ### Settings File
 Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while installing the chart.
 
 ```console
-$ helm install --namespace rook-ceph --name rook-ceph rook-stable/rook-ceph -f values.yaml
+$ helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph -f values.yaml
 ```
 
 Here are the sample settings to get you started.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -41,6 +41,8 @@
 - Rook no longer supports Kubernetes `1.8` and `1.9`.
 - Rook no longer supports running more than one monitor on the same node when `hostNetwork` and `allowMultiplePerNode` are `true`.
 - Rook Operator switches from Extensions v1beta1 to use Apps v1 API for DaemonSet and Deployment.
+- The build process no longer publishes the alpha, beta, and stable channels. The only channels published are `master` and `release`.
+The stability of storage providers is determined by the CRD versions rather than the overall product build, thus the channels were renamed to match this expectation.
 
 ### Ceph
 

--- a/build/release/Jenkinsfile.promote
+++ b/build/release/Jenkinsfile.promote
@@ -9,8 +9,8 @@ pipeline {
     }
 
     parameters {
-        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example, v0.5.0')
-        string(name: 'channel', defaultValue: 'alpha', description: 'The channel, for example, alpha.')
+        string(name: 'version', defaultValue: '', description: 'The version you are releasing, for example, v1.0.0')
+        string(name: 'channel', defaultValue: 'release', description: 'Only the release channel is supported.')
     }
 
     stages {

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -21,7 +21,7 @@ include ../makelib/helm.mk
 # Options
 
 CHANNEL ?= master
-ifeq ($(filter master alpha beta stable,$(CHANNEL)),)
+ifeq ($(filter master release,$(CHANNEL)),)
 $(error invalid channel $(CHANNEL))
 endif
 
@@ -131,7 +131,7 @@ HELM_TEMP := $(shell mktemp -d)
 HELM_URL := $(HELM_BASE_URL)/$(CHANNEL)
 
 promote.helm: $(HELM)
-#	copy existing charts to a temp dir, the combine with new charts, reindex, and upload
+#	copy existing charts to a temp dir, then combine with new charts, reindex, and upload
 	@$(S3_SYNC) s3://$(HELM_S3_BUCKET)/$(CHANNEL) $(HELM_TEMP)
 	@$(S3_SYNC) s3://$(S3_BUCKET)/build/$(BRANCH_NAME)/$(VERSION)/charts $(HELM_TEMP)
 	@$(HELM) repo index --url $(HELM_URL) $(HELM_TEMP)
@@ -205,7 +205,7 @@ help:
 	@echo '    VERSION      Sets the release version.'
 	@echo '    BRANCH_NAME  Name of the branch we're releasing from.'
 	@echo '    CHANNEL      Sets the release channel. Can be set to master,'
-	@echo '                 alpha, beta, or stable. Default is not set.'
+	@echo '                 or release. Default is not set.'
 	@echo '    PLATFORMS    The supported platforms to build when running.'
 	@echo '                 the build.all target. The default is'
 	@echo '                 all supported platforms'

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -7,7 +7,7 @@ At a high level the release workflow is as follows:
 1. Jenkins CI will build, publish and test every commit from master
 2. Integration testing happens on a build that is a candidate for release.
 3. If all goes well we tag the release and create a new release branch if needed.
-4. Depending on the stability and feedback from the field, we might promote the build to beta and stable channels.
+4. Each release build will be promoted to the release channel.
 
 Jenkins has all the jobs to do the release -- there is no need to perform any of the release tasks on a build/dev machine.
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The `alpha`, `beta`, and `stable` channels do not match the rook release process. Each storage provider defines their own stability based on the CRDs rather than defining it with the release process. Rook really only has two release streams: master and the official releases. Master is published with each merge, while releases go through a signoff process to ensure quality. Thus, the `alpha`, `beta`, and `stable` channels are removed and replaced with a single `release` channel. See [the detailed notes on this change](https://github.com/rook/rook/issues/1885#issuecomment-460444455).

The `release` channel is only used for promoting the helm chart. The docker images do not receive a channel tag so the versioning can be controlled very carefully for the stateful upgrades.

@bassam @jbw976 PTAL

**Which issue is resolved by this Pull Request:**
Resolves #1885

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)
