### PR TITLE
Backport multi cluster osd failure

### DIFF
--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -160,7 +160,7 @@ func (a *OsdAgent) configureDevices(context *clusterd.Context, devices *DeviceOs
 	if devices == nil || len(devices.Entries) == 0 {
 		logger.Infof("no more devices to configure")
 		if cvSupported {
-			return getCephVolumeOSDs(context, a.cluster.Name)
+			return getCephVolumeOSDs(context, a.cluster.Name, a.cluster.FSID)
 		}
 		return osds, nil
 	}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -88,6 +88,156 @@ var cephVolumeTestResult = `{
 }
 `
 
+var cephVolumeTestResultMultiCluster = `{
+    "0": [
+        {
+            "devices": [
+                "/dev/sdb"
+            ],
+            "lv_name": "osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "lv_path": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "lv_size": "<8.00g",
+            "lv_tags": "ceph.block_device=/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894,ceph.block_uuid=X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=4bfe8b72-5e69-4330-b6c0-4d914db8ab89,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=dbe407e0-c1cb-495e-b30a-02e01de6c8ae,ceph.osd_id=0,ceph.type=block,ceph.vdo=0",
+            "lv_uuid": "X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7",
+            "name": "osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "path": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "tags": {
+                "ceph.block_device": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+                "ceph.block_uuid": "X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7",
+                "ceph.cephx_lockbox_secret": "",
+                "ceph.cluster_fsid": "451267e6-883f-4936-8dff-080d781c67d5",
+                "ceph.cluster_name": "ceph",
+                "ceph.crush_device_class": "None",
+                "ceph.encrypted": "0",
+                "ceph.osd_fsid": "dbe407e0-c1cb-495e-b30a-02e01de6c8ae",
+                "ceph.osd_id": "0",
+                "ceph.type": "block",
+                "ceph.vdo": "0"
+            },
+            "type": "block",
+            "vg_name": "ceph-93550251-f76c-4219-a33f-df8805de7b9e"
+        },
+
+        {
+            "devices": [
+                "/dev/sdc"
+            ],
+            "lv_name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_size": "<8.00g",
+            "lv_tags": "ceph.block_device=/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0,ceph.block_uuid=tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=4bfe8b72-5e69-4330-b6c0-4d914db8ab89,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=265d47ca-3e3c-4ef2-ac83-a44b7fb7feee,ceph.osd_id=1,ceph.type=block,ceph.vdo=0",
+            "lv_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+            "name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "tags": {
+                "ceph.block_device": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+                "ceph.block_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+                "ceph.cephx_lockbox_secret": "",
+                "ceph.cluster_fsid": "4bfe8b72-5e69-4330-b6c0-4d914db8ab89",
+                "ceph.cluster_name": "ceph",
+                "ceph.crush_device_class": "None",
+                "ceph.encrypted": "0",
+                "ceph.osd_fsid": "265d47ca-3e3c-4ef2-ac83-a44b7fb7feee",
+                "ceph.osd_id": "1",
+                "ceph.type": "block",
+                "ceph.vdo": "0"
+            },
+            "type": "block",
+            "vg_name": "ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42"
+        }
+    ]
+}
+`
+var cephVolumeTestResultMultiClusterMultiOSD = `{
+    "0": [
+        {
+            "devices": [
+                "/dev/sdb"
+            ],
+            "lv_name": "osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "lv_path": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "lv_size": "<8.00g",
+            "lv_tags": "ceph.block_device=/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894,ceph.block_uuid=X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=4bfe8b72-5e69-4330-b6c0-4d914db8ab89,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=dbe407e0-c1cb-495e-b30a-02e01de6c8ae,ceph.osd_id=0,ceph.type=block,ceph.vdo=0",
+            "lv_uuid": "X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7",
+            "name": "osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "path": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+            "tags": {
+                "ceph.block_device": "/dev/ceph-93550251-f76c-4219-a33f-df8805de7b9e/osd-data-d1cb42c3-60f6-4347-82eb-3188dc3df894",
+                "ceph.block_uuid": "X39Wps-Qewq-d8LV-kj2p-ZqC3-IFQn-C35sV7",
+                "ceph.cephx_lockbox_secret": "",
+                "ceph.cluster_fsid": "451267e6-883f-4936-8dff-080d781c67d5",
+                "ceph.cluster_name": "ceph",
+                "ceph.crush_device_class": "None",
+                "ceph.encrypted": "0",
+                "ceph.osd_fsid": "dbe407e0-c1cb-495e-b30a-02e01de6c8ae",
+                "ceph.osd_id": "0",
+                "ceph.type": "block",
+                "ceph.vdo": "0"
+            },
+            "type": "block",
+            "vg_name": "ceph-93550251-f76c-4219-a33f-df8805de7b9e"
+        },
+
+        {
+            "devices": [
+                "/dev/sdc"
+            ],
+            "lv_name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_size": "<8.00g",
+            "lv_tags": "ceph.block_device=/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0,ceph.block_uuid=tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=4bfe8b72-5e69-4330-b6c0-4d914db8ab89,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=265d47ca-3e3c-4ef2-ac83-a44b7fb7feee,ceph.osd_id=1,ceph.type=block,ceph.vdo=0",
+            "lv_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+            "name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "tags": {
+                "ceph.block_device": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+                "ceph.block_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+                "ceph.cephx_lockbox_secret": "",
+                "ceph.cluster_fsid": "4bfe8b72-5e69-4330-b6c0-4d914db8ab89",
+                "ceph.cluster_name": "ceph",
+                "ceph.crush_device_class": "None",
+                "ceph.encrypted": "0",
+                "ceph.osd_fsid": "265d47ca-3e3c-4ef2-ac83-a44b7fb7feee",
+                "ceph.osd_id": "1",
+                "ceph.type": "block",
+                "ceph.vdo": "0"
+            },
+            "type": "block",
+            "vg_name": "ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42"
+        }
+    ],
+    "1": [
+        {
+            "devices": [
+                "/dev/sdc"
+            ],
+            "lv_name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "lv_size": "<8.00g",
+            "lv_tags": "ceph.block_device=/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0,ceph.block_uuid=tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk,ceph.cephx_lockbox_secret=,ceph.cluster_fsid=4bfe8b72-5e69-4330-b6c0-4d914db8ab89,ceph.cluster_name=ceph,ceph.crush_device_class=None,ceph.encrypted=0,ceph.osd_fsid=265d47ca-3e3c-4ef2-ac83-a44b7fb7feee,ceph.osd_id=1,ceph.type=block,ceph.vdo=0",
+            "lv_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+            "name": "osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "path": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+            "tags": {
+                "ceph.block_device": "/dev/ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42/osd-data-5100eb6b-3a61-4fc1-80ee-86aec275b8b0",
+                "ceph.block_uuid": "tpdiTi-9Ozq-SrWi-p6od-LohX-s4U0-n2V0vk",
+                "ceph.cephx_lockbox_secret": "",
+                "ceph.cluster_fsid": "4bfe8b72-5e69-4330-b6c0-4d914db8ab89",
+                "ceph.cluster_name": "ceph",
+                "ceph.crush_device_class": "None",
+                "ceph.encrypted": "0",
+                "ceph.osd_fsid": "265d47ca-3e3c-4ef2-ac83-a44b7fb7feee",
+                "ceph.osd_id": "1",
+                "ceph.type": "block",
+                "ceph.vdo": "0"
+            },
+            "type": "block",
+            "vg_name": "ceph-dfb1ca03-eb4f-4a5f-84b4-f4734aaefd42"
+        }
+    ]
+}
+`
+
 func TestParseCephVolumeResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
@@ -102,10 +252,52 @@ func TestParseCephVolumeResult(t *testing.T) {
 	}
 
 	context := &clusterd.Context{Executor: executor}
-	osds, err := getCephVolumeOSDs(context, "rook")
+	osds, err := getCephVolumeOSDs(context, "rook", "4bfe8b72-5e69-4330-b6c0-4d914db8ab89")
 	assert.Nil(t, err)
 	require.NotNil(t, osds)
 	assert.Equal(t, 2, len(osds))
+}
+
+func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		logger.Infof("%s %+v", command, args)
+
+		if command == "ceph-volume" {
+			return cephVolumeTestResultMultiCluster, nil
+		}
+
+		return "", fmt.Errorf("unknown command %s %+v", command, args)
+	}
+
+	context := &clusterd.Context{Executor: executor}
+	osds, err := getCephVolumeOSDs(context, "rook", "451267e6-883f-4936-8dff-080d781c67d5")
+	assert.Nil(t, err)
+	require.NotNil(t, osds)
+	assert.Equal(t, 1, len(osds))
+	assert.Equal(t, osds[0].UUID, "dbe407e0-c1cb-495e-b30a-02e01de6c8ae")
+}
+
+func TestCephVolumeResultMultiClusterMultiOSD(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		logger.Infof("%s %+v", command, args)
+
+		if command == "ceph-volume" {
+			return cephVolumeTestResultMultiClusterMultiOSD, nil
+		}
+
+		return "", fmt.Errorf("unknown command %s %+v", command, args)
+	}
+
+	context := &clusterd.Context{Executor: executor}
+	osds, err := getCephVolumeOSDs(context, "rook", "451267e6-883f-4936-8dff-080d781c67d5")
+	assert.Nil(t, err)
+	require.NotNil(t, osds)
+	assert.Equal(t, 1, len(osds))
+	assert.Equal(t, osds[0].UUID, "dbe407e0-c1cb-495e-b30a-02e01de6c8ae")
 }
 
 func TestSanitizeOSDsPerDevice(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**
Multiple ceph clusters on single node creates incorrect UUID in the "getCephVolumeOSDs" method.
This results in OSD failures with "failed to fetch mon config (--no-mon-config to skip)" error. Updated getCephVolumeOSDs method to use fsid filter while retriving devices.

**Which issue is resolved by this Pull Request:**
Resolves #2696

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]