### PR TITLE
osddaemon: run vgchange -ay during init

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -16,7 +16,7 @@
   - The on-host log directory for OSDs was set incorrectly to `<dataDirHostPath>/<namespace>/log`;
     fix this to be `<dataDirHostPath>/log/<namespace>`, the same as other daemons.
   - Use the mon configuration database for directory-based OSDs, and do not generate a config
-
+  - During each OSD Pod init `vgchange -ay` command will be run activate any VGs on the server. This is to counter issues with hosts not having the LVM services enabled (e.g., https://github.com/rook/rook/issues/3640).
 
 ### EdgeFS
 


### PR DESCRIPTION
**Description of your changes:**

Running `vgchange -ay` will enable all VGs on the host. This will remove
the need to have the lvm* services running on the host. In such a case
with a host, this would lead to all OSDs on that host to be unavailable
and the OSD Pods crashlooping as they can't find their VG and / or LV.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #3640

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]