### PR TITLE
ceph: add psp.yaml example

### DIFF
--- a/Documentation/ceph-psp.md
+++ b/Documentation/ceph-psp.md
@@ -10,36 +10,7 @@ See the [Rook overall PSP document](./psp.md) before continuing on here with Cep
 
 ##### PodSecurityPolicy
 
-You need at least one `PodSecurityPolicy` that allows privileged `Pod` execution. Here is an example
-that is reasonably pared down for Ceph, though more work to minimize permissions can be done:
-
-```yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: privileged
-spec:
-  fsGroup:
-    rule: RunAsAny
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    - 'hostPath'
-    - 'flexVolume'
-  hostPID: true
-  # hostNetwork is required for using host networking
-  hostNetwork: false
-```
+You need at least one `PodSecurityPolicy` that allows privileged `Pod` execution. Please look at [https://github.com/rook/rook/cluster/examples/kubernetes/ceph/psp.yaml](psp.yaml) for a reasonably pared down for Ceph.
 
 **Hint**: Allowing `hostNetwork` usage is required when using `hostNetwork: true` in the Cluster
 Resource Definition! You are then also required to allow the usage of `hostPorts` in the

--- a/cluster/examples/kubernetes/ceph/psp.yaml
+++ b/cluster/examples/kubernetes/ceph/psp.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: rook
+spec:
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+    - 'flexVolume'
+  hostPID: true
+  hostNetwork: true
+  hostIPC: true
+  # The following section is only needed when hostNetwork: true
+  hostPorts:
+    # Ceph msgr2 port
+    - min: 3300
+      max: 3300
+    # Ceph msgr1 ports
+    - min: 6789
+      max: 7300
+    # Ceph MGR Prometheus Metrics
+    - min: 9283
+      max: 9283


### PR DESCRIPTION
The current doc was outdated and hardcoded, so removing the example from
the doc and add a proper psp.yaml file that people can use and
contribute too.

Closes: https://github.com/rook/rook/issues/3309
Signed-off-by: Sébastien Han <seb@redhat.com>

[skip ci]