### PR TITLE
ceph: bump to 14.2.3

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -91,7 +91,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 - `external`:
   - `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster).
 - `cephVersion`: The version information for launching the ceph daemons.
-  - `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v13.2.6-20190604` or `ceph/ceph:v14.2.2-20190826`.
+  - `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v13.2.6-20190604` or `ceph/ceph:v14.2.3-20190904`.
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
   To ensure a consistent version of the image is running across all nodes in the cluster, it is recommended to use a very specific image version.
   Tags also exist that would give the latest version, but they are only recommended for test environments. For example, the tag `v14` will be updated each time a new nautilus build is released.
@@ -357,7 +357,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -389,7 +389,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -432,7 +432,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -469,7 +469,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -515,7 +515,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -553,7 +553,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -617,7 +617,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -664,7 +664,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -750,7 +750,7 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826 # the image version **must** match the version of the external Ceph cluster
+    image: ceph/ceph:v14.2.3-20190904 # the image version **must** match the version of the external Ceph cluster
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -77,7 +77,7 @@ metadata:
 spec:
   cephVersion:
     # For the latest ceph images, see https://hub.docker.com/r/ceph/ceph/tags
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -20,4 +20,4 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826 # MUST match external cluster version
+    image: ceph/ceph:v14.2.3-20190904 # MUST match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -32,7 +32,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
     allowUnsupported: false
   dashboard:
     enabled: true

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -14,7 +14,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
     allowUnsupported: true
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -20,7 +20,7 @@ spec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    image: ceph/ceph:v14.2.2-20190826
+    image: ceph/ceph:v14.2.3-20190904
     # Whether to allow unsupported versions of Ceph. Currently mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Octopus is the version allowed when this is set to true.
     # Do not set to true in production.

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -89,7 +89,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v14.2.2-20190826"
+              "image": "ceph/ceph:v14.2.3-20190904"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -17,7 +17,7 @@ include ../image.mk
 # ====================================================================================
 # Image Build Options
 
-CEPH_VERSION = v14.2.2-20190826
+CEPH_VERSION = v14.2.3-20190904
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 OPERATOR_SDK_VERSION = v0.10.0
@@ -30,7 +30,7 @@ OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
 endif
 
-OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) 
+OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
 YQ := $(TOOLS_HOST_DIR)/yq.v2
 
 # ====================================================================================

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -202,7 +202,7 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	err = validateExternalClusterSpec(c)
 	assert.Error(t, err)
 
-	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.2-20190826"
+	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.3-20190904"
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err)
 }

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -41,7 +41,7 @@ const (
 	// test with the latest mimic build
 	mimicTestImage = "ceph/ceph:v13"
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14.2.2-20190826"
+	nautilusTestImage = "ceph/ceph:v14.2.3-20190904"
 	helmChartName     = "local/rook-ceph"
 	helmDeployName    = "rook-ceph"
 	cephOperatorLabel = "app=rook-ceph-operator"

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -145,7 +145,7 @@ func StartLoadTestCluster(t func() *testing.T, namespace string) (LoadTestCluste
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
 
-	i := installer.NewCephInstaller(t, kh.Clientset, false, installer.VersionMaster, cephv1.CephVersionSpec{Image: "ceph/ceph:v14.2.2-20190826"})
+	i := installer.NewCephInstaller(t, kh.Clientset, false, installer.VersionMaster, cephv1.CephVersionSpec{Image: "ceph/ceph:v14.2.3-20190904"})
 
 	op := LoadTestCluster{i, kh, nil, t, namespace}
 	op.Setup()


### PR DESCRIPTION
Let's use the latest minor release of Ceph.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.