### PR TITLE
[osd on pvc] deactivate device from lvm after OSD Prepare and OSD daemon pod ends

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -59,6 +59,7 @@ var osdStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts the osd daemon", // OSDs that were provisioned by ceph-volume
 }
+
 var (
 	osdDataDeviceFilter string
 	ownerRefID          string

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -420,8 +420,8 @@ func getCephVolumeOSDs(context *clusterd.Context, clusterName string, cephfsid s
 		}
 		osds = append(osds, osd)
 	}
-
 	logger.Infof("%d ceph-volume osd devices configured on this node", len(osds))
+
 	return osds, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Santosh Pillai <sapillai@redhat.com>

**Description of your changes:**
- When LVM uses a block PV (either via the OSD prepare job or the OSD pod), it appears to open the device and not release it when the accessing container terminates. This results in kube/OCP being unable to detach the PV from that node (and so can't attach to a different node).

One possible solutions (short-term-fix) is to use lvchange -an and ask LVM to release the device.
Code Changes:
- Running `lvchange -an <vg group name>` to deactivate the device.
- This command runs after 'osd prepare' completes.
- This command also runs after the 'osd daemon pod' is deleted or if the ceph-osd process terminates for some reasons. 

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip-ci]