### PR TITLE
Update openshift with Ceph-CSI image versions as in Kubernetes case

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-openshift-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift-with-csi.yaml
@@ -123,11 +123,11 @@ spec:
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: "true"
         - name: ROOK_CSI_CEPHFS_IMAGE
-          value: "quay.io/cephcsi/cephfsplugin:v1.0.0"
+          value: "quay.io/cephcsi/cephfsplugin:canary"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
         - name: ROOK_CSI_RBD_IMAGE
-          value: "quay.io/cephcsi/rbdplugin:v1.0.0"
+          value: "quay.io/cephcsi/rbdplugin:canary"
         - name: ROOK_CSI_REGISTRAR_IMAGE
           value: "quay.io/k8scsi/csi-node-driver-registrar:v1.0.2"
         - name: ROOK_CSI_PROVISIONER_IMAGE


### PR DESCRIPTION
PR #3217 changed the CSI pod manifest to drop some parameters to the
ceph-csi pods. This also resulted in a change to the operator with CSI
yaml for non-openshift case, but failed to update similar yaml's for
the openshift case.

This commit rectifies the problem for openshift.

Updates #3312

[skip ci]