### PR TITLE
Ceph (and EdgeFS?) cluster is being deleted after K8S cluster restart or api/etcd issues

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -69,7 +69,7 @@ type childController interface {
 }
 
 func newCluster(c *cephv1.CephCluster, context *clusterd.Context) *cluster {
-	ownerRef := ClusterOwnerRef(c.Namespace, string(c.UID))
+	ownerRef := ClusterOwnerRef(c.Name, string(c.UID))
 	return &cluster{
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -814,12 +814,12 @@ func (c *ClusterController) updateClusterStatus(namespace, name string, state ce
 	}
 }
 
-func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
+func ClusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
-		Name:               namespace,
+		Name:               clusterName,
 		UID:                types.UID(clusterID),
 		BlockOwnerDeletion: &blockOwner,
 	}

--- a/pkg/operator/edgefs/cluster/cluster.go
+++ b/pkg/operator/edgefs/cluster/cluster.go
@@ -67,7 +67,7 @@ func newCluster(c *edgefsv1beta1.Cluster, context *clusterd.Context) *cluster {
 		Namespace: c.Namespace,
 		Spec:      c.Spec,
 		stopCh:    make(chan struct{}),
-		ownerRef:  ClusterOwnerRef(c.Namespace, string(c.UID)),
+		ownerRef:  ClusterOwnerRef(c.Name, string(c.UID)),
 	}
 }
 

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -84,12 +84,12 @@ func NewClusterController(context *clusterd.Context, containerImage string) *Clu
 	}
 }
 
-func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
+func ClusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
-		Name:               namespace,
+		Name:               clusterName,
 		UID:                types.UID(clusterID),
 		BlockOwnerDeletion: &blockOwner,
 	}


### PR DESCRIPTION
**Description of your changes:**
If you restart your whole kubernetes cluster or when you have a short interruption in the etcd or kube-api service (like 10 seconds) kubernetes can trigger a rebuild of the whole internal object graph af which a full garbage collector run is performed. When this happens all components in the CephCluster are beeing deleted by the kubernetes garbage collector. This includes all the secrets and configmaps!

If cause of this issue is that all components in the CephCluster have an ownerreference referencing the CephCluster by UID. When the CephCluster is destroyed all components in it will be as well. By the "name" in the ownerreference that of the namespace in witch the CephCluster is deployed.

When the kubernetes garbage collector does a full run it makes an api request for the "owner" based on the name and not the UID. This most likely returns a 404 in which case the garbage collector performs a "vritual delete" of the object (it's removed from the graph but no delete call is made to the api). The result is that all components in the CephCluster now reference an object no longer in the graph and are identified as "dangling" and destroyed.

Though I couldn't find any docs on it I think the intended behaviour is for the components to reference the CephCluster CRD instance and not the namespace. This pull request makes the operator match that assumption.

This was all tested on Kubernetes 1.15 with Rook v1.0.4 for the CephCluster resource. I couldn't find any changes in the kubernetes garbage collector triggering this. This bug might have been present for quite a while.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

// known CI issue
[skip ci]