### PR TITLE
Edgefs: Add s3 proxy container to S3X pod, backport to 1.0 branch

### DIFF
--- a/Documentation/edgefs-cluster-crd.md
+++ b/Documentation/edgefs-cluster-crd.md
@@ -17,7 +17,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   serviceAccount: rook-edgefs-cluster
   dataDirHostPath: /data
   storage:
@@ -40,7 +40,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   serviceAccount: rook-edgefs-cluster
   dataDirHostPath: /data
   storage:
@@ -63,7 +63,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 ### Cluster metadata
 - `name`: The name that will be used internally for the EdgeFS cluster. Most commonly the name is the same as the namespace since multiple clusters are not supported in the same namespace.
 - `namespace`: The Kubernetes namespace that will be created for the Rook cluster. The services, pods, and other resources created by the operator will be added to this namespace. The common scenario is to create a single Rook cluster. If multiple clusters are created, they must not have conflicting devices or host paths.
-- `edgefsImageName`: EdgeFS image to use. If not specified then `edgefs/edgefs:latest` is used. We recommend to specify particular image version for production use, for example `edgefs/edgefs:1.1.0`.
+- `edgefsImageName`: EdgeFS image to use. If not specified then `edgefs/edgefs:latest` is used. We recommend to specify particular image version for production use, for example `edgefs/edgefs:1.1.8`.
 
 ### Cluster Settings
 - `dataDirHostPath`: The path on the host ([hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)) where config and data should be stored for each of the services. If the directory does not exist, it will be created. Because this directory persists on the host, it will remain after pods are deleted. If `storage` settings not provided then provisioned hostPath will also be used as a storage device for Target pods (automatic provisioning via `rtlfs`).
@@ -192,7 +192,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-edgefs-cluster
   # cluster level storage configuration and selection
@@ -216,7 +216,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-edgefs-cluster
   # cluster level storage configuration and selection
@@ -250,7 +250,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-edgefs-cluster
   placement:
@@ -285,7 +285,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0
+  edgefsImageName: edgefs/edgefs:1.1.8
   dataDirHostPath: /var/lib/rook
   serviceAccount: rook-edgefs-cluster
   # cluster level resource requests/limits configuration

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -90,7 +90,7 @@ func (c *S3Controller) CreateOrUpdate(s edgefsv1beta1.S3, update bool, ownerRefs
 	}
 
 	var rookImageVer string
-	rookImageComponents := strings.Split(rookImage, ":")
+	rookImageComponents := strings.Split(c.rookImage, ":")
 	if len(rookImageComponents) == 2 {
 		rookImageVer = rookImageComponents[1]
 	} else {

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -78,7 +78,7 @@ func (c *SWIFTController) CreateOrUpdate(s edgefsv1beta1.SWIFT, update bool, own
 	rookImage := defaultSWIFTImage
 
 	var rookImageVer string
-	rookImageComponents := strings.Split(rookImage, ":")
+	rookImageComponents := strings.Split(c.rookImage, ":")
 	if len(rookImageComponents) == 2 {
 		rookImageVer = rookImageComponents[1]
 	} else {


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>

**Description of your changes:**
S3 proxy container has added to S3X pod, backport to 1.0 branch
**Which issue is resolved by this Pull Request:**
Resolves #3169

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
