### PR TITLE
docs: added missing delete for new manifest structure

### DIFF
--- a/Documentation/ceph-teardown.md
+++ b/Documentation/ceph-teardown.md
@@ -27,7 +27,7 @@ kubectl delete storageclass rook-ceph-block
 kubectl delete -f kube-registry.yaml
 ```
 
-## Delete the Cluster CRD
+## Delete the CephCluster CRD
 After those block and file resources have been cleaned up, you can then delete your Rook cluster. This is important to delete **before removing the Rook operator and agent or else resources may not be cleaned up properly**.
 ```console
 kubectl -n rook-ceph delete cephcluster rook-ceph
@@ -38,15 +38,12 @@ Verify that the cluster CRD has been deleted before continuing to the next step.
 kubectl -n rook-ceph get cephcluster
 ```
 
-## Delete the Operator
-This will begin the process of all cluster resources being cleaned up, after which you can delete the operator and related resources such as the agent and discover daemonsets with the following:
+## Delete the Operator and related Resources
+This will begin the process of the Rook Ceph operator and all other resources being cleaned up.
+This includes related resources such as the agent and discover daemonsets with the following commands:
 ```console
 kubectl delete -f operator.yaml
-```
-
-Optionally remove the rook-ceph namespace if it is not in use by any other resources.
-```
-kubectl delete namespace rook-ceph
+kubectl delete -f common.yaml
 ```
 
 ## Delete the data on hosts


### PR DESCRIPTION
This corrects the cleanup instructions to delete operator.yaml but also
common.yaml to remove the reamining objects in one go.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3148 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]