### PR TITLE
Need CSI RBD image added to example

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -44,6 +44,8 @@ spec:
           value: "quay.io/cephcsi/cephcsi:canary"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
+        - name: ROOK_CSI_RBD_IMAGE
+          value: "quay.io/cephcsi/rbdplugin:canary"
         - name: ROOK_CSI_REGISTRAR_IMAGE
           value: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
         - name: ROOK_CSI_PROVISIONER_IMAGE


### PR DESCRIPTION
**Description of your changes:**

The operator-with-csi.yaml example now needs the updated CSI RBD image
specified explicitly, otherwise the old image is looking for the
metadata arg and fails to start the csi containers.

Changes have already merged that fix openshift, but upstream 1.15 is
still broken.

**Which issue is resolved by this Pull Request:**

Partial #3312

Signed-off-by: John Griffith john.griffith8@gmail.com