### PR TITLE
ceph: adjust M-to-Mi rounding in PV creation

### DIFF
--- a/pkg/daemon/ceph/client/image.go
+++ b/pkg/daemon/ceph/client/image.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/display"
 	"github.com/rook/rook/pkg/util/exec"
 )
 
@@ -68,6 +69,9 @@ func ListImages(context *clusterd.Context, clusterName, poolName string) ([]Ceph
 
 // CreateImage creates a block storage image.
 // If dataPoolName is not empty, the image will use poolName as the metadata pool and the dataPoolname for data.
+// If size is zero an empty image will be created. Otherwise, an image will be
+// created with a size rounded up to the nearest Mi. The adjusted image size is
+// placed in return value CephBlockImage.Size.
 func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoolName string, size uint64) (*CephBlockImage, error) {
 	if size > 0 && size < ImageMinSize {
 		// rbd tool uses MB as the smallest unit for size input.  0 is OK but anything else smaller
@@ -100,7 +104,15 @@ func CreateImage(context *clusterd.Context, clusterName, name, poolName, dataPoo
 		}
 	}
 
-	return &CephBlockImage{Name: name, Size: size}, nil
+	// report the adjusted size which will always be >= to the requested size
+	var newSizeBytes uint64
+	if sizeMB > 0 {
+		newSizeBytes = display.MbTob(uint64(sizeMB))
+	} else {
+		newSizeBytes = 0
+	}
+
+	return &CephBlockImage{Name: name, Size: newSizeBytes}, nil
 }
 
 func DeleteImage(context *clusterd.Context, clusterName, name, poolName string) error {


### PR DESCRIPTION
Example of failure scenarios:
```
   - requested PVC 500M = 500,000,000 bytes
   - PV is created as:
        (500M / 2**20)Mi = "476"Mi
        But 476Mi = 476 * 2**20 = 499122176 < 500M
```
So, rounding back up loses some of the precision.


From the k8s documentation:

> Claims will remain unbound indefinitely if a matching volume does not
   exist. Claims will be bound as matching volumes become available. For
   example, a cluster provisioned with many 50Gi PVs would not match a
   PVC requesting 100Gi. The PVC can be bound when a 100Gi PV is added
   to the cluster.

which is inline with the behavior observed in which a 500M PVC is never
bound. However, the documentation also states:

> If a PV was dynamically provisioned for a new PVC, the loop will
   always bind that PV to the PVC. Otherwise, the user will always get
   at least what they asked for

which suggests that an _explicit_ binding can be created, and perhaps
something has changed with respect to this binding that has caused the
failures in newer versions of k8s. in any case, this was tested with 1.15 and solves the issues. 

fixes: #3391
fixes: #2922