### PR TITLE
ceph: backport of PR #3400 "wrong pool name for CephFS StorageClass" to release-1.0 branch

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -350,7 +350,7 @@ kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.
 
 This
 [storageclass](../cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml)
-expect a pool named `cephfs_data` in your Ceph cluster. You can create this
+expect a pool named `myfs-data0` in your Ceph cluster. You can create this
 pool using [rook file-system
 CRD](https://github.com/rook/rook/blob/v1.0/Documentation/ceph-filesystem-crd.md).
 

--- a/cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml
@@ -18,7 +18,7 @@ parameters:
 
   # Ceph pool into which the volume shall be created
   # Required for provisionVolume: "true"
-  pool: cephfs_data
+  pool: myfs-data0
 
   # Root path of an existing CephFS volume
   # Required for provisionVolume: "false"


### PR DESCRIPTION
* This error is found in creating CephFS StorageClass using document `Documentation/ceph-csi-drivers.md`
* **`kubectl apply -f cluster/examples/kubernetes/ceph/csi/example/cephfs/storageclass.yaml` product error:** The CephBlockPool "cephfs_data" is invalid: metadata.name: Invalid value: "cephfs_data": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
* accoding to `Documentation/ceph-filesystem-crd.md` linked from `Documentation/ceph-csi-drivers.md` file and field test, it should be `myfs-data0`

Signed-off-by: Joel Huang <joelhy@gmail.com>
(cherry picked from commit bc031adbfd11c6f940d1c57f3192951304654f29)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]