### PR TITLE
Added portable and failure-domain label to the OSD deployment

### DIFF
--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -137,6 +137,7 @@ type StorageClassDeviceSet struct {
 	Placement            Placement                  `json:"placement,omitempty"`            // Placement constraints for the devices
 	Config               map[string]string          `json:"config,omitempty"`               // Provider-specific device configuration
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"` // List of PVC templates for the underlying storage devices
+	Portable             bool                       `json:"portable,omitempty"`             // OSD portablity across the hosts
 }
 
 type VolumeSource struct {
@@ -145,4 +146,5 @@ type VolumeSource struct {
 	Resources                   v1.ResourceRequirements              `json:"resources,omitempty"`
 	Placement                   Placement                            `json:"placement,omitempty"`
 	Config                      map[string]string                    `json:"config,omitempty"`
+	Portable                    bool                                 `json:"portable,omitempty"` // OSD portablity across the hosts
 }

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -49,6 +49,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rooka
 					ClaimName: pvc.GetName(),
 					ReadOnly:  false,
 				},
+				Portable: storageClassDeviceSet.Portable,
 			})
 			logger.Infof("successfully provisioned osd for storageClassDeviceSet %s of set %v", storageClassDeviceSet.Name, i)
 		}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -57,6 +57,8 @@ const (
 	clusterAvailableSpaceReserve        = 0.05
 	serviceAccountName                  = "rook-ceph-osd"
 	unknownID                           = -1
+	portableKey                         = "portable"
+	failureDomainKey                    = "failure-domain"
 	cephOsdPodMinimumMemory      uint64 = 4096 // minimum amount of memory in MB to run the pod
 )
 
@@ -143,6 +145,7 @@ type osdProperties struct {
 	placement      rookalpha.Placement
 	metadataDevice string
 	location       string
+	portable       bool
 }
 
 // Start the osd management
@@ -233,6 +236,7 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 			pvc:           volume.PersistentVolumeClaimSource,
 			resources:     volume.Resources,
 			placement:     volume.Placement,
+			portable:      volume.Portable,
 		}
 
 		// update the orchestration status of this pvc to the starting state
@@ -719,6 +723,7 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				pvc:           volumeSource.PersistentVolumeClaimSource,
 				resources:     volumeSource.Resources,
 				placement:     volumeSource.Placement,
+				portable:      volumeSource.Portable,
 			}, nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: rohan47 <rohanrgupta1996@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Added portable and failure-domain label to the OSD deployment.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
