### PR TITLE
Add object bucket claim details to admin guide

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -1,0 +1,119 @@
+---
+title: Object Bucket Claim
+weight: 2850
+indent: true
+---
+
+# Ceph Object Bucket Claim
+
+Rook supports the creation of new buckets and access to existing buckets via two custom resources:
+
+- an `Object Bucket Claim (OBC)` is custom resource which requests a bucket (new or existing) and is described by a Custom Resource Definition (CRD) shown below.
+- an `Object Bucket (OB)` is a custom resource automatically generated when a bucket is provisioned. It is a global resource, typically not visible to non-admin users, and contains information specific to the bucket. It is described by an OB CRD, also shown below.
+
+An OBC references a storage class which is created by an administrator. The storage class defines whether the bucket requested is a new bucket or an existing bucket. It also defines the bucket retention policy.
+Users request a new or existing bucket by creating an OBC which is shown below. The ceph provisioner detects the OBC and creates a new bucket or grants access to an existing bucket, depending the the storage class referenced in the OBC. It also generates a Secret which provides credentials to access the bucket, and a ConfigMap which contains the bucket's endpoint. Application pods consume the information in the Secret and ConfigMap to access the bucket
+
+## Sample
+
+### OBC Custom Resource
+```yaml
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ceph-bucket [1]
+  namespace: rook-ceph [2]
+spec:
+  bucketName: [3]
+  generateBucketName: photo-booth [4]
+  storageClassName: rook-ceph-bucket [4]
+  additionalConfig: [5]
+    ANY_KEY: VALUE ...
+```
+1. `name` of the `ObjectBucketClaim`. This name becomes the name of the Secret and ConfigMap.
+1. `namespace`(optional) of the `ObjectBucketClaim`, which is also the namespace of the ConfigMap and Secret.
+1. `bucketName` name of the `bucket`.
+**Not** recommended for new buckets since names must be unique within
+an entire object store.
+1. `generateBucketName` value becomes the prefix for a randomly generated name, if supplied then `bucketName` must be empty.
+If both `bucketName` and `generateBucketName` are supplied then `BucketName` has precedence and `GenerateBucketName` is ignored.
+If both `bucketName` and `generateBucketName` are blank or omitted then the storage class is expected to contain the name of an _existing_ bucket. It's an error if all three bucket related names are blank or omitted.
+1. `storageClassName` which defines the StorageClass which contains the names of the bucket provisioner, the object-store and specifies the bucket retention policy.
+1. `additionalConfig` is an optional list of key-value pairs used to define attributes specific to the bucket being provisioned by this OBC. This information is typically tuned to a particular bucket provisioner and my limit application portability. Examples can include config values such as tenant, user and policy settings, etc.
+
+### OBC Custom Resource after Bucket Provisioning
+```yaml
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  creationTimestamp: "2019-10-18T09:54:01Z"
+  generation: 2
+  name: ceph-bucket
+  namespace: default [1]
+  resourceVersion: "559491"
+spec:
+  ObjectBucketName: obc-default-ceph-bucket [2]
+  additionalConfig: null
+  bucketName: photo-booth-c1178d61-1517-431f-8408-ec4c9fa50bee [3]
+  cannedBucketAcl: ""
+  ssl: false
+  storageClassName: rook-ceph-bucket [4]
+  versioned: false
+status:
+  Phase: bound [5]
+```
+1. `namespace` where OBC got created.
+1. `ObjectBucketName` generated OB name created using name space and OBC name.
+1. the generated (in this case), unique `bucket name` for the new bucket.
+1. name of the storage class from OBC got created.
+1. phases of bucket creation:
+    - _Pending_: the operator is processing the request.
+    - _Bound_: the operator finished processing the request and linked the OBC and OB
+    - _Released_: the OB has been deleted, leaving the OBC unclaimed but unavailable.
+    - _Failed_: not currently set.
+
+### App Pod
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod
+  namespace: dev-user
+spec:
+  containers:
+  - name: mycontainer
+    image: redis
+    envFrom: [1]
+    - configMapRef:
+        name: ceph-bucket [2]
+    - secretRef:
+        name: ceph-bucket [3]
+```
+1. use `env:` if mapping of the defined key names to the env var names used by the app is needed.
+1. makes available to the pod as env variables: `BUCKET_HOST`, `BUCKET_PORT`, `BUCKET_NAME`
+1. makes available to the pod as env variables: `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`
+
+### StorageClass
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-bucket
+  labels:
+    aws-s3/object [1]
+provisioner: ceph.rook.io/bucket [2]
+parameters: [3]
+  objectStoreName: my-store
+  objectStoreNamespace: rook-ceph
+  region: us-west-1
+  bucketName: ceph-bucket [4]
+reclaimPolicy: Delete [5]
+```
+1. `label`(optional) here associates this `StorageClass` to a specific provisioner.
+1. `provisioner` responsible for handling `OBCs` referencing this `StorageClass`.
+1. **all** `parameter` required.
+1. `bucketName` is required for access to existing buckets but is omitted when provisioning new buckets.
+Unlike greenfield provisioning, the brownfield bucket name appears in the `StorageClass`, not the `OBC`.
+1. rook-ceph provisioner decides how to treat the `reclaimPolicy` when an `OBC` is deleted for the bucket. See explanation as [specified in Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain)
++ _Delete_ = physically delete the bucket.
++ _Retain_ = do not physically delete the bucket.

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -107,6 +107,46 @@ To directly retrieve the secrets:
 kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep AccessKey | awk '{print $2}' | base64 --decode
 kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep SecretKey | awk '{print $2}' | base64 --decode
 ```
+## Create an Object Bucket Claim
+
+Creating an Object Bucket Claim (OBC) causes the Rook-Ceph bucket provisioner to create a new bucket or to grant access to an existing bucket. OBCs reference a Storage Class which is created by a cluster administrator. The Storage Class defines the object storage system, the bucket retention policy, and, when granting access to existing (brownfield) buckets, the name of the bucket. If a new bucket is desired then the OBC contains the bucket name or a prefix used for a random bucket name. See the [Object Bucket Claim Documentation](ceph-object-bucket-claim.md) for more detail on the `CephObjectBucketClaims`.
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: rook-ceph-bucket
+provisioner: ceph.rook.io/bucket
+reclaimPolicy: Delete
+parameters:
+  objectStoreName: my-store
+  objectStoreNamespace: rook-ceph
+  region: us-east-1
+```
+```bash
+# Above Storage class for new bucket provisioning, below command need to executed by administrator
+kubectl create -f storageclass-bucket.yaml
+```
+```yaml
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ceph-bucket
+spec:
+  generateBucketName: ceph-bkt
+  storageClassName: rook-ceph-bucket
+```
+
+After creating the OBC, a secret and ConfigMap are created with the same name as the OBC and in the same namespace. The secret contains credentials used by the application pod to access the bucket. The configmap contains bucket endpoint information and is also consumed by the pod.
+
+The following commands extract key pieces of information from the secret and configmap:"
+
+```bash
+#config-map, secret, OBC will part of default if no specific name space mentioned
+kubectl -n default get cm ceph-bucket -o yaml | grep BUCKET_HOST | awk '{print $2}'
+kubectl -n default get secret ceph-bucket -o yaml | grep AWS_ACCESS_KEY_ID | awk '{print $2}' | base64 --decode
+kubectl -n default get secret ceph-bucket -o yaml | grep AWS_SECRET_ACCESS_KEY | awk '{print $2}' | base64 --decode
+```
 
 ## Consume the Object Storage
 

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -57,59 +57,10 @@ kubectl create -f object.yaml
 kubectl -n rook-ceph get pod -l app=rook-ceph-rgw
 ```
 
-## Create a User
-
-Next, create a `CephObjectStoreUser`, which will be used to connect to the RGW service in the cluster using the S3 API.
-
-See the [Object Store User CRD](ceph-object-store-user-crd.md) for more detail on the settings available for a `CephObjectStoreUser`.
-
-```yaml
-apiVersion: ceph.rook.io/v1
-kind: CephObjectStoreUser
-metadata:
-  name: my-user
-  namespace: rook-ceph
-spec:
-  store: my-store
-  displayName: "my display name"
-```
-
-When the `CephObjectStoreUser` is created, the Rook operator will then create the RGW user on the specified `CephObjectStore` and store the Access Key and Secret Key in a kubernetes secret in the same namespace as the `CephObjectStoreUser`.
-
-```console
-# Create the object store user
-kubectl create -f object-user.yaml
-
-# To confirm the object store user is configured, describe the secret
-kubectl -n rook-ceph describe secret rook-ceph-object-user-my-store-my-user
-
-Name:		rook-ceph-object-user-my-store-my-user
-Namespace:	rook-ceph
-Labels:			app=rook-ceph-rgw
-			      rook_cluster=rook-ceph
-			      rook_object_store=my-store
-Annotations:	<none>
-
-Type:	kubernetes.io/rook
-
-Data
-====
-AccessKey:  20 bytes
-SecretKey:  40 bytes
-```
-
-The AccessKey and SecretKey data fields can be mounted in a pod as an environment variable. More information on consuming
-kubernetes secrets can be found in the [K8s secret documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
-
-To directly retrieve the secrets:
-
-```console
-kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep AccessKey | awk '{print $2}' | base64 --decode
-kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep SecretKey | awk '{print $2}' | base64 --decode
-```
-## Create an Object Bucket Claim
-
-Creating an Object Bucket Claim (OBC) causes the Rook-Ceph bucket provisioner to create a new bucket or to grant access to an existing bucket. OBCs reference a Storage Class which is created by a cluster administrator. The Storage Class defines the object storage system, the bucket retention policy, and, when granting access to existing (brownfield) buckets, the name of the bucket. If a new bucket is desired then the OBC contains the bucket name or a prefix used for a random bucket name. See the [Object Bucket Claim Documentation](ceph-object-bucket-claim.md) for more detail on the `CephObjectBucketClaims`.
+## Create a Bucket
+Now that the object store is configured, next we need to create a bucket where a client can read and write objects. A bucket can be created by defining a storage class, similar to the pattern used by block and file storage.
+First, define the storage class that will allow object clients to create a bucket.
+The storage class defines the object storage system, the bucket retention policy, and other properties required by the administrator. Save the following as `storageclass-bucket-delete.yaml` (the example is named as such due to the `Delete` reclaim policy).
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -124,9 +75,14 @@ parameters:
   region: us-east-1
 ```
 ```bash
-# Above Storage class for new bucket provisioning, below command need to executed by administrator
-kubectl create -f storageclass-bucket.yaml
+kubectl create -f storageclass-bucket-delete.yaml
 ```
+
+Based on this storage class, an object client can now request a bucket by creating an Object Bucket Claim (OBC).
+When the OBC is created, the Rook-Ceph bucket provisioner will create a new bucket. Notice that the OBC
+references the storage class that was created above.
+Save the following as `object-bucket-claim-delete.yaml` (the example is named as such due to the `Delete` reclaim policy):
+
 ```yaml
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
@@ -136,37 +92,39 @@ spec:
   generateBucketName: ceph-bkt
   storageClassName: rook-ceph-bucket
 ```
+```bash
+kubectl create -f object-bucket-claim-delete.yaml
+```
+Now that the claim is created, the operator will create the bucket as well as generate other artifacts to enable access to the bucket. A secret and ConfigMap are created with the same name as the OBC and in the same namespace.
+The secret contains credentials used by the application pod to access the bucket.
+The ConfigMap contains bucket endpoint information and is also consumed by the pod.
+See the [Object Bucket Claim Documentation](ceph-object-bucket-claim.md) for more details on the `CephObjectBucketClaims`.
 
-After creating the OBC, a secret and ConfigMap are created with the same name as the OBC and in the same namespace. The secret contains credentials used by the application pod to access the bucket. The configmap contains bucket endpoint information and is also consumed by the pod.
+### Client Connections
 
 The following commands extract key pieces of information from the secret and configmap:"
 
 ```bash
 #config-map, secret, OBC will part of default if no specific name space mentioned
-kubectl -n default get cm ceph-bucket -o yaml | grep BUCKET_HOST | awk '{print $2}'
-kubectl -n default get secret ceph-bucket -o yaml | grep AWS_ACCESS_KEY_ID | awk '{print $2}' | base64 --decode
-kubectl -n default get secret ceph-bucket -o yaml | grep AWS_SECRET_ACCESS_KEY | awk '{print $2}' | base64 --decode
+export AWS_HOST=$(kubectl -n default get cm ceph-bucket -o yaml | grep BUCKET_HOST | awk '{print $2}')
+export AWS_ACCESS_KEY_ID=$(kubectl -n default get secret ceph-bucket -o yaml | grep AWS_ACCESS_KEY_ID | awk '{print $2}' | base64 --decode)
+export AWS_SECRET_ACCESS_KEY=$(kubectl -n default get secret ceph-bucket -o yaml | grep AWS_SECRET_ACCESS_KEY | awk '{print $2}' | base64 --decode)
 ```
 
 ## Consume the Object Storage
 
-Use an S3 compatible client to create a bucket in the `CephObjectStore`.
+Now that you have the object store configured and a bucket created, you can consume the
+object storage from an S3 client.
 
-This section will allow you to test connecting to the `CephObjectStore` and uploading and downloading from it. Run the following commands after you have connected to the [Rook toolbox](ceph-toolbox.md).
-
-### Install s3cmd
-
-To test the `CephObjectStore` we will install the `s3cmd` tool into the toobox pod.
-
-```console
-yum --assumeyes install s3cmd
-```
+This section will guide you through testing the connection to the `CephObjectStore` and uploading and downloading from it.
+Run the following commands after you have connected to the [Rook toolbox](ceph-toolbox.md).
 
 ### Connection Environment Variables
 
-To simplify the s3 client commands, you will want to set the four environment variables for use by your client (ie. inside the toolbox):
+To simplify the s3 client commands, you will want to set the four environment variables for use by your client (ie. inside the toolbox).
+See above for retrieving the variables for a bucket created by an `ObjectBucketClaim`.
 
-```console
+```bash
 export AWS_HOST=<host>
 export AWS_ENDPOINT=<endpoint>
 export AWS_ACCESS_KEY_ID=<accessKey>
@@ -178,31 +136,23 @@ export AWS_SECRET_ACCESS_KEY=<secretKey>
 * `Access key`: The user's `access_key` as printed above
 * `Secret key`: The user's `secret_key` as printed above
 
-The variables for the user generated in this example would be:
+The variables for the user generated in this example might be:
 
-```console
+```bash
 export AWS_HOST=rook-ceph-rgw-my-store.rook-ceph
 export AWS_ENDPOINT=10.104.35.31:80
 export AWS_ACCESS_KEY_ID=XEZDB3UJ6X7HVBE7X7MA
 export AWS_SECRET_ACCESS_KEY=7yGIZON7EhFORz0I40BFniML36D2rl8CQQ5kXU6l
 ```
 
-The access key and secret key can be retrieved as described in the section above on [creating a user](#create-a-user).
+The access key and secret key can be retrieved as described in the section above on [client connections](#client-connections) or
+below in the section [creating a user](#create-a-user) if you are not creating the buckets with an `ObjectBucketClaim`.
 
-### Create a bucket
+### Install s3cmd
 
-Now that the user connection variables were set above, we can proceed to perform operations such as creating buckets.
-
-Create a bucket in the `CephObjectStore`
-
-```console
-s3cmd mb --no-ssl --host=${AWS_HOST} --region=":default-placement" --host-bucket="" s3://rookbucket
-```
-
-List buckets in the `CephObjectStore`
-
-```console
-s3cmd ls --no-ssl --host=${AWS_HOST}
+To test the `CephObjectStore` we will install the `s3cmd` tool into the toolbox pod.
+```bash
+yum --assumeyes install s3cmd
 ```
 
 ### PUT or GET an object
@@ -276,3 +226,56 @@ rook-ceph-rgw-my-store-external   NodePort    10.111.113.237   <none>        80:
 ```
 
 Internally the rgw service is running on port `80`. The external port in this case is `31536`. Now you can access the `CephObjectStore` from anywhere! All you need is the hostname for any machine in the cluster, the external port, and the user credentials.
+
+## Create a User
+
+If you need to create an independent set of user credentials to access the S3 endpoint,
+create a `CephObjectStoreUser`. The user will be used to connect to the RGW service in the cluster using the S3 API.
+The user will be independent of any object bucket claims that you might have created in the earlier
+instructions in this document.
+
+See the [Object Store User CRD](ceph-object-store-user-crd.md) for more detail on the settings available for a `CephObjectStoreUser`.
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: my-user
+  namespace: rook-ceph
+spec:
+  store: my-store
+  displayName: "my display name"
+```
+
+When the `CephObjectStoreUser` is created, the Rook operator will then create the RGW user on the specified `CephObjectStore` and store the Access Key and Secret Key in a kubernetes secret in the same namespace as the `CephObjectStoreUser`.
+
+```bash
+# Create the object store user
+kubectl create -f object-user.yaml
+
+# To confirm the object store user is configured, describe the secret
+kubectl -n rook-ceph describe secret rook-ceph-object-user-my-store-my-user
+
+Name:		rook-ceph-object-user-my-store-my-user
+Namespace:	rook-ceph
+Labels:			app=rook-ceph-rgw
+			      rook_cluster=rook-ceph
+			      rook_object_store=my-store
+Annotations:	<none>
+
+Type:	kubernetes.io/rook
+
+Data
+====
+AccessKey:	20 bytes
+SecretKey:	40 bytes
+```
+
+The AccessKey and SecretKey data fields can be mounted in a pod as an environment variable. More information on consuming
+kubernetes secrets can be found in the [K8s secret documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
+
+To directly retrieve the secrets:
+```bash
+kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep AccessKey | awk '{print $2}' | base64 --decode
+kubectl -n rook-ceph get secret rook-ceph-object-user-my-store-my-user -o yaml | grep SecretKey | awk '{print $2}' | base64 --decode
+```


### PR DESCRIPTION
Signed-off-by: Jiffin Tony Thottan <jthottan@redhat.com>

**Description of your changes:**
Adding OBC details to Rook Documentation in ceph-object.md and CRD definitions as ceph-object-bucket-claim-crd.md

**Which issue is resolved by this Pull Request:**
Resolves #3655

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]
