### PR TITLE
helm: fix PSP use cluster role

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -252,7 +252,7 @@ metadata:
     rbac.ceph.rook.io/aggregate-to-rook-ceph-system-psp-user: "true"
 rules:
 - apiGroups:
-  - apps
+  - policy
   resources:
   - podsecuritypolicies
   resourceNames:


### PR DESCRIPTION
Backport from `master` branch, as requested by @galexrt.

1b21e42a90c3a452b6ac736122ce0c60ca64fa89 introduced a regression, where
podsecuritypolicy resource has been changed from 'extensions' group to
'apps', when it should be changed to 'policy'.

This prevents rook operator from spawning on a cluster with PSP enabled.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
