### PR TITLE
Add optional containers count for restore/zap option

### DIFF
--- a/Documentation/edgefs-cluster-crd.md
+++ b/Documentation/edgefs-cluster-crd.md
@@ -79,7 +79,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
 - `devicesResurrectMode`: When enabled, this mode attempts to recreate cluster based on previous CRD definition. If this flag set to one of the parameters, then operator will only adjust networking. Often used when clean up of old devices is needed. Only applicable when used with `dataDirHostPath`.
   - `restore`: Attempt to restart and restore previously enabled cluster CRD.
   - `restoreZap`: Attempt to re-initialize previously selected `devices` prior to restore. By default cluster assumes that selected devices have no logical partitions and considered empty.
-  - `restoreZapWait`: Attempt to cleanup previously selected `devices` and wait for cluster delete. This is useful when clean up of old devices is needed.
+  - `restoreZapWait`: Attempt to cleanup previously selected `devices` and wait for cluster delete. This is useful when clean up of old devices is needed. Additional containers count should be specified if cluster was originally created with a total per-node capacity that exceeding `maxContainerCapacity` option, e.g., `devicesResurrectMode: "restoreZapWait: 2"`.
 - `serviceAccount`: The service account under which the EdgeFS pods will run that will give access to ConfigMaps in the cluster's namespace. If not set, the default of `rook-edgefs-cluster` will be used.
 - `chunkCacheSize`: Limit amount of memory allocated for dynamic chunk cache. By default Target pod uses up to 75% of available memory as chunk caching area. This option can influence this allocation strategy.
 - `placement`: [placement configuration settings](#placement-configuration-settings)

--- a/pkg/apis/edgefs.rook.io/v1beta1/cluster.go
+++ b/pkg/apis/edgefs.rook.io/v1beta1/cluster.go
@@ -41,4 +41,5 @@ type DevicesResurrectOptions struct {
 	NeedToResurrect bool
 	NeedToZap       bool
 	NeedToWait      bool
+	SlaveContainers int
 }

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -404,8 +404,16 @@ func (c *Cluster) createPodSpec(rookImage string, dro edgefsv1beta1.DevicesResur
 			if devConfig.IsGatewayNode {
 				continue
 			}
+
+			rtrdContainersCount := 0
 			if len(devConfig.RtrdSlaves) > 0 {
-				for i := range devConfig.RtrdSlaves {
+				rtrdContainersCount = len(devConfig.RtrdSlaves)
+			} else {
+				rtrdContainersCount = dro.SlaveContainers
+			}
+
+			if rtrdContainersCount > 0 {
+				for i := 0; i < rtrdContainersCount; i++ {
 					if dro.NeedToZap {
 						initContainers = append(initContainers, c.makeDaemonContainer(rookImage, dro, true, i+1))
 					}

--- a/tests/framework/installer/edgefs_manifest.go
+++ b/tests/framework/installer/edgefs_manifest.go
@@ -315,6 +315,7 @@ metadata:
 spec:
   edgefsImageName: edgefs/edgefs:latest   # specify version here, i.e. edgefs/edgefs:1.0.0 etc
   serviceAccount: rook-edgefs-cluster
+  skipHostPrepare: true
   dataDirHostPath: /var/lib/edgefs
   storage: # cluster level storage configuration and selection
     useAllNodes: true


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>

**Description of your changes:**
Add optional container count parameter into devicesResurrectMode cluster CRD option
**Which issue is resolved by this Pull Request:**
Resolves #3087

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
