### PR TITLE
ceph: fix monitor pvc storage on ebs

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -670,6 +670,7 @@ func (c *Cluster) startMon(m *monConfig, hostname string) error {
 	if pvcExists || (!deploymentExists && c.spec.Mon.VolumeClaimTemplate != nil) {
 		pvcName := m.ResourceName
 		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, opspec.DaemonVolumesDataPVC(pvcName))
+		opspec.AddVolumeMountSubPath(&d.Spec.Template.Spec, "ceph-daemon-data")
 		logger.Debugf("adding pvc volume source %s to mon deployment %s", pvcName, d.Name)
 	} else {
 		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, opspec.DaemonVolumesDataHostPath(m.DataPathMap)...)


### PR DESCRIPTION
**Description of your changes:**

there is a build here for testing `noahdesu/rook-ceph-master-no-lifecycle-e`

1. initializes ownership on files using init container rather than life cycle hook. see commit message for explanation.

2. make sure that pvc file system mount uses empty directory for daemon data

ext4 adds some extra directories in the root, so this PR mounts in a subdirectory.

```
[vm 0 ~]$ oc -n rook-ceph log rook-ceph-mon-a-5cf4748c6-nvmzd -c list-container-data-dir
total 20
drwxrwsr-x. 3 root 1000630000  4096 Aug  8 20:06 .
drwxr-x---. 1 ceph ceph          20 Aug  8 20:06 ..
drwxrwS---. 2 root 1000630000 16384 Aug  8 20:06 lost+found
```

**Which issue is resolved by this Pull Request:**
Resolves #3591 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
