### PR TITLE
Update edgefs-quickstart.md

### DIFF
--- a/Documentation/edgefs-quickstart.md
+++ b/Documentation/edgefs-quickstart.md
@@ -83,7 +83,7 @@ Create the cluster:
 kubectl create -f cluster.yaml
 ```
 
-Use `kubectl` to list pods in the `rook` namespace. You should be able to see the following pods once they are all running.
+Use `kubectl` to list pods in the `rook-edgefs` namespace. You should be able to see the following pods once they are all running.
 The number of target pods will depend on the number of nodes in the cluster and the number of devices and directories configured.
 
 ```bash


### PR DESCRIPTION
Correct the namespace of rook cluster. It should be `rook-edgefs`

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [x] Documentation has been updated, if necessary.

[skip ci]
