### PR TITLE
ceph: osd: fix startup on sdn

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -328,3 +328,18 @@ func TestHostNetwork(t *testing.T) {
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
 }
+
+func TestOsdOnSDNFlag(t *testing.T) {
+	hostnetwork := false
+	v := cephver.Mimic
+	args := osdOnSDNFlag(hostnetwork, v)
+	assert.Empty(t, args)
+
+	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 2}
+	args = osdOnSDNFlag(hostnetwork, v)
+	assert.NotEmpty(t, args)
+
+	v = cephver.Octopus
+	args = osdOnSDNFlag(hostnetwork, v)
+	assert.NotEmpty(t, args)
+}


### PR DESCRIPTION
This commit adds a new flag to the osd startup so that on msgr2 (default
on Nautilus and above) the osd is able to find the IP address in the
container to bind to.

This requires this Ceph patch https://github.com/ceph/ceph/pull/28589
and is already present in Octopus.

Closes: https://github.com/rook/rook/issues/3140
Signed-off-by: Sébastien Han <seb@redhat.com>

// known CI issues
[skip ci]