### PR TITLE
Fix CRD Validation: disruptionManagement and mgr modules

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -39,6 +39,16 @@ spec:
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string
+            disruptionManagement:
+              properties:
+                machineDisruptionBudgetNamespace:
+                  type: string
+                managePodBudgets:
+                  type: boolean
+                osdMaintenanceTimeout:
+                  type: integer
+                manageMachineDisruptionBudgets:
+                  type: boolean
             skipUpgradeChecks:
               type: boolean
             mon:
@@ -64,6 +74,16 @@ spec:
                   type: boolean
             storage:
               properties:
+                disruptionManagement:
+                  properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
+                    managePodBudgets:
+                      type: boolean
+                    osdMaintenanceTimeout:
+                      type: integer
+                    manageMachineDisruptionBudgets:
+                      type: boolean
                 useAllNodes:
                   type: boolean
                 nodes:

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -59,6 +59,7 @@ spec:
                   maximum: 9
                   minimum: 0
                   type: integer
+                volumeClaimTemplate: {}
             mgr:
               properties:
                 modules:
@@ -141,6 +142,7 @@ spec:
                 config: {}
                 topologyAware:
                   type: boolean
+                storageClassDeviceSets: {}
             monitoring:
               properties:
                 enabled:
@@ -151,6 +153,10 @@ spec:
               properties:
                 workers:
                   type: integer
+            external:
+              properties:
+                enable:
+                  type: boolean
             placement: {}
             resources: {}
   additionalPrinterColumns:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -38,8 +38,8 @@ spec:
   mon:
     count: 3
     allowMultiplePerNode: false
-  mgr:
-    modules: []
+  # mgr:
+    # modules:
     # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
     # are already enabled by other settings in the cluster CR and the "rook" module is always enabled.
     # - name: pg_autoscaler

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -39,7 +39,7 @@ spec:
     count: 3
     allowMultiplePerNode: false
   mgr:
-    modules:
+    modules: []
     # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
     # are already enabled by other settings in the cluster CR and the "rook" module is always enabled.
     # - name: pg_autoscaler

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -78,6 +78,7 @@ spec:
                   maximum: 9
                   minimum: 0
                   type: integer
+                volumeClaimTemplate: {}
             mgr:
               properties:
                 modules:
@@ -160,6 +161,7 @@ spec:
                 config: {}
                 topologyAware:
                   type: boolean
+                storageClassDeviceSets: {}
             monitoring:
               properties:
                 enabled:
@@ -170,6 +172,10 @@ spec:
               properties:
                 workers:
                   type: integer
+            external:
+              properties:
+                enable:
+                  type: boolean
             placement: {}
             resources: {}
   additionalPrinterColumns:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -58,6 +58,16 @@ spec:
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string
+            disruptionManagement:
+              properties:
+                machineDisruptionBudgetNamespace:
+                  type: string
+                managePodBudgets:
+                  type: boolean
+                osdMaintenanceTimeout:
+                  type: integer
+                manageMachineDisruptionBudgets:
+                  type: boolean
             skipUpgradeChecks:
               type: boolean
             mon:
@@ -85,6 +95,8 @@ spec:
               properties:
                 disruptionManagement:
                   properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
                     managePodBudgets:
                       type: boolean
                     osdMaintenanceTimeout:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-crds.yaml
@@ -61,6 +61,7 @@ spec:
                   maximum: 9
                   minimum: 0
                   type: integer
+                volumeClaimTemplate: {}
             mgr:
               properties:
                 modules:
@@ -143,6 +144,7 @@ spec:
                 config: {}
                 topologyAware:
                   type: boolean
+                storageClassDeviceSets: {}
             monitoring:
               properties:
                 enabled:
@@ -153,6 +155,10 @@ spec:
               properties:
                 workers:
                   type: integer
+            external:
+              properties:
+                enable:
+                  type: boolean
             placement: {}
             resources: {}
   additionalPrinterColumns:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-crds.yaml
@@ -41,6 +41,16 @@ spec:
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string
+            disruptionManagement:
+              properties:
+                machineDisruptionBudgetNamespace:
+                  type: string
+                managePodBudgets:
+                  type: boolean
+                osdMaintenanceTimeout:
+                  type: integer
+                manageMachineDisruptionBudgets:
+                  type: boolean
             skipUpgradeChecks:
               type: boolean
             mon:
@@ -68,6 +78,8 @@ spec:
               properties:
                 disruptionManagement:
                   properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
                     managePodBudgets:
                       type: boolean
                     osdMaintenanceTimeout:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -112,13 +112,23 @@ spec:
             dataDirHostPath:
               pattern: ^/(\S+)
               type: string
+            disruptionManagement:
+              properties:
+                machineDisruptionBudgetNamespace:
+                  type: string
+                managePodBudgets:
+                  type: boolean
+                osdMaintenanceTimeout:
+                  type: integer
+                manageMachineDisruptionBudgets:
+                  type: boolean
             mon:
               properties:
                 allowMultiplePerNode:
                   type: boolean
                 count:
                   maximum: 9
-                  minimum: 1
+                  minimum: 0
                   type: integer
             mgr:
               properties:
@@ -137,6 +147,8 @@ spec:
               properties:
                 disruptionManagement:
                   properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
                     managePodBudgets:
                       type: boolean
                     osdMaintenanceTimeout:
@@ -212,8 +224,6 @@ spec:
                   type: integer
             placement: {}
             resources: {}
-          required:
-          - mon
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -130,6 +130,7 @@ spec:
                   maximum: 9
                   minimum: 0
                   type: integer
+                volumeClaimTemplate: {}
             mgr:
               properties:
                 modules:
@@ -212,6 +213,7 @@ spec:
                 config: {}
                 topologyAware:
                   type: boolean
+                storageClassDeviceSets: {}
             monitoring:
               properties:
                 enabled:
@@ -222,6 +224,10 @@ spec:
               properties:
                 workers:
                   type: integer
+            external:
+              properties:
+                enable:
+                  type: boolean
             placement: {}
             resources: {}
   additionalPrinterColumns:


### PR DESCRIPTION
While [validating](https://github.com/sebastian-philipp/rook-ceph-client-python#regenerate) the CRD validation, I had to fix six issues:

* disruptionManagement: Some validations were missing
* cluster.yaml example: `spec.mgr.modules` is not explicitly set to `nullable`
* Also: Removed `required: mon` in `ceph_manifests.go`
* `volumeClaimTemplate` was missing
* `storageClassDeviceSets` was missing
* `external.enable` was missing

[test ceph min]