### PR TITLE
ceph: Use secretfile to pass secret key to cephfs mount (#2123)

### DIFF
--- a/cmd/rookflex/cmd/mount.go
+++ b/cmd/rookflex/cmd/mount.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
+	"github.com/rook/rook/pkg/util"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/version"
 	k8smount "k8s.io/kubernetes/pkg/util/mount"
@@ -235,9 +236,16 @@ func mountCephFS(client *rpc.Client, opts *flexvolume.AttachOptions) error {
 		}
 	}
 
+	// write secret key to temporary file
+	secretfile, err := util.CreateTempFile(clientAccessInfo.SecretKey)
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %+v", err)
+	}
+	defer os.Remove(secretfile)
+
 	options := []string{
 		fmt.Sprintf("name=%s", clientAccessInfo.UserName),
-		fmt.Sprintf("secret=%s", clientAccessInfo.SecretKey),
+		fmt.Sprintf("secretfile=%s", secretfile),
 	}
 
 	// Get kernel version

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -48,3 +48,26 @@ func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 
 	logger.Infof("Config file %s:\n%s", path, string(contents))
 }
+
+// CreateTempFile creates a temporary file and writes
+// the given contents into the file.
+// The name of the file is returned by the function.
+// It is the callers responsibility to remove the file when no
+// longer needed.
+func CreateTempFile(contents string) (string, error) {
+	tmpfile, err := ioutil.TempFile("", "rook")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary file: %+v", err)
+	}
+	name := tmpfile.Name()
+	if _, err := tmpfile.WriteString(contents); err != nil {
+		_ = tmpfile.Close()
+		_ = os.Remove(name)
+		return "", fmt.Errorf("failed to write contents to temporary file: %+v", err)
+	}
+	if err = tmpfile.Close(); err != nil {
+		_ = os.Remove(name)
+		return "", fmt.Errorf("failed to sync write to temporary file: %+v", err)
+	}
+	return name, nil
+}

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTempFile(t *testing.T) {
+	name, err := CreateTempFile("hello world")
+	if assert.NoError(t, err) {
+		assert.NotEqual(t, "", name, "the created file should have a name")
+		b, err := ioutil.ReadFile(name)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "hello world", string(b))
+		}
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

Pass the secret key to mount in a temporary file
to avoid leaking the secret to logs if the mount
fails.

**Which issue is resolved by this Pull Request:**
Resolves #2123

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
