### PR TITLE
fix usage of Infof in CephClusterController

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -195,7 +195,7 @@ func (c *ClusterController) onK8sNodeAdd(obj interface{}) {
 			continue
 		}
 		if cluster.Info == nil {
-			logger.Info("Cluster %s is not ready. Skipping orchestration.", cluster.Namespace)
+			logger.Infof("Cluster %s is not ready. Skipping orchestration.", cluster.Namespace)
 			continue
 		}
 


### PR DESCRIPTION
**Description of your changes:**

Currently the ClusterController logs out a message like:
```
Cluster %s is not ready. Skipping orchestration.rook-ceph
```
without the "placeholders" fullfilled. This is because the code uses the
logger.Info() instead of logger.Infof() function.
This change fixes that to use Infof and therefore corrects the log
message.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.