### PR TITLE
ceph csi: Create and maintain mon config to be consumed by csi

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -116,7 +116,12 @@ expects a pool named `rbd` in your Ceph cluster. You can create this pool using
 [rook pool
 CRD](https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md).
 
-Please update `monitors` to reflect the Ceph monitors.
+Update the value of the `clusterID` field to match the namespace that rook is
+running in. When Ceph CSI is deployed by Rook, the operator will automatically
+maintain a config map whose contents will match this key. By default this is
+"rook-ceph".
+
+Then create the storage class:
 
 ```console
 kubectl create -f cluster/examples/kubernetes/ceph/csi/example/rbd/storegeclass.yaml

--- a/cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
@@ -4,14 +4,10 @@ metadata:
    name: csi-rbd
 provisioner: rbd.csi.ceph.com
 parameters:
-    # Comma separated list of Ceph monitors
-    # if using FQDN, make sure csi plugin's dns policy is appropriate.
-    monitors: mon1:port,mon2:port,...
-
-    # if "monitors" parameter is not set, driver to get monitors from same
-    # secret as admin/user credentials. "monValueFromSecret" provides the
-    # key in the secret whose value is the mons
-    #monValueFromSecret: "monitors"
+    # Specify a string that identifies your cluster. Ceph CSI supports any
+    # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
+    # for example "rook-ceph".
+    clusterID: rook-ceph
 
     # Ceph pool into which the RBD image shall be created
     pool: rbd

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
@@ -67,7 +67,6 @@ spec:
             - "--v=5"
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
-            - "--metadatastorage=k8s_configmap"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"
@@ -94,6 +93,8 @@ spec:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - name: ceph-csi-config
+              mountPath: /etc/ceph-csi-config/
       volumes:
         - name: host-dev
           hostPath:
@@ -111,3 +112,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/rbd.csi.ceph.com
             type: DirectoryOrCreate
+        - name: ceph-csi-config
+          configMap:
+            name: ceph-csi-config
+

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
@@ -114,5 +114,8 @@ spec:
             type: DirectoryOrCreate
         - name: ceph-csi-config
           configMap:
-            name: ceph-csi-config
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: csi-cluster-config-json
+                path: config.json
 

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -117,5 +117,8 @@ spec:
             path: /lib/modules
         - name: ceph-csi-config
           configMap:
-            name: ceph-csi-config
+            name: rook-ceph-mon-endpoints
+            items:
+              - key: csi-cluster-config-json
+                path: config.json
 

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -52,7 +52,6 @@ spec:
             - "--v=5"
             - "--drivername=rbd.csi.ceph.com"
             - "--containerized=true"
-            - "--metadatastorage=k8s_configmap"
           env:
             - name: HOST_ROOTFS
               value: "/rootfs"
@@ -85,6 +84,8 @@ spec:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - name: ceph-csi-config
+              mountPath: /etc/ceph-csi-config/
       volumes:
         - name: plugin-dir
           hostPath:
@@ -114,3 +115,7 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - name: ceph-csi-config
+          configMap:
+            name: ceph-csi-config
+

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -41,11 +41,11 @@ spec:
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: "true"
         - name: ROOK_CSI_CEPHFS_IMAGE
-          value: "quay.io/cephcsi/cephfsplugin:v1.0.0"
+          value: "quay.io/cephcsi/cephfsplugin:canary"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
         - name: ROOK_CSI_RBD_IMAGE
-          value: "quay.io/cephcsi/rbdplugin:v1.0.0"
+          value: "quay.io/cephcsi/rbdplugin:canary"
         - name: ROOK_CSI_REGISTRAR_IMAGE
           value: "quay.io/k8scsi/csi-node-driver-registrar:v1.0.2"
         - name: ROOK_CSI_PROVISIONER_IMAGE

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -62,6 +62,9 @@ const (
 	adminSecretName   = "admin-secret"
 	clusterSecretName = "cluster-name"
 
+	// configuration map for csi
+	csiConfigKey = "csi-cluster-config-json"
+
 	// DefaultMonCount Default mon count for a cluster
 	DefaultMonCount = 3
 	// MaxMonCount Maximum allowed mon count for a cluster
@@ -463,10 +466,17 @@ func (c *Cluster) saveMonConfig() error {
 		return fmt.Errorf("failed to marshal mon mapping. %+v", err)
 	}
 
+	csiConfigValue, err := FormatCsiClusterConfig(
+		c.Namespace, c.clusterInfo.Monitors)
+	if err != nil {
+		return fmt.Errorf("failed to format csi config: %+v", err)
+	}
+
 	configMap.Data = map[string]string{
 		EndpointDataKey: FlattenMonEndpoints(c.clusterInfo.Monitors),
 		MaxMonIDKey:     strconv.Itoa(c.maxMonID),
 		MappingKey:      string(monMapping),
+		csiConfigKey:    csiConfigValue,
 	}
 
 	if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {


### PR DESCRIPTION
**Description of your changes:**

Create and maintain a config map that meets the requirements of
the ceph csi such that Rook can maintain the contents of config
map with up-to-date mon information to be used later by csi.

Comes with matching changes to csi templates and things. Right now the PR requires an ceph csi "canary" image which ought to be temporary but should be useful to demonstrate the feature in rook.


**Which issue is resolved by this Pull Request:**
Resolves #2649

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]