### PR TITLE
Ceph: Stop disabling scrubbing during osd orchestration

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -148,38 +148,6 @@ func OSDRemove(context *clusterd.Context, clusterName string, osdID int) (string
 	return string(buf), err
 }
 
-func DisableScrubbing(context *clusterd.Context, clusterName string) (string, error) {
-	args := []string{"osd", "set", "noscrub"}
-	buf, err := ExecuteCephCommand(context, clusterName, args)
-	if err != nil {
-		return string(buf), fmt.Errorf("failed to set noscrub: %+v", err)
-	}
-
-	args = []string{"osd", "set", "nodeep-scrub"}
-	buf, err = ExecuteCephCommand(context, clusterName, args)
-	if err != nil {
-		return string(buf), fmt.Errorf("failed to set nodeep-scrub: %+v", err)
-	}
-
-	return string(buf), nil
-}
-
-func EnableScrubbing(context *clusterd.Context, clusterName string) (string, error) {
-	args := []string{"osd", "unset", "noscrub"}
-	buf, err := ExecuteCephCommand(context, clusterName, args)
-	if err != nil {
-		return string(buf), fmt.Errorf("failed to unset noscrub: %+v", err)
-	}
-
-	args = []string{"osd", "unset", "nodeep-scrub"}
-	buf, err = ExecuteCephCommand(context, clusterName, args)
-	if err != nil {
-		return string(buf), fmt.Errorf("failed to unset nodeep-scrub: %+v", err)
-	}
-
-	return string(buf), nil
-}
-
 func (usage *OSDUsage) ByID(osdID int) *OSDNodeUsage {
 	for i := range usage.OSDNodes {
 		if usage.OSDNodes[i].ID == osdID {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -142,16 +142,6 @@ func (c *Cluster) Start() error {
 		logger.Warningf("useAllNodes is set to false and no nodes are specified, no OSD pods are going to be created")
 	}
 
-	// disable scrubbing during orchestration and ensure it gets enabled again afterwards
-	if o, err := client.DisableScrubbing(c.context, c.Namespace); err != nil {
-		logger.Warningf("failed to disable scrubbing: %+v. %s", err, o)
-	}
-	defer func() {
-		if o, err := client.EnableScrubbing(c.context, c.Namespace); err != nil {
-			logger.Warningf("failed to enable scrubbing: %+v. %s", err, o)
-		}
-	}()
-
 	if c.DesiredStorage.UseAllNodes {
 		// resolve all storage nodes
 		c.DesiredStorage.Nodes = nil


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Setting `noscrub` during osd orchestration raises ceph health warnings since the feature is disabled. Users of the ceph dashboard are seeing this more often as the operator is triggering the orchestration more often when adding nodes or devices. Per @liewegas the `noscrub` really doesn't need to be set by rook. 

**Which issue is resolved by this Pull Request:**
Resolves #1703 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

// known CI issue
[skip ci]