### PR TITLE
k8sutil: Ensure rook version label has valid syntax

### DIFF
--- a/pkg/operator/k8sutil/k8sutil_test.go
+++ b/pkg/operator/k8sutil/k8sutil_test.go
@@ -51,3 +51,18 @@ func TestTruncateNodeName(t *testing.T) {
 		assert.Equal(t, result, TruncateNodeName(params[0], params[1]))
 	}
 }
+
+func TestValidateLabelValue(t *testing.T) {
+	// The key is the result, and the value is the input.
+	tests := map[string]string{
+		"":                        "",
+		"1.0":                     "1.0",
+		"1.0.0-git1697.ga265cdfd": "1.0.0+git1697.ga265cdfd",
+		"this-entry-is-more-than-63-characters-long-so-it-will-be-trunca": "this-entry-is-more-than-63-characters-long-so-it-will-be-truncated",
+		"1": ".1.",
+	}
+
+	for result, input := range tests {
+		assert.Equal(t, result, validateLabelValue(input))
+	}
+}


### PR DESCRIPTION

**Description of your changes:**

Replace any invalid characters and ensure length
and format for the rook version label, to avoid
problems with version strings that contain
illegal characters (common characters that aren't
valid in labels would be + and ~, for example).

Kubernetes label syntax:
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

**Which issue is resolved by this Pull Request:**
Resolves #3434 

**Checklist:**
- [ ] Documentation has been updated, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
