### PR TITLE
rgw: change default frontend on nautilus

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,6 +11,7 @@ an example usage
 
 - Rook can now be configured to read "region" and "zone" labels on Kubernetes nodes and use that information as part of the CRUSH location for the OSDs.
 - Rgw pods have liveness probe enabled
+- Rgw is now configured with the Beast backend as of the Nautilus release
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 )
 
 func newConfig() *clusterConfig {
+	clusterInfo := &cephconfig.ClusterInfo{
+		CephVersion: cephver.Mimic,
+	}
 	return &clusterConfig{
 		store: cephv1.CephObjectStore{
 			Spec: cephv1.ObjectStoreSpec{
 				Gateway: cephv1.GatewaySpec{},
-			}}}
+			}},
+		clusterInfo: clusterInfo}
 }
 
 func TestPortString(t *testing.T) {
@@ -63,4 +69,20 @@ func TestPortString(t *testing.T) {
 	cfg.store.Spec.Gateway.SecurePort = 443
 	result = cfg.portString()
 	assert.Equal(t, "", result)
+}
+
+func TestFrontend(t *testing.T) {
+	cfg := newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
+
+	result := rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "civetweb", result)
+
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	result = rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "beast", result)
+
+	cfg.clusterInfo.CephVersion = cephver.Octopus
+	result = rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "beast", result)
 }


### PR DESCRIPTION
As per: ceph/ceph#26599, Beast is now the
default fronted for rados gateway.
Newly created cluster as of Nautilus will use it by default.

Re-added version of 03587352d531becc4d53ff7635a3d183176fa51b
Resolves: #2707
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]