### PR TITLE
bugfix: copy helm chart aside for packaging

### DIFF
--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -36,12 +36,15 @@ $(HELM):
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 	@$(HELM) init -c
 
+# TODO: after helm 3.0 released just pass --set image.tag=foo
+# to helm lint and helm package steps
 define helm.chart
 $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
 	@echo === helm package $(1)
-	@$(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' $(HELM_CHARTS_DIR)/$(1)/values.yaml
-	@$(HELM) lint --strict $(abspath $(HELM_CHARTS_DIR)/$(1))
-	@$(HELM) package --version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(HELM_CHARTS_DIR)/$(1))
+	@cp -r $(HELM_CHARTS_DIR)/$(1) $(OUTPUT_DIR)
+	@$(SED_CMD) 's|%%VERSION%%|$(VERSION)|g' $(OUTPUT_DIR)/$(1)/values.yaml
+	@$(HELM) lint --strict $(abspath $(OUTPUT_DIR)/$(1))
+	@$(HELM) package --version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(OUTPUT_DIR)/$(1))
 $(HELM_INDEX): $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz
 endef
 $(foreach p,$(HELM_CHARTS),$(eval $(call helm.chart,$(p))))


### PR DESCRIPTION
In order to not leave any modified file after release, lets put
chart tree aside and run sed logic on it.

Signed-off-by: Dinar Valeev <k0da@opensuse.org>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves  #3746

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
