### PR TITLE
Edgefs: Prevents multiple targets deployment on the same node

### DIFF
--- a/Documentation/edgefs-csi.md
+++ b/Documentation/edgefs-csi.md
@@ -50,9 +50,9 @@ EdgeFS CSI plugins implement an interface between CSI enabled Container Orchestr
 ## EdgeFS CSI drivers configuration
 For each driver type (NFS/ISCSI) we have already prepared configuration files examples, there are:
 
-[EdgeFS CSI NFS driver config](../cluster/examples/kubernetes/edgefs/csi/nfs/edgefs-nfs-csi-driver-config.yaml)
+[EdgeFS CSI NFS driver config](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes/edgefs/csi/nfs/edgefs-nfs-csi-driver-config.yaml)
 
-[EdgeFS CSI ISCSI driver config](../cluster/examples/kubernetes/edgefs/csi/iscsi/edgefs-iscsi-csi-driver-config.yaml)
+[EdgeFS CSI ISCSI driver config](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes/edgefs/csi/iscsi/edgefs-iscsi-csi-driver-config.yaml)
 
 
 Secret file configuration options example:
@@ -305,10 +305,10 @@ kubectl get volumesnapshotcontents.snapshot.storage.k8s.io
 
 ### To create volume's clone from existing snapshot you should:
 
-- Create snapshotter storage class [Example yaml](../csi/iscsi/examples/snapshots/snapshot-class.yaml)
+- Create snapshotter storage class [Example yaml](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes/edgefs/csi/iscsi/examples/snapshots/snapshot-class.yaml)
 - Have an existing PVC based on EdgeFS ISCSI LUN
-- Take snapshot from volume [Example yaml](../csi/iscsi/examples/snapshots/create-snapshot.yaml)
-- Clone volume from existing snapshot [Example yaml](../csi/iscsi/examples/snapshots/nginx-snapshot-clone-volume.yaml)
+- Take snapshot from volume [Example yaml](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes/edgefs/csi/iscsi/examples/snapshots/create-snapshot.yaml)
+- Clone volume from existing snapshot [Example yaml](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes/edgefs/csi/iscsi/examples/snapshots/nginx-snapshot-clone-volume.yaml)
 
 
 ## Troubleshooting and log collection

--- a/cluster/examples/kubernetes/edgefs/cluster.yaml
+++ b/cluster/examples/kubernetes/edgefs/cluster.yaml
@@ -128,7 +128,7 @@ metadata:
   name: rook-edgefs
   namespace: rook-edgefs
 spec:
-  edgefsImageName: edgefs/edgefs:1.1.0   # specify version here, i.e. edgefs/edgefs:1.1.0 etc
+  edgefsImageName: edgefs/edgefs:1.1.8   # specify version here, i.e. edgefs/edgefs:1.1.0 etc
   serviceAccount: rook-edgefs-cluster
   dataDirHostPath: /var/lib/edgefs
   #dataVolumeSize: 10Gi

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -438,21 +438,19 @@ func (c *Cluster) createPodSpec(rookImage string, dro edgefsv1beta1.DevicesResur
 		ServiceAccountName: c.serviceAccount,
 		Affinity: &v1.Affinity{
 			PodAntiAffinity: &v1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
 					{
-						Weight: int32(100),
-						PodAffinityTerm: v1.PodAffinityTerm{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{
-										Key:      k8sutil.AppAttr,
-										Operator: metav1.LabelSelectorOpIn,
-										Values:   []string{appName},
-									},
+
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      k8sutil.AppAttr,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{appName},
 								},
 							},
-							TopologyKey: v1.LabelHostname,
 						},
+						TopologyKey: v1.LabelHostname,
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Statefulset pod's template antiAffinity changed
**Which issue is resolved by this Pull Request:**
Resolves #3181

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]