### PR TITLE
Ceph: Update tests and examples to Nautilus 14.2.1

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -23,7 +23,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -221,7 +221,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -253,7 +253,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -296,7 +296,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -333,7 +333,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -379,7 +379,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -417,7 +417,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -70,7 +70,7 @@ metadata:
 spec:
   cephVersion:
     # For the latest ceph images, see https://hub.docker.com/r/ceph/ceph/tags
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -283,7 +283,7 @@ These images are tagged in a few ways:
 The majority of the upgrade will be handled by the Rook operator. Begin the upgrade by changing the
 Ceph image field in the cluster CRD (`spec:cephVersion:image`).
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v14.2.0-20190410'
+NEW_CEPH_IMAGE='ceph/ceph:v14.2.1-20190430'
 CLUSTER_NAME="$ROOK_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge \
   -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
@@ -296,9 +296,9 @@ version has fully updated is rather simple.
 watch kubectl -n $ROOK_NAMESPACE describe pods | grep "Image:.*ceph/ceph" | sort | uniq
 # This cluster is not yet finished:
 #      Image:         ceph/ceph:v13.2.2-20181023
-#      Image:         ceph/ceph:v14.2.0-20190410
+#      Image:         ceph/ceph:v14.2.1-20190430
 # This cluster is also finished:
-#      Image:         ceph/ceph:v14.2.0-20190410
+#      Image:         ceph/ceph:v14.2.1-20190430
 ```
 
 #### 3. Enable Nautilus features

--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
     allowUnsupported: true
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/ceph:v14.2.0-20190410
+    image: ceph/ceph:v14.2.1-20190430
     # Whether to allow unsupported versions of Ceph. Currently luminous, mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Do not set to true in production.
     allowUnsupported: false

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -44,7 +44,7 @@ const (
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14.2.0-20190319"
+	nautilusTestImage = "ceph/ceph:v14.2.1-20190430"
 	helmChartName     = "local/rook-ceph"
 	helmDeployName    = "rook-ceph"
 )


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the nautilus 14.2.1 image now generated in the `ceph/ceph` dockerhub, we can update the latest examples that rook is using.

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]