### PR TITLE
ceph: schedule mons across failure domains

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -19,6 +19,7 @@ storage cluster.
 - [OSD Dedicated Network](#osd-dedicated-network)
 - [Phantom OSD Removal](#phantom-osd-removal)
 - [Change Failure Domain](#change-failure-domain)
+- [Monitor placement](#monitor-placement)
 
 ## Prerequisites
 
@@ -658,3 +659,23 @@ crush_rule: replicapool_host_rule
 If the cluster's health was `HEALTH_OK` when we performed this change, immediately, the new rule is applied to the cluster transparently without service disruption.
 
 Exactly the same approach can be used to change from `host` back to `osd`.
+
+## Monitor placement
+
+Rook will try to schedule Ceph monitor pods on different physical nodes by
+default. When available, Rook will also consider failure domain information in
+the form of Kubernetes node labels when scheduling Ceph monitors.
+
+Currently Rook supports the node label
+`failure-domain.beta.kubernetes.io/zone=<zone>` which can be applied to a node
+to specify its failure domain using the command:
+
+```
+kubectl label node <node> failure-domain.beta.kubernetes.io/zone=<zone>
+```
+
+Rook uses failure domain labels by trying to schedule monitor pods on different
+failure domains. And all nodes without failure domain labels are treated as a single
+failure domain from a scheduling point of view. When placing multiple monitor
+pods within a single failure domain Rook will try to run the pods on different
+physical nodes.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,6 +22,12 @@ an example usage
 - `NodeAffinity` can be applied to `rook-ceph-agent DaemonSet` with `AGENT_NODE_AFFINITY` environment variable.
 - `NodeAffinity` can be applied to `rook-discover DaemonSet` with `DISCOVER_AGENT_NODE_AFFINITY` environment variable.
 - Rook does not create an initial CRUSH map anymore and let Ceph do it normally
+- Ceph monitor placement will now take failure zones into account [see the
+  documentation](Documentation/ceph-advanced-configuration.md#monitor-placement)
+  for more information.
+- The cluster CRD option to allow multiple monitors to be scheduled on the same
+  node---`spec.Mon.AllowMultiplePerNode`---is now active when a cluster is first
+  created. Previously, it was ignored when a cluster was first installed.
 
 ## Breaking Changes
 

--- a/pkg/operator/ceph/cluster/mon/node.go
+++ b/pkg/operator/ceph/cluster/mon/node.go
@@ -21,85 +21,19 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"github.com/rook/rook/pkg/util"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// getMonNodes detects the nodes that are available for new mons to start.
-func (c *Cluster) getMonNodes() ([]v1.Node, error) {
-	availableNodes, nodes, err := c.getAvailableMonNodes()
-	if err != nil {
-		return nil, err
-	}
-	logger.Infof("Found %d running nodes without mons", len(availableNodes))
-
-	// if all nodes already have mons and the user has given the mon.count, add all nodes to be available
-	if c.spec.Mon.AllowMultiplePerNode && len(availableNodes) == 0 {
-		logger.Infof("All nodes are running mons. Adding all %d nodes to the availability.", len(nodes.Items))
-		for _, node := range nodes.Items {
-			valid, err := k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
-			if err != nil {
-				logger.Warning("failed to validate node %s %v", node.Name, err)
-			} else if valid {
-				availableNodes = append(availableNodes, node)
-			}
-		}
-	}
-
-	return availableNodes, nil
-}
-
-func (c *Cluster) getAvailableMonNodes() ([]v1.Node, *v1.NodeList, error) {
-	nodeOptions := metav1.ListOptions{}
-	nodeOptions.TypeMeta.Kind = "Node"
-	nodes, err := c.context.Clientset.CoreV1().Nodes().List(nodeOptions)
-	if err != nil {
-		return nil, nil, err
-	}
-	logger.Debugf("there are %d nodes available for %d mons", len(nodes.Items), len(c.clusterInfo.Monitors))
-
-	// get the nodes that have mons assigned
-	nodesInUse, err := c.getNodesWithMons(nodes)
-	if err != nil {
-		logger.Warningf("could not get nodes with mons. %+v", err)
-		nodesInUse = util.NewSet()
-	}
-
-	// choose nodes for the new mons that don't have mons currently
-	availableNodes := []v1.Node{}
-	for _, node := range nodes.Items {
-		if !nodesInUse.Contains(node.Name) {
-			valid, err := k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
-			if err != nil {
-				logger.Warning("failed to validate node %s %v", node.Name, err)
-			} else if valid {
-				availableNodes = append(availableNodes, node)
-			}
-		}
-	}
-
-	return availableNodes, nodes, nil
-}
-
-func (c *Cluster) getNodesWithMons(nodes *v1.NodeList) (*util.Set, error) {
-	// get the mon pods and their node affinity
-	options := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appName)}
-	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(options)
-	if err != nil {
-		return nil, err
-	}
-	nodesInUse := util.NewSet()
-	for _, pod := range pods.Items {
-		hostname := pod.Spec.NodeSelector[v1.LabelHostname]
-		logger.Debugf("mon pod on node %s", hostname)
-		name, ok := getNodeNameFromHostname(nodes, hostname)
-		if !ok {
-			logger.Errorf("mon %s on hostname %s not found in node list", pod.Name, hostname)
-		}
-		nodesInUse.Add(name)
-	}
-	return nodesInUse, nil
+// NodeUsage is a mapping between a Node and computed metadata about the node
+// that is used in monitor pod scheduling.
+type NodeUsage struct {
+	Node *v1.Node
+	// The number of monitor pods assigned to the node
+	MonCount int
+	// The node is available for scheduling monitor pods. This is equivalent to
+	// evaluating k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
+	MonValid bool
 }
 
 // Get the number of mons that the operator should be starting
@@ -189,4 +123,77 @@ func getNodeInfoFromNode(n v1.Node) (*NodeInfo, error) {
 		return nil, fmt.Errorf("couldn't get IP of node %s", nr.Name)
 	}
 	return nr, nil
+}
+
+// Returns a hierarchical representation of the nodes in the cluster organized
+// by zone failure domain and annotated with the number of monitor pods assigned
+// to each node and if the node is valid for scheduling monitor pods. The
+// purpose of this structure is to provide a unified view of information
+// required for making monitor scheduling decisions.
+func (c *Cluster) getNodeMonUsage() ([][]NodeUsage, error) {
+	// get all k8s node objects
+	nodeOptions := metav1.ListOptions{}
+	nodeOptions.TypeMeta.Kind = "Node"
+	nodes, err := c.context.Clientset.CoreV1().Nodes().List(nodeOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// get all pod objects labeled as a monitor
+	podOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appName)}
+	pods, err := c.context.Clientset.CoreV1().Pods(c.Namespace).List(podOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// generate a list of nodes that includes the number of monitor pods
+	// assigned to each node. this is equivalent to:
+	//
+	//   SELECT Node, Count(*) FROM Nodes
+	//   JOIN Pods ON Nodes.Hostname == Pods.Hostname
+	//   GROUP BY Node
+	//
+	nodeUsages := []NodeUsage{}
+	for i, node := range nodes.Items {
+		valid, err := k8sutil.ValidNode(node, cephv1.GetMonPlacement(c.spec.Placement))
+		if err != nil {
+			logger.Warning("failed to validate node %s %v", node.Name, err)
+			continue
+		}
+		nodeUsage := NodeUsage{Node: &nodes.Items[i], MonCount: 0, MonValid: valid}
+		for _, pod := range pods.Items {
+			hostname := pod.Spec.NodeSelector[v1.LabelHostname]
+			if node.Name == hostname || node.Labels[v1.LabelHostname] == hostname {
+				nodeUsage.MonCount++
+			}
+		}
+		nodeUsages = append(nodeUsages, nodeUsage)
+	}
+
+	// generate a hierarchical representation of the nodes grouped by the name
+	// of the node's zone failure domain label. the zone label named "" is used
+	// for nodes without a zone annotation.
+	nodesByZone := make(map[string][]NodeUsage)
+	for _, nodeUsage := range nodeUsages {
+		zone, ok := nodeUsage.Node.Labels["failure-domain.beta.kubernetes.io/zone"]
+		if !ok {
+			zone = ""
+		}
+		nodesByZone[zone] = append(nodesByZone[zone], nodeUsage)
+	}
+
+	// compute the final form used for scheduling. this form is an array of
+	// nodes by zone, with non-labeled nodes appearing in the final zone. this
+	// organization reflects the preference made by the scheduler of using nodes
+	// with zone annotations before non-labeled nodes.
+	res := [][]NodeUsage{}
+	for zone, nodeUsage := range nodesByZone {
+		if zone == "" {
+			res = append(res, nodeUsage)
+		} else {
+			res = append([][]NodeUsage{nodeUsage}, res...)
+		}
+	}
+
+	return res, nil
 }

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -37,7 +37,8 @@ var validTopologyLabelKeys = []string{
 }
 
 // ValidNodeNoSched returns true if the node (1) meets Rook's placement terms,
-// and (2) is ready. False otherwise.
+// and (2) is ready. Unlike ValidNode, this method will ignore the
+// Node.Spec.Unschedulable flag. False otherwise.
 func ValidNodeNoSched(node v1.Node, placement rookalpha.Placement) (bool, error) {
 	p, err := NodeMeetsPlacementTerms(node, placement, false)
 	if err != nil {

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -36,13 +36,9 @@ var validTopologyLabelKeys = []string{
 	"failure-domain.kubernetes.io",
 }
 
-// ValidNode returns true if the node (1) is schedulable, (2) meets Rook's placement terms, and
-// (3) is ready. False otherwise.
-func ValidNode(node v1.Node, placement rookalpha.Placement) (bool, error) {
-	if !GetNodeSchedulable(node) {
-		return false, nil
-	}
-
+// ValidNodeNoSched returns true if the node (1) meets Rook's placement terms,
+// and (2) is ready. False otherwise.
+func ValidNodeNoSched(node v1.Node, placement rookalpha.Placement) (bool, error) {
 	p, err := NodeMeetsPlacementTerms(node, placement, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if node meets Rook placement terms. %+v", err)
@@ -56,6 +52,16 @@ func ValidNode(node v1.Node, placement rookalpha.Placement) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// ValidNode returns true if the node (1) is schedulable, (2) meets Rook's placement terms, and
+// (3) is ready. False otherwise.
+func ValidNode(node v1.Node, placement rookalpha.Placement) (bool, error) {
+	if !GetNodeSchedulable(node) {
+		return false, nil
+	}
+
+	return ValidNodeNoSched(node, placement)
 }
 
 // GetValidNodes returns all nodes that (1) are not cordoned, (2) meet Rook's placement terms, and


### PR DESCRIPTION
**Description of your changes:**
ceph: schedule mons across failure domains

**Which issue is resolved by this Pull Request:**
Resolves #2603 

this patch introduces failure-domain aware scheduling for monitor pods.
previously the only policy was to avoid scheduling monitors on the same
nodes. the new policy tries to spread monitors across zones and nodes.

   NOTE: this patch only enforces the well-known k8s "zone"
   failure-domain label (i.e. it does not look for region labels). this
   decision is made for two reasons. first, eliminating explicit
   scheduling is an important goal and will be done as part of upcoming
   work. this will enable all supported failure-domain labels to be
   handled. second, the "zone" domain is likely more appropriate for a
   larger portion of users (as opposed to the geographical distinction
   made with region), and supporting multiple failure domain types would
   add significant complexity for a temporary resolution to failure
   domain scheduling.

at a high-level this patch introduces a data structure `NodeUsage` that
is a pairing of a v1.Node and metadata relevant to scheduling: number of
monitor pods on the node, and its status w.r.t. to being scheduable for
new monitor pods.

each scheduling event computes a unified data structure that organizes
for each node a `NodeUsage` structure into per-failure-zone groups.
subsequent algorithms rely soley on this unified structure to make
scheduling decisions.

there are two entry points to the changes made:

1) during orchestration mon:Cluster:assignMons is invoked to make a
place new monitor pods onto nodes. the core scheduling logic is now
self-contained in mon:scheduleMonitor which implements node and zone
aware scheduling policies.

2) periodic health checks resolve any conflicts that may occur due to
changes to the cluster (e.g. new nodes, configuration changes, etc...).
the two existing checks: mons on invalid nodes, and overloaded nodes are
both handled.

fixes: #2603

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>