### PR TITLE
Tests: Collect all logs for pods in the integration tests

### DIFF
--- a/tests/framework/installer/cassandra_installer.go
+++ b/tests/framework/installer/cassandra_installer.go
@@ -164,11 +164,8 @@ func (ci *CassandraInstaller) UninstallCassandra(systemNamespace string, namespa
 func (ci *CassandraInstaller) GatherAllCassandraLogs(systemNamespace, namespace, testName string) {
 	if !ci.T().Failed() && Env.Logs != "all" {
 		return
-	} else if ci.T().Failed() {
-		GatherCRDObjectDebuggingInfo(ci.k8sHelper, systemNamespace)
-		GatherCRDObjectDebuggingInfo(ci.k8sHelper, namespace)
 	}
 	logger.Infof("Gathering all logs from Cassandra Cluster %s", namespace)
-	ci.k8sHelper.GetLogs("rook-cassandra-operator", Env.HostType, systemNamespace, testName)
-	ci.k8sHelper.GetLogs("rook-cassandra", Env.HostType, namespace, testName)
+	ci.k8sHelper.GetLogsFromNamespace(systemNamespace, testName, Env.HostType)
+	ci.k8sHelper.GetLogsFromNamespace(namespace, testName, Env.HostType)
 }

--- a/tests/framework/installer/cockroachdb_installer.go
+++ b/tests/framework/installer/cockroachdb_installer.go
@@ -152,11 +152,8 @@ func (h *CockroachDBInstaller) UninstallCockroachDB(systemNamespace, namespace s
 func (h *CockroachDBInstaller) GatherAllCockroachDBLogs(systemNamespace, namespace, testName string) {
 	if !h.T().Failed() && Env.Logs != "all" {
 		return
-	} else if h.T().Failed() {
-		GatherCRDObjectDebuggingInfo(h.k8shelper, systemNamespace)
-		GatherCRDObjectDebuggingInfo(h.k8shelper, namespace)
 	}
 	logger.Infof("Gathering all logs from cockroachdb cluster %s", namespace)
-	h.k8shelper.GetLogs("rook-cockroachdb-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetLogs("rook-cockroachdb", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, Env.HostType)
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, Env.HostType)
 }

--- a/tests/framework/installer/edgefs_installer.go
+++ b/tests/framework/installer/edgefs_installer.go
@@ -154,11 +154,8 @@ func (h *EdgefsInstaller) UninstallEdgefs(systemNamespace, namespace string) {
 func (h *EdgefsInstaller) GatherAllEdgefsLogs(systemNamespace, namespace, testName string) {
 	if !h.T().Failed() && Env.Logs != "all" {
 		return
-	} else if h.T().Failed() {
-		GatherCRDObjectDebuggingInfo(h.k8shelper, systemNamespace)
-		GatherCRDObjectDebuggingInfo(h.k8shelper, namespace)
 	}
 	logger.Infof("Gathering all logs from edgefs cluster %s", namespace)
-	h.k8shelper.GetLogs("rook-edgefs-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetLogs("rook-edgefs", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, Env.HostType)
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, Env.HostType)
 }

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/coreos/pkg/capnslog"
-	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -104,12 +103,4 @@ func concatYaml(first, second string) string {
 	return first + `
 ---
 ` + second
-}
-
-// GatherCRDObjectDebuggingInfo gathers all the descriptions for pods, pvs and pvcs
-func GatherCRDObjectDebuggingInfo(k8shelper *utils.K8sHelper, namespace string) {
-	k8shelper.PrintPodDescribeForNamespace(namespace)
-	k8shelper.PrintPVs(true /*detailed*/)
-	k8shelper.PrintPVCs(namespace, true /*detailed*/)
-	k8shelper.PrintStorageClasses(true /*detailed*/)
 }

--- a/tests/framework/installer/nfs_installer.go
+++ b/tests/framework/installer/nfs_installer.go
@@ -192,11 +192,8 @@ func (h *NFSInstaller) UninstallNFSServer(systemNamespace, namespace string) {
 func (h *NFSInstaller) GatherAllNFSServerLogs(systemNamespace, namespace, testName string) {
 	if !h.T().Failed() && Env.Logs != "all" {
 		return
-	} else if h.T().Failed() {
-		GatherCRDObjectDebuggingInfo(h.k8shelper, systemNamespace)
-		GatherCRDObjectDebuggingInfo(h.k8shelper, namespace)
 	}
 	logger.Infof("Gathering all logs from NFSServer %s", namespace)
-	h.k8shelper.GetLogs("rook-nfs-operator", Env.HostType, systemNamespace, testName)
-	h.k8shelper.GetLogs("rook-nfs", Env.HostType, namespace, testName)
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, Env.HostType)
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, Env.HostType)
 }

--- a/tests/framework/installer/provisioners.go
+++ b/tests/framework/installer/provisioners.go
@@ -61,7 +61,7 @@ func InstallHostPathProvisioner(k8shelper *utils.K8sHelper) error {
 	err = k8shelper.WaitForLabeledPodsToRun("k8s-app=hostpath-provisioner", "kube-system")
 	if err != nil {
 		logger.Errorf("hostpath provisioner pod is not running: %+v", err)
-		k8shelper.PrintPodDescribeForNamespace("kube-system")
+		k8shelper.GetPodDescribeFromNamespace("kube-system", "hostPathProvisioner", Env.HostType)
 		k8shelper.PrintStorageClasses(true /*detailed*/)
 		return err
 	}

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -100,7 +100,9 @@ type TestCluster struct {
 }
 
 // StartTestCluster creates new instance of TestCluster struct
-func StartTestCluster(t func() *testing.T, namespace, storeType string, useHelm, useDevices bool, mons, rbdMirrorWorkers int, rookVersion string, cephVersion cephv1.CephVersionSpec) (*TestCluster, *utils.K8sHelper) {
+func StartTestCluster(t func() *testing.T, namespace, storeType string, useHelm, useDevices bool, mons,
+	rbdMirrorWorkers int, rookVersion string, cephVersion cephv1.CephVersionSpec) (*TestCluster, *utils.K8sHelper) {
+
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
 
@@ -127,7 +129,7 @@ func (op *TestCluster) Setup() {
 	if !isRookInstalled || err != nil {
 		logger.Errorf("Rook was not installed successfully: %v", err)
 		if !op.installer.T().Failed() {
-			op.installer.GatherAllRookLogs(op.namespace, installer.SystemNamespace(op.namespace), op.installer.T().Name())
+			op.installer.GatherAllRookLogs(op.installer.T().Name(), op.namespace, installer.SystemNamespace(op.namespace))
 		}
 		op.T().Fail()
 		op.Teardown()
@@ -140,5 +142,5 @@ func (op *TestCluster) SetInstallData(version string) {}
 
 // TearDownRook is a wrapper for tearDown after Suite
 func (op *TestCluster) Teardown() {
-	op.installer.UninstallRook(op.namespace)
+	op.installer.UninstallRook(op.namespace, true)
 }

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -182,22 +182,19 @@ func (o MCTestOperations) Teardown() {
 		}
 	}()
 
-	o.installer.GatherAllRookLogs(o.namespace1, o.systemNamespace, o.T().Name())
-	o.installer.GatherAllRookLogs(o.namespace2, o.systemNamespace, o.T().Name())
-
-	o.installer.UninstallRookFromMultipleNS(installer.SystemNamespace(o.namespace1), o.namespace1, o.namespace2)
+	o.installer.UninstallRookFromMultipleNS(true, installer.SystemNamespace(o.namespace1), o.namespace1, o.namespace2)
 }
 
 func (o MCTestOperations) startCluster(namespace, store string, errCh chan error) {
 	logger.Infof("starting cluster %s", namespace)
 	if err := o.installer.CreateK8sRookCluster(namespace, o.systemNamespace, store); err != nil {
-		o.installer.GatherAllRookLogs(namespace, o.systemNamespace, o.T().Name())
+		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
 		errCh <- fmt.Errorf("failed to create cluster %s. %+v", namespace, err)
 		return
 	}
 
 	if err := o.installer.CreateK8sRookToolbox(namespace); err != nil {
-		o.installer.GatherAllRookLogs(namespace, o.systemNamespace, o.T().Name())
+		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
 		errCh <- fmt.Errorf("failed to create toolbox for %s. %+v", namespace, err)
 		return
 	}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Now we collect logs for all pods and all their init and main containers during the integration tests. No longer will we be missing logs from the integration tests as long as the pods  are available when they are collected at the end of the test. The pod descriptions are also written to a log file instead of being included inline with the test output.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
