### PR TITLE
backport: ceph: osd: fix cli arg

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -631,8 +631,9 @@ func osdOnSDNFlag(hostnetwork bool, v cephver.CephVersion) []string {
 	// for more details: https://github.com/rook/rook/issues/3140
 	if !hostnetwork {
 		if v.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 2}) {
-			args = append(args, "--ms-learn-addr-from-peer", "false")
+			args = append(args, "--ms-learn-addr-from-peer=false")
 		}
 	}
+
 	return args
 }


### PR DESCRIPTION
Somehow during startup the arg got misinterpreted by ceph-osd and was
failing with:

2019-06-19 15:23:09.098967 I | exec: Running command: ceph-osd --foreground --id 0 --osd-uuid feceb7d7-3148-4a0d-af7a-753ba2f21a92 --conf /var/lib/rook/osd0/rook-ceph.config --cluster ceph --default-log-to-file false --ms-learn-addr-from-peer false
2019-06-19 15:23:09.135921 I | unrecognized arg false
failed to start osd. Failed to complete '': exit status 1.

Now we concatenate the whole flag to avoid that.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 6d620054723d4fc0ebc47d6d103d8410b4a8a544)

Backport of: https://github.com/rook/rook/pull/3389

[skip ci]
Known CI issue