### PR TITLE
ceph: check for equiv device config maps in operator

### DIFF
--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -193,7 +193,7 @@ func udevBlockMonitor(c chan string, period time.Duration) {
 	}
 }
 
-func deviceListsEqual(a, b string) (bool, error) {
+func DeviceListsEqual(a, b string) (bool, error) {
 	var d0 []sys.LocalDisk
 	var d1 []sys.LocalDisk
 
@@ -264,7 +264,7 @@ func updateDeviceCM(context *clusterd.Context) error {
 		}
 		lastDevice = deviceStr
 	}
-	devicesEqual, err := deviceListsEqual(deviceStr, lastDevice)
+	devicesEqual, err := DeviceListsEqual(deviceStr, lastDevice)
 	if err != nil {
 		return fmt.Errorf("failed to compare device lists: %v", err)
 	}


### PR DESCRIPTION
Description of your changes:

this is an attempt to reduce the number of false positive config map
updates used to trigger orchestration for hotpluggin

Which issue is resolved by this Pull Request: Resolves #3029

// known CI issues
[skip ci]