### PR TITLE
DNM: Ceph integration: sleep after rbac creation

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -213,6 +213,10 @@ func (h *CephInstaller) CreateK8sRookClusterWithHostPathAndDevices(namespace, sy
 		}
 	}
 
+	sleepSec := 10
+	logger.Infof("Sleeping %ds to give ETCD time to settle...", sleepSec)
+	time.Sleep(time.Duration(sleepSec) * time.Second)
+
 	logger.Infof("Starting Rook Cluster with yaml")
 	settings := &ClusterSettings{namespace, storeType, dataDirHostPath, useAllDevices, mon.Count, rbdMirrorWorkers, cephVersion}
 	rookCluster := h.Manifests.GetRookCluster(settings)


### PR DESCRIPTION
This PR attempts to fix #3469, but we need to run a few CI jobs with this to make sure that the issue doesn't repeat.

CI fails randomly with the error (newlines added for git):
```
op-cluster: unknown ceph major version. failed to complete ceph version
job. failed to run CmdReporter rook-ceph-detect-version successfully.
failed to delete existing results ConfigMap rook-ceph-detect-version.
failed to delete ConfigMap rook-ceph-detect-version. configmaps
"rook-ceph-detect-version" is forbidden: User
"system:serviceaccount:upgrade-ns-system:rook-ceph-system" cannot delete
resource "configmaps" in API group "" in the namespace "<cluster ns>"
```

I was seeing some issues like this in one of my test environments, and
it would be fixed if I deleted and restarted the operator. I suspected
that my ETCD was using a slow disk and that the RBAC was taking longer
to propagate than the test was giving it. Let me open up a PR that adds
a short sleep before creating the Ceph cluster CR, and we can see if
this error continues to repeat.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #3469 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/v1.0/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](../CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](/INSTALL.md#skip-ci) for more details.
