### PR TITLE
Memory limit checked if it really exists

### DIFF
--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -229,19 +229,21 @@ func CheckPodMemory(resources v1.ResourceRequirements, cephPodMinimumMemory uint
 		return nil
 	}
 
-	// This means LIMIT and REQUEST are either identical or different but still we use LIMIT as a reference
-	if uint64(podMemoryLimit.Value()) < display.MbTob(cephPodMinimumMemory) {
-		return fmt.Errorf(errorMessage, display.BToMb(uint64(podMemoryLimit.Value())), cephPodMinimumMemory)
-	}
+	if !podMemoryLimit.IsZero() {
+		// This means LIMIT and REQUEST are either identical or different but still we use LIMIT as a reference
+		if uint64(podMemoryLimit.Value()) < display.MbTob(cephPodMinimumMemory) {
+			return fmt.Errorf(errorMessage, display.BToMb(uint64(podMemoryLimit.Value())), cephPodMinimumMemory)
+		}
 
-	// This means LIMIT < REQUEST
-	// Kubernetes will refuse to schedule that pod however it's still valuable to indicate that user's input was incorrect
-	if uint64(podMemoryLimit.Value()) < uint64(podMemoryRequest.Value()) {
-		extraErrorLine := `\n
-		User has specified a pod memory limit %dmb below the pod memory request %dmb in the cluster CR.\n
-		Rook will create pods that are expected to fail to serve as a more apparent error indicator to the user.`
+		// This means LIMIT < REQUEST
+		// Kubernetes will refuse to schedule that pod however it's still valuable to indicate that user's input was incorrect
+		if uint64(podMemoryLimit.Value()) < uint64(podMemoryRequest.Value()) {
+			extraErrorLine := `\n
+			User has specified a pod memory limit %dmb below the pod memory request %dmb in the cluster CR.\n
+			Rook will create pods that are expected to fail to serve as a more apparent error indicator to the user.`
 
-		return fmt.Errorf(extraErrorLine, display.BToMb(uint64(podMemoryLimit.Value())), display.BToMb(uint64(podMemoryRequest.Value())))
+			return fmt.Errorf(extraErrorLine, display.BToMb(uint64(podMemoryLimit.Value())), display.BToMb(uint64(podMemoryRequest.Value())))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
I have implemented the trivial solution with a test to verify that it is working and to avoid future problems.

Besides that, I have explored another possibility, basically is to use "LimitRange" in common.yaml.
I think that if we are going to use just one container by pod, this could be other approach that will allow us to avoid to hardcode the memory limits for each kind of pod ("cephRbdMirrorPodMinimumMemory", "cephMgrPodMinimumMemory", "cephMonPodMinimumMemory", "cephMdsPodMinimumMemory" ) and to have a function to check this limits.
As disadvantage we have that we cannot use a default value for each kind of pod.

It can be done using this specification in "common.yaml" (default values can be adjusted)
```
---
apiVersion: v1
kind: LimitRange
metadata:
  name: mem-limit-range
  namespace: rook-ceph
spec:
  limits:
  - default:
      memory: 4096M
    defaultRequest:
      memory: 1024M
    type: Container
---
```
This allows to use this defaults if the user do not declare a memory limit or memory request in the cluster crd.
See:
https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/#if-you-do-not-specify-a-memory-limit

This change will imply to remove the "spec.CheckPodMemory" function. But i think that everything is more intuitive and easy to manage.
Probably i miss something else and what i propose is not suitable, but here is the idea. :-)

## **Tests executed**

**Before modification:**

/usr/bin/go test -timeout 30s github.com/rook/rook/pkg/operator/ceph/spec -run ^(TestCheckPodMemory)$

--- FAIL: TestCheckPodMemory (0.00s)
    /home/jolmomar/go/src/github.com/rook/rook/pkg/operator/ceph/spec/spec_test.go:95: Error case 3: refuse to run the pod with 0mb of ram, provide at least 1024mb.
FAIL
FAIL	github.com/rook/rook/pkg/operator/ceph/spec	0.030s
Error: Tests failed.

**After modification:**

/usr/bin/go test -timeout 30s github.com/rook/rook/pkg/operator/ceph/spec -run ^(TestCheckPodMemory)$

ok  	github.com/rook/rook/pkg/operator/ceph/spec	(cached)
Success: Tests passed.


**Manual test:**
Creating a cluster and using only the memory request for the mons and managers in the crd:

cluster.yaml

```
...
mgr:
  requests:
    cpu: "500m"
    memory: "10Mi"
# The above example requests/limits can also be added to the mon and osd components
mon:
  requests:
    cpu: "50m"
    memory: "10Mi"
...

```


Resolves #3564

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

Signed-off-by: Juan Miguel Olmo Martínez jolmomar@redhat.com