### PR TITLE
Ceph directory-based OSDs: config refactoring

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,6 +15,8 @@
   - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
   - The on-host log directory for OSDs was set incorrectly to `<dataDirHostPath>/<namespace>/log`;
     fix this to be `<dataDirHostPath>/log/<namespace>`, the same as other daemons.
+  - Use the mon configuration database for directory-based OSDs, and do not generate a config
+
 
 ### EdgeFS
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,9 +9,12 @@
 
 - The job for detecting the Ceph version can be started with node affinity or tolerations according to the same settings in the Cluster CR as the mons.
 - A new CR property `skipUpgradeChecks` has been added, which allows you force an upgrade by skipping daemon checks. Use this at **YOUR OWN RISK**, only if you know what you're doing. To understand Rook's upgrade process of Ceph, read the [upgrade doc](Documentation/ceph-upgrade.html#ceph-version-upgrades).
-- Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
 - Mon Quorum Disaster Recovery guide has been updated to work with the latest Rook and Ceph release.
 - A new CRD property `PreservePoolsOnDelete` has been added to Filesystem(fs) and Object Store(os) resources in order to increase protection against data loss. if it is set to `true`, associated pools won't be deleted when the main resource(fs/os) is deleted. Creating again the deleted fs/os with the same name will reuse the preserved pools.
+- OSDs:
+  - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
+  - The on-host log directory for OSDs was set incorrectly to `<dataDirHostPath>/<namespace>/log`;
+    fix this to be `<dataDirHostPath>/log/<namespace>`, the same as other daemons.
 
 ### EdgeFS
 

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -199,7 +199,7 @@ func TestHttpBindFix(t *testing.T) {
 	for _, test := range vers {
 		c.clusterInfo.CephVersion = test.ver
 
-		expectedInitContainers := 0
+		expectedInitContainers := 1
 		if !test.hasFix {
 			expectedInitContainers += 2
 		}

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// don't list caps in keyring; allow OSD to get those from mons
+	keyringTemplate = `[osd.%s]
+key = %s
+`
+)
+
+func (c *Cluster) generateKeyring(osdID string, d *apps.Deployment) error {
+	resourceName := d.GetName()
+
+	user := fmt.Sprintf("osd.%s", osdID)
+	access := []string{"osd", "allow *", "mon", "allow profile osd"}
+	ownerRef := &metav1.OwnerReference{
+		UID:        d.UID,
+		APIVersion: "v1",
+		Kind:       "deployment",
+		Name:       resourceName,
+	}
+	s := keyring.GetSecretStore(c.context, c.Namespace, ownerRef)
+
+	key, err := s.GenerateKey(user, access)
+	if err != nil {
+		return err
+	}
+
+	keyring := fmt.Sprintf(keyringTemplate, osdID, key)
+	return s.CreateOrUpdate(resourceName, keyring)
+}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -251,7 +251,17 @@ func TestDiscoverOSDs(t *testing.T) {
 	clusterInfo := &cephconfig.ClusterInfo{
 		CephVersion: cephver.Nautilus,
 	}
-	c := New(clusterInfo, &clusterd.Context{}, "ns", "myversion", cephv1.CephVersionSpec{},
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			// very simple stub that just reports success
+			return "", nil
+		},
+	}
+	context := &clusterd.Context{
+		Executor: executor,
+	}
+	c := New(clusterInfo, context, "ns", "myversion", cephv1.CephVersionSpec{},
 		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 	node1 := "n1"
 	node2 := "n2"

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -27,6 +27,7 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	cephclient "github.com/rook/rook/pkg/daemon/client"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
@@ -265,6 +266,32 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			{Name: "CEPH_VOLUME_DEBUG", Value: "1"},
 		}...)
 
+	} else if osd.IsDirectory {
+		command = []string{"ceph-osd"}
+		args = opconfig.DefaultFlags(c.clusterInfo.FSID, path.Join(osd.DataPath, "keyring"), c.clusterInfo.CephVersion)
+		args = append(args,
+			"--foreground",
+			"--id", osdID,
+			"--osd-data", osd.DataPath,
+			"--osd-uuid", osd.UUID,
+			"--setuser", "ceph",
+			"--setgroup", "ceph",
+			"--osd-objectstore", "filestore", /* always? */
+			"--osd-max-object-name-len", "256",
+			"--osd-max-object-namespace-len", "64",
+		)
+
+		// Set configs in mon cfg database
+		monstore := opconfig.GetMonStore(c.context, c.Namespace)
+		who := fmt.Sprintf("osd.%s", osdID)
+		// crush_location
+		loc, err := getCRUSHLocation(osdProps)
+		if err != nil {
+			return nil, fmt.Errorf("failed to determine CRUSH location for osd.%s. %+v", osdID, err)
+		}
+		if err := monstore.Set(who, "crush_location", loc); err != nil {
+			return nil, fmt.Errorf("failed to set CRUSH location for osd.%s. %+v", osdID, err)
+		}
 	} else {
 		// other osds can launch the osd daemon directly
 		command = []string{"ceph-osd"}
@@ -820,4 +847,12 @@ func (c *Cluster) getOSDLabels(osdID int, failureDomainValue string, portable bo
 		FailureDomainKey:    failureDomainValue,
 		portableKey:         strconv.FormatBool(portable),
 	}
+}
+
+func getCRUSHLocation(p osdProperties) (string, error) {
+	locs, err := cephclient.FormatLocation(p.location, p.crushHostname)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(locs, " "), nil
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -26,7 +26,6 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -198,22 +197,8 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	assert.Nil(t, err)
 	// pod spec should have a volume for the given dir in the main container and the init container
 	podSpec := deployment.Spec.Template.Spec
-	assert.Equal(t, 5, len(podSpec.Volumes))
 	require.Equal(t, 1, len(podSpec.Containers))
-	cont := podSpec.Containers[0]
-	assert.Equal(t, 5, len(cont.VolumeMounts))
-	assert.Equal(t, "/var/lib/rook", cont.VolumeMounts[0].MountPath)
-	assert.Equal(t, "/etc/ceph", cont.VolumeMounts[1].MountPath)
-	assert.Equal(t, "/var/log/ceph", cont.VolumeMounts[2].MountPath)
-	assert.Equal(t, "/my/root/path", cont.VolumeMounts[3].MountPath)
-
-	require.Equal(t, 2, len(podSpec.InitContainers))
-	initCont := podSpec.InitContainers[0]
-	assert.Equal(t, 4, len(initCont.VolumeMounts))
-	assert.Equal(t, "/var/lib/rook", initCont.VolumeMounts[0].MountPath)
-	assert.Equal(t, "/etc/ceph", initCont.VolumeMounts[1].MountPath)
-	assert.Equal(t, "/var/log/ceph", initCont.VolumeMounts[2].MountPath)
-	assert.Equal(t, "/my/root/path", initCont.VolumeMounts[3].MountPath)
+	require.Equal(t, 0, len(podSpec.InitContainers))
 
 	// the default osd created on a node will be under /var/lib/rook, which won't need an extra mount
 	osd = OSDInfo{
@@ -226,21 +211,8 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	assert.Nil(t, err)
 	// pod spec should have a volume for the given dir in the main container and the init container
 	podSpec = deployment.Spec.Template.Spec
-	assert.Equal(t, 4, len(podSpec.Volumes))
 	require.Equal(t, 1, len(podSpec.Containers))
-	cont = podSpec.Containers[0]
-	require.Equal(t, 4, len(cont.VolumeMounts))
-	assert.Equal(t, "/var/lib/rook", cont.VolumeMounts[0].MountPath)
-	assert.Equal(t, "/etc/ceph", cont.VolumeMounts[1].MountPath)
-
-	assert.Equal(t, (9 + len(k8sutil.ClusterDaemonEnvVars(c.cephVersion.Image))), len(cont.Env))
-
-	require.Equal(t, 2, len(podSpec.InitContainers))
-	initCont = podSpec.InitContainers[0]
-	require.Equal(t, 3, len(initCont.VolumeMounts))
-	assert.Equal(t, "/var/lib/rook", initCont.VolumeMounts[0].MountPath)
-	assert.Equal(t, "/etc/ceph", initCont.VolumeMounts[1].MountPath)
-	assert.Equal(t, "/var/log/ceph", initCont.VolumeMounts[2].MountPath)
+	require.Equal(t, 0, len(podSpec.InitContainers))
 }
 
 func TestStorageSpecConfig(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -128,7 +128,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, c.Namespace, deployment.Spec.Template.ObjectMeta.Labels["rook_cluster"])
 	assert.Equal(t, 0, len(deployment.Spec.Template.ObjectMeta.Annotations))
 
-	assert.Equal(t, 2, len(deployment.Spec.Template.Spec.InitContainers))
+	assert.Equal(t, 3, len(deployment.Spec.Template.Spec.InitContainers))
 	initCont := deployment.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, "rook/rook:myversion", initCont.Image)
 	assert.Equal(t, "config-init", initCont.Name)
@@ -198,7 +198,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	// pod spec should have a volume for the given dir in the main container and the init container
 	podSpec := deployment.Spec.Template.Spec
 	require.Equal(t, 1, len(podSpec.Containers))
-	require.Equal(t, 0, len(podSpec.InitContainers))
+	require.Equal(t, 1, len(podSpec.InitContainers))
 
 	// the default osd created on a node will be under /var/lib/rook, which won't need an extra mount
 	osd = OSDInfo{
@@ -212,7 +212,7 @@ func TestStorageSpecDevicesAndDirectories(t *testing.T) {
 	// pod spec should have a volume for the given dir in the main container and the init container
 	podSpec = deployment.Spec.Template.Spec
 	require.Equal(t, 1, len(podSpec.Containers))
-	require.Equal(t, 0, len(podSpec.InitContainers))
+	require.Equal(t, 1, len(podSpec.InitContainers))
 }
 
 func TestStorageSpecConfig(t *testing.T) {

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -71,13 +71,6 @@ var (
 	// VarLogCephDir defines Ceph logging directory. It is made overwriteable only for unit tests where it
 	// may be needed to send data intended for /var/log/ceph to a temporary test dir.
 	VarLogCephDir = "/var/log/ceph"
-
-	// chownUserGroup represents ceph:ceph
-	chownUserGroup = CephUser + ":" + CephGroup
-
-	// ContainerPostStartCmd is the command we run before starting any Ceph daemon
-	// It makes sure Ceph directories are owned by 'ceph'
-	ContainerPostStartCmd = []string{"chown", "--recursive", chownUserGroup, VarLogCephDir}
 )
 
 // normalizeKey converts a key in any format to a key with underscores.

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -102,7 +102,7 @@ func PodVolumes(dataDirHostPath, namespace string, confGeneratedInPod bool) []v1
 	return []v1.Volume{
 		{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
 		configVolume,
-		StoredLogVolume(path.Join(dataDirHostPath, "log", namespace)),
+		StoredLogVolume(path.Join(dataDirHostPath, namespace, "log")),
 	}
 }
 

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -353,25 +353,38 @@ func StoredLogVolumeMount() v1.VolumeMount {
 	}
 }
 
-func generateLifeCycleCmd(dataDirHostPath string) []string {
-	cmd := config.ContainerPostStartCmd
-
-	if dataDirHostPath != "" {
-		cmd = append(cmd, dataDirHostPath)
+// ChownCephDataDirsInitContainer returns an init container which `chown`s the given data
+// directories as the `ceph:ceph` user in the container. It also `chown`s the Ceph log dir in the
+// container automatically.
+// Doing a chown in a post start lifecycle hook does not reliably complete before the OSD
+// process starts, which can cause the pod to fail without the lifecycle hook's chown command
+// completing. It can take an arbitrarily long time for a pod restart to successfully chown the
+// directory. This is a race condition for all daemons; therefore, do this in an init container.
+// See more discussion here: https://github.com/rook/rook/pull/3594#discussion_r312279176
+func ChownCephDataDirsInitContainer(
+	dpm config.DataPathMap,
+	containerImage string,
+	volumeMounts []v1.VolumeMount,
+	resources v1.ResourceRequirements,
+	securityContext *v1.SecurityContext,
+) v1.Container {
+	args := make([]string, 0, 5)
+	args = append(args,
+		"--verbose",
+		"--recursive",
+		"ceph:ceph",
+		config.VarLogCephDir,
+	)
+	if dpm.ContainerDataDir != "" {
+		args = append(args, dpm.ContainerDataDir)
 	}
-
-	return cmd
-}
-
-// PodLifeCycle returns a pod lifecycle resource to execute actions before a pod starts
-func PodLifeCycle(dataDirHostPath string) *v1.Lifecycle {
-	cmd := generateLifeCycleCmd(dataDirHostPath)
-
-	return &v1.Lifecycle{
-		PostStart: &v1.Handler{
-			Exec: &v1.ExecAction{
-				Command: cmd,
-			},
-		},
+	return v1.Container{
+		Name:            "chown-container-data-dir",
+		Command:         []string{"chown"},
+		Args:            args,
+		Image:           containerImage,
+		VolumeMounts:    volumeMounts,
+		Resources:       resources,
+		SecurityContext: securityContext,
 	}
 }

--- a/pkg/operator/ceph/spec/spec_test.go
+++ b/pkg/operator/ceph/spec/spec_test.go
@@ -20,10 +20,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -55,14 +53,6 @@ func TestMountsMatchVolumes(t *testing.T) {
 			{Moniker: "RookVolumeMounts(false)", Mounts: RookVolumeMounts(true)}},
 	}
 	volsMountsTestDef.TestMountsMatchVolumes(t)
-}
-
-func TestGenerateLifeCycleCmd(t *testing.T) {
-	cmd := generateLifeCycleCmd("")
-	assert.Equal(t, config.ContainerPostStartCmd, cmd)
-
-	cmd = generateLifeCycleCmd("foo")
-	assert.Equal(t, append(config.ContainerPostStartCmd, "foo"), cmd)
 }
 
 func TestCheckPodMemory(t *testing.T) {


### PR DESCRIPTION
The goal is to run dir-based OSDs using the new config patterns used by the other Ceph daemons.

This will hopefully be several very small commits that each still have reasonably working dir-based OSDs.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
