### PR TITLE
Set image version in manifests to v1.0.6

### DIFF
--- a/Documentation/ceph-toolbox.md
+++ b/Documentation/ceph-toolbox.md
@@ -36,7 +36,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -45,10 +45,10 @@ With this upgrade guide, there are a few notes to consider:
 
 ## Patch Release Upgrades
 Unless otherwise noted due to extenuating requirements, upgrades from one patch release of Rook to
-another are as simple as updating the image of the Rook operator. For example, when Rook v1.0.5 is
+another are as simple as updating the image of the Rook operator. For example, when Rook v1.0.6 is
 released, the process of updating from v1.0.0 should be as simple as running the following:
 ```
-kubectl -n rook-ceph-system set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.0.5
+kubectl -n rook-ceph-system set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.0.6
 ```
 
 
@@ -212,7 +212,7 @@ to aid users in any manifest-related auditing they wish to do.
 ### 3. Update the Rook operator image
 The largest portion of the upgrade is triggered when the operator's image is updated to `v1.0.x`.
 ```sh
-kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.0.5
+kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.0.6
 ```
 
 Watch now in amazement as the Ceph mons, mgrs, OSDs, rbd-mirrors, mdses and rgws are terminated and
@@ -255,7 +255,7 @@ to proceed with the next step before the mdses and rgws are finished updating.
 ```
 
 ### 5. Verify the updated cluster
-At this point, your Rook operator should be running version `rook/ceph:v1.0.5`
+At this point, your Rook operator should be running version `rook/ceph:v1.0.6`
 
 Verify the Ceph cluster's health using the [health verification section](#health-verification).
 

--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-after-reboot-check
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-before-reboot-check
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -186,7 +186,7 @@ subjects:
        serviceAccountName: rook-cassandra-operator
        containers:
        - name: rook-cassandra-operator
-         image: rook/cassandra:v1.0.5
+         image: rook/cassandra:v1.0.6
          imagePullPolicy: "Always"
          args: ["cassandra", "operator"]
          env:

--- a/cluster/examples/kubernetes/ceph/operator-openshift-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift-with-csi.yaml
@@ -109,7 +109,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-with-csi.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.0.5
+        image: rook/ceph:v1.0.6
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: rook-cockroachdb-operator
       containers:
       - name: rook-cockroachdb-operator
-        image: rook/cockroachdb:v1.0.5
+        image: rook/cockroachdb:v1.0.6
         args: ["cockroachdb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -236,7 +236,7 @@ spec:
       serviceAccountName: rook-edgefs-system
       containers:
       - name: rook-edgefs-operator
-        image: rook/edgefs:v1.0.5
+        image: rook/edgefs:v1.0.6
         imagePullPolicy: "Always"
         args: ["edgefs", "operator"]
         env:

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: rook-minio-operator
       containers:
       - name: rook-minio-operator
-        image: rook/minio:v1.0.5
+        image: rook/minio:v1.0.6
         args: ["minio", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -103,7 +103,7 @@ spec:
       serviceAccountName: rook-nfs-operator
       containers:
       - name: rook-nfs-operator
-        image: rook/nfs:v1.0.5
+        image: rook/nfs:v1.0.6
         imagePullPolicy: IfNotPresent
         args: ["nfs", "operator"]
         env:
@@ -192,7 +192,7 @@ spec:
       serviceAccount: rook-nfs-provisioner
       containers:
       - name: rook-nfs-provisioner
-        image: rook/nfs:v1.0.5
+        image: rook/nfs:v1.0.6
         imagePullPolicy: IfNotPresent
         args: ["nfs", "provisioner","--provisioner=rook.io/nfs-provisioner"]
         env:


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Set the version of the rook/ceph image to v1.0.6 for the release.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]