### PR TITLE
Add k8s 1.15 and remove 1.10 from integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,11 +89,11 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
-                        "aws_1.10.x": "v1.10.12",
                         "aws_1.11.x": "v1.11.8",
                         "aws_1.12.x": "v1.12.6",
-                        "aws_1.13.x": "v1.13.4",
-                        "aws_1.14.x": "v1.14.1"
+                        "aws_1.13.x": "v1.13.7",
+                        "aws_1.14.x": "v1.14.3",
+                        "aws_1.15.x": "v1.15.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -6,6 +6,7 @@
 - Creation of storage pools through the custom resource definitions (CRDs) now allows users to optionally specify `deviceClass` property to enable
 distribution of the data only across the specified device class. See [Ceph Block Pool CRD](Documentation/ceph-pool-crd.md#ceph-block-pool-crd) for
 an example usage
+- Added K8s 1.15 to the test matrix and removed K8s 1.10 from the test matrix.
 - OwnerReferences are created with the fully qualified `apiVersion` such that the references will work properly on OpenShift.
 
 ### Ceph


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the release of K8s 1.15 we need to add it to the test matrix. In continuing with our pattern of supporting the most recent five releases, we will drop 1.10 at the same time.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]