### PR TITLE
fix random OSD daemon pod failures when running OSD on PVC

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -67,6 +67,7 @@ var (
 	osdUUID             string
 	osdIsDevice         bool
 	pvcBackedOSD        bool
+	lvPath              string
 )
 
 func addOSDFlags(command *cobra.Command) {
@@ -95,6 +96,7 @@ func addOSDFlags(command *cobra.Command) {
 	osdStartCmd.Flags().StringVar(&osdUUID, "osd-uuid", "", "the osd UUID")
 	osdStartCmd.Flags().StringVar(&osdStoreType, "osd-store-type", "", "whether the osd is bluestore or filestore")
 	osdStartCmd.Flags().BoolVar(&pvcBackedOSD, "pvc-backed-osd", false, "Whether the OSD backing store in PVC or not")
+	osdStartCmd.Flags().StringVar(&lvPath, "lv-path", "", "LV path for the OSD created by ceph volume")
 
 	// add the subcommands to the parent osd command
 	osdCmd.AddCommand(osdConfigCmd,
@@ -142,7 +144,7 @@ func startOSD(cmd *cobra.Command, args []string) error {
 	commonOSDInit(osdStartCmd)
 
 	context := createContext()
-	err := osddaemon.StartOSD(context, osdStoreType, osdStringID, osdUUID, pvcBackedOSD, args)
+	err := osddaemon.StartOSD(context, osdStoreType, osdStringID, osdUUID, lvPath, pvcBackedOSD, args)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -293,3 +293,21 @@ func testGetRemovedDevicesHelper(t *testing.T, storeConfig *config.StoreConfig) 
 	assert.NotNil(t, mappingEntry)
 	assert.Equal(t, 1, mappingEntry.Data)
 }
+
+func TestGetVolumeGroupName(t *testing.T) {
+	validLVPath := "/dev/vgName1/lvName2"
+	invalidLVPath1 := "/dev//vgName2"
+	invalidLVPath2 := "/dev/"
+
+	vgName, err := getVolumeGroupName(validLVPath)
+	assert.Nil(t, err)
+	assert.Equal(t, vgName, "vgName1")
+
+	vgName, err = getVolumeGroupName(invalidLVPath1)
+	assert.NotNil(t, err)
+	assert.Equal(t, vgName, "")
+
+	vgName, err = getVolumeGroupName(invalidLVPath2)
+	assert.NotNil(t, err)
+	assert.Equal(t, vgName, "")
+}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -415,6 +415,7 @@ func getCephVolumeOSDs(context *clusterd.Context, clusterName string, cephfsid s
 			UUID:                osdFSID,
 			CephVolumeInitiated: true,
 			IsFileStore:         isFilestore,
+			LVPath:              lv,
 		}
 		osds = append(osds, osd)
 	}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -130,6 +130,8 @@ type OSDInfo struct {
 	IsDirectory         bool   `json:"is-directory"`
 	DevicePartUUID      string `json:"device-part-uuid"`
 	CephVolumeInitiated bool   `json:"ceph-volume-initiated"`
+	//LVPath is the logical Volume path for an OSD created by Ceph-volume with format '/dev/<Volume Group>/<Logical Volume>'
+	LVPath string `json:"lv-path"`
 }
 
 type OrchestrationStatus struct {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -49,6 +49,7 @@ const (
 	encryptedDeviceEnvVarName           = "ROOK_ENCRYPTED_DEVICE"
 	osdMetadataDeviceEnvVarName         = "ROOK_METADATA_DEVICE"
 	pvcBackedOSDVarName                 = "ROOK_PVC_BACKED_OSD"
+	lvPathVarName                       = "ROOK_LV_PATH"
 	rookBinariesMountPath               = "/rook"
 	rookBinariesVolumeName              = "rook-binaries"
 	blockPVCMapperInitContainer         = "blkdevmapper"
@@ -263,6 +264,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 	if osdProps.pvc.ClaimName != "" {
 		volumeMounts = append(volumeMounts, getPvcOSDBridgeMount(osdProps.pvc.ClaimName))
 		envVars = append(envVars, pvcBackedOSDEnvVar("true"))
+		envVars = append(envVars, lvPathEnvVariable(osd.LVPath))
 	}
 
 	privileged := true
@@ -706,6 +708,10 @@ func dataDirectoriesEnvVar(dataDirectories string) v1.EnvVar {
 
 func pvcBackedOSDEnvVar(pvcBacked string) v1.EnvVar {
 	return v1.EnvVar{Name: pvcBackedOSDVarName, Value: pvcBacked}
+}
+
+func lvPathEnvVariable(lvPath string) v1.EnvVar {
+	return v1.EnvVar{Name: lvPathVarName, Value: lvPath}
 }
 
 func getDirectoriesFromContainer(osdContainer v1.Container) []rookalpha.Directory {


### PR DESCRIPTION

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
 OSD pods when running on PVC fail randomly due to some race condition:
 OSD daemon pod was activating the volume group using vgchange -an without any volume group name.
 - This caused the pods to fail randomly when number of OSDs is more, say greater than 10.
 - This fix adds Volume group name while activating/deactivating volume groups to fix this

**Which issue is resolved by this Pull Request:**
Resolves #3612

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
