### PR TITLE
[Fix-2543-ceph]: Set min_size value for Pools

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -231,6 +231,11 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, clusterName string, n
 		return err
 	}
 
+        // set min_pool size for the pool based on the size of the pool
+	if err = SetPoolProperty(context, clusterName, newPool.Name, "min_size", strconv.FormatUint(uint64(Ceil(newPool.Size -(newPool.Size/2)), 10)); err != nil {
+		return err
+	}
+
 	// ensure that the newly created pool gets an application tag
 	err = givePoolAppTag(context, clusterName, newPool.Name, appName)
 	if err != nil {


### PR DESCRIPTION
As of now min_size value is defaulted to 1 based
2543 issue. So after pool creation updating min_size to
ceiling(size - (size/2))

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/rook/rook/issues/2543

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
