### PR TITLE
rook: Add image pull secrets option

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -60,6 +60,7 @@ an example usage
 - The CSI driver is enabled by default. Documentation has been changed significantly for block and filesystem to use the CSI driver instead of flex.
 While the flex driver is still supported, it is anticipated to be deprecated soon.
 - The `Mon.PreferredCount` setting has been removed.
+- imagePullSecrets option added to helm-chart
 
 ## Known Issues
 

--- a/cluster/charts/rook-ceph/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph/templates/_helpers.tpl
@@ -14,3 +14,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Define imagePullSecrets option to pass to all service accounts
+*/}}
+{{- define "imagePullSecrets" }}
+{{- if .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- end -}}

--- a/cluster/charts/rook-ceph/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph/templates/serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
     operator: rook
     storage-backend: ceph
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the Ceph OSDs. Must exist and cannot be renamed.
 apiVersion: v1
@@ -17,6 +18,7 @@ metadata:
     operator: rook
     storage-backend: ceph
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the Ceph Mgr. Must exist and cannot be renamed.
 apiVersion: v1
@@ -27,6 +29,7 @@ metadata:
     operator: rook
     storage-backend: ceph
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{ template "imagePullSecrets" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -36,27 +39,32 @@ metadata:
     operator: rook
     storage-backend: ceph
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the cephfs csi driver
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the cephfs csi provisioner
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi driver
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
+{{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi provisioner
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
+{{ template "imagePullSecrets" . }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -105,3 +105,7 @@ hostpathRequiresPrivileged: false
 
 # Disable automatic orchestration when new devices are discovered.
 disableDeviceHotplug: false
+
+# imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
+# imagePullSecrets:
+# - name: my-registry-secret

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -705,6 +705,9 @@ metadata:
   labels:
     operator: rook
     storage-backend: ceph
+# imagePullSecrets:
+# - name: my-registry-secret
+
 # OLM: END SERVICE ACCOUNT SYSTEM
 # OLM: BEGIN OPERATOR ROLEBINDING
 ---
@@ -757,6 +760,9 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
   namespace: rook-ceph
+# imagePullSecrets:
+# - name: my-registry-secret
+
 # OLM: END SERVICE ACCOUNT OSD
 # OLM: BEGIN SERVICE ACCOUNT MGR
 ---
@@ -766,6 +772,9 @@ kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
   namespace: rook-ceph
+# imagePullSecrets:
+# - name: my-registry-secret
+
 # OLM: END SERVICE ACCOUNT MGR
 # OLM: BEGIN CMD REPORTER SERVICE ACCOUNT
 ---


### PR DESCRIPTION
Allow to specify imagePullSecrets to pull operator images from private registry

Signed-off-by: Maksim Nabokikh <maksim.nabokikh@flant.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Helps to keep image of rook operator in private registry in terms of security, latency issues or public registry access problems.
With this PR deployments and daemonsets cat recive imagePullSecrets either from command line or from operator pod specs.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
