### PR TITLE
Rook-Ceph CSV templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,6 @@ distclean: go.distclean clean
 prune:
 	@$(MAKE) -C images prune
 
-generate-csv-ceph-template:
-	@cluster/olm/ceph/generate-rook-csv-templates.sh
-
 csv-ceph:
 	@cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,9 @@ distclean: go.distclean clean
 prune:
 	@$(MAKE) -C images prune
 
+generate-csv-ceph-template:
+	@cluster/olm/ceph/generate-rook-csv-templates.sh
+
 csv-ceph:
 	@cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)
 

--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+export OLM_SKIP_PKG_FILE_GEN="true"
+
+OLM_CATALOG_DIR=cluster/olm/ceph
+DEPLOY_DIR="$OLM_CATALOG_DIR/deploy"
+CRDS_DIR="$DEPLOY_DIR/crds"
+
+TMP_CSV_GEN_FILE="$OLM_CATALOG_DIR/deploy/olm-catalog/rook-ceph.v9999.9999.9999.clusterserviceversion.yaml"
+TEMPLATES_DIR="$OLM_CATALOG_DIR/templates"
+
+function generate_template() {
+    local provider=$1
+
+    local csv_template_file="$TEMPLATES_DIR/rook-ceph-${provider}.vVERSION.clusterserviceversion.yaml.in"
+
+    # v9999.9999.9999 is just a placeholder. operator-sdk requires valid semver here.
+    (cluster/olm/ceph/generate-rook-csv.sh "9999.9999.9999" $provider "{{.RookOperatorImage}}")
+    mv $TMP_CSV_GEN_FILE $csv_template_file
+
+    # replace the placeholder with the templated value
+    sed -i "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g"  $csv_template_file
+}
+
+# start clean
+rm -f $TMP_CSV_GEN_FILE
+if [ -d $TEMPLATES_DIR ]; then
+    rm -rf $TEMPLATES_DIR
+fi
+mkdir -p $TEMPLATES_DIR
+
+generate_template "ocp"
+generate_template "k8s"
+
+cp -R $CRDS_DIR $TEMPLATES_DIR/

--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -26,7 +26,7 @@ function generate_template() {
     mv $TMP_CSV_GEN_FILE $csv_template_file
 
     # replace the placeholder with the templated value
-    sed -i "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g"  $csv_template_file
+    sed -i "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
 }
 
 # start clean

--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -3,6 +3,12 @@ set -e
 
 export OLM_SKIP_PKG_FILE_GEN="true"
 
+if [ -f "Dockerfile" ]; then
+    # if this is being executed from the images/ceph/ dir,
+    # back out to the source dir
+    cd ../../
+fi
+
 OLM_CATALOG_DIR=cluster/olm/ceph
 DEPLOY_DIR="$OLM_CATALOG_DIR/deploy"
 CRDS_DIR="$DEPLOY_DIR/crds"

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -13,6 +13,7 @@ PACKAGE_FILE="$OLM_CATALOG_DIR/assemble/rook-ceph.package.yaml"
 SUPPORTED_PLATFORMS='k8s|ocp'
 
 operator_sdk="${OPERATOR_SDK:-operator-sdk}"
+yq="${YQ_TOOL:-yq}"
 
 ##########
 # CHECKS #
@@ -23,7 +24,7 @@ if [ ! command -v operator-sdk &>/dev/null ] && [ ! -f $operator_sdk ]; then
     exit 1
 fi
 
-if ! command -v yq &>/dev/null; then
+if [ ! command -v yq &>/dev/null ] && [ ! -f $yq ]; then
     echo "yq is not installed"
     echo "follow instructions here: https://github.com/mikefarah/yq#install"
     exit 1
@@ -77,10 +78,10 @@ fi
 #############
 # VARIABLES #
 #############
-YQ_CMD_DELETE=(yq delete -i)
-YQ_CMD_MERGE_OVERWRITE=(yq merge --inplace --overwrite --append)
-YQ_CMD_MERGE=(yq merge --inplace --append)
-YQ_CMD_WRITE=(yq write --inplace)
+YQ_CMD_DELETE=($yq delete -i)
+YQ_CMD_MERGE_OVERWRITE=($yq merge --inplace --overwrite --append)
+YQ_CMD_MERGE=($yq merge --inplace --append)
+YQ_CMD_WRITE=($yq write --inplace)
 OP_SDK_CMD=($operator_sdk olm-catalog gen-csv --csv-version)
 OPERATOR_YAML_FILE_K8S="cluster/examples/kubernetes/ceph/operator.yaml"
 OPERATOR_YAML_FILE_OCP="cluster/examples/kubernetes/ceph/operator-openshift.yaml"

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -12,11 +12,13 @@ ASSEMBLE_FILE_OCP="$OLM_CATALOG_DIR/assemble/metadata-openshift.yaml"
 PACKAGE_FILE="$OLM_CATALOG_DIR/assemble/rook-ceph.package.yaml"
 SUPPORTED_PLATFORMS='k8s|ocp'
 
+operator_sdk="${OPERATOR_SDK:-operator-sdk}"
+
 ##########
 # CHECKS #
 ##########
-if ! command -v operator-sdk &>/dev/null; then
-    echo "operator-sdk is not installed"
+if [ ! command -v operator-sdk &>/dev/null ] && [ ! -f $operator_sdk ]; then
+    echo "operator-sdk is not installed $operator_sdk"
     echo "follow instructions here: https://github.com/operator-framework/operator-sdk/#quick-start"
     exit 1
 fi
@@ -79,7 +81,7 @@ YQ_CMD_DELETE=(yq delete -i)
 YQ_CMD_MERGE_OVERWRITE=(yq merge --inplace --overwrite --append)
 YQ_CMD_MERGE=(yq merge --inplace --append)
 YQ_CMD_WRITE=(yq write --inplace)
-OP_SDK_CMD=(operator-sdk olm-catalog gen-csv --csv-version)
+OP_SDK_CMD=($operator_sdk olm-catalog gen-csv --csv-version)
 OPERATOR_YAML_FILE_K8S="cluster/examples/kubernetes/ceph/operator.yaml"
 OPERATOR_YAML_FILE_OCP="cluster/examples/kubernetes/ceph/operator-openshift.yaml"
 COMMON_YAML_FILE="cluster/examples/kubernetes/ceph/common.yaml"

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -203,7 +203,9 @@ generate_service_account_yaml
 generate_crds_yaml
 generate_csv "$@"
 hack_csv
-generate_package
+if [ -z "${OLM_SKIP_PKG_FILE_GEN}" ]; then
+    generate_package
+fi
 apply_rook_op_img
 cleanup
 

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -76,7 +76,8 @@ fi
 # VARIABLES #
 #############
 YQ_CMD_DELETE=(yq delete -i)
-YQ_CMD_MERGE=(yq merge --inplace --overwrite --append)
+YQ_CMD_MERGE_OVERWRITE=(yq merge --inplace --overwrite --append)
+YQ_CMD_MERGE=(yq merge --inplace --append)
 YQ_CMD_WRITE=(yq write --inplace)
 OP_SDK_CMD=(operator-sdk olm-catalog gen-csv --csv-version)
 OPERATOR_YAML_FILE_K8S="cluster/examples/kubernetes/ceph/operator.yaml"
@@ -108,10 +109,10 @@ function generate_csv(){
     "${OP_SDK_CMD[@]}" "$VERSION"
     popd &> /dev/null
     mv "$DEFAULT_CSV_FILE_NAME" "$DESIRED_CSV_FILE_NAME"
-    "${YQ_CMD_MERGE[@]}" "$DESIRED_CSV_FILE_NAME" "$ASSEMBLE_FILE_COMMON"
+    "${YQ_CMD_MERGE_OVERWRITE[@]}" "$DESIRED_CSV_FILE_NAME" "$ASSEMBLE_FILE_COMMON"
 
     if [[ "$PLATFORM" == "k8s" ]]; then
-        "${YQ_CMD_MERGE[@]}" "$DESIRED_CSV_FILE_NAME" "$ASSEMBLE_FILE_K8S"
+        "${YQ_CMD_MERGE_OVERWRITE[@]}" "$DESIRED_CSV_FILE_NAME" "$ASSEMBLE_FILE_K8S"
         "${YQ_CMD_WRITE[@]}" "$DESIRED_CSV_FILE_NAME" metadata.name "rook-ceph.v${VERSION}"
         "${YQ_CMD_WRITE[@]}" "$DESIRED_CSV_FILE_NAME" spec.displayName "Rook-Ceph"
         "${YQ_CMD_WRITE[@]}" "$DESIRED_CSV_FILE_NAME" metadata.annotations.createdAt "$(date +"%Y-%m-%dT%H-%M-%SZ")"

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -25,5 +25,6 @@ RUN curl --fail -sSL -o /tini https://github.com/krallin/tini/releases/download/
 COPY rook rookflex toolbox.sh /usr/local/bin/
 COPY ceph-csi /etc/ceph-csi
 COPY ceph-monitoring /etc/ceph-monitoring
+COPY ceph-csv-templates /etc/ceph-csv-templates
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
 CMD [""]

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -20,8 +20,24 @@ include ../image.mk
 CEPH_VERSION = v14.2.2-20190722
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
+OPERATOR_SDK_VERSION = v0.10.0
 
 TEMP := $(shell mktemp -d)
+
+ifeq ($(HOST_PLATFORM),linux_amd64)
+OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
+endif
+ifeq ($(PLATFORM),linux_arm64)
+# host os not supported
+endif
+ifeq ($(PLATFORM),darwin_amd64)
+OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
+endif
+ifeq ($(PLATFORM),windows_amd64)
+# host os not supported
+endif
+
+OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) 
 
 # ====================================================================================
 # Build Rook
@@ -34,7 +50,12 @@ do.build: generate-csv-ceph-templates
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
 	@cp -r ../../cluster/examples/kubernetes/ceph/csi/template $(TEMP)/ceph-csi
 	@cp -r ../../cluster/examples/kubernetes/ceph/monitoring $(TEMP)/ceph-monitoring
-	@cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates
+	# for the CSV templates, we ignore host platforms the operator-sdk doesn't support
+	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+		cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates;\
+	else\
+		mkdir $(TEMP)/ceph-csv-templates;\
+	fi
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
@@ -43,6 +64,14 @@ do.build: generate-csv-ceph-templates
 		$(TEMP)
 	@rm -fr $(TEMP)
 
-generate-csv-ceph-templates:
-	@../../cluster/olm/ceph/generate-rook-csv-templates.sh
+generate-csv-ceph-templates: $(OPERATOR_SDK)
+	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+		OPERATOR_SDK=$(OPERATOR_SDK) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
+	fi
+
+$(OPERATOR_SDK):
+	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+		curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM) -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION);\
+		chmod +x $(OPERATOR_SDK);\
+        fi
 

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -27,9 +27,7 @@ TEMP := $(shell mktemp -d)
 
 ifeq ($(HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
-endif
-ifeq ($(HOST_PLATFORM),darwin_amd64)
-OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
+INCLUDE_CSV_TEMPLATES = true
 endif
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) 
@@ -46,8 +44,7 @@ do.build: generate-csv-ceph-templates
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
 	@cp -r ../../cluster/examples/kubernetes/ceph/csi/template $(TEMP)/ceph-csi
 	@cp -r ../../cluster/examples/kubernetes/ceph/monitoring $(TEMP)/ceph-monitoring
-	# Copy temlated csv manifest only if operator-sdk is supported for the host platform.
-	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates;\
 	else\
 		mkdir $(TEMP)/ceph-csv-templates;\
@@ -61,18 +58,20 @@ do.build: generate-csv-ceph-templates
 	@rm -fr $(TEMP)
 
 generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
-	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		OPERATOR_SDK=$(OPERATOR_SDK) YQ_TOOL=$(YQ) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
 	fi
 
 $(YQ):
-	@echo === installing yq $(GOHOST)
-	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get gopkg.in/mikefarah/yq.v2
-	@rm -fr $(TOOLS_HOST_DIR)/tmp
+	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
+		echo === installing yq $(GOHOST);\
+		mkdir -p $(TOOLS_HOST_DIR)/tmp;\
+		GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get gopkg.in/mikefarah/yq.v2;\
+		rm -fr $(TOOLS_HOST_DIR)/tmp;\
+	fi
 
 $(OPERATOR_SDK):
-	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
+	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM) -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION);\
 		chmod +x $(OPERATOR_SDK);\
         fi

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -26,7 +26,7 @@ TEMP := $(shell mktemp -d)
 # ====================================================================================
 # Build Rook
 
-do.build:
+do.build: generate-csv-ceph-templates
 	@echo === docker build $(CEPH_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp toolbox.sh $(TEMP)
@@ -34,6 +34,7 @@ do.build:
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
 	@cp -r ../../cluster/examples/kubernetes/ceph/csi/template $(TEMP)/ceph-csi
 	@cp -r ../../cluster/examples/kubernetes/ceph/monitoring $(TEMP)/ceph-monitoring
+	@cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
@@ -41,3 +42,7 @@ do.build:
 		-t $(CEPH_IMAGE) \
 		$(TEMP)
 	@rm -fr $(TEMP)
+
+generate-csv-ceph-templates:
+	@../../cluster/olm/ceph/generate-rook-csv-templates.sh
+

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -21,23 +21,19 @@ CEPH_VERSION = v14.2.2-20190722
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 OPERATOR_SDK_VERSION = v0.10.0
+GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go
 
 TEMP := $(shell mktemp -d)
 
 ifeq ($(HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 endif
-ifeq ($(PLATFORM),linux_arm64)
-# host os not supported
-endif
-ifeq ($(PLATFORM),darwin_amd64)
+ifeq ($(HOST_PLATFORM),darwin_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
-endif
-ifeq ($(PLATFORM),windows_amd64)
-# host os not supported
 endif
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) 
+YQ := $(TOOLS_HOST_DIR)/yq.v2
 
 # ====================================================================================
 # Build Rook
@@ -50,7 +46,7 @@ do.build: generate-csv-ceph-templates
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rookflex $(TEMP)
 	@cp -r ../../cluster/examples/kubernetes/ceph/csi/template $(TEMP)/ceph-csi
 	@cp -r ../../cluster/examples/kubernetes/ceph/monitoring $(TEMP)/ceph-monitoring
-	# for the CSV templates, we ignore host platforms the operator-sdk doesn't support
+	# Copy temlated csv manifest only if operator-sdk is supported for the host platform.
 	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
 		cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates;\
 	else\
@@ -64,10 +60,16 @@ do.build: generate-csv-ceph-templates
 		$(TEMP)
 	@rm -fr $(TEMP)
 
-generate-csv-ceph-templates: $(OPERATOR_SDK)
+generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
 	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\
-		OPERATOR_SDK=$(OPERATOR_SDK) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
+		OPERATOR_SDK=$(OPERATOR_SDK) YQ_TOOL=$(YQ) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
 	fi
+
+$(YQ):
+	@echo === installing yq $(GOHOST)
+	@mkdir -p $(TOOLS_HOST_DIR)/tmp
+	@GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get gopkg.in/mikefarah/yq.v2
+	@rm -fr $(TOOLS_HOST_DIR)/tmp
 
 $(OPERATOR_SDK):
 	@if [ ! "$(OPERATOR_SDK_PLATFORM)" = "" ]; then\


### PR DESCRIPTION
**Description of your changes:**

The ocs-operator would like to consume a CSV template from the rook-ceph operator's container image. This template is used to merge the rook-ceph operator into the ocs-operators unified CSV file.

In addition to the CSV templates, I've also included the rook related CRDs in the container image for extraction. 

**Usage Example** extracting CSV template for OCP from the rook-ceph container image. 

```
ROOK_CEPH_IMAGE=<some-image>
docker run --rm -it --entrypoint=cat $ROOK_CEPH_IMAGE /etc/ceph-csv-templates/rook-ceph-ocp.vVERSION.clusterserviceversion.yaml.in
```

**Usage Example** extract a crd
```
ROOK_CEPH_IMAGE=<some-image>
docker run --rm -it --entrypoint=cat $ROOK_CEPH_IMAGE /etc/ceph-csv-templates/crds/ceph_crd.yaml
```

**Usage Example** List all CRDs. 
```
ROOK_CEPH_IMAGE=<some-image>
docker run --rm -it --entrypoint=ls $ROOK_CEPH_IMAGE -l /etc/ceph-csv-templates/crds
total 16
-rw-rw-r--. 1 root root 2233 Aug 15 21:49 ceph_crd.yaml
-rw-rw-r--. 1 root root  364 Aug 15 21:49 rookcephblockpools.crd.yaml
-rw-rw-r--. 1 root root  378 Aug 15 21:49 rookcephobjectstores.crd.yaml
-rw-rw-r--. 1 root root  410 Aug 15 21:49 rookcephobjectstoreusers.crd.yaml

```

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
