### PR TITLE
Integration tests: use 'kubectl apply' vs create

### DIFF
--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -54,7 +54,7 @@ func CreateBlockOperation(k8shelp *utils.K8sHelper, manifests installer.CephMani
 // size - not user for k8s implementation since its descried on the pvc yaml definition
 // Output - k8s create pvc operation output and/or error
 func (b *BlockOperation) Create(manifest string, size int) (string, error) {
-	args := []string{"create", "-f", "-"}
+	args := []string{"apply", "-f", "-"}
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
 		return "", fmt.Errorf("Unable to create block -- : %s", err)
@@ -65,11 +65,11 @@ func (b *BlockOperation) Create(manifest string, size int) (string, error) {
 }
 
 func (b *BlockOperation) CreatePvc(claimName, storageClassName, mode string) error {
-	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
+	return b.k8sClient.ResourceOperation("apply", b.manifests.GetBlockPvcDef(claimName, storageClassName, mode))
 }
 
 func (b *BlockOperation) CreateStorageClass(poolName, storageClassName, reclaimPolicy, namespace string, varClusterName bool) error {
-	return b.k8sClient.ResourceOperation("create", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, varClusterName))
+	return b.k8sClient.ResourceOperation("apply", b.manifests.GetBlockStorageClassDef(poolName, storageClassName, reclaimPolicy, namespace, varClusterName))
 }
 
 func (b *BlockOperation) DeletePvc(claimName, storageClassName, mode string) error {
@@ -139,7 +139,7 @@ func (b *BlockOperation) DeleteBlockImage(image BlockImage, namespace string) er
 // manifest - Pod definition  - pod should be defined to use a pvc that was created earlier
 // Output  - k8s create pod operation output and/or error
 func (b *BlockOperation) BlockMap(manifest string) (string, error) {
-	args := []string{"create", "-f", "-"}
+	args := []string{"apply", "-f", "-"}
 	result, err := b.k8sClient.KubectlWithStdin(manifest, args...)
 	if err != nil {
 		return "", fmt.Errorf("Unable to map block -- : %s", err)

--- a/tests/framework/clients/filesystem.go
+++ b/tests/framework/clients/filesystem.go
@@ -41,7 +41,7 @@ func CreateFilesystemOperation(k8sh *utils.K8sHelper, manifests installer.CephMa
 // Create creates a filesystem in Rook
 func (f *FilesystemOperation) Create(name, namespace string) error {
 	logger.Infof("creating the filesystem via CRD")
-	if err := f.k8sh.ResourceOperation("create", f.manifests.GetFilesystem(namespace, name, 2)); err != nil {
+	if err := f.k8sh.ResourceOperation("apply", f.manifests.GetFilesystem(namespace, name, 2)); err != nil {
 		return err
 	}
 

--- a/tests/framework/clients/nfs.go
+++ b/tests/framework/clients/nfs.go
@@ -41,7 +41,7 @@ func CreateNFSOperation(k8sh *utils.K8sHelper, manifests installer.CephManifests
 func (n *NFSOperation) Create(namespace, name, pool string, daemonCount int) error {
 
 	logger.Infof("creating the NFS daemons via CRD")
-	if err := n.k8sh.ResourceOperation("create", n.manifests.GetNFS(namespace, name, pool, daemonCount)); err != nil {
+	if err := n.k8sh.ResourceOperation("apply", n.manifests.GetNFS(namespace, name, pool, daemonCount)); err != nil {
 		return err
 	}
 

--- a/tests/framework/clients/object.go
+++ b/tests/framework/clients/object.go
@@ -43,7 +43,7 @@ func CreateObjectOperation(k8sh *utils.K8sHelper, manifests installer.CephManife
 func (o *ObjectOperation) Create(namespace, storeName string, replicaCount int32) error {
 
 	logger.Infof("creating the object store via CRD")
-	if err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStore(namespace, storeName, int(replicaCount), rgwPort)); err != nil {
+	if err := o.k8sh.ResourceOperation("apply", o.manifests.GetObjectStore(namespace, storeName, int(replicaCount), rgwPort)); err != nil {
 		return err
 	}
 

--- a/tests/framework/clients/object_user.go
+++ b/tests/framework/clients/object_user.go
@@ -18,11 +18,11 @@ package clients
 
 import (
 	"fmt"
+	"strings"
 
 	rgw "github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
-	"strings"
 )
 
 // ObjectUserOperation is wrapper for k8s rook object user operations
@@ -66,7 +66,7 @@ func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, u
 func (o *ObjectUserOperation) Create(namespace string, userid string, displayName string, store string) error {
 
 	logger.Infof("creating the object store user via CRD")
-	if err := o.k8sh.ResourceOperation("create", o.manifests.GetObjectStoreUser(namespace, userid, displayName, store)); err != nil {
+	if err := o.k8sh.ResourceOperation("apply", o.manifests.GetObjectStoreUser(namespace, userid, displayName, store)); err != nil {
 		return err
 	}
 	return nil

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -40,7 +40,7 @@ func CreatePoolOperation(k8sh *utils.K8sHelper, manifests installer.CephManifest
 }
 
 func (p *PoolOperation) Create(name, namespace string, replicas int) error {
-	return p.createOrUpdatePool(name, namespace, "create", replicas)
+	return p.createOrUpdatePool(name, namespace, "apply", replicas)
 }
 
 func (p *PoolOperation) Delete(name string, namespace string) error {
@@ -110,7 +110,7 @@ func (p *PoolOperation) CephPoolExists(namespace, name string) (bool, error) {
 }
 
 func (p *PoolOperation) CreateStorageClassAndPvc(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode string) error {
-	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
+	return p.k8sh.ResourceOperation("apply", p.manifests.GetBlockPoolStorageClassAndPvcDef(namespace, poolName, storageClassName, reclaimPolicy, blockName, mode))
 }
 
 func (p *PoolOperation) DeleteStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) error {
@@ -129,5 +129,5 @@ func (p *PoolOperation) DeletePvc(blockName, storageClassName, mode string) erro
 }
 
 func (p *PoolOperation) CreateStorageClass(namespace, poolName, storageClassName, reclaimPolicy string) error {
-	return p.k8sh.ResourceOperation("create", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
+	return p.k8sh.ResourceOperation("apply", p.manifests.GetBlockPoolStorageClass(namespace, poolName, storageClassName, reclaimPolicy))
 }

--- a/tests/framework/clients/read_write.go
+++ b/tests/framework/clients/read_write.go
@@ -38,7 +38,7 @@ func (f *ReadWriteOperation) CreateWriteClient(volName string) ([]string, error)
 	logger.Infof("creating the filesystem via replication controller")
 	writerSpec := getDeployment(volName)
 
-	if err := f.k8sh.ResourceOperation("create", writerSpec); err != nil {
+	if err := f.k8sh.ResourceOperation("apply", writerSpec); err != nil {
 		return nil, err
 	}
 

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -48,7 +48,7 @@ var (
 	createBaseTestDir = true
 	// ** end of Variables to modify
 	logger              = capnslog.NewPackageLogger("github.com/rook/rook", "installer")
-	createArgs          = []string{"create", "-f"}
+	createArgs          = []string{"apply", "-f"}
 	createFromStdinArgs = append(createArgs, "-")
 	deleteArgs          = []string{"delete", "-f"}
 	deleteFromStdinArgs = append(deleteArgs, "-")

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -1315,7 +1315,7 @@ spec:
   sessionAffinity: None
   type: NodePort
 `
-	_, err := k8sh.KubectlWithStdin(externalSvc, []string{"create", "-f", "-"}...)
+	_, err := k8sh.KubectlWithStdin(externalSvc, []string{"apply", "-f", "-"}...)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create external service. %+v", err)
 	}

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -61,7 +61,7 @@ func testNFSDaemons(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.S
 }
 
 func createFilesystemConsumerPod(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
-	mtfsErr := podWithFilesystem(k8sh, s, filePodName, namespace, filesystemName, "create", getFilesystemTestPod)
+	mtfsErr := podWithFilesystem(k8sh, s, filePodName, namespace, filesystemName, "apply", getFilesystemTestPod)
 	require.Nil(s.T(), mtfsErr)
 	filePodRunning := k8sh.IsPodRunning(filePodName, namespace)
 	if !filePodRunning {

--- a/tests/integration/ceph_block_create_test.go
+++ b/tests/integration/ceph_block_create_test.go
@@ -97,53 +97,6 @@ func (s *BlockCreateSuite) TestCreatingPVCWithVariousAccessModes() {
 	s.CheckCreatingPVC("rox", "ReadOnlyMany")
 }
 
-// Test case when persistentvolumeclaim is created for a valid storage class twice
-func (s *BlockCreateSuite) TestCreateSamePVCTwice() {
-	logger.Infof("Test creating PVC(create block images) twice")
-	claimName := "test-twice-claim"
-	poolName := "test-twice-pool"
-	storageClassName := "rook-ceph-block"
-	reclaimPolicy := "Delete"
-	defer s.tearDownTest(claimName, poolName, storageClassName, reclaimPolicy, "ReadWriteOnce")
-	status, _ := s.kh.GetPVCStatus(defaultNamespace, claimName)
-	logger.Infof("PVC %s status: %s", claimName, status)
-	s.testClient.BlockClient.List(s.namespace)
-
-	logger.Infof("create pool and storageclass")
-	err := s.testClient.PoolClient.Create(poolName, s.namespace, 1)
-	require.NoError(s.T(), err)
-
-	err = s.testClient.BlockClient.CreateStorageClass(poolName, storageClassName, reclaimPolicy, s.namespace, true)
-	require.NoError(s.T(), err)
-
-	logger.Infof("make sure storageclass is created")
-	err = s.kh.IsStorageClassPresent("rook-ceph-block")
-	require.Nil(s.T(), err)
-
-	logger.Infof("create pvc")
-	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	require.NoError(s.T(), err)
-
-	logger.Infof("check status of PVC")
-	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
-
-	b1, err := s.testClient.BlockClient.List(s.namespace)
-	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), s.initBlockCount+1, len(b1), "Make sure new block image is created")
-
-	logger.Infof("Create same pvc again and expect an error")
-	err = s.testClient.BlockClient.CreatePvc(claimName, storageClassName, "ReadWriteOnce")
-	assert.NotNil(s.T(), err)
-
-	logger.Infof("check status of PVC")
-	require.True(s.T(), s.kh.WaitUntilPVCIsBound(defaultNamespace, claimName))
-
-	logger.Infof("check block image count")
-	b2, _ := s.testClient.BlockClient.List(s.namespace)
-	assert.Equal(s.T(), len(b1), len(b2), "Make sure new block image is created")
-
-}
-
 func (s *BlockCreateSuite) TestBlockStorageMountUnMountForStatefulSets() {
 	poolName := "stspool"
 	storageClassName := "stssc"

--- a/tests/integration/ceph_csi_test.go
+++ b/tests/integration/ceph_csi_test.go
@@ -203,7 +203,7 @@ spec:
        readOnly: false
   restartPolicy: Never
 `
-	err := k8sh.ResourceOperation("create", pod)
+	err := k8sh.ResourceOperation("apply", pod)
 	require.Nil(s.T(), err)
 	isPodRunning := k8sh.IsPodRunning(csiTestRBDPodName, namespace)
 	if !isPodRunning {
@@ -256,7 +256,7 @@ spec:
        readOnly: false
   restartPolicy: Never
 `
-	err := k8sh.ResourceOperation("create", pod)
+	err := k8sh.ResourceOperation("apply", pod)
 	require.Nil(s.T(), err)
 	isPodRunning := k8sh.IsPodRunning(csiTestCephFSPodName, namespace)
 	if !isPodRunning {

--- a/tests/integration/ceph_filesystem_mountuser_test.go
+++ b/tests/integration/ceph_filesystem_mountuser_test.go
@@ -98,7 +98,7 @@ func createFilesystemMountCephCredentials(helper *clients.TestClient, k8sh *util
 }
 
 func createFilesystemMountUserConsumerPod(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string, filesystemName string) {
-	mtfsErr := podWithFilesystem(k8sh, s, fileMountUserPodName, namespace, filesystemName, "create", getFilesystemMountUserTestPod)
+	mtfsErr := podWithFilesystem(k8sh, s, fileMountUserPodName, namespace, filesystemName, "apply", getFilesystemMountUserTestPod)
 	require.Nil(s.T(), mtfsErr)
 	filePodRunning := k8sh.IsPodRunning(fileMountUserPodName, namespace)
 	if !filePodRunning {

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -215,5 +215,5 @@ subjects:
 ---
 `
 	logger.Infof("creating the new resources that have been added since 1.0")
-	return s.k8sh.ResourceOperation("create", newResources)
+	return s.k8sh.ResourceOperation("apply", newResources)
 }

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -41,7 +41,7 @@ func createPVCAndMountMysqlPod(t func() *testing.T, kh *utils.K8sHelper, storage
 	if _, err := kh.GetPVCStatus(defaultNamespace, pvcName); err != nil {
 		logger.Infof("Create PVC")
 
-		mySqlPodOperation(kh, storageClassName, appName, appLabel, pvcName, "create")
+		mySqlPodOperation(kh, storageClassName, appName, appLabel, pvcName, "apply")
 
 		// Wait till mysql pod is up
 		require.True(t(), kh.IsPodInExpectedState(appLabel, "", "Running"))

--- a/tests/longhaul/block_with_fencing_test.go
+++ b/tests/longhaul/block_with_fencing_test.go
@@ -63,7 +63,7 @@ func (s *BlockLongHaulSuiteWithFencing) SetupSuite() {
 		logger.Infof("Creating PVC and mounting it to pod with readOnly set to false")
 		err = s.testClient.BlockClient.CreatePvc("block-pv-one", "rook-ceph-block", "ReadWriteOnce")
 		require.Nil(s.T(), err)
-		mountUnmountPVCOnPod(s.kh, "block-rw", "block-pv-one", "false", "create")
+		mountUnmountPVCOnPod(s.kh, "block-rw", "block-pv-one", "false", "apply")
 		require.True(s.T(), s.kh.IsPodRunning("block-rw", defaultNamespace))
 
 		filename := "longhaul"
@@ -87,7 +87,7 @@ func (s *BlockLongHaulSuiteWithFencing) TestBlockWithFencingLonghaulRun() {
 
 func blockVolumeFencingOperations(s *BlockLongHaulSuiteWithFencing, wg *sync.WaitGroup, podName string, pvcName string) {
 	defer wg.Done()
-	mountUnmountPVCOnPod(s.kh, podName, pvcName, "true", "create")
+	mountUnmountPVCOnPod(s.kh, podName, pvcName, "true", "apply")
 	require.True(s.T(), s.kh.IsPodRunning(podName, defaultNamespace))
 	message := "this is long running test"
 	require.Nil(s.T(), s.kh.ReadFromPod("default", podName, "longhaul", message))


### PR DESCRIPTION
Some integration tests fail due to resources from a previous integration
run not being cleaned up properly. Instead of using 'kubectl create' --
which fails with an error if the resource already exists -- to create
resources, use 'kubectl apply' -- which does not fail for pre-existing
resources. 'kubectl apply' will give a warning that it should be used to
apply changes to resources created with 'create' or 'apply', but there
is no error.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
