### PR TITLE
Remove outdated cluster/charts/rook-ceph/.gitignore

### DIFF
--- a/cluster/charts/rook-ceph/.gitignore
+++ b/cluster/charts/rook-ceph/.gitignore
@@ -1,1 +1,0 @@
-values.yaml-e


### PR DESCRIPTION
**Description of your changes:**

Since values.yaml is no longer generated from a template
thanks to #3701, the .gitignore file shouldn't be needed.

[skip ci]

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
