### PR TITLE
Correctly set osd mem target for inited clusters

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -243,7 +243,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			// As of Nautilus Ceph auto-tunes its osd_memory_target on the fly so we don't need to force it
 			if !c.clusterInfo.CephVersion.IsAtLeastNautilus() && !c.resources.Limits.Memory().IsZero() {
 				osdMemoryTargetValue := float32(c.resources.Limits.Memory().Value()) * osdMemoryTargetSafetyFactor
-				commonArgs = append(commonArgs, fmt.Sprintf("--osd-memory-target=%f", osdMemoryTargetValue))
+				args = append(args, fmt.Sprintf("--osd-memory-target=%f", osdMemoryTargetValue))
 			}
 		}
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -167,7 +167,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 		configEnvVars = append(configEnvVars, v1.EnvVar{Name: "ROOK_IS_DEVICE", Value: "true"})
 	}
 
-	commonArgs := []string{
+	// default args when the ceph cluster isn't initialized
+	defaultArgs := []string{
 		"--foreground",
 		"--id", osdID,
 		"--conf", osd.Config,
@@ -176,6 +177,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 		"--cluster", osd.Cluster,
 		"--osd-uuid", osd.UUID,
 	}
+
+	var commonArgs []string
 
 	// Set osd memory target to the best appropriate value
 	if !osd.IsFileStore {
@@ -217,7 +220,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			"--source-path", sourcePath,
 			"--mount-path", osd.DataPath,
 			"--"},
-			commonArgs...)
+			defaultArgs...)
 
 	} else if osd.CephVolumeInitiated {
 		// if the osd was provisioned by ceph-volume, we need to launch it with rook as the parent process
@@ -238,21 +241,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			"--setuser-match-path", osd.DataPath,
 		}
 
-		// Set osd memory target to the best appropriate value
-		if !osd.IsFileStore {
-			// As of Nautilus Ceph auto-tunes its osd_memory_target on the fly so we don't need to force it
-			if !c.clusterInfo.CephVersion.IsAtLeastNautilus() && !c.resources.Limits.Memory().IsZero() {
-				osdMemoryTargetValue := float32(c.resources.Limits.Memory().Value()) * osdMemoryTargetSafetyFactor
-				args = append(args, fmt.Sprintf("--osd-memory-target=%f", osdMemoryTargetValue))
-			}
-		}
-
-		if c.clusterInfo.CephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-			args = append(args, "--default-log-to-file", "false")
-		}
-
-		args = append(args, osdOnSDNFlag(c.HostNetwork, c.clusterInfo.CephVersion)...)
-
 		// mount /run/udev in the container so ceph-volume (via `lvs`)
 		// can access the udev database
 		volumes = append(volumes, v1.Volume{
@@ -267,8 +255,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 	} else {
 		// other osds can launch the osd daemon directly
 		command = []string{"ceph-osd"}
-		args = commonArgs
+		args = defaultArgs
 	}
+
+	args = append(args, commonArgs...)
 
 	if osdProps.pvc.ClaimName != "" {
 		volumeMounts = append(volumeMounts, getPvcOSDBridgeMount(osdProps.pvc.ClaimName))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Correctly set osd mem target for inited clusters
    
Previously, the value was set to commonArgs, resulting in dead code,
since common arg isn't used after the append (see the first commit in the PR).

Then fix some duplicated code (the second commit).

The bug was introduced in https://github.com/rook/rook/pull/3005

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
