### PR TITLE
ceph: stop creating initial crushmap

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,6 +20,7 @@ an example usage
 - Ceph CRUSH tunable are not enforced to "firefly" anymore, Ceph picks the right tunable for its own version, to read more about tunable [see the Ceph documentation](http://docs.ceph.com/docs/master/rados/operations/crush-map/#tunables)
 - `NodeAffinity` can be applied to `rook-ceph-agent DaemonSet` with `AGENT_NODE_AFFINITY` environment variable.
 - `NodeAffinity` can be applied to `rook-discover DaemonSet` with `DISCOVER_AGENT_NODE_AFFINITY` environment variable.
+- Rook does not create an initial CRUSH map anymore and let Ceph do it normally
 
 ## Breaking Changes
 

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -18,58 +18,12 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/rook/rook/pkg/clusterd"
 )
-
-const defaultCrushMap = `# begin crush map
-tunable choose_local_tries 0
-tunable choose_local_fallback_tries 0
-tunable choose_total_tries 50
-tunable chooseleaf_descend_once 1
-tunable chooseleaf_vary_r 1
-tunable chooseleaf_stable 0
-tunable straw_calc_version 1
-tunable allowed_bucket_algs 22
-
-# types
-type 0 osd
-type 1 host
-type 2 chassis
-type 3 rack
-type 4 row
-type 5 pdu
-type 6 pod
-type 7 room
-type 8 datacenter
-type 9 region
-type 10 root
-
-# default bucket
-root default {
-	id -1   # do not change unnecessarily
-	alg straw
-	hash 0  # rjenkins1
-}
-
-# rules
-rule replicated_ruleset {
-	ruleset 0
-	type replicated
-	min_size 1
-	max_size 10
-	step take default
-	step chooseleaf firstn 0 type host
-	step emit
-}
-
-# end crush map
-`
 
 type CrushMap struct {
 	Devices []struct {
@@ -141,28 +95,6 @@ func GetCrushMap(context *clusterd.Context, clusterName string) (CrushMap, error
 	return c, nil
 }
 
-func SetCrushMap(context *clusterd.Context, clusterName, compiledMap string) (string, error) {
-	args := []string{"osd", "setcrushmap", "-i", compiledMap}
-	buf, err := NewCephCommand(context, clusterName, args).Run()
-	if err != nil {
-		return string(buf), fmt.Errorf("failed to set compiled crushmap. %v", err)
-	}
-
-	return string(buf), nil
-}
-
-func SetCrushTunables(context *clusterd.Context, clusterName, profile string) (string, error) {
-	args := []string{"osd", "crush", "tunables", profile}
-	cmd := NewCephCommand(context, clusterName, args)
-	cmd.JsonOutput = false
-	buf, err := cmd.Run()
-	if err != nil {
-		return "", fmt.Errorf("%+v, %s", err, string(buf))
-	}
-
-	return string(buf), nil
-}
-
 func CrushReweight(context *clusterd.Context, clusterName string, id int, weight float64) (string, error) {
 	args := []string{"osd", "crush", "reweight", fmt.Sprintf("osd.%d", id), fmt.Sprintf("%.1f", weight)}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
@@ -202,45 +134,6 @@ func GetCrushHostName(context *clusterd.Context, clusterName string, osdID int) 
 	}
 
 	return result.Location.Host, nil
-}
-
-func CreateDefaultCrushMap(context *clusterd.Context, clusterName string) (string, error) {
-	// create a temp file that we will use to write the default decompiled crush map to
-	decompiledMap, err := ioutil.TempFile("", "")
-	if err != nil {
-		return "", fmt.Errorf("failed to open decompiled crush map temp file: %+v", err)
-	}
-	defer decompiledMap.Close()
-	defer os.Remove(decompiledMap.Name())
-
-	// write the default decompiled crush map to the temp file
-	_, err = decompiledMap.WriteString(defaultCrushMap)
-	if err != nil {
-		return "", fmt.Errorf("failed to write decompiled crush map to %s: %+v", decompiledMap.Name(), err)
-	}
-
-	// create a temp file to serve as the output file for the compilation process
-	compiledMap, err := ioutil.TempFile("", "")
-	if err != nil {
-		return "", fmt.Errorf("failed to open compiled crush map temp file: %+v", err)
-	}
-	defer compiledMap.Close()
-	defer os.Remove(compiledMap.Name())
-
-	// compile the crush map to an output file
-	args := []string{"-c", decompiledMap.Name(), "-o", compiledMap.Name()}
-	output, err := context.Executor.ExecuteCommandWithOutput(false, "", CrushTool, args...)
-	if err != nil {
-		return output, fmt.Errorf("failed to compile crushmap from %s: %+v", decompiledMap.Name(), err)
-	}
-
-	// set the compiled crush map on the cluster
-	output, err = SetCrushMap(context, clusterName, compiledMap.Name())
-	if err != nil {
-		return output, fmt.Errorf("failed to set crushmap to %s: %+v", compiledMap.Name(), err)
-	}
-
-	return "", nil
 }
 
 func FormatLocation(location, hostName string) ([]string, error) {

--- a/pkg/daemon/ceph/config/keyring.go
+++ b/pkg/daemon/ceph/config/keyring.go
@@ -32,7 +32,6 @@ const (
 	AdminKeyringTemplate = `
 [client.admin]
 	key = %s
-	auid = 0
 	caps mds = "allow *"
 	caps mon = "allow *"
 	caps osd = "allow *"

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -28,7 +28,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
@@ -197,11 +196,6 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 		return fmt.Errorf("the cluster identity was not established: %+v", c.Info)
 	}
 
-	err = c.createInitialCrushMap()
-	if err != nil {
-		return fmt.Errorf("failed to create initial crushmap: %+v", err)
-	}
-
 	mgrs := mgr.New(c.Info, c.context, c.Namespace, rookImage,
 		spec.CephVersion, cephv1.GetMgrPlacement(spec.Placement), cephv1.GetMgrAnnotations(c.Spec.Annotations),
 		spec.Network.HostNetwork, spec.Dashboard, cephv1.GetMgrResources(spec.Resources), c.ownerRef, c.Spec.DataDirHostPath)
@@ -233,65 +227,6 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 	// Notify the child controllers that the cluster spec might have changed
 	for _, child := range c.childControllers {
 		child.ParentClusterChanged(*c.Spec, clusterInfo)
-	}
-
-	return nil
-}
-
-func (c *cluster) createInitialCrushMap() error {
-	configMapExists := false
-	createCrushMap := false
-
-	cm, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(crushConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-
-		// crush config map was not found, meaning we haven't created the initial crush map
-		createCrushMap = true
-	} else {
-		// crush config map was found, look in it to verify we've created the initial crush map
-		configMapExists = true
-		val, ok := cm.Data[crushmapCreatedKey]
-		if !ok {
-			createCrushMap = true
-		} else if val != "1" {
-			createCrushMap = true
-		}
-	}
-
-	if !createCrushMap {
-		// no need to create the crushmap, bail out
-		return nil
-	}
-
-	logger.Info("creating initial crushmap")
-	out, err := client.CreateDefaultCrushMap(c.context, c.Namespace)
-	if err != nil {
-		return fmt.Errorf("failed to create initial crushmap: %+v. output: %s", err, out)
-	}
-
-	logger.Info("created initial crushmap")
-
-	// save the fact that we've created the initial crushmap to a configmap
-	configMap := &v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      crushConfigMapName,
-			Namespace: c.Namespace,
-		},
-		Data: map[string]string{crushmapCreatedKey: "1"},
-	}
-	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
-
-	if !configMapExists {
-		if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(configMap); err != nil {
-			return fmt.Errorf("failed to create configmap %s: %+v", crushConfigMapName, err)
-		}
-	} else {
-		if _, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(configMap); err != nil {
-			return fmt.Errorf("failed to update configmap %s: %+v", crushConfigMapName, err)
-		}
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -31,33 +31,9 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
-	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func TestCreateInitialCrushMap(t *testing.T) {
-	clientset := testop.New(3)
-	executor := &exectest.MockExecutor{}
-	context := &clusterd.Context{Clientset: clientset, Executor: executor}
-	c := newCluster(&cephv1.CephCluster{}, context)
-	c.Namespace = "rook294"
-
-	// create the initial crush map and verify that a configmap value was created that says the crush map was created
-	err := c.createInitialCrushMap()
-	assert.Nil(t, err)
-	cm, err := clientset.CoreV1().ConfigMaps(c.Namespace).Get(crushConfigMapName, metav1.GetOptions{})
-	assert.Nil(t, err)
-	assert.NotNil(t, cm)
-	assert.Equal(t, "1", cm.Data[crushmapCreatedKey])
-
-	// the crushmap should NOT get created again
-	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
-		return "", fmt.Errorf("crushmap was already created, we shouldn't be calling this again")
-	}
-	err = c.createInitialCrushMap()
-	assert.Nil(t, err)
-}
 
 func TestClusterDelete(t *testing.T) {
 	nodeName := "node841"

--- a/pkg/operator/ceph/config/keyring/admin.go
+++ b/pkg/operator/ceph/config/keyring/admin.go
@@ -29,7 +29,6 @@ const (
 	adminKeyringTemplate = `
 [client.admin]
 	key = %s
-	auid = 0
 	caps mds = "allow *"
 	caps mon = "allow *"
 	caps osd = "allow *"


### PR DESCRIPTION
This commit does:

* remove dead code SetCrushTunables()
* stop creating initial crushmap

There is no need to create an initial crushmap, since Ceph natively does
that for us.
We don't delete the existing configmap containing the initial crush map
of already deployed cluster, perhaps people are using for whatever
reason. It does not harm to keep it around.

Closes: https://github.com/rook/rook/issues/3138
Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
