### PR TITLE
ceph: fail when metadataDevice not used by cephvol

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -148,7 +148,7 @@ Below are the settings available, both at the cluster and individual node level,
 ### OSD Configuration Settings
 The following storage selection settings are specific to Ceph and do not apply to other backends. All variables are key-value pairs represented as strings.
 
-- `metadataDevice`: Name of a device to use for the metadata of OSDs on each node.  Performance can be improved by using a low latency device (such as SSD or NVMe) as the metadata device, while other spinning platter (HDD) devices on a node are used to store data.
+- `metadataDevice`: Name of a device to use for the metadata of OSDs on each node.  Performance can be improved by using a low latency device (such as SSD or NVMe) as the metadata device, while other spinning platter (HDD) devices on a node are used to store data. Provisioning will fail if the user specifies a `metadataDevice` but that device is not used as a metadata device by Ceph. Notably, `ceph-volume` will not use a device of the same device class (HDD, SSD, NVMe) as OSD devices for metadata, resulting in this failure.
 - `storeType`: `filestore` or `bluestore`, the underlying storage format to use for each OSD. The default is set dynamically to `bluestore` for devices, while `filestore` is the default for directories. Set this store type explicitly to override the default. Warning: Bluestore is **not** recommended for directories in production. Bluestore does not purge data from the directory and over time will grow without the ability to compact or shrink.
 - `databaseSizeMB`:  The size in MB of a bluestore database. Include quotes around the size.
 - `walSizeMB`:  The size in MB of a bluestore write ahead log (WAL). Include quotes around the size.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,7 @@ an example usage
 - OwnerReferences are created with the fully qualified `apiVersion` such that the references will work properly on OpenShift.
 - Linear disk device can now be used for Ceph OSDs.
 - The integration tests can be triggered for specific storage providers rather than always running all tests. See the [dev guide](INSTALL.md#test-storage-provider) for more details.
+- Provisioning will fail if the user specifies a `metadataDevice` but that device is not used as a metadata device by Ceph.
 
 ### Ceph
 


### PR DESCRIPTION
Signed-off-by: Michael Vollman <michael.b.vollman@gmail.com>

**Description of your changes:**
Fail when metadataDevice is specified but ceph-volume batch does not
automatically use the metadataDevice as the block.db.

**Which issue is resolved by this Pull Request:**
Resolves #3092

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
