### PR TITLE
tests: do not require actual docker cli

### DIFF
--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -105,7 +105,11 @@ func (k8sh *K8sHelper) MakeContext() *clusterd.Context {
 }
 
 func (k8sh *K8sHelper) GetDockerImage(image string) error {
-	return k8sh.executor.ExecuteCommand(false, "", "docker", "pull", image)
+	dockercmd := os.Getenv("DOCKERCMD")
+	if dockercmd == "" {
+		dockercmd = "docker"
+	}
+	return k8sh.executor.ExecuteCommand(false, "", dockercmd, "pull", image)
 }
 
 // SetDeploymentVersion sets the container version on the deployment. It is assumed to be the rook/ceph image.


### PR DESCRIPTION
**Description of your changes:**

Add an environment variable to the test code such that instead of docker cli being required an equivalent cli tool, such as "podman" can be used instead.
As far as I could see this was the only use of a container runtime tool anywhere else in the test code.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
