### PR TITLE
Implement grpc metrics for cephcsi

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -127,7 +127,7 @@ These metrics are meant to be collected by prometheus but can be acceses through
 for example `curl -X get http://[pod ip]:[liveness-port][liveness-path]  2>/dev/null | grep csi`
 the expected output should be
 ```bash
-[root@worker2 /]# curl -X GET http://10.109.65.142:8080/metrics 2>/dev/null | grep csi
+[root@worker2 /]# curl -X GET http://10.109.65.142:9080/metrics 2>/dev/null | grep csi
 # HELP csi_liveness Liveness Probe
 # TYPE csi_liveness gauge
 csi_liveness 1

--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -121,15 +121,18 @@ kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshot.yaml
 kubectl delete -f cluster/examples/kubernetes/ceph/csi/example/rbd/snapshotclass.yaml
 ```
 
-#### Liveness Sidecar
+## Liveness Sidecar
+
 All CSI pods are deployed with a sidecar container that provides a prometheus metric for tracking if the CSI plugin is alive and runnning.
 These metrics are meant to be collected by prometheus but can be acceses through a GET request to a specific node ip.
 for example `curl -X get http://[pod ip]:[liveness-port][liveness-path]  2>/dev/null | grep csi`
 the expected output should be
+
 ```bash
-[root@worker2 /]# curl -X GET http://10.109.65.142:9080/metrics 2>/dev/null | grep csi
+curl -X GET http://10.109.65.142:9080/metrics 2>/dev/null | grep csi
 # HELP csi_liveness Liveness Probe
 # TYPE csi_liveness gauge
 csi_liveness 1
 ```
-Check the [monitoring doc](https://github.com/rook/rook.github.io/blob/master/docs/rook/master/ceph-monitoring.md) to see how to integrate CSI liveness into ceph monitoring.
+
+Check the [monitoring doc](ceph-monitoring.md) to see how to integrate CSI liveness into ceph monitoring.

--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -135,4 +135,5 @@ curl -X GET http://10.109.65.142:9080/metrics 2>/dev/null | grep csi
 csi_liveness 1
 ```
 
-Check the [monitoring doc](ceph-monitoring.md) to see how to integrate CSI liveness into ceph monitoring.
+Check the [monitoring doc](ceph-monitoring.md) to see how to integrate CSI
+liveness and grpc metrics into ceph monitoring.

--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -86,7 +86,7 @@ To enable prometheus alerts,
 first, create the RBAC rules to enable monitoring,
 ```BASH
 kubectl create -f cluster/examples/kubernetes/ceph/monitoring/rbac.yaml
-``` 
+```
 then, make following changes to `cluster.yaml` and deploy.
 ```YAML
 monitoring:
@@ -128,8 +128,11 @@ After this you only need to create the service monitor as stated above.
 
 ### CSI Liveness
 
-To integrate CSI Liveness into ceph monitoring we will need to deploy a service and service monitor.
+To integrate CSI liveness and grpc into ceph monitoring we will need to deploy
+a service and service monitor.
+
 ```bash
-kubectl create -f csi-liveness-service-monitor.yaml
+kubectl create -f csi-metrics-service-monitor.yaml
 ```
+
 This will create the service monitor to have promethues monitor CSI

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -105,6 +105,10 @@ spec:
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: "{{ .Values.enableCsiCephfsDriver }}"
 {{- end }}
+{{- if .Values.enableCsiGrpcMetrics }}
+        - name: ROOK_CSI_ENABLE_GRPC_METRICS
+          value: "{{ .Values.enableCsiGrpcMetrics }}"
+{{- end }}
 {{- if .Values.enableFlexDriver }}
         - name: ROOK_ENABLE_FLEX_DRIVER
           value: "{{ .Values.enableFlexDriver }}"

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -56,6 +56,7 @@ pspEnable: true
 ## Settings for whether to disable the drivers or other daemons if they are not needed
 enableCsiRbdDriver: true
 enableCsiCephfsDriver: true
+enableCsiGrpcMetrics: true
 enableFlexDriver: true
 enableDiscoveryDaemon: true
 

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -92,7 +92,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8081"
+            - "--livenessport=9081"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -144,6 +144,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8081
+      targetPort: 9081
   selector:
     app: csi-cephfsplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: csi-cephfsplugin-provisioner
+        contains: csi-cephfsplugin-metrics
     spec:
       serviceAccount: rook-csi-cephfs-provisioner-sa
       containers:
@@ -131,19 +132,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-cephfsplugin-provisioner
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9081
-  selector:
-    app: csi-cephfsplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -141,7 +141,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9081

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -62,7 +62,14 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
             - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
+            - "--metricsport=9091"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -93,8 +100,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9081"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9081"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -57,7 +57,14 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
             - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
+            - "--metricsport=9091"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -88,8 +95,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9081"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9081"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -136,7 +136,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9081

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -87,7 +87,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8081"
+            - "--livenessport=9081"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -139,6 +139,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8081
+      targetPort: 9081
   selector:
     app: csi-cephfsplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: csi-cephfsplugin-provisioner
+        contains: csi-cephfsplugin-metrics
     spec:
       serviceAccount: rook-csi-cephfs-provisioner-sa
       containers:
@@ -126,19 +127,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-cephfsplugin-provisioner
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9081
-  selector:
-    app: csi-cephfsplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
@@ -1,15 +1,19 @@
 ---
-# This is a service to expose the liveness side car
+# This is a service to expose the liveness and grpc metrics
 apiVersion: v1
 kind: Service
 metadata:
-  name: csi-liveness-cephfsplugin-provisioner
+  name: csi-cephfsplugin-metrics
   labels:
-    app: csi-liveness
+    app: csi-metrics
 spec:
   ports:
     - name: csi-http-metrics
       port: 8080
+      protocol: TCP
+      targetPort: 9081
+    - name: csi-grpc-metrics
+      port: 8081
       protocol: TCP
       targetPort: 9081
   selector:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-svc.yaml
@@ -1,0 +1,16 @@
+---
+# This is a service to expose the liveness side car
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-liveness-cephfsplugin-provisioner
+  labels:
+    app: csi-liveness
+spec:
+  ports:
+    - name: csi-http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: 9081
+  selector:
+    contains: csi-cephfsplugin-metrics

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -156,7 +156,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9081

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: csi-cephfsplugin
+        contains: csi-cephfsplugin-metrics
     spec:
       serviceAccount: rook-csi-cephfs-plugin-sa
       hostNetwork: true
@@ -146,19 +147,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-cephfsplugin
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9081
-  selector:
-    app: csi-cephfsplugin

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -55,7 +55,14 @@ spec:
             - "--metadatastorage=k8s_configmap"
             - "--mountcachedir=/mount-cache-dir"
             - "--pidlimit=-1"
+            - "--metricsport=9091"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: NODE_ID
               valueFrom:
                 fieldRef:
@@ -94,8 +101,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9081"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9081"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -93,7 +93,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8081"
+            - "--livenessport=9081"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -159,6 +159,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8081
+      targetPort: 9081
   selector:
     app: csi-cephfsplugin

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -165,7 +165,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9080

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -79,7 +79,14 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
             - "--containerized=true"
             - "--pidlimit=-1"
+            - "--metricsport=9090"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HOST_ROOTFS
               value: "/rootfs"
             - name: NODE_ID
@@ -114,8 +121,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9080"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9080"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: csi-rbdplugin-provisioner
+        contains: csi-rbdplugin-metrics
     spec:
       serviceAccount: rook-csi-rbd-provisioner-sa
       containers:
@@ -155,19 +156,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-rbdplugin-provisioner
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9080
-  selector:
-    app: csi-rbdplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -113,7 +113,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8080"
+            - "--livenessport=9080"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -168,6 +168,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8080
+      targetPort: 9080
   selector:
     app: csi-rbdplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -106,7 +106,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8080"
+            - "--livenessport=9080"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -161,6 +161,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8080
+      targetPort: 9080
   selector:
     app: csi-rbdplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -72,7 +72,14 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
             - "--containerized=true"
             - "--pidlimit=-1"
+            - "--metricsport=9090"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HOST_ROOTFS
               value: "/rootfs"
             - name: NODE_ID
@@ -107,8 +114,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9080"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9080"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: csi-rbdplugin-provisioner
+        contains: csi-rbdplugin-metrics
     spec:
       serviceAccount: rook-csi-rbd-provisioner-sa
       containers:
@@ -148,19 +149,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-rbdplugin-provisioner
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9080
-  selector:
-    app: csi-rbdplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -158,7 +158,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9080

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
@@ -1,15 +1,19 @@
 ---
-# This is a service to expose the liveness side car
+# This is a service to expose the liveness and grpc metrics
 apiVersion: v1
 kind: Service
 metadata:
-  name: csi-liveness-rbdplugin-provisioner
+  name: csi-rbdplugin-metrics
   labels:
-    app: csi-liveness
+    app: csi-metrics
 spec:
   ports:
     - name: csi-http-metrics
       port: 8080
+      protocol: TCP
+      targetPort: 9080
+    - name: csi-grpc-metrics
+      port: 8081
       protocol: TCP
       targetPort: 9080
   selector:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-svc.yaml
@@ -1,0 +1,16 @@
+---
+# This is a service to expose the liveness side car
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-liveness-rbdplugin-provisioner
+  labels:
+    app: csi-liveness
+spec:
+  ports:
+    - name: csi-http-metrics
+      port: 8080
+      protocol: TCP
+      targetPort: 9080
+  selector:
+    contains: csi-rbdplugin-metrics

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         app: csi-rbdplugin
-        contains: liveness
+        contains: csi-rbdplugin-metrics
     spec:
       serviceAccount: rook-csi-rbd-plugin-sa
       hostNetwork: true
@@ -150,19 +150,3 @@ spec:
           emptyDir: {
             medium: "Memory"
           }
----
-# This is a service to expose the liveness side car
-apiVersion: v1
-kind: Service
-metadata:
-  name: csi-liveness-rbdplugin
-  labels:
-    app: csi-liveness
-spec:
-  ports:
-    - name: csi-http-metrics
-      port: 8080
-      protocol: TCP
-      targetPort: 9080
-  selector:
-    app: csi-rbdplugin

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -96,7 +96,7 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=8080"
+            - "--livenessport=9080"
             - "--livenesspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
@@ -163,6 +163,6 @@ spec:
     - name: http-metrics
       port: 8080
       protocol: TCP
-      targetPort: 8080
+      targetPort: 9080
   selector:
     app: csi-rbdplugin

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -55,7 +55,14 @@ spec:
             - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
             - "--containerized=true"
             - "--pidlimit=-1"
+            - "--metricsport=9090"
+            - "--metricspath=/metrics"
+            - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HOST_ROOTFS
               value: "/rootfs"
             - name: NODE_ID
@@ -96,8 +103,8 @@ spec:
           args:
             - "--type=liveness"
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--livenessport=9080"
-            - "--livenesspath=/metrics"
+            - "--metricsport=9080"
+            - "--metricspath=/metrics"
             - "--polltime=60s"
             - "--timeout=3s"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -160,7 +160,7 @@ metadata:
     app: csi-liveness
 spec:
   ports:
-    - name: http-metrics
+    - name: csi-http-metrics
       port: 8080
       protocol: TCP
       targetPort: 9080

--- a/cluster/examples/kubernetes/ceph/monitoring/csi-liveness-service-monitor.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/csi-liveness-service-monitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   namespaceSelector:
     matchNames:
-      - default
+      - rook-ceph
   selector:
     matchLabels:
       app: csi-liveness

--- a/cluster/examples/kubernetes/ceph/monitoring/csi-liveness-service-monitor.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/csi-liveness-service-monitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: csi-liveness
   namespace: rook-ceph
   labels:
-    team: rook 
+    team: rook
 spec:
   namespaceSelector:
     matchNames:
@@ -14,6 +14,6 @@ spec:
     matchLabels:
       app: csi-liveness
   endpoints:
-  - port: http-metrics1
-    path: /metrics
-    interval: 5s
+    - port: csi-http-metrics
+      path: /metrics
+      interval: 5s

--- a/cluster/examples/kubernetes/ceph/monitoring/csi-metrics-service-monitor.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/csi-metrics-service-monitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: csi-liveness
+  name: csi-metrics
   namespace: rook-ceph
   labels:
     team: rook
@@ -12,8 +12,12 @@ spec:
       - rook-ceph
   selector:
     matchLabels:
-      app: csi-liveness
+      app: csi-metrics
   endpoints:
     - port: csi-http-metrics
+      path: /metrics
+      interval: 5s
+    # comment csi-grpc-metrics realated information if csi grpc metrics is not enabled
+    - port: csi-grpc-metrics
       path: /metrics
       interval: 5s

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -214,6 +214,8 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
+        - name: ROOK_CSI_ENABLE_GRPC_METRICS
+          value: "true"
 
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "true"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -155,6 +155,8 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
+        - name: ROOK_CSI_ENABLE_GRPC_METRICS
+          value: "true"
         # The default version of CSI supported by Rook will be started. To change the version
         # of the CSI driver to something other than what is officially supported, change
         # these images to the desired release of the CSI driver.

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -65,6 +65,8 @@ func init() {
 	operatorCmd.Flags().StringVar(&csi.CephFSPluginTemplatePath, "csi-cephfs-plugin-template-path", csi.DefaultCephFSPluginTemplatePath, "path to ceph-csi cephfs plugin template")
 	operatorCmd.Flags().StringVar(&csi.CephFSProvisionerSTSTemplatePath, "csi-cephfs-provisioner-sts-template-path", csi.DefaultCephFSProvisionerSTSTemplatePath, "path to ceph-csi cephfs provisioner statefulset template")
 	operatorCmd.Flags().StringVar(&csi.CephFSProvisionerDepTemplatePath, "csi-cephfs-provisioner-dep-template-path", csi.DefaultCephFSProvisionerDepTemplatePath, "path to ceph-csi cephfs provisioner deployment template")
+	//csi grpc flag
+	operatorCmd.Flags().BoolVar(&csi.EnableCSIGRPCMetrics, "csi-enable-grpc-metrics", true, "enable grpc metrics in ceph-csi")
 
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
 	flags.SetLoggingFlags(operatorCmd.Flags())

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -29,12 +29,13 @@ import (
 )
 
 type Param struct {
-	CSIPluginImage   string
-	RegistrarImage   string
-	ProvisionerImage string
-	AttacherImage    string
-	SnapshotterImage string
-	DriverNamePrefix string
+	CSIPluginImage       string
+	RegistrarImage       string
+	ProvisionerImage     string
+	AttacherImage        string
+	SnapshotterImage     string
+	DriverNamePrefix     string
+	EnableCSIGRPCMetrics string
 }
 
 type templateParam struct {
@@ -46,8 +47,9 @@ type templateParam struct {
 var (
 	CSIParam Param
 
-	EnableRBD    = false
-	EnableCephFS = false
+	EnableRBD            = false
+	EnableCephFS         = false
+	EnableCSIGRPCMetrics = false
 
 	// template paths
 	RBDPluginTemplatePath         string
@@ -151,6 +153,9 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if tp.DriverNamePrefix == "" {
 		tp.DriverNamePrefix = fmt.Sprintf("%s.", namespace)
 	}
+
+	tp.EnableCSIGRPCMetrics = fmt.Sprintf("%t", EnableCSIGRPCMetrics)
+
 	if ver.Minor < provDeploymentSuppVersion {
 		deployProvSTS = true
 	}

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -153,17 +153,17 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if EnableRBD {
 		rbdPlugin, err = templateToDaemonSet("rbdplugin", RBDPluginTemplatePath, tp)
 		if err != nil {
-			return fmt.Errorf("failed to load rbd plugin template: %v", err)
+			return fmt.Errorf("failed to load rbdplugin template: %+v", err)
 		}
 		if deployProvSTS {
 			rbdProvisionerSTS, err = templateToStatefulSet("rbd-provisioner", RBDProvisionerSTSTemplatePath, tp)
 			if err != nil {
-				return fmt.Errorf("failed to load rbd provisioner statefulset template: %v", err)
+				return fmt.Errorf("failed to load rbd provisioner statefulset template: %+v", err)
 			}
 		} else {
 			rbdProvisionerDeployment, err = templateToDeployment("rbd-provisioner", RBDProvisionerDepTemplatePath, tp)
 			if err != nil {
-				return fmt.Errorf("failed to load rbd provisioner deployment template: %v", err)
+				return fmt.Errorf("failed to load rbd provisioner deployment template: %+v", err)
 			}
 		}
 
@@ -171,17 +171,17 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if EnableCephFS {
 		cephfsPlugin, err = templateToDaemonSet("cephfsplugin", CephFSPluginTemplatePath, tp)
 		if err != nil {
-			return fmt.Errorf("failed to load CephFS plugin template: %v", err)
+			return fmt.Errorf("failed to load CephFS plugin template: %+v", err)
 		}
 		if deployProvSTS {
 			cephfsProvisionerSTS, err = templateToStatefulSet("cephfs-provisioner", CephFSProvisionerSTSTemplatePath, tp)
 			if err != nil {
-				return fmt.Errorf("failed to load CephFS provisioner statefulset template: %v", err)
+				return fmt.Errorf("failed to load CephFS provisioner statefulset template: %+v", err)
 			}
 		} else {
 			cephfsProvisionerDeployment, err = templateToDeployment("cephfs-provisioner", CephFSProvisionerDepTemplatePath, tp)
 			if err != nil {
-				return fmt.Errorf("failed to load rbd provisioner deployment template: %v", err)
+				return fmt.Errorf("failed to load rbd provisioner deployment template: %+v", err)
 			}
 		}
 	}
@@ -189,38 +189,38 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if rbdPlugin != nil {
 		err = k8sutil.CreateDaemonSet("csi rbd plugin", namespace, clientset, rbdPlugin)
 		if err != nil {
-			return fmt.Errorf("failed to start rbdplugin daemonset: %v\n%v", err, rbdPlugin)
+			return fmt.Errorf("failed to start rbdplugin daemonset: %+v\n%+v", err, rbdPlugin)
 		}
 	}
 	if rbdProvisionerSTS != nil {
 		_, err = k8sutil.CreateStatefulSet("csi rbd provisioner", namespace, "csi-rbdplugin-provisioner", clientset, rbdProvisionerSTS)
 		if err != nil {
-			return fmt.Errorf("failed to start rbd provisioner statefulset: %v\n%v", err, rbdProvisionerSTS)
+			return fmt.Errorf("failed to start rbd provisioner statefulset: %+v\n%+v", err, rbdProvisionerSTS)
 		}
 	} else if rbdProvisionerDeployment != nil {
 		err = k8sutil.CreateDeployment("csi rbd provisioner", namespace, "csi-rbdplugin-provisioner", clientset, rbdProvisionerDeployment)
 		if err != nil {
-			return fmt.Errorf("failed to start rbd provisioner deployment: %v\n%v", err, rbdProvisionerDeployment)
+			return fmt.Errorf("failed to start rbd provisioner deployment: %+v\n%+v", err, rbdProvisionerDeployment)
 		}
 	}
 
 	if cephfsPlugin != nil {
 		err = k8sutil.CreateDaemonSet("csi cephfs plugin", namespace, clientset, cephfsPlugin)
 		if err != nil {
-			return fmt.Errorf("failed to start cephfs plugin daemonset: %v\n%v", err, cephfsPlugin)
+			return fmt.Errorf("failed to start cephfs plugin daemonset: %+v\n%+v", err, cephfsPlugin)
 		}
 	}
 
 	if cephfsProvisionerSTS != nil {
 		_, err = k8sutil.CreateStatefulSet("csi cephfs provisioner", namespace, "csi-cephfsplugin-provisioner", clientset, cephfsProvisionerSTS)
 		if err != nil {
-			return fmt.Errorf("failed to start cephfs provisioner statefulset: %v\n%v", err, cephfsProvisionerSTS)
+			return fmt.Errorf("failed to start cephfs provisioner statefulset: %+v\n%+v", err, cephfsProvisionerSTS)
 		}
 
 	} else if cephfsProvisionerDeployment != nil {
 		err = k8sutil.CreateDeployment("csi cephfs provisioner", namespace, "csi-cephfsplugin-provisioner", clientset, cephfsProvisionerDeployment)
 		if err != nil {
-			return fmt.Errorf("failed to start cephfs provisioner deployment: %v\n%v", err, cephfsProvisionerDeployment)
+			return fmt.Errorf("failed to start cephfs provisioner deployment: %+v\n%+v", err, cephfsProvisionerDeployment)
 		}
 	}
 	return nil

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func loadTemplate(name, templatePath string, p templateParam) (string, error) {
@@ -41,6 +42,20 @@ func loadTemplate(name, templatePath string, p templateParam) (string, error) {
 	}
 	err = t.Execute(&writer, p)
 	return writer.String(), err
+}
+
+func templateToService(name, templatePath string, p templateParam) (*corev1.Service, error) {
+	var svc corev1.Service
+	t, err := loadTemplate(name, templatePath, p)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load service template. %+v", err)
+	}
+
+	err = yaml.Unmarshal([]byte(t), &svc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal service template %+v", err)
+	}
+	return &svc, nil
 }
 
 func templateToStatefulSet(name, templatePath string, p templateParam) (*apps.StatefulSet, error) {

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -47,12 +47,12 @@ func templateToStatefulSet(name, templatePath string, p templateParam) (*apps.St
 	var ss apps.StatefulSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load statefulset template. %+v", err)
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ss)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal statefulset template %+v", err)
 	}
 	return &ss, nil
 }
@@ -61,12 +61,12 @@ func templateToDaemonSet(name, templatePath string, p templateParam) (*apps.Daem
 	var ds apps.DaemonSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load daemonset template. %+v", err)
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal daemonset template %+v", err)
 	}
 	return &ds, nil
 }
@@ -75,12 +75,12 @@ func templateToDeployment(name, templatePath string, p templateParam) (*apps.Dep
 	var ds apps.Deployment
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load deployment template. %+v", err)
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal deployment template %+v", err)
 	}
 	return &ds, nil
 }

--- a/pkg/operator/k8sutil/daemonset.go
+++ b/pkg/operator/k8sutil/daemonset.go
@@ -34,7 +34,7 @@ func CreateDaemonSet(name, namespace string, clientset kubernetes.Interface, ds 
 			_, err = clientset.AppsV1().DaemonSets(namespace).Update(ds)
 		}
 		if err != nil {
-			return fmt.Errorf("failed to start %s daemonset: %v\n%v", name, err, ds)
+			return fmt.Errorf("failed to start %s daemonset: %+v\n%+v", name, err, ds)
 		}
 	}
 	return err

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -226,7 +226,7 @@ func addLabel(key, value string, labels map[string]string) {
 	labels[key] = value
 }
 
-func CreateDeployment(name, namespace, appName string, clientset kubernetes.Interface, dep *apps.Deployment) error {
+func CreateDeployment(name, namespace string, clientset kubernetes.Interface, dep *apps.Deployment) error {
 	_, err := clientset.AppsV1().Deployments(namespace).Create(dep)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -233,7 +233,7 @@ func CreateDeployment(name, namespace, appName string, clientset kubernetes.Inte
 			_, err = clientset.AppsV1().Deployments(namespace).Update(dep)
 		}
 		if err != nil {
-			return fmt.Errorf("failed to start %s deployment: %v\n%v", name, err, dep)
+			return fmt.Errorf("failed to start %s deployment: %+v\n%+v", name, err, dep)
 		}
 	}
 	return err

--- a/pkg/operator/k8sutil/statefulset.go
+++ b/pkg/operator/k8sutil/statefulset.go
@@ -52,7 +52,7 @@ func CreateStatefulSet(name, namespace, appName string, clientset kubernetes.Int
 	label := ss.GetLabels()
 	svc, err := makeHeadlessSvc(appName, namespace, label, clientset)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start %s service: %v\n%v", name, err, ss)
+		return nil, fmt.Errorf("failed to start %s service: %+v\n%+v", name, err, ss)
 	}
 
 	_, err = clientset.AppsV1().StatefulSets(namespace).Create(ss)
@@ -61,7 +61,7 @@ func CreateStatefulSet(name, namespace, appName string, clientset kubernetes.Int
 			_, err = clientset.AppsV1().StatefulSets(namespace).Update(ss)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to start %s statefulset: %v\n%v", name, err, ss)
+			return nil, fmt.Errorf("failed to start %s statefulset: %+v\n%+v", name, err, ss)
 		}
 	}
 	return svc, err

--- a/pkg/operator/k8sutil/statefulset.go
+++ b/pkg/operator/k8sutil/statefulset.go
@@ -22,47 +22,28 @@ import (
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // make a headless svc for statefulset
-func makeHeadlessSvc(name, namespace string, label map[string]string, clientset kubernetes.Interface) (*corev1.Service, error) {
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    label,
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: label,
-			Ports:    []corev1.ServicePort{{Name: "dummy", Port: 1234}},
-		},
-	}
-
+func CreateService(name, namespace string, clientset kubernetes.Interface, svc *corev1.Service) error {
 	_, err := clientset.CoreV1().Services(namespace).Create(svc)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return nil, fmt.Errorf("failed to create %s headless service. %+v", name, err)
+		return fmt.Errorf("failed to create %s service. %+v", name, err)
 	}
-	return svc, nil
+	return nil
 }
 
-// create a apps.statefulset and a headless svc
-func CreateStatefulSet(name, namespace, appName string, clientset kubernetes.Interface, ss *apps.StatefulSet) (*corev1.Service, error) {
-	label := ss.GetLabels()
-	svc, err := makeHeadlessSvc(appName, namespace, label, clientset)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start %s service: %+v\n%+v", name, err, ss)
-	}
-
-	_, err = clientset.AppsV1().StatefulSets(namespace).Create(ss)
+// create a apps.statefulset
+func CreateStatefulSet(name, namespace string, clientset kubernetes.Interface, ss *apps.StatefulSet) error {
+	_, err := clientset.AppsV1().StatefulSets(namespace).Create(ss)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			_, err = clientset.AppsV1().StatefulSets(namespace).Update(ss)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to start %s statefulset: %+v\n%+v", name, err, ss)
+			return fmt.Errorf("failed to start %s statefulset: %+v\n%+v", name, err, ss)
 		}
 	}
-	return svc, err
+	return nil
 }

--- a/tests/framework/installer/ceph_csi_templates.go
+++ b/tests/framework/installer/ceph_csi_templates.go
@@ -123,26 +123,6 @@ const (
                   mountPath: /etc/ceph-csi-config/
                 - name: keys-tmp-dir
                   mountPath: /tmp/csi/keys
-            - name: liveness-prometheus
-              image: {{ .CSIPluginImage }}
-              args:
-                - "--type=liveness"
-                - "--endpoint=$(CSI_ENDPOINT)"
-                - "--livenessport=8080"
-                - "--livenesspath=/metrics"
-                - "--polltime=60s"
-                - "--timeout=3s"
-              env:
-                - name: CSI_ENDPOINT
-                  value: unix:///csi/csi.sock
-                - name: POD_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-              volumeMounts:
-                - name: socket-dir
-                  mountPath: /csi
-              imagePullPolicy: "IfNotPresent"
           volumes:
             - name: host-dev
               hostPath:
@@ -264,26 +244,6 @@ const (
                   mountPath: /etc/ceph-csi-config/
                 - name: keys-tmp-dir
                   mountPath: /tmp/csi/keys
-            - name: liveness-prometheus
-              image: {{ .CSIPluginImage }}
-              args:
-                - "--type=liveness"
-                - "--endpoint=$(CSI_ENDPOINT)"
-                - "--livenessport=8080"
-                - "--livenesspath=/metrics"
-                - "--polltime=60s"
-                - "--timeout=3s"
-              env:
-                - name: CSI_ENDPOINT
-                  value: unix:///csi/csi.sock
-                - name: POD_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-              volumeMounts:
-                - name: plugin-dir
-                  mountPath: /csi
-              imagePullPolicy: "IfNotPresent"
           volumes:
             - name: plugin-dir
               hostPath:
@@ -409,26 +369,6 @@ const (
                   mountPath: /etc/ceph-csi-config/
                 - name: keys-tmp-dir
                   mountPath: /tmp/csi/keys
-            - name: liveness-prometheus
-              image: {{ .CSIPluginImage }}
-              args:
-                - "--type=liveness"
-                - "--endpoint=$(CSI_ENDPOINT)"
-                - "--livenessport=8081"
-                - "--livenesspath=/metrics"
-                - "--polltime=60s"
-                - "--timeout=3s"
-              env:
-                - name: CSI_ENDPOINT
-                  value: unix:///csi/csi.sock
-                - name: POD_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-              volumeMounts:
-                - name: socket-dir
-                  mountPath: /csi
-              imagePullPolicy: "IfNotPresent"
           volumes:
             - name: socket-dir
               hostPath:
@@ -544,26 +484,6 @@ const (
                   mountPath: /etc/ceph-csi-config/
                 - name: keys-tmp-dir
                   mountPath: /tmp/csi/keys
-            - name: liveness-prometheus
-              image: {{ .CSIPluginImage }}
-              args:
-                - "--type=liveness"
-                - "--endpoint=$(CSI_ENDPOINT)"
-                - "--livenessport=8081"
-                - "--livenesspath=/metrics"
-                - "--polltime=60s"
-                - "--timeout=3s"
-              env:
-                - name: CSI_ENDPOINT
-                  value: unix:///csi/csi.sock
-                - name: POD_IP
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: status.podIP
-              volumeMounts:
-                - name: plugin-dir
-                  mountPath: /csi
-              imagePullPolicy: "IfNotPresent"
           volumes:
             - name: plugin-dir
               hostPath:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1303,6 +1303,8 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_RBD
           value: "true"
+        - name: ROOK_CSI_ENABLE_GRPC_METRICS
+          value: "true"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

grpc metrics is made an option in rook this can be enabled with ROOK_CSI_ENABLE_GRPC_METRCS variable in operator.yaml this will help admin who wants to check the grpc metrics of the ceph-csi plugins

This also changes the liveness probe port range of 9080 ad 9081
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

depends on https://github.com/ceph/ceph-csi/pull/566

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]
leseb: known ci issue