### PR TITLE
Ceph osd: lower OSD pod minimum mem to 2Gb

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -275,7 +275,7 @@ Here are the current minimum amounts of memory in MB to apply so that Rook will 
 
 - `mon`: 1024MB
 - `mgr`: 512MB
-- `osd`: 4096MB
+- `osd`: 2048MB
 - `mds`: 4096MB
 - `rbdmirror`: 512MB
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -53,6 +53,7 @@ an example usage
    - If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
 - Rook can now manage PodDisruptionBudgets for the following Daemons: OSD, Mon, RGW, MDS. OSD budgets are dynamically managed as documented in the [design](https://github.com/rook/rook/blob/master/design/ceph-managed-disruptionbudgets.md). This can be enabled with the `managePodBudgets` flag in the cluster CR. When this is enabled, drains on OSDs will be blocked by default and dynamically unblocked in a safe manner one failureDomain at a time. When a failure domain is draining, it will be marked as no out for a longer time than the default DOWN/OUT interval.
 - Flexvolume plugin now supports dynamic PVC expansion.
+- The Rook-enforced minimum memory for OSD pods has been reduced from 4096M to 2048M
 
 ### YugabyteDB
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -61,7 +61,7 @@ const (
 	serviceAccountName                  = "rook-ceph-osd"
 	unknownID                           = -1
 	portableKey                         = "portable"
-	cephOsdPodMinimumMemory      uint64 = 4096 // minimum amount of memory in MB to run the pod
+	cephOsdPodMinimumMemory      uint64 = 2048 // minimum amount of memory in MB to run the pod
 )
 
 // Cluster keeps track of the OSDs


### PR DESCRIPTION
Some users have reported issues running Ceph OSDs in environments
without beefy systems. After consulting with Ceph experts, we believe
2Gb is still a safe minimum for Ceph for users with more modest systems
that won't result in disfunction in Ceph.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
We hope this will help with #3132 but are not certain it will resolve the issue.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]