### PR TITLE
Read node labels for provider topology

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -71,7 +71,9 @@ For more details on the mons and when to choose a number other than `3`, see the
 - `resources`: [resources configuration settings](#cluster-wide-resources-configuration-settings)
 - `storage`: Storage selection and configuration that will be used across the cluster.  Note that these settings can be overridden for specific nodes.
   - `useAllNodes`: `true` or `false`, indicating if all nodes in the cluster should be used for storage according to the cluster level storage selection and configuration values.
-  If individual nodes are specified under the `nodes` field below, then `useAllNodes` must be set to `false`.
+  If individual nodes are specified under the `nodes` field, then `useAllNodes` must be set to `false`.
+  - `topologyAware`: `true` or `false`, indicating whether Rook will look for and use topology/failure domain labels on Kubernetes nodes (e.g. "region" or "zone") as part of the CRUSH location for OSDs.
+  Node labels must follow the formatting of the failure domain [well-known labels](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/).
   - `nodes`: Names of individual nodes in the cluster that should have their storage included in accordance with either the cluster level configuration specified above or any node specific overrides described in the next section below.
   `useAllNodes` must be set to `false` to use specific nodes and their config.
   See [node settings](#node-settings) below.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,7 +4,9 @@
 
 ## Notable Features
 
-### <Storage Provider>
+### Ceph
+
+- Rook can now be configured to read "region" and "zone" labels on Kubernetes nodes and use that information as part of the CRUSH location for the OSDs.
 
 ## Breaking Changes
 

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -27,11 +27,12 @@ import (
 // ************************************************************************************
 
 type StorageScopeSpec struct {
-	Nodes       []Node            `json:"nodes,omitempty"`
-	UseAllNodes bool              `json:"useAllNodes,omitempty"`
-	NodeCount   int               `json:"nodeCount,omitempty"`
-	Location    string            `json:"location,omitempty"`
-	Config      map[string]string `json:"config"`
+	Nodes         []Node            `json:"nodes,omitempty"`
+	UseAllNodes   bool              `json:"useAllNodes,omitempty"`
+	TopologyAware bool              `json:"topologyAware,omitempty"`
+	NodeCount     int               `json:"nodeCount,omitempty"`
+	Location      string            `json:"location,omitempty"`
+	Config        map[string]string `json:"config"`
 	Selection
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -157,7 +157,7 @@ func (c *Cluster) Start() error {
 		logger.Debugf("storage nodes: %+v", c.DesiredStorage.Nodes)
 	}
 	// generally speaking, this finds nodes which are capable of running new osds
-	validNodes := k8sutil.GetValidNodes(c.DesiredStorage.Nodes, c.context.Clientset, c.placement)
+	validNodes := k8sutil.GetValidNodes(c.DesiredStorage, c.context.Clientset, c.placement)
 
 	// no valid node is ready to run an osd
 	if len(validNodes) == 0 {

--- a/pkg/operator/edgefs/cluster/utils.go
+++ b/pkg/operator/edgefs/cluster/utils.go
@@ -93,7 +93,7 @@ func (c *cluster) getClusterNodes() ([]rookalpha.Node, error) {
 			c.Spec.Storage.Nodes = append(c.Spec.Storage.Nodes, storageNode)
 		}
 	}
-	validNodes := k8sutil.GetValidNodes(c.Spec.Storage.Nodes, c.context.Clientset, edgefsv1beta1.GetTargetPlacement(c.Spec.Placement))
+	validNodes := k8sutil.GetValidNodes(c.Spec.Storage, c.context.Clientset, edgefsv1beta1.GetTargetPlacement(c.Spec.Placement))
 	c.Spec.Storage.Nodes = validNodes
 	return validNodes, nil
 }


### PR DESCRIPTION
This PR reads the labels on a Kubernetes node, looking for provider topology information (e.g. `failure-domain.kubernetes.io`) and appending any it found to the Ceph OSD location.

Resolves #2883

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>