### PR TITLE
cassandra: JMX prometheus exporter

### DIFF
--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -85,6 +85,7 @@ In the Cassandra model, each cluster contains datacenters and each datacenter co
 * `name`: Name of the rack. Usually, a rack corresponds to an availability zone.
 * `members`: Number of Cassandra members for the specific rack. (In Cassandra documentation, they are called nodes. We don't call them nodes to avoid confusion as a Cassandra Node corresponds to a Kubernetes Pod, not a Kubernetes Node).
 * `storage`: Defines the volumes to use for each Cassandra member. Currently, only 1 volume is supported.
+* `jmxExporterConfigMapName`: Name of configmap that will be used for [jmx_exporter](https://github.com/prometheus/jmx_exporter). Exporter listens on port 9180. If the name not specified, the exporter will not be run. 
 * `resources`: Defines the CPU and RAM resources for the Cassandra Pods.
 * `annotations`: Key value pair list of annotations to add.
 * `placement`: Defines the placement of Cassandra Pods. Has the following subfields:

--- a/Documentation/cassandra.md
+++ b/Documentation/cassandra.md
@@ -148,3 +148,59 @@ If everything looks OK in the operator logs, you can also look in the logs for o
 ```console
 kubectl -n rook-cassandra logs rook-cassandra-0
 ```
+
+## Cassandra Monitoring
+
+To enable jmx_exporter for cassandra rack, you should specify `jmxExporterConfigMapName` option for rack in CassandraCluster CRD.
+
+For example:
+```yaml
+apiVersion: cassandra.rook.io/v1alpha1
+kind: Cluster
+metadata:
+  name: my-cassandra
+  namespace: rook-cassandra
+spec:
+  ...
+  datacenter:
+    name: my-datacenter
+    racks:
+    - name: my-rack
+      members: 3
+      jmxExporterConfigMapName: jmx-exporter-settings
+      storage:
+        volumeClaimTemplates:
+        - metadata:
+            name: rook-cassandra-data
+          spec:
+            storageClassName: my-storage-class
+            resources:
+              requests:
+                storage: 200Gi
+```
+
+Simple config map example to get all metrics:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jmx-exporter-settings
+  namespace: rook-cassandra
+data:
+  jmx_exporter_config.yaml: |
+    lowercaseOutputLabelNames: true
+    lowercaseOutputName: true
+    whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
+```
+
+ConfigMap's data field must contain `jmx_exporter_config.yaml` key with jmx exporter settings.
+
+There is no automatic reloading mechanism for pods when the config map updated.
+After the configmap changed, you should restart all rack pods manually:
+
+```bash
+NAMESPACE=<namespace>
+CLUSTER=<cluster_name>
+RACKS=$(kubectl get sts -n ${NAMESPACE} -l "cassandra.rook.io/cluster=${CLUSTER}")
+echo ${RACKS} | xargs -n1 kubectl rollout restart -n ${NAMESPACE}
+```

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,8 @@
 
 ### YugabyteDB
 
+### Cassandra
+- Added [JMX Prometheus exporter](https://github.com/prometheus/jmx_exporter) support.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -45,6 +45,8 @@ spec:
                       type: integer
                     configMapName:
                       type: string
+                    jmxExporterConfigMapName:
+                      type: string
                     storage:
                       type: object
                       properties:

--- a/design/cassandra/cluster-creation.md
+++ b/design/cassandra/cluster-creation.md
@@ -30,6 +30,9 @@ spec:
       # Optional: configMapName references a user's custom configuration for
       # a specific Cassandra Rack 
       configMapName: "cassandra-config"
+      # Optional: configMapName with single jmx_exporter_config.yaml file 
+      # reference a custom jmx prometheus exporter configuration for CassandraRack
+      jmxExporterConfigMapName: "jmx-prometheus-config"
       # Rook Common Type: StorageSpec
       storage:
         volumeClaims:

--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -26,6 +26,8 @@ RUN mkdir -p /sidecar/plugins
 ADD rook /sidecar/
 # Jolokia plugin for JMX<->HTTP
 ADD "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.0/jolokia-jvm-1.6.0-agent.jar" /sidecar/plugins/jolokia.jar
+# JMX exporter for prometheus metrics
+ADD "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar" /sidecar/plugins/jmx_prometheus.jar
 
 # Run tini as PID 1 and avoid signal handling issues
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${ARCH} /sidecar/tini

--- a/pkg/apis/cassandra.rook.io/v1alpha1/types.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/types.go
@@ -95,6 +95,8 @@ type RackSpec struct {
 	Members int32 `json:"members"`
 	// User-provided ConfigMap applied to the specific statefulset.
 	ConfigMapName *string `json:"configMapName,omitempty"`
+	// User-provided ConfigMap for jmx prometheus exporter
+	JMXExporterConfigMapName *string `json:"jmxExporterConfigMapName,omitempty"`
 	// Storage describes the underlying storage that Cassandra will consume.
 	Storage rook.StorageScopeSpec `json:"storage"`
 	// The annotations-related configuration to add/set on each Pod related object.

--- a/pkg/apis/cassandra.rook.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/zz_generated.deepcopy.go
@@ -214,6 +214,11 @@ func (in *RackSpec) DeepCopyInto(out *RackSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.JMXExporterConfigMapName != nil {
+		in, out := &in.JMXExporterConfigMapName, &out.JMXExporterConfigMapName
+		*out = new(string)
+		**out = **in
+	}
 	in.Storage.DeepCopyInto(&out.Storage)
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations

--- a/pkg/operator/cassandra/sidecar/config.go
+++ b/pkg/operator/cassandra/sidecar/config.go
@@ -45,7 +45,12 @@ const (
 	scyllaJMXPath              = "/usr/lib/scylla/jmx/scylla-jmx"
 
 	// Common
-	jolokiaPath            = constants.PluginDirName + "/" + "jolokia.jar"
+	jolokiaPath = constants.PluginDirName + "/" + "jolokia.jar"
+
+	jmxExporterPath       = constants.PluginDirName + "/" + "jmx_prometheus.jar"
+	jmxExporterConfigPath = configDirCassandra + "/" + "jmx_exporter_config.yaml"
+	jmxExporterPort       = "9180"
+
 	entrypointPath         = "/entrypoint.sh"
 	rackDCPropertiesFormat = "dc=%s" + "\n" + "rack=%s" + "\n" + "prefer_local=false" + "\n"
 )
@@ -134,11 +139,15 @@ func (m *MemberController) generateCassandraConfigFiles() error {
 		return fmt.Errorf("error setting HEAP_NEWSIZE: %s", err.Error())
 	}
 
-	// Add jolokia javaagent
-	jolokiaConfig := []byte(fmt.Sprintf(`JVM_OPTS="$JVM_OPTS %s"`,
-		getJolokiaConfig()))
+	// Generate jmx_agent_config
+	jmxConfig := ""
+	if _, err := os.Stat(jmxExporterConfigPath); !os.IsNotExist(err) {
+		jmxConfig = getJmxExporterConfig()
+	}
 
-	err = ioutil.WriteFile(cassandraEnvPath, append(cassandraEnv, jolokiaConfig...), os.ModePerm)
+	agentsConfig := []byte(fmt.Sprintf(`JVM_OPTS="$JVM_OPTS %s %s"`, getJolokiaConfig(), jmxConfig))
+
+	err = ioutil.WriteFile(cassandraEnvPath, append(cassandraEnv, agentsConfig...), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error trying to write cassandra-env.sh: %s", err.Error())
 	}
@@ -365,7 +374,6 @@ func (m *MemberController) getSeeds() (string, error) {
 	sel := fmt.Sprintf("%s,%s=%s", constants.SeedLabel, constants.ClusterNameLabel, m.cluster)
 
 	for {
-
 		services, err = m.kubeClient.CoreV1().Services(m.namespace).List(metav1.ListOptions{LabelSelector: sel})
 		if err != nil {
 			return "", err
@@ -411,6 +419,10 @@ func getJolokiaConfig() string {
 		cmd = append(cmd, fmt.Sprintf("%s=%s", opt.flag, opt.value))
 	}
 	return fmt.Sprintf("-javaagent:%s=%s", jolokiaPath, strings.Join(cmd, ","))
+}
+
+func getJmxExporterConfig() string {
+	return fmt.Sprintf("-javaagent:%s=%s:%s", jmxExporterPath, jmxExporterPort, jmxExporterConfigPath)
 }
 
 // Merge YAMLs merges two arbitrary YAML structures on the top level.


### PR DESCRIPTION
Export prometheus metrics for cassandra in sidecar container

Signed-off-by: Maksim Nabokikh <maksim.nabokikh@flant.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add jmx exporter with standard configuration to sidecar container.

Test steps:
* Start minikube with `tests/scripts/minikube.sh up`
* Deploy cassandra from `cluster/examples/kubernetes/cassandra`
* Get the metrics with curl

This dashboard seems ok https://grafana.com/dashboards/5408 for monitoring

**Which issue is resolved by this Pull Request:**
Resolves #2530

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
