### PR TITLE
ceph: Check before copying binaries in osd pods

### DIFF
--- a/pkg/daemon/ceph/osd/init.go
+++ b/pkg/daemon/ceph/osd/init.go
@@ -89,6 +89,11 @@ func copyBinary(sourceDir, targetDir, filename string) error {
 	targetPath := path.Join(targetDir, filename)
 	logger.Infof("copying %s to %s", sourcePath, targetPath)
 
+	// Check if the target path exists, and skip the copy if it does
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	}
+
 	sourceFile, err := os.Open(sourcePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Before performing the copy, the OSD init container now checks
destination path exists, and unlinks it if it does.

The OSD pods copy the rook and tini binaries into a shared volume using
an init container. In restarting pods, this copy could fail with 'text
file busy'(ETXTBUSY), because the destination file in the shared volume
could be under execution. The restarting pods will enter a
'Init:CrashLoopBackOff' state after this, leaving the ceph cluster
degraded.

Unlinking the destination file before copying will allow the copy to
successfully complete and the pod to restart successfully. This leaves a
stale file in the shared volume, which will be cleaned up when the
process that was executing it exits.

Fixes #2674.



<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)