### PR TITLE
ceph: osd use copy-binaries top level cmd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -352,11 +352,12 @@ func (c *Cluster) getCopyBinariesContainer() (v1.Volume, *v1.Container) {
 	mount := v1.VolumeMount{Name: rookBinariesVolumeName, MountPath: rookBinariesMountPath}
 
 	return volume, &v1.Container{
-		Args:         []string{"ceph", "osd", "copybins"},
+		Args: []string{
+			"copy-binaries",
+			"--copy-to-dir", rookBinariesMountPath},
 		Name:         "copy-bins",
 		Image:        k8sutil.MakeRookImage(c.rookVersion),
 		VolumeMounts: []v1.VolumeMount{mount},
-		Env:          []v1.EnvVar{{Name: "ROOK_PATH", Value: rookBinariesMountPath}},
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -44,9 +44,7 @@ func TestPodContainer(t *testing.T) {
 	assert.Equal(t, 2, len(c.Spec.Containers))
 	container := c.Spec.Containers[0]
 	logger.Infof("container: %+v", container)
-	assert.Equal(t, "ceph", container.Args[0])
-	assert.Equal(t, "osd", container.Args[1])
-	assert.Equal(t, "copybins", container.Args[2])
+	assert.Equal(t, "copy-binaries", container.Args[0])
 	container = c.Spec.Containers[1]
 	assert.Equal(t, "/rook/tini", container.Command[0])
 	assert.Equal(t, "--", container.Args[0])
@@ -271,7 +269,6 @@ func TestStorageSpecConfig(t *testing.T) {
 	assert.Equal(t, "rook-ceph-osd-prepare-node1", job.ObjectMeta.Name)
 	container := job.Spec.Template.Spec.Containers[0]
 	assert.NotNil(t, container)
-	verifyEnvVar(t, container.Env, "ROOK_PATH", "/rook", true)
 	container = job.Spec.Template.Spec.Containers[1]
 	assert.NotNil(t, container)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_STORE", "bluestore", true)


### PR DESCRIPTION
Replace usage of the custom osd copybins command with the new top-level
copy-binaries command introduced with cmd-reporter.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]

// known random failure
[skip ci]