### PR TITLE
ceph: add per OSD custom deviceClass support

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -13,6 +13,7 @@ an example usage
 - Provisioning will fail if the user specifies a `metadataDevice` but that device is not used as a metadata device by Ceph.
 - Allow `metadataDevice` to be set per OSD device in the device specific `config` section.
 - [YugabyteDB](https://www.yugabyte.com/) is now supported by Rook with a new operator. You can deploy, configure and manage instances of this high-performance distributed SQL database. Create an instance of the new `ybcluster.yugabytedb.rook.io` custom resource to easily deploy a cluster of YugabyteDB Database. Checkout its [user guide](Documentation/yugabytedb.md) to get started with YugabyteDB.
+- Added `deviceClass` to the per OSD device specific `config` section for setting custom crush device class per OSD..
 
 ### Ceph
 

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -275,9 +275,9 @@ func commonOSDInit(cmd *cobra.Command) {
 // Parse the devices, which are comma separated. A colon indicates a non-default number of osds per device
 // or a non collocated metadata device.
 // For example, one osd will be created on each of sda and sdb, with 5 osds on the nvme01 device.
-//   sda:1,sdb:1,nvme01:5
+//   sda:1:,sdb:1:,nvme01:5:
 // For example, 3 osds will use sdb SSD for db and 3 osds will use sdc SSD for db.
-//   sdd:1:sdb,sde:1:sdb,sdf:1:sdb,sdg:1:sdc,sdh:1:sdc,sdi:1:sdc
+//   sdd:1::sdb,sde:1::sdb,sdf:1::sdb,sdg:1::sdc,sdh:1::sdc,sdi:1::sdc
 func parseDevices(devices string) ([]osddaemon.DesiredDevice, error) {
 	var result []osddaemon.DesiredDevice
 	parsed := strings.Split(devices, ",")
@@ -294,8 +294,11 @@ func parseDevices(devices string) ([]osddaemon.DesiredDevice, error) {
 			}
 			d.OSDsPerDevice = count
 		}
-		if len(parts) > 2 {
-			d.MetadataDevice = parts[2]
+		if len(parts) > 2 && parts[2] != "" {
+			d.DeviceClass = parts[2]
+		}
+		if len(parts) > 3 {
+			d.MetadataDevice = parts[3]
 		}
 		result = append(result, d)
 	}

--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -49,8 +49,8 @@ func TestParseDesiredDevices(t *testing.T) {
 	assert.Nil(t, result)
 	assert.NotNil(t, err)
 
-	// metadataDevice and OSDsPerDevice
-	devices = "sdd:1:sdb,sde:1:sdb,sdf:1:sdc,sdg:1:sdc"
+	// metadataDevice, deviceClass and OSDsPerDevice
+	devices = "sdd:1::sdb,sde:1::sdb,sdf:1::sdc,sdg:1:tst:sdc"
 	result, err = parseDevices(devices)
 	assert.Equal(t, "sdd", result[0].Name)
 	assert.Equal(t, "sde", result[1].Name)
@@ -60,6 +60,10 @@ func TestParseDesiredDevices(t *testing.T) {
 	assert.Equal(t, 1, result[1].OSDsPerDevice)
 	assert.Equal(t, 1, result[2].OSDsPerDevice)
 	assert.Equal(t, 1, result[3].OSDsPerDevice)
+	assert.Equal(t, "", result[0].DeviceClass)
+	assert.Equal(t, "", result[1].DeviceClass)
+	assert.Equal(t, "", result[2].DeviceClass)
+	assert.Equal(t, "tst", result[3].DeviceClass)
 	assert.Equal(t, "sdb", result[0].MetadataDevice)
 	assert.Equal(t, "sdb", result[1].MetadataDevice)
 	assert.Equal(t, "sdc", result[2].MetadataDevice)

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -76,6 +76,7 @@ type DesiredDevice struct {
 	Name           string
 	OSDsPerDevice  int
 	MetadataDevice string
+	DeviceClass    string
 	IsFilter       bool
 }
 

--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -44,6 +44,7 @@ const (
 	OSDsPerDeviceKey   = "osdsPerDevice"
 	EncryptedDeviceKey = "encryptedDevice"
 	MetadataDeviceKey  = "metadataDevice"
+	DeviceClassKey     = "deviceClass"
 )
 
 type StoreConfig struct {
@@ -53,6 +54,7 @@ type StoreConfig struct {
 	JournalSizeMB   int    `json:"journalSizeMB,omitempty"`
 	OSDsPerDevice   int    `json:"osdsPerDevice,omitempty"`
 	EncryptedDevice bool   `json:"encryptedDevice,omitempty"`
+	DeviceClass     string `json:"deviceClass,omitempty"`
 }
 
 func ToStoreConfig(config map[string]string) StoreConfig {
@@ -71,6 +73,8 @@ func ToStoreConfig(config map[string]string) StoreConfig {
 			storeConfig.OSDsPerDevice = convertToIntIgnoreErr(v)
 		case EncryptedDeviceKey:
 			storeConfig.EncryptedDevice = (v == "true")
+		case DeviceClassKey:
+			storeConfig.DeviceClass = v
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -549,6 +549,12 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 			} else {
 				devSuffix += ":1"
 			}
+			if deviceClass, ok := device.Config[config.DeviceClassKey]; ok {
+				logger.Infof("osd %s requested with deviceClass %s (node %s)", device.Name, deviceClass, osdProps.crushHostname)
+				devSuffix += ":" + deviceClass
+			} else {
+				devSuffix += ":"
+			}
 			if md, ok := device.Config[config.MetadataDeviceKey]; ok {
 				logger.Infof("osd %s requested with metadataDevice %s (node %s)", device.Name, md, osdProps.crushHostname)
 				devSuffix += ":" + md


### PR DESCRIPTION
Signed-off-by: Michael Vollman <michael.b.vollman@gmail.com>

**Description of your changes:**
Add deviceClass as a per OSD config option under
storage/nodes/devices/config for setting a custom crush device class
per OSD.

Example CRD:
```
  storage:
    nodes:
    - name: "ceph001"
      devices:
      - name: "sdc"
        config:
          deviceClass: "tst"
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
