### PR TITLE
ceph: fix upgrade commands

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -46,12 +46,11 @@ var (
 
 func getCephMonVersionString(context *clusterd.Context, clusterName string) (string, error) {
 	args := []string{"version"}
-	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
-
-	output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return "", fmt.Errorf("failed to run 'ceph version'. %+v", err)
 	}
+	output := string(buf)
 	logger.Debug(output)
 
 	return output, nil
@@ -59,12 +58,11 @@ func getCephMonVersionString(context *clusterd.Context, clusterName string) (str
 
 func getAllCephDaemonVersionsString(context *clusterd.Context, clusterName string) (string, error) {
 	args := []string{"versions"}
-	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
-
-	output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return "", fmt.Errorf("failed to run 'ceph versions'. %+v", err)
 	}
+	output := string(buf)
 	logger.Debug(output)
 
 	return output, nil
@@ -104,23 +102,30 @@ func GetAllCephDaemonVersions(context *clusterd.Context, clusterName string) (*C
 }
 
 // EnableMessenger2 enable the messenger 2 protocol on Nautilus clusters
-func EnableMessenger2(context *clusterd.Context) error {
-	_, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "mon", "enable-msgr2")
+func EnableMessenger2(context *clusterd.Context, clusterName string) error {
+	args := []string{"mon", "enable-msgr2"}
+	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return fmt.Errorf("failed to enable msgr2 protocol. %+v", err)
 	}
+	output := string(buf)
+	logger.Debug(output)
 	logger.Infof("successfully enabled msgr2 protocol")
 
 	return nil
 }
 
 // EnableNautilusOSD disallows pre-Nautilus OSDs and enables all new Nautilus-only functionality
-func EnableNautilusOSD(context *clusterd.Context) error {
-	_, err := context.Executor.ExecuteCommandWithOutput(false, "", "ceph", "osd", "require-osd-release", "nautilus")
+func EnableNautilusOSD(context *clusterd.Context, clusterName string) error {
+	args := []string{"osd", "require-osd-release", "nautilus"}
+	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return fmt.Errorf("failed to disallow pre-nautilus osds and enable all new nautilus-only functionality: %+v", err)
 	}
+	output := string(buf)
+	logger.Debug(output)
 	logger.Infof("successfully disallowed pre-nautilus osds and enabled all new nautilus-only functionality")
+
 	return nil
 }
 
@@ -201,12 +206,11 @@ func OkToContinue(context *clusterd.Context, namespace, deployment, daemonType, 
 func okToStopDaemon(context *clusterd.Context, deployment, clusterName, daemonType, daemonName string) error {
 	if !stringInSlice(daemonType, daemonNoCheck) {
 		args := []string{daemonType, "ok-to-stop", daemonName}
-		command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName)
-
-		output, err := context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+		buf, err := NewCephCommand(context, clusterName, args).Run()
 		if err != nil {
 			return fmt.Errorf("deployment %s cannot be stopped. %+v", deployment, err)
 		}
+		output := string(buf)
 		logger.Debugf("deployment %s is ok to be updated. %s", deployment, output)
 	}
 

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -60,7 +60,7 @@ func TestEnableMessenger2(t *testing.T) {
 	}
 	context := &clusterd.Context{Executor: executor}
 
-	err := EnableMessenger2(context)
+	err := EnableMessenger2(context, "rook-ceph")
 	assert.NoError(t, err)
 }
 
@@ -73,7 +73,7 @@ func TestEnableNautilusOSD(t *testing.T) {
 	}
 	context := &clusterd.Context{Executor: executor}
 
-	err := EnableNautilusOSD(context)
+	err := EnableNautilusOSD(context, "rook-ceph")
 	assert.NoError(t, err)
 }
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -291,7 +291,7 @@ func (c *Cluster) startMons(targetCount int) error {
 				// If length is one, this clearly indicates that all the mons are running the same version
 				// We are doing this because 'ceph version' might return the Ceph version that a majority of mons has but not all of them
 				// so instead of trying to active msgr2 when mons are not ready, we activate it when we believe that's the right time
-				client.EnableMessenger2(c.context)
+				client.EnableMessenger2(c.context, c.Namespace)
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -205,7 +205,7 @@ func (c *Cluster) Start() error {
 					}
 					// if the version of these OSDs is Nautilus then we run the command
 					if osdVersion.IsAtLeastNautilus() {
-						client.EnableNautilusOSD(c.context)
+						client.EnableNautilusOSD(c.context, c.Namespace)
 					}
 				}
 			}


### PR DESCRIPTION
Several commands were not using the cli finalizer function which builds
up the right argument to run a ceph command. This was working on the
operator since it used to have an /etc/ceph/ceph.conf file so we could
ran the command without specifying the ceph conf and key paths.
However, we recently removed that and it silently broke this "already"
broken code :).

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
