### PR TITLE
Fixed HighMonLeaderChanges Alert

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -87,7 +87,7 @@ spec:
     - alert: CephMonHighNumberOfLeaderChanges
       annotations:
         description: 'Ceph Monitor "{{ $labels.job }}": instance {{ $labels.instance
-          }} has seen {{ $value }} leader changes per minute recently.'
+          }} has seen {{ $value | printf "%.2f" }} leader changes per minute recently.'
         message: Storage Cluster has seen many leader changes recently.
         severity_level: warning
         storage_type: ceph


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
rounded the value of MonLeaderChange Rate to 2 decimal points (e.g. 2.44)
previously, we had 16 decimal points (e.g. 2.4406779661016946).
This makes the alert notification more sensible and readable.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]