### PR TITLE
ceph: check that empty zone contains valid nodes

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -626,7 +626,7 @@ func (c *ClusterController) onDeviceCMUpdate(oldObj, newObj interface{}) {
 	}
 
 	if devicesEqual {
-		logger.Infof("device lists are equal. skipping orchestration")
+		logger.Debugf("device lists are equal. skipping orchestration")
 		return
 	}
 

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -363,7 +363,22 @@ func (c *Cluster) findInvalidMonitorPlacement(desiredMonCount int) (*NodeUsage, 
 			}
 		}
 		if !monFoundInZone {
-			emptyZone = true
+			// emptyZone is used below to imply that an empty zone exists AND
+			// that zone contains a valid node (i.e. a node that new pods can be
+			// assigned). this check enforces that assumption by checking that
+			// the zone contains at least one valid node.
+			validNodeInZone := false
+			for _, nodeUsage := range nodeZones[zi] {
+				if nodeUsage.MonValid {
+					validNodeInZone = true
+					break
+				}
+			}
+			if validNodeInZone {
+				emptyZone = true
+			}
+			logger.Debugf("rebalance: empty zone found. validNodeInZone: %t, emptyZone %t",
+				validNodeInZone, emptyZone)
 		}
 	}
 


### PR DESCRIPTION
a helper flag indicating the exitence of an empty zone (empty = no
monitor pods) is computed when checking the health of the cluster in
order to determine if mons from overloaded zones have some new location
they can be scheduled. the computation of this flag did not check that
the empty zone contains valid nodes that pods can be scheduled on to.
this lead to a mon creation loop.

fixes: #3545

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.