### PR TITLE
ceph:pools: polish logic flow a bit in createReplicationCrushRule()

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -248,11 +248,9 @@ func createReplicationCrushRule(context *clusterd.Context, clusterName string, n
 	}
 
 	// set the crush root to the default if not already specified
-	var crushRoot string
+	crushRoot := "default"
 	if newPool.CrushRoot != "" {
 		crushRoot = newPool.CrushRoot
-	} else {
-		crushRoot = "default"
 	}
 	args := []string{"osd", "crush", "rule", "create-replicated", ruleName, crushRoot, failureDomain}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This is not changing the behavior of the code but making the
flow of logic in the createReplicationCrushRule() function consistent
by removing an else branch. This was just a reflex when I was reading
the code.

**Which issue is resolved by this Pull Request:**

Resolves no issue, merely some code hygiene.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary. _(not needed)_
- [x] Unit tests have been added, if necessary. _(not needed: already covered)_
- [x] Integration tests have been added, if necessary. _(not needed)_
- [x] Pending release notes updated with breaking and/or notable changes, if necessary. _(not needed)_
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary. _(not needed)_
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary. _(not needed)_
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments) _(not needed)_
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details. _(not skipping CI)_
