### PR TITLE
ceph: add metrics for flexvolume driver

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -150,6 +150,8 @@ func generateFlexSettings(enableSELinuxRelabeling, enableFSGroup bool) ([]byte, 
 		Status: flexvolume.StatusSuccess,
 		Capabilities: &flexvolume.DriverCapabilities{
 			Attach: false,
+			// Required for metrics
+			SupportsMetrics: true,
 			// Required for any mount performed on a host running selinux
 			SELinuxRelabel: enableSELinuxRelabeling,
 			FSGroup:        enableFSGroup,


### PR DESCRIPTION
This allows to export persistent volume metrics.

Signed-off-by: Maksim Nabokikh <maksim.nabokikh@flant.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
According to https://github.com/kubernetes/kubernetes/issues/67400 in kubernetes 1.13 metrics support for flex volume was added.
I wonder, is adding support metrics flag enough to fix the issue?

**Which issue is resolved by this Pull Request:**
Resolves #1659

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
