### PR TITLE
ceph nfs: fix the host path for pod volume

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -331,7 +331,7 @@ func (c *ClusterController) onAdd(obj interface{}) {
 	fileController.StartWatch(cluster.stopCh)
 
 	// Start nfs ganesha CRD watcher
-	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef)
+	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, cluster.Spec.DataDirHostPath, cluster.Namespace, c.rookImage, cluster.Spec.CephVersion, cluster.Spec.Network.HostNetwork, cluster.ownerRef)
 	ganeshaController.StartWatch(cluster.stopCh)
 
 	cluster.childControllers = []childController{

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -43,10 +43,11 @@ var CephNFSResource = opkit.CustomResource{
 	Kind:    reflect.TypeOf(cephv1.CephNFS{}).Name(),
 }
 
-// NFSCephNFSController represents a controller for NFS custom resources
+// CephNFSController represents a controller for NFS custom resources
 type CephNFSController struct {
 	clusterInfo        *cephconfig.ClusterInfo
 	context            *clusterd.Context
+	dataDirHostPath    string
 	namespace          string
 	rookImage          string
 	cephVersion        cephv1.CephVersionSpec
@@ -55,16 +56,17 @@ type CephNFSController struct {
 	orchestrationMutex sync.Mutex
 }
 
-// NewNFSCephNFSController create controller for watching NFS custom resources created
-func NewCephNFSController(clusterInfo *cephconfig.ClusterInfo, context *clusterd.Context, namespace, rookImage string, cephVersion cephv1.CephVersionSpec, hostNetwork bool, ownerRef metav1.OwnerReference) *CephNFSController {
+// NewCephNFSController create controller for watching NFS custom resources created
+func NewCephNFSController(clusterInfo *cephconfig.ClusterInfo, context *clusterd.Context, dataDirHostPath, namespace, rookImage string, cephVersion cephv1.CephVersionSpec, hostNetwork bool, ownerRef metav1.OwnerReference) *CephNFSController {
 	return &CephNFSController{
-		clusterInfo: clusterInfo,
-		context:     context,
-		namespace:   namespace,
-		rookImage:   rookImage,
-		cephVersion: cephVersion,
-		hostNetwork: hostNetwork,
-		ownerRef:    ownerRef,
+		clusterInfo:     clusterInfo,
+		context:         context,
+		dataDirHostPath: dataDirHostPath,
+		namespace:       namespace,
+		rookImage:       rookImage,
+		cephVersion:     cephVersion,
+		hostNetwork:     hostNetwork,
+		ownerRef:        ownerRef,
 	}
 }
 

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -98,7 +98,7 @@ func (c *CephNFSController) makeDeployment(n cephv1.CephNFS, name, configName st
 		Containers:     []v1.Container{c.daemonContainer(n, name, binariesMount)},
 		RestartPolicy:  v1.RestartPolicyAlways,
 		Volumes: append(
-			opspec.PodVolumes("", ""),
+			opspec.PodVolumes(c.dataDirHostPath, c.namespace),
 			configVolume,
 			binariesVolume,
 		),


### PR DESCRIPTION
Fix the host path for the Ceph NFS pod's log volume

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #3139 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
