### PR TITLE
Backport: Ceph host networking upgrade and document mon failover after upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -280,14 +280,13 @@ func TestHostNetwork(t *testing.T) {
 	val, message := extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3", val, message)
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
-	assert.Equal(t, "$(ROOK_POD_IP)", val, message)
+	assert.Equal(t, "", val)
+	assert.Equal(t, "arg not found: --public-bind-addr", message)
 
 	monConfig.Port = 6790
 	pod = c.makeMonPod(monConfig, nodes[2].Name)
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3:6790", val, message)
-	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-bind-addr")
-	assert.Equal(t, "$(ROOK_POD_IP):6790", val, message)
 	assert.NotNil(t, pod)
 }
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -160,12 +160,13 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) v1.Container {
 func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 	podIPEnvVar := "ROOK_POD_IP"
 	publicAddr := monConfig.PublicIP
-	publicBindAddr := opspec.ContainerEnvVarReference(podIPEnvVar)
+
+	// Handle the non-default port for host networking. If host networking is not being used,
+	// the service created elsewhere will handle the non-default port redirection to the default port inside the container.
 	if c.HostNetwork && monConfig.Port != DefaultMsgr1Port {
 		logger.Warningf("Starting mon %s with host networking on a non-default port %d. The mon must be failed over before enabling msgr2.",
 			monConfig.DaemonName, monConfig.Port)
 		publicAddr = fmt.Sprintf("%s:%d", publicAddr, monConfig.Port)
-		publicBindAddr = fmt.Sprintf("%s:%d", publicBindAddr, monConfig.Port)
 	}
 
 	container := v1.Container{
@@ -179,9 +180,6 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			// If the mon is already in the monmap, when the port is left off of --public-addr,
 			// it will still advertise on the previous port b/c monmap is saved to mon database.
 			config.NewFlag("public-addr", publicAddr),
-			// Opposite of the above, --public-bind-addr will *not* still advertise on the previous
-			// port, which makes sense because this is the pod IP, which changes with every new pod.
-			config.NewFlag("public-bind-addr", publicBindAddr),
 		),
 		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
@@ -198,6 +196,14 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			k8sutil.PodIPEnvVar(podIPEnvVar),
 		),
 		Resources: cephv1.GetMonResources(c.spec.Resources),
+	}
+
+	// If host networking is enabled, we don't need a bind addr that is different from the public addr
+	if !c.HostNetwork {
+		// Opposite of the above, --public-bind-addr will *not* still advertise on the previous
+		// port, which makes sense because this is the pod IP, which changes with every new pod.
+		container.Args = append(container.Args,
+			config.NewFlag("public-bind-addr", opspec.ContainerEnvVarReference(podIPEnvVar)))
 	}
 
 	// If deploying Nautilus and newer we need a new port of the monitor container


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two upgrade fixes backported to 1.0:
- Documentation: The default mon port has changed from 6790 to 6789. With the msgr2 work in nautilus, the mons need to be listening on the default ports. These instructions will direct users to failover the mons to the new default port.
- Clusters using host networking will not work if the non-default port is being used by the mons. Previous to rook 1.0 the mons were all using the non-default port 6790 and now they are using the default port of 6789 from 1.0. Now host networking will preserve the non-default port to allow upgrades to continue working. This change will allow the mons to continue working on the non-default port after upgrade. However, the mons cannot enable msgr2 with this configuration. The mons will need to be failed over so they will start using the default ports before msgr2 can be enabled. This will also be added to the upgrade doc.

**Which issue is resolved by this Pull Request:**
Resolves #3104 #3111  

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
