### PR TITLE
ceph: use latest 14.2.2 code

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/daemon-base:latest-nautilus-devel
+    image: ceph/ceph:v14.2.2-20190722
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/daemon-base:latest-nautilus-devel
+    image: ceph/ceph:v14.2.2-20190722
     allowUnsupported: true
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     # v12 is luminous, v13 is mimic, and v14 is nautilus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/daemon-base:latest-nautilus-devel
+    image: ceph/ceph:v14.2.2-20190722
     # Whether to allow unsupported versions of Ceph. Currently luminous, mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Do not set to true in production.
     allowUnsupported: false
@@ -46,7 +46,7 @@ spec:
     # requires Prometheus to be pre-installed
     enabled: false
     # namespace to deploy prometheusRule in. If empty, namespace of the cluster will be used.
-    # Recommended: 
+    # Recommended:
     # If you have a single rook-ceph cluster, set the rulesNamespace to the same namespace as the cluster or keep it empty.
     # If you have multiple rook-ceph clusters in the same k8s cluster, choose the same namespace (ideally, namespace with prometheus
     # deployed) to set rulesNamespace for all the clusters. Otherwise, you will get duplicate alerts with multiple alert definitions.

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -89,7 +89,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/daemon-base:latest-nautilus-devel"
+              "image": "ceph/ceph:v14.2.2-20190722"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -17,14 +17,8 @@ include ../image.mk
 # ====================================================================================
 # Image Build Options
 
-ifeq ($(GOARCH),amd64)
-CEPH_VERSION = latest-nautilus-devel
-BASEIMAGE = ceph/daemon-base:$(CEPH_VERSION)
-else
-CEPH_VERSION = v14.2.1-20190430
+CEPH_VERSION = v14.2.2-20190722
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
-endif
-
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 
 TEMP := $(shell mktemp -d)

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -44,7 +44,7 @@ const (
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/daemon-base:latest-nautilus-devel"
+	nautilusTestImage = "ceph/ceph:v14.2.2-20190722"
 	helmChartName     = "local/rook-ceph"
 	helmDeployName    = "rook-ceph"
 )


### PR DESCRIPTION
14.2.2 is out and along with it numerous fixes so let's use it.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]