### PR TITLE
Add linear to support diskType

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,6 +8,7 @@ distribution of the data only across the specified device class. See [Ceph Block
 an example usage
 - Added K8s 1.15 to the test matrix and removed K8s 1.10 from the test matrix.
 - OwnerReferences are created with the fully qualified `apiVersion` such that the references will work properly on OpenShift.
+- Linear disk device can now be used for Ceph OSDs.
 
 ### Ceph
 

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -76,7 +76,12 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 		}
 
 		diskType, ok := diskProps["TYPE"]
-		if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType) {
+		if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType && diskType != sys.LinearType) {
+			if !ok {
+				logger.Warningf("skipping device %s: diskType is empty", d)
+			} else {
+				logger.Warningf("skipping device %s: unsupported diskType %+s", d, diskType)
+			}
 			// unsupported disk type, just continue
 			continue
 		}

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	DiskType  = "disk"
-	SSDType   = "ssd"
-	PartType  = "part"
-	CryptType = "crypt"
-	LVMType   = "lvm"
-	sgdisk    = "sgdisk"
-	mountCmd  = "mount"
+	DiskType   = "disk"
+	SSDType    = "ssd"
+	PartType   = "part"
+	CryptType  = "crypt"
+	LVMType    = "lvm"
+	LinearType = "linear"
+	sgdisk     = "sgdisk"
+	mountCmd   = "mount"
 )
 
 type Partition struct {


### PR DESCRIPTION
Signed-off-by: Ash Wu <hSATAC@gmail.com>


**Which issue is resolved by this Pull Request:**

Allow linear disks create by `mdadm --create --level=linear ...` can be used as OSD device.

Tested against `ceph/ceph:v13.2.4-20190109` image.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
