### PR TITLE
Add K8S_NAMESPACE env to EdgeFS containers

### DIFF
--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -146,6 +146,10 @@ func (c *Cluster) makeAuditdContainer(containerImage string) v1.Container {
 					},
 				},
 			},
+			{
+				Name:  "K8S_NAMESPACE",
+				Value: c.Namespace,
+			},
 		},
 		SecurityContext: securityContext,
 		VolumeMounts:    volumeMounts,
@@ -280,6 +284,10 @@ func (c *Cluster) makeDaemonContainer(containerImage string, dro edgefsv1beta1.D
 						FieldPath: "spec.nodeName",
 					},
 				},
+			},
+			{
+				Name:  "K8S_NAMESPACE",
+				Value: c.Namespace,
 			},
 		},
 		SecurityContext: securityContext,

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -239,7 +239,7 @@ func (c *ISCSIController) iscsiContainer(svcname, name, containerImage string, i
 				},
 			},
 			{
-				Name: "KUBERNETES_NAMESPACE",
+				Name: "K8S_NAMESPACE",
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{
 						FieldPath: "metadata.namespace",

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -296,7 +296,7 @@ func (c *ISGWController) isgwContainer(svcname, name, containerImage string, isg
 				},
 			},
 			{
-				Name: "KUBERNETES_NAMESPACE",
+				Name: "K8S_NAMESPACE",
 				ValueFrom: &v1.EnvVarSource{
 					FieldRef: &v1.ObjectFieldSelector{
 						FieldPath: "metadata.namespace",

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -226,6 +226,14 @@ func (c *NFSController) nfsContainer(svcname, name, containerImage string, nfsSp
 					},
 				},
 			},
+			{
+				Name: "K8S_NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
 		},
 		SecurityContext: securityContext,
 		Resources:       nfsSpec.Resources,

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -299,6 +299,14 @@ func (c *S3Controller) s3Container(svcname, name, containerImage, args string, s
 				},
 			},
 			{
+				Name: "K8S_NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
 				Name:  "EFSS3_HTTP_PORT",
 				Value: fmt.Sprint(s3Spec.Port),
 			},

--- a/pkg/operator/edgefs/s3x/s3x.go
+++ b/pkg/operator/edgefs/s3x/s3x.go
@@ -269,6 +269,14 @@ func (c *S3XController) s3xContainer(svcname, name, containerImage string, s3xSp
 				},
 			},
 			{
+				Name: "K8S_NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
 				Name:  "EFSS3X_HTTP_PORT",
 				Value: fmt.Sprint(s3xSpec.Port),
 			},

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -285,6 +285,14 @@ func (c *SWIFTController) swiftContainer(svcname, name, containerImage, args str
 				},
 			},
 			{
+				Name: "K8S_NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
 				Name:  "EFSSWIFT_HTTP_PORT",
 				Value: fmt.Sprint(swiftSpec.Port),
 			},


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>
**Description of your changes:**
K8S_NAMESPACE env been added to specific EdgeFS containers
**Which issue is resolved by this Pull Request:**
Resolves #3097

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]