### PR TITLE
ceph/operator.yaml: fix alignment and add newline

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -46,7 +46,7 @@ spec:
           value: "true"
         # To disable RBAC, uncomment the following:
         # - name: RBAC_ENABLED
-        #  value: "false"
+        #   value: "false"
         # Rook Agent toleration. Will tolerate all taints with all keys.
         # Choose between NoSchedule, PreferNoSchedule and NoExecute:
         # - name: AGENT_TOLERATION
@@ -63,20 +63,20 @@ spec:
         #   value: "Any"
         # Set the path where the Rook agent can find the flex volumes
         # - name: FLEXVOLUME_DIR_PATH
-        #  value: "<PathToFlexVolumes>"
+        #   value: "<PathToFlexVolumes>"
         # Set the path where kernel modules can be found
         # - name: LIB_MODULES_DIR_PATH
-        #  value: "<PathToLibModules>"
+        #   value: "<PathToLibModules>"
         # Mount any extra directories into the agent container
         # - name: AGENT_MOUNTS
-        #  value: "somemount=/host/path:/container/path,someothermount=/host/path2:/container/path2"
+        #   value: "somemount=/host/path:/container/path,someothermount=/host/path2:/container/path2"
         # Rook Discover toleration. Will tolerate all taints with all keys.
         # Choose between NoSchedule, PreferNoSchedule and NoExecute:
         # - name: DISCOVER_TOLERATION
         #   value: "NoSchedule"
         # (Optional) Rook Discover toleration key. Set this to the key of the taint you want to tolerate
         # - name: DISCOVER_TOLERATION_KEY
-        #  value: "<KeyOfTheTaintToTolerate>"
+        #   value: "<KeyOfTheTaintToTolerate>"
         # Allow rook to create multiple file systems. Note: This is considered
         # an experimental feature in Ceph as described at
         # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

This commit fixes misaligned example values in operator.yaml and adds a
newline at the end of the file, which is considered a good practice.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
