### PR TITLE
ceph: fix osdsPerDevice config

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -541,11 +541,12 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		deviceNames := make([]string, len(osdProps.devices))
 		for i, device := range osdProps.devices {
 			devSuffix := ""
-			count := "1"
 			if count, ok := device.Config[config.OSDsPerDeviceKey]; ok {
 				logger.Infof("%s osds requested on device %s (node %s)", count, device.Name, osdProps.crushHostname)
+				devSuffix += ":" + count
+			} else {
+				devSuffix += ":1"
 			}
-			devSuffix += ":" + count
 			if md, ok := device.Config[config.MetadataDeviceKey]; ok {
 				logger.Infof("osd %s requested with metadataDevice %s (node %s)", device.Name, md, osdProps.crushHostname)
 				devSuffix += ":" + md


### PR DESCRIPTION
Signed-off-by: Michael Vollman <michael.b.vollman@gmail.com>

**Description of your changes:**
Fix variable scoping issue that is ignoring osdsPerDevice config
setting.  Ensure that in all scenarios both the global and per OSD
osdsPerDevice setting are honored.  When both are set the more specific
setting will be used.

**Which issue is resolved by this Pull Request:**
Resolves #3599 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
