### PR TITLE
Start the ceph device discovery only based on env var

### DIFF
--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -166,15 +166,6 @@ func (o *Operator) startSystemDaemons(externalCeph bool) error {
 		}
 	}
 
-	// The discover daemon is only needed for local clusters where OSDs will be created.
-	// External clusters do not create OSDs locally.
-	if !externalCeph {
-		rookDiscover := discover.New(o.context.Clientset)
-		if err := rookDiscover.Start(namespace, o.rookImage, o.securityAccount); err != nil {
-			return fmt.Errorf("Error starting device discovery daemonset: %v", err)
-		}
-	}
-
 	serverVersion, err := o.context.Clientset.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("error getting server version: %v", err)


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The decision to start the device discovery daemonset is made by an env var on the operator pod since in some scenarios the discovery needs to be started immediately with the operator
instead of being delay to start with the cluster. The discovery service is already started [here](https://github.com/rook/rook/blob/master/pkg/operator/ceph/operator.go#L100-L105), so there is no need to start it inside `startSystemDaemons()`.
 
**Which issue is resolved by this Pull Request:**
Resolves #3697

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
