### PR TITLE
Helm: Always apply boolean settings

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -85,38 +85,24 @@ spec:
           value: {{ .Values.discover.nodeAffinity }}
 {{- end }}
 {{- end }}
-{{- if .Values.hostpathRequiresPrivileged }}
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
-          value: {{ .Values.hostpathRequiresPrivileged }}
-{{- end }}
+          value: "{{ .Values.hostpathRequiresPrivileged }}"
         - name: ROOK_LOG_LEVEL
           value: {{ .Values.logLevel }}
         - name: ROOK_ENABLE_SELINUX_RELABELING
-          value: {{ .Values.enableSelinuxRelabeling | quote }}
-{{- if .Values.disableDeviceHotplug }}
+          value: "{{ .Values.enableSelinuxRelabeling }}"
         - name: ROOK_DISABLE_DEVICE_HOTPLUG
-          value: {{ .Values.disableDeviceHotplug }}
-{{- end }}
-{{- if .Values.enableCsiRbdDriver }}
+          value: "{{ .Values.disableDeviceHotplug }}"
         - name: ROOK_CSI_ENABLE_RBD
           value: "{{ .Values.enableCsiRbdDriver }}"
-{{- end }}
-{{- if .Values.enableCsiCephfsDriver }}
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: "{{ .Values.enableCsiCephfsDriver }}"
-{{- end }}
-{{- if .Values.enableCsiGrpcMetrics }}
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: "{{ .Values.enableCsiGrpcMetrics }}"
-{{- end }}
-{{- if .Values.enableFlexDriver }}
         - name: ROOK_ENABLE_FLEX_DRIVER
           value: "{{ .Values.enableFlexDriver }}"
-{{- end }}
-{{- if .Values.enableDiscoveryDaemon }}
         - name: ROOK_ENABLE_DISCOVERY_DAEMON
           value: "{{ .Values.enableDiscoveryDaemon }}"
-{{- end }}
 
         - name: NODE_NAME
           valueFrom:

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -74,10 +74,13 @@ func (h *HelmHelper) GetLocalRookHelmChartVersion(chartName string) (string, err
 }
 
 // InstallLocalRookHelmChart installs a give helm chart
-func (h *HelmHelper) InstallLocalRookHelmChart(chartName string, deployName string, chartVersion string, namespace string) error {
+func (h *HelmHelper) InstallLocalRookHelmChart(chartName string, deployName string, chartVersion string, namespace, chartSettings string) error {
 	cmdArgs := []string{"install", chartName, "--name", deployName, "--version", chartVersion}
 	if namespace != "" {
 		cmdArgs = append(cmdArgs, "--namespace", namespace)
+	}
+	if chartSettings != "" {
+		cmdArgs = append(cmdArgs, "--set", chartSettings)
 	}
 	var result string
 	var err error

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -47,8 +47,6 @@ func checkIfRookClusterIsInstalled(s suite.Suite, k8sh *utils.K8sHelper, opNames
 		"Make sure there is 1 rook-operator present in Running state")
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-agent", opNamespace, 1, "Running"),
 		"Make sure there is 1 rook-ceph-agent present in Running state")
-	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-discover", opNamespace, 1, "Running"),
-		"Make sure there is 1 rook-discover present in Running state")
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-mgr", clusterNamespace, 1, "Running"),
 		"Make sure there is 1 rook-ceph-mgr present in Running state")
 	assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-osd", clusterNamespace, 1, "Running"),


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The boolean helm settings were only being applied if their value was true. If the desired value was false, the value would be skipped in the chart instead of adding it with the value of false.

Also adds a check to the integration tests a non-default setting to disable the discovery service with the helm chart and verify whether it is running.

**Which issue is resolved by this Pull Request:**
Resolves #3804 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
