### PR TITLE
tests: fix git describe repo path in k8s-vagrant-multi-node script

### DIFF
--- a/tests/scripts/k8s-vagrant-multi-node.sh
+++ b/tests/scripts/k8s-vagrant-multi-node.sh
@@ -11,7 +11,7 @@ function init() {
         mkdir -p "${REPO_DIR}"
         git clone https://github.com/galexrt/k8s-vagrant-multi-node.git "${REPO_DIR}"
         # checkout latest tag of the repo initially after clone
-        git -C "${REPO_DIR}" checkout "$(git describe --tags `git rev-list --tags --max-count=1`)"
+        git -C "${REPO_DIR}" checkout "$(git -C "${REPO_DIR}" describe --tags `git rev-list --tags --max-count=1`)"
     else
         git -C "${REPO_DIR}" pull || { echo "git pull failed with exit code $?. continuing as the repo is already there ..."; }
     fi


### PR DESCRIPTION
**Description of your changes:**
This fixs that the `git describe` is run with the `-C REPO_PATH` flag to
correctly get the latest tag of the k8s-vagrant-multi-node repo and not
the Rook repository.

**Which issue is resolved by this Pull Request:**
Resolves the issues @jbw976 had in Slack #dev channel (https://rook-io.slack.com/archives/C741SA742/p1558197621001100).

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]