### PR TITLE
doc: document csi naming "prefix" as the rook operator namespace

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -45,7 +45,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-block
-provisioner: rbd.csi.ceph.com
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
     # clusterID is the namespace where the rook cluster is running
     clusterID: rook-ceph
@@ -59,6 +60,11 @@ parameters:
 # Delete the rbd volume when a PVC is deleted
 reclaimPolicy: Delete
 ```
+
+If you've deployed the Rook operator in a namespace other than "rook-ceph"
+as is common change the prefix in the provisioner to match the namespace
+you used. For example, if the Rook operator is running in "rook-op" the
+provisioner value should be "rook-op.rbd.csi.ceph.com".
 
 Create the storage class.
 ```bash

--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -86,7 +86,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
-provisioner: cephfs.csi.ceph.com
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   # clusterID is the namespace where operator is deployed.
   clusterID: rook-ceph
@@ -111,6 +112,11 @@ parameters:
 
 reclaimPolicy: Delete
 ```
+
+If you've deployed the Rook operator in a namespace other than "rook-ceph"
+as is common change the prefix in the provisioner to match the namespace
+you used. For example, if the Rook operator is running in "rook-op" the
+provisioner value should be "rook-op.rbd.csi.ceph.com".
 
 Create the storage class.
 ```bash


### PR DESCRIPTION
**Description of your changes:**

Update the rbd and cephfs docs to include the new prefixed style
of name for the rook-managed csi instances. Document that this
prefix must match the namespace the rook operator is deployed in.

**Which issue is resolved by this Pull Request:**
Resolves #3617

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]