### PR TITLE
Ceph: fix error when creating monmap in Octopus

### DIFF
--- a/pkg/daemon/ceph/config/keyring.go
+++ b/pkg/daemon/ceph/config/keyring.go
@@ -30,14 +30,14 @@ const (
 	// AdminKeyringTemplate is a string template of Ceph keyring settings which allow connection
 	// as admin. The key value must be filled in by the admin auth key for the cluster.
 	AdminKeyringTemplate = `
-	[client.admin]
-		key = %s
-		auid = 0
-		caps mds = "allow *"
-		caps mon = "allow *"
-		caps osd = "allow *"
-		caps mgr = "allow *"
-	`
+[client.admin]
+	key = %s
+	auid = 0
+	caps mds = "allow *"
+	caps mon = "allow *"
+	caps osd = "allow *"
+	caps mgr = "allow *"
+`
 )
 
 // AdminKeyring returns the filled-out admin keyring


### PR DESCRIPTION
Adjust keyring template because ceph-mon in Octopus fails to
parse keyring file which has leading indention.

Fixes: https://github.com/rook/rook/issues/3384
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3384 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
