### PR TITLE
Bump kube version 1.14.1 some workarounds were necessary for this.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -412,7 +412,8 @@
     "pkg/provisioner/api/errors",
   ]
   pruneopts = "UT"
-  revision = "5b3f4e3b90edc8c914edb04fb5dc0dfee5f9f0d4"
+  revision = "a2a5b76832ebeb63aa76f14e36082617d5adb730"
+  source = "github.com/rohantmp/lib-bucket-provisioner"
 
 [[projects]]
   branch = "master"
@@ -542,14 +543,6 @@
   ]
   pruneopts = "UT"
   revision = "bf6a532e95b1f7a62adf0ab5050a5bb2237ad2f4"
-
-[[projects]]
-  branch = "master"
-  digest = "1:da278413b1e908bf462b4bc1caac1108c3f24522e27e446e2de584bc6e59cbcb"
-  name = "github.com/rook/operator-kit"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "e7b2e1264fff5f1dc9d506089af2399621b5a0c1"
 
 [[projects]]
   digest = "1:d707dbc1330c0ed177d4642d6ae102d5e2c847ebd0eb84562d0dc4f024531cfc"
@@ -850,23 +843,25 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "40a48860b5abbba9aa891b02b32da429b08d96a0"
-  version = "kubernetes-1.14.0"
+  revision = "6e4e0e4f393bf5e8bbff570acd13217aa5a770cd"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:5b60f7bda6ce2daa695784a4a4d366bc8b0ab1603fd144025d313b0dc7b9f5b1"
+  digest = "1:3a19e26a15beaf247387de7eb4e52797ce688bd0d507b4a46d5f0f8f0f49083e"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
     "pkg/apis/apiextensions/v1beta1",
     "pkg/client/clientset/clientset",
+    "pkg/client/clientset/clientset/fake",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
     "pkg/features",
   ]
   pruneopts = "UT"
-  revision = "53c4693659ed354d76121458fb819202dd1635fa"
-  version = "kubernetes-1.14.0"
+  revision = "727a075fdec8319bf095330e344b3ccc668abc73"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:12e1193fca56eef2efa8e94239f96011a2ac8f60cba50f04da1babad5029de99"
@@ -924,8 +919,8 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "d7deff9243b165ee192f5551710ea4285dcfd615"
-  version = "kubernetes-1.14.0"
+  revision = "6a84e37a896db9780c75367af8d2ed2bb944022e"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:f1762b5ef39911603327ac0ac2f57e3adf005b268f9ae91c405e1d7749ae1bd0"
@@ -1012,8 +1007,8 @@
     "plugin/pkg/authorizer/webhook",
   ]
   pruneopts = "UT"
-  revision = "8b27c41bdbb11ff103caa673315e097bf0289171"
-  version = "kubernetes-1.14.0"
+  revision = "1ec86e4da56ce0573788fc12bb3a5530600c0e5d"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:f07252504bce93f28bb2ad35ed560707b066c8cf5ea11f11d6fa3984822ccd87"
@@ -1242,7 +1237,7 @@
   ]
   pruneopts = "T"
   revision = "50b561225d70b3eb79a1faafd3dfe7b1a62cbe73"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   branch = "master"
@@ -1286,8 +1281,8 @@
   name = "k8s.io/kube-controller-manager"
   packages = ["config/v1alpha1"]
   pruneopts = "UT"
-  revision = "97ed623e38350ab8a3cce36d6003ff9ab27f6669"
-  version = "kubernetes-1.14.0"
+  revision = "97e4e67125a687ca6d4310fec43015a96a37f116"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:e60662eae49be670de501df7393dc4bfa8c5a4fa9a88915dc14e61b461c0935b"
@@ -1349,8 +1344,8 @@
     "pkg/volume/util/volumepathhandler",
   ]
   pruneopts = "UT"
-  revision = "641856db18352033a0d96dbc99153fa3b27298e5"
-  version = "v1.14.0"
+  revision = "b7394102d6ef778017f2ca4046abbaa23b88c290"
+  version = "v1.14.1"
 
 [[projects]]
   branch = "master"
@@ -1431,7 +1426,6 @@
     "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api",
     "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api/errors",
     "github.com/pkg/errors",
-    "github.com/rook/operator-kit",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
@@ -1446,6 +1440,7 @@
     "k8s.io/api/storage/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,31 +60,31 @@ ignored = [
 
 [[constraint]]
   name = "k8s.io/kubernetes"
-  version = "=v1.14.0"
+  version = "=v1.14.1"
 
 [[constraint]]
   name = "k8s.io/kube-controller-manager"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/api"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/code-generator"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/client-go"
@@ -116,7 +116,7 @@ ignored = [
 
 [[override]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[override]]
   name = "k8s.io/client-go"
@@ -126,3 +126,8 @@ ignored = [
 [[constraint]]
   branch = "master"
   name = "github.com/kube-object-storage/lib-bucket-provisioner"
+
+# workaround until fix is merged https://github.com/kube-object-storage/lib-bucket-provisioner/pull/136
+[[override]]
+  name = "github.com/kube-object-storage/lib-bucket-provisioner"
+  source = "github.com/rohantmp/lib-bucket-provisioner"

--- a/pkg/daemon/ceph/agent/cluster/controller.go
+++ b/pkg/daemon/ceph/agent/cluster/controller.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	opcluster "github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/daemon/ceph/agent/flexvolume/attachment/resource.go
+++ b/pkg/daemon/ceph/agent/flexvolume/attachment/resource.go
@@ -20,8 +20,8 @@ package attachment
 import (
 	"reflect"
 
-	opkit "github.com/rook/operator-kit"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 

--- a/pkg/operator-kit/client.go
+++ b/pkg/operator-kit/client.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kit for Kubernetes operators
+package operatorkit
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	serverVersionV170 = "v1.7.0"
+)
+
+// NewHTTPClient creates a Kubernetes client to interact with API extensions for Custom Resources
+func NewHTTPClient(group, version string, schemeBuilder runtime.SchemeBuilder) (rest.Interface, *runtime.Scheme, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewHTTPClientFromConfig(group, version, schemeBuilder, config)
+}
+
+// NewHTTPClient creates a Kubernetes client from a given Kubernetes *rest.Config to interact with API extensions for Custom Resources
+func NewHTTPClientFromConfig(group, version string, schemeBuilder runtime.SchemeBuilder, config *rest.Config) (rest.Interface, *runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := schemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, nil, err
+	}
+
+	config.GroupVersion = &schema.GroupVersion{Group: group, Version: version}
+
+	config.APIPath = "/apis"
+	config.ContentType = runtime.ContentTypeJSON
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+
+	client, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, scheme, nil
+}

--- a/pkg/operator-kit/resource.go
+++ b/pkg/operator-kit/resource.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Some of the code was modified from https://github.com/coreos/etcd-operator
+which also has the apache 2.0 license.
+*/
+
+// Package kit for Kubernetes operators
+package operatorkit
+
+import (
+	"fmt"
+	"time"
+
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CustomResource is for creating a Kubernetes TPR/CRD
+type CustomResource struct {
+	// Name of the custom resource
+	Name string
+
+	// Plural of the custom resource in plural
+	Plural string
+
+	// Group the custom resource belongs to
+	Group string
+
+	// Version which should be defined in a const above
+	Version string
+
+	// Scope of the CRD. Namespaced or cluster
+	Scope apiextensionsv1beta1.ResourceScope
+
+	// Kind is the serialized interface of the resource.
+	Kind string
+
+	// ShortNames is the shortened version of the resource
+	ShortNames []string
+}
+
+// Context hold the clientsets used for creating and watching custom resources
+type Context struct {
+	Clientset             kubernetes.Interface
+	APIExtensionClientset apiextensionsclient.Interface
+	Interval              time.Duration
+	Timeout               time.Duration
+}
+
+// CreateCustomResources creates the given custom resources and waits for them to initialize
+// The resource is of kind CRD if the Kubernetes server is 1.7.0 and above.
+// The resource is of kind TPR if the Kubernetes server is below 1.7.0.
+func CreateCustomResources(context Context, resources []CustomResource) error {
+
+	var lastErr error
+	for _, resource := range resources {
+		if err := createCRD(context, resource); err != nil {
+			lastErr = err
+		}
+	}
+
+	for _, resource := range resources {
+		if err := waitForCRDInit(context, resource); err != nil {
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}
+
+func createCRD(context Context, resource CustomResource) error {
+	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
+	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   resource.Group,
+			Version: resource.Version,
+			Scope:   resource.Scope,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Singular:   resource.Name,
+				Plural:     resource.Plural,
+				Kind:       resource.Kind,
+				ShortNames: resource.ShortNames,
+			},
+		},
+	}
+
+	_, err := context.APIExtensionClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	if err != nil {
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create %s CRD. %+v", resource.Name, err)
+		}
+	}
+	return nil
+}
+
+func waitForCRDInit(context Context, resource CustomResource) error {
+	crdName := fmt.Sprintf("%s.%s", resource.Plural, resource.Group)
+	return wait.Poll(context.Interval, context.Timeout, func() (bool, error) {
+		crd, err := context.APIExtensionClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1beta1.Established:
+				if cond.Status == apiextensionsv1beta1.ConditionTrue {
+					return true, nil
+				}
+			case apiextensionsv1beta1.NamesAccepted:
+				if cond.Status == apiextensionsv1beta1.ConditionFalse {
+					return false, fmt.Errorf("Name conflict: %v\n", cond.Reason)
+				}
+			}
+		}
+		return false, nil
+	})
+}

--- a/pkg/operator-kit/resource_test.go
+++ b/pkg/operator-kit/resource_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package operatorkit
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var exampleResource = CustomResource{
+	Name:    "example",
+	Plural:  "examples",
+	Group:   "example.com",
+	Version: "v1alpha",
+	Scope:   apiextensionsv1beta1.NamespaceScoped,
+}
+
+func TestCreateCRDCustomResource(t *testing.T) {
+	ctx := Context{
+		APIExtensionClientset: apiextensionsclientfake.NewSimpleClientset(),
+		Interval:              100 * time.Millisecond,
+		Timeout:               1 * time.Second,
+	}
+
+	err := createCRD(ctx, exampleResource)
+	assert.NoError(t, err)
+
+	crdName := fmt.Sprintf("%s.%s", exampleResource.Plural, exampleResource.Group)
+	crd, err := ctx.APIExtensionClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
+	if err != nil {
+		assert.Fail(t, fmt.Sprintf("CustomResource.Create: %+v", err))
+	}
+
+	assert.Equal(t, crdName, crd.ObjectMeta.Name)
+	assert.Equal(t, "examples", crd.Spec.Names.Plural)
+	assert.Equal(t, "example", crd.Spec.Names.Singular)
+	assert.Equal(t, "example.com", crd.Spec.Group)
+	assert.Equal(t, "v1alpha", crd.Spec.Version)
+	assert.Equal(t, apiextensionsv1beta1.NamespaceScoped, crd.Spec.Scope)
+}

--- a/pkg/operator-kit/watcher.go
+++ b/pkg/operator-kit/watcher.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kit for Kubernetes operators
+package operatorkit
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	// ErrVersionOutdated indicates that the custom resource is outdated and needs to be refreshed
+	ErrVersionOutdated = errors.New("requested version is outdated in apiserver")
+)
+
+// ResourceWatcher watches a custom resource for desired state
+type ResourceWatcher struct {
+	resource              CustomResource
+	namespace             string
+	resourceEventHandlers cache.ResourceEventHandlerFuncs
+	client                rest.Interface
+	scheme                *runtime.Scheme
+}
+
+// NewWatcher creates an instance of a custom resource watcher for the given resource
+func NewWatcher(resource CustomResource, namespace string, handlers cache.ResourceEventHandlerFuncs, client rest.Interface) *ResourceWatcher {
+	return &ResourceWatcher{
+		resource:              resource,
+		namespace:             namespace,
+		resourceEventHandlers: handlers,
+		client:                client,
+	}
+}
+
+// Watch begins watching the custom resource (TPR/CRD). The call will block until a Done signal is raised during in the context.
+// When the watch has detected a create, update, or delete event, it will handled by the functions in the resourceEventHandlers. After the callback returns, the watch loop will continue for the next event.
+// If the callback returns an error, the error will be logged.
+func (w *ResourceWatcher) Watch(objType runtime.Object, done <-chan struct{}) error {
+	source := cache.NewListWatchFromClient(
+		w.client,
+		w.resource.Plural,
+		w.namespace,
+		fields.Everything())
+	_, controller := cache.NewInformer(
+		source,
+
+		// The object type.
+		objType,
+
+		// resyncPeriod
+		// Every resyncPeriod, all resources in the cache will retrigger events.
+		// Set to 0 to disable the resync.
+		0,
+
+		// Your custom resource event handlers.
+		w.resourceEventHandlers)
+
+	go controller.Run(done)
+	<-done
+	return nil
+}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	discoverDaemon "github.com/rook/rook/pkg/daemon/discover"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/config"

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -23,10 +23,10 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -21,10 +21,10 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -22,10 +22,10 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	daemonconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -22,10 +22,10 @@ import (
 	"reflect"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -24,10 +24,10 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/ceph/agent"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/ceph/csi"

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -22,12 +22,12 @@ import (
 	"reflect"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	ceph "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/model"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -26,10 +26,10 @@ import (
 	"strings"
 	"time"
 
-	opkit "github.com/rook/operator-kit"
 	cockroachdbv1alpha1 "github.com/rook/rook/pkg/apis/cockroachdb.rook.io/v1alpha1"
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"

--- a/pkg/operator/cockroachdb/operator.go
+++ b/pkg/operator/cockroachdb/operator.go
@@ -23,8 +23,8 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 )
 

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/edgefs/iscsi"
 	"github.com/rook/rook/pkg/operator/edgefs/isgw"
 	"github.com/rook/rook/pkg/operator/edgefs/nfs"

--- a/pkg/operator/edgefs/iscsi/controller.go
+++ b/pkg/operator/edgefs/iscsi/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/edgefs/isgw/controller.go
+++ b/pkg/operator/edgefs/isgw/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/edgefs/nfs/controller.go
+++ b/pkg/operator/edgefs/nfs/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/edgefs/operator.go
+++ b/pkg/operator/edgefs/operator.go
@@ -24,8 +24,8 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/edgefs/cluster"
 	"github.com/rook/rook/pkg/operator/k8sutil"

--- a/pkg/operator/edgefs/s3/controller.go
+++ b/pkg/operator/edgefs/s3/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/edgefs/s3x/controller.go
+++ b/pkg/operator/edgefs/s3x/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/edgefs/swift/controller.go
+++ b/pkg/operator/edgefs/swift/controller.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1beta1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1beta1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -22,10 +22,10 @@ import (
 	"reflect"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	miniov1alpha1 "github.com/rook/rook/pkg/apis/minio.rook.io/v1alpha1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -23,9 +23,9 @@ import (
 	s "strings"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	nfsv1alpha1 "github.com/rook/rook/pkg/apis/nfs.rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/clusterd"
+	opkit "github.com/rook/rook/pkg/operator-kit"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"


### PR DESCRIPTION
- Move operator-kit package in-repo.
- Temporarily redirect kube-object-storage/lib-bucket-provisioner
to rohantmp/lib-bucket-provisioner.

Workaround for this: https://github.com/kube-object-storage/lib-bucket-provisioner/pull/136

We could use this to workaround or we could go another way.  Needed to make this anyway to unblock myself from rebasing on my WIP PR which depends on kube 14.1

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
