### PR TITLE
Ceph: OSD pods should always use hostname for node selector

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -765,7 +765,12 @@ func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 		return "", err
 	}
 	for _, pod := range podList.Items {
-		return pod.Spec.NodeName, nil
+		name, err := k8sutil.GetNodeHostName(c.context.Clientset, pod.Spec.NodeName)
+		if err != nil {
+			logger.Warningf("falling back to node name %s since hostname not found for node", pod.Spec.NodeName)
+			name = pod.Spec.NodeName
+		}
+		return name, nil
 	}
 	return "", err
 }

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -108,6 +108,19 @@ func GetNodeNameFromHostname(clientset kubernetes.Interface, hostName string) (s
 	return hostName, fmt.Errorf("node not found")
 }
 
+// GetNodeHostName returns the hostname label given the node name.
+func GetNodeHostName(clientset kubernetes.Interface, nodeName string) (string, error) {
+	node, err := clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	hostname, ok := node.Labels[v1.LabelHostname]
+	if !ok {
+		return "", fmt.Errorf("hostname not found on the node")
+	}
+	return hostname, nil
+}
+
 // GetNodeHostNames returns the name of the node resource mapped to their hostname label.
 // Typically these will be the same name, but sometimes they are not such as when nodes have a longer
 // dns name, but the hostname is short.


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The node selector for running OSDs on PVCs was using the k8s node name rather than the node's hostname. In clusters where the node name is different from the hostname this would cause the osd daemons to be in pending state indefinitely. Now the node selector will use the hostname as expected.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
