### PR TITLE
backport: rgw: change default frontend on nautilus

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -37,6 +37,7 @@
   Ceph version which Rook has detected in the pod(s) being run by the resource.
 - OSDs provisioned by `ceph-volume` now supports `metadataDevice` and `databaseSizeMB` options.
 - The flex driver can be configured to properly disable SELinux relabeling and FSGroup with the settings in operator.yaml.
+- Rgw is now configured with the Beast backend as of the Nautilus release
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -20,15 +20,21 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 )
 
 func newConfig() *clusterConfig {
+	clusterInfo := &cephconfig.ClusterInfo{
+		CephVersion: cephver.Mimic,
+	}
 	return &clusterConfig{
 		store: cephv1.CephObjectStore{
 			Spec: cephv1.ObjectStoreSpec{
 				Gateway: cephv1.GatewaySpec{},
-			}}}
+			}},
+		clusterInfo: clusterInfo}
 }
 
 func TestPortString(t *testing.T) {
@@ -63,4 +69,20 @@ func TestPortString(t *testing.T) {
 	cfg.store.Spec.Gateway.SecurePort = 443
 	result = cfg.portString()
 	assert.Equal(t, "", result)
+}
+
+func TestFrontend(t *testing.T) {
+	cfg := newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
+
+	result := rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "civetweb", result)
+
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	result = rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "beast", result)
+
+	cfg.clusterInfo.CephVersion = cephver.Octopus
+	result = rgwFrontend(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "beast", result)
 }


### PR DESCRIPTION
As per: ceph/ceph#26599, Beast is now the
default fronted for rados gateway.
Newly created cluster as of Nautilus will use it by default.

Re-added version of 03587352d531becc4d53ff7635a3d183176fa51b
Resolves: #2707
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 0317de90968d40d5783255d8366ad7f952d4a4ea)

// known CI issues
[skip ci]