### PR TITLE
tests/scripts: Fix minikube script

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -124,7 +124,7 @@ KUBE_VERSION=${KUBE_VERSION:-"v1.14.1"}
 MEMORY=${MEMORY:-"3000"}
 
 # use vda1 instead of sda1 when running with the libvirt driver
-VM_DRIVER=$(minikube config get vm-driver)
+VM_DRIVER=$(minikube config get vm-driver 2>/dev/null || echo "virtualbox")
 if [[ "$VM_DRIVER" == "kvm2" ]]; then
   DISK="vda1"
 else


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Default to virtualbox driver. `minikube config get vm-driver` does not
work when default is used.

**Which issue is resolved by this Pull Request:**
Resolves #3208

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]