### PR TITLE
EdgeFS: Allow control over K8s service type via CRD

### DIFF
--- a/cluster/examples/kubernetes/edgefs/s3.yaml
+++ b/cluster/examples/kubernetes/edgefs/s3.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   instances: 1
   #s3type: s3s                    # s3 (default) for path style, s3s for buckets as DNS style
+  #serviceType: NodePort          # define ServiceType (default ClusterIP)
+  #externalPort: 30303            # define NodePort for HTTP port (default auto)
+  #secureExternalPort: 30443      # define NodePort for HTTPS port (default auto)
   #port: 4500                     # HTTP port (default is 9982 or 9983 for s3s)
   #securePort: 4501               # HTTPS port (default is 8443 or 8444 for s3s)
   #sslCertificateRef: ssl-secret

--- a/pkg/apis/edgefs.rook.io/v1beta1/types.go
+++ b/pkg/apis/edgefs.rook.io/v1beta1/types.go
@@ -160,6 +160,12 @@ type S3Spec struct {
 	Port uint `json:"port,omitempty"`
 	//S3 Https port (default value 9443)
 	SecurePort uint `json:"securePort,omitempty"`
+	// Service type to expose (default value ClusterIP)
+	ServiceType string `json:"serviceType,omitempty"`
+	// S3 Http external port
+	ExternalPort uint `json:"externalPort,omitempty"`
+	// S3 Https external port
+	SecureExternalPort uint `json:"secureExternalPort,omitempty"`
 	// The name of the secret that stores the ssl certificate for secure s3 connections
 	SSLCertificateRef string `json:"sslCertificateRef,omitempty"`
 	// S3 type: s3 (bucket as url, default), s3s (bucket as DNS subdomain), s3g (new, experimental)
@@ -198,6 +204,12 @@ type SWIFTSpec struct {
 	Port uint `json:"port,omitempty"`
 	//S3 Https port (default value 9443)
 	SecurePort uint `json:"securePort,omitempty"`
+	// Service type to expose (default value ClusterIP)
+	ServiceType string `json:"serviceType,omitempty"`
+	// S3 Http external port
+	ExternalPort uint `json:"externalPort,omitempty"`
+	// S3 Https external port
+	SecureExternalPort uint `json:"secureExternalPort,omitempty"`
 	// The name of the secret that stores the ssl certificate for secure s3 connections
 	SSLCertificateRef string            `json:"sslCertificateRef,omitempty"`
 	ResourceProfile   string            `json:"resourceProfile,omitempty"`
@@ -236,6 +248,12 @@ type S3XSpec struct {
 	Port uint `json:"port,omitempty"`
 	//S3X Https port (default value 3001)
 	SecurePort uint `json:"securePort,omitempty"`
+	// Service type to expose (default value ClusterIP)
+	ServiceType string `json:"serviceType,omitempty"`
+	// S3 Http external port
+	ExternalPort uint `json:"externalPort,omitempty"`
+	// S3 Https external port
+	SecureExternalPort uint `json:"secureExternalPort,omitempty"`
 	// The name of the secret that stores the ssl certificate for secure s3x connections
 	SSLCertificateRef string            `json:"sslCertificateRef,omitempty"`
 	ResourceProfile   string            `json:"resourceProfile,omitempty"`
@@ -319,6 +337,10 @@ type ISGWSpec struct {
 	Direction string `json:"direction,omitempty"`
 	// ISGW remote URL
 	RemoteURL string `json:"remoteURL,omitempty"`
+	// ISGW ServiceType (default is ClusterIP)
+	ServiceType string `json:"serviceType,omitempty"`
+	// ISGW external port
+	ExternalPort uint `json:"externalPort,omitempty"`
 	// ISGW Replication Type
 	ReplicationType string `json:"replicationType,omitempty"`
 	// ISGW Metadata Only flag, all or versions

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -253,7 +253,7 @@ func (c *Cluster) makeUIService(name string) *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
-			Type:     v1.ServiceTypeNodePort,
+			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{
 					Name:     "http-ui",

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -115,7 +115,7 @@ func (c *ISCSIController) makeISCSIService(name, svcname, namespace string, iscs
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
-			Type:     v1.ServiceTypeNodePort,
+			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{Name: "grpc", Port: 49000, Protocol: v1.ProtocolTCP},
 				{Name: "port", Port: defaultPort, Protocol: v1.ProtocolTCP},

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -139,7 +139,7 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
-			Type:     v1.ServiceTypeNodePort,
+			Type:     k8sutil.ParseServiceType(isgwSpec.ServiceType),
 			Ports: []v1.ServicePort{
 				{Name: "grpc", Port: 49000, Protocol: v1.ProtocolTCP},
 			},
@@ -153,8 +153,11 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 			return svc
 		}
 		lport, _ := strconv.Atoi(port)
-
-		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{Name: "lport", Port: int32(lport), Protocol: v1.ProtocolTCP})
+		lportServicePort := v1.ServicePort{Name: "lport", Port: int32(lport), Protocol: v1.ProtocolTCP}
+		if isgwSpec.ExternalPort != 0 {
+			lportServicePort.NodePort = int32(isgwSpec.ExternalPort)
+		}
+		svc.Spec.Ports = append(svc.Spec.Ports, lportServicePort)
 
 		if laddr != defaultLocalIPAddr && laddr != defaultLocalIPv6Addr {
 			logger.Infof("ISGW service %s assigned with externalIP=%s", svcname, laddr)

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -108,7 +108,7 @@ func (c *NFSController) makeNFSService(name, svcname, namespace string) *v1.Serv
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
-			Type:     v1.ServiceTypeNodePort,
+			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{Name: "grpc", Port: 49000, Protocol: v1.ProtocolTCP},
 				{Name: "nfs-tcp", Port: 2049, Protocol: v1.ProtocolTCP},

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -43,6 +43,7 @@ const (
 	etcVolumeFolder    = ".etc"
 	defaultPort        = 9982
 	defaultSecurePort  = 9443
+	defaultServiceType = "ClusterIP"
 )
 
 // Start the S3 manager
@@ -70,6 +71,10 @@ func (c *S3Controller) CreateOrUpdate(s edgefsv1beta1.S3, update bool, ownerRefs
 
 	if s.Spec.SecurePort == 0 {
 		s.Spec.SecurePort = defaultSecurePort
+	}
+
+	if s.Spec.ServiceType == "" {
+		s.Spec.ServiceType = defaultServiceType
 	}
 
 	imageArgs := "s3"
@@ -138,6 +143,16 @@ func (c *S3Controller) CreateOrUpdate(s edgefsv1beta1.S3, update bool, ownerRefs
 
 func (c *S3Controller) makeS3Service(name, svcname, namespace string, s3Spec edgefsv1beta1.S3Spec) *v1.Service {
 	labels := getLabels(name, svcname, namespace)
+	httpPort := v1.ServicePort{Name: "port", Port: int32(s3Spec.Port), Protocol: v1.ProtocolTCP}
+	httpsPort := v1.ServicePort{Name: "secure-port", Port: int32(s3Spec.SecurePort), Protocol: v1.ProtocolTCP}
+
+	if s3Spec.ExternalPort != 0 {
+		httpPort.NodePort = int32(s3Spec.ExternalPort)
+	}
+	if s3Spec.SecureExternalPort != 0 {
+		httpsPort.NodePort = int32(s3Spec.SecureExternalPort)
+	}
+
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -146,11 +161,11 @@ func (c *S3Controller) makeS3Service(name, svcname, namespace string, s3Spec edg
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
-			Type:     v1.ServiceTypeNodePort,
+			Type:     k8sutil.ParseServiceType(s3Spec.ServiceType),
 			Ports: []v1.ServicePort{
 				{Name: "grpc", Port: 49000, Protocol: v1.ProtocolTCP},
-				{Name: "port", Port: int32(s3Spec.Port), Protocol: v1.ProtocolTCP},
-				{Name: "secure-port", Port: int32(s3Spec.SecurePort), Protocol: v1.ProtocolTCP},
+				httpPort,
+				httpsPort,
 			},
 		},
 	}

--- a/pkg/operator/k8sutil/service.go
+++ b/pkg/operator/k8sutil/service.go
@@ -61,3 +61,19 @@ func UpdateService(
 	serviceDefinition.ResourceVersion = existing.ResourceVersion
 	return clientset.CoreV1().Services(namespace).Update(serviceDefinition)
 }
+
+// ParseServiceType parses a string and returns a*v1.ServiceType. If the ServiceType is invalid,
+// this should be considered an error.
+func ParseServiceType(serviceString string) v1.ServiceType {
+	switch serviceString {
+	case "ClusterIP":
+		return v1.ServiceTypeClusterIP
+	case "ExternalName":
+		return v1.ServiceTypeExternalName
+	case "NodePort":
+		return v1.ServiceTypeNodePort
+	case "LoadBalancer":
+		return v1.ServiceTypeLoadBalancer
+	}
+	return v1.ServiceType("")
+}

--- a/pkg/operator/k8sutil/service_test.go
+++ b/pkg/operator/k8sutil/service_test.go
@@ -1,0 +1,20 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestParseServiceType(t *testing.T) {
+	validServiceTypes := []string{"ClusterIP", "NodePort", "LoadBalancer", "ExternalName"}
+	for _, serviceType := range validServiceTypes {
+		assert.Equal(t, v1.ServiceType(serviceType), ParseServiceType(serviceType))
+	}
+
+	invalidServiceTypes := []string{"", "nodeport", "notarealservice"}
+	for _, serviceType := range invalidServiceTypes {
+		assert.Equal(t, v1.ServiceType(""), ParseServiceType(serviceType))
+	}
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Allow users to define Kubernetes users to define ServiceType and NodePort via the CRD spec.  This changes the current behavior, which deploys all services into the K8s cluster as NodePort services on auto-selected ports.  The intent is to provide users more control over services and make accessing services via other methods simpler (e.g., LaodBalancer, ingress controller).  It also reduces the number of ports exposed outside of the Kubernetes cluster.

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test edgefs]