### PR TITLE
Fix: topologyAware does not pick up failure domains.

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -173,6 +173,7 @@ func (c *Cluster) Start() error {
 		return nil
 	}
 	logger.Infof("%d of the %d storage nodes are valid", len(validNodes), len(c.DesiredStorage.Nodes))
+	c.ValidStorage = *c.DesiredStorage.DeepCopy()
 	c.ValidStorage.Nodes = validNodes
 
 	// start the jobs to provision the OSD devices and directories
@@ -544,7 +545,7 @@ func getIDFromDeployment(deployment *apps.Deployment) int {
 
 func (c *Cluster) resolveNode(nodeName string) *rookalpha.Node {
 	// fully resolve the storage config and resources for this node
-	rookNode := c.DesiredStorage.ResolveNode(nodeName)
+	rookNode := c.ValidStorage.ResolveNode(nodeName)
 	if rookNode == nil {
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

The crush location was being stored in `c.ValidStorage.Nodes`, but the value was being stored in `c.DesiredStorage.Nodes`. I ensured that DesiredStorage was being updated as well.

I have verified that the failure-domain labels are being read and propagated to the crush map.

**Which issue is resolved by this Pull Request:**
Resolves #3430

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/v1.0/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](/INSTALL.md#skip-ci) for more details.
