### PR TITLE
docs: updated Ceph mon disaster recovery guide

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,6 +9,7 @@
 
 - A new CR property `skipUpgradeChecks` has been added, which allows you force an upgrade by skipping daemon checks. Use this at **YOUR OWN RISK**, only if you know what you're doing. To understand Rook's upgrade process of Ceph, read the [upgrade doc](Documentation/ceph-upgrade.html#ceph-version-upgrades).
 - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
+- Mon Quorum Disaster Recovery guide has been updated to work with the latest Rook and Ceph release.
 
 ### EdgeFS
 


### PR DESCRIPTION
**Description of your changes:**

This updates the Ceph mon disaster recovery guide to use the correct
paths and commands for the current Rook Ceph release.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**

Not sure if there is an actual issue open to update the guide.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]