### PR TITLE
No longer generate "release" docker tag during release build promotion

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -160,16 +160,14 @@ build.image.$(1).$(2).$(3):
 build.all.images: build.image.$(1).$(2).$(3)
 publish.image.$(1).$(2).$(3): ; @docker push $(1)/$(2)-$(3):$(VERSION)
 publish.all.images: publish.image.$(1).$(2).$(3)
+# tag the master image, but do not tag the release image with a generic channel tag
 promote.image.$(1).$(2).$(3):
 	@docker pull $(1)/$(2)-$(3):$(VERSION)
-	@[ "$(CHANNEL)" = "master" ] || docker tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
 	@docker tag $(1)/$(2)-$(3):$(VERSION) $(1)/$(2)-$(3):$(CHANNEL)
-	@[ "$(CHANNEL)" = "master" ] || docker push $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
-	@docker push $(1)/$(2)-$(3):$(CHANNEL)
+	@[ "$(CHANNEL)" = "release" ] || docker push $(1)/$(2)-$(3):$(CHANNEL)
 promote.all.images: promote.image.$(1).$(2).$(3)
 clean.image.$(1).$(2).$(3):
 	@[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(VERSION))" ] || docker rmi $(1)/$(2)-$(3):$(VERSION)
-	@[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL))" ] || docker rmi $(1)/$(2)-$(3):$(VERSION)-$(CHANNEL)
 	@[ -z "$$$$(docker images -q $(1)/$(2)-$(3):$(CHANNEL))" ] || docker rmi $(1)/$(2)-$(3):$(CHANNEL)
 clean.all.images: clean.image.$(1).$(2).$(3)
 endef
@@ -178,9 +176,9 @@ $(foreach r,$(REGISTRIES), $(foreach i,$(IMAGES), $(foreach a,$(IMAGE_ARCHS),$(e
 publish.manifest.image.%: publish.all.images $(MANIFEST_TOOL)
 	@$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(VERSION)
 
+# add the "master" tag to the master image, but do not add the "release" tag for the release channel
 promote.manifest.image.%: promote.all.images $(MANIFEST_TOOL)
-	@[ "$(CHANNEL)" = "master" ] || $(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(VERSION)-$(CHANNEL)
-	@$(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(CHANNEL)
+	@[ "$(CHANNEL)" = "release" ] || $(MANIFEST_TOOL) push from-args --platforms $(IMAGE_PLATFORMS) --template $(DOCKER_REGISTRY)/$*-ARCH:$(VERSION) --target $(DOCKER_REGISTRY)/$*:$(CHANNEL)
 
 build.images: build.all.images
 publish.images: $(addprefix publish.manifest.image.,$(IMAGES))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
To support upgrades, the operator relies on a changing tag between versions so that when a pod spec is updated, k8s will restart the pod due to the new image name. If the image name does not change, the operator cannot control the upgrade deployment. Therefore, we do not support a generic docker tag such as `rook/ceph:release`. For production we expect specific version tags to be specified in the operator such as `rook/ceph:v1.0.0`.

If someone desires to deploy the latest release build, the expectation is that they will sync the latest manifests in the release branch, then deploy. The release branch always has the latest release tags (ie. `rook/ceph:v1.0.0`) in the manifests so the user doesn't have to think about which one to deploy. 

Rook does not have a scenario where a generic `release` tag on the docker images is useful or supported. For testing, users can use the `master` tag. For production, users should use the specific version tags in order to support upgrade.

The master build is tagged with a generic tag for convenience of testing the latest builds, but it is important to note that upgrades are not supported between master builds.

This PR assumes the changes in #3061 where the release channels are renamed.

**Which issue is resolved by this Pull Request:**
Resolves #1885 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md#comments)

[skip ci]