### PR TITLE
minio: update documentation in regards to #3478

### DIFF
--- a/Documentation/minio-object-store-crd.md
+++ b/Documentation/minio-object-store-crd.md
@@ -56,6 +56,63 @@ spec:
 
 ## Cluster Settings
 
+### Minio accessKey and secretKey
+
+It is recommended to update the values of `accessKey` and `secretKey` in the `object-store.yaml` to a secure key pair, which is described in the [Minio client quickstart guide](https://docs.minio.io/docs/minio-client-quickstart-guide)
+
+The default kubernetes secret resource will look like:
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-keys
+  namespace: rook-minio
+type: Opaque
+data:
+  # Base64 encoded string: "TEMP_DEMO_ACCESS_KEY"
+  username: VEVNUF9ERU1PX0FDQ0VTU19LRVk=
+  # Base64 encoded string: "TEMP_DEMO_SECRET_KEY"
+  password: VEVNUF9ERU1PX1NFQ1JFVF9LRVk=
+```
+
+You can use any mechanism to generate the new secure key pair, but you need to be sure the values are base64 encoded when being entered into kubernetes.
+It is recommended to do the following in order to prevent new line feeds and carriage returns from being added into the base64 encoded value:
+```bash
+$ cat minio-object-store.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-keys
+  namespace: rook-minio
+type: Opaque
+data:
+  username: #1
+  password: #2
+
+
+$ MINIO_ACCESS_KEY=$(echo -n "minio" | base64 -w0)
+$ MINIO_SECRET_KEY=$(echo -n "minio123" | base64 -w0)
+$ sed -i "s/#1/$MINIO_ACCESS_KEY/g" minio-object-store.yaml
+$ sed -i "s/#2/$MINIO_SECRET_KEY/g" minio-object-store.yaml
+
+$ cat minio-object-store.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-keys
+  namespace: rook-minio
+type: Opaque
+data:
+  username: bWluaW8K
+  password: bWluaW8xMjMK
+```
+
+For further information in regards to this, please refer to the following related GitHub issues: [minio/minio](https://github.com/minio/minio/issues/7750) and [rook/minio](https://github.com/rook/rook/issues/3478)
+
+
 ### Minio Specific Settings
 
 The settings below are specific to Minio object stores:


### PR DESCRIPTION
creating custom access/secret keys without properly base64 encoding them resulted in failed access to minio dashboard

Signed-off-by: jbmcfar <jbmcfar@sandia.gov>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Updated the minio object store documentation in regards to changing `accessKey` and `secretKey` values that could potentially result in failed to access to the minio dashboard. An example was shown with how it was resolved and links were added to the corresponding GitHub issues.

**Which issue is resolved by this Pull Request:**
Resolves #3478 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]