### PR TITLE
Validate cephfilesystem.metadataServer properties

### DIFF
--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -120,6 +120,18 @@ spec:
     singular: cephfilesystem
   scope: Namespaced
   version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            metadataServer:
+              properties:
+                activeCount:
+                  type: integer
+                  minimum: 1
+                activeStandby:
+                  type: boolean
   additionalPrinterColumns:
     - name: MdsCount
       type: string


### PR DESCRIPTION
When the activeCount attribute is set to 0, rook operator aborts the operation, (func filesystem.validateFilesystem check values before creation). Unfortunately the invalid value is stored in the cephfilesystem.metadataServer.activeCount property. This produces a certain level of inconsistency in the cephfilesystem resource that probably we should fix.

The inconsistency appears easily querying the status of the cephfilesystem resource after downgrade from 1 to 0 , for example:

```
# kubectl -n rook-ceph get cephfilesystem
NAME      MDSCOUNT   AGE
myfs      0          134m    <------------------ THIS IS NOT TRUE
```

I have introduced a validation of the metadataServer properties for the cephfilesystem resource. This protects the resource against wrong values, and provides to the final user some feedback when a wrong value is used in the object definition file.

We have also the possibility of using default values, but i have preferred not to include this modification because this feature is now in Alpha state (k8 1.15).
See:  https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting

[skip ci]

**Resolves** https://github.com/rook/rook/issues/3233

### Issue reproduced and fix evidences:

Starting with a cluster with a filesystem supported by a couple of active/standby MDS (activeCount=1). if we try to update to 0 the ActiveCount parameter we have this situation:

1.We start with a working ceph filesystem (activeCount=1)

```
# kubectl -n rook-ceph get cephfilesystem
NAME      MDSCOUNT   AGE
myfs      1          133m

# kubectl -n rook-ceph get pod -l app=rook-ceph-mds
NAME                                    READY     STATUS    RESTARTS   AGE
rook-ceph-mds-myfs-a-6885d65bb6-trk8z   1/1       Running   0          133m
rook-ceph-mds-myfs-b-7845f47596-t8szt   1/1       Running   0          133m
```

2. If we change the activeCount property to 0:

```
# sed -i 's/activeCount: 1/activeCount: 0/' filesystem.yaml & kubectl apply -f filesystem.yaml
[1] 760970
cephfilesystem.ceph.rook.io/myfs configured
[1]+  Done                    sed -i 's/activeCount: 1/activeCount: 0/' filesystem.yaml

# kubectl -n rook-ceph get cephfilesystem
NAME      MDSCOUNT   AGE
myfs      0          134m    <------------------ THIS IS NOT TRUE

# kubectl -n rook-ceph get pod -l app=rook-ceph-mds
NAME                                    READY     STATUS    RESTARTS   AGE
rook-ceph-mds-myfs-a-6885d65bb6-trk8z   1/1       Running   0          134m
rook-ceph-mds-myfs-b-7845f47596-t8szt   1/1       Running   0          134m

```
3. Taking a look to the operator log, we can see that this "downgrade" has been aborted because is not allowed to have an ActiveCount value lower than 1:

```
2019-07-30 17:27:26.919250 I | op-file: number of mds active changed from 1 to 0
2019-07-30 17:27:26.920246 I | op-file: updating filesystem myfs
2019-07-30 17:27:26.920271 E | op-file: failed to create (modify) filesystem myfs: MetadataServer.ActiveCount must be at least 1
```

The "no validation" of the MetadataServer properties could produce more problems, for example, we can use even a not numeric value for this property:

```
$ sed -i 's/activeCount: 1/activeCount: jmo/' filesystem.yaml & kubectl apply -f filesystem.yaml
cephfilesystem.ceph.rook.io/myfs configured

[jolmomar@juanmipc ceph]$ kubectl -n rook-ceph get cephfilesystem
NAME      MDSCOUNT   AGE
myfs      jmo        16h  <------------ Funny thing!!
```

### Behavior after modification:

**- Trying to use an string value: "activeCount: jmo"**

```
$ kubectl apply -f filesystem.yaml
The CephFilesystem "myfs" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"ceph.rook.io/v1", "kind":"CephFilesystem", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"ceph.rook.io/v1\",\"kind\":\"CephFilesystem\",\"metadata\":{\"annotations\":{},\"name\":\"myfs\",\"namespace\":\"rook-ceph\"},\"spec\":{\"dataPools\":[{\"failureDomain\":\"host\",\"replicated\":{\"size\":3}}],\"metadataPool\":{\"replicated\":{\"size\":3}},\"metadataServer\":{\"activeCount\":\"jmo\",\"activeStandby\":true,\"annotations\":null,\"placement\":null,\"resources\":null}}}\n"}, "creationTimestamp":"2019-08-01T11:55:10Z", "generation":1, "name":"myfs", "namespace":"rook-ceph", "uid":"883f1575-5cd4-40be-b14b-fc33746e3f05"}, "spec":map[string]interface {}{"dataPools":[]interface {}{map[string]interface {}{"failureDomain":"host", "replicated":map[string]interface {}{"size":3}}}, "metadataPool":map[string]interface {}{"replicated":map[string]interface {}{"size":3}}, "metadataServer":map[string]interface {}{"activeCount":"jmo", "activeStandby":true, "annotations":interface {}(nil), "placement":interface {}(nil), "resources":interface {}(nil)}}}: validation failure list:
spec.metadataServer.activeCount in body must be of type integer: "string"

$ kubectl -n rook-ceph get cephfilesystem
No resources found
```
Note: No requests arriving to operator in order to create/update cephfilesystem objects.

**- Trying to use a not allowed value: "activeCount: 0"**

```
$ kubectl apply -f filesystem.yaml
The CephFilesystem "myfs" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"ceph.rook.io/v1", "kind":"CephFilesystem", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"ceph.rook.io/v1\",\"kind\":\"CephFilesystem\",\"metadata\":{\"annotations\":{},\"name\":\"myfs\",\"namespace\":\"rook-ceph\"},\"spec\":{\"dataPools\":[{\"failureDomain\":\"host\",\"replicated\":{\"size\":3}}],\"metadataPool\":{\"replicated\":{\"size\":3}},\"metadataServer\":{\"activeCount\":0,\"activeStandby\":true,\"annotations\":null,\"placement\":null,\"resources\":null}}}\n"}, "creationTimestamp":"2019-08-01T11:56:39Z", "generation":1, "name":"myfs", "namespace":"rook-ceph", "uid":"c950ebaa-9b2a-4611-b9f9-0443f285556a"}, "spec":map[string]interface {}{"dataPools":[]interface {}{map[string]interface {}{"failureDomain":"host", "replicated":map[string]interface {}{"size":3}}}, "metadataPool":map[string]interface {}{"replicated":map[string]interface {}{"size":3}}, "metadataServer":map[string]interface {}{"activeCount":0, "activeStandby":true, "annotations":interface {}(nil), "placement":interface {}(nil), "resources":interface {}(nil)}}}: validation failure list:
spec.metadataServer.activeCount in body should be greater than or equal to 1

$ kubectl -n rook-ceph get cephfilesystem
No resources found

```
Note: No requests arriving to operator in order to create/update cephfilesystem objects.

**- Trying to use correct value: "activeCount: 1"**

```
$ kubectl apply -f filesystem.yaml
cephfilesystem.ceph.rook.io/myfs created

$ kubectl -n rook-ceph get cephfilesystem
NAME      MDSCOUNT   AGE
myfs      1          4s
```

Note: The request to create a new cephfilesystem object is procesed by the operator

 **- Trying to use an string value for a boolean property: "activeStandby: jmo"**

```
$ kubectl apply -f filesystem.yaml
The CephFilesystem "myfs" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"ceph.rook.io/v1", "kind":"CephFilesystem", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"ceph.rook.io/v1\",\"kind\":\"CephFilesystem\",\"metadata\":{\"annotations\":{},\"name\":\"myfs\",\"namespace\":\"rook-ceph\"},\"spec\":{\"dataPools\":[{\"failureDomain\":\"host\",\"replicated\":{\"size\":3}}],\"metadataPool\":{\"replicated\":{\"size\":3}},\"metadataServer\":{\"activeCount\":1,\"activeStandby\":\"jmo\",\"annotations\":null,\"placement\":null,\"resources\":null}}}\n"}, "creationTimestamp":"2019-08-01T12:04:04Z", "generation":1, "name":"myfs", "namespace":"rook-ceph", "uid":"26f42296-bdb6-4b3b-86b3-c17437162186"}, "spec":map[string]interface {}{"dataPools":[]interface {}{map[string]interface {}{"failureDomain":"host", "replicated":map[string]interface {}{"size":3}}}, "metadataPool":map[string]interface {}{"replicated":map[string]interface {}{"size":3}}, "metadataServer":map[string]interface {}{"activeCount":1, "activeStandby":"jmo", "annotations":interface {}(nil), "placement":interface {}(nil), "resources":interface {}(nil)}}}: validation failure list:
spec.metadataServer.activeStandby in body must be of type boolean: "string"

$ kubectl -n rook-ceph get cephfilesystem
No resources found.
```
-----------------------------------------------------------------------------------------

**Cheklist**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.



Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>




