### PR TITLE
Remove unused clusterd.GetAvailableDevices

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -30,20 +30,6 @@ var (
 	isRBD  = regexp.MustCompile("^rbd[0-9]+p?[0-9]{0,}$")
 )
 
-func GetAvailableDevices(devices []*sys.LocalDisk) []string {
-
-	var available []string
-	for _, device := range devices {
-		logger.Debugf("Evaluating device %+v", device)
-		if GetDeviceEmpty(device) {
-			logger.Debugf("Available device: %s", device.Name)
-			available = append(available, device.Name)
-		}
-	}
-
-	return available
-}
-
 // check whether a device is completely empty
 func GetDeviceEmpty(device *sys.LocalDisk) bool {
 	return device.Parent == "" && (device.Type == sys.DiskType || device.Type == sys.SSDType || device.Type == sys.CryptType || device.Type == sys.LVMType) && len(device.Partitions) == 0 && device.Filesystem == ""

--- a/pkg/clusterd/disk_test.go
+++ b/pkg/clusterd/disk_test.go
@@ -19,44 +19,8 @@ import (
 	"testing"
 
 	exectest "github.com/rook/rook/pkg/util/exec/test"
-	"github.com/rook/rook/pkg/util/sys"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestAvailableDisks(t *testing.T) {
-
-	// no disks discovered for a node is an error
-	disks := GetAvailableDevices([]*sys.LocalDisk{})
-	assert.Equal(t, 0, len(disks))
-
-	// no available disks because of the formatting
-	d1 := &sys.LocalDisk{Name: "sda", UUID: "myuuid1", Size: 123, Rotational: true, Readonly: false, Filesystem: "btrfs", Type: sys.DiskType, HasChildren: true}
-	disks = GetAvailableDevices([]*sys.LocalDisk{d1})
-	assert.Equal(t, 0, len(disks))
-
-	// multiple available disks
-	d2 := &sys.LocalDisk{Name: "sdb", UUID: "myuuid2", Size: 123, Rotational: true, Readonly: false, Type: sys.DiskType, HasChildren: true}
-	d3 := &sys.LocalDisk{Name: "sdc", UUID: "myuuid3", Size: 123, Rotational: true, Readonly: false, Type: sys.DiskType, HasChildren: true}
-	disks = GetAvailableDevices([]*sys.LocalDisk{d1, d2, d3})
-
-	assert.Equal(t, 2, len(disks))
-	assert.Equal(t, "sdb", disks[0])
-	assert.Equal(t, "sdc", disks[1])
-
-	// partitions don't result in more available devices
-	d4 := &sys.LocalDisk{Name: "sdb1", UUID: "myuuid4", Size: 123, Rotational: true, Readonly: false, Type: sys.PartType, HasChildren: true}
-	d5 := &sys.LocalDisk{Name: "sdb2", UUID: "myuuid5", Size: 123, Rotational: true, Readonly: false, Type: sys.PartType, HasChildren: true}
-	disks = GetAvailableDevices([]*sys.LocalDisk{d1, d2, d3, d4, d5})
-	assert.Equal(t, 2, len(disks))
-	assert.Equal(t, "sdb", disks[0])
-	assert.Equal(t, "sdc", disks[1])
-
-	// Crypt disk type results in available disk
-	d6 := &sys.LocalDisk{Name: "sdd", UUID: "myuuid2", Size: 123, Rotational: true, Readonly: false, Type: sys.CryptType, HasChildren: true}
-	disks = GetAvailableDevices([]*sys.LocalDisk{d6})
-	assert.Equal(t, 1, len(disks))
-
-}
 
 func TestDiscoverDevices(t *testing.T) {
 	executor := &exectest.MockExecutor{


### PR DESCRIPTION
Signed-off-by: Ash Wu <hSATAC@gmail.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**

`clusterd.GetAvailableDevices` method is no longer used anywhere.

It could be removed along with the test if it's not required anymore.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

// known CI issues
[skip ci]