### PR TITLE
ceph: refactor rgw bootstrap

### DIFF
--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -36,7 +36,6 @@ spec:
     port: 80
     securePort:
     instances: 1
-    allNodes: false
     # A key/value list of annotations
     annotations:
     #  key: value
@@ -85,8 +84,7 @@ The gateway settings correspond to the RGW daemon settings.
 - `sslCertificateRef`: If the certificate is not specified, SSL will not be configured. If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](http://docs.ceph.com/docs/master/install/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form."
 - `port`: The port on which the RGW pods and the RGW service will be listening (not encrypted).
 - `securePort`: The secure port on which RGW pods will be listening. An SSL certificate must be specified.
-- `instances`: The number of pods that will be started to load balance this object store. Ignored if `allNodes` is true.
-- `allNodes`: Whether RGW pods should be started on all nodes. If true, a daemonset is created. If false, `instances` must be set.
+- `instances`: The number of pods that will be started to load balance this object store.
 - `annotations`: Key value pair list of annotations to add.
 - `placement`: The Kubernetes placement settings to determine where the RGW pods should be started in the cluster.
 - `resources`: Set resource requests/limits for the Gateway Pod(s), see [Resource Requirements/Limits](ceph-cluster-crd.md#resource-requirementslimits).

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -42,7 +42,6 @@ spec:
     port: 80
     securePort:
     instances: 1
-    allNodes: false
 ```
 
 When the object store is created the Rook operator will create all the pools and other resources necessary to start the service. This may take a minute to complete.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -13,6 +13,7 @@ an example usage
 - Rgw pods have liveness probe enabled
 - Rgw is now configured with the Beast backend as of the Nautilus release
 - OSD: newly updated cluster from 0.9 to 1.0.3 and thus Ceph Nautilus will have their OSDs allowing new features for Nautilus
+- Rgw instances have their own key and thus are properly reflected in the Ceph status
 
 ## Breaking Changes
 
@@ -23,5 +24,12 @@ an example usage
 ### <Storage Provider>
 
 ## Deprecations
+
+### Ceph
+
+- For rgw, when deploying an object store with `object.yaml`, using `allNodes` is not supported anymore, a transition path has been implemented in the code though.
+So if you were using `allNodes: true`, Rook will replace each daemonset with a deployment (one for one replacement) gradually.
+This operation will be triggered on an update or when a new version of the operator is deployed.
+Once complete, it is expected that you edit your object CR with `kubectl -n rook-ceph edit cephobjectstore.ceph.rook.io/my-store` and set `allNodes: false` and `instances` with the current number of rgw instances.
 
 ### <Storage Provider>

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -31,10 +31,8 @@ spec:
     port: 80
     # The port that RGW pods will listen on (https). An ssl certificate is required.
     securePort:
-    # The number of pods in the rgw deployment (ignored if allNodes=true)
+    # The number of pods in the rgw deployment
     instances: 1
-    # Whether the rgw pods should be deployed on all nodes as a daemonset
-    allNodes: false
     # The affinity rules to apply to the rgw deployment or daemonset.
     placement:
     #  nodeAffinity:

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -30,10 +30,8 @@ spec:
     port: 8080
     # The port that RGW pods will listen on (https). An ssl certificate is required.
     securePort:
-    # The number of pods in the rgw deployment (ignored if allNodes=true)
+    # The number of pods in the rgw deployment
     instances: 1
-    # Whether the rgw pods should be deployed on all nodes as a daemonset
-    allNodes: false
     # The affinity rules to apply to the rgw deployment or daemonset.
     placement:
     #  nodeAffinity:

--- a/cluster/examples/kubernetes/ceph/object-test.yaml
+++ b/cluster/examples/kubernetes/ceph/object-test.yaml
@@ -20,4 +20,3 @@ spec:
     port: 80
     securePort:
     instances: 1
-    allNodes: false

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -30,10 +30,8 @@ spec:
     port: 80
     # The port that RGW pods will listen on (https). An ssl certificate is required.
     securePort:
-    # The number of pods in the rgw deployment (ignored if allNodes=true)
+    # The number of pods in the rgw deployment
     instances: 1
-    # Whether the rgw pods should be deployed on all nodes as a daemonset
-    allNodes: false
     # The affinity rules to apply to the rgw deployment or daemonset.
     placement:
     #  nodeAffinity:

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -151,7 +151,6 @@ metadata:
               "port": 8080,
               "securePort": null,
               "instances": 1,
-              "allNodes": false,
               "placement": null,
               "annotations": null,
               "resources": null

--- a/design/object-store.md
+++ b/design/object-store.md
@@ -34,7 +34,6 @@ spec:
     port: 80
     securePort: 443
     instances: 3
-    allNodes: false
 ```
 
 Now create the object store.
@@ -82,8 +81,7 @@ The gateway settings correspond to the RGW service.
 - `sslCertificateRef`: If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. The secret must be in the same namespace as the Rook cluster. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](http://docs.ceph.com/docs/master/install/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form." If the certificate is not specified, SSL will not be configured.
 - `port`: The service port where the RGW service will be listening (http)
 - `securePort`: The service port where the RGW service will be listening (https)
-- `instances`: The number of RGW pods that will be started for this object store (ignored if allNodes=true)
-- `allNodes`: Whether all nodes in the cluster should run RGW as a daemonset
+- `instances`: The number of RGW pods that will be started for this object store
 - `placement`: The rgw pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
 
 The RGW service can be configured to listen on both http and https by specifying both `port` and `securePort`.
@@ -95,7 +93,6 @@ The RGW service can be configured to listen on both http and https by specifying
     port: 80
     securePort: 443
     instances: 1
-    allNodes: false
 ```
 
 ### Realms, Zone Groups, and Zones

--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -62,7 +62,7 @@ func (c *Cluster) generateKeyring(m *mgrConfig) error {
 	/* TODO: can we change this ownerref to be the deployment or service? */
 	s := keyring.GetSecretStore(c.context, c.Namespace, &c.ownerRef)
 
-	key, err := s.GenerateKey(m.ResourceName, user, access)
+	key, err := s.GenerateKey(user, access)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/cluster/rbd/config.go
+++ b/pkg/operator/ceph/cluster/rbd/config.go
@@ -46,7 +46,7 @@ func (m *Mirroring) generateKeyring(daemonConfig *daemonConfig) error {
 	access := []string{"mon", "profile rbd-mirror", "osd", "profile rbd"}
 	s := keyring.GetSecretStore(m.context, m.Namespace, &m.ownerRef)
 
-	key, err := s.GenerateKey(daemonConfig.ResourceName, user, access)
+	key, err := s.GenerateKey(user, access)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -65,7 +65,7 @@ func keyringSecretName(resourceName string) string {
 // GenerateKey generates a key for a Ceph user with the given access permissions. It returns the key
 // generated on success. Ceph will always return the most up-to-date key for a daemon, and the key
 // usually does not change.
-func (k *SecretStore) GenerateKey(resourceName, user string, access []string) (string, error) {
+func (k *SecretStore) GenerateKey(user string, access []string) (string, error) {
 	// get-or-create-key for the user account
 	key, err := client.AuthGetOrCreateKey(k.context, k.namespace, user, access)
 	if err != nil {

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -52,20 +52,20 @@ func TestGenerateKey(t *testing.T) {
 
 	generateKey = "generatedsecretkey"
 	failGenerateKey = false
-	k, e := s.GenerateKey("testresource", "testuser", []string{"test", "access"})
+	k, e := s.GenerateKey("testuser", []string{"test", "access"})
 	assert.NoError(t, e)
 	assert.Equal(t, "generatedsecretkey", k)
 
 	generateKey = "differentsecretkey"
 	failGenerateKey = false
-	k, e = s.GenerateKey("testresource", "testuser", []string{"test", "access"})
+	k, e = s.GenerateKey("testuser", []string{"test", "access"})
 	assert.NoError(t, e)
 	assert.Equal(t, "differentsecretkey", k)
 
 	// make sure error on fail
 	generateKey = "failgeneratekey"
 	failGenerateKey = true
-	_, e = s.GenerateKey("newresource", "newuser", []string{"new", "access"})
+	_, e = s.GenerateKey("newuser", []string{"new", "access"})
 	assert.Error(t, e)
 }
 

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -46,7 +46,7 @@ func (c *Cluster) generateKeyring(m *mdsConfig, deploymentUID types.UID) error {
 	}
 	s := keyring.GetSecretStore(c.context, c.fs.Namespace, ownerRef)
 
-	key, err := s.GenerateKey(m.ResourceName, user, access)
+	key, err := s.GenerateKey(user, access)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
@@ -29,7 +30,7 @@ import (
 
 const (
 	keyringTemplate = `
-[client.radosgw.gateway]
+[%s]
 key = %s
 caps mon = "allow rw"
 caps osd = "allow rwx"
@@ -86,17 +87,22 @@ func (c *clusterConfig) portString() string {
 	return portString
 }
 
+func generateCephXUser(name string) string {
+	user := strings.TrimPrefix(name, AppName)
+	return "client" + strings.Replace(user, "-", ".", -1)
+}
+
 func (c *clusterConfig) generateKeyring(replicationControllerOwnerRef *metav1.OwnerReference) error {
-	user := "client.radosgw.gateway"
+	user := generateCephXUser(replicationControllerOwnerRef.Name)
 	/* TODO: this says `osd allow rwx` while template says `osd allow *`; which is correct? */
 	access := []string{"osd", "allow rwx", "mon", "allow rw"}
 	s := keyring.GetSecretStore(c.context, c.store.Namespace, replicationControllerOwnerRef)
 
-	key, err := s.GenerateKey(c.instanceName(), user, access)
+	key, err := s.GenerateKey(user, access)
 	if err != nil {
 		return err
 	}
 
-	keyring := fmt.Sprintf(keyringTemplate, key)
-	return s.CreateOrUpdate(c.instanceName(), keyring)
+	keyring := fmt.Sprintf(keyringTemplate, user, key)
+	return s.CreateOrUpdate(replicationControllerOwnerRef.Name, keyring)
 }

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -24,7 +24,6 @@ import (
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -96,16 +95,6 @@ func (c *clusterConfig) generateKeyring(replicationControllerOwnerRef *metav1.Ow
 	key, err := s.GenerateKey(c.instanceName(), user, access)
 	if err != nil {
 		return err
-	}
-
-	// Delete legacy key store for upgrade from Rook v0.9.x to v1.0.x
-	err = c.context.Clientset.CoreV1().Secrets(c.store.Namespace).Delete(c.instanceName(), &metav1.DeleteOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debugf("legacy rgw key %s is already removed", c.instanceName())
-		} else {
-			logger.Warningf("legacy rgw key %s could not be removed. %+v", c.instanceName(), err)
-		}
 	}
 
 	keyring := fmt.Sprintf(keyringTemplate, key)

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -86,3 +86,8 @@ func TestFrontend(t *testing.T) {
 	result = rgwFrontend(cfg.clusterInfo.CephVersion)
 	assert.Equal(t, "beast", result)
 }
+
+func TestGenerateCephXUser(t *testing.T) {
+	fakeUser := generateCephXUser("rook-ceph-rgw-fake-store-fake-user")
+	assert.Equal(t, "client.fake.store.fake.user", fakeUser)
+}

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -29,10 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
+func (c *clusterConfig) startDeployment(rgwConfig *rgwConfig) (*apps.Deployment, error) {
+	replicas := int32(1)
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.instanceName(),
+			Name:      rgwConfig.ResourceName,
 			Namespace: c.store.Namespace,
 			Labels:    c.getLabels(),
 		},
@@ -40,8 +41,8 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: c.getLabels(),
 			},
-			Template: c.makeRGWPodSpec(),
-			Replicas: &c.store.Spec.Gateway.Instances,
+			Template: c.makeRGWPodSpec(rgwConfig),
+			Replicas: &replicas,
 			Strategy: apps.DeploymentStrategy{
 				Type: apps.RecreateDeploymentStrategyType,
 			},
@@ -79,55 +80,15 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 	return deployment, err
 }
 
-func (c *clusterConfig) startDaemonset() (*apps.DaemonSet, error) {
-	d := &apps.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.instanceName(),
-			Namespace: c.store.Namespace,
-			Labels:    c.getLabels(),
-		},
-		Spec: apps.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: c.getLabels(),
-			},
-			UpdateStrategy: apps.DaemonSetUpdateStrategy{
-				Type: apps.RollingUpdateDaemonSetStrategyType,
-			},
-			Template: c.makeRGWPodSpec(),
-		},
-	}
-	k8sutil.AddRookVersionLabelToDaemonSet(d)
-	opspec.AddCephVersionLabelToDaemonSet(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
-
-	logger.Debugf("starting rgw daemonset: %+v", d)
-	daemonSet, err := c.context.Clientset.AppsV1().DaemonSets(c.store.Namespace).Create(d)
-	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("failed to create rgw daemonset %s: %+v", c.instanceName(), err)
-		}
-		logger.Infof("daemonset for rgw %s already exists. updating if needed", c.instanceName())
-		// There may be a *lot* of rgws, and they are stateless, so don't bother waiting until the
-		// entire daemonset is updated to move on.
-		// TODO: is the above statement safe to assume?
-		// TODO: Are there any steps for RGW that need to happen before the daemons upgrade?
-		daemonSet, err = c.context.Clientset.AppsV1().DaemonSets(c.store.Namespace).Update(d)
-		if err != nil {
-			return nil, fmt.Errorf("failed to update rgw daemonset %s. %+v", c.instanceName(), err)
-		}
-	}
-	return daemonSet, nil
-}
-
-func (c *clusterConfig) makeRGWPodSpec() v1.PodTemplateSpec {
+func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) v1.PodTemplateSpec {
 	podSpec := v1.PodSpec{
 		InitContainers: []v1.Container{},
 		Containers: []v1.Container{
-			c.makeDaemonContainer(),
+			c.makeDaemonContainer(rgwConfig),
 		},
 		RestartPolicy: v1.RestartPolicyAlways,
 		Volumes: append(
-			opspec.DaemonVolumes(c.DataPathMap, c.instanceName()),
+			opspec.DaemonVolumes(c.DataPathMap, rgwConfig.ResourceName),
 			c.mimeTypesVolume(),
 		),
 		HostNetwork: c.hostNetwork,
@@ -154,7 +115,7 @@ func (c *clusterConfig) makeRGWPodSpec() v1.PodTemplateSpec {
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   c.instanceName(),
+			Name:   rgwConfig.ResourceName,
 			Labels: c.getLabels(),
 		},
 		Spec: podSpec,
@@ -164,7 +125,7 @@ func (c *clusterConfig) makeRGWPodSpec() v1.PodTemplateSpec {
 	return podTemplateSpec
 }
 
-func (c *clusterConfig) makeDaemonContainer() v1.Container {
+func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 
 	// start the rgw daemon in the foreground
 	container := v1.Container{
@@ -177,13 +138,13 @@ func (c *clusterConfig) makeDaemonContainer() v1.Container {
 			append(
 				opspec.DaemonFlags(c.clusterInfo, c.store.Name),
 				"--foreground",
-				"--name=client.radosgw.gateway",
+				cephconfig.NewFlag("name", generateCephXUser(rgwConfig.ResourceName)),
 				cephconfig.NewFlag("host", opspec.ContainerEnvVarReference("POD_NAME")),
 				cephconfig.NewFlag("rgw-mime-types-file", mimeTypesMountPath()),
 			), c.defaultSettings().GlobalFlags()..., // use default settings as flags until mon kv store supported
 		),
 		VolumeMounts: append(
-			opspec.DaemonVolumeMounts(c.DataPathMap, c.instanceName()),
+			opspec.DaemonVolumeMounts(c.DataPathMap, rgwConfig.ResourceName),
 			c.mimeTypesVolumeMount(),
 		),
 		Env:       opspec.DaemonEnvVars(c.cephVersion.Image),

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -56,7 +57,12 @@ func TestPodSpecs(t *testing.T) {
 		DataPathMap: data,
 	}
 
-	s := c.makeRGWPodSpec()
+	resourceName := fmt.Sprintf("%s-%s", AppName, c.store.Name)
+	rgwConfig := &rgwConfig{
+		ResourceName: resourceName,
+	}
+
+	s := c.makeRGWPodSpec(rgwConfig)
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
@@ -91,7 +97,11 @@ func TestSSLPodSpec(t *testing.T) {
 	}
 	c.hostNetwork = true
 
-	s := c.makeRGWPodSpec()
+	resourceName := fmt.Sprintf("%s-%s", AppName, c.store.Name)
+	rgwConfig := &rgwConfig{
+		ResourceName: resourceName,
+	}
+	s := c.makeRGWPodSpec(rgwConfig)
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",

--- a/pkg/operator/k8sutil/daemonset.go
+++ b/pkg/operator/k8sutil/daemonset.go
@@ -19,8 +19,8 @@ package k8sutil
 import (
 	"fmt"
 
-	"k8s.io/api/apps/v1"
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -62,4 +62,16 @@ func AddRookVersionLabelToDaemonSet(d *v1.DaemonSet) {
 		d.Labels = map[string]string{}
 	}
 	addRookVersionLabel(d.Labels)
+}
+
+// GetDaemonsets returns a list of daemonsets names labels matching a given selector
+// example of a label selector might be "app=rook-ceph-mon, mon!=b"
+// more: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+func GetDaemonsets(clientset kubernetes.Interface, namespace, labelSelector string) (*apps.DaemonSetList, error) {
+	listOptions := metav1.ListOptions{LabelSelector: labelSelector}
+	daemonsets, err := clientset.AppsV1().DaemonSets(namespace).List(listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deployments with labelSelector %s: %v", labelSelector, err)
+	}
+	return daemonsets, nil
 }


### PR DESCRIPTION
* remove legacy code
* remove support for AllNodes where we would deploy one rgw per node on
all the nodes
* a transition path is implemented in the code so that if someone has an
existing deployment, daemonsets will be removed and replaced by an
deployments
* when using "instances", each rgw deployed has its own key which makes
Ceph reporting the exact number of rgw running, see:

```
[root@rook-ceph-operator-775cf575c5-bh4sr /]# ceph -s
  cluster:
    id:     611fcf39-0669-4864-9a12-debb35c0397a
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 12h)
    mgr: a(active, since 12h)
    osd: 3 osds: 3 up (since 12h), 3 in (since 12h)
    rgw: 3 daemons active (my.store.a, my.store.b, my.store.c)

  data:
    pools:   6 pools, 600 pgs
    objects: 235 objects, 3.8 KiB
    usage:   3.0 GiB used, 84 GiB / 87 GiB avail
    pgs:     600 active+clean
```
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3245 #2474 #2957 

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]