### PR TITLE
Add lvm2 package to pre-reqs in docs

### DIFF
--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -33,6 +33,18 @@ Normally, on Linux, kernel modules can be found in `/lib/modules`. However, ther
 
 On certain distributions it may be necessary to mount additional directories into the agent container. That is what the environment variable `AGENT_MOUNTS` is for. Also see the documentation in [helm-operator](helm-operator.md) on the parameter `agent.mounts`. The format of the variable content should be `mountname1=/host/path1:/container/path1,mountname2=/host/path2:/container/path2`.
 
+## LVM package
+
+Some Linux distributions do not ship with the `lvm2` package. This package is required on all storage nodes in your k8s cluster. Please install it using your Linux distribution's package manager; for example:
+
+```Bash
+# Centos
+sudo yum install -y lvm2
+
+# Ubuntu
+sudo apt-get install -y lvm2
+```
+
 ## Bootstrapping Kubernetes
 
 Rook will run wherever Kubernetes is running. Here are some simple environments to help you get started with Rook.


### PR DESCRIPTION
**Description**

As discussed in Issue 2591 (https://github.com/rook/rook/issues/2591) the lvm2 package may be missing from some Linux distributions, this documentation update alerts the user to this pre-req.

**Resolves**
[Issue 2591](https://github.com/rook/rook/issues/2591)


Signed-off-by: Sachin Agarwal <sachinkagarwal@gmail.com>

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

@travisn - as discussed on Slack

[skip ci]