### PR TITLE
Change the ceph image to point to latest-nautilus-devel

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.1-20190430
+    image: ceph/daemon-base:latest-nautilus-devel
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.1-20190430
+    image: ceph/daemon-base:latest-nautilus-devel
     allowUnsupported: true
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/ceph:v14.2.1-20190430
+    image: ceph/daemon-base:latest-nautilus-devel
     # Whether to allow unsupported versions of Ceph. Currently luminous, mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Do not set to true in production.
     allowUnsupported: false

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -89,7 +89,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v14.2.1-20190430"
+              "image": "ceph/daemon-base:latest-nautilus-devel"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -17,10 +17,15 @@ include ../image.mk
 # ====================================================================================
 # Image Build Options
 
-CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
-
+ifeq ($(GOARCH),amd64)
+CEPH_VERSION = latest-nautilus-devel
+BASEIMAGE = ceph/daemon-base:$(CEPH_VERSION)
+else
 CEPH_VERSION = v14.2.1-20190430
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
+endif
+
+CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
 TEMP := $(shell mktemp -d)
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -44,7 +44,7 @@ const (
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14.2.1-20190430"
+	nautilusTestImage = "ceph/daemon-base:latest-nautilus-devel"
 	helmChartName     = "local/rook-ceph"
 	helmDeployName    = "rook-ceph"
 )


### PR DESCRIPTION
Currently in cluster deploy, ceph image points to ceph/ceph:v14.2.1-20190430.
Changing this to use ceph/ceph:latest-nautlius-devel as its the latest nautilus.

Signed-off-by: Poornima G <pgurusid@redhat.com>

// known CI issues
[skip ci]