### PR TITLE
Ceph Flex driver: properly configure SELinuxRelabeling and FSGroup settings

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -36,6 +36,7 @@
   Jobs, and StatefulSets. These identify the Rook version which last modified the resource and the
   Ceph version which Rook has detected in the pod(s) being run by the resource.
 - OSDs provisioned by `ceph-volume` now supports `metadataDevice` and `databaseSizeMB` options.
+- The flex driver can be configured to properly disable SELinux relabeling and FSGroup with the settings in operator.yaml.
 
 ## Breaking Changes
 

--- a/cmd/rookflex/cmd/init.go
+++ b/cmd/rookflex/cmd/init.go
@@ -51,9 +51,9 @@ func initPlugin(cmd *cobra.Command, args []string) error {
 		rookEnableFSGroup = true
 	}
 
-	status := DriverStatus{
+	status := flexvolume.DriverStatus{
 		Status: flexvolume.StatusSuccess,
-		Capabilities: &DriverCapabilities{
+		Capabilities: &flexvolume.DriverCapabilities{
 			Attach: false,
 			// Required for any mount performed on a host running selinux
 			SELinuxRelabel: rookEnableSelinuxRelabeling,
@@ -65,36 +65,4 @@ func initPlugin(cmd *cobra.Command, args []string) error {
 	}
 	os.Exit(0)
 	return nil
-}
-
-// FIX: After we move to the k8s 1.13 dependencies, we can remove this type
-// and reference the type in k8s.io/kubernetes/pkg/volume/flexvolume/driver-call.go
-type DriverStatus struct {
-	// Status of the callout. One of "Success", "Failure" or "Not supported".
-	Status string `json:"status"`
-	// Reason for success/failure.
-	Message string `json:"message,omitempty"`
-	// Path to the device attached. This field is valid only for attach calls.
-	// ie: /dev/sdx
-	DevicePath string `json:"device,omitempty"`
-	// Cluster wide unique name of the volume.
-	VolumeName string `json:"volumeName,omitempty"`
-	// Represents volume is attached on the node
-	Attached bool `json:"attached,omitempty"`
-	// Returns capabilities of the driver.
-	// By default we assume all the capabilities are supported.
-	// If the plugin does not support a capability, it can return false for that capability.
-	Capabilities *DriverCapabilities `json:",omitempty"`
-	// Returns the actual size of the volume after resizing is done, the size is in bytes.
-	ActualVolumeSize int64 `json:"volumeNewSize,omitempty"`
-}
-
-// FIX: After we move to the k8s 1.13 dependencies, we can remove this type
-// and reference the type in k8s.io/kubernetes/pkg/volume/flexvolume/driver-call.go
-type DriverCapabilities struct {
-	Attach           bool `json:"attach"`
-	SELinuxRelabel   bool `json:"selinuxRelabel"`
-	SupportsMetrics  bool `json:"supportsMetrics"`
-	FSGroup          bool `json:"fsGroup"`
-	RequiresFSResize bool `json:"requiresFSResize"`
 }

--- a/pkg/operator/ceph/provisioner/provisioner_test.go
+++ b/pkg/operator/ceph/provisioner/provisioner_test.go
@@ -41,7 +41,7 @@ func TestProvisionImage(t *testing.T) {
 	clientset := test.New(3)
 	namespace := "ns"
 	configDir, _ := ioutil.TempDir("", "")
-	os.Setenv("POD_NAMESPACE", "rook-system")
+	os.Setenv("POD_NAMESPACE", "rook-ceph")
 	defer os.Setenv("POD_NAMESPACE", "")
 	defer os.RemoveAll(configDir)
 	executor := &exectest.MockExecutor{
@@ -78,7 +78,7 @@ func TestProvisionImage(t *testing.T) {
 	assert.Equal(t, "pvc-uid-1-1", pv.Name)
 	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
 	assert.Equal(t, v1.PersistentVolumeReclaimRetain, pv.Spec.PersistentVolumeReclaimPolicy)
-	assert.Equal(t, "foo.io/rook", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
+	assert.Equal(t, "foo.io/rook-ceph", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
 	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
 	assert.Equal(t, "testCluster", pv.Spec.PersistentVolumeSource.FlexVolume.Options["clusterNamespace"])
 	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])
@@ -94,7 +94,7 @@ func TestProvisionImage(t *testing.T) {
 	assert.Equal(t, "pvc-uid-1-1", pv.Name)
 	assert.NotNil(t, pv.Spec.PersistentVolumeSource.FlexVolume)
 	assert.Equal(t, v1.PersistentVolumeReclaimRecycle, pv.Spec.PersistentVolumeReclaimPolicy)
-	assert.Equal(t, "foo.io/rook", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
+	assert.Equal(t, "foo.io/rook-ceph", pv.Spec.PersistentVolumeSource.FlexVolume.Driver)
 	assert.Equal(t, "ext3", pv.Spec.PersistentVolumeSource.FlexVolume.FSType)
 	assert.Equal(t, "testCluster", pv.Spec.PersistentVolumeSource.FlexVolume.Options["clusterNamespace"])
 	assert.Equal(t, "class-1", pv.Spec.PersistentVolumeSource.FlexVolume.Options["storageClass"])


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The settings for `ROOK_ENABLE_SELINUX_RELABELING` and `ROOK_ENABLE_FSGROUP` have been ignored since `v0.9.3`. The flex settings cannot be passed to the driver with environment variables. There is no context available for returning the flex settings except that the flex driver can look in a config file in the same directory. When the flex driver is copied to the flex directory, the settings will also be written in a "flex.config" file in the same directory. The flex driver will look in its current directory for these settings. If there is an error loading the file, the default settings will be used.

At the same time, the second commit will remove obsolete version checks for unsupported versions of K8s. The flex driver no longer needs to check whether a kubelet restart is needed, whether the namespace-specific driver can be supported, and a copy of k8s 1.13 client types can be removed since we have updated to a newer k8s client.

**Which issue is resolved by this Pull Request:**
Resolves #2892 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]