### PR TITLE
generate-rook-csv.sh: fix DEFAULT_CSV_FILE_NAME

### DIFF
--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -6,7 +6,6 @@ set -e
 ##################
 OLM_CATALOG_DIR=cluster/olm/ceph
 CSV_PATH="$OLM_CATALOG_DIR/deploy/olm-catalog"
-DEFAULT_CSV_FILE_NAME="${CSV_PATH}/ceph.csv.yaml"
 ASSEMBLE_FILE_COMMON="$OLM_CATALOG_DIR/assemble/metadata-common.yaml"
 ASSEMBLE_FILE_K8S="$OLM_CATALOG_DIR/assemble/metadata-k8s.yaml"
 ASSEMBLE_FILE_OCP="$OLM_CATALOG_DIR/assemble/metadata-openshift.yaml"
@@ -66,6 +65,7 @@ if [[ -z $3 ]]; then
 fi
 ROOK_OP_VERSION=$3
 
+DEFAULT_CSV_FILE_NAME="${CSV_PATH}/ceph/${VERSION}/ceph.v${VERSION}.clusterserviceversion.yaml"
 DESIRED_CSV_FILE_NAME="${CSV_PATH}/rook-ceph.v${VERSION}.clusterserviceversion.yaml"
 if [[ -f "$DESIRED_CSV_FILE_NAME" ]]; then
     echo "$DESIRED_CSV_FILE_NAME already exists, not doing anything."


### PR DESCRIPTION
With operator-sdk version 0.8.1, default csv file is created with following message:
```
NFO[0000] Created deploy/olm-catalog/ceph/1.0.1/ceph.v1.0.1.clusterserviceversion.yaml
```

Without this patch, `mv` in the script fails, as default file does not
exist.

I honestly don't know if this is the right approach, since I never generated such CSV files, but I've made some whitespace changes in #3240 and I wanted to test them and I found that this is not really working for me.

Logs from the error I saw:
```
$ bash -x cluster/olm/ceph/generate-rook-csv.sh 1.0.1 k8s rook/ceph:v1.0.1
+ set -e
+ OLM_CATALOG_DIR=cluster/olm/ceph
+ CSV_PATH=cluster/olm/ceph/deploy/olm-catalog
+ DEFAULT_CSV_FILE_NAME=cluster/olm/ceph/deploy/olm-catalog/ceph.csv.yaml
+ ASSEMBLE_FILE_COMMON=cluster/olm/ceph/assemble/metadata-common.yaml
+ ASSEMBLE_FILE_K8S=cluster/olm/ceph/assemble/metadata-k8s.yaml
+ ASSEMBLE_FILE_OCP=cluster/olm/ceph/assemble/metadata-openshift.yaml
+ PACKAGE_FILE=cluster/olm/ceph/assemble/rook-ceph.package.yaml
+ SUPPORTED_PLATFORMS='k8s|ocp'
+ command -v operator-sdk
+ command -v yq
+ [[ -z 1.0.1 ]]
+ VERSION=1.0.1
+ [[ -z k8s ]]
+ [[ -n k8s ]]
+ [[ ! k8s =~ k8s|ocp ]]
+ PLATFORM=k8s
+ [[ -z rook/ceph:v1.0.1 ]]
+ ROOK_OP_VERSION=rook/ceph:v1.0.1
+ DESIRED_CSV_FILE_NAME=cluster/olm/ceph/deploy/olm-catalog/rook-ceph.v1.0.1.clusterserviceversion.yaml
+ [[ -f cluster/olm/ceph/deploy/olm-catalog/rook-ceph.v1.0.1.clusterserviceversion.yaml ]]
+ YQ_CMD_DELETE=(yq delete -i)
+ YQ_CMD_MERGE=(yq merge --inplace --overwrite --append)
+ YQ_CMD_WRITE=(yq write --inplace)
+ OP_SDK_CMD=(operator-sdk olm-catalog gen-csv --csv-version)
+ OPERATOR_YAML_FILE_K8S=cluster/examples/kubernetes/ceph/operator.yaml
+ OPERATOR_YAML_FILE_OCP=cluster/examples/kubernetes/ceph/operator-openshift.yaml
+ COMMON_YAML_FILE=cluster/examples/kubernetes/ceph/common.yaml
+ OLM_OPERATOR_YAML_FILE=cluster/olm/ceph/deploy/operator.yaml
+ OLM_ROLE_YAML_FILE=cluster/olm/ceph/deploy/role.yaml
+ OLM_ROLE_BINDING_YAML_FILE=cluster/olm/ceph/deploy/role_binding.yaml
+ OLM_SERVICE_ACCOUNT_YAML_FILE=cluster/olm/ceph/deploy/service_account.yaml
+ CEPH_CRD_YAML_FILE=cluster/olm/ceph/deploy/crds/ceph_crd.yaml
+ CEPH_BLOCK_POOLS_CRD_YAML_FILE=cluster/olm/ceph/deploy/crds/rookcephblockpools.crd.yaml
+ CEPH_OBJECT_STORE_YAML_FILE=cluster/olm/ceph/deploy/crds/rookcephobjectstores.crd.yaml
+ CEPH_OBJECT_STORE_USERS_YAML_FILE=cluster/olm/ceph/deploy/crds/rookcephobjectstoreusers.crd.yaml
+ create_directories
+ mkdir -p cluster/olm/ceph/deploy/crds
+ generate_operator_yaml 1.0.1 k8s rook/ceph:v1.0.1
+ platform=k8s
+ operator_file=cluster/examples/kubernetes/ceph/operator.yaml
+ [[ k8s == \o\c\p ]]
+ sed -n '/^# OLM: BEGIN OPERATOR DEPLOYMENT$/,/# OLM: END OPERATOR DEPLOYMENT$/p' cluster/examples/kubernetes/ceph/operator.yaml
+ generate_role_yaml
+ sed -n '/^# OLM: BEGIN OPERATOR ROLE$/,/# OLM: END OPERATOR ROLE$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN CLUSTER ROLE$/,/# OLM: END CLUSTER ROLE$/p' cluster/examples/kubernetes/ceph/common.yaml
+ generate_role_binding_yaml
+ sed -n '/^# OLM: BEGIN OPERATOR ROLEBINDING$/,/# OLM: END OPERATOR ROLEBINDING$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN CLUSTER ROLEBINDING$/,/# OLM: END CLUSTER ROLEBINDING$/p' cluster/examples/kubernetes/ceph/common.yaml
+ generate_service_account_yaml
+ sed -n '/^# OLM: BEGIN SERVICE ACCOUNT SYSTEM$/,/# OLM: END SERVICE ACCOUNT SYSTEM$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN SERVICE ACCOUNT OSD$/,/# OLM: END SERVICE ACCOUNT OSD$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN SERVICE ACCOUNT MGR$/,/# OLM: END SERVICE ACCOUNT MGR$/p' cluster/examples/kubernetes/ceph/common.yaml
+ generate_crds_yaml
+ sed -n '/^# OLM: BEGIN CEPH CRD$/,/# OLM: END CEPH CRD$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN CEPH OBJECT STORE CRD$/,/# OLM: END CEPH OBJECT STORE CRD$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN CEPH OBJECT STORE USERS CRD$/,/# OLM: END CEPH OBJECT STORE USERS CRD$/p' cluster/examples/kubernetes/ceph/common.yaml
+ sed -n '/^# OLM: BEGIN CEPH BLOCK POOL CRD$/,/# OLM: END CEPH BLOCK POOL CRD$/p' cluster/examples/kubernetes/ceph/common.yaml
+ generate_csv 1.0.1 k8s rook/ceph:v1.0.1
+ pushd cluster/olm/ceph
+ operator-sdk olm-catalog gen-csv --csv-version 1.0.1
INFO[0000] Generating CSV manifest version 1.0.1        
WARN[0000] Required csv fields not filled in file deploy/olm-catalog/ceph/1.0.1/ceph.v1.0.1.clusterserviceversion.yaml:
	spec.keywords
	spec.maintainers
	spec.provider 
INFO[0000] Created deploy/olm-catalog/ceph/1.0.1/ceph.v1.0.1.clusterserviceversion.yaml 
+ popd
+ mv cluster/olm/ceph/deploy/olm-catalog/ceph.csv.yaml cluster/olm/ceph/deploy/olm-catalog/rook-ceph.v1.0.1.clusterserviceversion.yaml
mv: cannot stat 'cluster/olm/ceph/deploy/olm-catalog/ceph.csv.yaml': No such file or directory
```

[skip ci]