### PR TITLE
Ensure the ceph-csi secret exists on upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mon
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateClusterSecrets(t *testing.T) {
+	clientset := test.New(1)
+	configDir := "ns"
+	os.MkdirAll(configDir, 0755)
+	defer os.RemoveAll(configDir)
+	adminSecret := "AQDkLIBd9vLGJxAAnXsIKPrwvUXAmY+D1g0X1Q=="
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
+			logger.Infof("COMMAND: %s %v", command, args)
+			if command == "ceph-authtool" && args[0] == "--create-keyring" {
+				filename := args[1]
+				assert.NoError(t, ioutil.WriteFile(filename, []byte(fmt.Sprintf("key = %s", adminSecret)), 0644))
+			}
+			return "", nil
+		},
+	}
+	context := &clusterd.Context{
+		Clientset: clientset,
+		Executor:  executor,
+	}
+	namespace := "ns"
+	ownerRef := &metav1.OwnerReference{}
+	info, maxID, mapping, err := CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	assert.NoError(t, err)
+	assert.Equal(t, -1, maxID)
+	require.NotNil(t, info)
+	assert.Equal(t, adminSecret, info.AdminSecret)
+	assert.NotEqual(t, "", info.FSID)
+	assert.NotNil(t, mapping)
+
+	// check for the cluster secret
+	secret, err := clientset.CoreV1().Secrets(namespace).Get("rook-ceph-mon", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, adminSecret, string(secret.Data["admin-secret"]))
+
+	// check for the csi secret
+	secret, err = clientset.CoreV1().Secrets(namespace).Get("rook-ceph-csi", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, adminSecret, string(secret.Data["adminKey"]))
+
+	// delete the csi secret and confirm it is created again
+	opts := &metav1.DeleteOptions{}
+	err = clientset.CoreV1().Secrets(namespace).Delete("rook-ceph-csi", opts)
+	assert.NoError(t, err)
+
+	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	require.NoError(t, err)
+	secret, err = clientset.CoreV1().Secrets(namespace).Get("rook-ceph-csi", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, adminSecret, string(secret.Data["adminKey"]))
+}


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CSI secret was only being created for new clusters. Upgraded clusters did not have the secret generated. To support upgraded clusters to use CSI, we always ensure the csi secret exists when the orchestration runs.

**Which issue is resolved by this Pull Request:**
Resolves #3874 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
