### PR TITLE
Add CephCluster RBAC to the OSD service account

### DIFF
--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -43,6 +43,9 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: [ "get", "list", "watch", "create", "update", "delete" ]
+- apiGroups: ["ceph.rook.io"]
+  resources: ["cephclusters", "cephclusters/finalizers"]
+  verbs: [ "get", "list", "create", "update", "delete" ]
 ---
 # Aspects of ceph-mgr that operate within the cluster's namespace
 kind: Role

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -515,7 +515,7 @@ rules:
   verbs: [ "get", "list", "watch", "create", "update", "delete" ]
 - apiGroups: ["ceph.rook.io"]
   resources: ["cephclusters", "cephclusters/finalizers"]
-  verbs: ["*"]
+  verbs: [ "get", "list", "create", "update", "delete" ]
 ---
 # Aspects of ceph-mgr that require access to the system namespace
 kind: ClusterRole

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1085,6 +1085,9 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: [ "get", "list", "watch", "create", "update", "delete" ]
+- apiGroups: ["ceph.rook.io"]
+  resources: ["cephclusters", "cephclusters/finalizers"]
+  verbs: [ "get", "list", "create", "update", "delete" ]
 ---
 # Aspects of ceph-mgr that operate within the cluster's namespace
 kind: Role


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In order for the osd service account to reference the cephcluster CR in the owner references, OpenShift requires access to the CephCluster CRD. This adds the minimal changes needed to appease OpenShift.

**Which issue is resolved by this Pull Request:**
Resolves #3466 

@ron1 I also hit this in OpenShift, thanks for helping track it down!

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
