### PR TITLE
Update example pvc.yaml to reflect name of example rdb storageclass

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/rbd/pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: csi-rbd
+  storageClassName: rook-ceph-block


### PR DESCRIPTION
**Description of your changes:**

The ceph rbd pvc example points to a storageclass that doesn't match the name in the example storageclass manifests. This causes the rbd example manifests for the pod and pvc fail. 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]