### PR TITLE
Copy binaries init container for osds on pvcs provisioning

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -69,9 +69,7 @@ func (c *Cluster) makeJob(osdProps osdProperties) (*batch.Job, error) {
 	if osdProps.pvc.ClaimName == "" {
 		podSpec.Spec.NodeSelector = map[string]string{v1.LabelHostname: osdProps.crushHostname}
 	} else {
-		podSpec.Spec.InitContainers = []v1.Container{
-			c.getPVCInitContainer(osdProps.pvc),
-		}
+		podSpec.Spec.InitContainers = append(podSpec.Spec.InitContainers, c.getPVCInitContainer(osdProps.pvc))
 	}
 
 	job := &batch.Job{


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The init container for copying binaries was being overwritten by the init container for initializing pvcs. This change appends the init containers so all expected init containers are preserved. This is related to #3573 that just merged where the copy binaries container was converted to an init container.

With this issue all clusters with OSDs on PVCs will fail to create the OSD prepare jobs. Evidence that we need an integration test using PVCs...

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
