### PR TITLE
Backport: OSDs on SDN, OwnerReferences for OpenShift, and enable flex metrics

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,6 +4,8 @@
 
 ## Notable Features
 
+- OwnerReferences are created with the fully qualified `apiVersion` such that the references will work properly on OpenShift.
+
 ### Minio Object Stores
 
 - Now have an additional label named `objectstore` with the name of the Object Store, to allow better selection for Services.

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -150,6 +150,8 @@ func generateFlexSettings(enableSELinuxRelabeling, enableFSGroup bool) ([]byte, 
 		Status: flexvolume.StatusSuccess,
 		Capabilities: &flexvolume.DriverCapabilities{
 			Attach: false,
+			// Required for metrics
+			SupportsMetrics: true,
 			// Required for any mount performed on a host running selinux
 			SELinuxRelabel: enableSELinuxRelabeling,
 			FSGroup:        enableFSGroup,

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -117,7 +117,7 @@ func (c *cluster) detectCephVersion(image string, timeout time.Duration) (*cephv
 		},
 	}
 	k8sutil.AddRookVersionLabelToJob(job)
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.ownerRef)
 
 	// run the job to detect the version
 	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job, true); err != nil {
@@ -179,7 +179,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 		},
 		Data: placeholderConfig,
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&cm.ObjectMeta, &c.ownerRef)
 	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)
@@ -282,7 +282,7 @@ func (c *cluster) createInitialCrushMap() error {
 		},
 		Data: map[string]string{crushmapCreatedKey: "1"},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &configMap.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
 
 	if !configMapExists {
 		if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -793,7 +793,7 @@ func (c *ClusterController) updateClusterStatus(namespace, name string, state ce
 func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
-		APIVersion:         ClusterResource.Version,
+		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
 		Name:               namespace,
 		UID:                types.UID(clusterID),

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -255,7 +255,7 @@ func (c *Cluster) getOrGenerateDashboardPassword() (string, error) {
 		Data: secrets,
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &secret.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&secret.ObjectMeta, &c.ownerRef)
 
 	_, err = c.context.Clientset.CoreV1().Secrets(c.Namespace).Create(secret)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -107,7 +107,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
 		d.ObjectMeta.Annotations = prometheusAnnotations
 	}
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	return d
 }
 
@@ -290,7 +290,7 @@ func (c *Cluster) makeMetricsService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -314,7 +314,7 @@ func (c *Cluster) makeDashboardService(name string, port int) *v1.Service {
 			},
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -198,7 +198,7 @@ func createClusterAccessSecret(clientset kubernetes.Interface, namespace string,
 		Data: secrets,
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(clientset, namespace, &secret.ObjectMeta, ownerRef)
+	k8sutil.SetOwnerRef(&secret.ObjectMeta, ownerRef)
 
 	if _, err = clientset.CoreV1().Secrets(namespace).Create(secret); err != nil {
 		return fmt.Errorf("failed to save mon secrets. %+v", err)

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -456,7 +456,7 @@ func (c *Cluster) saveMonConfig() error {
 			Namespace: c.Namespace,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &configMap.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
 
 	monMapping, err := json.Marshal(c.mapping)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -47,7 +47,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 			Selector: labels,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svcDef.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svcDef.ObjectMeta, &c.ownerRef)
 	if c.HostNetwork {
 		svcDef.Spec.ClusterIP = v1.ClusterIPNone
 	}

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -59,7 +59,7 @@ func (c *Cluster) makeDeployment(monConfig *monConfig, hostname string) *apps.De
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&d.ObjectMeta)
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 
 	pod := c.makeMonPod(monConfig, hostname)
 	replicaCount := int32(1)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -75,7 +75,7 @@ func (c *Cluster) makeJob(nodeName string, devices []rookalpha.Device,
 	}
 	k8sutil.AddRookVersionLabelToJob(job)
 	opspec.AddCephVersionLabelToJob(c.clusterInfo.CephVersion, job)
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &job.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.ownerRef)
 	return job, nil
 }
 
@@ -327,7 +327,7 @@ func (c *Cluster) makeDeployment(nodeName string, selection rookalpha.Selection,
 	c.annotations.ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &deployment.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.ownerRef)
 	c.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	return deployment, nil
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -328,3 +328,18 @@ func TestHostNetwork(t *testing.T) {
 	assert.Equal(t, true, r.Spec.Template.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, r.Spec.Template.Spec.DNSPolicy)
 }
+
+func TestOsdOnSDNFlag(t *testing.T) {
+	hostnetwork := false
+	v := cephver.Mimic
+	args := osdOnSDNFlag(hostnetwork, v)
+	assert.Empty(t, args)
+
+	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 2}
+	args = osdOnSDNFlag(hostnetwork, v)
+	assert.NotEmpty(t, args)
+
+	v = cephver.Octopus
+	args = osdOnSDNFlag(hostnetwork, v)
+	assert.NotEmpty(t, args)
+}

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -64,7 +64,7 @@ func (m *Mirroring) makeDeployment(daemonConfig *daemonConfig) *apps.Deployment 
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	opspec.AddCephVersionLabelToDeployment(m.ClusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRef(m.context.Clientset, m.Namespace, &d.ObjectMeta, &m.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &m.ownerRef)
 	return d
 }
 

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -96,7 +96,7 @@ func (k *SecretStore) CreateOrUpdate(resourceName, keyring string) error {
 		},
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(k.context.Clientset, k.namespace, &secret.ObjectMeta, k.ownerRef)
+	k8sutil.SetOwnerRef(&secret.ObjectMeta, k.ownerRef)
 
 	return k.createSecret(secret)
 }

--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -197,7 +197,7 @@ func (s *Store) createOrUpdateMonHostSecrets(clusterInfo *cephconfig.ClusterInfo
 		Type: k8sutil.RookType,
 	}
 	clientset := s.context.Clientset
-	k8sutil.SetOwnerRef(clientset, s.namespace, &secret.ObjectMeta, s.ownerRef)
+	k8sutil.SetOwnerRef(&secret.ObjectMeta, s.ownerRef)
 
 	_, err := clientset.CoreV1().Secrets(s.namespace).Get(storeName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -153,7 +153,7 @@ func createOverrideMap(t *testing.T,
 			Name: k8sutil.ConfigOverrideName,
 		},
 	}
-	k8sutil.SetOwnerRef(context.Clientset, namespace, &cm.ObjectMeta, ownerRef)
+	k8sutil.SetOwnerRef(&cm.ObjectMeta, ownerRef)
 	_, err := context.Clientset.CoreV1().ConfigMaps(namespace).Create(cm)
 	assert.NoError(t, err)
 }
@@ -167,7 +167,7 @@ func updateOverrideMap(t *testing.T, overrideText string,
 		},
 		Data: map[string]string{k8sutil.ConfigOverrideVal: overrideText},
 	}
-	k8sutil.SetOwnerRef(context.Clientset, namespace, &cm.ObjectMeta, ownerRef)
+	k8sutil.SetOwnerRef(&cm.ObjectMeta, ownerRef)
 	_, err := context.Clientset.CoreV1().ConfigMaps(namespace).Update(cm)
 	assert.NoError(t, err)
 }

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -80,7 +80,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.fs.Namespace, &d.ObjectMeta, c.ownerRefs)
+	k8sutil.SetOwnerRefs(&d.ObjectMeta, c.ownerRefs)
 	return d
 }
 

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -170,7 +170,7 @@ func (c *CephNFSController) runGaneshaRadosGraceJob(n cephv1.CephNFS, name, acti
 			},
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, n.Namespace, &job.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.ownerRef)
 
 	// run the job to detect the version
 	if err := k8sutil.RunReplaceableJob(c.context.Clientset, job, false); err != nil {

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -58,7 +58,7 @@ func (c *CephNFSController) createCephNFSService(n cephv1.CephNFS, name string) 
 			},
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, n.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	if c.hostNetwork {
 		svc.Spec.ClusterIP = v1.ClusterIPNone
 	}
@@ -86,7 +86,7 @@ func (c *CephNFSController) makeDeployment(n cephv1.CephNFS, name, configName st
 		},
 	}
 	n.Spec.Server.Annotations.ApplyToObjectMeta(&deployment.ObjectMeta)
-	k8sutil.SetOwnerRef(c.context.Clientset, n.Namespace, &deployment.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.ownerRef)
 	configMapSource := &v1.ConfigMapVolumeSource{
 		LocalObjectReference: v1.LocalObjectReference{Name: configName},
 		Items:                []v1.KeyToPath{{Key: "config", Path: "ganesha.conf"}},

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -50,7 +50,7 @@ func (c *clusterConfig) startDeployment() (*apps.Deployment, error) {
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	c.store.Spec.Gateway.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
+	k8sutil.SetOwnerRefs(&d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw deployment: %+v", d)
 	deployment, err := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Get(d.Name, metav1.GetOptions{})
@@ -98,7 +98,7 @@ func (c *clusterConfig) startDaemonset() (*apps.DaemonSet, error) {
 	}
 	k8sutil.AddRookVersionLabelToDaemonSet(d)
 	opspec.AddCephVersionLabelToDaemonSet(c.clusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &d.ObjectMeta, c.ownerRefs)
+	k8sutil.SetOwnerRefs(&d.ObjectMeta, c.ownerRefs)
 
 	logger.Debugf("starting rgw daemonset: %+v", d)
 	daemonSet, err := c.context.Clientset.AppsV1().DaemonSets(c.store.Namespace).Create(d)
@@ -211,7 +211,7 @@ func (c *clusterConfig) startService() (string, error) {
 			Selector: labels,
 		},
 	}
-	k8sutil.SetOwnerRefs(c.context.Clientset, c.store.Namespace, &svc.ObjectMeta, c.ownerRefs)
+	k8sutil.SetOwnerRefs(&svc.ObjectMeta, c.ownerRefs)
 	if c.hostNetwork {
 		svc.Spec.ClusterIP = v1.ClusterIPNone
 	}

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -176,7 +176,7 @@ func (c *ObjectStoreUserController) createUser(context *clusterd.Context, u *cep
 		StringData: secrets,
 		Type:       k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(context.Clientset, u.Namespace, &secret.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&secret.ObjectMeta, &c.ownerRef)
 
 	_, err = context.Clientset.CoreV1().Secrets(u.Namespace).Create(secret)
 	if err != nil {

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -105,7 +105,7 @@ func newCluster(c *cockroachdbv1alpha1.Cluster, context *clusterd.Context) *clus
 func clusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
-		APIVersion:         ClusterResource.Version,
+		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
 		Name:               namespace,
 		UID:                types.UID(clusterID),

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -211,7 +211,7 @@ func (c *ClusterController) createClientService(cluster *cluster) error {
 			Ports:    createServicePorts(httpPort, grpcPort),
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, cluster.namespace, &clientService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(&clientService.ObjectMeta, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(clientService); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -261,7 +261,7 @@ func (c *ClusterController) createReplicaService(cluster *cluster) error {
 			Ports:                    createServicePorts(httpPort, grpcPort),
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, cluster.namespace, &replicaService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(&replicaService.ObjectMeta, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(replicaService); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -291,7 +291,7 @@ func (c *ClusterController) createPodDisruptionBudget(cluster *cluster) error {
 			MaxUnavailable: &maxUnavailable,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, cluster.namespace, &pdb.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(&pdb.ObjectMeta, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.PolicyV1beta1().PodDisruptionBudgets(cluster.namespace).Create(pdb); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -340,7 +340,7 @@ func (c *ClusterController) createStatefulSet(cluster *cluster) error {
 	}
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.Spec.Template.ObjectMeta)
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.ObjectMeta)
-	k8sutil.SetOwnerRef(c.context.Clientset, cluster.namespace, &statefulSet.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(&statefulSet.ObjectMeta, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.AppsV1().StatefulSets(cluster.namespace).Create(statefulSet); err != nil {
 		if !errors.IsAlreadyExists(err) {

--- a/pkg/operator/edgefs/cluster/cluster.go
+++ b/pkg/operator/edgefs/cluster/cluster.go
@@ -90,7 +90,7 @@ func (c *cluster) createInstance(rookImage string) error {
 		},
 		Data: placeholderConfig,
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &cm.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&cm.ObjectMeta, &c.ownerRef)
 	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(cm)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create override configmap %s. %+v", c.Namespace, err)

--- a/pkg/operator/edgefs/cluster/configmap.go
+++ b/pkg/operator/edgefs/cluster/configmap.go
@@ -166,7 +166,7 @@ func (c *cluster) createClusterConfigMap(nodes []rookalpha.Node, deploymentConfi
 		Data: dataMap,
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &configMap.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
 	if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {
 		if errors.IsAlreadyExists(err) {
 			if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(configMap); err != nil {

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -87,7 +87,7 @@ func NewClusterController(context *clusterd.Context, containerImage string) *Clu
 func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
-		APIVersion:         ClusterResource.Version,
+		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
 		Name:               namespace,
 		UID:                types.UID(clusterID),

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -192,7 +192,7 @@ func (c *Cluster) makeMgrService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -227,7 +227,7 @@ func (c *Cluster) makeRestapiService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -257,7 +257,7 @@ func (c *Cluster) makeUIService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 
 	if c.dashboardSpec.LocalAddr != "" {
 		ip := net.ParseIP(c.dashboardSpec.LocalAddr)
@@ -352,7 +352,7 @@ func (c *Cluster) makeDeployment(name, clusterName, rookImage string, replicas i
 			Replicas: &replicas,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	c.annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/cluster/prepare/prepare.go
+++ b/pkg/operator/edgefs/cluster/prepare/prepare.go
@@ -150,7 +150,7 @@ func (c *Cluster) makeJob(name, clusterName, rookImage string, nodeName string) 
 		},
 		Spec: batch.JobSpec{Template: podSpec},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &ds.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&ds.ObjectMeta, &c.ownerRef)
 	return ds
 }
 

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -514,7 +514,7 @@ func (c *Cluster) makeStatefulSet(replicas int32, rookImage string, dro edgefsv1
 		}
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &statefulSet.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&statefulSet.ObjectMeta, &c.ownerRef)
 	c.annotations.ApplyToObjectMeta(&statefulSet.ObjectMeta)
 	c.annotations.ApplyToObjectMeta(&statefulSet.Spec.Template.ObjectMeta)
 	c.placement.ApplyToPodSpec(&statefulSet.Spec.Template.Spec)
@@ -556,7 +556,7 @@ func (c *Cluster) makeHeadlessService() (*v1.Service, error) {
 			Ports:                    c.makeHeadlessServicePorts(udpTotemPortDefault),
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, c.Namespace, &headlessService.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&headlessService.ObjectMeta, &c.ownerRef)
 
 	return headlessService, nil
 }

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -119,7 +119,7 @@ func (c *ISCSIController) makeISCSIService(name, svcname, namespace string, iscs
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -186,7 +186,7 @@ func (c *ISCSIController) makeDeployment(svcname, namespace, rookImage string, i
 			Replicas: &instancesCount,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	iscsiSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 
 	return d

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -168,7 +168,7 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{Name: "dfport", Port: int32(lport), Protocol: v1.ProtocolTCP})
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -234,7 +234,7 @@ func (c *ISGWController) makeDeployment(svcname, namespace, rookImage string, is
 			Replicas: &instancesCount,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	return d
 }
 

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -122,7 +122,7 @@ func (c *NFSController) makeNFSService(name, svcname, namespace string) *v1.Serv
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -188,7 +188,7 @@ func (c *NFSController) makeDeployment(svcname, namespace, rookImage string, nfs
 			Replicas: &nfsSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	nfsSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -151,7 +151,7 @@ func (c *S3Controller) makeS3Service(name, svcname, namespace string, s3Spec edg
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -239,7 +239,7 @@ func (c *S3Controller) makeDeployment(svcname, namespace, rookImage, imageArgs s
 			Replicas: &s3Spec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	s3Spec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/s3x/s3x.go
+++ b/pkg/operator/edgefs/s3x/s3x.go
@@ -127,7 +127,7 @@ func (c *S3XController) makeS3XService(name, svcname, namespace string, s3xSpec 
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -223,7 +223,7 @@ func (c *S3XController) makeDeployment(svcname, namespace, rookImage string, s3x
 			Replicas: &s3xSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	s3xSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -139,7 +139,7 @@ func (c *SWIFTController) makeSWIFTService(name, svcname, namespace string, swif
 		},
 	}
 
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
 	return svc
 }
 
@@ -226,7 +226,7 @@ func (c *SWIFTController) makeDeployment(svcname, namespace, rookImage, imageArg
 			Replicas: &swiftSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	return d
 }
 

--- a/pkg/operator/k8sutil/kvstore.go
+++ b/pkg/operator/k8sutil/kvstore.go
@@ -75,7 +75,7 @@ func (kv *ConfigMapKVStore) SetValueWithLabels(storeName, key, value string, lab
 		if labels != nil {
 			cm.Labels = labels
 		}
-		SetOwnerRef(kv.clientset, kv.namespace, &cm.ObjectMeta, &kv.ownerRef)
+		SetOwnerRef(&cm.ObjectMeta, &kv.ownerRef)
 
 		_, err = kv.clientset.CoreV1().ConfigMaps(kv.namespace).Create(cm)
 		return err

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -20,14 +20,7 @@ package k8sutil
 // MergeResourceRequirements merges two resource requirements together (first overrides second values)
 import (
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-)
-
-var (
-	skipSetOwnerRefEnv bool
-	testedSetOwnerRef  bool
 )
 
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {
@@ -67,45 +60,13 @@ func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.Resourc
 	return first
 }
 
-func SetOwnerRef(clientset kubernetes.Interface, namespace string, object *metav1.ObjectMeta, ownerRef *metav1.OwnerReference) {
+func SetOwnerRef(object *metav1.ObjectMeta, ownerRef *metav1.OwnerReference) {
 	if ownerRef == nil {
 		return
 	}
-	SetOwnerRefs(clientset, namespace, object, []metav1.OwnerReference{*ownerRef})
+	SetOwnerRefs(object, []metav1.OwnerReference{*ownerRef})
 }
 
-func SetOwnerRefs(clientset kubernetes.Interface, namespace string, object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
-	if !testedSetOwnerRef {
-		testSetOwnerRef(clientset, namespace, ownerRefs)
-		testedSetOwnerRef = true
-	}
-	if skipSetOwnerRefEnv {
-		return
-	}
-
-	// We want to set the owner ref unless we detect if it needs to be skipped.
-	object.OwnerReferences = ownerRefs
-}
-
-func testSetOwnerRef(clientset kubernetes.Interface, namespace string, ownerRefs []metav1.OwnerReference) {
-	// Confirm if we can create a resource with the ownerref set to the cluster CRD.
-	// Some versions of OpenShift may not have support for setting the ownerref to a CRD.
-	// See https://github.com/kubernetes/kubernetes/pull/62810
-	cm := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "rook-test-ownerref",
-			Namespace:       namespace,
-			OwnerReferences: ownerRefs,
-		},
-		Data: map[string]string{},
-	}
-	_, err := clientset.CoreV1().ConfigMaps(namespace).Create(cm)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		logger.Warningf("OwnerReferences will not be set on resources created by rook. failed to test that it can be set. %+v", err)
-		skipSetOwnerRefEnv = true
-		return
-	}
-
-	logger.Infof("verified the ownerref can be set on resources")
-	skipSetOwnerRefEnv = false
+func SetOwnerRefs(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+	object.SetOwnerReferences(ownerRefs)
 }

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -106,7 +106,7 @@ func (c *Controller) makeMinioHeadlessService(name, namespace string, spec minio
 			ClusterIP: v1.ClusterIPNone,
 		},
 	}
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &svc.ObjectMeta, &ownerRef)
+	k8sutil.SetOwnerRef(&svc.ObjectMeta, &ownerRef)
 
 	svc, err := c.context.Clientset.CoreV1().Services(namespace).Create(svc)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
@@ -296,7 +296,7 @@ func (c *Controller) makeMinioStatefulSet(name, namespace string, spec miniov1al
 		},
 	}
 	annotations.ApplyToObjectMeta(&sts.ObjectMeta)
-	k8sutil.SetOwnerRef(c.context.Clientset, namespace, &sts.ObjectMeta, &ownerRef)
+	k8sutil.SetOwnerRef(&sts.ObjectMeta, &ownerRef)
 	sts, err = c.context.Clientset.AppsV1().StatefulSets(namespace).Create(sts)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("failed to create minio statefulset. %+v", err)

--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -108,7 +108,7 @@ func newNfsServer(c *nfsv1alpha1.NFSServer, context *clusterd.Context) *nfsServe
 func nfsOwnerRef(namespace, nfsServerID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
-		APIVersion:         NFSResource.Version,
+		APIVersion:         fmt.Sprintf("%s/%s", NFSResource.Group, NFSResource.Version),
 		Kind:               NFSResource.Kind,
 		Name:               namespace,
 		UID:                types.UID(nfsServerID),


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The following fixes are backported to the release-1.0 branch:
- Enable metrics for the flexvolume driver
- Enable OwnerReferences to properly garbage collect resources owned by CRs in OpenShift
- Fix OSDs to start when on an SDN by using the `--ms-learn-addr-from-peer` flag. Also requires the ceph/ceph:v14.2.2 release to take effect.

**Which issue is resolved by this Pull Request:**
Resolves #1659 #2944 #3140 

**Checklist:**
- [X] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]