### PR TITLE
ceph: run pod with privileged

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -24,6 +24,7 @@ import (
 
 	rookcephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -274,7 +275,8 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 			},
 			InitialDelaySeconds: 60,
 		},
-		Lifecycle: opspec.PodLifeCycle(""),
+		Lifecycle:       opspec.PodLifeCycle(""),
+		SecurityContext: mon.PodSecurityContext(),
 	}
 	return container
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -131,7 +131,9 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, hostname string) *v1.Pod {
  */
 
 // Init and daemon containers require the same context, so we call it 'pod' context
-func podSecurityContext() *v1.SecurityContext {
+
+// PodSecurityContext detects if the pod needs privileges to run
+func PodSecurityContext() *v1.SecurityContext {
 	privileged := false
 	if os.Getenv("ROOK_HOSTPATH_REQUIRES_PRIVILEGED") == "true" {
 		privileged = true
@@ -161,7 +163,7 @@ func (c *Cluster) makeChownDataDirInitContainer(monConfig *monConfig) v1.Contain
 		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
 		Resources:       cephv1.GetMonResources(c.spec.Resources),
-		SecurityContext: podSecurityContext(),
+		SecurityContext: PodSecurityContext(),
 	}
 	return container
 }
@@ -181,7 +183,7 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) v1.Container {
 		),
 		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
-		SecurityContext: podSecurityContext(),
+		SecurityContext: PodSecurityContext(),
 		// filesystem creation does not require ports to be exposed
 		Env:       opspec.DaemonEnvVars(c.spec.CephVersion.Image),
 		Resources: cephv1.GetMonResources(c.spec.Resources),
@@ -221,7 +223,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 		),
 		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    opspec.DaemonVolumeMounts(monConfig.DataPathMap, keyringStoreName),
-		SecurityContext: podSecurityContext(),
+		SecurityContext: PodSecurityContext(),
 		Ports: []v1.ContainerPort{
 			{
 				Name:          "client",

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rbd
 
 import (
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -79,11 +80,12 @@ func (m *Mirroring) makeMirroringDaemonContainer(daemonConfig *daemonConfig) v1.
 			"--foreground",
 			"--name="+fullDaemonName(daemonConfig.DaemonID),
 		),
-		Image:        m.cephVersion.Image,
-		VolumeMounts: opspec.DaemonVolumeMounts(daemonConfig.DataPathMap, daemonConfig.ResourceName),
-		Env:          opspec.DaemonEnvVars(m.cephVersion.Image),
-		Resources:    m.resources,
-		Lifecycle:    opspec.PodLifeCycle(""),
+		Image:           m.cephVersion.Image,
+		VolumeMounts:    opspec.DaemonVolumeMounts(daemonConfig.DataPathMap, daemonConfig.ResourceName),
+		Env:             opspec.DaemonEnvVars(m.cephVersion.Image),
+		Resources:       m.resources,
+		Lifecycle:       opspec.PodLifeCycle(""),
+		SecurityContext: mon.PodSecurityContext(),
 	}
 	return container
 }

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -116,8 +117,9 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 		Env: append(
 			opspec.DaemonEnvVars(c.cephVersion.Image),
 		),
-		Resources: c.fs.Spec.MetadataServer.Resources,
-		Lifecycle: opspec.PodLifeCycle(""),
+		Resources:       c.fs.Spec.MetadataServer.Resources,
+		Lifecycle:       opspec.PodLifeCycle(""),
+		SecurityContext: mon.PodSecurityContext(),
 	}
 
 	return container

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -19,6 +19,7 @@ package object
 import (
 	"fmt"
 
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -133,7 +134,8 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 			},
 			InitialDelaySeconds: 10,
 		},
-		Lifecycle: opspec.PodLifeCycle(""),
+		Lifecycle:       opspec.PodLifeCycle(""),
+		SecurityContext: mon.PodSecurityContext(),
 	}
 
 	if c.store.Spec.Gateway.SSLCertificateRef != "" {


### PR DESCRIPTION
Before each pod starts, the daemon changes the ownership of
/var/log/ceph which is bindmounted on a hostPath.

On OpenShift envionments, the container must be privileged in order to
successfully change the owernship.

Closes: https://github.com/rook/rook/issues/3499
Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]