### PR TITLE
ceph: controller: fix panic on cr update

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -503,7 +503,28 @@ func (c *ClusterController) onUpdate(oldObj, newObj interface{}) {
 		}
 		cluster.Info.CephVersion = *version
 	} else {
-		logger.Infof("ceph version is still %s on image %s", &cluster.Info.CephVersion, cluster.Spec.CephVersion.Image)
+		// At this point, clusterInfo might not be initialized
+		// If we have deployed a new operator and failed on allowUnsupported
+		// there is no way we can continue, even we set allowUnsupported to true clusterInfo is gone
+		// So we have to re-populate it
+		if !cluster.Info.IsInitialized() {
+			logger.Infof("cluster information are not initialized, populating them.")
+
+			cluster.Info, _, _, err = mon.LoadClusterInfo(c.context, cluster.Namespace)
+			if err != nil {
+				logger.Errorf("failed to load clusterInfo %+v", err)
+			}
+
+			// Re-setting cluster version too since LoadClusterInfo does not load it
+			version, err := cluster.detectCephVersion(newClust.Spec.CephVersion.Image, 15*time.Minute)
+			if err != nil {
+				logger.Errorf("unknown ceph major version. %+v", err)
+				return
+			}
+			cluster.Info.CephVersion = *version
+
+			logger.Infof("ceph version is still %s on image %s", &cluster.Info.CephVersion, cluster.Spec.CephVersion.Image)
+		}
 	}
 
 	logger.Debugf("old cluster: %+v", oldClust.Spec)


### PR DESCRIPTION
If we are running a Ceph cluster that has an unsupported version and if
we have set allowUnsupported: false, a newly bootstrap operator will
fail to start. To fix this, the user will update the CR and set
allowUnsupported: true, however at this point clusterInfo hasn't been
initialized so the operator will panic because we were referencing a nil
pointer.

To fix this, we re-populate clusterInfo if necessary and things go
smoothly.

Closes: https://github.com/rook/rook/issues/3137
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]