### PR TITLE
ROOK_CURRENT_NAMESPACE_ONLY environment variable configurable with helm for operator deployment

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -100,6 +100,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `logLevel`                   | Global log level                                                                                        | `INFO`                                                 |
 | `nodeSelector`               | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
 | `tolerations`                | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
+| `currentNamespaceOnly`   | Whether the operator should watch cluster CRD in its own namespace or not                               | `false`                                                 |
 | `hostpathRequiresPrivileged` | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
 | `agent.flexVolumeDirPath`    | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
 | `agent.libModulesDirPath`    | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         args: ["ceph", "operator"]
         env:
         - name: ROOK_CURRENT_NAMESPACE_ONLY
-          value: "true"
+          value: {{ .Values.currentNamespaceOnly | quote }}
 {{- if not .Values.rbacEnable }}
         - name: RBAC_ENABLED
           value: "false"

--- a/cluster/charts/rook-ceph/values.yaml.tmpl
+++ b/cluster/charts/rook-ceph/values.yaml.tmpl
@@ -29,6 +29,9 @@ nodeSelector:
 # Tolerations for the rook-ceph-operator to allow it to run on nodes with particular taints
 tolerations: []
 
+# Whether rook watches its current namespace for CRDs or the entire cluster, defaults to false
+currentNamespaceOnly: false
+
 # Interval at which to get the ceph status and update the cluster custom resource status
 cephStatusCheckInterval: "60s"
 


### PR DESCRIPTION
**Description of your changes:**
`ROOK_CURRENT_NAMESPACE_ONLY` environment variable was added to the deployment of the ceph operator.
It was hard-coded to `true` into the template.
This variable is now configurable using `helm` deployment strategy.

**Which issue is resolved by this Pull Request:**
Resolves #3327

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
