### PR TITLE
ceph: fix typo error storegeclass

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -124,7 +124,7 @@ maintain a config map whose contents will match this key. By default this is
 Then create the storage class:
 
 ```console
-kubectl create -f cluster/examples/kubernetes/ceph/csi/example/rbd/storegeclass.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
 ```
 
 ## Create RBD Secret
@@ -370,7 +370,7 @@ Update the value of the `clusterID` field to match the namespace that rook is
 running in.
 
 ```console
-kubectl create -f cluster/examples/kubernetes/ceph/csi/example/cephfs/storegeclass.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml
 ```
 
 ## Create CephFS Secret


### PR DESCRIPTION
The word "storegeclass" should be "storageclass"

Signed-off-by: Joel Huang <joelhy@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]