### PR TITLE
Allow running minimal test matrix for ceph tests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,3 +183,13 @@ all tests will be executed.
 These options should **not** be used if there are any changes to code which is shared with other
 storage providers. If there is any risk of affecting another storage provider, all tests should
 be executed in the CI.
+
+### [test ceph min]
+
+By default all the ceph test suites run on all versions of K8s. For more efficient
+CI times, we can choose to run each test suite on only one K8s version by using the tag:
+```
+[test ceph min]
+```
+
+This option should only be used for changes with lower risk.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,9 @@ pipeline {
                         env.testProvider = "cassandra"
                     } else if (body.contains("[test ceph]")) {
                         env.testProvider = "ceph"
+                    } else if (body.contains("[test ceph min]")) {
+                        env.testProvider = "ceph"
+                        env.testArgs = "min-test-matrix"
                     } else if (body.contains("[test cockroachdb]")) {
                         env.testProvider = "cockroachdb"
                     } else if (body.contains("[test edgefs]")) {
@@ -176,7 +179,8 @@ def RunIntegrationTest(k, v) {
                               set -o pipefail
                               export PATH="/tmp/rook-tests-scripts-helm/linux-amd64:$PATH" \
                                   KUBECONFIG=$HOME/admin.conf \
-                                  STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+'''
+                                  STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
+                                  TEST_ARGUMENTS='''+"${env.testArgs}"+'''
                               kubectl config view
                               _output/tests/linux_amd64/integration -test.v -test.timeout 7200s --host_type '''+"${k}"+''' --logs '''+"${env.getLogs}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
                     }

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -100,6 +100,12 @@ func (k8sh *K8sHelper) VersionAtLeast(minVersion string) bool {
 	return v.AtLeast(version.MustParseSemantic(minVersion))
 }
 
+func (k8sh *K8sHelper) VersionMinorMatches(minVersion string) bool {
+	v := version.MustParseSemantic(k8sh.GetK8sServerVersion())
+	requestedVersion := version.MustParseSemantic(minVersion)
+	return v.Major() == requestedVersion.Major() && v.Minor() == requestedVersion.Minor()
+}
+
 func (k8sh *K8sHelper) MakeContext() *clusterd.Context {
 	return &clusterd.Context{Clientset: k8sh.Clientset, RookClientset: k8sh.RookClientset, Executor: k8sh.executor}
 }

--- a/tests/integration/ceph_block_create_test.go
+++ b/tests/integration/ceph_block_create_test.go
@@ -59,7 +59,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 	s.namespace = "block-k8s-ns"
 	mons := 1
 	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, s.namespace, "bluestore", false, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	s.op, s.kh = StartTestCluster(s.T, blockCreateMinimalTestVersion, s.namespace, "bluestore", false, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	initialBlocks, err := s.testClient.BlockClient.List(s.namespace)
 	assert.Nil(s.T(), err)

--- a/tests/integration/ceph_csi_test.go
+++ b/tests/integration/ceph_csi_test.go
@@ -42,7 +42,7 @@ const (
 func runCephCSIE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, t *testing.T, namespace string) {
 
 	if !k8sh.VersionAtLeast("v1.13.0") {
-		logger.Info("Skiping csi tests as kube version is less than 1.13.0")
+		logger.Info("Skipping csi tests as kube version is less than 1.13.0")
 		t.Skip()
 	}
 

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -69,7 +69,7 @@ func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
 	mons := 1
 	rbdMirrorWorkers := 1
-	hs.op, hs.kh = StartTestCluster(hs.T, hs.namespace, "bluestore", true, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	hs.op, hs.kh = StartTestCluster(hs.T, helmMinimalTestVersion, hs.namespace, "bluestore", true, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	hs.helper = clients.CreateTestClient(hs.kh, hs.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -141,6 +141,8 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
+	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
+
 	i := installer.NewCephInstaller(t, kh.Clientset, false, installer.VersionMaster, installer.NautilusVersion)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1)}

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -74,7 +74,7 @@ func (suite *SmokeSuite) SetupSuite() {
 	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 1
-	suite.op, suite.k8sh = StartTestCluster(suite.T, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	suite.op, suite.k8sh = StartTestCluster(suite.T, smokeSuiteMinimalTestVersion, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	suite.helper = clients.CreateTestClient(suite.k8sh, suite.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -64,7 +64,7 @@ func (s *UpgradeSuite) SetupSuite() {
 	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 0
-	s.op, s.k8sh = StartTestCluster(s.T, s.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.Version1_0, installer.MimicVersion)
+	s.op, s.k8sh = StartTestCluster(s.T, upgradeMinimalTestVersion, s.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.Version1_0, installer.MimicVersion)
 	s.helper = clients.CreateTestClient(s.k8sh, s.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_zblock_mount_unmount_test.go
+++ b/tests/integration/ceph_zblock_mount_unmount_test.go
@@ -92,7 +92,7 @@ func (s *BlockMountUnMountSuite) SetupSuite() {
 	useDevices := true
 	mons := 1
 	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, s.namespace, "filestore", useHelm, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	s.op, s.kh = StartTestCluster(s.T, blockMountMinimalTestVersion, s.namespace, "filestore", useHelm, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	s.bc = s.testClient.BlockClient
 }


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
There are six test suites and six k8s versions where we currently run the tests. For efficiency we can restrict the testing to one suite per k8s version. Bigger or riskier changes should still run the full set of suites on all versions. To trigger the smaller test matrix, add this to the PR description:
[test ceph min]

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
