### PR TITLE
ceph: enable LoadBalancerService and LoadBalancerIP as options in Roo…

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -61,6 +61,8 @@ If this value is empty, each pod will get an ephemeral directory to store their 
   - `ssl`: Whether to serve the dashboard via SSL, ignored on Ceph versions older than `13.2.2`
 - `network`: The network settings for the cluster
   - `hostNetwork`: uses network of the hosts instead of using the SDN below the containers.
+  - `loadBalancerService`: Turns the `rook-ceph-mon` service into a Kubernetes `LoadBalancer` service. By default, `rook-ceph-mon` launches as a ClusterIP service. Boolean.
+  - `loadBalancerIP`: Assigns a `LoadBalancerIP` to the `rook-ceph-mon` `LoadBalancer` service. Is ignored if `loadBalancerService` is not enabled. 
 - `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health design doc](https://github.com/rook/rook/blob/master/design/mon-health.md).
 - `rbdMirroring`: The settings for rbd mirror daemon(s). Configuring which pools or images to be mirrored must be completed in the rook toolbox by running the

--- a/pkg/apis/ceph.rook.io/v1/spec_test.go
+++ b/pkg/apis/ceph.rook.io/v1/spec_test.go
@@ -73,7 +73,9 @@ storage:
 		},
 		DataDirHostPath: "/var/lib/rook",
 		Network: rookalpha.NetworkSpec{
-			HostNetwork: true,
+			HostNetwork:         true,
+			LoadBalancerService: false,
+			LoadBalancerIP:      "",
 		},
 		Storage: rookalpha.StorageScopeSpec{
 			UseAllNodes: false,

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -87,6 +87,15 @@ type NetworkSpec struct {
 
 	// Set of named ports that can be configured for this resource
 	Ports []PortSpec `json:"ports,omitempty"`
+
+	// LoadBalancerService ensures that the Ceph `mon` service is exposed externally.
+	// Currently only respected by the Ceph backend.
+	LoadBalancerService bool `json:"loadBalancerService,omitempty"`
+
+	// LoadBalancerIP to support assignment of load balancer IP by cloud provider
+	// to Ceph `mon` service. Only applied if `loadBalancerService` is enabled.
+	// Currently only respected by the Ceph backend.
+	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 }
 
 type PortSpec struct {


### PR DESCRIPTION
…k config


This patches https://github.com/rook/rook/issues/3404.

The gist of this PR is that the `mon` service for Ceph now allows
a) being declared as a LoadBalancer service, and b) allows operators
to supply a custom LoadBalancerIP if desired.

This effectively means cluster operators can now expose their Ceph clusters
externally from within configuration.

To do this, I've modified the `rook.NetworkSpec` interface accordingly.
This interface is currently consumed by both Cassandra and Ceph - however,
no changes to the Cassandra code have been made to honor this.

*Tests*

I noticed that we only test one particular YAML configuration of Ceph rather
than for different configuration options, and that Ceph tests are keyed only
to use the version of rook to decide which YAML to use.

This makes it prohibitive to test for multiple different YAML configurations
in the same rook version. I have accordingly left out tests for the interim
to keep changes small and reasonable.

Signed-off-by: Akshat Mahajan <akshatm.bkk@gmail.com>

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
