### PR TITLE
Backport: Set correct name of OwnerReferences to avoid unexpected garbage collection

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -67,7 +67,7 @@ type childController interface {
 }
 
 func newCluster(c *cephv1.CephCluster, context *clusterd.Context) *cluster {
-	ownerRef := ClusterOwnerRef(c.Namespace, string(c.UID))
+	ownerRef := ClusterOwnerRef(c.Name, string(c.UID))
 	return &cluster{
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -811,12 +811,12 @@ func (c *ClusterController) updateClusterStatus(namespace, name string, state ce
 	return nil
 }
 
-func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
+func ClusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
-		Name:               namespace,
+		Name:               clusterName,
 		UID:                types.UID(clusterID),
 		BlockOwnerDeletion: &blockOwner,
 	}

--- a/pkg/operator/edgefs/cluster/cluster.go
+++ b/pkg/operator/edgefs/cluster/cluster.go
@@ -65,7 +65,7 @@ func newCluster(c *edgefsv1beta1.Cluster, context *clusterd.Context) *cluster {
 		Namespace: c.Namespace,
 		Spec:      c.Spec,
 		stopCh:    make(chan struct{}),
-		ownerRef:  ClusterOwnerRef(c.Namespace, string(c.UID)),
+		ownerRef:  ClusterOwnerRef(c.Name, string(c.UID)),
 	}
 }
 

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -84,12 +84,12 @@ func NewClusterController(context *clusterd.Context, containerImage string) *Clu
 	}
 }
 
-func ClusterOwnerRef(namespace, clusterID string) metav1.OwnerReference {
+func ClusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
-		Name:               namespace,
+		Name:               clusterName,
 		UID:                types.UID(clusterID),
 		BlockOwnerDeletion: &blockOwner,
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the CephCluster `name` is different from the `namespace`, the K8s garbage collector will delete resources unexpectedly when it is rebuilding its GC info. See #3530 for more details.

By default the name and namespace are both `rook-ceph`, so this is only an issue if one of those was changed).

**Which issue is resolved by this Pull Request:**
Resolves #3575 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
