### PR TITLE
Clean up verbose Ceph logging

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -486,11 +486,11 @@ func (c *ClusterController) onK8sNodeUpdate(oldObj, newObj interface{}) {
 
 	// Checking for NoSchedule added to storage node
 	if oldNodeSchedulable == false && newNodeSchedulable == false {
-		logger.Debugf("Skipping cluster update. Updated node %s was and is still unschedulable", newNode.Labels[v1.LabelHostname])
+		// Skipping cluster update. Updated node was and is still unschedulable
 		return
 	}
 	if oldNodeSchedulable == true && newNodeSchedulable == true {
-		logger.Debugf("Skipping cluster update. Updated node %s was and it is still schedulable", oldNode.Labels[v1.LabelHostname])
+		// Skipping cluster update. Updated node was and is still schedulable
 		return
 	}
 
@@ -711,7 +711,7 @@ func (c *ClusterController) onDeviceCMUpdate(oldObj, newObj interface{}) {
 
 	for _, cluster := range c.clusterMap {
 		if cluster.Info == nil {
-			logger.Info("Cluster %s is not ready. Skipping orchestration on device change", cluster.Namespace)
+			logger.Infof("Cluster %s is not ready. Skipping orchestration on device change", cluster.Namespace)
 			continue
 		}
 		logger.Infof("Running orchestration for namespace %s after device change", cluster.Namespace)

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -92,7 +92,7 @@ func (r *ReconcileClusterDisruption) reconcile(request reconcile.Request) (recon
 		logger.Debugf("discovered NamespacedName: %s", request.NamespacedName)
 	}
 	r.namelessRetries = 0
-	logger.Infof("reconciling %s", request.NamespacedName)
+	logger.Debugf("reconciling %s", request.NamespacedName)
 
 	// get the ceph cluster
 	cephCluster := &cephv1.CephCluster{}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
A few minor log messages to cleanup the operator logs... The log messages for orchestrations being skipped due to nodes still being schedulable or unschedulable is filling the logs. The log message for reconciling is now debug, and also fixed another formatting log message.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
