### PR TITLE
ceph: backport of PR #3396 "fix typo error storegeclass" to release-1.0 branch

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -119,7 +119,7 @@ CRD](https://github.com/rook/rook/blob/v1.0/Documentation/ceph-pool-crd.md).
 Please update `monitors` to reflect the Ceph monitors.
 
 ```console
-kubectl create -f cluster/examples/kubernetes/ceph/csi/example/rbd/storegeclass.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
 ```
 
 ## Create RBD Secret
@@ -357,7 +357,7 @@ CRD](https://github.com/rook/rook/blob/v1.0/Documentation/ceph-filesystem-crd.md
 Please update `monitors` to reflect the Ceph monitors.
 
 ```console
-kubectl create -f cluster/examples/kubernetes/ceph/csi/example/cephfs/storegeclass.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml
 ```
 
 ## Create CephFS Secret


### PR DESCRIPTION
The word "storegeclass" should be "storageclass"

Signed-off-by: Joel Huang <joelhy@gmail.com>
(cherry picked from commit d4945d65333d34c30325255a557275e675c540cb)
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]