### PR TITLE
ceph: log osd recovery at info level

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -108,7 +108,7 @@ func (m *Monitor) osdStatus() error {
 		} else {
 			logger.Debugf("osd.%d is healthy.", id)
 			if tracked {
-				logger.Debugf("osd.%d recovered, stopping tracking.", id)
+				logger.Infof("osd.%d recovered, stopping tracking.", id)
 				delete(m.lastStatus, id)
 			}
 		}


### PR DESCRIPTION
for the osd recovery case (DOWN->UP) log at a matching log level as the
message indicating the OSD went down.

fixes: #2904

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>

// known CI issues
[skip ci]