### PR TITLE
Documentation(Ceph) Improve update 0.9 to 1.0 docs

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -272,8 +272,7 @@ Instead of changing the port, the recommended process is to failover the mons,
 which will create new mons on port 6789. While the operator will automate most of this process, there are
 several steps required to induce the operator to failover a mon.
 1. Cause the mon to fail by setting the replicas on the mon deployment to zero. For example, if your mon is named `mon-a`:
-   - `kubectl -n rook-ceph edit deploy rook-ceph-mon-a`
-1. Find the line with `replicas: 1` and change it to `replicas: 0`. Save the change and exit the editor.
+   - `kubectl -n $ROOK_NAMESPACE scale deploy rook-ceph-mon-a --replicas=0`
 1. Wait for 5-10 minutes for the operator to fail over the mon. You will see messages in the operator log that the mon is down and will be failed over after a timeout.
 The length of the timeout is dependent on the setting `ROOK_MON_OUT_INTERVAL` in the Rook operator deployment (operator.yaml).
 1. After the timeout, a new mon will be started and the old mon deployment will be automatically removed.


### PR DESCRIPTION
 - Changed an instruction that used vi to a kubectl scale command

Signed-off-by: Danilo Riecken P. de Morais <danilo.riecken@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Minor improvement that reduces the time to execute the update by eliminating one step that uses vi.
Also uses the shell variable as the rest of the document.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]