### PR TITLE
Nodes always in OrchestrationStatusStarting

### DIFF
--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -235,6 +235,13 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 				currentTimeoutMinutes++
 				if currentTimeoutMinutes == timeoutMinutes {
 					config.addError("timed out waiting for %d nodes: %+v", remainingNodes.Count(), remainingNodes)
+					//start to remove remainingNodes waiting timeout.
+					for remainingNode := range remainingNodes.Iter() {
+						clearNodeName := k8sutil.TruncateNodeName(orchestrationStatusMapName, remainingNode)
+						if err := c.kv.ClearStore(clearNodeName); err != nil {
+							config.addError("failed to clear node %s status with name %s. %+v", remainingNode, clearNodeName, err)
+						}
+					}
 					return false
 				}
 				logger.Infof("waiting on orchestration status update from %d remaining nodes", remainingNodes.Count())


### PR DESCRIPTION
When osd nodes do not finish the prepare jobs, the user remove the
nodes manully and it causes nodes always is
'OrchestrationStatusStarting' status.
Try to remove them after completeProvisionTimeout.

Signed-off-by: James Lu <jamesluhz@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]