### PR TITLE
Minikube test script: push v14 instead of v13 image only when needed

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -95,7 +95,8 @@ function copy_images() {
     if [[ "$1" == "" || "$1" == "ceph" ]]; then
       echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-      copy_image_to_cluster ceph/ceph:v13 ceph/ceph:v13
+      # uncomment to push the nautilus image when needed
+      #copy_image_to_cluster ceph/ceph:v14 ceph/ceph:v14
     fi
 
     if [[ "$1" == "" || "$1" == "cockroachdb" ]]; then


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The same minikube instance is used many times over its lifetime. Copying the ceph image every time there is an update to the rook image just isn't necessary. Thus, make it optional to copy the ceph image into the cluster. Pushing the ceph image can be done by uncommenting in the script when needed.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/v1.0/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
- [X] Add the flag for skipping the CI if this PR does not require a build. See [here](/INSTALL.md#skip-ci) for more details.

[skip ci]