### PR TITLE
fix(fencing): Changes API for MachineDisruptionBudget

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -486,16 +486,6 @@
   revision = "072f7d777dc81aac0dd222686e1516dd9e7db38b"
 
 [[projects]]
-  digest = "1:231797c5447a21f16af4127737f8546a1cc77014ed65dc409a37245133b285f5"
-  name = "github.com/openshift/machine-api-operator"
-  packages = [
-    "pkg/apis/healthchecking",
-    "pkg/apis/healthchecking/v1alpha1",
-  ]
-  pruneopts = "UT"
-  revision = "a0949226d20ea454cf08252a182a8e32054027c3"
-
-[[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
   name = "github.com/pborman/uuid"
   packages = ["."]
@@ -1413,6 +1403,17 @@
   revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
+  digest = "1:ecfd5c449c5f0b25f6b174201fab4047574338aedb451210768301cf41428fa9"
+  name = "kubevirt.io/machine-remediation-operator"
+  packages = [
+    "pkg/apis/machineremediation",
+    "pkg/apis/machineremediation/v1alpha1",
+  ]
+  pruneopts = "UT"
+  revision = "1ccdf20edddfdef900eafc3df308cc844791eea9"
+  version = "v0.3.12"
+
+[[projects]]
   branch = "release-0.2"
   digest = "1:9f0ef29c01f23bbd2913084e7d9c692115c6c480ef6d1d5807773f077a1c57d3"
   name = "sigs.k8s.io/controller-runtime"
@@ -1508,7 +1509,6 @@
     "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api",
     "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api/errors",
     "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1",
-    "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1",
     "github.com/pkg/errors",
     "github.com/rook/operator-kit",
     "github.com/spf13/cobra",
@@ -1574,6 +1574,7 @@
     "k8s.io/kubernetes/pkg/scheduler/api",
     "k8s.io/kubernetes/pkg/util/mount",
     "k8s.io/kubernetes/pkg/volume/flexvolume",
+    "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -132,5 +132,5 @@ ignored = [
   name = "github.com/kube-object-storage/lib-bucket-provisioner"
 
 [[override]]
-  name = "github.com/openshift/machine-api-operator"
-  revision = "a0949226d20ea454cf08252a182a8e32054027c3"
+  name = "kubevirt.io/machine-remediation-operator"
+  version = "v0.3.12"

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -144,7 +144,7 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - healthchecking.openshift.io
+  - machineremediation.kubevirt.io
   resources:
   - machinedisruptionbudgets
   verbs:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -669,7 +669,7 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - healthchecking.openshift.io
+  - machineremediation.kubevirt.io
   resources:
   - machinedisruptionbudgets
   verbs:
@@ -679,6 +679,12 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
 - apiGroups:
   - machine.openshift.io
   resources:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
@@ -77,7 +77,7 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - healthchecking.openshift.io
+  - machineremediation.kubevirt.io
   resources:
   - machinedisruptionbudgets
   verbs:

--- a/pkg/operator/ceph/disruption/controllerconfig/context.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/context.go
@@ -24,9 +24,10 @@ import (
 
 // Context passed to the controller when associating it with the manager.
 type Context struct {
-	ClusterdContext   *clusterd.Context
-	OperatorNamespace string
-	ReconcileCanaries *LockingBool
+	ClusterdContext                     *clusterd.Context
+	OperatorNamespace                   string
+	ReconcileCanaries                   *LockingBool
+	RegisterMachineDisruptionController bool
 }
 
 // LockingBool is a bool coupled with a sync.Mutex

--- a/pkg/operator/ceph/disruption/machinedisruption/add.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/add.go
@@ -17,9 +17,9 @@ limitations under the License.
 package machinedisruption
 
 import (
-	healthchecking "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
+	machineremediation "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -32,7 +32,7 @@ import (
 // https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg
 func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 	mgrScheme := mgr.GetScheme()
-	healthchecking.AddToScheme(mgrScheme)
+	machineremediation.AddToScheme(mgrScheme)
 	cephv1.AddToScheme(mgrScheme)
 
 	reconcileMachineDisruption := &MachineDisruptionReconciler{
@@ -53,7 +53,7 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 		return err
 	}
 
-	return c.Watch(&source.Kind{Type: &healthchecking.MachineDisruptionBudget{}}, &handler.EnqueueRequestForOwner{
+	return c.Watch(&source.Kind{Type: &machineremediation.MachineDisruptionBudget{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &cephv1.CephCluster{},
 	})

--- a/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/reconcile.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	healthchecking "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	machineremediation "kubevirt.io/machine-remediation-operator/pkg/apis/machineremediation/v1alpha1"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephClient "github.com/rook/rook/pkg/daemon/ceph/client"
@@ -84,7 +84,7 @@ func (r *MachineDisruptionReconciler) reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
-	mdb := &healthchecking.MachineDisruptionBudget{
+	mdb := &machineremediation.MachineDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateMDBInstanceName(request.Name, request.Namespace),
 			Namespace: cephClusterInstance.Spec.DisruptionManagement.MachineDisruptionBudgetNamespace,
@@ -96,7 +96,7 @@ func (r *MachineDisruptionReconciler) reconcile(request reconcile.Request) (reco
 		// If the MDB is not found creating the MDB for the cephCluster
 		maxUnavailable := int32(0)
 		// Generating the MDB instance for the cephCluster
-		newMDB := &healthchecking.MachineDisruptionBudget{
+		newMDB := &machineremediation.MachineDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      generateMDBInstanceName(request.Name, request.Namespace),
 				Namespace: cephClusterInstance.Spec.DisruptionManagement.MachineDisruptionBudgetNamespace,
@@ -106,7 +106,7 @@ func (r *MachineDisruptionReconciler) reconcile(request reconcile.Request) (reco
 				},
 				OwnerReferences: []metav1.OwnerReference{cephCluster.ClusterOwnerRef(cephClusterInstance.GetName(), string(cephClusterInstance.GetUID()))},
 			},
-			Spec: healthchecking.MachineDisruptionBudgetSpec{
+			Spec: machineremediation.MachineDisruptionBudgetSpec{
 				MaxUnavailable: &maxUnavailable,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{

--- a/pkg/operator/ceph/disruption/register_controllers.go
+++ b/pkg/operator/ceph/disruption/register_controllers.go
@@ -59,7 +59,7 @@ func AddToManager(m manager.Manager, c *controllerconfig.Context) error {
 		}
 	}
 
-	if EnableMachineDisruptionBudget {
+	if EnableMachineDisruptionBudget && c.RegisterMachineDisruptionController {
 		for _, f := range MachineDisruptionBudgetAddToManagerFuncs {
 			if err := f(m, c); err != nil {
 				return err

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -692,7 +692,7 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - healthchecking.openshift.io
+  - machineremediation.kubevirt.io
   resources:
   - machinedisruptionbudgets
   verbs:


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <aranjan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This commit changes API for MachineDisruptionBudget used by the MDB controller as machine-remediation-operator reconciles on kubevirt's MDB CRs.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/3952

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
