### PR TITLE
Fix inconsistency regarding csv-ceph Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ Targets:
     check              Runs unit tests.
     clean              Remove all files that are created by building.
     codegen            Run code generators.
-    csv                Generate a CSV file for OLM.
+    csv-ceph           Generate a CSV file for OLM.
     distclean          Remove all files that are created
                        by building or configuring.
     fmt                Check formatting of go sources.

--- a/cluster/olm/ceph/README.md
+++ b/cluster/olm/ceph/README.md
@@ -1,6 +1,6 @@
 # Build Rook's CSV file
 
-Just run `make CSV_VERSION=1.0.0 csv` like this:
+Just run `make CSV_VERSION=1.0.0 csv-ceph` like this:
 
 ```bash
 $ make csv-ceph CSV_VERSION=1.0.1 CSV_PLATFORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1
@@ -18,4 +18,4 @@ Your Rook CSV 1.0.1 file for k8s is ready at: cluster/olm/ceph/deploy/olm-catalo
 Push it to https://github.com/operator-framework/community-operators as well as the CRDs files from cluster/olm/ceph/deploy/crds and the package file cluster/olm/ceph/assemble/rook-ceph.package.yaml.
 ```
 
-Or for OpenShift use: `$ make CSV_VERSION=1.0.0 CSV_PLATFORM=ocp csv`.
+Or for OpenShift use: `$ make CSV_VERSION=1.0.0 CSV_PLATFORM=ocp csv-ceph`.

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -33,7 +33,7 @@ if [[ -z "$1" ]]; then
     echo ""
     echo "ARGUMENT'S ORDER MATTERS"
     echo ""
-    echo "make csv CSV_VERSION=1.0.1 CSV_PLATORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
+    echo "make csv-ceph CSV_VERSION=1.0.1 CSV_PLATFORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
     exit 1
 fi
 VERSION=$1
@@ -43,7 +43,7 @@ if [[ -z $2 ]]; then
     echo ""
     echo "ARGUMENT'S ORDER MATTERS"
     echo ""
-    echo "make csv CSV_VERSION=1.0.1 CSV_PLATORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
+    echo "make csv-ceph CSV_VERSION=1.0.1 CSV_PLATFORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
     exit 1
 fi
 
@@ -61,7 +61,7 @@ if [[ -z $3 ]]; then
     echo ""
     echo "ARGUMENT'S ORDER MATTERS"
     echo ""
-    echo "make csv CSV_VERSION=1.0.1 CSV_PLATORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
+    echo "make csv-ceph CSV_VERSION=1.0.1 CSV_PLATFORM=k8s ROOK_OP_VERSION=rook/ceph:v1.0.1"
     exit 1
 fi
 ROOK_OP_VERSION=$3


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

0fc3775b990d0c79356be33f8fc8416a897560fc added `csv-ceph` Makefile target, but in documentation and examples it was inconsistently referred as `csv`. This PR makes things consistent.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)