### PR TITLE
backport: ceph: stop enforcing crush tunable

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -39,6 +39,7 @@
 - The flex driver can be configured to properly disable SELinux relabeling and FSGroup with the settings in operator.yaml.
 - Rgw is now configured with the Beast backend as of the Nautilus release
 - OSD: newly updated cluster from 0.9 to 1.0.3 and thus Ceph Nautilus will have their OSDs allowing new features for Nautilus
+- Ceph CRUSH tunable are not enforced to "firefly" anymore, Ceph picks the right tunable for its own version, to read more about tunable [see the Ceph documentation](http://docs.ceph.com/docs/master/rados/operations/crush-map/#tunables)
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -203,17 +203,6 @@ func GetCrushHostName(context *clusterd.Context, clusterName string, osdID int) 
 }
 
 func CreateDefaultCrushMap(context *clusterd.Context, clusterName string) (string, error) {
-	// first set crush tunables to a firefly profile in order to support older clients
-	// (e.g., hyperkube uses a firefly rbd tool)
-	crushTunablesProfile := "firefly"
-	logger.Infof("setting crush tunables to %s", crushTunablesProfile)
-	output, err := SetCrushTunables(context, clusterName, crushTunablesProfile)
-	if err != nil {
-		return output, fmt.Errorf("failed to set crush tunables to profile %s: %+v", crushTunablesProfile, err)
-	} else {
-		logger.Infof("succeeded setting crush tunables to profile %s: %s", crushTunablesProfile, output)
-	}
-
 	// create a temp file that we will use to write the default decompiled crush map to
 	decompiledMap, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -238,7 +227,7 @@ func CreateDefaultCrushMap(context *clusterd.Context, clusterName string) (strin
 
 	// compile the crush map to an output file
 	args := []string{"-c", decompiledMap.Name(), "-o", compiledMap.Name()}
-	output, err = context.Executor.ExecuteCommandWithOutput(false, "", CrushTool, args...)
+	output, err := context.Executor.ExecuteCommandWithOutput(false, "", CrushTool, args...)
 	if err != nil {
 		return output, fmt.Errorf("failed to compile crushmap from %s: %+v", decompiledMap.Name(), err)
 	}


### PR DESCRIPTION
This requirement is long gone and was reported in 2017. Clients should
have been updated by then, so there is no reason to set the CRUSH
tunable to such an old client. Actually, we should let Ceph run its own
tunable. They can always be changed later. Also, this was really
restrictive and applied on every orchestration and thus would override
any other config done by an administrator. Even worse, this will trigger
data movement back and forth...

Closes: https://github.com/rook/rook/issues/3138
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit d3845e7f7598d154a7ab39d4b35090ec7c3e4c30)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]
Known CI issue.