### PR TITLE
ci: do not skip if null

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,8 @@ pipeline {
                         env.testProvider = "edgefs"
                     } else if (body.contains("[test nfs]")) {
                         env.testProvider = "nfs"
+                    } else {
+                        env.testProvider = ""
                     }
                     echo ("integration test provider: ${env.testProvider}")
                 }


### PR DESCRIPTION
If no storage provider is found, let's assign env.testProvider with an
empty string so that we wil run all the tests.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test edgefs]