### PR TITLE
ceph: Delete and recreate rook-ceph-detect-version job

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -119,7 +119,7 @@ func (c *cluster) detectCephVersion(image string, timeout time.Duration) (*cephv
 	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
 
 	// run the job to detect the version
-	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job); err != nil {
+	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job, true); err != nil {
 		return nil, fmt.Errorf("failed to start version job. %+v", err)
 	}
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -256,7 +256,7 @@ func (c *Cluster) startProvisioning(config *provisionConfig) {
 }
 
 func (c *Cluster) runJob(job *batch.Job, nodeName string, config *provisionConfig, action string) bool {
-	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job); err != nil {
+	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job, false); err != nil {
 		if !errors.IsAlreadyExists(err) {
 			// we failed to create job, update the orchestration status for this node
 			message := fmt.Sprintf("failed to create %s job for node %s. %+v", action, nodeName, err)

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -173,7 +173,7 @@ func (c *CephNFSController) runGaneshaRadosGraceJob(n cephv1.CephNFS, name, acti
 	k8sutil.SetOwnerRef(c.context.Clientset, n.Namespace, &job.ObjectMeta, &c.ownerRef)
 
 	// run the job to detect the version
-	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job); err != nil {
+	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job, false); err != nil {
 		return fmt.Errorf("failed to start job %s. %+v", job.Name, err)
 	}
 


### PR DESCRIPTION
The ceph controller will delete and recreate the detect-version job, when
an already existing job is found. This helps avoid cluster creation from
getting hung up on waiting for an already existing/stale job to finish.

Fixes #3081.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]