### PR TITLE
ceph: prune support for empty dataDirHostPath

### DIFF
--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -90,20 +90,17 @@ func confGeneratedInPodVolumeAndMount() (v1.Volume, v1.VolumeMount) {
 }
 
 // PodVolumes fills in the volumes parameter with the common list of Kubernetes volumes for use in Ceph pods.
-// This function is only used for OSDs.
+// This function is only used for OSDs. dataDirHostPath MUST be specified.
 func PodVolumes(dataPaths *config.DataPathMap, dataDirHostPath string, confGeneratedInPod bool) []v1.Volume {
 
-	dataDirSource := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
-	if dataDirHostPath != "" {
-		dataDirSource = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: dataDirHostPath}}
-	}
 	configVolume, _ := configOverrideConfigMapVolumeAndMount()
 	if confGeneratedInPod {
 		configVolume, _ = confGeneratedInPodVolumeAndMount()
 	}
 
 	v := []v1.Volume{
-		{Name: k8sutil.DataDirVolume, VolumeSource: dataDirSource},
+		{Name: k8sutil.DataDirVolume, VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: dataDirHostPath}}},
 		configVolume,
 	}
 	v = append(v, StoredLogAndCrashVolume(dataPaths.HostLogDir(), dataPaths.HostCrashDir())...)

--- a/pkg/operator/ceph/spec/spec_test.go
+++ b/pkg/operator/ceph/spec/spec_test.go
@@ -30,11 +30,12 @@ import (
 func TestPodVolumes(t *testing.T) {
 	dataPathMap := opconfig.NewDatalessDaemonDataPathMap("rook-ceph", "/var/lib/rook")
 
-	if err := test.VolumeIsEmptyDir(k8sutil.DataDirVolume, PodVolumes(dataPathMap, "", false)); err != nil {
-		t.Errorf("PodVolumes(\"\") - data dir source is not EmptyDir: %s", err.Error())
-	}
 	if err := test.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/sdb", PodVolumes(dataPathMap, "/dev/sdb", false)); err != nil {
-		t.Errorf("PodVolumes(\"/dev/sdb\") - data dir source is not HostPath: %s", err.Error())
+		t.Errorf("PodVolumes(\"/dev/sdb\") - data dir source is not HostPath: %v", err.Error())
+	}
+
+	if err := test.VolumeIsHostPath(k8sutil.DataDirVolume, "/dev/vdg", PodVolumes(dataPathMap, "/dev/vdg", true)); err != nil {
+		t.Errorf("PodVolumes(\"/dev/vdg\") - data dir source is not HostPath: %v", err.Error())
 	}
 }
 


### PR DESCRIPTION
There was some vestigial support for empty ("") dataDirHostPaths in the
Ceph source. Remove this support.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #2324

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]