### PR TITLE
Fix onDelete func panic

### DIFF
--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -187,7 +187,11 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *ClusterController) onDelete(obj interface{}) {
-	cluster := obj.(*cockroachdbv1alpha1.Cluster).DeepCopy()
+	cluster, ok := obj.(*cockroachdbv1alpha1.Cluster)
+	if !ok {
+		return
+	}
+	cluster = cluster.DeepCopy()
 	logger.Infof("cluster %s deleted from namespace %s", cluster.Name, cluster.Namespace)
 }
 

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -322,8 +322,11 @@ func (c *ClusterController) handleUpdate(newClust *edgefsv1beta1.Cluster, cluste
 }
 
 func (c *ClusterController) onDelete(obj interface{}) {
-	clust := obj.(*edgefsv1beta1.Cluster).DeepCopy()
-
+	clust, ok := obj.(*edgefsv1beta1.Cluster)
+	if !ok {
+		return
+	}
+	clust = clust.DeepCopy()
 	logger.Infof("delete event for cluster %s in namespace %s", clust.Name, clust.Namespace)
 
 	err := c.handleDelete(clust, time.Duration(clusterDeleteRetryInterval)*time.Second)

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -352,7 +352,11 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *Controller) onDelete(obj interface{}) {
-	objectstore := obj.(*miniov1alpha1.ObjectStore).DeepCopy()
+	objectstore, ok := obj.(*miniov1alpha1.ObjectStore)
+	if !ok {
+		return
+	}
+	objectstore = objectstore.DeepCopy()
 	logger.Infof("Delete Minio object store %s", objectstore.Name)
 
 	// Cleanup is handled by the owner references set in 'onAdd' and the k8s garbage collector.

--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -436,7 +436,11 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *Controller) onDelete(obj interface{}) {
-	cluster := obj.(*nfsv1alpha1.NFSServer).DeepCopy()
+	cluster, ok := obj.(*nfsv1alpha1.NFSServer)
+	if !ok {
+		return
+	}
+	cluster = cluster.DeepCopy()
 	logger.Infof("cluster %s deleted from namespace %s", cluster.Name, cluster.Namespace)
 }
 


### PR DESCRIPTION
onDelete obj in some case will return DeletedFinalStateUnknown type, we need use assert.

Signed-off-by: xiaorui.zou <xiaorui.zou@gmail.com>

**Description of your changes:**

 //  * OnDelete will get the final state of the item if it is known, otherwise
//      it will get an object of type DeletedFinalStateUnknown. This can
//      happen if the watch is closed and misses the delete event and we don't
//      notice the deletion until the subsequent re-list.

so  a run-time panic  will occur.   
[skip ci]