### PR TITLE
DNM: ceph: null configOverride sets option to default

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -301,15 +301,19 @@ affect all Ceph daemons, a daemon type, an individual Ceph daemon, or a glob mat
 daemons. It may also use a
 [mask](https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#sections-and-masks).
 `option` is the configuration option to be overridden, and `value` is the value to set on the
-configuration option. All properties are strings.
+configuration option. All properties are strings. `value` may also be a null value (`null` or `~` in
+YAML; `null` in JSON), which will configure Ceph to use the default value for a parameter.
+
+If an item is removed from the `configOverrides` section, Rook will no longer control the option,
+and Ceph will retain the most recently set value.
 
 Rook will only set configuration overrides once when an orchestration is run. For example, on node
 addition or removal, when disks change on a node, or when the operator starts (or restarts). This
 means that users can change Ceph's configuration from the CLI or dashboard as desired without Rook
 constantly fighting to control the setting. This is particularly valuable in situations where values
-need to be changed to debug errors or test changes to tuning parameters.
+need to be changed temporarily to debug errors or test changes to tuning parameters.
 
-**WARNING:** Remember that Rook will set these overrides any time the operator restarts, so user
+**WARNING:** Remember that Rook will set these overrides any time an orchestration is run, so user
 changes via Ceph's CLI or dashboard to values set here will not persist forever.
 
 Some examples:
@@ -330,6 +334,12 @@ Some examples:
     - who: osd/rack:foo
       option: debug_ms
       value: "20"
+    - who: mon.b
+      option: debug_ms
+      value: ~
+    - who: mon.c
+      option: debug_ms
+      value: null
 ```
 
 #### Advanced config

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -145,16 +145,19 @@ spec:
 #      deviceFilter: "^sd."
   # Override Ceph configs. These can be overridden by the user at runtime using the Ceph CLI, and
   # Rook will set them back to the values set here when the operator restarts.
-  configOverrides:
-    - who: global
-      option: debug ms
-      value: "1/5"
-    - who: osd.0
-      option: debug_osd
-      value: "10"
-    - who: mon.a
-      option: debug-mon
-      value: "10"
+  # configOverrides:
+  #   - who: global
+  #     option: debug ms
+  #     value: "10"
+  #   - who: global
+  #     option: debug ms
+  #     value: ~
+  #   - who: osd.0
+  #     option: debug_osd
+  #     value: "10"
+  #   - who: mon.a
+  #     option: debug-mon
+  #     value: "10"
   disruptionManagement: #The section for configuring management of daemon disruptions
     managePodBudgets: false #if `true`, the operator will create and manage PodDsruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph-managed-disruptionbudgets.md). The operator will block eviction of OSDs by default and unblock them safely when drains are detected.
     osdMaintenanceTimeout: 30 # is a duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -150,6 +150,7 @@ spec:
                     type: string
                   value:
                     type: string
+                    nullable: true
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -165,9 +165,9 @@ type ConfigOverridesSpec []ConfigOverride
 // `ceph config set <who> <option> <value>` (or similar) command.
 // See Ceph docs: https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
 type ConfigOverride struct {
-	Who    string `json:"who"`
-	Option string `json:"option"`
-	Value  string `json:"value"`
+	Who    string  `json:"who"`
+	Option string  `json:"option"`
+	Value  *string `json:"value"`
 }
 
 type MonSpec struct {

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -56,7 +56,7 @@ func DefaultFlags(fsid, mountedKeyringPath string, cephVersion version.CephVersi
 
 // makes it possible to be slightly less verbose to create a ConfigOverride here
 func configOverride(who, option, value string) rookceph.ConfigOverride {
-	return rookceph.ConfigOverride{Who: who, Option: option, Value: value}
+	return rookceph.ConfigOverride{Who: who, Option: option, Value: &value}
 }
 
 // DefaultCentralizedConfigs returns the default configuration options Rook will set in Ceph's

--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -50,26 +50,36 @@ func TestMonStore_Set(t *testing.T) {
 
 	monStore := GetMonStore(ctx, "ns")
 
+	stringPointer := func(s string) *string {
+		return &s
+	}
+
 	// setting with spaces converts to underscores
-	e := monStore.Set("global", "debug ms", "10")
+	e := monStore.Set("global", "debug ms", stringPointer("10"))
 	assert.NoError(t, e)
 	assert.Contains(t, execedCmd, "config set global debug_ms 10")
 
 	// setting with dashes converts to underscores
-	e = monStore.Set("osd.0", "debug-osd", "20")
+	e = monStore.Set("osd.0", "debug-osd", stringPointer("20"))
 	assert.NoError(t, e)
 	assert.Contains(t, execedCmd, " config set osd.0 debug_osd 20 ")
 
 	// setting with underscores stays the same
-	e = monStore.Set("mds.*", "debug_mds", "15")
+	e = monStore.Set("mds.*", "debug_mds", stringPointer("15"))
 	assert.NoError(t, e)
 	assert.Contains(t, execedCmd, " config set mds.* debug_mds 15 ")
 
 	// errors returned as expected
 	execInjectErr = true
-	e = monStore.Set("mon.*", "unknown_setting", "10")
+	e = monStore.Set("mon.*", "unknown_setting", stringPointer("10"))
 	assert.Error(t, e)
 	assert.Contains(t, execedCmd, " config set mon.* unknown_setting 10 ")
+
+	// unset when nil
+	execInjectErr = false
+	e = monStore.Set("global", "debug_ms", nil)
+	assert.NoError(t, e)
+	assert.Contains(t, execedCmd, " config rm global debug_ms")
 }
 
 func TestMonStore_SetAll(t *testing.T) {

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -206,6 +206,7 @@ spec:
                     type: string
                   value:
                     type: string
+                    nullable: true
           required:
           - mon
   additionalPrinterColumns:


### PR DESCRIPTION
Alternative to #3767 

There was no option previously to remove a config value from Ceph's
config database via the CRD once a value had been previously set. Allow
the user to set `value` to a null value (`null` or `~` in YAML, or
`null` in JSON) to indicate that Ceph should take the default value for
an option. Also clarify that if an override is removed from the Rook
CRD, the option will retain its previously set value and that Rook will
no longer try to manage the option.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
