### PR TITLE
Updated ceph image from v14.2.0-20190319 to v14.2.1-20190430

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -19,7 +19,7 @@ include ../image.mk
 
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
-CEPH_VERSION = v14.2.0-20190319
+CEPH_VERSION = v14.2.1-20190430
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 
 TEMP := $(shell mktemp -d)


### PR DESCRIPTION
ceph image v14.2.0-20190319 has 3 high vulnerabilities so
updated it to v14.2.1-20190430
Signed-off-by: rohan47 <rohgupta@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3120 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
