### PR TITLE
ceph: Check before copying binaries in osd pods

### DIFF
--- a/pkg/daemon/ceph/osd/init.go
+++ b/pkg/daemon/ceph/osd/init.go
@@ -89,6 +89,11 @@ func copyBinary(sourceDir, targetDir, filename string) error {
 	targetPath := path.Join(targetDir, filename)
 	logger.Infof("copying %s to %s", sourcePath, targetPath)
 
+	// Check if the target path exists, and skip the copy if it does
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	}
+
 	sourceFile, err := os.Open(sourcePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Before performing the copy, the OSD init container now checks
destination path exists. If the destination exists, it skips the copy.

The OSD pods copy the rook and tini binaries into a shared volume using
an init container. In restarting pods, this copy could fail with 'text
file busy'(ETXTBUSY), because the destination file in the shared volume
could be under execution. The restarting pods will enter a
'Init:CrashLoopBackOff' state after this, leaving the ceph cluster
degraded. Skipping the copy will allow the init containers to complete
successfully, allowing the pod to restart.

Fixes #2674.

Signed-off-by: Kaushal M <kshlmster@gmail.com>

(cherry picked from commit f48f73300f9d129cc8fdc48c71934bfec02788aa)
Backport of #3099.



<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)