### PR TITLE
backport: ceph: upgrade apply osd nautilus flag

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -38,6 +38,7 @@
 - OSDs provisioned by `ceph-volume` now supports `metadataDevice` and `databaseSizeMB` options.
 - The flex driver can be configured to properly disable SELinux relabeling and FSGroup with the settings in operator.yaml.
 - Rgw is now configured with the Beast backend as of the Nautilus release
+- OSD: newly updated cluster from 0.9 to 1.0.3 and thus Ceph Nautilus will have their OSDs allowing new features for Nautilus
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -27,6 +27,7 @@ import (
 // CephDaemonsVersions is a structure that can be used to parsed the output of the 'ceph versions' command
 type CephDaemonsVersions struct {
 	Mon     map[string]int `json:"mon,omitempty"`
+	Osd     map[string]int `json:"osd,omitempty"`
 	Mgr     map[string]int `json:"mgr,omitempty"`
 	Mds     map[string]int `json:"mds,omitempty"`
 	Overall map[string]int `json:"overall,omitempty"`
@@ -92,6 +93,17 @@ func EnableMessenger2(context *clusterd.Context) error {
 		return fmt.Errorf("failed to enable msgr2 protocol: %+v", err)
 	}
 	logger.Infof("successfully enabled msgr2 protocol")
+
+	return nil
+}
+
+// EnableNautilusOSD disallows pre-Nautilus OSDs and enables all new Nautilus-only functionality
+func EnableNautilusOSD(context *clusterd.Context) error {
+	_, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "osd", "require-osd-release", "nautilus")
+	if err != nil {
+		return fmt.Errorf("failed to disallow pre-nautilus osds and enable all new nautilus-only functionality: %+v", err)
+	}
+	logger.Infof("successfully disallowed pre-nautilus osds and enabled all new nautilus-only functionality")
 
 	return nil
 }

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -63,3 +63,18 @@ func TestEnableMessenger2(t *testing.T) {
 	err := EnableMessenger2(context)
 	assert.Nil(t, err)
 }
+
+func TestEnableNautilusOSD(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
+		assert.Equal(t, "osd", args[0])
+		assert.Equal(t, "require-osd-release", args[1])
+		assert.Equal(t, "nautilus", args[2])
+		assert.Equal(t, 3, len(args))
+		return "", nil
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	err := EnableNautilusOSD(context)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
When OSDs are running on Nautilus we always disable old osd features and
aplpy the onces for Nautilus as described in the upgrade doc.
During an upgrade or the next time an orchestration will be called the
command will be applied. The command is idempotent so we can run it each
time.
This can be backported for 1.0.3

Closes: https://github.com/rook/rook/issues/2960
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit cba9a359a0b546aa84e852936d11d3a2c5eb2f92)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]