### PR TITLE
ceph: rewind http bind fix on upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -128,6 +128,10 @@ func (c *Cluster) Start() error {
 			return fmt.Errorf("failed to generate keyring for %s. %+v", resourceName, err)
 		}
 
+		if !c.needHttpBindFix() {
+			c.clearHttpBindFix(mgrConfig)
+		}
+
 		// start the deployment
 		d := c.makeDeployment(mgrConfig)
 		logger.Debugf("starting mgr deployment: %+v", d)


### PR DESCRIPTION
**Description of your changes:**

when upgrading to a newer version of ceph that doesn't need the http
binding fix, this patch unwinds the configuration fix which may still be
present when upgrading from a cluster without the fix. if the
configuration fix remains then the dashboard and prometheus servers will
not be able to properly configure themselves.

**Which issue is resolved by this Pull Request:**
Resolves n/a