### PR TITLE
ceph: serial osd node provisioning

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/rook/rook/pkg/clusterd"
 )
@@ -63,6 +64,38 @@ type OSDDump struct {
 		Up  json.Number `json:"up"`
 		In  json.Number `json:"in"`
 	} `json:"osds"`
+	Flags string `json:"flags"`
+}
+
+// IsFlagSet checks if an OSD flag is set
+func (dump *OSDDump) IsFlagSet(checkFlag string) bool {
+	flags := strings.Split(dump.Flags, ",")
+	for _, flag := range flags {
+		if flag == checkFlag {
+			return true
+		}
+	}
+	return false
+}
+
+// SetOSDFlag enables an osd flag
+func SetOSDFlag(context *clusterd.Context, clusterName string, flag string) error {
+	args := []string{"osd", "set", flag}
+	_, err := NewCephCommand(context, clusterName, args).Run()
+	if err != nil {
+		return fmt.Errorf("failed to set flag %s: %+v", flag, err)
+	}
+	return nil
+}
+
+// UnsetOSDFlag disables an osd flag
+func UnsetOSDFlag(context *clusterd.Context, clusterName string, flag string) error {
+	args := []string{"osd", "unset", flag}
+	_, err := NewCephCommand(context, clusterName, args).Run()
+	if err != nil {
+		return fmt.Errorf("failed to unset flag %s: %+v", flag, err)
+	}
+	return nil
 }
 
 // StatusByID returns status and inCluster states for given OSD id


### PR DESCRIPTION
Signed-off-by: Michael Vollman <michael.b.vollman@gmail.com>

**Description of your changes:**
Only provision one node at a time to ensure the safety of rolling
cluster updates.  Verify all placement groups are healthy before moving
on to the next node.  Set the noout and norebalance flags when the ceph
image version is changing.  Unset these flags only if they were not
already set once upgrade completes successfully.

**Which issue is resolved by this Pull Request:**
Resolves #2900

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
