### PR TITLE
correct namespace for csi resources  in upgrade doc

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -221,14 +221,14 @@ Replace the namespace names in the new resources:
 sed "s/ROOK_SYSTEM_NAMESPACE/$ROOK_SYSTEM_NAMESPACE/g" upgrade-from-v1.0-create.yaml > upgrade-from-v1.0-create.yaml.tmp
 sed "s/ROOK_NAMESPACE/$ROOK_NAMESPACE/g" upgrade-from-v1.0-create.yaml.tmp > upgrade-from-v1.0-create.yaml
 rm -f upgrade-from-v1.0-create.yaml.tmp
-sed -i "s/ROOK_NAMESPACE/$ROOK_NAMESPACE/g" upgrade-from-v1.0-apply.yaml
+sed -i "s/ROOK_SYSTEM_NAMESPACE/$ROOK_SYSTEM_NAMESPACE/g" upgrade-from-v1.0-apply.yaml
 ```
 
 If you have a v1.0 cluster running with CSI drivers enabled, delete the rbac rules created for CSI
 
 ```sh
-kubectl -n $ROOK_NAMESPACE delete clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner-rules
-kubectl -n $ROOK_NAMESPACE delete clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner-rules
+kubectl -n $ROOK_SYSTEM_NAMESPACE delete clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner-rules
+kubectl -n $ROOK_SYSTEM_NAMESPACE delete clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner-rules
 ```
 
 Apply the new permissions:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
@@ -103,7 +103,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: rook-ceph-system
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
   labels:
     operator: rook
     storage-backend: ceph

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
@@ -134,18 +134,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSYTEM_NAMESPACE
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTTEM_NAMESPACE
   name: cephfs-external-provisioner-cfg
 rules:
   - apiGroups: [""]
@@ -162,11 +162,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-csi-provisioner-role-cfg
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTTEM_NAMESPACE
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSTTEM_NAMESPACE
 roleRef:
   kind: Role
   name: cephfs-external-provisioner-cfg
@@ -251,7 +251,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSTEM_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: cephfs-csi-nodeplugin
@@ -264,7 +264,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSTEM_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: cephfs-external-provisioner-runner
@@ -274,18 +274,18 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
   name: rbd-external-provisioner-cfg
 rules:
   - apiGroups: [""]
@@ -302,11 +302,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-csi-provisioner-role-cfg
-  namespace: ROOK_NAMESPACE
+  namespace: ROOK_SYSTEM_NAMESPACE
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSTEM_NAMESPACE
 roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg
@@ -409,7 +409,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSYTEM_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: rbd-csi-nodeplugin
@@ -422,7 +422,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: ROOK_NAMESPACE
+    namespace: ROOK_SYSYTEM_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: rbd-external-provisioner-runner


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
CSI pods should look for the resources created in ROOK_SYSTEM_NAMESPACE instead
of ROOK_NAMESPACE 

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[test min ceph]