### PR TITLE
Container Linux - Daemonsets missing required field "selector"

### DIFF
--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ceph-after-reboot-check
   namespace: rook-ceph
 spec:
+  selector:
+    matchLabels:
+      app: ceph-after-reboot-check
   template:
     metadata:
       labels:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ceph-before-reboot-check
   namespace: rook-ceph
 spec:
+  selector:
+    matchLabels:
+      app: ceph-before-reboot-check
   template:
     metadata:
       labels:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add selectors to Container Linux update operator daemonsets. 

**Which issue is resolved by this Pull Request:**
Resolves #3339

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]