### PR TITLE
Update Ceph-CSI manifests as per changes to ceph-csi repository

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner.yaml
@@ -33,6 +33,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner.yaml
@@ -21,6 +21,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
+            - "--timeout=60s"
+            - "--retry-interval-start=500ms"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock
@@ -44,8 +46,8 @@ spec:
           image:  {{ .SnapshotterImage }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--connection-timeout=15s"
             - "--v=5"
+            - "--timeout=60s"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/tests/framework/installer/ceph_csi_templates.go
+++ b/tests/framework/installer/ceph_csi_templates.go
@@ -41,6 +41,8 @@ const (
               args:
                 - "--csi-address=$(ADDRESS)"
                 - "--v=5"
+                - "--timeout=60s"
+                - "--retry-interval-start=500ms"
               env:
                 - name: ADDRESS
                   value: unix:///csi/csi-provisioner.sock
@@ -65,8 +67,8 @@ const (
               image:  {{ .SnapshotterImage }}
               args:
                 - "--csi-address=$(ADDRESS)"
-                - "--connection-timeout=15s"
                 - "--v=5"
+                - "--timeout=60s"
               env:
                 - name: ADDRESS
                   value: unix:///csi/csi-provisioner.sock
@@ -285,6 +287,8 @@ const (
               args:
                 - "--csi-address=$(ADDRESS)"
                 - "--v=5"
+                - "--timeout=60s"
+                - "--retry-interval-start=500ms"
               env:
                 - name: ADDRESS
                   value: unix:///csi/csi-provisioner.sock


### PR DESCRIPTION
Ceph-CSI repository had a recent PR [1] merged that contains
changes to the pod manifests.

This PR to Rook updates the pod manifests to catch up with the
changes to Ceph-CSI master.

Once Ceph-CSI has a 1.1.0 release, future PRs to Rook on manifest
changes would track that branch (at least for Rook 1.1 release).

[1] PR in ceph-csi changing the manifest:
  https://github.com/ceph/ceph-csi/pull/443

Signed-off-by: ShyamsundarR <srangana@redhat.com>

// known CI issues
[skip ci]