### PR TITLE
New OSD design skeleton

### DIFF
--- a/cmd/rook/cmdreporter/cmdreporter.go
+++ b/cmd/rook/cmdreporter/cmdreporter.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/cmd/rook/rook"
+	cmdreporter "github.com/rook/rook/pkg/daemon/cmdreporter"
+	"github.com/spf13/cobra"
+)
+
+// Cmd is the main command for operator and daemons.
+var Cmd = &cobra.Command{
+	Use:   "cmd-reporter",
+	Short: "Utility to run a given command to completion and store the result in a ConfigMap.",
+	Long:  "Utility to run a given command to completion and store the result in a ConfigMap.",
+}
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a given command to completion, and store the result in a ConfigMap.",
+	Long: `Run a given command to completion, and store the Stdout, Stderr, and return code
+results of the command in a ConfigMap. If the ConfigMap already exists, the
+Stdout, Stderr, and return code data which may be present in the ConfigMap
+will be overwritten.
+
+If cmd-reporter succeeds in running the command to completion, no error is
+reported, even if the command's return code is nonzero (failure). Run will
+return an error if the command could not be run for any reason or if there was
+an error storing the command results into the ConfigMap. An application label
+is applied to the ConfigMap, and if the label already exists and has a
+different application's name name, this returns an error, as this may indicate
+that it is not safe for cmd-reporter to edit the ConfigMap.`,
+	Args: cobra.NoArgs,
+	RunE: runJob,
+}
+
+var copyBinsCmd = &cobra.Command{
+	Use:   "copy-binaries",
+	Short: "Copy 'rook' and 'tini' binaries from a container to a given directory.",
+	Long: `Copy 'rook' and 'tini' binaries from a container to a given directory.
+'cmd-reporter run' may often need to be run from a container other than the
+container containing the 'rook' binary. Use this command to copy the 'rook' and
+required 'tini' binaries from the container containing the 'rook' binary to a
+Kubernetes EmptyDir volume mounted at the given directory in a pod's init
+container. From the pod's main container, mount the volume which now contains
+the 'rook' and 'tini' binaries, and call 'rook cmd-reporter run' from 'tini'
+in order to run the desired command from a non-Rook container.`,
+	Args: cobra.NoArgs,
+	RunE: copyJob,
+}
+
+var (
+	// run sub-command
+	commandString string
+	configMapName string
+	namespace     string
+
+	// copy-binaries sub-command
+	copyToDir string
+)
+
+func init() {
+	// run sub-command
+	runCmd.Flags().StringVar(&commandString, "command", "",
+		"The command to run in JSON list syntax. e.g., '[\"command\", \"--flag\", \"value\", \"arg\"]'")
+	runCmd.MarkFlagRequired("command")
+
+	runCmd.Flags().StringVar(&configMapName, "config-map-name", "",
+		"The name of the ConfigMap into which the result of the command will be stored.")
+	runCmd.MarkFlagRequired("config-map-name")
+
+	runCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace in which to create the ConfigMap.")
+	runCmd.MarkFlagRequired("namespace")
+
+	// copy-binaries sub-command
+	copyBinsCmd.Flags().StringVar(&copyToDir, "copy-to-dir", "",
+		"The directory into which 'tini' and 'rook' binaries will be copied.")
+	copyBinsCmd.MarkFlagRequired("copy-to-dir")
+
+	// cmd-reporter main command
+	Cmd.AddCommand(runCmd, copyBinsCmd)
+}
+
+func runJob(cCmd *cobra.Command, cArgs []string) error {
+	cmd, args, err := cmdreporter.FlagArgumentToCommand(commandString)
+	if err != nil {
+		rook.TerminateFatal(fmt.Errorf("failed to parse '--command' argument [%s]. %+v", commandString, err))
+	}
+
+	k8s, _, _, err := rook.GetClientset()
+	if err != nil {
+		rook.TerminateFatal(fmt.Errorf("failed to start command-reporter. failed to init k8s client. %+v", err))
+	}
+
+	reporter, err := cmdreporter.New(k8s, cmd, args, configMapName, namespace)
+	if err != nil {
+		rook.TerminateFatal(fmt.Errorf("cannot start command-reporter. %+v", err))
+	}
+	return reporter.Run()
+}
+
+func copyJob(cCmd *cobra.Command, cArgs []string) error {
+	if err := cmdreporter.CopyBinaries(copyToDir); err != nil {
+		rook.TerminateFatal(fmt.Errorf("could not copy binaries to %s. %+v", copyToDir, err))
+	}
+	return nil
+}

--- a/cmd/rook/main.go
+++ b/cmd/rook/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/rook/rook/cmd/rook/cassandra"
 	"github.com/rook/rook/cmd/rook/ceph"
+	"github.com/rook/rook/cmd/rook/cmdreporter"
 	"github.com/rook/rook/cmd/rook/cockroachdb"
 	"github.com/rook/rook/cmd/rook/edgefs"
 	"github.com/rook/rook/cmd/rook/minio"
@@ -44,5 +45,6 @@ func addCommands() {
 		minio.Cmd,
 		edgefs.Cmd,
 		nfs.Cmd,
-		cassandra.Cmd)
+		cassandra.Cmd,
+		cmdreporter.Cmd)
 }

--- a/pkg/daemon/cmdreporter/copybins.go
+++ b/pkg/daemon/cmdreporter/copybins.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// override these for unit testing
+var defaultRookDir = "/usr/local/bin"
+var defaultTiniDir = "/"
+
+// CopyBinaries copies the "tini" and "rook" binaries to a shared volume at the target path.
+func CopyBinaries(target string) error {
+	if err := copyBinary(defaultRookDir, target, "rook"); err != nil {
+		return err
+	}
+	return copyBinary(defaultTiniDir, target, "tini")
+}
+
+func copyBinary(sourceDir, targetDir, filename string) error {
+	sourcePath := path.Join(sourceDir, filename)
+	targetPath := path.Join(targetDir, filename)
+	logger.Infof("copying %s to %s", sourcePath, targetPath)
+
+	// Check if the source path exists, and look in PATH if it doesn't
+	if _, err := os.Stat(sourcePath); err != nil {
+		if sourcePath, err = exec.LookPath(filename); err != nil {
+			return err
+		}
+	}
+
+	// Check if the target path exists, and skip the copy if it does
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	}
+
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.Create(targetPath)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
+		return err
+	}
+
+	return os.Chmod(targetPath, 0755)
+}

--- a/pkg/daemon/cmdreporter/copybins_test.go
+++ b/pkg/daemon/cmdreporter/copybins_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyBinaries(t *testing.T) {
+
+	createTestBinary := func(binPath string) {
+		f, err := os.Create(binPath)
+		assert.NoError(t, err)
+		// the binary should just be the text showing where it was copied from so we can verify it
+		_, err = f.WriteString(binPath)
+		assert.NoError(t, err)
+		err = os.Chmod(binPath, 0755)
+		assert.NoError(t, err)
+		f.Close()
+	}
+
+	mkdir := func(dir string) {
+		err := os.MkdirAll(dir, 0755)
+		assert.NoError(t, err)
+	}
+
+	cleanDir := func(dir string) {
+		err := os.RemoveAll(dir)
+		assert.NoError(t, err)
+		mkdir(dir)
+	}
+
+	fileText := func(binPath string) string {
+		b, err := ioutil.ReadFile(binPath)
+		assert.NoError(t, err)
+		return string(b)
+	}
+
+	// set up the initial test directory tree without bins
+	// testRootDir/
+	//   bin/
+	//   copy-to-dir/
+	testRootDir, err := ioutil.TempDir("", "rook-cmd-reporter-copy-binaries-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(testRootDir)
+	// create a test PATH="testRootDir/bin"
+	envPath := path.Join(testRootDir, "bin")
+	mkdir(envPath)
+	oPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oPath)
+	err = os.Setenv("PATH", envPath)
+	assert.NoError(t, err)
+	// create initial copy-to-dir
+	copyToDir := path.Join(testRootDir, "copy-to-dir")
+	mkdir(copyToDir)
+	// set default rook dir for unit tests
+	oDefaultRookDir := defaultRookDir
+	defaultRookDir = path.Join(testRootDir, "/usr/local/bin")
+	defer func() { defaultRookDir = oDefaultRookDir }()
+	// set default tini dir for unit tests
+	oDefaultTiniDir := defaultTiniDir
+	defaultTiniDir = path.Join(testRootDir, "/")
+	defer func() { defaultTiniDir = oDefaultTiniDir }()
+
+	// expect failure if rook binary is available in path but not tini
+	// testRootDir/
+	//   bin/
+	//     rook
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "rook"))
+
+	err = CopyBinaries(copyToDir)
+	assert.Error(t, err)
+	if err == nil {
+		panic(err)
+	}
+
+	err = os.Remove(path.Join(envPath, "rook"))
+	assert.NoError(t, err)
+
+	// expect failure if tini binary is available in path but not rook
+	// testRootDir/
+	//   bin/
+	//     tini
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "tini"))
+
+	err = CopyBinaries(copyToDir)
+	assert.Error(t, err)
+	if err == nil {
+		panic(err)
+	}
+
+	err = os.Remove(path.Join(envPath, "tini"))
+	assert.NoError(t, err)
+
+	// expect success if both binaries are available in path
+	// testRootDir/
+	//   bin/
+	//     rook
+	//     tini
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "rook"))
+	createTestBinary(path.Join(envPath, "tini"))
+	cleanDir(copyToDir)
+
+	err = CopyBinaries(copyToDir)
+	assert.NoError(t, err)
+	r := fileText(path.Join(copyToDir, "rook"))
+	assert.Contains(t, r, path.Join(testRootDir, "bin/rook"))
+	r = fileText(path.Join(copyToDir, "tini"))
+	assert.Contains(t, r, path.Join(testRootDir, "bin/tini"))
+
+	// expect success if both binaries are available in default locations AND in path
+	// additionally expect that the binaries will be taken from the default location in this case
+	// testRootDir/
+	//   tini
+	//   usr/local/bin/
+	//     rook
+	//   bin/
+	//     rook
+	//     tini
+	//   copy-to-dir/
+	mkdir(defaultRookDir)
+	createTestBinary(path.Join(defaultRookDir, "rook"))
+	createTestBinary(path.Join(defaultTiniDir, "tini"))
+	cleanDir(copyToDir)
+
+	err = CopyBinaries(copyToDir)
+	assert.NoError(t, err)
+	r = fileText(path.Join(copyToDir, "rook"))
+	assert.Contains(t, r, path.Join(testRootDir, "usr/local/bin/rook"))
+	r = fileText(path.Join(copyToDir, "tini"))
+	assert.Contains(t, r, path.Join(testRootDir, "tini"))
+}

--- a/pkg/daemon/cmdreporter/runner.go
+++ b/pkg/daemon/cmdreporter/runner.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// AppName is the app name reported by cmd-reporter, notably on the ConfigMap's application label.
+	AppName = "cmd-reporter"
+
+	// ConfigMapStdoutKey defines the key in the ConfigMap where stdout is reported.
+	ConfigMapStdoutKey = "stdout"
+
+	// ConfigMapStderrKey defines the key in the ConfigMap where stderr is reported.
+	ConfigMapStderrKey = "stderr"
+
+	// ConfigMapRetcodeKey defines the key in the ConfigMap where the return code is reported.
+	ConfigMapRetcodeKey = "retcode"
+)
+
+var (
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "job-reporter-cmd")
+)
+
+// Runner is a process intended to be run in simple Kubernetes jobs. The Runner runs a
+// command in a job and stores the results in a ConfigMap which can be read by the operator.
+type Runner struct {
+	clientset     kubernetes.Interface
+	cmd           []string
+	args          []string
+	configMapName string
+	namespace     string
+}
+
+// New creates a new Runner and returns an error if cmd, configMapName, or Namespace aren't specified.
+func New(clientset kubernetes.Interface, cmd, args []string, configMapName, namespace string) (*Runner, error) {
+	if clientset == nil {
+		return nil, fmt.Errorf("Kubernetes client interface was not specified")
+	}
+	if len(cmd) == 0 || cmd[0] == "" {
+		return nil, fmt.Errorf("cmd was not specified")
+	}
+	if configMapName == "" {
+		return nil, fmt.Errorf("the config map name was not specified")
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("the namespace must be specified")
+	}
+	return &Runner{
+		clientset:     clientset,
+		cmd:           cmd,
+		args:          args,
+		configMapName: configMapName,
+		namespace:     namespace,
+	}, nil
+}
+
+// Create a simple representation struct for a command and its args so that Go's native JSON
+// (un)marshalling can be used to convert a Kubernetes representation of command+args into a string
+// representation automatically without the user having to fiddle with specifying their command+args
+// in string form manually.
+type commandRepresentation struct {
+	Cmd  []string `json:"cmd"`
+	Args []string `json:"args"`
+}
+
+// CommandToFlagArgument converts a command and arguments in typical Kubernetes container format
+// into a string representation of the command+args that is compatible with the job reporter's
+// command line flag "--command".
+// This only returns the argument to "--command" and not the "--command" text itself.
+func CommandToFlagArgument(cmd []string, args []string) (string, error) {
+	r := &commandRepresentation{Cmd: cmd, Args: args}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal command+args into an argument string. %+v", err)
+	}
+	a := string(b)
+	return a, nil
+}
+
+// FlagArgumentToCommand converts a string representation of a command compatible with the job
+// reporter's command line flag "--command" into a command and arguments in typical Kubernetes
+// container format, i.e., a list of command strings and a list of arguments.
+// This function processes the argument to "--command" but not the "--command" text itself.
+func FlagArgumentToCommand(flagArg string) (cmd []string, args []string, err error) {
+	b := []byte(flagArg)
+	r := &commandRepresentation{}
+	if err := json.Unmarshal(b, r); err != nil {
+		return []string{}, []string{}, fmt.Errorf("failed to unmarshal command from argument. %+v", err)
+	}
+	return r.Cmd, r.Args, nil
+}
+
+// Run a given command to completion, and store the Stdout, Stderr, and return code
+// results of the command in a ConfigMap. If the ConfigMap already exists, the
+// Stdout, Stderr, and return code data which may be present in the ConfigMap
+// will be overwritten.
+//
+// If cmd-reporter succeeds in running the command to completion, no error is
+// reported, even if the command's return code is nonzero (failure). Run will
+// return an error if the command could not be run for any reason or if there was
+// an error storing the command results into the ConfigMap. An application label
+// is applied to the ConfigMap, and if the label already exists and has a
+// different application's name name, this returns an error, as this may indicate
+// that it is not safe for cmd-reporter to edit the ConfigMap.
+func (r *Runner) Run() error {
+	stdout, stderr, retcode, err := r.runCommand()
+	if err != nil {
+		return fmt.Errorf("system failed to run command. %+v", err)
+	}
+
+	if err := r.saveToConfigMap(stdout, stderr, retcode); err != nil {
+		return fmt.Errorf("failed to save command output to ConfigMap. %+v", err)
+	}
+
+	return nil
+}
+
+var execCommand = exec.Command
+
+func (r *Runner) runCommand() (stdout, stderr string, retcode int, err error) {
+	retcode = -1 // default retcode to -1
+
+	baseCmd := r.cmd[0]
+	fullArgs := append(r.cmd[1:], r.args...)
+
+	var capturedStdout bytes.Buffer
+	var capturedStderr bytes.Buffer
+
+	// Capture stdout and stderr, and also send both to the container stdout/stderr, similar to the
+	// 'tee' command
+	stdoutTee := io.MultiWriter(&capturedStdout, os.Stdout)
+	stderrTee := io.MultiWriter(&capturedStderr, os.Stdout)
+
+	c := execCommand(baseCmd, fullArgs...)
+	c.Stdout = stdoutTee
+	c.Stderr = stderrTee
+
+	cmdStr := fmt.Sprintf("%s %s", c.Path, strings.Join(c.Args, " "))
+	logger.Infof("running command: %s", cmdStr)
+
+	if err := c.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// c.ProcessState.ExitCode is available with Go 1.12 and could replace if block below
+			if stat, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				retcode = stat.ExitStatus()
+			}
+			// it's possible the above failed to parse the return code, so report the whole error
+			logger.Infof("command finished with error: %+v", err)
+		} else {
+			return "", "", -1, fmt.Errorf("failed to run command [%s]. %+v", cmdStr, err)
+		}
+	} else {
+		retcode = 0
+	}
+
+	return string(capturedStdout.Bytes()), string(capturedStderr.Bytes()), retcode, nil
+}
+
+func (r *Runner) saveToConfigMap(stdout, stderr string, retcode int) error {
+	retcodeStr := fmt.Sprintf("%d", retcode)
+
+	k8s := r.clientset
+	cm, err := k8s.CoreV1().ConfigMaps(r.namespace).Get(r.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to determine if ConfigMap %s is preexisting. %+v", r.configMapName, err)
+		}
+
+		// the given config map doesn't exist yet, create it now
+		cm = &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      r.configMapName,
+				Namespace: r.namespace,
+				Labels: map[string]string{
+					k8sutil.AppAttr: AppName,
+				},
+			},
+			Data: map[string]string{
+				ConfigMapStdoutKey:  stdout,
+				ConfigMapStderrKey:  stderr,
+				ConfigMapRetcodeKey: retcodeStr,
+			},
+		}
+
+		if _, err := k8s.CoreV1().ConfigMaps(r.namespace).Create(cm); err != nil {
+			return fmt.Errorf("failed to create ConfigMap %s. %+v", r.configMapName, err)
+		}
+		return nil
+	}
+
+	// if the operator has created the configmap with a different app name, we assume that we aren't
+	// allowed to modify the ConfigMap
+	if app, ok := cm.Labels[k8sutil.AppAttr]; !ok || (ok && app == "") {
+		// label is unset or set to empty string
+		cm.Labels[k8sutil.AppAttr] = AppName
+	} else if ok && app != "" && app != AppName {
+		// label is set and not equal to the cmd-reporter app name
+		return fmt.Errorf("ConfigMap [%s] already has label [%s] that differs from cmd-reporter's "+
+			"label [%s]; this may indicate that it is not safe for cmd-reporter to modify the ConfigMap.",
+			r.configMapName, fmt.Sprintf("%s=%s", k8sutil.AppAttr, app), fmt.Sprintf("%s=%s", k8sutil.AppAttr, AppName))
+	}
+
+	for _, k := range []string{ConfigMapStdoutKey, ConfigMapStderrKey, ConfigMapRetcodeKey} {
+		if v, ok := cm.Data[k]; ok {
+			logger.Warningf("ConfigMap [%s] data key [%s] is already set to [%s] and will be overwritten.", r.configMapName, k, v)
+		}
+	}
+
+	// given configmap already exists, update it
+	cm.Data[ConfigMapStdoutKey] = stdout
+	cm.Data[ConfigMapStderrKey] = stderr
+	cm.Data[ConfigMapRetcodeKey] = retcodeStr
+
+	if _, err := k8s.CoreV1().ConfigMaps(r.namespace).Update(cm); err != nil {
+		return fmt.Errorf("failed to update ConfigMap %s. %+v", r.configMapName, err)
+	}
+
+	return nil
+}

--- a/pkg/daemon/cmdreporter/runner_test.go
+++ b/pkg/daemon/cmdreporter/runner_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCommandMarshallingUnmarshalling(t *testing.T) {
+	type args struct {
+		cmd  []string
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{name: "one command only", args: args{cmd: []string{"one"}, args: []string{}}},
+		{name: "no command or args", args: args{
+			cmd: []string{}, args: []string{}}},
+		{name: "no command w/ args", args: args{
+			cmd: []string{}, args: []string{"arg1", "arg2"}}},
+		{name: "one command w/ args", args: args{
+			cmd: []string{"one"}, args: []string{"arg1", "arg2"}}},
+		{name: "multi command only", args: args{
+			cmd: []string{"one", "two", "three"}, args: []string{}}},
+		{name: "multi command and arg", args: args{
+			cmd: []string{"one", "two", "three"}, args: []string{"arg1", "arg2", "--", "arg3"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagArg, err1 := CommandToFlagArgument(tt.args.cmd, tt.args.args)
+			if err1 != nil {
+				t.Errorf("CommandToFlagArgument() error = %+v, wanted no err", err1)
+			}
+			cmd, args, err2 := FlagArgumentToCommand(flagArg)
+			if err2 != nil {
+				t.Errorf("FlagArgumentToCommand() error = %+v, wanted no err", err2)
+			}
+			if err1 != nil || err2 != nil {
+				return
+			}
+			assert.Equal(t, tt.args.cmd, cmd)
+			assert.Equal(t, tt.args.args, args)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	client := fake.NewSimpleClientset
+	type fields struct {
+		clientset     kubernetes.Interface
+		cmd           []string
+		args          []string
+		configMapName string
+		namespace     string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"all is well", fields{client(), []string{"cmd"}, []string{"args"}, "myConfigMap", "myNamespace"}, false},
+		{"no k8s client", fields{nil, []string{"cmd"}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"no command", fields{client(), []string{}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"empty command", fields{client(), []string{""}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"three commands", fields{client(), []string{"one", "two", "three"}, []string{"args"}, "myConfigMap", "myNamespace"}, false},
+		{"no args", fields{client(), []string{"cmd"}, []string{}, "myConfigMap", "myNamespace"}, false},
+		{"empty arg", fields{client(), []string{"cmd"}, []string{""}, "myConfigMap", "myNamespace"}, false}, // an empty arg can still be valid
+		{"three args", fields{client(), []string{"cmd"}, []string{"arg1", "arg2", "arg3"}, "myConfigMap", "myNamespace"}, false},
+		{"no configmap name", fields{client(), []string{"cmd"}, []string{"args"}, "", "myNamespace"}, true},
+		{"no namespace", fields{client(), []string{"cmd"}, []string{"args"}, "myConfigMap", ""}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := New(
+				tt.fields.clientset,
+				tt.fields.cmd,
+				tt.fields.args,
+				tt.fields.configMapName,
+				tt.fields.namespace,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Runner.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				assert.NotNil(t, r)
+				assert.Equal(t, tt.fields.clientset, r.clientset)
+				assert.Equal(t, tt.fields.cmd, r.cmd)
+				assert.Equal(t, tt.fields.args, r.args)
+				assert.Equal(t, tt.fields.configMapName, r.configMapName)
+				assert.Equal(t, tt.fields.namespace, r.namespace)
+			}
+		})
+	}
+}
+
+func TestRunner_Run(t *testing.T) {
+	origExecCommand := execCommand
+	execCommand = mockExecCommand
+	defer func() { execCommand = origExecCommand }()
+
+	newClient := fake.NewSimpleClientset
+
+	verifyConfigMap := func(client kubernetes.Interface, stdout, stderr, retval, cmName, namespace string) {
+		cm, err := client.CoreV1().ConfigMaps(namespace).Get(cmName, metav1.GetOptions{})
+		fmt.Println("configmap:", cm)
+		assert.NoError(t, err)
+		assert.Equal(t, stdout, cm.Data[ConfigMapStdoutKey])
+		assert.Equal(t, stderr, cm.Data[ConfigMapStderrKey])
+		assert.Equal(t, retval, cm.Data[ConfigMapRetcodeKey])
+	}
+
+	verifyCommand := func(cmd, args []string, command string) {
+		err := os.Setenv("GO_HELPER_PROCESS_PRINT_COMMAND", "1")
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_PRINT_COMMAND") }()
+
+		k8s := newClient()
+		r, err := New(k8s, cmd, args, "command-configmap", "command-namespace")
+		assert.NoError(t, err)
+		assert.NoError(t, r.Run())
+
+		verifyConfigMap(k8s, command, "", "0", "command-configmap", "command-namespace")
+	}
+
+	verifyCommand([]string{"grep"}, []string{"-e", ".*time"}, "grep -e .*time")
+	verifyCommand([]string{"ceph-volume", "inventory"}, []string{"--format=json-pretty"}, "ceph-volume inventory --format=json-pretty")
+	verifyCommand([]string{"ceph-volume", "lvm", "list"}, []string{}, "ceph-volume lvm list")
+
+	verifyOutputs := func(stdout, stderr, retcode string) {
+		err := os.Setenv("GO_HELPER_PROCESS_STDOUT", stdout)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_STDOUT") }()
+		err = os.Setenv("GO_HELPER_PROCESS_STDERR", stderr)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_STDERR") }()
+		err = os.Setenv("GO_HELPER_PROCESS_RETCODE", retcode)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_RETCODE") }()
+
+		k8s := newClient()
+		r, err := New(k8s, []string{"standin-cmd"}, []string{"--some", "arg"}, "outputs-configmap", "outputs-namespace")
+		assert.NoError(t, err)
+		assert.NoError(t, r.Run())
+
+		verifyConfigMap(k8s, stdout, stderr, retcode, "outputs-configmap", "outputs-namespace")
+	}
+
+	verifyOutputs("", "", "0")
+	verifyOutputs("", "", "11")
+	verifyOutputs("this is my stdout", "", "0")
+	verifyOutputs("", "this is my stderr", "23")
+	verifyOutputs("this is ...", "... mixed outputs", "23")
+
+	// Verify that cmd-reporter won't overwrite a preexisting configmap with a different app name
+	k8s := newClient()
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-configmap",
+			Namespace: "preexisting-namespace",
+			Labels: map[string]string{
+				k8sutil.AppAttr: "some-other-application",
+			},
+		},
+		Data: map[string]string{},
+	}
+	k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(cm)
+	r, err := New(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	assert.NoError(t, err)
+	assert.Error(t, r.Run())
+	cm, err = k8s.CoreV1().ConfigMaps("preexisting-namespace").Get("preexisting-configmap", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, cm.Data, ConfigMapStdoutKey)
+	assert.NotContains(t, cm.Data, ConfigMapStderrKey)
+	assert.NotContains(t, cm.Data, ConfigMapRetcodeKey)
+
+	// Verify that cmd-reporter WILL overwrite a preexisting configmap with cmd-reporter's app name
+	k8s = newClient()
+	cm = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-configmap",
+			Namespace: "preexisting-namespace",
+			Labels: map[string]string{
+				k8sutil.AppAttr: AppName,
+			},
+		},
+		Data: map[string]string{},
+	}
+	k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(cm)
+	r, err = New(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	assert.NoError(t, err)
+	assert.NoError(t, r.Run())
+	verifyConfigMap(k8s, "", "", "0", "preexisting-configmap", "preexisting-namespace")
+}
+
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func mockExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestCmdReporterHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	// the existing environment will contain variables which define the desired return from the
+	// fake command which will be run.
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+// TestHelperProcess isn't a real test. It's used as a helper process
+// for TestParameterRun.
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func TestCmdReporterHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+	userCommand := args
+
+	// test should set these in its environment to control the output of the test commands
+	stdout := os.Getenv("GO_HELPER_PROCESS_STDOUT")
+	stderr := os.Getenv("GO_HELPER_PROCESS_STDERR")
+	retcode := os.Getenv("GO_HELPER_PROCESS_RETCODE")
+
+	if os.Getenv("GO_HELPER_PROCESS_PRINT_COMMAND") == "1" {
+		stdout = strings.Join(userCommand, " ")
+		stderr = ""
+		retcode = ""
+	}
+
+	if stdout != "" {
+		fmt.Fprintf(os.Stdout, stdout)
+	}
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, stderr)
+	}
+	if retcode != "" {
+		rc, err := strconv.Atoi(retcode)
+		if err != nil {
+			panic(err)
+		}
+		os.Exit(rc)
+	}
+	os.Exit(0)
+}

--- a/pkg/operator/ceph/cluster/newosd/cephvolume.go
+++ b/pkg/operator/ceph/cluster/newosd/cephvolume.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package newosd
+
+import (
+	"fmt"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/config"
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/k8sutil/cmdreporter"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type cephVolumeJobConfiguration struct {
+	parentController *Controller
+	hostname         string
+	jobName          string
+	appName          string
+	cephVolumeArgs   []string
+}
+
+func (j *cephVolumeJobConfiguration) cmdReporter() (*cmdreporter.CmdReporter, error) {
+	c := j.parentController
+	cephCluster := c.cephCluster.spec
+	commonLabels := opspec.AppLabels(j.appName, c.namespace)
+
+	// Use stdbuf to capture the python output buffer such that we can write to the pod log as the
+	// logging happens instead of using the default buffering that will log everything after
+	// ceph-volume exits
+	cmd := []string{"stdbuf"}
+	args := append([]string{"-oL", "ceph-volume"}, j.cephVolumeArgs...)
+	cmdReporter, err := cmdreporter.New(
+		c.context.Clientset, &c.ownerRef,
+		j.appName, j.jobName, c.namespace,
+		cmd, args,
+		c.rookImage, c.cephCluster.spec.CephVersion.Image)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ceph-volume job for node %s. %+v", j.hostname, err)
+	}
+
+	dataPathMap := config.NewDatalessDaemonDataPathMap(c.namespace, cephCluster.DataDirHostPath)
+
+	// update job spec for ceph-volume needs
+	job := cmdReporter.Job()
+	applyLabelsToObjectMeta(commonLabels, &job.ObjectMeta)
+	applyLabelsToObjectMeta(commonLabels, &job.Spec.Template.ObjectMeta)
+	opspec.AddCephVersionLabelToJob(c.cephCluster.info.CephVersion, job)
+	annotations := cephv1.GetOSDAnnotations(cephCluster.Annotations)
+	annotations.ApplyToObjectMeta(&job.ObjectMeta)
+	annotations.ApplyToObjectMeta(&job.Spec.Template.ObjectMeta)
+
+	// update pod spec for ceph-volume needs
+	podSpec := &job.Spec.Template.Spec
+	podSpec.ServiceAccountName = serviceAccountName
+	deviceVols, _ := deviceVolsAndMounts()
+	podSpec.Volumes = append(podSpec.Volumes,
+		append(
+			deviceVols,
+			opspec.StoredLogVolume(dataPathMap.ContainerLogDir),
+		)...,
+	)
+	podSpec.HostNetwork = cephCluster.Network.HostNetwork
+	// TODO: HostIPC for encrypted devices
+	if cephCluster.Network.HostNetwork {
+		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	}
+	placement := cephv1.GetOSDPlacement(cephCluster.Placement)
+	placement.ApplyToPodSpec(podSpec)
+
+	// update container spec for ceph-volume needs
+	if len(podSpec.Containers) < 1 {
+		return nil, fmt.Errorf("CmdReporter did not return a runner container in its batch job: %+v", job)
+	}
+	container := &podSpec.Containers[0]
+	_, deviceVolMounts := deviceVolsAndMounts()
+	container.VolumeMounts = append(container.VolumeMounts,
+		append(
+			deviceVolMounts,
+			opspec.StoredLogVolumeMount(),
+		)...,
+	)
+	container.SecurityContext = &v1.SecurityContext{
+		// ceph-volume containers mount /dev, so privilege is required
+		Privileged:             newBool(true),
+		RunAsUser:              newInt64(0),
+		RunAsNonRoot:           newBool(false),
+		ReadOnlyRootFilesystem: newBool(false),
+	}
+	container.Resources = cephv1.GetOSDResources(j.parentController.cephCluster.spec.Resources)
+
+	return cmdReporter, nil
+}
+
+func applyLabelsToObjectMeta(labels map[string]string, m *metav1.ObjectMeta) {
+	for k, v := range labels {
+		m.Labels[k] = v
+	}
+}
+
+func deviceVolsAndMounts() ([]v1.Volume, []v1.VolumeMount) {
+	vols := []v1.Volume{
+		// c-v needs access to /dev to find and prepare devices
+		{Name: "dev", VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}},
+		// mount /run/udev so ceph-volume (via `lvs`) can access the udev database
+		{Name: "run-udev", VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}},
+	}
+	mounts := []v1.VolumeMount{
+		{Name: "dev", MountPath: "/dev"},
+		{Name: "run-udev", MountPath: "/run/udev"},
+	}
+	return vols, mounts
+}

--- a/pkg/operator/ceph/cluster/newosd/inventorier.go
+++ b/pkg/operator/ceph/cluster/newosd/inventorier.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package newosd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+)
+
+type cephVolumeInventoryResult struct {
+	Available       bool                      `json:"available"`
+	LVs             []cephVolumeInventoryLV   `json:"lvs"`
+	Path            string                    `json:"path"`
+	RejectedReasons []string                  `json:"rejected_reasons"`
+	SysAPI          cephVolumeInventorySysAPI `json:"sys_api"`
+}
+
+type cephVolumeInventorySysAPI struct {
+	Locked     int                                     `json:"locked"` // int `0` or `1`
+	Partitions map[string]cephVolumeInventoryPartition `json:"partitions"`
+	Path       string                                  `json:"path"`
+	Rotational string                                  `json:"rotational"` // string `"0"` or `"1"`
+	Size       float64                                 `json:"size"`
+}
+
+type cephVolumeInventoryLV struct {
+	BlockUUID   string `json:"block_uuid"`
+	ClusterFSID string `json:"cluster_fsid"`
+	ClusterName string `json:"cluster_name"`
+	Name        string `json:"name"`
+	OsdFSID     string `json:"osd_fsid"`
+	OsdID       string `json:"osd_id"`
+	LVType      string `json:"type"`
+}
+
+type cephVolumeInventoryPartition struct {
+	Sectors    string `json:"sectors"` // yes this is actually reported as a string ... sigh
+	SectorSize int    `json:"sectorsize"`
+}
+
+type inventoriedNode struct {
+	resolvedNode     rookalpha.Node
+	inventory        []cephVolumeInventoryResult
+	rawInventoryJSON string
+	err              error
+}
+
+// Run an inventorier routine for each node which comes in the nodes channel, and put the
+// inventoried output on the inventoried nodes channel.
+func (c *Controller) inventoryNodes(nodesCh <-chan rookalpha.Node, inventoriedNodesCh chan<- inventoriedNode) {
+	var wg sync.WaitGroup
+
+	for n := range nodesCh {
+		logger.Debugf("Inventorying node %+v", n)
+
+		jobName := k8sutil.TruncateNodeName(inventoryAppNameFmt, n.Name)
+
+		jobConfig := &cephVolumeJobConfiguration{
+			parentController: c,
+			hostname:         n.Name,
+			appName:          inventoryAppName,
+			jobName:          jobName,
+			cephVolumeArgs:   []string{"inventory", "--format=json-pretty"},
+		}
+		cmdReporter, err := jobConfig.cmdReporter()
+		if err != nil {
+			msg := fmt.Sprintf("failed to inventory node %s. %+v", n.Name, err)
+			logger.Errorf(msg) // since error is being returned in channel, log it immediately
+			in := inventoriedNode{
+				resolvedNode:     n,
+				inventory:        []cephVolumeInventoryResult{},
+				rawInventoryJSON: "",
+				err:              fmt.Errorf(msg),
+			}
+			inventoriedNodesCh <- in
+			continue
+		}
+
+		wg.Add(1)
+		go func(n rookalpha.Node) {
+			defer wg.Done()
+			stdout, stderr, retcode, err := cmdReporter.Run(osdInventoryTimeout)
+			inventory, err := parseInventory(stdout, stderr, retcode, err, n.Name)
+			in := inventoriedNode{
+				resolvedNode:     n,
+				inventory:        inventory,
+				rawInventoryJSON: stdout,
+				err:              err,
+			}
+			if in.err != nil {
+				// since error is being returned in channel, log it immediately
+				logger.Errorf("%+v", in.err)
+			}
+			inventoriedNodesCh <- in
+		}(n)
+
+		// wait a few seconds after each CmdReporter run to ease pressure on Kube API server
+		<-time.After(3 * time.Second)
+	}
+
+	// closer
+	go func() {
+		wg.Wait()
+		close(inventoriedNodesCh)
+		logger.Debugf("all nodes have been inventoried")
+	}()
+}
+
+func parseInventory(
+	stdout, stderr string, retcode int, err error, nodeName string,
+) ([]cephVolumeInventoryResult, error) {
+	res := []cephVolumeInventoryResult{}
+	if err != nil {
+		return res, fmt.Errorf("failed to inventory node %s due to an unexpected error. %+v", nodeName, err)
+	}
+	if retcode != 0 {
+		combinedOut := fmt.Sprintf(`
+stdout: %s
+stderr: %s
+retval: %d`, stdout, stderr, retcode)
+		return res, fmt.Errorf("failed to inventory node %s due to a ceph-volume error: %s", nodeName, combinedOut)
+	}
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		logger.Errorf("failed to parse inventory from node %s: %s", nodeName, stdout)
+		return []cephVolumeInventoryResult{}, fmt.Errorf("failed to parse inventory from node %s. %+v", nodeName, err)
+	}
+	return res, nil
+}

--- a/pkg/operator/ceph/cluster/newosd/node.go
+++ b/pkg/operator/ceph/cluster/newosd/node.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package newosd
+
+import (
+	"fmt"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+)
+
+// TODO: test that user-specified node overrides aren't clobbered by anything in this file
+
+// Get the full scope of the user's storage request. Basically, if `UseAllNodes` is set, populate
+// the resultant StorageScopeSpec with every single Kubernetes node.
+//
+// The resultant StorageScopeSpec's Nodes will be resolved before the spec is returned.
+func (c *Controller) getDesiredStorage() (*rookalpha.StorageScopeSpec, error) {
+	desiredStorage := c.cephCluster.spec.Storage.DeepCopy()
+
+	if desiredStorage.UseAllNodes {
+		desiredStorage.Nodes = []rookalpha.Node{}
+		hostnameMap, err := k8sutil.GetNodeHostNames(c.context.Clientset)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine the scope of the user-defined storage request. "+
+				"failed to get Kubernetes nodes and hostnames. %+v", err)
+		}
+		for _, hostname := range hostnameMap {
+			storageNode := rookalpha.Node{
+				Name: hostname,
+			}
+			desiredStorage.Nodes = append(desiredStorage.Nodes, storageNode)
+		}
+	}
+
+	// resolve desired nodes
+	desiredStorage.Nodes = c.resolvedNodes(desiredStorage)
+
+	return desiredStorage, nil
+}
+
+// return all of the nodes from the desiredStorage which can be resolved, in their resolved state
+func (c *Controller) resolvedNodes(desiredStorage *rookalpha.StorageScopeSpec) []rookalpha.Node {
+	resolvedNodes := make([]rookalpha.Node, 0, len(desiredStorage.Nodes))
+	for _, n := range desiredStorage.Nodes {
+		rn := c.resolveNode(desiredStorage, &n)
+		if rn == nil {
+			logger.Errorf("cannot use node for storage. node did not resolve: %+v", n)
+			continue
+		}
+		resolvedNodes = append(resolvedNodes, *rn)
+	}
+	return resolvedNodes
+}
+
+// fully resolve the storage config and resources for this node
+func (c *Controller) resolveNode(desiredStorage *rookalpha.StorageScopeSpec, node *rookalpha.Node) *rookalpha.Node {
+	rookNode := desiredStorage.ResolveNode(node.Name)
+	if rookNode == nil {
+		return nil
+	}
+	resources := cephv1.GetOSDResources(c.cephCluster.spec.Resources)
+	rookNode.Resources = k8sutil.MergeResourceRequirements(rookNode.Resources, resources)
+
+	return rookNode
+}
+
+// Find the nodes on which Rook is allowed to provision new OSDs. This will return a subset of nodes
+// defined in desiredStorage.
+func (c *Controller) getProvisionableNodes(desiredStorage *rookalpha.StorageScopeSpec) []rookalpha.Node {
+	if desiredStorage.UseAllNodes == false && len(desiredStorage.Nodes) == 0 {
+		logger.Warningf("useAllNodes is set to false and no nodes are specified, no OSD pods are going to be created")
+		return []rookalpha.Node{}
+	}
+
+	// if any nodes (even user-specified ones) don't meet placement criteria, don't count them provisionable
+	provisionableNodes := k8sutil.GetValidNodes(
+		*desiredStorage, c.context.Clientset, cephv1.GetOSDPlacement(c.cephCluster.spec.Placement))
+	logger.Debugf("nodes available for OSD provisioning: %+v", provisionableNodes)
+
+	// indicate in the info message report what nodes were considered for provisionability
+	nodeSearchScope := "user-requested"
+	if desiredStorage.UseAllNodes {
+		nodeSearchScope = "Kubernetes"
+	}
+	logger.Infof("%d of %d %s nodes are available for OSD provisioning",
+		len(provisionableNodes), len(desiredStorage.Nodes), nodeSearchScope)
+
+	return provisionableNodes
+}

--- a/pkg/operator/ceph/cluster/newosd/osd.go
+++ b/pkg/operator/ceph/cluster/newosd/osd.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package newosd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/rook/rook/pkg/clusterd"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-osd")
+
+const (
+	serviceAccountName = "rook-ceph-osd"
+
+	osdAppName    = "rook-ceph-osd"
+	osdAppNameFmt = "rook-ceph-osd-%d"
+
+	inventoryAppName    = "rook-ceph-osd-inventory"
+	inventoryAppNameFmt = "rook-ceph-osd-inventory-%s"
+	osdInventoryTimeout = 10 * time.Minute // TODO: is this a good value?
+
+	clusterAvailableSpaceReserve = 0.05
+	unknownID                    = -1
+)
+
+// Controller keeps track of the OSDs
+type Controller struct {
+	context     *clusterd.Context
+	namespace   string
+	cephCluster *cephCluster
+	rookImage   string
+	ownerRef    metav1.OwnerReference
+}
+
+type cephCluster struct {
+	spec        *cephv1.ClusterSpec
+	storeConfig *osdconfig.StoreConfig
+	info        *cephconfig.ClusterInfo
+}
+
+// NewController creates a new controller for configuring and running Ceph OSDs.
+func NewController(
+	context *clusterd.Context,
+	namespace string,
+	cephSpec *cephv1.ClusterSpec,
+	cephInfo *cephconfig.ClusterInfo,
+	rookImage string,
+	ownerRef metav1.OwnerReference,
+) *Controller {
+	storeConfig := osdconfig.ToStoreConfig(cephSpec.Storage.Config)
+	return &Controller{
+		context:   context,
+		namespace: namespace,
+		cephCluster: &cephCluster{
+			spec:        cephSpec,
+			storeConfig: &storeConfig,
+			info:        cephInfo,
+		},
+		rookImage: rookImage,
+		ownerRef:  ownerRef,
+	}
+}
+
+// Start the osd management
+func (c *Controller) Start() error {
+	logger.Infof("OSD controller started for namespace %s", c.namespace)
+
+	// Validate pod's memory if specified
+	r := cephv1.GetOSDResources(c.cephCluster.spec.Resources)
+	err := opspec.CheckPodMemory(r, cephOsdPodMinimumMemory)
+	if err != nil {
+		return fmt.Errorf("user-requested OSD pod resource requirements are insufficient. %+v", err)
+	}
+
+	desiredStorage, err := c.getDesiredStorage()
+	if err != nil {
+		return fmt.Errorf("OSD controller failed. %+v", err)
+	}
+	logger.Debugf("desiredStorage: %+v", desiredStorage)
+
+	provisionableNodes := c.getProvisionableNodes(desiredStorage)
+
+	provisionableNodeCh := make(chan rookalpha.Node, len(provisionableNodes))
+	go func() {
+		defer close(provisionableNodeCh)
+		for _, n := range provisionableNodes {
+			provisionableNodeCh <- n
+		}
+	}()
+
+	inventoriedNodeCh := make(chan inventoriedNode, len(provisionableNodes))
+	go c.inventoryNodes(provisionableNodeCh, inventoriedNodeCh)
+
+	for in := range inventoriedNodeCh {
+		logger.Debugf("inventoried node: %+v", in)
+	}
+
+	// TODO: because ceph-volume only reports disks in /dev/ (i.e., not /dev/disk/by-X/... paths),
+	// inventory is invalidated if the node reboots after the inventory is taken, because those
+	// paths aren't guaranteed to be consistent across reboots. How do we resolve this?
+
+	// TODO: provision new OSDs on provisionable nodes with provisionable disks
+
+	// TODO: should we whitelist or blacklist disks? I get some `/dev/dm-N` disks reported back as
+	// available, but that is not true, as they are associated with Ceph disks
+
+	// TODO: find nodes already provisioned with OSDs ???
+
+	// TODO: get osd inventory from nodes that are newly provisionable and nodes which are already
+	// provisioned with osds
+
+	// TODO: start OSDs on the OSD inventory from above
+
+	// TODO: what does automatic osd removal look like now?
+
+	// if len(config.errorMessages) > 0 {
+	// 	return fmt.Errorf("%d failures encountered while running osds in namespace %s: %+v",
+	// 		len(config.errorMessages), c.Namespace, strings.Join(config.errorMessages, "\n"))
+	// }
+
+	logger.Infof("finished running OSDs in namespace %s", c.namespace)
+	return nil
+}

--- a/pkg/operator/ceph/cluster/newosd/spec.go
+++ b/pkg/operator/ceph/cluster/newosd/spec.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package newosd
+
+import (
+	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+)
+
+const (
+	osdLabelKey                    = "ceph-osd-id"
+	cephOsdPodMinimumMemory uint64 = 4096 // minimum amount of memory in MB to run the pod
+)
+
+func newInt32(i int32) *int32 { return &i }
+
+func newInt64(i int64) *int64 { return &i }
+
+func newBool(b bool) *bool { return &b }
+
+func (c *Controller) osdAppLabels(osdID string) map[string]string {
+	labels := opspec.PodLabels(osdAppName, c.namespace, "osd", osdID)
+	// Add "ceph_osd_id: <osd ID>" for legacy"
+	labels[osdLabelKey] = osdID
+	return labels
+}

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/daemon/cmdreporter"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	batch "k8s.io/api/batch/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// CmdReporterContainerName defines the name of the CmdReporter container which runs the
+	// 'rook cmd-reporter' command.
+	CmdReporterContainerName = "cmd-reporter"
+
+	// CopyBinariesInitContainerName defines the name of the CmdReporter init container which copies
+	// the 'rook' and 'tini' binaries.
+	CopyBinariesInitContainerName = "init-copy-binaries"
+
+	// CopyBinariesMountDir defines the dir into which the 'rook' and 'tini' binaries will be copied
+	// in the CmdReporter job pod's containers.
+	CopyBinariesMountDir = "/rook/copied-binaries"
+)
+
+var (
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "CmdReporter")
+)
+
+// CmdReporter is a wrapper for Rook's cmd-reporter commandline utility allowing operators to us the
+// utility without fully specifying the job, pod, and container templates manually.
+type CmdReporter struct {
+	// inputs
+	clientset kubernetes.Interface
+
+	// filled in during creation
+	job *batch.Job
+}
+
+type cmdReporterCfg struct {
+	clientset    kubernetes.Interface
+	ownerRef     *metav1.OwnerReference
+	appName      string
+	jobName      string
+	jobNamespace string
+	cmd          []string
+	args         []string
+	rookImage    string
+	runImage     string
+}
+
+// New creates a new CmdReporter.
+//
+// All parameters must be set with the exception of the arg list which is allowed to be empty.
+//
+// The common app label will be applied to the job and pod specs which CmdReporter creates
+// identified by the app name specified. The job and the configmap which returns the result of the
+// job will be identified with the job name specified. Everything will be created in the job
+// namespace and will be owned by the owner reference given.
+//
+// The Rook image defines the Rook image from which the 'rook' and 'tini' binaries will be taken in
+// order to run the cmd and args in the run image. If the run image is the same as the Rook image,
+// then the command will run without the binaries being copied from the same Rook image.
+func New(
+	clientset kubernetes.Interface,
+	ownerRef *metav1.OwnerReference,
+	appName, jobName, jobNamespace string,
+	cmd, args []string,
+	rookImage, runImage string,
+) (*CmdReporter, error) {
+	if clientset == nil || ownerRef == nil {
+		return nil, fmt.Errorf("clientset [%+v] and owner reference [%+v] must be specified", clientset, ownerRef)
+	}
+	if appName == "" || jobName == "" || jobNamespace == "" {
+		return nil, fmt.Errorf("app name [%s], job name [%s], and job namespace [%s] must be specified", appName, jobName, jobNamespace)
+	}
+	// at least one command must be set, and it cannot be an empty string
+	if len(cmd) == 0 || cmd[0] == "" {
+		return nil, fmt.Errorf("command [%+v] must be specified", cmd)
+	}
+	if rookImage == "" || runImage == "" {
+		return nil, fmt.Errorf("Rook image [%s] and run image [%s] must be specified", rookImage, runImage)
+	}
+	cfg := &cmdReporterCfg{
+		clientset:    clientset,
+		ownerRef:     ownerRef,
+		jobName:      jobName,
+		jobNamespace: jobNamespace,
+		cmd:          cmd,
+		args:         args,
+		rookImage:    rookImage,
+		runImage:     runImage,
+	}
+
+	job, err := cfg.initJobSpec()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes job spec for CmdReporter job %s. %+v", jobName, err)
+	}
+	return &CmdReporter{
+		clientset: clientset,
+		job:       job,
+	}, nil
+}
+
+// Job returns a pointer to the basic, filled-out Kubernetes job which will run the CmdReporter. The
+// operator may add additional information to this spec, such as labels, environment variables,
+// volumes, volume mounts, etc. before the CmdReporter is run.
+func (cr *CmdReporter) Job() *batch.Job {
+	return cr.job
+}
+
+// Run runs the Kubernetes job and waits for the output ConfigMap. It returns the stdout, stderr,
+// and retcode of the command as long as the image ran it, even if the retcode is nonzero (failure).
+// An error is reported only if the command was not run to completion successfully. When this
+// returns, the ConfigMap is cleaned up (destroyed).
+func (cr *CmdReporter) Run(timeout time.Duration) (stdout, stderr string, retcode int, retErr error) {
+	jobName := cr.job.Name
+	namespace := cr.job.Namespace
+	errMsg := fmt.Sprintf("failed to run CmdReporter %s successfully.", jobName)
+
+	// the configmap MUST be deleted, because we will wait on its presence to determine when the
+	// job is done running
+	delOpts := &k8sutil.DeleteOptions{}
+	delOpts.Wait = true
+	delOpts.ErrorOnTimeout = true
+	// configmap's name will be the same as the app
+	err := k8sutil.DeleteConfigMap(cr.clientset, jobName, namespace, delOpts)
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to delete existing results ConfigMap %s. %+v", errMsg, jobName, retErr)
+	}
+
+	if err := k8sutil.RunReplaceableJob(cr.clientset, cr.job, true); err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to run job. %+v", errMsg, err)
+	}
+
+	listOpts := metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		FieldSelector: fmt.Sprintf("metadata.name=%s", jobName),
+	}
+
+	list, err := cr.clientset.CoreV1().ConfigMaps(namespace).List(listOpts)
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to list the current ConfigMaps in order to watch for our results ConfigMap %s. %+v", errMsg, jobName, err)
+	}
+	if len(list.Items) > 0 {
+		// this is very unlikely, but we're already here
+		return "", "", -1, fmt.Errorf("%s. a ConfigMap with the same name as the expected results [%s] already exists", errMsg, jobName)
+	}
+
+	watchOpts := listOpts.DeepCopy()
+	watchOpts.Watch = true
+	watchOpts.ResourceVersion = list.ResourceVersion
+
+	watcher, err := cr.clientset.CoreV1().ConfigMaps(namespace).Watch(*watchOpts)
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to watch for changes to ConfigMaps. %+v", errMsg, err)
+	}
+
+	// timeout timer cannot be started inline in the select statement, or the timeout will be
+	// restarted any time k8s hangs up on the watcher and a new watcher is started
+	timeoutCh := time.After(timeout)
+
+WatchLoop:
+	for {
+		select {
+		case _, ok := <-watcher.ResultChan():
+			if !ok {
+				watcher.Stop()
+				logger.Infof("Kubernetes hung up the watcher for CmdReporter %s result ConfigMap; starting a replacement watcher", jobName)
+				watcher, err = cr.clientset.CoreV1().ConfigMaps(namespace).Watch(*watchOpts)
+				if err != nil {
+					return "", "", -1, fmt.Errorf("%s. failed to start replacement watcher for changes to ConfigMaps. %+v", errMsg, err)
+				}
+			} else {
+				logger.Debugf("job %s has returned results", jobName)
+				break WatchLoop
+			}
+		case <-timeoutCh:
+			watcher.Stop()
+			return "", "", -1, fmt.Errorf("%s. timed out waiting for results ConfigMap %s", errMsg, jobName)
+		}
+	}
+	watcher.Stop()
+
+	resultMap, err := cr.clientset.CoreV1().ConfigMaps(namespace).Get(jobName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. results ConfigMap %s should be available, but we got an error. %+v", errMsg, jobName, err)
+	}
+
+	dat := resultMap.Data
+	var ok bool
+	if stdout, ok = dat[cmdreporter.ConfigMapStdoutKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate stdout in ConfigMap", errMsg)
+	}
+	if stderr, ok = dat[cmdreporter.ConfigMapStderrKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate stderr in ConfigMap", errMsg)
+	}
+	var strRetcode string
+	if strRetcode, ok = dat[cmdreporter.ConfigMapRetcodeKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate retcode in ConfigMap", errMsg)
+	}
+	if retcode, err = strconv.Atoi(strRetcode); err != nil {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter returned a retcode value [%s] that could not be parsed to an int. %+v", errMsg, strRetcode, err)
+	}
+
+	return stdout, stderr, retcode, nil
+}
+
+func (cr *cmdReporterCfg) initJobSpec() (*batch.Job, error) {
+	cmdReporterContainer, err := cr.container()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runner container. %+v", err)
+	}
+
+	podSpec := v1.PodSpec{
+		// ServiceAccountName: serviceAccountName,
+		InitContainers: cr.initContainers(),
+		Containers: []v1.Container{
+			*cmdReporterContainer,
+		},
+		RestartPolicy: v1.RestartPolicyOnFailure,
+	}
+	copyBinsVol, _ := copyBinariesVolAndMount()
+	podSpec.Volumes = []v1.Volume{copyBinsVol}
+
+	commonLabels := map[string]string{k8sutil.AppAttr: cr.appName}
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.jobName,
+			Namespace: cr.jobNamespace,
+			Labels:    commonLabels,
+		},
+		Spec: batch.JobSpec{
+			Completions: newInt32(1),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: commonLabels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	k8sutil.AddRookVersionLabelToJob(job)
+	k8sutil.SetOwnerRef(cr.clientset, cr.jobNamespace, &job.ObjectMeta, cr.ownerRef)
+
+	return job, nil
+}
+
+func (cr *cmdReporterCfg) initContainers() []v1.Container {
+	if !cr.needToCopyBinaries() {
+		return []v1.Container{}
+	}
+
+	c := v1.Container{
+		Name: CopyBinariesInitContainerName,
+		// Command: the rook command is the default entrypoint of rook images already
+		Args: []string{
+			"cmd-reporter", "copy-binaries",
+			"--copy-to-dir", CopyBinariesMountDir,
+		},
+		Image: cr.rookImage,
+	}
+	_, copyBinsMount := copyBinariesVolAndMount()
+	c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
+
+	return []v1.Container{c}
+}
+
+func (cr *cmdReporterCfg) container() (*v1.Container, error) {
+	userCmdArg, err := cmdreporter.CommandToFlagArgument(cr.cmd, cr.args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert user cmd %+v and args %+v into an argument for '--command'. %+v", cr.cmd, cr.args, err)
+	}
+
+	cmd := []string{
+		path.Join(CopyBinariesMountDir, "tini"), "--", path.Join(CopyBinariesMountDir, "rook"),
+	}
+	if !cr.needToCopyBinaries() {
+		// tini -- rook is already the cmd entrypoint if we don't need to copy binaries
+		cmd = nil
+	}
+
+	c := &v1.Container{
+		Name:    CmdReporterContainerName,
+		Command: cmd,
+		Args: []string{
+			"cmd-reporter", "run",
+			"--command", userCmdArg,
+			"--config-map-name", cr.jobName,
+			"--namespace", cr.jobNamespace,
+		},
+		Image: cr.runImage,
+	}
+	if cr.needToCopyBinaries() {
+		_, copyBinsMount := copyBinariesVolAndMount()
+		c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
+	}
+
+	return c, nil
+}
+
+func (cr *cmdReporterCfg) needToCopyBinaries() bool {
+	return cr.rookImage != cr.runImage
+}
+
+// return a matched volume and mount for copying binaries
+func copyBinariesVolAndMount() (v1.Volume, v1.VolumeMount) {
+	vName := k8sutil.PathToVolumeName(CopyBinariesMountDir)
+	mDir := CopyBinariesMountDir
+	v := v1.Volume{Name: vName, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	m := v1.VolumeMount{Name: vName, MountPath: mDir}
+	return v, m
+}
+
+func newInt32(i int32) *int32 { return &i }

--- a/pkg/operator/k8sutil/configmap.go
+++ b/pkg/operator/k8sutil/configmap.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeleteConfigMap deletes a ConfigMap.
+func DeleteConfigMap(clientset kubernetes.Interface, cmName, namespace string, opts *DeleteOptions) error {
+	k8sOpts := BaseKubernetesDeleteOptions()
+	delete := func() error { return clientset.CoreV1().ConfigMaps(namespace).Delete(cmName, k8sOpts) }
+	verify := func() error {
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Get(cmName, metav1.GetOptions{})
+		return err
+	}
+	resource := fmt.Sprintf("ConfigMap %s", cmName)
+	defaultWaitOptions := &WaitOptions{RetryCount: 20, RetryInterval: 2 * time.Second}
+	return DeleteResource(delete, verify, resource, opts, defaultWaitOptions)
+}

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDeleteConfigMap(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"test": "data",
+		},
+	}
+
+	_, err := k8s.CoreV1().ConfigMaps("test-namespace").Create(cm)
+	assert.NoError(t, err)
+
+	// There is no need to test all permutations, as the `DeleteResource` function is already
+	// tested. Setting Wait=true and ErrorOnTimeout=true will cause both the delete and verify
+	// functions to be exercised, and it will return error if either fail with an unexpected error.
+	opts := &DeleteOptions{}
+	opts.Wait = true
+	opts.ErrorOnTimeout = true
+	err = DeleteConfigMap(k8s, "test-configmap", "test-namespace", opts)
+	assert.NoError(t, err)
+
+	_, err = k8s.CoreV1().ConfigMaps("test-namespace").Get("test-configmap", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/pkg/operator/k8sutil/delete.go
+++ b/pkg/operator/k8sutil/delete.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BaseKubernetesDeleteOptions returns the base set of Kubernetes delete options which most delete
+// operations should use.
+func BaseKubernetesDeleteOptions() *metav1.DeleteOptions {
+	p := metav1.DeletePropagationForeground
+	g := int64(0)
+	return &metav1.DeleteOptions{GracePeriodSeconds: &g, PropagationPolicy: &p}
+}
+
+// DeleteOptions are a common set of options controlling the behavior of k8sutil delete operations.
+// DeleteOptions is a superset of WaitOptions.
+type DeleteOptions struct {
+	// MustDelete controls the idempotency of the delete operation. If MustDelete is true and the
+	// resource being deleted does not exist, the delete operation is considered a failure. If
+	// MustDelete is false and the resource being deleted does not exist, the delete operation is
+	// considered a success.
+	MustDelete bool
+
+	// DeleteOptions is a superset of WaitOptions.
+	WaitOptions
+}
+
+// Use this for unit testing
+var unitTestRetryIntervalRecord time.Duration
+
+// DeleteResource implements the DeleteOptions logic around deletion of a Kubernetes resource.
+//
+// The delete and verify functions used as parameters should implement and return the error from the
+// Kubernetes `Delete` and `Get` commands respectively.
+//
+// The resource string will be used to report the resource in log and error messages. A good pattern
+// would be to set this string to the resource type (e.g., Deployment) and the name of the resource
+// (e.g., my-deployment).
+//
+// The default wait options should specify sane defaults for retry count and retry interval for
+// deletion of the specific resource type. Only retry count and interval will be used from this
+// parameter.
+func DeleteResource(
+	delete func() error,
+	verify func() error,
+	resource string,
+	opts *DeleteOptions,
+	defaultWaitOptions *WaitOptions,
+) error {
+	if err := delete(); err != nil {
+		if errors.IsNotFound(err) && opts.MustDelete {
+			return fmt.Errorf("failed to delete %s; it does not exist. %+v", resource, err)
+		} else if errors.IsNotFound(err) && !opts.MustDelete {
+			logger.Debugf("%s is already deleted", resource)
+			return nil
+		}
+		return fmt.Errorf("failed to delete %s. %+v", resource, err)
+	}
+
+	if !opts.Wait {
+		return nil
+	}
+
+	// if default wait options aren't set, still provide something of a default
+	retries := opts.retryCountOrDefault(defaultWaitOptions.retryCountOrDefault(30))
+	retryInterval := opts.retryIntervalOrDefault(defaultWaitOptions.retryIntervalOrDefault(5 * time.Second))
+	unitTestRetryIntervalRecord = retryInterval
+	var i uint
+	var err error
+	// less-than-or-equal is important; i=0 is the first "try". It isn't a "re-try" until i=1.
+	for i = 0; i <= retries; i++ {
+		err = verify()
+		if err != nil && errors.IsNotFound(err) {
+			logger.Debugf("%s was deleted after %d retries every %v seconds", resource, i, retryInterval/time.Second)
+			return nil
+		}
+		logger.Infof("Retrying %d more times every %v seconds for %s to be deleted",
+			retries-i, retryInterval/time.Second, resource)
+		if retries-i > 0 {
+			time.Sleep(retryInterval)
+		}
+	}
+
+	msg := fmt.Sprintf("failed to delete %s. gave up waiting after %d retries every %v seconds. %+v",
+		resource, retries, retryInterval/time.Second, err)
+	if opts.ErrorOnTimeout {
+		return fmt.Errorf(msg)
+	}
+	logger.Warningf(msg)
+	return nil
+}

--- a/pkg/operator/k8sutil/delete_test.go
+++ b/pkg/operator/k8sutil/delete_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestDeleteResource(t *testing.T) {
+	var deleteError error
+	stubDelete := func() error { return deleteError }
+
+	k8sNotFoundError := errors.NewNotFound(schema.GroupResource{Group: "group", Resource: "resource"}, "test")
+
+	var verifyCount int
+	var verifyReturnDeletedAtCount int
+	stubVerify := func() error {
+		verifyCount++
+		fmt.Println("verifyCount:", verifyCount, "   - returnNilAt:", verifyReturnDeletedAtCount)
+		if verifyCount == verifyReturnDeletedAtCount {
+			return k8sNotFoundError
+		}
+		return fmt.Errorf("still not verified")
+	}
+
+	defaultWaitOpts := &WaitOptions{RetryCount: 2, RetryInterval: 1 * time.Millisecond}
+
+	// Failure to delete should return error
+	deleteError = fmt.Errorf("err on delete")
+	err := DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.Error(t, err)
+
+	// NotFound error should return error if DeleteOptions.MustDelete is set
+	deleteError = k8sNotFoundError
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{MustDelete: true}, defaultWaitOpts)
+	assert.Error(t, err)
+
+	// Default behavior should be to continue if resource doesn't exist
+	deleteError = k8sNotFoundError
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Default behavior should be to NOT wait to verify resource
+	deleteError = nil
+	verifyCount = 0
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.Zero(t, verifyCount)
+
+	// Verify that the default wait options are picked up
+	// And that the verify function is called one time more than the retry count
+	// And that delete can report error on timeout
+	deleteError = nil
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 1000000 // do not return verify success
+	deleteOpts := &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.Error(t, err)
+	assert.Equal(t, 3, verifyCount)
+	assert.Equal(t, 1*time.Millisecond, unitTestRetryIntervalRecord)
+
+	// Test that delete will not report error on timeout if so configured
+	deleteOpts.ErrorOnTimeout = false
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Verify that delete will return successfully after some retries
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 2
+	deleteOpts = &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Verify that specified retry count and interval in delete opts are picked up
+	deleteError = nil
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 1000000 // do not return verify success
+	deleteOpts = &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	deleteOpts.RetryCount = 5
+	deleteOpts.RetryInterval = 2 * time.Millisecond
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.Error(t, err)
+	assert.Equal(t, 6, verifyCount)
+	assert.Equal(t, 2*time.Millisecond, unitTestRetryIntervalRecord)
+}

--- a/pkg/operator/k8sutil/job.go
+++ b/pkg/operator/k8sutil/job.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// RunReplaceableJob runs a Kubernetes job with the intention that the job can be replaced by
+// another call to this function with the same job name. For example, if a storage operator is
+// restarted/updated before the job can complete, the operator's next run of the job should replace
+// the previous job if deleteIfFound is set to true.
 func RunReplaceableJob(clientset kubernetes.Interface, job *batch.Job, deleteIfFound bool) error {
 	// check if the job was already created and what its status is
 	existingJob, err := clientset.BatchV1().Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
@@ -80,6 +84,7 @@ func WaitForJobCompletion(clientset kubernetes.Interface, job *batch.Job, timeou
 	})
 }
 
+// DeleteBatchJob deletes a Kubernetes job.
 func DeleteBatchJob(clientset kubernetes.Interface, namespace, name string, wait bool) error {
 	propagation := metav1.DeletePropagationForeground
 	gracePeriod := int64(0)

--- a/pkg/operator/k8sutil/options.go
+++ b/pkg/operator/k8sutil/options.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"time"
+)
+
+// WaitOptions are a common set of options controlling the behavior of k8sutil operations. If
+// WaitOptions are specified, the operation should wait in a loop and verify that the operation
+// being performed was successful.
+type WaitOptions struct {
+	// Wait defines whether the operation should wait in a loop and verify that the operation was
+	// successful before returning.
+	Wait bool
+
+	// RetryCount defines how many times the operation should retry verification in the wait loop
+	// before giving up. If RetryCount is zero, the operation should default to a sane value based
+	// on the operation.
+	RetryCount uint
+
+	// RetryInterval defines the time the operation will wait before retrying verification. If
+	// RetryInterval is zero, the operation should default to a sane value based on the operation.
+	RetryInterval time.Duration
+
+	// ErrorOnTimeout defines whether the operation should time out with an error. If ErrorOnTimeout
+	// is true and the operation times out, the operation is considered a failure. If ErrorOnTimeout
+	// is false and the operation times out, the operation should log a warning but not not report
+	// failure.
+	ErrorOnTimeout bool
+}
+
+func (w *WaitOptions) retryCountOrDefault(def uint) uint {
+	if w.RetryCount > 0 {
+		return w.RetryCount
+	}
+	return def
+}
+
+func (w *WaitOptions) retryIntervalOrDefault(def time.Duration) time.Duration {
+	if w.RetryInterval > 0 {
+		return w.RetryInterval
+	}
+	return def
+}


### PR DESCRIPTION
**Description of your changes:**
Implement the skeleton for the new OSD design.

All of the early commits are various discrete stages in the process of writing a reusable daemon for running a command in a pod and returning the result in a ConfigMap called `cmd-reporter`. This includes a helper/wrapper in `operator/k8sutils` that abstracts away ~100 lines of the boilerplate which an operator would need to implement to run `cmd-reporter`.

The actual OSD framework begins with detecting nodes on which OSDs need to be prepared taken largely wholesale from the old OSD code. The framework stops after the first stage (see #3247), running `ceph-volume inventory`. This successfully establishes a basic OSD preparation pipeline and makes use of the `cmd-reporter` functionality.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]
