### PR TITLE
Add k8s 1.16 to the integration test matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,11 +108,11 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,yugabytedb-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
-                        "aws_1.11.x": "v1.11.8",
-                        "aws_1.12.x": "v1.12.6",
-                        "aws_1.13.x": "v1.13.7",
-                        "aws_1.14.x": "v1.14.3",
-                        "aws_1.15.x": "v1.15.0"
+                        "aws_1.12.x": "v1.12.10",
+                        "aws_1.13.x": "v1.13.11",
+                        "aws_1.14.x": "v1.14.7",
+                        "aws_1.15.x": "v1.15.4",
+                        "aws_1.16.x": "v1.16.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Action Required
 
 ## Notable Features
-
+- Added K8s 1.16 to the test matrix and removed K8s 1.11 from the test matrix.
 
 ### Ceph
 

--- a/tests/framework/clients/object_user.go
+++ b/tests/framework/clients/object_user.go
@@ -54,7 +54,7 @@ func (o *ObjectUserOperation) UserSecretExists(namespace string, store string, u
 	//err = success and found_sec not "No resources found." means it was found
 	//err = success and found_sec contains "No resources found." means it was not found
 	//err != success is an other error
-	if err == nil && !strings.Contains(message, "No resources found.") {
+	if err == nil && !strings.Contains(message, "No resources found") {
 		logger.Infof("Object User Secret Exists")
 		return true
 	}

--- a/tests/framework/installer/edgefs_manifest.go
+++ b/tests/framework/installer/edgefs_manifest.go
@@ -155,7 +155,7 @@ subjects:
   namespace: ` + namespace + `
 ---
 # The deployment for the rook operator
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-edgefs-operator
@@ -165,6 +165,9 @@ metadata:
     storage-backend: edgefs
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rook-edgefs-operator
   template:
     metadata:
       labels:

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -39,11 +39,11 @@ const (
 	// UPDATE these versions when the integration test matrix changes
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
-	blockMinimalTestVersion        = "1.11.0"
-	multiClusterMinimalTestVersion = "1.12.0"
-	helmMinimalTestVersion         = "1.13.0"
-	upgradeMinimalTestVersion      = "1.14.0"
-	smokeSuiteMinimalTestVersion   = "1.15.0"
+	blockMinimalTestVersion        = "1.12.0"
+	multiClusterMinimalTestVersion = "1.13.0"
+	helmMinimalTestVersion         = "1.14.0"
+	upgradeMinimalTestVersion      = "1.15.0"
+	smokeSuiteMinimalTestVersion   = "1.16.0"
 )
 
 var (

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -68,8 +68,8 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 		time.Sleep(5 * time.Second)
 	}
 	assert.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid))
-	userInfo, gosuErr := helper.ObjectUserClient.GetUser(namespace, storeName, userid)
-	assert.Nil(s.T(), gosuErr)
+	userInfo, err := helper.ObjectUserClient.GetUser(namespace, storeName, userid)
+	require.NoError(s.T(), err)
 	assert.Equal(s.T(), userid, userInfo.UserID)
 	assert.Equal(s.T(), userdisplayname, *userInfo.DisplayName)
 	logger.Infof("Done creating object store user")


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
K8s 1.16 was released today. This adds v1.16.0 to the test matrix and also updates the other k8s versions to the latest patch releases for testing.

Still need to update documentation about supported versions...

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test full]