### PR TITLE
fix Prometheus permissions and servicemonitor configurations

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -81,20 +81,23 @@ You can find Prometheus Consoles here: https://github.com/ceph/cephmetrics/tree/
 A guide to how you can write your own Prometheus consoles can be found on the official Prometheus site here: https://prometheus.io/docs/visualization/consoles/.
 
 ## Prometheus Alerts
-To enable prometheus alerts during cluster deployment, make following changes to `cluster.yaml`
+To enable prometheus alerts,
+
+first, create the RBAC rules to enable monitoring,
+```BASH
+kubectl create -f cluster/examples/kubernetes/ceph/monitoring/rbac.yaml
+``` 
+then, make following changes to `cluster.yaml` and deploy.
 ```YAML
 monitoring:
   enabled: true
   rulesNamespace: "rook-ceph"
 ```
-_Note: This expects prometheus to be pre-installed by the admin._
 
-To enable prometheus alerts after cluster is deployed, run the following commands:  
 ```BASH
-cd cluster/examples/kubernetes/ceph/monitoring
-kubectl create -f prometheus-ceph-v<VERSION>-rules.yaml
+kubectl apply -f cluster.yaml
 ```
-_where, VERSION is the version of ceph cluster to be monitored_
+_Note: This expects prometheus to be pre-installed by the admin._
 
 ## Grafana Dashboards
 The dashboards have been created by [@galexrt](https://github.com/galexrt). For feedback on the dashboards please reach out to him on the [Rook.io Slack](https://slack.rook.io).

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -30,6 +30,7 @@ an example usage
 - The cluster CRD option to allow multiple monitors to be scheduled on the same
   node---`spec.Mon.AllowMultiplePerNode`---is now active when a cluster is first
   created. Previously, it was ignored when a cluster was first installed.
+- The Cluster CRD now provides option to enable prometheus based monitoring, provided that prometheus is pre-installed.
 - Upgrades have drastically improved, Rook intelligently checks for each daemon state before and after upgrading. To learn more about the upgrade workflow see [Ceph Upgrades](Documentation/ceph-upgrade.md)
 - Rook Operator now supports 2 new environmental variables: `AGENT_TOLERATIONS` and `DISCOVER_TOLERATIONS`. Each accept list of tolerations for agent and discover pods accordingly.
 - Ceph daemons now run under 'ceph' user and not 'root' anymore (monitor or osd store already owned by 'root' will keep running under 'root')

--- a/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml
@@ -1,0 +1,72 @@
+---
+# OLM: BEGIN ROLE
+# Aspects for creation of monitoring resources
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: rook-ceph
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+# OLM: END ROLE
+---
+# OLM: BEGIN ROLE BINDING
+# Allow creation of monitoring resources
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitor
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph
+# OLM: END ROLE BINDING
+---
+# OLM: BEGIN ROLE
+# Aspects for metrics collection
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: rook-ceph
+rules:
+ - apiGroups:
+   - ""
+   resources:
+    - services
+    - endpoints
+    - pods
+   verbs:
+    - get
+    - list
+    - watch
+# OLM: END ROLE
+---
+# OLM: BEGIN ROLE BINDING
+# Allow collection of metrics
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-metrics
+subjects:
+- kind: ServiceAccount
+  # change to the serviceaccount and namespace to use for monitoring
+  name: prometheus-k8s
+  namespace: rook-ceph
+# OLM: END ROLE BINDING
+---

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -243,6 +243,8 @@ func (c *Cluster) enableServiceMonitor(service *v1.Service) error {
 	serviceMonitor.SetName(name)
 	serviceMonitor.SetNamespace(namespace)
 	k8sutil.SetOwnerRef(&serviceMonitor.ObjectMeta, &c.ownerRef)
+	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespace}
+	serviceMonitor.Spec.Selector.MatchLabels = service.GetLabels()
 	if _, err := k8sutil.CreateOrUpdateServiceMonitor(serviceMonitor); err != nil {
 		return fmt.Errorf("service monitor could not be enabled. %+v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
this adds the access for rook to create monitoring resources
across namespaces and provides servicemonitor config to
monitor the current service being created

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

// 
[test ceph]