### PR TITLE
ceph: do not require mon in common.yaml

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -45,10 +45,8 @@ spec:
                   type: boolean
                 count:
                   maximum: 9
-                  minimum: 1
+                  minimum: 0
                   type: integer
-              required:
-              - count
             network:
               properties:
                 hostNetwork:
@@ -80,7 +78,7 @@ spec:
                           encryptedDevice:
                             type: string
                             pattern: ^(true|false)$
-                      useAllDevices: 
+                      useAllDevices:
                         type: boolean
                       deviceFilter: {}
                       directories:
@@ -99,7 +97,7 @@ spec:
                       location: {}
                       resources: {}
                   type: array
-                useAllDevices: 
+                useAllDevices:
                   type: boolean
                 deviceFilter: {}
                 location: {}
@@ -110,7 +108,7 @@ spec:
                       path:
                         type: string
                 config: {}
-                topologyAware: 
+                topologyAware:
                   type: boolean
             monitoring:
               properties:
@@ -124,8 +122,6 @@ spec:
                   type: integer
             placement: {}
             resources: {}
-          required:
-          - mon
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -141,8 +141,6 @@ spec:
                   type: integer
             placement: {}
             resources: {}
-          required:
-          - mon
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string


### PR DESCRIPTION
For the external cluster setup, we don't have monitors to deploy because
we connect to external ones. So in the common.yaml we must not require a
mon section to be defined in the cluster CR.

Signed-off-by: Sébastien Han <seb@redhat.com>

Resolves: #3713 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
