### PR TITLE
Allow configuration of two Ceph mgr daemons

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -32,6 +32,10 @@ spec:
   mon:
     count: 3
     allowMultiplePerNode: false
+  # set the amount of mgrs to be started, the maximum number of mgr.count is 2
+  mgr:
+    count: 2
+    allowMultiplePerNode: false
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -72,6 +72,9 @@ type ClusterSpec struct {
 	// A spec for mon related options
 	Mon MonSpec `json:"mon"`
 
+	// A spec for mgr related options
+	Mgr MgrSpec `json:"mgr"`
+
 	// A spec for rbd mirroring
 	RBDMirroring RBDMirroringSpec `json:"rbdMirroring"`
 
@@ -129,6 +132,12 @@ const (
 )
 
 type MonSpec struct {
+	Count                int  `json:"count"`
+	PreferredCount       int  `json:"preferredCount"`
+	AllowMultiplePerNode bool `json:"allowMultiplePerNode"`
+}
+
+type MgrSpec struct {
 	Count                int  `json:"count"`
 	PreferredCount       int  `json:"preferredCount"`
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode"`

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -203,7 +203,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 
 	mgrs := mgr.New(c.Info, c.context, c.Namespace, rookImage,
 		spec.CephVersion, cephv1.GetMgrPlacement(spec.Placement), cephv1.GetMgrAnnotations(c.Spec.Annotations),
-		spec.Network.HostNetwork, spec.Dashboard, cephv1.GetMgrResources(spec.Resources), c.ownerRef, c.Spec.DataDirHostPath)
+		spec.Network.HostNetwork, spec.Mgr.Count, spec.Mgr.AllowMultiplePerNode, spec.Dashboard, cephv1.GetMgrResources(spec.Resources), c.ownerRef, c.Spec.DataDirHostPath)
 	err = mgrs.Start()
 	if err != nil {
 		return fmt.Errorf("failed to start the ceph mgr. %+v", err)

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -62,6 +62,8 @@ func TestStartMGR(t *testing.T) {
 		rookalpha.Placement{},
 		rookalpha.Annotations{},
 		false,
+		1,
+		false,
 		cephv1.DashboardSpec{Enabled: true},
 		v1.ResourceRequirements{},
 		metav1.OwnerReference{},

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -43,6 +43,8 @@ func TestPodSpec(t *testing.T) {
 		rookalpha.Placement{},
 		rookalpha.Annotations{},
 		false,
+		1,
+		false,
 		cephv1.DashboardSpec{},
 		v1.ResourceRequirements{
 			Limits: v1.ResourceList{
@@ -91,6 +93,8 @@ func TestServiceSpec(t *testing.T) {
 		rookalpha.Placement{},
 		rookalpha.Annotations{},
 		false,
+		1,
+		false,
 		cephv1.DashboardSpec{},
 		v1.ResourceRequirements{},
 		metav1.OwnerReference{},
@@ -114,6 +118,8 @@ func TestHostNetwork(t *testing.T) {
 		rookalpha.Placement{},
 		rookalpha.Annotations{},
 		true,
+		1,
+		false,
 		cephv1.DashboardSpec{},
 		v1.ResourceRequirements{},
 		metav1.OwnerReference{},


### PR DESCRIPTION
base on this PR: https://github.com/rook/rook/pull/3028 , configure mgr in CephCluster spec.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Base on this PR: https://github.com/rook/rook/pull/3028,  add the configuration of mgr to the CephCluster spec. Then, user can set the number of deployments of the mgr in the CephCluster spec. 

**Which issue is resolved by this Pull Request:**
Resolves # 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)