### PR TITLE
ceph: enable ceph-volume debug logs

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -169,6 +169,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 		configEnvVars = append(configEnvVars, v1.EnvVar{Name: "ROOK_IS_DEVICE", Value: "true"})
 	}
 
+	// Activate verbose mode for ceph-volume on prepare
+	if osd.CephVolumeInitiated {
+		configEnvVars = append(configEnvVars, v1.EnvVar{Name: "CEPH_VOLUME_DEBUG", Value: "1"})
+	}
+
 	// default args when the ceph cluster isn't initialized
 	defaultArgs := []string{
 		"--foreground",
@@ -253,6 +258,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 		volumeMounts = append(volumeMounts, v1.VolumeMount{
 			Name:      "run-udev",
 			MountPath: "/run/udev"})
+
+		// Activate verbose mode for ceph-volume on activate
+		envVars = append(envVars, []v1.EnvVar{
+			{Name: "CEPH_VOLUME_DEBUG", Value: "1"},
+		}...)
 
 	} else {
 		// other osds can launch the osd daemon directly


### PR DESCRIPTION
It's fine to enable debug logs from c-v, it's not so verbose and really
useful when debugging.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
