### PR TITLE
ceph: Add dynamic flexvolume expansion

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -168,6 +168,9 @@ parameters:
   fstype: xfs
 # Optional, default reclaimPolicy is "Delete". Other options are: "Retain", "Recycle" as documented in https://kubernetes.io/docs/concepts/storage/storage-classes/
 reclaimPolicy: Retain
+# Optional, if you want to add dynamic resize for PVC. Works for Kubernetes 1.14+
+# For now only ext3, ext4, xfs resize support provided, like in Kubernetes itself.
+allowVolumeExpansion: true
 ```
 
 Create the pool and storage class.
@@ -228,6 +231,8 @@ parameters:
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
   fstype: xfs
+# Works for Kubernetes 1.14+
+allowVolumeExpansion: true
 ```
 
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -54,6 +54,7 @@ an example usage
 - The Ceph cluster custom resource now contains a `configOverrides` section where users can specify
   configuration changes to Ceph which Rook should apply.
 - Rook can now manage PodDisruptionBudgets for the following Daemons: OSD, Mon, RGW, MDS. OSD budgets are dynamically managed as documented in the [design](https://github.com/rook/rook/blob/master/design/ceph-managed-disruptionbudgets.md). This can be enabled with the `managePodBudgets` flag in the cluster CR. When this is enabled, drains on OSDs will be blocked by default and dynamically unblocked in a safe manner one failureDomain at a time. When a failure domain is draining, it will be marked as no out for a longer time than the default DOWN/OUT interval.
+- Flexvolume plugin now supports dynamic PVC expansion.
 
 ### YugabyteDB
 

--- a/cluster/examples/kubernetes/ceph/flex/storageclass-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass-ec.yaml
@@ -32,6 +32,8 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 provisioner: ceph.rook.io/block
+# Works for Kubernetes 1.14+
+allowVolumeExpansion: true
 parameters:
   # If you want to use erasure coded pool with RBD, you need to create two pools (as seen above): one erasure coded and one replicated.
   # You need to specify the replicated pool here in the `blockPool` parameter, it is used for the metadata of the images.

--- a/cluster/examples/kubernetes/ceph/flex/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass-test.yaml
@@ -17,6 +17,8 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 provisioner: ceph.rook.io/block
+# Works for Kubernetes 1.14+
+allowVolumeExpansion: true
 parameters:
   blockPool: replicapool
   clusterNamespace: rook-ceph

--- a/cluster/examples/kubernetes/ceph/flex/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass.yaml
@@ -18,6 +18,8 @@ kind: StorageClass
 metadata:
   name: rook-ceph-block
 provisioner: ceph.rook.io/block
+# Works for Kubernetes 1.14+
+allowVolumeExpansion: true
 parameters:
   blockPool: replicapool
   # Specify the namespace of the rook cluster from which to create volumes.

--- a/cmd/rookflex/cmd/expander.go
+++ b/cmd/rookflex/cmd/expander.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
+	"github.com/spf13/cobra"
+	"os/exec"
+	"strconv"
+)
+
+var (
+	expandFSCmd = &cobra.Command{
+		Use:   "expandfs",
+		Short: "Expands the size of pod filesystem",
+		RunE:  handleExpandFs,
+	}
+)
+
+func init() {
+	RootCmd.AddCommand(expandFSCmd)
+}
+
+func handleExpandFs(cmd *cobra.Command, args []string) error {
+	var opts = &flexvolume.ExpandOptions{}
+
+	err := json.Unmarshal([]byte(args[0]), opts)
+	if err != nil {
+		return fmt.Errorf("could not parse options for expand %s, got %+v", args[1], err)
+	}
+	client, err := getRPCClient()
+	if err != nil {
+		return fmt.Errorf("error getting RPC client: %+v", err)
+	}
+
+	size, err := strconv.ParseUint(args[3], 10, 64)
+	if err != nil {
+		return fmt.Errorf("error while decoding RBD size: %+v", err)
+	}
+
+	err = client.Call("Controller.Expand", flexvolume.ExpandArgs{ExpandOptions: opts, Size: size}, nil)
+	if err != nil {
+		return fmt.Errorf("error while resizing RBD: %+v", err)
+	}
+
+	var command *exec.Cmd
+	switch opts.FsType {
+	case "ext3", "ext4":
+		command = exec.Command("resize2fs", args[2])
+	case "xfs":
+		command = exec.Command("xfs_growfs", "-d", args[2])
+	default:
+		log(client, fmt.Sprintf("resize is not supported for fs: %s", opts.FsType), false)
+		return nil
+	}
+	err = command.Run()
+	if err != nil {
+		return fmt.Errorf("error resizing FS: %+v", err)
+	}
+	return nil
+}

--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -19,6 +19,7 @@ package flexvolume
 
 import (
 	"fmt"
+	"github.com/rook/rook/pkg/util/display"
 	"os"
 	"path"
 	"path/filepath"
@@ -193,6 +194,17 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 	*devicePath, err = c.volumeManager.Attach(attachOpts.Image, attachOpts.BlockPool, attachOpts.MountUser, attachOpts.MountSecret, attachOpts.ClusterNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to attach volume %s/%s: %+v", attachOpts.BlockPool, attachOpts.Image, err)
+	}
+	return nil
+}
+
+// Expand RBD image
+func (c *Controller) Expand(expandArgs ExpandArgs, _ *struct{}) error {
+	expandOpts := expandArgs.ExpandOptions
+	sizeInMb := display.BToMb(expandArgs.Size)
+	err := c.volumeManager.Expand(expandOpts.Image, expandOpts.Pool, expandOpts.ClusterNamespace, sizeInMb)
+	if err != nil {
+		return fmt.Errorf("failed to resize volume %s/%s: %+v", expandOpts.Pool, expandOpts.Image, err)
 	}
 	return nil
 }

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -161,6 +161,18 @@ func (vm *VolumeManager) Attach(image, pool, id, key, clusterNamespace string) (
 	}
 }
 
+func (vm *VolumeManager) Expand(image, pool, clusterNamespace string, size uint64) error {
+	monitors, keyring, err := getClusterInfo(vm.context, clusterNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to resize volume %s/%s cluster %s. %+v", pool, image, clusterNamespace, err)
+	}
+	err = cephclient.ExpandImage(vm.context, clusterNamespace, image, pool, monitors, keyring, size)
+	if err != nil {
+		return fmt.Errorf("failed to resize volume %s/%s cluster %s. %+v", pool, image, clusterNamespace, err)
+	}
+	return nil
+}
+
 // Detach the volume
 func (vm *VolumeManager) Detach(image, pool, id, key, clusterNamespace string, force bool) error {
 	// check if the volume is attached

--- a/pkg/daemon/ceph/agent/flexvolume/manager/fake.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/fake.go
@@ -23,6 +23,7 @@ type FakeVolumeManager struct {
 	FakeInit   func() error
 	FakeAttach func(image, pool, id, key, clusterName string) (string, error)
 	FakeDetach func(image, pool, clusterName string, force bool) error
+	FakeExpand func(image, pool, clusterName string, size uint64) error
 }
 
 // Init initializes the FakeVolumeManager
@@ -45,6 +46,13 @@ func (f *FakeVolumeManager) Attach(image, pool, id, key, clusterName string) (st
 func (f *FakeVolumeManager) Detach(image, pool, id, key, clusterName string, force bool) error {
 	if f.FakeDetach != nil {
 		return f.FakeDetach(image, pool, clusterName, force)
+	}
+	return nil
+}
+
+func (f *FakeVolumeManager) Expand(image, pool, clusterName string, size uint64) error {
+	if f.FakeExpand != nil {
+		return f.FakeExpand(image, pool, clusterName, size)
 	}
 	return nil
 }

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -152,8 +152,9 @@ func generateFlexSettings(enableSELinuxRelabeling, enableFSGroup bool) ([]byte, 
 			// Required for metrics
 			SupportsMetrics: true,
 			// Required for any mount performed on a host running selinux
-			SELinuxRelabel: enableSELinuxRelabeling,
-			FSGroup:        enableFSGroup,
+			SELinuxRelabel:   enableSELinuxRelabeling,
+			FSGroup:          enableFSGroup,
+			RequiresFSResize: true,
 		},
 	}
 	result, err := json.Marshal(status)

--- a/pkg/daemon/ceph/agent/flexvolume/types.go
+++ b/pkg/daemon/ceph/agent/flexvolume/types.go
@@ -28,6 +28,7 @@ type VolumeManager interface {
 	Init() error
 	Attach(image, pool, id, key, clusterName string) (string, error)
 	Detach(image, pool, id, key, clusterName string, force bool) error
+	Expand(image, pool, clusterName string, size uint64) error
 }
 
 type VolumeController interface {
@@ -58,6 +59,22 @@ type AttachOptions struct {
 	Pod              string `json:"kubernetes.io/pod.name"`
 	PodID            string `json:"kubernetes.io/pod.uid"`
 	PodNamespace     string `json:"kubernetes.io/pod.namespace"`
+}
+
+type ExpandOptions struct {
+	Pool             string `json:"pool"`
+	RW               string `json:"kubernetes.io/readwrite"`
+	ClusterNamespace string `json:"clusterNamespace"`
+	DataBlockPool    string `json:"dataBlockPool"`
+	Image            string `json:"image"`
+	FsType           string `json:"kubernetes.io/fsType"`
+	StorageClass     string `json:"storageClass"`
+	VolumeName       string `json:"kubernetes.io/pvOrVolumeName"`
+}
+
+type ExpandArgs struct {
+	ExpandOptions *ExpandOptions
+	Size          uint64
 }
 
 type LogMessage struct {

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -64,16 +64,16 @@ func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 
 }
 
-func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode string) error {
-	return b.k8sClient.ResourceOperation("apply", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
+func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode, size string) error {
+	return b.k8sClient.ResourceOperation("apply", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode, size))
 }
 
 func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, reclaimPolicy, namespace string, varClusterName bool) error {
 	return b.k8sClient.ResourceOperation("apply", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, varClusterName))
 }
 
-func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode string) error {
-	err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
+func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode, size string) error {
+	err := b.k8sClient.ResourceOperation("delete", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode, size))
 	return err
 }
 

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -124,7 +124,7 @@ func (p *PoolOperation) DeleteStorageClassAndPvc(namespace, poolName, storageCla
 }
 
 func (p *PoolOperation) DeletePvc(blockName, storageClassName, mode string) error {
-	err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPvcDef(blockName, storageClassName, mode))
+	err := p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPvcDef(blockName, storageClassName, mode, "1M"))
 	return err
 }
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -33,7 +33,7 @@ type CephManifests interface {
 	GetCleanupPod(node, removalDir string) string
 	GetBlockPoolDef(poolName string, namespace string, replicaSize string) string
 	GetBlockStorageClassDef(poolName string, storageClassName string, reclaimPolicy string, namespace string, varClusterName bool) string
-	GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string
+	GetBlockPvcDef(claimName string, storageClassName string, accessModes string, size string) string
 	GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string
 	GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string
 	GetFilesystem(namepace, name string, activeCount int) string
@@ -1707,13 +1707,14 @@ kind: StorageClass
 metadata:
    name: ` + storageClassName + `
 provisioner: ceph.rook.io/block
+allowVolumeExpansion: true
 reclaimPolicy: ` + reclaimPolicy + `
 parameters:
     blockPool: ` + poolName + `
     ` + namespaceParameter + `: ` + namespace
 }
 
-func (m *CephManifestsMaster) GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string {
+func (m *CephManifestsMaster) GetBlockPvcDef(claimName, storageClassName, accessModes, size string) string {
 	return `apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -1725,12 +1726,12 @@ spec:
     - ` + accessModes + `
   resources:
     requests:
-      storage: 1M`
+      storage: ` + size
 }
 
 func (m *CephManifestsMaster) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string {
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"),
-		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
+		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode, "1M")))
 }
 
 func (m *CephManifestsMaster) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string {

--- a/tests/framework/installer/ceph_manifests_v1.0.go
+++ b/tests/framework/installer/ceph_manifests_v1.0.go
@@ -1309,7 +1309,7 @@ parameters:
     ` + namespaceParameter + `: ` + namespace
 }
 
-func (m *CephManifestsV1_0) GetBlockPvcDef(claimName string, storageClassName string, accessModes string) string {
+func (m *CephManifestsV1_0) GetBlockPvcDef(claimName, storageClassName, accessModes, size string) string {
 	return `apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -1321,12 +1321,12 @@ spec:
     - ` + accessModes + `
   resources:
     requests:
-      storage: 1M`
+      storage: ` + size
 }
 
 func (m *CephManifestsV1_0) GetBlockPoolStorageClassAndPvcDef(namespace string, poolName string, storageClassName string, reclaimPolicy string, blockName string, accessMode string) string {
 	return concatYaml(m.GetBlockPoolDef(poolName, namespace, "1"),
-		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode)))
+		concatYaml(m.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, false), m.GetBlockPvcDef(blockName, storageClassName, accessMode, "1M")))
 }
 
 func (m *CephManifestsV1_0) GetBlockPoolStorageClass(namespace string, poolName string, storageClassName string, reclaimPolicy string) string {

--- a/tests/integration/ceph_block_create_test.go
+++ b/tests/integration/ceph_block_create_test.go
@@ -81,7 +81,7 @@ func (s *BlockCreateSuite) TestCreatePVCWhenNoStorageClassExists() {
 	reclaimPolicy := "Delete"
 	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, "ReadWriteOnce")
 
-	err := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
+	err := s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce", "1M")
 	require.NoError(s.T(), err)
 
 	// check status of PVC
@@ -161,7 +161,7 @@ func (s *BlockCreateSuite) statefulSetDataCleanup(namespace, poolName, storageCl
 }
 
 func (s *BlockCreateSuite) tearDownTest(claimName string, poolName string, storageClassName string, reclaimPolicy string, accessMode string) {
-	s.testClient.BlockClient.DeletePvc(claimName, storageClassName, accessMode)
+	s.testClient.BlockClient.DeletePvc(claimName, storageClassName, accessMode, "1M")
 	s.testClient.PoolClient.Delete(poolName, s.namespace)
 	s.testClient.BlockClient.DeleteStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace)
 }
@@ -189,7 +189,7 @@ func (s *BlockCreateSuite) CheckCreatingPVC(pvcName, pvcAccessMode string) {
 	require.Nil(s.T(), err)
 
 	// create pvc
-	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode)
+	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, pvcAccessMode, "1M")
 	require.NoError(s.T(), err)
 
 	// check status of PVC

--- a/tests/integration/ceph_zblock_mount_unmount_test.go
+++ b/tests/integration/ceph_zblock_mount_unmount_test.go
@@ -111,7 +111,7 @@ func (s *BlockMountUnMountSuite) setupPVCs() {
 	require.Nil(s.T(), cbErr)
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, s.pvcNameRWO), "Make sure PVC is Bound")
 
-	cbErr2 := s.testClient.BlockClient.CreatePvc(s.pvcNameRWX, storageClassNameRWO, "ReadWriteMany")
+	cbErr2 := s.testClient.BlockClient.CreatePvc(s.pvcNameRWX, storageClassNameRWO, "ReadWriteMany", "1M")
 	require.Nil(s.T(), cbErr2)
 	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, s.pvcNameRWX), "Make sure PVC is Bound")
 

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -61,7 +61,7 @@ func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 	createStorageClassAndPool(s.T, s.testClient, s.kh, s.namespace, "rook-ceph-block", "rook-pool")
 	if _, err := s.kh.GetPVCStatus(defaultNamespace, "block-pv-one"); err != nil {
 		logger.Infof("Creating PVC and mounting it to pod with readOnly set to false")
-		err = s.testClient.BlockClient.CreatePvc("block-pv-one", "rook-ceph-block", "ReadWriteOnce")
+		err = s.testClient.BlockClient.CreatePvc("block-pv-one", "rook-ceph-block", "ReadWriteOnce", "1M")
 		require.Nil(s.T(), err)
 		mountUnmountPVCOnPod(s.kh, "block-rw", "block-pv-one", "false", "apply")
 		require.True(s.T(), s.kh.IsPodRunning("block-rw", defaultNamespace))


### PR DESCRIPTION
Allow to dynamic resize of rook volums.

Signed-off-by: Maksim Nabokikh <maksim.nabokikh@flant.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
1. Increase PVC size.
2. Delete stateful pod.
3. Magic.
4. Your volume grows up!

Works for kubernetes 1.14.0+

Tested with minikube 1.14.1.

**Which issue is resolved by this Pull Request:**
Resolves #1169

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
