### PR TITLE
Backport: Include CSI image in helm chart values

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -93,12 +93,48 @@ spec:
           value: "{{ .Values.enableSelinuxRelabeling }}"
         - name: ROOK_DISABLE_DEVICE_HOTPLUG
           value: "{{ .Values.disableDeviceHotplug }}"
+{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_RBD
-          value: "{{ .Values.enableCsiRbdDriver }}"
+          value: {{ .Values.csi.enableRbdDriver | quote }}
+{{- end }}
+{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_CEPHFS
-          value: "{{ .Values.enableCsiCephfsDriver }}"
+          value: {{ .Values.csi.enableCephfsDriver | quote }}
+{{- end }}
+{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
-          value: "{{ .Values.enableCsiGrpcMetrics }}"
+          value: {{ .Values.csi.enableGrpcMetrics | quote }}
+{{- end }}
+{{- if .Values.csi.cephcsi }}
+{{- if .Values.csi.cephcsi.image }}
+        - name: ROOK_CSI_CEPH_IMAGE
+          value: {{ .Values.csi.cephcsi.image | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.csi.registrar }}
+{{- if .Values.csi.registrar.image }}
+        - name: ROOK_CSI_REGISTRAR_IMAGE
+          value: {{ .Values.csi.registrar.image | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.csi.provisioner }}
+{{- if .Values.csi.provisioner.image }}
+        - name: ROOK_CSI_PROVISIONER_IMAGE
+          value: {{ .Values.csi.provisioner.image | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.csi.snapshotter }}
+{{- if .Values.csi.snapshotter.image }}
+        - name: ROOK_CSI_SNAPSHOTTER_IMAGE
+          value: {{ .Values.csi.snapshotter.image | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.csi.attacher }}
+{{- if .Values.csi.attacher.image }}
+        - name: ROOK_CSI_ATTACHER_IMAGE
+          value: {{ .Values.csi.attacher.image | quote }}
+{{- end }}
+{{- end }}
         - name: ROOK_ENABLE_FLEX_DRIVER
           value: "{{ .Values.enableFlexDriver }}"
         - name: ROOK_ENABLE_DISCOVERY_DAEMON

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -53,11 +53,24 @@ rbacEnable: true
 ##
 pspEnable: true
 
-## Settings for whether to disable the drivers or other daemons if they are not needed
-enableCsiRbdDriver: true
-enableCsiCephfsDriver: true
-enableCsiGrpcMetrics: true
-enableFlexDriver: false
+## Settings for whether to disable the drivers or other daemons if they are not
+## needed
+csi:
+  enableRbdDriver: true
+  enableCephfsDriver: true
+  enableGrpcMetrics: true
+  #cephcsi:
+    #image: quay.io/cephcsi/cephcsi:v1.2.0
+  #registrar:
+    #image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+  #provisioner:
+    #image: quay.io/k8scsi/csi-provisioner:v1.3.0
+  #snapshotter:
+    #image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+  #attacher:
+    #image: quay.io/k8scsi/csi-attacher:v1.2.0
+
+enableFlexDriver: true
 enableDiscoveryDaemon: true
 
 ## Rook Agent configuration


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The Helm Chart should include values for the CSI images so Rook with CSI can pull the required
images from a private container registry.

cherry-pick of https://github.com/rook/rook/pull/3884

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
