### PR TITLE
 OSD: CRUSH map can be based on node or PVC in case of PVC backed OSD

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -63,6 +63,7 @@ spec:
    storageClassDeviceSets:
     - name: set1
       count: 3
+      portable: false
       volumeClaimTemplates:
       - metadata:
           name: data
@@ -203,6 +204,7 @@ The following are the settings for Storage Class Device Sets which can be config
 - `count`: The number of devices in the set.
 - `resources`: The CPU and RAM requests/limits for the devices.(Optional)
 - `placement`: The placement criteria for the devices. Default is no placement criteria.(Optional)
+- `portable`: If `true`, the OSDs will be allowed to move between nodes during failover. This requires a storage class that supports portability (e.g. `aws-ebs`, but not the local storage provisioner). If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
 - `volumeClaimTemplates`: A list of PVC templates to use for provisioning the underlying storage devices.
   - `resources.requests.storage`: The desired capacity for the underlying storage devices.
   - `storageClassName`: The StorageClass to provision PVCs from. Default would be to use the cluster-default StorageClass.
@@ -613,6 +615,7 @@ spec:
     storageClassDeviceSets:
     - name: set1
       count: 3
+      portable: false
       resources:
         limits:
           cpu: "500m"

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -45,6 +45,9 @@ an example usage
   [monitor settings for more detail](Documentation/ceph-cluster-crd.md#mon-settings).
 - Ceph OSDs can be created by using StorageClassDeviceSet. See docs on [Storage Class Device Sets](Documentation/ceph-cluster-crd.md#storage-class-device-sets).
 - Rook can now connect to an external cluster, for more info about external cluster [read the design](https://github.com/rook/rook/blob/master/design/ceph-external-cluster.md) as well as the documentation [Ceph External cluster](Documentation/ceph-cluster-crd.md#external-cluster)
+- Added a new property in `storageClassDeviceSets` named `portable`: 
+   - If `true`, the OSDs will be allowed to move between nodes during failover. This requires a storage class that supports portability (e.g. `aws-ebs`, but not the local storage provisioner).
+   - If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
 
 ### YugabyteDB
 

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -25,6 +25,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -199,6 +200,16 @@ func AddLabelToDeployement(key, value string, d *v1.Deployment) {
 		d.Labels = map[string]string{}
 	}
 	addLabel(key, value, d.Labels)
+}
+
+func AddLabelToPod(key, value string, p *corev1.PodTemplateSpec) {
+	if p == nil {
+		return
+	}
+	if p.Labels == nil {
+		p.Labels = map[string]string{}
+	}
+	addLabel(key, value, p.Labels)
 }
 
 func AddLabelToJob(key, value string, b *batchv1.Job) {


### PR DESCRIPTION
Signed-off-by: rohan47 <rohgupta@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Added a new property in the `storageClassDeviceSet` named `portable`. 
- `true`: The CRUSH map will use the PVC name in place of the host (already the behavior with the OSDs on PVCs)
- `false`: The CRUSH map will use the host name (the traditional behavior)

**Which issue is resolved by this Pull Request:**
Resolves #3648 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
