### PR TITLE
ceph-op: Remove taint check in "is node scheduable" func

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -195,8 +195,12 @@ func (c *ClusterController) onK8sNodeAdd(obj interface{}) {
 	}
 
 	for _, cluster := range c.clusterMap {
+		if k8sutil.NodeIsTolerable(*newNode, cephv1.GetOSDPlacement(cluster.Spec.Placement).Tolerations, false) == false {
+			logger.Debugf("Skipping -> Node is not tolerable for cluster %s", cluster.Namespace)
+			continue
+		}
 		if cluster.Spec.Storage.UseAllNodes == false {
-			logger.Debugf("Skipping -> Do not use all Nodes")
+			logger.Debugf("Skipping -> Do not use all Nodes in cluster %s", cluster.Namespace)
 			continue
 		}
 		if cluster.Info == nil {

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -114,12 +114,6 @@ func GetNodeSchedulable(node v1.Node) bool {
 	if node.Spec.Unschedulable {
 		return false
 	}
-	for i := range node.Spec.Taints {
-		if node.Spec.Taints[i].Effect == "NoSchedule" {
-			logger.Debugf("Node %s is unschedulable", node.Labels[v1.LabelHostname])
-			return false
-		}
-	}
 	return true
 }
 


### PR DESCRIPTION
**Description of your changes:**

This removes the unnecessary check for taints on nodes in the
`GetNodeSchedulable()` function. This fixes that even though the user
has specified `tolerations` for, e.g., `NoSchedule` taints, that would
be ignored and the node(s) directly be "marked" as unschedulable.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #3050.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci] Added due to known CI issues