### PR TITLE
contrib: add an helper script to perform backports

### DIFF
--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -256,6 +256,8 @@ After the PR is open, you can make changes simply by pushing new commits. Your P
 
 ### Backport a Fix to a Release Branch
 
+#### Manual flow
+
 The flow for getting a fix into a release branch is to first make the commit to master following the process outlined above.
 After the commit is in master, you'll need to cherry-pick the commit to the intended release branch.
 You can do this by first creating a local branch that is based off the release branch, for example:
@@ -275,9 +277,17 @@ Now go ahead and push to your origin:
 git push origin HEAD
 ```
 
-The last step is to open a PR with the base being the intended release branch.
-Once the PR is approved and merged, then your backported change will be available in the next release.
+#### Automated flow
 
+You will find a script at `contrib/backport_to_stable_branch.sh` at the root of the Rook repository.
+Execute it and it will do the necessary things and will push the backport branch.
+Then go on the Rook Github web page and create your pull request.
+
+#### Create the backport pull request
+
+The last step is to open a PR with the base being the intended release branch.
+If you don't know how to do this, [read Github documentation on changing the base branch range](https://help.github.com/en/articles/creating-a-pull-request#changing-the-branch-range-and-destination-repository).
+Once the PR is approved and merged, then your backported change will be available in the next release.
 
 ## Debugging operators locally
 
@@ -287,7 +297,7 @@ A common operator developer practice is to run the operator locally on the devel
 
 In order to support this external operator mode, rook detects if the operator is running outside of the cluster (using standard cluster env) and changes the behavior as follows:
 - Connecting to Kubernetes API will load the config from the user `~/.kube/config`.
-- Instead of the default [CommandExecutor](../pkg/util/exec/exec.go) this mode uses a [TranslateCommandExecutor](../pkg/util/exec/translate_exec.go) that executes every command issued by the operator to run as a Kubernetes job inside the cluster, so that any tools that the operator needs from its image can be called. For example, in cockroachdb 
+- Instead of the default [CommandExecutor](../pkg/util/exec/exec.go) this mode uses a [TranslateCommandExecutor](../pkg/util/exec/translate_exec.go) that executes every command issued by the operator to run as a Kubernetes job inside the cluster, so that any tools that the operator needs from its image can be called. For example, in cockroachdb
 
 ### Building locally
 

--- a/contrib/backport_to_stable_branch.sh
+++ b/contrib/backport_to_stable_branch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -e
+shopt -s extglob # enable extended pattern matching features
+
+
+#############
+# VARIABLES #
+#############
+stable_branch=$1
+commit=$2
+bkp_branch_name=bkp-$1
+bkp_branch_name_prefix=bkp
+bkp_branch=$bkp_branch_name-$bkp_branch_name_prefix-$stable_branch
+
+
+#############
+# FUNCTIONS #
+#############
+verify_commit () {
+  for com in ${commit//,/ }; do
+    if [[ $(git cat-file -t "$com" 2>/dev/null) != commit ]]; then
+      echo "$com does not exist in your tree"
+      echo "Run 'git fetch upstream master && git pull upstream master --rebase'"
+      echo "Where 'upstream' is the remote name of the rook/rook repository"
+      exit 1
+    fi
+  done
+}
+
+git_status () {
+  if [[ $(git status --porcelain | wc -l) -gt 0 ]]; then
+    echo "It looks like you have not committed changes:"
+    echo ""
+    git status --short
+    echo ""
+    echo ""
+    echo "Press ENTER to continue or Ctrl+c to break."
+    read -r
+  fi
+}
+
+checkout () {
+  git checkout --no-track -b "$bkp_branch" origin/"$stable_branch"
+}
+
+cherry_pick () {
+  local x
+  for com in ${commit//,/ }; do
+    x="$x $com"
+  done
+  # Trim the first white space and use an array
+  # Reference: https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions
+  # shellcheck disable=SC2206
+  x=(${x##*( )})
+  git cherry-pick -x -s "${x[@]}"
+}
+
+push () {
+  git push origin "$bkp_branch"
+}
+
+cleanup () {
+  echo "Moving back to previous branch"
+  git checkout -
+  git branch -D "$bkp_branch"
+}
+
+test_args () {
+  if [ $# -lt 3 ]; then
+    echo "Please run the script like this: ./contrib/backport_to_stable_branch.sh STABLE_BRANCH_NAME COMMIT_SHA1 BACKPORT_BRANCH_NAME"
+    echo "We accept multiple commits as soon as they are commas-separated."
+    echo "e.g: ./contrib/backport_to_stable_branch.sh release-1.0 6892670d317698771be7e96ce9032bc27d3fd1e5,8756c553cc8c213fc4996fc5202c7b687eb645a3 my-work"
+    exit 1
+  fi
+}
+
+
+########
+# MAIN #
+########
+test_args "$@"
+git_status
+verify_commit
+checkout
+cherry_pick
+push
+cleanup


### PR DESCRIPTION
Run the script like this:

./contrib/backport_to_stable_branch.sh STABLE_BRANCH_NAME COMMIT_SHA1 BACKPORT_BRANCH_NAME

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)

[skip ci]