### PR TITLE
Docs: Add CSI doc back to the TOC

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -1,4 +1,3 @@
-
 ---
 title: Ceph CSI
 weight: 3200
@@ -124,7 +123,7 @@ kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshotclass
 
 #### Liveness Sidecar
 All CSI pods are deployed with a sidecar container that provides a prometheus metric for tracking if the CSI plugin is alive and runnning.
-These metrics are meant to be collected by prometheus but can be acceses through a GET request to a specific node ip. 
+These metrics are meant to be collected by prometheus but can be acceses through a GET request to a specific node ip.
 for example `curl -X get http://[pod ip]:[liveness-port][liveness-path]  2>/dev/null | grep csi`
 the expected output should be
 ```bash


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CSI doc is not showing up in the table of contents in the master branch. Instead it is showing up at the root and has the title "Rook", which happens for all topics that have an incorrect header. 

The fix is to remove an extra line before the title info.

[skip ci] 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
