### PR TITLE
Add cmd-reporter daemon; use it to get ceph version

### DIFF
--- a/Documentation/ceph-psp.md
+++ b/Documentation/ceph-psp.md
@@ -127,5 +127,19 @@ subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
   namespace: rook-ceph
-
+---
+# Allow the rook-ceph-cmd-reporter serviceAccount to use the privileged PSP
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-cmd-reporter-psp
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: rook-ceph
 ```

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -76,4 +76,22 @@ rules:
   - "*"
   verbs:
   - "*"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/rolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/rolebinding.yaml
@@ -76,4 +76,18 @@ subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
   namespace: {{ .Release.Namespace }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph/templates/serviceaccount.yaml
@@ -27,3 +27,12 @@ metadata:
     operator: rook
     storage-backend: ceph
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  labels:
+    operator: rook
+    storage-backend: ceph
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -494,8 +494,16 @@ metadata:
   name: rook-ceph-mgr
   namespace: rook-ceph
 # OLM: END SERVICE ACCOUNT MGR
-# OLM: BEGIN CLUSTER ROLE
 ---
+# OLM: BEGIN CMD REPORTER SERVICE ACCOUNT
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: rook-ceph
+# OLM: END CMD REPORTER SERVICE ACCOUNT
+---
+# OLM: BEGIN CLUSTER ROLE
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -569,10 +577,30 @@ rules:
   verbs:
   - "*"
 # OLM: END CLUSTER ROLE
-#
-# OLM: BEGIN CLUSTER ROLEBINDING
 ---
-  # Allow the operator to create resources in this cluster's namespace
+# OLM: BEGIN CMD REPORTER ROLE
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+# OLM: END CMD REPORTER ROLE
+---
+# OLM: BEGIN CLUSTER ROLEBINDING
+# Allow the operator to create resources in this cluster's namespace
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -645,5 +673,21 @@ subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
   namespace: rook-ceph
----
 # OLM: END CLUSTER ROLEBINDING
+---
+# OLM: BEGIN CMD REPORTER ROLEBINDING
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: rook-ceph
+# OLM: END CMD REPORTER ROLEBINDING
+---

--- a/cmd/rook/main.go
+++ b/cmd/rook/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/cmd/rook/minio"
 	"github.com/rook/rook/cmd/rook/nfs"
 	rook "github.com/rook/rook/cmd/rook/rook"
+	"github.com/rook/rook/cmd/rook/util"
 	"github.com/rook/rook/cmd/rook/version"
 )
 
@@ -39,10 +40,16 @@ func addCommands() {
 	rook.RootCmd.AddCommand(
 		version.VersionCmd,
 		discoverCmd,
+
+		// backend commands
 		ceph.Cmd,
 		cockroachdb.Cmd,
 		minio.Cmd,
 		edgefs.Cmd,
 		nfs.Cmd,
-		cassandra.Cmd)
+		cassandra.Cmd,
+
+		// util commands
+		util.CmdReporterCmd,
+		util.CopyBinsCmd)
 }

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -91,7 +91,7 @@ func LogStartupInfo(cmdFlags *pflag.FlagSet) {
 	logger.Infof("flag values: %s", strings.Join(flagValues, ", "))
 }
 
-// NewContext create nad initializes a cluster context
+// NewContext creates and initializes a cluster context
 func NewContext() *clusterd.Context {
 	var err error
 

--- a/cmd/rook/util/cmdreporter.go
+++ b/cmd/rook/util/cmdreporter.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/daemon/util"
+
+	"github.com/rook/rook/cmd/rook/rook"
+	"github.com/spf13/cobra"
+)
+
+// CmdReporterCmd defines a top-level utility command which runs a given command and stores the
+// results in a ConfigMap. Operators are advised to use operator/k8sutil.CmdReporter, which wraps
+// this functionality neatly rather than calling this with a custom setup.
+var CmdReporterCmd = &cobra.Command{
+	Use:   "cmd-reporter",
+	Short: "Run a given command to completion, and store the result in a ConfigMap.",
+	Long: `Run a given command to completion, and store the Stdout, Stderr, and return code
+results of the command in a ConfigMap. If the ConfigMap already exists, the
+Stdout, Stderr, and return code data which may be present in the ConfigMap
+will be overwritten.
+
+If cmd-reporter succeeds in running the command to completion, no error is
+reported, even if the command's return code is nonzero (failure). Run will
+return an error if the command could not be run for any reason or if there was
+an error storing the command results into the ConfigMap. An application label
+is applied to the ConfigMap, and if the label already exists and has a
+different application's name name, this returns an error, as this may indicate
+that it is not safe for cmd-reporter to edit the ConfigMap.`,
+	Args: cobra.NoArgs,
+	RunE: runCmdReporter,
+}
+
+var (
+	// run sub-command
+	commandString string
+	configMapName string
+	namespace     string
+
+	// copy-binaries sub-command
+	copyToDir string
+)
+
+func init() {
+	// cmd-reporter
+	CmdReporterCmd.Flags().StringVar(&commandString, "command", "",
+		"The command to run in JSON list syntax. e.g., '[\"command\", \"--flag\", \"value\", \"arg\"]'")
+	CmdReporterCmd.MarkFlagRequired("command")
+
+	CmdReporterCmd.Flags().StringVar(&configMapName, "config-map-name", "",
+		"The name of the ConfigMap into which the result of the command will be stored.")
+	CmdReporterCmd.MarkFlagRequired("config-map-name")
+
+	CmdReporterCmd.Flags().StringVar(&namespace, "namespace", "", "The namespace in which to create the ConfigMap.")
+	CmdReporterCmd.MarkFlagRequired("namespace")
+}
+
+func runCmdReporter(cCmd *cobra.Command, cArgs []string) error {
+	cmd, args, err := util.CmdReporterFlagArgumentToCommand(commandString)
+	if err != nil {
+		rook.TerminateFatal(fmt.Errorf("failed to parse '--command' argument [%s]. %+v", commandString, err))
+	}
+
+	context := rook.NewContext()
+	reporter, err := util.NewCmdReporter(context.Clientset, cmd, args, configMapName, namespace)
+	if err != nil {
+		rook.TerminateFatal(fmt.Errorf("cannot start command-reporter. %+v", err))
+	}
+	return reporter.Run()
+}

--- a/cmd/rook/util/copybins.go
+++ b/cmd/rook/util/copybins.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/cmd/rook/rook"
+	"github.com/rook/rook/pkg/daemon/util"
+	"github.com/spf13/cobra"
+)
+
+// CopyBinsCmd defines a top-level utility command which copies rook and tini binaries from the Rook
+// container image to a directory.
+var CopyBinsCmd = &cobra.Command{
+	Use:   "copy-binaries",
+	Short: "Copy 'rook' and 'tini' binaries from a container to a given directory.",
+	Long: `Copy 'rook' and 'tini' binaries from a container to a given directory.
+As an example, 'cmd-reporter run' may often need to be run from a container
+other than the container containing the 'rook' binary. Use this command to copy
+the 'rook' and required 'tini' binaries from the container containing the 'rook'
+binary to a Kubernetes EmptyDir volume mounted at the given directory in a pod's
+init container. From the pod's main container, mount the volume which now
+contains the 'rook' and 'tini' binaries, and call 'rook cmd-reporter run' from
+'tini' in order to run the desired command from a non-Rook container.`,
+	Args: cobra.NoArgs,
+	RunE: runCopyBins,
+}
+
+func init() {
+	// copy-binaries
+	CopyBinsCmd.Flags().StringVar(&copyToDir, "copy-to-dir", "",
+		"The directory into which 'tini' and 'rook' binaries will be copied.")
+	CopyBinsCmd.MarkFlagRequired("copy-to-dir")
+}
+
+func runCopyBins(cCmd *cobra.Command, cArgs []string) error {
+	if err := util.CopyBinaries(copyToDir); err != nil {
+		rook.TerminateFatal(fmt.Errorf("could not copy binaries to %s. %+v", copyToDir, err))
+	}
+	return nil
+}

--- a/cmd/rook/util/doc.go
+++ b/cmd/rook/util/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util contains top-level utility commands which are neither storage backends nor
+// associated with a particular storage backend.
+package util

--- a/pkg/daemon/util/cmdreporter.go
+++ b/pkg/daemon/util/cmdreporter.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// CmdReporterAppName is the app name reported by cmd-reporter, notably on the ConfigMap's application label.
+	CmdReporterAppName = "rook-cmd-reporter"
+
+	// CmdReporterConfigMapStdoutKey defines the key in the ConfigMap where stdout is reported.
+	CmdReporterConfigMapStdoutKey = "stdout"
+
+	// CmdReporterConfigMapStderrKey defines the key in the ConfigMap where stderr is reported.
+	CmdReporterConfigMapStderrKey = "stderr"
+
+	// CmdReporterConfigMapRetcodeKey defines the key in the ConfigMap where the return code is reported.
+	CmdReporterConfigMapRetcodeKey = "retcode"
+)
+
+var (
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "job-reporter-cmd")
+)
+
+// CmdReporter is a process intended to be run in simple Kubernetes jobs. The CmdReporter runs a
+// command in a job and stores the results in a ConfigMap which can be read by the operator.
+type CmdReporter struct {
+	clientset     kubernetes.Interface
+	cmd           []string
+	args          []string
+	configMapName string
+	namespace     string
+}
+
+// NewCmdReporter creates a new CmdReporter and returns an error if cmd, configMapName, or Namespace aren't specified.
+func NewCmdReporter(clientset kubernetes.Interface, cmd, args []string, configMapName, namespace string) (*CmdReporter, error) {
+	if clientset == nil {
+		return nil, fmt.Errorf("Kubernetes client interface was not specified")
+	}
+	if len(cmd) == 0 || cmd[0] == "" {
+		return nil, fmt.Errorf("cmd was not specified")
+	}
+	if configMapName == "" {
+		return nil, fmt.Errorf("the config map name was not specified")
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("the namespace must be specified")
+	}
+	return &CmdReporter{
+		clientset:     clientset,
+		cmd:           cmd,
+		args:          args,
+		configMapName: configMapName,
+		namespace:     namespace,
+	}, nil
+}
+
+// Create a simple representation struct for a command and its args so that Go's native JSON
+// (un)marshalling can be used to convert a Kubernetes representation of command+args into a string
+// representation automatically without the user having to fiddle with specifying their command+args
+// in string form manually.
+type commandRepresentation struct {
+	Cmd  []string `json:"cmd"`
+	Args []string `json:"args"`
+}
+
+// CommandToCmdReporterFlagArgument converts a command and arguments in typical Kubernetes container format
+// into a string representation of the command+args that is compatible with the job reporter's
+// command line flag "--command".
+// This only returns the argument to "--command" and not the "--command" text itself.
+func CommandToCmdReporterFlagArgument(cmd []string, args []string) (string, error) {
+	r := &commandRepresentation{Cmd: cmd, Args: args}
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal command+args into an argument string. %+v", err)
+	}
+	return string(b), nil
+}
+
+// CmdReporterFlagArgumentToCommand converts a string representation of a command compatible with the job
+// reporter's command line flag "--command" into a command and arguments in typical Kubernetes
+// container format, i.e., a list of command strings and a list of arguments.
+// This function processes the argument to "--command" but not the "--command" text itself.
+func CmdReporterFlagArgumentToCommand(flagArg string) (cmd []string, args []string, err error) {
+	b := []byte(flagArg)
+	r := &commandRepresentation{}
+	if err := json.Unmarshal(b, r); err != nil {
+		return []string{}, []string{}, fmt.Errorf("failed to unmarshal command from argument. %+v", err)
+	}
+	return r.Cmd, r.Args, nil
+}
+
+// Run a given command to completion, and store the Stdout, Stderr, and return code
+// results of the command in a ConfigMap. If the ConfigMap already exists, the
+// Stdout, Stderr, and return code data which may be present in the ConfigMap
+// will be overwritten.
+//
+// If cmd-reporter succeeds in running the command to completion, no error is
+// reported, even if the command's return code is nonzero (failure). Run will
+// return an error if the command could not be run for any reason or if there was
+// an error storing the command results into the ConfigMap. An application label
+// is applied to the ConfigMap, and if the label already exists and has a
+// different application's name name, this returns an error, as this may indicate
+// that it is not safe for cmd-reporter to edit the ConfigMap.
+func (r *CmdReporter) Run() error {
+	stdout, stderr, retcode, err := r.runCommand()
+	if err != nil {
+		return fmt.Errorf("system failed to run command. %+v", err)
+	}
+
+	if err := r.saveToConfigMap(stdout, stderr, retcode); err != nil {
+		return fmt.Errorf("failed to save command output to ConfigMap. %+v", err)
+	}
+
+	return nil
+}
+
+var execCommand = exec.Command
+
+func (r *CmdReporter) runCommand() (stdout, stderr string, retcode int, err error) {
+	retcode = -1 // default retcode to -1
+
+	baseCmd := r.cmd[0]
+	fullArgs := append(r.cmd[1:], r.args...)
+
+	var capturedStdout bytes.Buffer
+	var capturedStderr bytes.Buffer
+
+	// Capture stdout and stderr, and also send both to the container stdout/stderr, similar to the
+	// 'tee' command
+	stdoutTee := io.MultiWriter(&capturedStdout, os.Stdout)
+	stderrTee := io.MultiWriter(&capturedStderr, os.Stdout)
+
+	c := execCommand(baseCmd, fullArgs...)
+	c.Stdout = stdoutTee
+	c.Stderr = stderrTee
+
+	cmdStr := fmt.Sprintf("%s %s", c.Path, strings.Join(c.Args, " "))
+	logger.Infof("running command: %s", cmdStr)
+
+	if err := c.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// c.ProcessState.ExitCode is available with Go 1.12 and could replace if block below
+			if stat, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				retcode = stat.ExitStatus()
+			}
+			// it's possible the above failed to parse the return code, so report the whole error
+			logger.Warningf("command finished unsuccessfully but return code could not be parsed. %+v", err)
+		} else {
+			return "", "", -1, fmt.Errorf("failed to run command [%s]. %+v", cmdStr, err)
+		}
+	} else {
+		retcode = 0
+	}
+
+	return string(capturedStdout.Bytes()), string(capturedStderr.Bytes()), retcode, nil
+}
+
+func (r *CmdReporter) saveToConfigMap(stdout, stderr string, retcode int) error {
+	retcodeStr := fmt.Sprintf("%d", retcode)
+
+	k8s := r.clientset
+	cm, err := k8s.CoreV1().ConfigMaps(r.namespace).Get(r.configMapName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to determine if ConfigMap %s is preexisting. %+v", r.configMapName, err)
+		}
+
+		// the given config map doesn't exist yet, create it now
+		cm = &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      r.configMapName,
+				Namespace: r.namespace,
+				Labels: map[string]string{
+					k8sutil.AppAttr: CmdReporterAppName,
+				},
+			},
+			Data: map[string]string{
+				CmdReporterConfigMapStdoutKey:  stdout,
+				CmdReporterConfigMapStderrKey:  stderr,
+				CmdReporterConfigMapRetcodeKey: retcodeStr,
+			},
+		}
+
+		if _, err := k8s.CoreV1().ConfigMaps(r.namespace).Create(cm); err != nil {
+			return fmt.Errorf("failed to create ConfigMap %s. %+v", r.configMapName, err)
+		}
+		return nil
+	}
+
+	// if the operator has created the configmap with a different app name, we assume that we aren't
+	// allowed to modify the ConfigMap
+	if app, ok := cm.Labels[k8sutil.AppAttr]; !ok || (ok && app == "") {
+		// label is unset or set to empty string
+		cm.Labels[k8sutil.AppAttr] = CmdReporterAppName
+	} else if ok && app != "" && app != CmdReporterAppName {
+		// label is set and not equal to the cmd-reporter app name
+		return fmt.Errorf("ConfigMap [%s] already has label [%s] that differs from cmd-reporter's "+
+			"label [%s]; this may indicate that it is not safe for cmd-reporter to modify the ConfigMap.",
+			r.configMapName, fmt.Sprintf("%s=%s", k8sutil.AppAttr, app), fmt.Sprintf("%s=%s", k8sutil.AppAttr, CmdReporterAppName))
+	}
+
+	for _, k := range []string{CmdReporterConfigMapStdoutKey, CmdReporterConfigMapStderrKey, CmdReporterConfigMapRetcodeKey} {
+		if v, ok := cm.Data[k]; ok {
+			logger.Warningf("ConfigMap [%s] data key [%s] is already set to [%s] and will be overwritten.", r.configMapName, k, v)
+		}
+	}
+
+	// given configmap already exists, update it
+	cm.Data[CmdReporterConfigMapStdoutKey] = stdout
+	cm.Data[CmdReporterConfigMapStderrKey] = stderr
+	cm.Data[CmdReporterConfigMapRetcodeKey] = retcodeStr
+
+	if _, err := k8s.CoreV1().ConfigMaps(r.namespace).Update(cm); err != nil {
+		return fmt.Errorf("failed to update ConfigMap %s. %+v", r.configMapName, err)
+	}
+
+	return nil
+}

--- a/pkg/daemon/util/cmdreporter_test.go
+++ b/pkg/daemon/util/cmdreporter_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCommandMarshallingUnmarshalling(t *testing.T) {
+	type args struct {
+		cmd  []string
+		args []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{name: "one command only", args: args{cmd: []string{"one"}, args: []string{}}},
+		{name: "no command or args", args: args{
+			cmd: []string{}, args: []string{}}},
+		{name: "no command w/ args", args: args{
+			cmd: []string{}, args: []string{"arg1", "arg2"}}},
+		{name: "one command w/ args", args: args{
+			cmd: []string{"one"}, args: []string{"arg1", "arg2"}}},
+		{name: "multi command only", args: args{
+			cmd: []string{"one", "two", "three"}, args: []string{}}},
+		{name: "multi command and arg", args: args{
+			cmd: []string{"one", "two", "three"}, args: []string{"arg1", "arg2", "--", "arg3"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flagArg, err1 := CommandToCmdReporterFlagArgument(tt.args.cmd, tt.args.args)
+			if err1 != nil {
+				t.Errorf("CommandToFlagArgument() error = %+v, wanted no err", err1)
+			}
+			cmd, args, err2 := CmdReporterFlagArgumentToCommand(flagArg)
+			if err2 != nil {
+				t.Errorf("FlagArgumentToCommand() error = %+v, wanted no err", err2)
+			}
+			if err1 != nil || err2 != nil {
+				return
+			}
+			assert.Equal(t, tt.args.cmd, cmd)
+			assert.Equal(t, tt.args.args, args)
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	client := fake.NewSimpleClientset
+	type fields struct {
+		clientset     kubernetes.Interface
+		cmd           []string
+		args          []string
+		configMapName string
+		namespace     string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{"all is well", fields{client(), []string{"cmd"}, []string{"args"}, "myConfigMap", "myNamespace"}, false},
+		{"no k8s client", fields{nil, []string{"cmd"}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"no command", fields{client(), []string{}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"empty command", fields{client(), []string{""}, []string{"args"}, "myConfigMap", "myNamespace"}, true},
+		{"three commands", fields{client(), []string{"one", "two", "three"}, []string{"args"}, "myConfigMap", "myNamespace"}, false},
+		{"no args", fields{client(), []string{"cmd"}, []string{}, "myConfigMap", "myNamespace"}, false},
+		{"empty arg", fields{client(), []string{"cmd"}, []string{""}, "myConfigMap", "myNamespace"}, false}, // an empty arg can still be valid
+		{"three args", fields{client(), []string{"cmd"}, []string{"arg1", "arg2", "arg3"}, "myConfigMap", "myNamespace"}, false},
+		{"no configmap name", fields{client(), []string{"cmd"}, []string{"args"}, "", "myNamespace"}, true},
+		{"no namespace", fields{client(), []string{"cmd"}, []string{"args"}, "myConfigMap", ""}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewCmdReporter(
+				tt.fields.clientset,
+				tt.fields.cmd,
+				tt.fields.args,
+				tt.fields.configMapName,
+				tt.fields.namespace,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Runner.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				assert.NotNil(t, r)
+				assert.Equal(t, tt.fields.clientset, r.clientset)
+				assert.Equal(t, tt.fields.cmd, r.cmd)
+				assert.Equal(t, tt.fields.args, r.args)
+				assert.Equal(t, tt.fields.configMapName, r.configMapName)
+				assert.Equal(t, tt.fields.namespace, r.namespace)
+			}
+		})
+	}
+}
+
+func TestRunner_Run(t *testing.T) {
+	origExecCommand := execCommand
+	execCommand = mockExecCommand
+	defer func() { execCommand = origExecCommand }()
+
+	newClient := fake.NewSimpleClientset
+
+	verifyConfigMap := func(client kubernetes.Interface, stdout, stderr, retval, cmName, namespace string) {
+		cm, err := client.CoreV1().ConfigMaps(namespace).Get(cmName, metav1.GetOptions{})
+		fmt.Println("configmap:", cm)
+		assert.NoError(t, err)
+		assert.Equal(t, stdout, cm.Data[CmdReporterConfigMapStdoutKey])
+		assert.Equal(t, stderr, cm.Data[CmdReporterConfigMapStderrKey])
+		assert.Equal(t, retval, cm.Data[CmdReporterConfigMapRetcodeKey])
+	}
+
+	verifyCommand := func(cmd, args []string, command string) {
+		err := os.Setenv("GO_HELPER_PROCESS_PRINT_COMMAND", "1")
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_PRINT_COMMAND") }()
+
+		k8s := newClient()
+		r, err := NewCmdReporter(k8s, cmd, args, "command-configmap", "command-namespace")
+		assert.NoError(t, err)
+		assert.NoError(t, r.Run())
+
+		verifyConfigMap(k8s, command, "", "0", "command-configmap", "command-namespace")
+	}
+
+	verifyCommand([]string{"grep"}, []string{"-e", ".*time"}, "grep -e .*time")
+	verifyCommand([]string{"ceph-volume", "inventory"}, []string{"--format=json-pretty"}, "ceph-volume inventory --format=json-pretty")
+	verifyCommand([]string{"ceph-volume", "lvm", "list"}, []string{}, "ceph-volume lvm list")
+
+	verifyOutputs := func(stdout, stderr, retcode string) {
+		err := os.Setenv("GO_HELPER_PROCESS_STDOUT", stdout)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_STDOUT") }()
+		err = os.Setenv("GO_HELPER_PROCESS_STDERR", stderr)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_STDERR") }()
+		err = os.Setenv("GO_HELPER_PROCESS_RETCODE", retcode)
+		assert.NoError(t, err)
+		defer func() { os.Unsetenv("GO_HELPER_PROCESS_RETCODE") }()
+
+		k8s := newClient()
+		r, err := NewCmdReporter(k8s, []string{"standin-cmd"}, []string{"--some", "arg"}, "outputs-configmap", "outputs-namespace")
+		assert.NoError(t, err)
+		assert.NoError(t, r.Run())
+
+		verifyConfigMap(k8s, stdout, stderr, retcode, "outputs-configmap", "outputs-namespace")
+	}
+
+	verifyOutputs("", "", "0")
+	verifyOutputs("", "", "11")
+	verifyOutputs("this is my stdout", "", "0")
+	verifyOutputs("", "this is my stderr", "23")
+	verifyOutputs("this is ...", "... mixed outputs", "23")
+
+	// Verify that cmd-reporter won't overwrite a preexisting configmap with a different app name
+	k8s := newClient()
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-configmap",
+			Namespace: "preexisting-namespace",
+			Labels: map[string]string{
+				k8sutil.AppAttr: "some-other-application",
+			},
+		},
+		Data: map[string]string{},
+	}
+	k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(cm)
+	r, err := NewCmdReporter(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	assert.NoError(t, err)
+	assert.Error(t, r.Run())
+	cm, err = k8s.CoreV1().ConfigMaps("preexisting-namespace").Get("preexisting-configmap", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, cm.Data, CmdReporterConfigMapStdoutKey)
+	assert.NotContains(t, cm.Data, CmdReporterConfigMapStderrKey)
+	assert.NotContains(t, cm.Data, CmdReporterConfigMapRetcodeKey)
+
+	// Verify that cmd-reporter WILL overwrite a preexisting configmap with cmd-reporter's app name
+	k8s = newClient()
+	cm = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "preexisting-configmap",
+			Namespace: "preexisting-namespace",
+			Labels: map[string]string{
+				k8sutil.AppAttr: CmdReporterAppName,
+			},
+		},
+		Data: map[string]string{},
+	}
+	k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(cm)
+	r, err = NewCmdReporter(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	assert.NoError(t, err)
+	assert.NoError(t, r.Run())
+	verifyConfigMap(k8s, "", "", "0", "preexisting-configmap", "preexisting-namespace")
+}
+
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func mockExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestCmdReporterHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	// the existing environment will contain variables which define the desired return from the
+	// fake command which will be run.
+	cmd.Env = append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+	return cmd
+}
+
+// TestHelperProcess isn't a real test. It's used as a helper process
+// for TestParameterRun.
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func TestCmdReporterHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "No command\n")
+		os.Exit(2)
+	}
+	userCommand := args
+
+	// test should set these in its environment to control the output of the test commands
+	stdout := os.Getenv("GO_HELPER_PROCESS_STDOUT")
+	stderr := os.Getenv("GO_HELPER_PROCESS_STDERR")
+	retcode := os.Getenv("GO_HELPER_PROCESS_RETCODE")
+
+	if os.Getenv("GO_HELPER_PROCESS_PRINT_COMMAND") == "1" {
+		stdout = strings.Join(userCommand, " ")
+		stderr = ""
+		retcode = ""
+	}
+
+	if stdout != "" {
+		fmt.Fprintf(os.Stdout, stdout)
+	}
+	if stderr != "" {
+		fmt.Fprintf(os.Stderr, stderr)
+	}
+	if retcode != "" {
+		rc, err := strconv.Atoi(retcode)
+		if err != nil {
+			panic(err)
+		}
+		os.Exit(rc)
+	}
+	os.Exit(0)
+}

--- a/pkg/daemon/util/copybins.go
+++ b/pkg/daemon/util/copybins.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// override these for unit testing
+var defaultRookDir = "/usr/local/bin"
+var defaultTiniDir = "/"
+
+// CopyBinaries copies the "tini" and "rook" binaries to a shared volume at the target path.
+func CopyBinaries(target string) error {
+	if err := copyBinary(defaultRookDir, target, "rook"); err != nil {
+		return err
+	}
+	return copyBinary(defaultTiniDir, target, "tini")
+}
+
+func copyBinary(sourceDir, targetDir, filename string) error {
+	sourcePath := path.Join(sourceDir, filename)
+	targetPath := path.Join(targetDir, filename)
+	logger.Infof("copying %s to %s", sourcePath, targetPath)
+
+	// Check if the source path exists, and look in PATH if it doesn't
+	if _, err := os.Stat(sourcePath); err != nil {
+		if sourcePath, err = exec.LookPath(filename); err != nil {
+			return err
+		}
+	}
+
+	// Check if the target path exists, and skip the copy if it does
+	if _, err := os.Stat(targetPath); err == nil {
+		return nil
+	}
+
+	sourceFile, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.Create(targetPath)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
+		return err
+	}
+
+	return os.Chmod(targetPath, 0755)
+}

--- a/pkg/daemon/util/copybins_test.go
+++ b/pkg/daemon/util/copybins_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyBinaries(t *testing.T) {
+
+	createTestBinary := func(binPath string) {
+		f, err := os.Create(binPath)
+		assert.NoError(t, err)
+		// the binary should just be the text showing where it was copied from so we can verify it
+		_, err = f.WriteString(binPath)
+		assert.NoError(t, err)
+		err = os.Chmod(binPath, 0755)
+		assert.NoError(t, err)
+		f.Close()
+	}
+
+	mkdir := func(dir string) {
+		err := os.MkdirAll(dir, 0755)
+		assert.NoError(t, err)
+	}
+
+	cleanDir := func(dir string) {
+		err := os.RemoveAll(dir)
+		assert.NoError(t, err)
+		mkdir(dir)
+	}
+
+	fileText := func(binPath string) string {
+		b, err := ioutil.ReadFile(binPath)
+		assert.NoError(t, err)
+		return string(b)
+	}
+
+	// set up the initial test directory tree without bins
+	// testRootDir/
+	//   bin/
+	//   copy-to-dir/
+	testRootDir, err := ioutil.TempDir("", "rook-cmd-reporter-copy-binaries-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(testRootDir)
+	// create a test PATH="testRootDir/bin"
+	envPath := path.Join(testRootDir, "bin")
+	mkdir(envPath)
+	oPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oPath)
+	err = os.Setenv("PATH", envPath)
+	assert.NoError(t, err)
+	// create initial copy-to-dir
+	copyToDir := path.Join(testRootDir, "copy-to-dir")
+	mkdir(copyToDir)
+	// set default rook dir for unit tests
+	oDefaultRookDir := defaultRookDir
+	defaultRookDir = path.Join(testRootDir, "/usr/local/bin")
+	defer func() { defaultRookDir = oDefaultRookDir }()
+	// set default tini dir for unit tests
+	oDefaultTiniDir := defaultTiniDir
+	defaultTiniDir = path.Join(testRootDir, "/")
+	defer func() { defaultTiniDir = oDefaultTiniDir }()
+
+	// expect failure if rook binary is available in path but not tini
+	// testRootDir/
+	//   bin/
+	//     rook
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "rook"))
+
+	err = CopyBinaries(copyToDir)
+	assert.Error(t, err)
+	if err == nil {
+		panic(err)
+	}
+
+	err = os.Remove(path.Join(envPath, "rook"))
+	assert.NoError(t, err)
+
+	// expect failure if tini binary is available in path but not rook
+	// testRootDir/
+	//   bin/
+	//     tini
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "tini"))
+
+	err = CopyBinaries(copyToDir)
+	assert.Error(t, err)
+	if err == nil {
+		panic(err)
+	}
+
+	err = os.Remove(path.Join(envPath, "tini"))
+	assert.NoError(t, err)
+
+	// expect success if both binaries are available in path
+	// testRootDir/
+	//   bin/
+	//     rook
+	//     tini
+	//   copy-to-dir/
+	createTestBinary(path.Join(envPath, "rook"))
+	createTestBinary(path.Join(envPath, "tini"))
+	cleanDir(copyToDir)
+
+	err = CopyBinaries(copyToDir)
+	assert.NoError(t, err)
+	r := fileText(path.Join(copyToDir, "rook"))
+	assert.Contains(t, r, path.Join(testRootDir, "bin/rook"))
+	r = fileText(path.Join(copyToDir, "tini"))
+	assert.Contains(t, r, path.Join(testRootDir, "bin/tini"))
+
+	// expect success if both binaries are available in default locations AND in path
+	// additionally expect that the binaries will be taken from the default location in this case
+	// testRootDir/
+	//   tini
+	//   usr/local/bin/
+	//     rook
+	//   bin/
+	//     rook
+	//     tini
+	//   copy-to-dir/
+	mkdir(defaultRookDir)
+	createTestBinary(path.Join(defaultRookDir, "rook"))
+	createTestBinary(path.Join(defaultTiniDir, "tini"))
+	cleanDir(copyToDir)
+
+	err = CopyBinaries(copyToDir)
+	assert.NoError(t, err)
+	r = fileText(path.Join(copyToDir, "rook"))
+	assert.Contains(t, r, path.Join(testRootDir, "usr/local/bin/rook"))
+	r = fileText(path.Join(copyToDir, "tini"))
+	assert.Contains(t, r, path.Join(testRootDir, "tini"))
+}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -283,7 +283,7 @@ func (c *ClusterController) onAdd(obj interface{}) {
 	// Start the Rook cluster components. Retry several times in case of failure.
 	validOrchestration := true
 	err = wait.Poll(clusterCreateInterval, clusterCreateTimeout, func() (bool, error) {
-		cephVersion, err := cluster.detectCephVersion(cluster.Spec.CephVersion.Image, 15*time.Minute)
+		cephVersion, err := cluster.detectCephVersion(c.rookImage, cluster.Spec.CephVersion.Image, 15*time.Minute)
 		if err != nil {
 			logger.Errorf("unknown ceph major version. %+v", err)
 			return false, nil
@@ -496,7 +496,7 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 	// if the image changed, we need to detect the new image version
 	if oldClust.Spec.CephVersion.Image != newClust.Spec.CephVersion.Image {
 		logger.Infof("the ceph version changed. detecting the new image version...")
-		version, err := cluster.detectCephVersion(newClust.Spec.CephVersion.Image, 15*time.Minute)
+		version, err := cluster.detectCephVersion(c.rookImage, newClust.Spec.CephVersion.Image, 15*time.Minute)
 		if err != nil {
 			logger.Errorf("unknown ceph major version. %+v", err)
 			return

--- a/pkg/operator/ceph/cluster/migration_test.go
+++ b/pkg/operator/ceph/cluster/migration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
 	testop "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -33,12 +33,12 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
-	"github.com/rook/rook/pkg/operator/ceph/object/user"
+	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
 	"github.com/rook/rook/pkg/operator/ceph/provisioner"
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -1,0 +1,382 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmdreporter
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/daemon/util"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// CmdReporterContainerName defines the name of the CmdReporter container which runs the
+	// 'rook cmd-reporter' command.
+	CmdReporterContainerName = "cmd-reporter"
+
+	// CopyBinariesInitContainerName defines the name of the CmdReporter init container which copies
+	// the 'rook' and 'tini' binaries.
+	CopyBinariesInitContainerName = "init-copy-binaries"
+
+	// CopyBinariesMountDir defines the dir into which the 'rook' and 'tini' binaries will be copied
+	// in the CmdReporter job pod's containers.
+	CopyBinariesMountDir = "/rook/copied-binaries"
+)
+
+var (
+	logger = capnslog.NewPackageLogger("github.com/rook/rook", "CmdReporter")
+)
+
+// CmdReporter is a wrapper for Rook's cmd-reporter commandline utility allowing operators to use
+// the utility without fully specifying the job, pod, and container templates manually.
+type CmdReporter struct {
+	// inputs
+	clientset kubernetes.Interface
+
+	// filled in during creation
+	job *batch.Job
+}
+
+type cmdReporterCfg struct {
+	clientset    kubernetes.Interface
+	ownerRef     *metav1.OwnerReference
+	appName      string
+	jobName      string
+	jobNamespace string
+	cmd          []string
+	args         []string
+	rookImage    string
+	runImage     string
+}
+
+// New creates a new CmdReporter.
+//
+// All parameters must be set with the exception of the arg list which is allowed to be empty.
+//
+// The common app label will be applied to the job and pod specs which CmdReporter creates
+// identified by the app name specified. The job and the configmap which returns the result of the
+// job will be identified with the job name specified. Everything will be created in the job
+// namespace and will be owned by the owner reference given.
+//
+// The Rook image defines the Rook image from which the 'rook' and 'tini' binaries will be taken in
+// order to run the cmd and args in the run image. If the run image is the same as the Rook image,
+// then the command will run without the binaries being copied from the same Rook image.
+func New(
+	clientset kubernetes.Interface,
+	ownerRef *metav1.OwnerReference,
+	appName, jobName, jobNamespace string,
+	cmd, args []string,
+	rookImage, runImage string,
+) (*CmdReporter, error) {
+	if clientset == nil || ownerRef == nil {
+		return nil, fmt.Errorf("clientset [%+v] and owner reference [%+v] must be specified", clientset, ownerRef)
+	}
+	if appName == "" || jobName == "" || jobNamespace == "" {
+		return nil, fmt.Errorf("app name [%s], job name [%s], and job namespace [%s] must be specified", appName, jobName, jobNamespace)
+	}
+	// at least one command must be set, and it cannot be an empty string
+	if len(cmd) == 0 || cmd[0] == "" {
+		return nil, fmt.Errorf("command [%+v] must be specified", cmd)
+	}
+	if rookImage == "" || runImage == "" {
+		return nil, fmt.Errorf("Rook image [%s] and run image [%s] must be specified", rookImage, runImage)
+	}
+	cfg := &cmdReporterCfg{
+		clientset:    clientset,
+		ownerRef:     ownerRef,
+		jobName:      jobName,
+		jobNamespace: jobNamespace,
+		cmd:          cmd,
+		args:         args,
+		rookImage:    rookImage,
+		runImage:     runImage,
+	}
+
+	job, err := cfg.initJobSpec()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes job spec for CmdReporter job %s. %+v", jobName, err)
+	}
+	return &CmdReporter{
+		clientset: clientset,
+		job:       job,
+	}, nil
+}
+
+// Job returns a pointer to the basic, filled-out Kubernetes job which will run the CmdReporter. The
+// operator may add additional information to this spec, such as labels, environment variables,
+// volumes, volume mounts, etc. before the CmdReporter is run.
+func (cr *CmdReporter) Job() *batch.Job {
+	return cr.job
+}
+
+// Run runs the Kubernetes job and waits for the output ConfigMap. It returns the stdout, stderr,
+// and retcode of the command as long as the image ran it, even if the retcode is nonzero (failure).
+// An error is reported only if the command was not run to completion successfully. When this
+// returns, the ConfigMap is cleaned up (destroyed).
+func (cr *CmdReporter) Run(timeout time.Duration) (stdout, stderr string, retcode int, retErr error) {
+	jobName := cr.job.Name
+	namespace := cr.job.Namespace
+	errMsg := fmt.Sprintf("failed to run CmdReporter %s successfully.", jobName)
+
+	// the configmap MUST be deleted, because we will wait on its presence to determine when the
+	// job is done running
+	delOpts := &k8sutil.DeleteOptions{}
+	delOpts.Wait = true
+	delOpts.ErrorOnTimeout = true
+	// configmap's name will be the same as the app
+	err := k8sutil.DeleteConfigMap(cr.clientset, jobName, namespace, delOpts)
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to delete existing results ConfigMap %s. %+v", errMsg, jobName, retErr)
+	}
+
+	if err := k8sutil.RunReplaceableJob(cr.clientset, cr.job, true); err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed to run job. %+v", errMsg, err)
+	}
+
+	if err := cr.waitForConfigMap(timeout); err != nil {
+		return "", "", -1, fmt.Errorf("%s. failed waiting for results ConfigMap %s. %+v", errMsg, jobName, err)
+	}
+	logger.Debugf("job %s has returned results", jobName)
+
+	resultMap, err := cr.clientset.CoreV1().ConfigMaps(namespace).Get(jobName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", -1, fmt.Errorf("%s. results ConfigMap %s should be available, but got an error instead. %+v", errMsg, jobName, err)
+	}
+
+	if err := k8sutil.DeleteBatchJob(cr.clientset, namespace, jobName, false); err != nil {
+		logger.Errorf("continuing after failing delete job %s; user may need to delete it manually. %+v", jobName, err)
+	}
+
+	// just to be explicit: delete idempotently, and don't wait for delete to complete
+	delOpts = &k8sutil.DeleteOptions{MustDelete: false, WaitOptions: k8sutil.WaitOptions{Wait: false}}
+	if err := k8sutil.DeleteConfigMap(cr.clientset, jobName, namespace, delOpts); err != nil {
+		logger.Errorf("continuing after failing to delete ConfigMap %s for job %s; user may need to delete it manually. %+v",
+			jobName, jobName, err)
+	}
+
+	dat := resultMap.Data
+	var ok bool
+	if stdout, ok = dat[util.CmdReporterConfigMapStdoutKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate stdout in ConfigMap", errMsg)
+	}
+	if stderr, ok = dat[util.CmdReporterConfigMapStderrKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate stderr in ConfigMap", errMsg)
+	}
+	var strRetcode string
+	if strRetcode, ok = dat[util.CmdReporterConfigMapRetcodeKey]; !ok {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter did not populate retcode in ConfigMap", errMsg)
+	}
+	if retcode, err = strconv.Atoi(strRetcode); err != nil {
+		return "", "", -1, fmt.Errorf("%s. cmd-reporter returned a retcode value [%s] that could not be parsed to an int. %+v", errMsg, strRetcode, err)
+	}
+
+	return stdout, stderr, retcode, nil
+}
+
+// return watcher or nil if configmap exists
+func (cr *CmdReporter) newWatcher() (watch.Interface, error) {
+	jobName := cr.job.Name
+	namespace := cr.job.Namespace
+
+	listOpts := metav1.ListOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		FieldSelector: fmt.Sprintf("metadata.name=%s", jobName),
+	}
+
+	list, err := cr.clientset.CoreV1().ConfigMaps(namespace).List(listOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list the current ConfigMaps in order to start ConfigMap watcher. %+v", err)
+	}
+	if len(list.Items) > 0 {
+		return nil, nil // exists
+	}
+
+	watchOpts := listOpts.DeepCopy()
+	watchOpts.Watch = true
+	watchOpts.ResourceVersion = list.ResourceVersion
+
+	watcher, err := cr.clientset.CoreV1().ConfigMaps(namespace).Watch(*watchOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start ConfigMap watcher. %+v", err)
+	}
+
+	return watcher, nil
+}
+
+// return nil when configmap exists
+func (cr *CmdReporter) waitForConfigMap(timeout time.Duration) error {
+	jobName := cr.job.Name
+
+	watcher, err := cr.newWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to start watcher for the results ConfigMap. %+v", err)
+	}
+	if watcher == nil {
+		return nil
+	}
+	defer func() {
+		if watcher != nil {
+			watcher.Stop()
+		}
+	}()
+
+	// timeout timer cannot be started inline in the select statement, or the timeout will be
+	// restarted any time k8s hangs up on the watcher and a new watcher is started
+	timeoutCh := time.After(timeout)
+
+	for {
+		select {
+		case _, ok := <-watcher.ResultChan():
+			if ok {
+				return nil
+			}
+			// if !ok, k8s has hung up the channel. hangups notably occur after the k8s API server
+			// clears its change history, which it keeps for only a limited time (~5 mins default)
+			logger.Infof("Kubernetes hung up the watcher for CmdReporter %s result ConfigMap %s; starting a replacement watcher", jobName, jobName)
+			watcher.Stop() // must clean up existing watcher before replacing it with a new one
+			watcher, err = cr.newWatcher()
+			if err != nil {
+				return fmt.Errorf("failed to start replacement watcher for the results ConfigMap. %+v", err)
+			}
+			if watcher == nil {
+				return nil
+			}
+		case <-timeoutCh:
+			return fmt.Errorf("timed out waiting for results ConfigMap")
+		}
+	}
+	// unreachable
+}
+
+func (cr *cmdReporterCfg) initJobSpec() (*batch.Job, error) {
+	cmdReporterContainer, err := cr.container()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runner container. %+v", err)
+	}
+
+	podSpec := v1.PodSpec{
+		InitContainers: cr.initContainers(),
+		Containers: []v1.Container{
+			*cmdReporterContainer,
+		},
+		RestartPolicy: v1.RestartPolicyOnFailure,
+	}
+	copyBinsVol, _ := copyBinariesVolAndMount()
+	podSpec.Volumes = []v1.Volume{copyBinsVol}
+
+	commonLabels := map[string]string{k8sutil.AppAttr: cr.appName}
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.jobName,
+			Namespace: cr.jobNamespace,
+			Labels:    commonLabels,
+		},
+		Spec: batch.JobSpec{
+			Completions: newInt32(1),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: commonLabels,
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+	k8sutil.AddRookVersionLabelToJob(job)
+	k8sutil.SetOwnerRef(&job.ObjectMeta, cr.ownerRef)
+
+	return job, nil
+}
+
+func (cr *cmdReporterCfg) initContainers() []v1.Container {
+	if !cr.needToCopyBinaries() {
+		return []v1.Container{}
+	}
+
+	c := v1.Container{
+		Name: CopyBinariesInitContainerName,
+		// Command: the rook command is the default entrypoint of rook images already
+		Args: []string{
+			"copy-binaries",
+			"--copy-to-dir", CopyBinariesMountDir,
+		},
+		Image: cr.rookImage,
+	}
+	_, copyBinsMount := copyBinariesVolAndMount()
+	c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
+
+	return []v1.Container{c}
+}
+
+func (cr *cmdReporterCfg) container() (*v1.Container, error) {
+	userCmdArg, err := util.CommandToCmdReporterFlagArgument(cr.cmd, cr.args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert user cmd %+v and args %+v into an argument for '--command'. %+v", cr.cmd, cr.args, err)
+	}
+
+	cmd := []string{
+		path.Join(CopyBinariesMountDir, "tini"), "--", path.Join(CopyBinariesMountDir, "rook"),
+	}
+	if !cr.needToCopyBinaries() {
+		// tini -- rook is already the cmd entrypoint if we don't need to copy binaries
+		cmd = nil
+	}
+
+	c := &v1.Container{
+		Name:    CmdReporterContainerName,
+		Command: cmd,
+		Args: []string{
+			"cmd-reporter",
+			"--command", userCmdArg,
+			"--config-map-name", cr.jobName,
+			"--namespace", cr.jobNamespace,
+		},
+		Image: cr.runImage,
+	}
+	if cr.needToCopyBinaries() {
+		_, copyBinsMount := copyBinariesVolAndMount()
+		c.VolumeMounts = []v1.VolumeMount{copyBinsMount}
+	}
+
+	return c, nil
+}
+
+func (cr *cmdReporterCfg) needToCopyBinaries() bool {
+	return cr.rookImage != cr.runImage
+}
+
+// return a matched volume and mount for copying binaries
+func copyBinariesVolAndMount() (v1.Volume, v1.VolumeMount) {
+	vName := k8sutil.PathToVolumeName(CopyBinariesMountDir)
+	mDir := CopyBinariesMountDir
+	v := v1.Volume{Name: vName, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	m := v1.VolumeMount{Name: vName, MountPath: mDir}
+	return v, m
+}
+
+func newInt32(i int32) *int32 { return &i }

--- a/pkg/operator/k8sutil/configmap.go
+++ b/pkg/operator/k8sutil/configmap.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeleteConfigMap deletes a ConfigMap.
+func DeleteConfigMap(clientset kubernetes.Interface, cmName, namespace string, opts *DeleteOptions) error {
+	k8sOpts := BaseKubernetesDeleteOptions()
+	delete := func() error { return clientset.CoreV1().ConfigMaps(namespace).Delete(cmName, k8sOpts) }
+	verify := func() error {
+		_, err := clientset.CoreV1().ConfigMaps(namespace).Get(cmName, metav1.GetOptions{})
+		return err
+	}
+	resource := fmt.Sprintf("ConfigMap %s", cmName)
+	defaultWaitOptions := &WaitOptions{RetryCount: 20, RetryInterval: 2 * time.Second}
+	return DeleteResource(delete, verify, resource, opts, defaultWaitOptions)
+}

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDeleteConfigMap(t *testing.T) {
+	k8s := fake.NewSimpleClientset()
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"test": "data",
+		},
+	}
+
+	_, err := k8s.CoreV1().ConfigMaps("test-namespace").Create(cm)
+	assert.NoError(t, err)
+
+	// There is no need to test all permutations, as the `DeleteResource` function is already
+	// tested. Setting Wait=true and ErrorOnTimeout=true will cause both the delete and verify
+	// functions to be exercised, and it will return error if either fail with an unexpected error.
+	opts := &DeleteOptions{}
+	opts.Wait = true
+	opts.ErrorOnTimeout = true
+	err = DeleteConfigMap(k8s, "test-configmap", "test-namespace", opts)
+	assert.NoError(t, err)
+
+	_, err = k8s.CoreV1().ConfigMaps("test-namespace").Get("test-configmap", metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, errors.IsNotFound(err))
+}

--- a/pkg/operator/k8sutil/delete.go
+++ b/pkg/operator/k8sutil/delete.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BaseKubernetesDeleteOptions returns the base set of Kubernetes delete options which most delete
+// operations should use.
+func BaseKubernetesDeleteOptions() *metav1.DeleteOptions {
+	p := metav1.DeletePropagationForeground
+	g := int64(0)
+	return &metav1.DeleteOptions{GracePeriodSeconds: &g, PropagationPolicy: &p}
+}
+
+// DeleteOptions are a common set of options controlling the behavior of k8sutil delete operations.
+// DeleteOptions is a superset of WaitOptions.
+type DeleteOptions struct {
+	// MustDelete controls the idempotency of the delete operation. If MustDelete is true and the
+	// resource being deleted does not exist, the delete operation is considered a failure. If
+	// MustDelete is false and the resource being deleted does not exist, the delete operation is
+	// considered a success.
+	MustDelete bool
+
+	// DeleteOptions is a superset of WaitOptions.
+	WaitOptions
+}
+
+// Use this for unit testing
+var unitTestRetryIntervalRecord time.Duration
+
+// DeleteResource implements the DeleteOptions logic around deletion of a Kubernetes resource.
+//
+// The delete and verify functions used as parameters should implement and return the error from the
+// Kubernetes `Delete` and `Get` commands respectively.
+//
+// The resource string will be used to report the resource in log and error messages. A good pattern
+// would be to set this string to the resource type (e.g., Deployment) and the name of the resource
+// (e.g., my-deployment).
+//
+// The default wait options should specify sane defaults for retry count and retry interval for
+// deletion of the specific resource type. Only retry count and interval will be used from this
+// parameter.
+func DeleteResource(
+	delete func() error,
+	verify func() error,
+	resource string,
+	opts *DeleteOptions,
+	defaultWaitOptions *WaitOptions,
+) error {
+	if err := delete(); err != nil {
+		if errors.IsNotFound(err) && opts.MustDelete {
+			return fmt.Errorf("failed to delete %s; it does not exist. %+v", resource, err)
+		} else if errors.IsNotFound(err) && !opts.MustDelete {
+			logger.Debugf("%s is already deleted", resource)
+			return nil
+		}
+		return fmt.Errorf("failed to delete %s. %+v", resource, err)
+	}
+
+	if !opts.Wait {
+		return nil
+	}
+
+	// if default wait options aren't set, still provide something of a default
+	retries := opts.retryCountOrDefault(defaultWaitOptions.retryCountOrDefault(30))
+	retryInterval := opts.retryIntervalOrDefault(defaultWaitOptions.retryIntervalOrDefault(5 * time.Second))
+	unitTestRetryIntervalRecord = retryInterval
+	var i uint
+	var err error
+	// less-than-or-equal is important; i=0 is the first "try". It isn't a "re-try" until i=1.
+	for i = 0; i <= retries; i++ {
+		err = verify()
+		if err != nil && errors.IsNotFound(err) {
+			logger.Debugf("%s was deleted after %d retries every %v seconds", resource, i, retryInterval/time.Second)
+			return nil
+		}
+		logger.Infof("Retrying %d more times every %v seconds for %s to be deleted",
+			retries-i, retryInterval/time.Second, resource)
+		if retries-i > 0 {
+			time.Sleep(retryInterval)
+		}
+	}
+
+	msg := fmt.Sprintf("failed to delete %s. gave up waiting after %d retries every %v seconds. %+v",
+		resource, retries, retryInterval/time.Second, err)
+	if opts.ErrorOnTimeout {
+		return fmt.Errorf(msg)
+	}
+	logger.Warningf(msg)
+	return nil
+}

--- a/pkg/operator/k8sutil/delete_test.go
+++ b/pkg/operator/k8sutil/delete_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestDeleteResource(t *testing.T) {
+	var deleteError error
+	stubDelete := func() error { return deleteError }
+
+	k8sNotFoundError := errors.NewNotFound(schema.GroupResource{Group: "group", Resource: "resource"}, "test")
+
+	var verifyCount int
+	var verifyReturnDeletedAtCount int
+	stubVerify := func() error {
+		verifyCount++
+		fmt.Println("verifyCount:", verifyCount, "   - returnNilAt:", verifyReturnDeletedAtCount)
+		if verifyCount == verifyReturnDeletedAtCount {
+			return k8sNotFoundError
+		}
+		return fmt.Errorf("still not verified")
+	}
+
+	defaultWaitOpts := &WaitOptions{RetryCount: 2, RetryInterval: 1 * time.Millisecond}
+
+	// Failure to delete should return error
+	deleteError = fmt.Errorf("err on delete")
+	err := DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.Error(t, err)
+
+	// NotFound error should return error if DeleteOptions.MustDelete is set
+	deleteError = k8sNotFoundError
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{MustDelete: true}, defaultWaitOpts)
+	assert.Error(t, err)
+
+	// Default behavior should be to continue if resource doesn't exist
+	deleteError = k8sNotFoundError
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Default behavior should be to NOT wait to verify resource
+	deleteError = nil
+	verifyCount = 0
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", &DeleteOptions{}, defaultWaitOpts)
+	assert.Zero(t, verifyCount)
+
+	// Verify that the default wait options are picked up
+	// And that the verify function is called one time more than the retry count
+	// And that delete can report error on timeout
+	deleteError = nil
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 1000000 // do not return verify success
+	deleteOpts := &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.Error(t, err)
+	assert.Equal(t, 3, verifyCount)
+	assert.Equal(t, 1*time.Millisecond, unitTestRetryIntervalRecord)
+
+	// Test that delete will not report error on timeout if so configured
+	deleteOpts.ErrorOnTimeout = false
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Verify that delete will return successfully after some retries
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 2
+	deleteOpts = &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.NoError(t, err)
+
+	// Verify that specified retry count and interval in delete opts are picked up
+	deleteError = nil
+	verifyCount = 0
+	verifyReturnDeletedAtCount = 1000000 // do not return verify success
+	deleteOpts = &DeleteOptions{}
+	deleteOpts.Wait = true
+	deleteOpts.ErrorOnTimeout = true
+	deleteOpts.RetryCount = 5
+	deleteOpts.RetryInterval = 2 * time.Millisecond
+	err = DeleteResource(stubDelete, stubVerify, "test resource name", deleteOpts, defaultWaitOpts)
+	assert.Error(t, err)
+	assert.Equal(t, 6, verifyCount)
+	assert.Equal(t, 2*time.Millisecond, unitTestRetryIntervalRecord)
+}

--- a/pkg/operator/k8sutil/job.go
+++ b/pkg/operator/k8sutil/job.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// RunReplaceableJob runs a Kubernetes job with the intention that the job can be replaced by
+// another call to this function with the same job name. For example, if a storage operator is
+// restarted/updated before the job can complete, the operator's next run of the job should replace
+// the previous job if deleteIfFound is set to true.
 func RunReplaceableJob(clientset kubernetes.Interface, job *batch.Job, deleteIfFound bool) error {
 	// check if the job was already created and what its status is
 	existingJob, err := clientset.BatchV1().Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
@@ -80,6 +84,7 @@ func WaitForJobCompletion(clientset kubernetes.Interface, job *batch.Job, timeou
 	})
 }
 
+// DeleteBatchJob deletes a Kubernetes job.
 func DeleteBatchJob(clientset kubernetes.Interface, namespace, name string, wait bool) error {
 	propagation := metav1.DeletePropagationForeground
 	gracePeriod := int64(0)

--- a/pkg/operator/k8sutil/options.go
+++ b/pkg/operator/k8sutil/options.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"time"
+)
+
+// WaitOptions are a common set of options controlling the behavior of k8sutil operations. If
+// WaitOptions are specified, the operation should wait in a loop and verify that the operation
+// being performed was successful.
+type WaitOptions struct {
+	// Wait defines whether the operation should wait in a loop and verify that the operation was
+	// successful before returning.
+	Wait bool
+
+	// RetryCount defines how many times the operation should retry verification in the wait loop
+	// before giving up. If RetryCount is zero, the operation should default to a sane value based
+	// on the operation.
+	RetryCount uint
+
+	// RetryInterval defines the time the operation will wait before retrying verification. If
+	// RetryInterval is zero, the operation should default to a sane value based on the operation.
+	RetryInterval time.Duration
+
+	// ErrorOnTimeout defines whether the operation should time out with an error. If ErrorOnTimeout
+	// is true and the operation times out, the operation is considered a failure. If ErrorOnTimeout
+	// is false and the operation times out, the operation should log a warning but not not report
+	// failure.
+	ErrorOnTimeout bool
+}
+
+func (w *WaitOptions) retryCountOrDefault(def uint) uint {
+	if w.RetryCount > 0 {
+		return w.RetryCount
+	}
+	return def
+}
+
+func (w *WaitOptions) retryIntervalOrDefault(def time.Duration) time.Duration {
+	if w.RetryInterval > 0 {
+		return w.RetryInterval
+	}
+	return def
+}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -964,6 +964,12 @@ metadata:
   name: rook-ceph-mgr
   namespace: ` + namespace + `
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -1007,6 +1013,25 @@ rules:
   - "*"
   verbs:
   - "*"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 ---
 # Allow the operator to create resources in this cluster's namespace
 kind: RoleBinding
@@ -1067,6 +1092,21 @@ subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
   namespace: ` + namespace + `
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
 `
 }
 

--- a/tests/integration/upgrade_test.go
+++ b/tests/integration/upgrade_test.go
@@ -152,5 +152,49 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 // Update the clusterroles that have been modified in master from the previous release
 func (s *UpgradeSuite) updateClusterRoles() error {
 	logger.Infof("Placeholder: create the new resources that have been added since 1.0")
-	return nil
+	namespace := s.namespace
+	newResources := `
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
+`
+	logger.Infof("creating the new resources that have been added since 1.0")
+	return s.k8sh.ResourceOperation("create", newResources)
 }


### PR DESCRIPTION
First, create new cmd-reporter daemon.
cmd-reporter runs a command and puts the results of the command into a
ConfigMap defined by its `--config-map-name` commandline flag.
cmd-reporter is intended to be run as a Kubernetes job where an
operator needs to run a single command and get return information back
from the command which is more than just success/failure.

The ConfigMap returned includes `stdout`, `stderr`, and `retcode` data
from the command. The ConfigMap may be preexisting, in which case
cmd-reporter will overwrite the return information in the ConfigMap.
cmd-reporter labels the ConfigMap with `app=cmd-reporter`, and if the
ConfigMap already has an app label which is different, cmd-reporter
fails without modifying the ConfigMap so as not to overwrite another
application's data in the event of a ConfigMap name+namespace collision.


Add a `DeleteResource` function that accepts new `DeleteOptions` and
`WaitOptions` structs as inputs. This new funciton is reusable and
extensible for any Kubernetes resource.

Implement a DeleteConfigMap function with the new DeleteResource
functionality.

Add a wrapper for the cmd-reporter function of the 'rook' binary to
k8sutil so that it's easier for operators to use the functionality.

Operators still need to have some idea of how CmdReporter works. It runs
the requested command in a job, but if the calling operator needs the
job to have special configuration, the operator must request the pointer
to the job struct from CmdReporter to modify it before calling the
CmdReporter's Run method.

And finally, use cmd-reporter to detect Ceph version. The job to detect Ceph version
needs to run in a security account context capable of getting/creating
ConfigMaps, so the Ceph operator's service account is passed down to its
child Ceph cluster controller, and the version job uses that.

**Which issue is resolved by this Pull Request:**
Resolves #2686

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issue
[skip ci]