### PR TITLE
Backport: Provision OSDs with metadataDevice config

### DIFF
--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -256,12 +256,12 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig,
 	if !legacyProvisioner {
 		if storeConfig.StoreType == config.Bluestore {
 			assert.Equal(t, 7, outputExecCount)
-			assert.Equal(t, 2, execCount)
+			assert.Equal(t, 3, execCount)
 		} else {
 			assert.Equal(t, 6, outputExecCount)
 			// filestore on a device has two more calls than bluestore because of the mount/unmount commands of the legacy sdx device
 			// where sdy is created as the new c-v osd
-			assert.Equal(t, 4, execCount)
+			assert.Equal(t, 5, execCount)
 		}
 	} else if storeConfig.StoreType == config.Bluestore {
 		assert.Equal(t, 12, outputExecCount) // Bluestore has 2 extra output exec calls to get device properties of each device to determine CRUSH weight


### PR DESCRIPTION
Signed-off-by: Michael Vollman michael.b.vollman@gmail.com

Description of your changes:

- Provision OSDs when metadataDevice is set instead of only running a ceph-volume report.
- Add ceph-volume report prior to provisioning to log what ceph-volume will configure before configuring it.
Which issue is resolved by this Pull Request:
Resolves #3108

(cherry picked from commit a8395274218fa28da0726fc3ad6c003df9a48e7c)

// known CI issues
[skip ci]