### PR TITLE
ceph: external be a bit more flexible on upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -37,6 +37,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/rbd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,12 +158,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	}
 
 	if c.Spec.External.Enable {
-		externalCephMonVersion, err := client.GetCephMonVersion(c.context, c.Namespace)
-		if err != nil {
-			return fmt.Errorf("failed to get ceph mon version. %+v", err)
-		}
-		c.Info.CephVersion = *externalCephMonVersion
-		err = cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(*version, c.Info.CephVersion)
+		c.Info.CephVersion, err = cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, *version)
 		if err != nil {
 			return fmt.Errorf("failed to validate ceph version between external and local. %+v", err)
 		}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	discoverDaemon "github.com/rook/rook/pkg/daemon/discover"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -61,6 +62,7 @@ const (
 	updateClusterInterval    = 30 * time.Second
 	updateClusterTimeout     = 1 * time.Hour
 	detectCephVersionTimeout = 15 * time.Minute
+	externalConnectionRetry  = 60 * time.Second
 )
 
 const (
@@ -254,19 +256,14 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	c.updateClusterStatus(namespace, name, cephv1.ClusterStateConnecting, "")
 
 	// loop until we find the secret necessary to connect to the external cluster
-	for {
-		var err error
-		cluster.Info, _, _, err = mon.LoadClusterInfo(c.context, namespace)
-		if err != nil {
-			logger.Warningf("waiting for the connection info of the external cluster. %+v", err)
-			time.Sleep(10 * time.Second)
-			continue
-		} else {
-			break
-		}
-	}
+	// then populate clusterInfo
+	cluster.Info = populateExternalClusterInfo(c.context, namespace)
 
-	logger.Infof("found the cluster info to connect to the external cluster. mons=%+v", cluster.Info.Monitors)
+	// Validate versions (local and external)
+	_, _, err = c.detectAndValidateCephVersion(cluster, cluster.Spec.CephVersion.Image)
+	if err != nil {
+		return fmt.Errorf("failed to detect and validate ceph version. %+v", err)
+	}
 
 	// Write the rook-ceph-config configmap (used by various daemons to apply config overrides)
 	// If we don't do this, daemons will never start, waiting forever for this configmap to be present
@@ -275,36 +272,11 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 		return err
 	}
 
-	// Let's write connection info (ceph config file and keyring) to the operator for health checks
-	err = mon.WriteConnectionConfig(cluster.context, cluster.Info)
+	// Apply CRD ConfigOverrideName to the external cluster
+	err = config.SetDefaultAndUserConfigs(cluster.context, namespace, cluster.Info, cluster.Spec.ConfigOverrides)
 	if err != nil {
-		return fmt.Errorf("failed to write connection info %+v", err)
-	}
-
-	// Get Ceph monitors version on the external cluster
-	cephMonVersion, err := client.GetCephMonVersion(c.context, namespace)
-	if err != nil {
-		return fmt.Errorf("failed to get ceph mon version. %+v", err)
-	}
-
-	// We only support Nautilus or newer
-	if !cephMonVersion.IsAtLeastNautilus() {
-		return fmt.Errorf("unsupported ceph version %s, need at least nautilus", cephMonVersion.String())
-	}
-
-	logger.Infof("detecting the image version provided for the external cluster...")
-	specCephVersionImage, err := cluster.detectCephVersion(c.rookImage, cluster.Spec.CephVersion.Image, detectCephVersionTimeout)
-	if err != nil {
-		return fmt.Errorf("unknown ceph major version. %+v", err)
-	}
-	specCephVersion := *specCephVersionImage
-
-	// Populate clusterInfo with the external cluster version
-	cluster.Info.CephVersion = *cephMonVersion
-
-	// Make sure the external cluster version and the ceph version in the provided image are identical
-	if !cephver.IsIdentical(specCephVersion, cluster.Info.CephVersion) {
-		return fmt.Errorf("wrong ceph version %s, external cluster version is %s, they must match", specCephVersion.String(), cephMonVersion.String())
+		// Mons are up, so something else is wrong
+		return fmt.Errorf("failed to set Rook and/or user-defined Ceph config options on the external cluster monitors. %+v", err)
 	}
 
 	// The cluster Identity must be established at this point
@@ -980,4 +952,23 @@ func validateExternalClusterSpec(cluster *cluster) error {
 	}
 
 	return nil
+}
+
+// Add validation in the code to fail if the external cluster has no OSDs keep waiting
+func populateExternalClusterInfo(context *clusterd.Context, namespace string) *cephconfig.ClusterInfo {
+	var clusterInfo *cephconfig.ClusterInfo
+	for {
+		var err error
+		clusterInfo, _, _, err = mon.LoadClusterInfo(context, namespace)
+		if err != nil {
+			logger.Warningf("waiting for the connection info of the external cluster. retrying in %s.", externalConnectionRetry.String())
+			time.Sleep(externalConnectionRetry)
+			continue
+		} else {
+			logger.Infof("found the cluster info to connect to the external cluster. mons=%+v", clusterInfo.Monitors)
+			break
+		}
+	}
+
+	return clusterInfo
 }

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -26,9 +26,8 @@ import (
 	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -108,14 +107,7 @@ func (c *FilesystemController) onAdd(obj interface{}) {
 	defer c.releaseOrchestrationLock()
 
 	if c.clusterSpec.External.Enable {
-		// health check should tell us if the external cluster has been upgraded and display a message
-		externalCephMonVersion, err := client.GetCephMonVersion(c.context, c.namespace)
-		if err != nil {
-			logger.Errorf("failed to get ceph mon version. %+v", err)
-			return
-		}
-
-		err = cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(c.clusterInfo.CephVersion, *externalCephMonVersion)
+		_, err := cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -25,8 +25,10 @@ import (
 	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	daemonconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -104,6 +106,22 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
 
+	if c.clusterSpec.External.Enable {
+		// health check should tell us if the external cluster has been upgraded and display a message
+		externalCephMonVersion, err := client.GetCephMonVersion(c.context, c.namespace)
+		if err != nil {
+			logger.Errorf("failed to get ceph mon version. %+v", err)
+			return
+		}
+
+		err = cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(c.clusterInfo.CephVersion, *externalCephMonVersion)
+		if err != nil {
+			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
+			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical
+			logger.Errorf("refusing to run new crd. %+v", err)
+			return
+		}
+	}
 	c.createOrUpdateStore(objectstore)
 }
 

--- a/pkg/operator/ceph/spec/version.go
+++ b/pkg/operator/ceph/spec/version.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+)
+
+// ValidateCephVersionsBetweenLocalAndExternalClusters makes sure an external cluster can be connected
+// by checking the external ceph versions available and comparing it with the local image provided
+func ValidateCephVersionsBetweenLocalAndExternalClusters(context *clusterd.Context, namespace string, localVersion cephver.CephVersion) (cephver.CephVersion, error) {
+	// health check should tell us if the external cluster has been upgraded and display a message
+	externalVersion, err := client.GetCephMonVersion(context, namespace)
+	if err != nil {
+		return cephver.CephVersion{}, fmt.Errorf("failed to get ceph mon version. %+v", err)
+	}
+
+	return *externalVersion, cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, *externalVersion)
+}

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -175,3 +175,36 @@ func TestIsInferior(t *testing.T) {
 	assert.True(t, IsInferior(CephVersion{15, 1, 3}, CephVersion{15, 2, 2}))
 	assert.True(t, IsInferior(CephVersion{15, 2, 1}, CephVersion{15, 2, 2}))
 }
+
+func TestValidateCephVersionsBetweenLocalAndExternalClusters(t *testing.T) {
+	// TEST 1: versions are identical
+	localCephVersion := CephVersion{Major: 14, Minor: 2, Extra: 1}
+	externalCephVersion := CephVersion{Major: 14, Minor: 2, Extra: 1}
+	err := ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.NoError(t, err)
+
+	// TEST 2: local cluster version major is lower than external cluster version
+	localCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 1}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.NoError(t, err)
+
+	// TEST 3: local cluster version major is higher than external cluster version
+	localCephVersion = CephVersion{Major: 15, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 1}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.Error(t, err)
+
+	// TEST 4: local version is > but from a minor release
+	// local version must never be higher
+	localCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 2}
+	externalCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 1}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.Error(t, err)
+
+	// TEST 5: external version is > but from a minor release
+	localCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 1}
+	externalCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 2}
+	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Add various upgrade tests so that the local cluster does not fail if
an upgrade is available on the external cluster.

Also, add better upgrades handling on update and on add. We now rely as
much as possible on a unique function that works both local and external
cluster 'detectAndValidateCephVersion()'. So the code will act the same
way wether a CR update is triggered or if the operator is restarted.

The health check now reports any topology changes on the external
cluster such as odd number of mons and low number. It will also detect
if the external cluster has been upgraded and will log that information,
  helping the admin in his/her decision to trigger an image upgrade.

Finally, we prevent the creation of new CRs if the external cluster
version has a higher major number than the local one.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/3731

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.