### PR TITLE
ceph: rgw: set proper port syntax on beast

### DIFF
--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -61,28 +61,46 @@ func (c *clusterConfig) defaultSettings() *cephconfig.Config {
 		Set("rgw log nonexistent bucket", "true").
 		Set("rgw intent log object name utc", "true").
 		Set("rgw enable usage log", "true").
-		Set("rgw frontends", fmt.Sprintf("%s port=%s", rgwFrontend(c.clusterInfo.CephVersion), c.portString())).
+		Set("rgw frontends", fmt.Sprintf("%s %s", rgwFrontend(c.clusterInfo.CephVersion), c.portString(c.clusterInfo.CephVersion))).
 		Set("rgw zone", c.store.Name).
 		Set("rgw zonegroup", c.store.Name)
 	return s
 }
 
-func (c *clusterConfig) portString() string {
+func (c *clusterConfig) portString(v cephver.CephVersion) string {
 	var portString string
+
 	port := c.store.Spec.Gateway.Port
 	if port != 0 {
-		portString = strconv.Itoa(int(port))
+		portString = fmt.Sprintf("port=%s", strconv.Itoa(int(port)))
 	}
 	if c.store.Spec.Gateway.SecurePort != 0 && c.store.Spec.Gateway.SSLCertificateRef != "" {
-		var separator string
-		if port != 0 {
-			separator = "+"
-		}
 		certPath := path.Join(certDir, certFilename)
-		// with ssl enabled, the port number must end with the letter s.
-		// e.g., "443s ssl_certificate=/etc/ceph/private/keyandcert.pem"
-		portString = fmt.Sprintf("%s%s%ds ssl_certificate=%s",
-			portString, separator, c.store.Spec.Gateway.SecurePort, certPath)
+		// This is the beast backend
+		// Config is: http://docs.ceph.com/docs/master/radosgw/frontends/#id3
+		if v.IsAtLeastNautilus() {
+			if port != 0 {
+				portString = fmt.Sprintf("%s ssl_port=%d ssl_certificate=%s",
+					portString, c.store.Spec.Gateway.SecurePort, certPath)
+			} else {
+				portString = fmt.Sprintf("ssl_port=%d ssl_certificate=%s",
+					c.store.Spec.Gateway.SecurePort, certPath)
+			}
+		} else {
+			// This is civetweb config
+			// Config is http://docs.ceph.com/docs/master/radosgw/frontends/#id5
+			var separator string
+			if port != 0 {
+				separator = "+"
+			} else {
+				// This means there is only one port and it's a secured one
+				portString = "port="
+			}
+			// with ssl enabled, the port number must end with the letter s.
+			// e.g., "443s ssl_certificate=/etc/ceph/private/keyandcert.pem"
+			portString = fmt.Sprintf("%s%s%ds ssl_certificate=%s",
+				portString, separator, c.store.Spec.Gateway.SecurePort, certPath)
+		}
 	}
 	return portString
 }

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -38,36 +38,78 @@ func newConfig() *clusterConfig {
 }
 
 func TestPortString(t *testing.T) {
-	// No port or secure port
+	// No port or secure port on civetweb
 	cfg := newConfig()
-	result := cfg.portString()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
+	result := cfg.portString(cfg.clusterInfo.CephVersion)
 	assert.Equal(t, "", result)
 
-	// Insecure port
+	// No port or secure port on beast
 	cfg = newConfig()
-	cfg.store.Spec.Gateway.Port = 80
-	result = cfg.portString()
-	assert.Equal(t, "80", result)
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "", result)
 
-	// Secure port
+	// Insecure port on civetweb
 	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
+	cfg.store.Spec.Gateway.Port = 80
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "port=80", result)
+
+	// Insecure port on beast
+	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	cfg.store.Spec.Gateway.Port = 80
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "port=80", result)
+
+	// Secure port on civetweb
+	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString()
-	assert.Equal(t, "443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "port=443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
-	// Both ports
+	// Both ports on civetweb
 	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
 	cfg.store.Spec.Gateway.Port = 80
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString()
-	assert.Equal(t, "80+443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "port=80+443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
-	// Secure port requires the cert
+	// Secure port on beast
 	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
 	cfg.store.Spec.Gateway.SecurePort = 443
-	result = cfg.portString()
+	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+
+	// Both ports on beast
+	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	cfg.store.Spec.Gateway.Port = 80
+	cfg.store.Spec.Gateway.SecurePort = 443
+	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "port=80 ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
+
+	// Secure port requires the cert on civetweb
+	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Mimic
+	cfg.store.Spec.Gateway.SecurePort = 443
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	assert.Equal(t, "", result)
+
+	// Secure port requires the cert on beast
+	cfg = newConfig()
+	cfg.clusterInfo.CephVersion = cephver.Nautilus
+	cfg.store.Spec.Gateway.SecurePort = 443
+	result = cfg.portString(cfg.clusterInfo.CephVersion)
 	assert.Equal(t, "", result)
 }
 


### PR DESCRIPTION
The beast fronted configuration for rgw is quite different than civetweb
so we adapted the construct of the arg line based on that configuration
requirement.

Closes: https://github.com/rook/rook/issues/3411
Signed-off-by: Sébastien Han <seb@redhat.com>

[skip ci]
known ci issue