### PR TITLE
ceph: make lifecycle hook chown less verbose

### DIFF
--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -77,7 +77,7 @@ var (
 
 	// ContainerPostStartCmd is the command we run before starting any Ceph daemon
 	// It makes sure Ceph directories are owned by 'ceph'
-	ContainerPostStartCmd = []string{"chown", "--recursive", "--verbose", chownUserGroup, VarLogCephDir}
+	ContainerPostStartCmd = []string{"chown", "--recursive", chownUserGroup, VarLogCephDir}
 )
 
 // normalizeKey converts a key in any format to a key with underscores.


### PR DESCRIPTION
It looks like on large store, the `--verbose` option is going over grpc
message buffer, since the output might be quite big.

See the error:

([chown --recursive --verbose ceph:ceph /var/log/ceph /data/rook-storage/osd11]) for
 Container "osd" in Pod "rook-ceph-osd-11-85dbbb5cd6-djttp_rook-ceph(4bf77ccd-d631-11e9-8334-fa163ed365ca)" failed - error: rpc error: code = ResourceExhausted desc = grpc: trying
to send message larger than max (15133688 vs. 8388608), message: ""

Removing the verbose flag should fix this.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 5b930872b9379cb505bff45216ec83fc586d78ae)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
