### PR TITLE
update csi storageclass

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/example/rbd/storageclass.yaml
@@ -5,8 +5,8 @@ metadata:
 provisioner: rbd.csi.ceph.com
 parameters:
     # Specify a string that identifies your cluster. Ceph CSI supports any
-    # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
-    # for example "rook-ceph".
+    # unique string. When Ceph CSI is deployed by Rook use the namespace of
+    # the Ceph cluster, for example "rook-ceph".
     clusterID: rook-ceph
 
     # Ceph pool into which the RBD image shall be created


### PR DESCRIPTION
I guess the namespace of the ceph cluster should be chosen, not specifically the rook namespace (with the operator)?