### PR TITLE
k8sutil: 1. Use label max length constant from k8s, 2. Add missing docstrings in pod.go

### DIFF
--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -143,8 +143,8 @@ func deleteResourceAndWait(namespace, name, resourceType string,
 // Note that the label may not match the version string exactly, since some characters used
 // in version strings are illegal in pod labels.
 func addRookVersionLabel(labels map[string]string) {
-	label := rookversion.Version
-	labels[RookVersionLabelKey] = validateLabelValue(label)
+	value := validateLabelValue(rookversion.Version)
+	labels[RookVersionLabelKey] = value
 }
 
 // validateLabelValue replaces any invalid characters
@@ -154,7 +154,7 @@ func addRookVersionLabel(labels map[string]string) {
 // See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 func validateLabelValue(value string) string {
 	repl := "-"
-	maxlen := 63
+	maxlen := validation.LabelValueMaxLength
 	re := regexp.MustCompile("[^a-z0-9A-Z._-]")
 	// restrict label value to valid character set
 	sanitized := re.ReplaceAllLiteralString(value, repl)

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -95,10 +95,18 @@ func ConfigDirEnvVar(dataDir string) v1.EnvVar {
 	return v1.EnvVar{Name: "ROOK_CONFIG_DIR", Value: dataDir}
 }
 
+// GetContainerImage returns the container image
+// matching the given name for a pod. If the pod
+// only has a single container, the name argument
+// is ignored.
 func GetContainerImage(pod *v1.Pod, name string) (string, error) {
 	return GetSpecContainerImage(pod.Spec, name, false)
 }
 
+// GetSpecContainerImage returns the container image
+// for a podspec, given a container name. The name is
+// ignored if the podspec has a single container, in
+// which case the image for that container is returned.
 func GetSpecContainerImage(spec v1.PodSpec, name string, initContainer bool) (string, error) {
 	containers := spec.Containers
 	if initContainer {
@@ -111,6 +119,8 @@ func GetSpecContainerImage(spec v1.PodSpec, name string, initContainer bool) (st
 	return image.Image, nil
 }
 
+// GetRunningPod reads the name and namespace of a pod from the
+// environment, and returns the pod (if it exists).
 func GetRunningPod(clientset kubernetes.Interface) (*v1.Pod, error) {
 	podName := os.Getenv(PodNameEnvVar)
 	if podName == "" {
@@ -128,6 +138,10 @@ func GetRunningPod(clientset kubernetes.Interface) (*v1.Pod, error) {
 	return pod, nil
 }
 
+// GetMatchingContainer takes a list of containers and a name,
+// and returns the first container in the list matching the
+// name. If the list contains a single container it is always
+// returned, even if the name does not match.
 func GetMatchingContainer(containers []v1.Container, name string) (v1.Container, error) {
 	var result *v1.Container
 	if len(containers) == 1 {
@@ -159,6 +173,7 @@ func MakeRookImage(version string) string {
 	return version
 }
 
+// PodsRunningWithLabel returns the number of running pods with the given label
 func PodsRunningWithLabel(clientset kubernetes.Interface, namespace, label string) (int, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: label})
 	if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

One commit to use the label max length constant from Kubernetes rather than
hard-coding it, and one commit to add missing docstrings to functions in pod.go.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/v1.0/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](/INSTALL.md#skip-ci) for more details.
