### PR TITLE
make getModifiedRookImagePath be generic and use it for isgw too

### DIFF
--- a/pkg/apis/edgefs.rook.io/v1beta1/utils.go
+++ b/pkg/apis/edgefs.rook.io/v1beta1/utils.go
@@ -17,6 +17,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"strings"
 )
 
 func ByteCountBinary(b uint64) string {
@@ -30,4 +31,30 @@ func ByteCountBinary(b uint64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+// GetModifiedRookImagePath takes current edgefs path to provide modified path to specific images
+// I.e in case of original edgefs path: edgefs/edgefs:1.2.25 then edgefs ui path should be
+// edgefs/edgefs-ui:1.2.25 and edgefs-restapi should be edgefs/edgefs-restapi:1.2.25
+// addon param is edgefs image suffix. To get restapi image path getModifiedRookImagePath(edgefsImage, "restapi")
+func GetModifiedRookImagePath(originRookImage, addon string) string {
+	imageParts := strings.Split(originRookImage, "/")
+	latestImagePartIndex := len(imageParts) - 1
+	modifiedImageName := "edgefs"
+	modifiedImageTag := "latest"
+
+	latestImagePart := imageParts[latestImagePartIndex]
+	imageVersionParts := strings.Split(latestImagePart, ":")
+	if len(imageVersionParts) > 1 {
+		modifiedImageTag = imageVersionParts[1]
+	}
+
+	if len(addon) > 0 {
+		modifiedImageName = fmt.Sprintf("%s-%s", imageVersionParts[0], addon)
+	} else {
+		modifiedImageName = fmt.Sprintf("%s", imageVersionParts[0])
+	}
+
+	imageParts[latestImagePartIndex] = fmt.Sprintf("%s:%s", modifiedImageName, modifiedImageTag)
+	return strings.Join(imageParts, "/")
 }

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -208,7 +208,7 @@ func (c *ISGWController) makeDeployment(svcname, namespace, rookImage string, is
 			Labels: getLabels(name, svcname, namespace),
 		},
 		Spec: v1.PodSpec{
-			Containers:         []v1.Container{c.isgwContainer(svcname, name, rookImage, isgwSpec)},
+			Containers:         []v1.Container{c.isgwContainer(svcname, name, edgefsv1beta1.GetModifiedRookImagePath(rookImage, "isgw"), isgwSpec)},
 			RestartPolicy:      v1.RestartPolicyAlways,
 			Volumes:            volumes,
 			HostIPC:            true,


### PR DESCRIPTION
Signed-off-by: Dmitry Yusupov <dmitry.yusupov@nexenta.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3481 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test edgefs]