### PR TITLE
ceph: mon: init chown for openshift

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -158,9 +158,10 @@ func (c *Cluster) makeChownDataDirInitContainer(monConfig *monConfig) v1.Contain
 			"ceph:ceph",
 			monConfig.DataPathMap.ContainerDataDir,
 		},
-		Image:        c.spec.CephVersion.Image,
-		VolumeMounts: opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
-		Resources:    cephv1.GetMonResources(c.spec.Resources),
+		Image:           c.spec.CephVersion.Image,
+		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
+		Resources:       cephv1.GetMonResources(c.spec.Resources),
+		SecurityContext: podSecurityContext(),
 	}
 	return container
 }


### PR DESCRIPTION
OpenShift environment requires privileged containers when interacting
with the host filesystem, typically via dataDirHostPath.
The init container that changes the ownership of dataDirHostPath was
missing the privileged flag and users were getting permission denied
errors on the chown command.

Fixes: https://github.com/rook/rook/issues/3485
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
