### PR TITLE
Backport #3815

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -89,7 +89,7 @@ func (m *Monitor) osdStatus() error {
 		}
 
 		if status != upStatus {
-			logger.Infof("osd.%d is marked 'DOWN'", id)
+			logger.Debugf("osd.%d is marked 'DOWN'", id)
 		} else {
 			logger.Debugf("osd.%d is healthy.", id)
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -473,7 +473,10 @@ func (c *Cluster) getPVCInitContainer(pvc v1.PersistentVolumeClaimVolumeSource) 
 	return v1.Container{
 		Name:  blockPVCMapperInitContainer,
 		Image: c.cephVersion.Image,
-		Args:  []string{"cp", "-a", fmt.Sprintf("/%s", pvc.ClaimName), fmt.Sprintf("/mnt/%s", pvc.ClaimName)},
+		Command: []string{
+			"cp",
+		},
+		Args: []string{"-a", fmt.Sprintf("/%s", pvc.ClaimName), fmt.Sprintf("/mnt/%s", pvc.ClaimName)},
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       pvc.ClaimName,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This is a backport PR for #3815 



1. Set the Command property for the OSD prepare init container blkdevmapper
    If a Ceph container image is specified which has a entrypoint then the Init container for osd prepare job blkdevmapper will fail. So set the Command property.
2. Changed the OSD DOWN message to debug level
    We want the OSD DOWN message to be shown when debug option is set to true in the rook-ceph operator.


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
