### PR TITLE
Trigger the integration tests for all branches if tags not set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,8 +41,6 @@ pipeline {
                         env.testProvider = "edgefs"
                     } else if (body.contains("[test nfs]")) {
                         env.testProvider = "nfs"
-                    } else {
-                        env.testProvider = ""
                     }
                     echo ("integration test provider: ${env.testProvider}")
                 }

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -62,7 +62,8 @@ type TestSuite interface {
 
 func SkipTestSuite(name string) bool {
 	testsToRun := os.Getenv("STORAGE_PROVIDER_TESTS")
-	if testsToRun == "" {
+	// jenkins passes "null" if the env var is not set.
+	if testsToRun == "" || testsToRun == "null" {
 		// run all test suites
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests for storage providers will be skipped, for example if the "test ceph" tag is specified. If the "test" tag is not specified all tests should be run. If the tag is not specified, the Jenkinsfile will pass "null", which needs to be handled by the test code deciding to run all the tests.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
