### PR TITLE
ceph: Look for binaries on PATH if not found

### DIFF
--- a/pkg/daemon/ceph/osd/init.go
+++ b/pkg/daemon/ceph/osd/init.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 
 	"path"
 	"path/filepath"
@@ -91,7 +92,12 @@ func copyBinary(sourceDir, targetDir, filename string) error {
 
 	// Check if the target path exists, and skip the copy if it does
 	if _, err := os.Stat(targetPath); err == nil {
-		return nil
+		// Check for binary on PATH
+		p, err := exec.LookPath(filename)
+		if err != nil {
+			return nil
+		}
+		sourcePath = path.Join(p, filename)
 	}
 
 	sourceFile, err := os.Open(sourcePath)


### PR DESCRIPTION
**Description of your changes:**

Similarly to #2675, try to find the rook binary
on `PATH` in case it isn't found in `/usr/local/bin/rook`.

This is needed when packaging rook according to FHS
guidelines, which prohibits placing system files
in `/usr/local`.
