### PR TITLE
Ceph: Use HTTP port if SSL is disabled

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -45,8 +45,12 @@ type mgrConfig struct {
 
 func (c *Cluster) dashboardPort() int {
 	if c.dashboard.Port == 0 {
-		// select default port
-		return dashboardPortHTTPS
+		// default port for HTTP/HTTPS
+		if c.dashboard.SSL {
+			return dashboardPortHTTPS
+		} else {
+			return dashboardPortHTTP
+		}
 	}
 	// crd validates port >= 0
 	return c.dashboard.Port

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -63,7 +63,7 @@ func TestStartMGR(t *testing.T) {
 		rookalpha.Placement{},
 		rookalpha.Annotations{},
 		cephv1.NetworkSpec{},
-		cephv1.DashboardSpec{Enabled: true},
+		cephv1.DashboardSpec{Enabled: true, SSL: true},
 		cephv1.MonitoringSpec{Enabled: true, RulesNamespace: ""},
 		cephv1.MgrSpec{},
 		v1.ResourceRequirements{},

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -309,6 +309,10 @@ func (c *Cluster) makeMetricsService(name string) *v1.Service {
 
 func (c *Cluster) makeDashboardService(name string, port int) *v1.Service {
 	labels := opspec.AppLabels(appName, c.Namespace)
+	portName := "https-dashboard"
+	if !c.dashboard.SSL {
+		portName = "dashboard"
+	}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-dashboard", name),
@@ -320,7 +324,7 @@ func (c *Cluster) makeDashboardService(name string, port int) *v1.Service {
 			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{
-					Name:     "https-dashboard",
+					Name:     portName,
 					Port:     int32(port),
 					Protocol: v1.ProtocolTCP,
 				},


### PR DESCRIPTION
**Description of your changes:**

Using port 8443 / dashboardHTTPS when not running HTTPS
is confusing, so use the dashboardHTTP port (7000 by
default) instead.

Also don't expose the dashboard port as "https-dashboard"
when not using https, instead expose as "dashboard".

**Which issue is resolved by this Pull Request:**
Resolves #3810

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
