### PR TITLE
Backport: LVM and other fixes for the v1.1.1 release

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -270,6 +270,15 @@ below, which you should change to match where your images are located.
 You can also remove the `ROOK_CSI_CEPHFS_IMAGE` and `ROOK_CSI_RBD_IMAGE` `env` variables that are
 no longer used in Rook.
 
+If you have configured the kubelet to use other than `/var/lib/kubelet` please
+add below to the operator `env` variables.
+
+```yaml
+env:
+    - name: ROOK_CSI_KUBELET_DIR_PATH
+      value: "/kubelet/path"
+```
+
 At the same time you edit the CSI driver settings, go ahead and update the operator deployment image:
 ```yaml
   image: rook/ceph:v1.1.0

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,3 +183,13 @@ all tests will be executed.
 These options should **not** be used if there are any changes to code which is shared with other
 storage providers. If there is any risk of affecting another storage provider, all tests should
 be executed in the CI.
+
+### [test ceph min]
+
+By default all the ceph test suites run on all versions of K8s. For more efficient
+CI times, we can choose to run each test suite on only one K8s version by using the tag:
+```
+[test ceph min]
+```
+
+This option should only be used for changes with lower risk.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,9 @@ pipeline {
                         env.testProvider = "cassandra"
                     } else if (body.contains("[test ceph]")) {
                         env.testProvider = "ceph"
+                    } else if (body.contains("[test ceph min]")) {
+                        env.testProvider = "ceph"
+                        env.testArgs = "min-test-matrix"
                     } else if (body.contains("[test cockroachdb]")) {
                         env.testProvider = "cockroachdb"
                     } else if (body.contains("[test edgefs]")) {
@@ -176,7 +179,8 @@ def RunIntegrationTest(k, v) {
                               set -o pipefail
                               export PATH="/tmp/rook-tests-scripts-helm/linux-amd64:$PATH" \
                                   KUBECONFIG=$HOME/admin.conf \
-                                  STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+'''
+                                  STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
+                                  TEST_ARGUMENTS='''+"${env.testArgs}"+'''
                               kubectl config view
                               _output/tests/linux_amd64/integration -test.v -test.timeout 7200s --host_type '''+"${k}"+''' --logs '''+"${env.getLogs}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
                     }

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -96,21 +96,14 @@ spec:
 {{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_RBD
           value: {{ .Values.csi.enableRbdDriver | quote }}
-{{- end }}
-{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: {{ .Values.csi.enableCephfsDriver | quote }}
-{{- end }}
-{{- if .Values.csi }}
 {{- if .Values.csi.kubeletDirPath }}
         - name: ROOK_CSI_KUBELET_DIR_PATH
           value: {{ .Values.csi.kubeletDirPath | quote }}
 {{- end }}
-{{- end }}
-{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: {{ .Values.csi.enableGrpcMetrics | quote }}
-{{- end }}
 {{- if .Values.csi.cephcsi }}
 {{- if .Values.csi.cephcsi.image }}
         - name: ROOK_CSI_CEPH_IMAGE
@@ -139,6 +132,7 @@ spec:
 {{- if .Values.csi.attacher.image }}
         - name: ROOK_CSI_ATTACHER_IMAGE
           value: {{ .Values.csi.attacher.image | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
         - name: ROOK_ENABLE_FLEX_DRIVER

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -102,6 +102,12 @@ spec:
           value: {{ .Values.csi.enableCephfsDriver | quote }}
 {{- end }}
 {{- if .Values.csi }}
+{{- if .Values.csi.kubeletDirPath }}
+        - name: ROOK_CSI_KUBELET_DIR_PATH
+          value: {{ .Values.csi.kubeletDirPath | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.csi }}
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: {{ .Values.csi.enableGrpcMetrics | quote }}
 {{- end }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -59,6 +59,7 @@ csi:
   enableRbdDriver: true
   enableCephfsDriver: true
   enableGrpcMetrics: true
+  #kubeletDirPath: /var/lib/kubelet
   #cephcsi:
     #image: quay.io/cephcsi/cephcsi:v1.2.0
   #registrar:

--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-after-reboot-check
-        image: rook/ceph:v1.1.0
+        image: rook/ceph:v1.1.1
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-before-reboot-check
-        image: rook/ceph:v1.1.0
+        image: rook/ceph:v1.1.1
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -186,7 +186,7 @@ subjects:
        serviceAccountName: rook-cassandra-operator
        containers:
        - name: rook-cassandra-operator
-         image: rook/cassandra:v1.1.0
+         image: rook/cassandra:v1.1.1
          imagePullPolicy: "Always"
          args: ["cassandra", "operator"]
          env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -120,7 +120,7 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com
+            path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com"
             type: DirectoryOrCreate
         - name: host-sys
           hostPath:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -115,7 +115,7 @@ spec:
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com
+            path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com"
             type: DirectoryOrCreate
         - name: host-sys
           hostPath:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -24,7 +24,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/csi.sock"
+            - "--kubelet-registration-path={{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/csi.sock"
           lifecycle:
             preStop:
               exec:
@@ -79,10 +79,10 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: csi-plugins-dir
-              mountPath: /var/lib/kubelet/plugins
+              mountPath: "{{ .KubeletDirPath }}/plugins"
               mountPropagation: "Bidirectional"
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: "{{ .KubeletDirPath }}/pods"
               mountPropagation: "Bidirectional"
             - name: host-sys
               mountPath: /sys
@@ -120,19 +120,19 @@ spec:
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/
+            path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}cephfs.csi.ceph.com/"
             type: DirectoryOrCreate
         - name: csi-plugins-dir
           hostPath:
-            path: /var/lib/kubelet/plugins
+            path: "{{ .KubeletDirPath }}/plugins"
             type: Directory
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: "{{ .KubeletDirPath }}/plugins_registry/"
             type: Directory
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: "{{ .KubeletDirPath }}/pods"
             type: Directory
         - name: host-sys
           hostPath:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -146,7 +146,7 @@ spec:
             path: /lib/modules
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com
+            path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com"
             type: DirectoryOrCreate
         - name: ceph-csi-config
           configMap:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -25,7 +25,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com/csi.sock"
+            - "--kubelet-registration-path={{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com/csi.sock"
           lifecycle:
             preStop:
               exec:
@@ -81,10 +81,10 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: "{{ .KubeletDirPath }}/pods"
               mountPropagation: "Bidirectional"
             - name: plugin-mount-dir
-              mountPath: /var/lib/kubelet/plugins
+              mountPath: "{{ .KubeletDirPath }}/plugins"
               mountPropagation: "Bidirectional"
             - mountPath: /dev
               name: host-dev
@@ -122,19 +122,19 @@ spec:
       volumes:
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com
+            path: "{{ .KubeletDirPath }}/plugins/{{ .DriverNamePrefix }}rbd.csi.ceph.com"
             type: DirectoryOrCreate
         - name: plugin-mount-dir
           hostPath:
-            path: /var/lib/kubelet/plugins
+            path: "{{ .KubeletDirPath }}/plugins"
             type: Directory
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: "{{ .KubeletDirPath }}/plugins_registry/"
             type: Directory
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: "{{ .KubeletDirPath }}/pods"
             type: Directory
         - name: host-dev
           hostPath:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -111,7 +111,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.1.0
+        image: rook/ceph:v1.1.1
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -181,7 +181,9 @@ spec:
         #  value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
         #- name: ROOK_CSI_ATTACHER_IMAGE
         #  value: "quay.io/k8scsi/csi-attacher:v1.2.0"
-
+        # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
+        #- name: ROOK_CSI_KUBELET_DIR_PATH
+        #  value: "/var/lib/kubelet"
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.1.0
+        image: rook/ceph:v1.1.1
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.1.0
+        image: rook/ceph:v1.1.1
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: rook-cockroachdb-operator
       containers:
       - name: rook-cockroachdb-operator
-        image: rook/cockroachdb:v1.1.0
+        image: rook/cockroachdb:v1.1.1
         args: ["cockroachdb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -370,7 +370,7 @@ spec:
       serviceAccountName: rook-edgefs-system
       containers:
       - name: rook-edgefs-operator
-        image: rook/edgefs:v1.1.0
+        image: rook/edgefs:v1.1.1
         imagePullPolicy: "Always"
         args: ["edgefs", "operator"]
         env:

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: rook-minio-operator
       containers:
       - name: rook-minio-operator
-        image: rook/minio:v1.1.0
+        image: rook/minio:v1.1.1
         args: ["minio", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -103,7 +103,7 @@ spec:
       serviceAccountName: rook-nfs-operator
       containers:
       - name: rook-nfs-operator
-        image: rook/nfs:v1.1.0
+        image: rook/nfs:v1.1.1
         imagePullPolicy: IfNotPresent
         args: ["nfs", "operator"]
         env:
@@ -192,7 +192,7 @@ spec:
       serviceAccount: rook-nfs-provisioner
       containers:
       - name: rook-nfs-provisioner
-        image: rook/nfs:v1.1.0
+        image: rook/nfs:v1.1.1
         imagePullPolicy: IfNotPresent
         args: ["nfs", "provisioner","--provisioner=rook.io/nfs-provisioner"]
         env:

--- a/cluster/examples/kubernetes/yugabytedb/operator.yaml
+++ b/cluster/examples/kubernetes/yugabytedb/operator.yaml
@@ -100,7 +100,7 @@ spec:
       serviceAccountName: rook-yugabytedb-operator
       containers:
       - name: rook-yugabytedb-operator
-        image: rook/yugabytedb:v1.1.0
+        image: rook/yugabytedb:v1.1.1
         args: ["yugabytedb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -21,6 +21,11 @@ spec:
         version: v1
         displayName: Ceph Object Store User
         description: Represents a Ceph Object Store User.
+      - kind: CephNFS
+        name: cephnfses.ceph.rook.io
+        version: v1
+        displayName: Ceph NFS
+        description: Represents a cluster of Ceph NFS ganesha gateways.
   displayName: Rook-Ceph
   description: |
 

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -95,6 +95,7 @@ CEPH_BLOCK_POOLS_CRD_YAML_FILE="$OLM_CATALOG_DIR/deploy/crds/rookcephblockpools.
 CEPH_OBJECT_STORE_YAML_FILE="$OLM_CATALOG_DIR/deploy/crds/rookcephobjectstores.crd.yaml"
 CEPH_OBJECT_STORE_USERS_YAML_FILE="$OLM_CATALOG_DIR/deploy/crds/rookcephobjectstoreusers.crd.yaml"
 CEPH_FILESYSTEMS_CRD_YAML_FILE="$OLM_CATALOG_DIR/deploy/crds/rookcephfilesystems.crd.yaml"
+CEPH_NFS_CRD_YAML_FILE="$OLM_CATALOG_DIR/deploy/crds/rookcephnfses.crd.yaml"
 
 #############
 # FUNCTIONS #
@@ -191,6 +192,7 @@ function generate_crds_yaml() {
     sed -n '/^# OLM: BEGIN CEPH OBJECT STORE CRD$/,/# OLM: END CEPH OBJECT STORE CRD$/p' "$COMMON_YAML_FILE" > "$CEPH_OBJECT_STORE_YAML_FILE"
     sed -n '/^# OLM: BEGIN CEPH OBJECT STORE USERS CRD$/,/# OLM: END CEPH OBJECT STORE USERS CRD$/p' "$COMMON_YAML_FILE" > "$CEPH_OBJECT_STORE_USERS_YAML_FILE"
     sed -n '/^# OLM: BEGIN CEPH BLOCK POOL CRD$/,/# OLM: END CEPH BLOCK POOL CRD$/p' "$COMMON_YAML_FILE" > "$CEPH_BLOCK_POOLS_CRD_YAML_FILE"
+     sed -n '/^# OLM: BEGIN CEPH NFS CRD$/,/# OLM: END CEPH NFS CRD$/p' "$COMMON_YAML_FILE" > "$CEPH_NFS_CRD_YAML_FILE"
 
     if [ -n "$OLM_INCLUDE_CEPHFS_CSI" ]; then
         sed -n '/^# OLM: BEGIN CEPH FS CRD$/,/# OLM: END CEPH FS CRD/p' "$COMMON_YAML_FILE" > "$CEPH_FILESYSTEMS_CRD_YAML_FILE"

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -68,6 +68,8 @@ func init() {
 	operatorCmd.Flags().StringVar(&csi.CephFSProvisionerDepTemplatePath, "csi-cephfs-provisioner-dep-template-path", csi.DefaultCephFSProvisionerDepTemplatePath, "path to ceph-csi cephfs provisioner deployment template")
 	operatorCmd.Flags().BoolVar(&csi.EnableCSIGRPCMetrics, "csi-enable-grpc-metrics", true, "enable grpc metrics in ceph-csi")
 
+	operatorCmd.Flags().StringVar(&csi.CSIParam.KubeletDirPath, "csi-kubelet-dir-path", csi.DefaultKubeletDirPath, "kubelet directory path for mounting volumes")
+
 	operatorCmd.Flags().BoolVar(&disruption.EnableMachineDisruptionBudget, "enable-machine-disruption-budget", false, "enable fencing controllers")
 
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -59,6 +59,7 @@ var osdStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts the osd daemon", // OSDs that were provisioned by ceph-volume
 }
+
 var (
 	osdDataDeviceFilter string
 	ownerRefID          string

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -141,6 +141,7 @@ func updateLVMConfig(context *clusterd.Context) error {
 	}
 
 	output := bytes.Replace(input, []byte("udev_sync = 1"), []byte("udev_sync = 0"), 1)
+	output = bytes.Replace(output, []byte("allow_changes_with_duplicate_pvs = 0"), []byte("allow_changes_with_duplicate_pvs = 1"), 1)
 	output = bytes.Replace(output, []byte("udev_rules = 1"), []byte("udev_rules = 0"), 1)
 	output = bytes.Replace(output, []byte("use_lvmetad = 1"), []byte("use_lvmetad = 0"), 1)
 	output = bytes.Replace(output, []byte("obtain_device_list_from_udev = 1"), []byte("obtain_device_list_from_udev = 0"), 1)

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -420,8 +420,8 @@ func getCephVolumeOSDs(context *clusterd.Context, clusterName string, cephfsid s
 		}
 		osds = append(osds, osd)
 	}
-
 	logger.Infof("%d ceph-volume osd devices configured on this node", len(osds))
+
 	return osds, nil
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -765,7 +765,12 @@ func (c *Cluster) getPVCHostName(pvcName string) (string, error) {
 		return "", err
 	}
 	for _, pod := range podList.Items {
-		return pod.Spec.NodeName, nil
+		name, err := k8sutil.GetNodeHostName(c.context.Clientset, pod.Spec.NodeName)
+		if err != nil {
+			logger.Warningf("falling back to node name %s since hostname not found for node", pod.Spec.NodeName)
+			name = pod.Spec.NodeName
+		}
+		return name, nil
 	}
 	return "", err
 }

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -36,6 +36,7 @@ type Param struct {
 	SnapshotterImage     string
 	DriverNamePrefix     string
 	EnableCSIGRPCMetrics string
+	KubeletDirPath       string
 }
 
 type templateParam struct {
@@ -76,6 +77,9 @@ const (
 	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.3.0"
 	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
 	DefaultSnapshotterImage = "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+
+	// kubelet directory path
+	DefaultKubeletDirPath = "/var/lib/kubelet"
 
 	// template
 	DefaultRBDPluginTemplatePath         = "/etc/ceph-csi/rbd/csi-rbdplugin.yaml"

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile_test.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedrain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCanaryTolerations(t *testing.T) {
+	uniqueTolerationsManual := []corev1.Toleration{
+		// key1
+		//   exists
+		{
+			Key:      "key1",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "key1",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectPreferNoSchedule,
+		},
+		//   equals with different values
+		{
+			Key:      "key1",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value1",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "key1",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value2",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+
+		//   with different effects
+		{
+			Key:      "key1",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value2",
+			Effect:   corev1.TaintEffectNoExecute,
+		},
+		// key2
+		{
+			Key:      "key2",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "key2",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value1",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "key2",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value2",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:      "key2",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "value2",
+			Effect:   corev1.TaintEffectNoExecute,
+		},
+	}
+
+	tolerationsWithDuplicates := make([]corev1.Toleration, 0)
+	for i := range uniqueTolerationsManual {
+		tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManual[i])
+
+		//append the previous one again if it's within range, else append the last one
+		if i > 0 {
+			tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManual[i-1])
+		} else {
+			tolerationsWithDuplicates = append(tolerationsWithDuplicates, uniqueTolerationsManual[len(uniqueTolerationsManual)-1])
+		}
+	}
+	uniqueTolerationsMap := make(map[corev1.Toleration]struct{})
+	for _, toleration := range tolerationsWithDuplicates {
+		uniqueTolerationsMap[toleration] = struct{}{}
+	}
+
+	uniqueTolerations := tolerationMapToList(uniqueTolerationsMap)
+
+	assert.Equal(t, len(uniqueTolerationsManual), len(uniqueTolerations))
+	for _, tolerationI := range uniqueTolerationsManual {
+		found := false
+		for _, tolerationJ := range uniqueTolerations {
+			if tolerationI == tolerationJ {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
+}

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -108,6 +108,19 @@ func GetNodeNameFromHostname(clientset kubernetes.Interface, hostName string) (s
 	return hostName, fmt.Errorf("node not found")
 }
 
+// GetNodeHostName returns the hostname label given the node name.
+func GetNodeHostName(clientset kubernetes.Interface, nodeName string) (string, error) {
+	node, err := clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	hostname, ok := node.Labels[v1.LabelHostname]
+	if !ok {
+		return "", fmt.Errorf("hostname not found on the node")
+	}
+	return hostname, nil
+}
+
 // GetNodeHostNames returns the name of the node resource mapped to their hostname label.
 // Typically these will be the same name, but sometimes they are not such as when nodes have a longer
 // dns name, but the hostname is short.

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -100,6 +100,12 @@ func (k8sh *K8sHelper) VersionAtLeast(minVersion string) bool {
 	return v.AtLeast(version.MustParseSemantic(minVersion))
 }
 
+func (k8sh *K8sHelper) VersionMinorMatches(minVersion string) bool {
+	v := version.MustParseSemantic(k8sh.GetK8sServerVersion())
+	requestedVersion := version.MustParseSemantic(minVersion)
+	return v.Major() == requestedVersion.Major() && v.Minor() == requestedVersion.Minor()
+}
+
 func (k8sh *K8sHelper) MakeContext() *clusterd.Context {
 	return &clusterd.Context{Clientset: k8sh.Clientset, RookClientset: k8sh.RookClientset, Executor: k8sh.executor}
 }

--- a/tests/integration/ceph_block_create_test.go
+++ b/tests/integration/ceph_block_create_test.go
@@ -59,7 +59,7 @@ func (s *BlockCreateSuite) SetupSuite() {
 	s.namespace = "block-k8s-ns"
 	mons := 1
 	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, s.namespace, "bluestore", false, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	s.op, s.kh = StartTestCluster(s.T, blockCreateMinimalTestVersion, s.namespace, "bluestore", false, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	initialBlocks, err := s.testClient.BlockClient.List(s.namespace)
 	assert.Nil(s.T(), err)

--- a/tests/integration/ceph_csi_test.go
+++ b/tests/integration/ceph_csi_test.go
@@ -42,7 +42,7 @@ const (
 func runCephCSIE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, t *testing.T, namespace string) {
 
 	if !k8sh.VersionAtLeast("v1.13.0") {
-		logger.Info("Skiping csi tests as kube version is less than 1.13.0")
+		logger.Info("Skipping csi tests as kube version is less than 1.13.0")
 		t.Skip()
 	}
 

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -69,7 +69,7 @@ func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
 	mons := 1
 	rbdMirrorWorkers := 1
-	hs.op, hs.kh = StartTestCluster(hs.T, hs.namespace, "bluestore", true, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	hs.op, hs.kh = StartTestCluster(hs.T, helmMinimalTestVersion, hs.namespace, "bluestore", true, false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	hs.helper = clients.CreateTestClient(hs.kh, hs.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -141,6 +141,8 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 
 	kh, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
+	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
+
 	i := installer.NewCephInstaller(t, kh.Clientset, false, installer.VersionMaster, installer.NautilusVersion)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1)}

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -74,7 +74,7 @@ func (suite *SmokeSuite) SetupSuite() {
 	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 1
-	suite.op, suite.k8sh = StartTestCluster(suite.T, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	suite.op, suite.k8sh = StartTestCluster(suite.T, smokeSuiteMinimalTestVersion, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	suite.helper = clients.CreateTestClient(suite.k8sh, suite.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -64,7 +64,7 @@ func (s *UpgradeSuite) SetupSuite() {
 	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 0
-	s.op, s.k8sh = StartTestCluster(s.T, s.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.Version1_0, installer.MimicVersion)
+	s.op, s.k8sh = StartTestCluster(s.T, upgradeMinimalTestVersion, s.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.Version1_0, installer.MimicVersion)
 	s.helper = clients.CreateTestClient(s.k8sh, s.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_zblock_mount_unmount_test.go
+++ b/tests/integration/ceph_zblock_mount_unmount_test.go
@@ -92,7 +92,7 @@ func (s *BlockMountUnMountSuite) SetupSuite() {
 	useDevices := true
 	mons := 1
 	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, s.namespace, "filestore", useHelm, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	s.op, s.kh = StartTestCluster(s.T, blockMountMinimalTestVersion, s.namespace, "filestore", useHelm, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	s.bc = s.testClient.BlockClient
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This backports a number of fixes and also sets the manifest versions to v1.1.1
- CSI kubelet path is configurable
- LVM cleanup and settings for rhel8
- NFS in the CSV

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
