### PR TITLE
added device class pool property

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -27,6 +27,7 @@ spec:
   failureDomain: host
   replicated:
     size: 3
+  deviceClass: hdd
 ```
 
 ### Erasure Coded
@@ -46,6 +47,7 @@ spec:
   erasureCoded:
     dataChunks: 2
     codingChunks: 1
+  deviceClass: hdd
 ```
 
 High performance applications typically will not use erasure coding due to the performance overhead of creating and distributing the chunks in the cluster.
@@ -75,6 +77,7 @@ you would be able to tolerate the loss of two devices. Similarly for erasure cod
 <br>In case you added another location type to your nodes in the [Storage Selection Settings](ceph-cluster-crd.md#storage-selection-settings) (e.g. `rack`), you can also specify this type as your failure domain.
 <br>**NOTE:** Neither Rook nor Ceph will prevent the user from creating a cluster where data (or chunks) cannot be replicated safely;
 it is Ceph's design to delay checking for OSDs until a write request is made, and the write will hang if there are not sufficient OSDs to satisfy the request.
+- `deviceClass`: Sets up the CRUSH rule for the pool to distribute data only on the specified device class. If left empty or unspecified, the pool will use the cluster's default CRUSH root, which usually distributes data over all OSDs, regardless of their class.
 - `crushRoot`: The root in the crush map to be used by the pool. If left empty or unspecified, the default root will be used. Creating a crush hierarchy for the OSDs currently requires the Rook toolbox to run the Ceph tools described [here](http://docs.ceph.com/docs/master/rados/operations/crush-map/#modifying-the-crush-map).
 
 ### Erasure Coding

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,6 +3,9 @@
 ## Action Required
 
 ## Notable Features
+- Creation of storage pools through the custom resource definitions (CRDs) now allows users to optionally specify `deviceClass` property to enable
+distribution of the data only across the specified device class. See [Ceph Block Pool CRD](Documentation/ceph-pool-crd.md#ceph-block-pool-crd) for
+an example usage
 
 ### Ceph
 

--- a/pkg/apis/ceph.rook.io/v1/blockpool.go
+++ b/pkg/apis/ceph.rook.io/v1/blockpool.go
@@ -18,7 +18,7 @@ package v1
 import "github.com/rook/rook/pkg/daemon/ceph/model"
 
 func (p *PoolSpec) ToModel(name string) *model.Pool {
-	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot}
+	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot, DeviceClass: p.DeviceClass}
 	r := p.Replication()
 	if r != nil {
 		pool.ReplicatedConfig.Size = r.Size

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -164,6 +164,9 @@ type PoolSpec struct {
 	// The root of the crush hierarchy utilized by the pool
 	CrushRoot string `json:"crushRoot"`
 
+	// The device class the OSD should set to (options are: hdd, ssd, or nvme)
+	DeviceClass string `json:"deviceClass"`
+
 	// The replication settings
 	Replicated ReplicatedSpec `json:"replicated"`
 

--- a/pkg/apis/ceph.rook.io/v1beta1/pool.go
+++ b/pkg/apis/ceph.rook.io/v1beta1/pool.go
@@ -18,7 +18,7 @@ package v1beta1
 import "github.com/rook/rook/pkg/daemon/ceph/model"
 
 func (p *PoolSpec) ToModel(name string) *model.Pool {
-	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot}
+	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot, DeviceClass: p.DeviceClass}
 	r := p.Replication()
 	if r != nil {
 		pool.ReplicatedConfig.Size = r.Size

--- a/pkg/apis/ceph.rook.io/v1beta1/types.go
+++ b/pkg/apis/ceph.rook.io/v1beta1/types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
@@ -144,6 +144,9 @@ type PoolSpec struct {
 
 	// The root of the crush hierarchy utilized by the pool
 	CrushRoot string `json:"crushRoot"`
+
+	// The device class the OSD should set to (options are: hdd, ssd, or nvme)
+	DeviceClass string `json:"deviceClass"`
 
 	// The replication settings
 	Replicated ReplicatedSpec `json:"replicated"`

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -64,7 +64,7 @@ func GetErasureCodeProfileDetails(context *clusterd.Context, clusterName, name s
 	return ecProfileDetails, nil
 }
 
-func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name, failureDomain, crushRoot string) error {
+func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, config model.ErasureCodedPoolConfig, name, failureDomain, crushRoot, deviceClass string) error {
 	// look up the default profile so we can use the default plugin/technique
 	defaultProfile, err := GetErasureCodeProfileDetails(context, clusterName, "default")
 	if err != nil {
@@ -83,6 +83,9 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterName string, con
 	}
 	if crushRoot != "" {
 		profilePairs = append(profilePairs, fmt.Sprintf("crush-root=%s", crushRoot))
+	}
+	if deviceClass != "" {
+		profilePairs = append(profilePairs, fmt.Sprintf("crush-device-class=%s", deviceClass))
 	}
 
 	args := []string{"osd", "erasure-code-profile", "set", name}
@@ -114,6 +117,7 @@ func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 		Number:        modelPool.Number,
 		FailureDomain: modelPool.FailureDomain,
 		CrushRoot:     modelPool.CrushRoot,
+		DeviceClass:   modelPool.DeviceClass,
 	}
 
 	if modelPool.Type == model.Replicated {

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -27,14 +27,18 @@ import (
 )
 
 func TestCreateProfile(t *testing.T) {
-	testCreateProfile(t, "", "myroot")
+	testCreateProfile(t, "", "myroot", "")
 }
 
 func TestCreateProfileWithFailureDomain(t *testing.T) {
-	testCreateProfile(t, "osd", "")
+	testCreateProfile(t, "osd", "", "")
 }
 
-func testCreateProfile(t *testing.T, failureDomain, crushRoot string) {
+func TestCreateProfileWithDeviceClass(t *testing.T) {
+	testCreateProfile(t, "osd", "", "hdd")
+}
+
+func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass string) {
 	cfg := model.ErasureCodedPoolConfig{DataChunkCount: 2, CodingChunkCount: 3, Algorithm: "myalg"}
 
 	executor := &exectest.MockExecutor{}
@@ -61,12 +65,16 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot string) {
 					assert.Equal(t, fmt.Sprintf("crush-root=%s", crushRoot), args[nextArg])
 					nextArg++
 				}
+				if deviceClass != "" {
+					assert.Equal(t, fmt.Sprintf("crush-device-class=%s", deviceClass), args[nextArg])
+					nextArg++
+				}
 				return "", nil
 			}
 		}
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
 
-	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain, crushRoot)
+	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain, crushRoot, deviceClass)
 	assert.Nil(t, err)
 }

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -42,6 +42,7 @@ type CephStoragePoolDetails struct {
 	ErasureCodeProfile string `json:"erasure_code_profile"`
 	FailureDomain      string `json:"failureDomain"`
 	CrushRoot          string `json:"crushRoot"`
+	DeviceClass        string `json:"deviceClass"`
 }
 
 type CephStoragePoolStats struct {
@@ -128,7 +129,7 @@ func CreatePoolWithProfile(context *clusterd.Context, clusterName string, newPoo
 	if newPoolReq.Type == model.ErasureCoded {
 		// create a new erasure code profile for the new pool
 		if err := CreateErasureCodeProfile(context, clusterName, newPoolReq.ErasureCodedConfig, newPool.ErasureCodeProfile,
-			newPoolReq.FailureDomain, newPoolReq.CrushRoot); err != nil {
+			newPoolReq.FailureDomain, newPoolReq.CrushRoot, newPoolReq.DeviceClass); err != nil {
 
 			return fmt.Errorf("failed to create erasure code profile for pool '%s': %+v", newPoolReq.Name, err)
 		}
@@ -253,8 +254,14 @@ func createReplicationCrushRule(context *clusterd.Context, clusterName string, n
 	} else {
 		crushRoot = "default"
 	}
+	args := []string{"osd", "crush", "rule", "create-replicated", ruleName, crushRoot, failureDomain}
 
-	args := []string{"osd", "crush", "rule", "create-simple", ruleName, crushRoot, failureDomain}
+	var deviceClass string
+	if newPool.DeviceClass != "" {
+		deviceClass = newPool.DeviceClass
+		args = append(args, deviceClass)
+	}
+
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return fmt.Errorf("failed to create crush rule %s. %+v", ruleName, err)

--- a/pkg/daemon/ceph/model/pool.go
+++ b/pkg/daemon/ceph/model/pool.go
@@ -39,6 +39,7 @@ type Pool struct {
 	Type               PoolType               `json:"type"`
 	FailureDomain      string                 `json:"failureDomain"`
 	CrushRoot          string                 `json:"crushRoot"`
+	DeviceClass        string                 `json:"deviceClass"`
 	ReplicatedConfig   ReplicatedPoolConfig   `json:"replicatedConfig"`
 	ErasureCodedConfig ErasureCodedPoolConfig `json:"erasureCodedConfig"`
 }

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -260,7 +260,7 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 	if isECPool {
 		// create a new erasure code profile for the new pool
 		if err := ceph.CreateErasureCodeProfile(context.context, context.ClusterName, poolSpec.ErasureCodedConfig, cephConfig.ErasureCodeProfile,
-			poolSpec.FailureDomain, poolSpec.CrushRoot); err != nil {
+			poolSpec.FailureDomain, poolSpec.CrushRoot, poolSpec.DeviceClass); err != nil {
 			return fmt.Errorf("failed to create erasure code profile for object store %s: %+v", context.Name, err)
 		}
 	}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -229,6 +229,7 @@ func ModelToSpec(pool model.Pool) cephv1.PoolSpec {
 	return cephv1.PoolSpec{
 		FailureDomain: pool.FailureDomain,
 		CrushRoot:     pool.CrushRoot,
+		DeviceClass:   pool.DeviceClass,
 		Replicated:    cephv1.ReplicatedSpec{Size: pool.ReplicatedConfig.Size},
 		ErasureCoded:  cephv1.ErasureCodedSpec{CodingChunks: ec.CodingChunkCount, DataChunks: ec.DataChunkCount, Algorithm: ec.Algorithm},
 	}
@@ -362,6 +363,7 @@ func ConvertRookLegacyPoolSpec(legacySpec cephbeta.PoolSpec) cephv1.PoolSpec {
 	return cephv1.PoolSpec{
 		FailureDomain: legacySpec.FailureDomain,
 		CrushRoot:     legacySpec.CrushRoot,
+		DeviceClass:   legacySpec.DeviceClass,
 		Replicated: cephv1.ReplicatedSpec{
 			Size: legacySpec.Replicated.Size,
 		},

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -253,6 +253,7 @@ func TestConvertLegacyPool(t *testing.T) {
 		Spec: cephbeta.PoolSpec{
 			FailureDomain: "fd202",
 			CrushRoot:     "root329",
+			DeviceClass:   "hdd",
 			Replicated:    cephbeta.ReplicatedSpec{Size: 5},
 			ErasureCoded: cephbeta.ErasureCodedSpec{
 				CodingChunks: 5,
@@ -270,6 +271,7 @@ func TestConvertLegacyPool(t *testing.T) {
 		Spec: cephv1.PoolSpec{
 			FailureDomain: "fd202",
 			CrushRoot:     "root329",
+			DeviceClass:   "hdd",
 			Replicated:    cephv1.ReplicatedSpec{Size: 5},
 			ErasureCoded: cephv1.ErasureCodedSpec{
 				CodingChunks: 5,


### PR DESCRIPTION
Signed-off-by: Santosh Pillai <sapillai@redhat.com>

**Description of your changes:**
- Updated code to use deviceClass property when a pool is created for both "replicated" and "erasure coded".
- Updated (ceph-pool-crd.md )documentation to reflect the changes. 
- One know [issue](https://github.com/rook/rook/issues/2016) is reproducible when updating erasure code pool with different settings - 

**Which issue is resolved by this Pull Request:**
Resolves #2890 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]
