### PR TITLE
ceph: skip orchestration when cluster is not yet configured

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -567,6 +567,10 @@ func (c *ClusterController) onDeviceCMUpdate(oldObj, newObj interface{}) {
 	}
 
 	for _, cluster := range c.clusterMap {
+		if cluster.Info == nil {
+			logger.Info("Cluster %s is not ready. Skipping orchestration on device change", cluster.Namespace)
+			continue
+		}
 		logger.Infof("Running orchestration for namespace %s after device change", cluster.Namespace)
 		err := cluster.createInstance(c.rookImage, cluster.Info.CephVersion)
 		if err != nil {


### PR DESCRIPTION
**Description of your changes:**

this skips orchestration when the device configmap receives an update
but the cluster hasn't been fully configured, which may leave some state
undefined and cause nil pointer dereferences accessing the cluster info
structure.

**Which issue is resolved by this Pull Request:**
Resolves #3001
