### PR TITLE
Tests: Ensure cluster does not exist before starting a test

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -128,35 +128,6 @@ func (k8sh *K8sHelper) Kubectl(args ...string) (string, error) {
 	return result, nil
 }
 
-func (k8sh *K8sHelper) PurgeClusters() error {
-	// get all namespaces
-	namespaces, err := k8sh.Clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get namespaces to remove finalizers. %+v", err)
-	}
-
-	// look for the clusters in all namespaces
-	for _, n := range namespaces.Items {
-		namespace := n.Name
-		logger.Infof("looking in namespace %s for clusters to purge", namespace)
-		clusters, err := k8sh.RookClientset.CephV1().CephClusters(namespace).List(metav1.ListOptions{})
-		if err != nil {
-			logger.Warningf("failed to get clusters in namespace %s. %+v", namespace, err)
-			continue
-		}
-		for _, cluster := range clusters.Items {
-			logger.Infof("Ensuring rook cluster crd %s in namespace %s is deleted", cluster.Name, namespace)
-			if _, err := k8sh.Kubectl("patch", "cephclusters.ceph.rook.io", cluster.Name, "-n", namespace, "-p", `{"metadata":{"finalizers": []}}`, "--type=merge"); err != nil {
-				logger.Warningf("failed to remove finalizer from cluster %s. %+v", cluster.Name, err)
-			}
-			if err := k8sh.RookClientset.CephV1().CephClusters(namespace).Delete(cluster.Name, &metav1.DeleteOptions{}); err != nil {
-				logger.Warningf("failed to delete cluster %s", cluster.Name)
-			}
-		}
-	}
-	return nil
-}
-
 // KubectlWithStdin is wrapper for executing kubectl commands in stdin
 func (k8sh *K8sHelper) KubectlWithStdin(stdin string, args ...string) (string, error) {
 


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CI instances are not always being properly cleaned up between runs. This is an attempt to get the Ceph tests to ensure a clean install before proceeding with the test.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
