### PR TITLE
ceph: properly propagate errors when deleting mds deployment

### DIFF
--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -140,15 +140,13 @@ func getMdsDeployments(context *clusterd.Context, namespace, fsName string) (*ap
 }
 
 func deleteMdsDeployment(context *clusterd.Context, namespace string, deployment *apps.Deployment) error {
-	errCount := 0
 	// Delete the mds deployment
 	logger.Infof("deleting mds deployment %s", deployment.Name)
 	var gracePeriod int64
 	propagation := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
 	if err := context.Clientset.AppsV1().Deployments(namespace).Delete(deployment.GetName(), options); err != nil {
-		errCount++
-		logger.Errorf("failed to delete mds deployment %s: %+v", deployment.GetName(), err)
+		return fmt.Errorf("failed to delete mds deployment %s: %+v", deployment.GetName(), err)
 	}
 	return nil
 }


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

When deleting mds deployment the error is logged, but not propagated
further down (it always returns nil). The two places using the function
checks the error, and acts upon it.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
