### PR TITLE
backport: change mdb controller to use namespace for checking status

### DIFF
--- a/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
@@ -121,7 +121,7 @@ func (r *MachineDisruptionReconciler) Reconcile(request reconcile.Request) (reco
 		mdb.Spec.MaxUnavailable = &maxUnavailable
 	}
 	// Check if the cluster is clean or not
-	_, isClean, err := cephClient.IsClusterClean(r.context.ClusterdContext, request.Name)
+	_, isClean, err := cephClient.IsClusterClean(r.context.ClusterdContext, request.Namespace)
 	if err != nil {
 		logger.Errorf("failed to get cephCluster status %+v", err)
 		maxUnavailable := int32(0)


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <aranjan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This commit changed mdb controller to make use of cephCluster's namespace instead of cephCluster's name for checking the ceph health as the ceph config is located in the cephCluster's namespace folder which can makes mdb controller fail when rook operator is deployed in any other namespace apart from rook-ceph.

**NOTE:** This is the backport of https://github.com/rook/rook/pull/3879

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
