### PR TITLE
ceph: osd reset 'run dir' to default location

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,6 +8,7 @@
 ### Ceph
 
 - A new CR property `skipUpgradeChecks` has been added, which allows you force an upgrade by skipping daemon checks. Use this at **YOUR OWN RISK**, only if you know what you're doing. To understand Rook's upgrade process of Ceph, read the [upgrade doc](Documentation/ceph-upgrade.html#ceph-version-upgrades).
+- Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
 
 ### EdgeFS
 

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -58,7 +58,6 @@ var (
 type GlobalConfig struct {
 	EnableExperimental       string `ini:"enable experimental unrecoverable data corrupting features,omitempty"`
 	FSID                     string `ini:"fsid,omitempty"`
-	RunDir                   string `ini:"run dir,omitempty"`
 	MonMembers               string `ini:"mon initial members,omitempty"`
 	MonHost                  string `ini:"mon host"`
 	LogFile                  string `ini:"log file,omitempty"`
@@ -146,7 +145,7 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 		logger.Warningf("failed to create config directory at %s: %+v", pathRoot, err)
 	}
 
-	configFile, err := createGlobalConfigFileSection(context, cluster, pathRoot, globalConfig)
+	configFile, err := createGlobalConfigFileSection(context, cluster, globalConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to create global config section, %+v", err)
 	}
@@ -176,7 +175,7 @@ func getQualifiedUser(user string) string {
 }
 
 // CreateDefaultCephConfig creates a default ceph config file.
-func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, runDir string) (*CephConfig, error) {
+func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*CephConfig, error) {
 
 	cephVersionEnv := os.Getenv("ROOK_CEPH_VERSION")
 	if cephVersionEnv != "" {
@@ -232,7 +231,6 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 	conf := &CephConfig{
 		GlobalConfig: &GlobalConfig{
 			FSID:                   cluster.FSID,
-			RunDir:                 runDir,
 			MonMembers:             strings.Join(monMembers, " "),
 			MonHost:                strings.Join(monHosts, ","),
 			PublicAddr:             context.NetworkInfo.PublicAddr,
@@ -275,7 +273,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 }
 
 // create a config file with global settings configured, and return an ini file
-func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterInfo, runDir string, userConfig *CephConfig) (*ini.File, error) {
+func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterInfo, userConfig *CephConfig) (*ini.File, error) {
 
 	var ceph *CephConfig
 
@@ -284,7 +282,7 @@ func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterIn
 		ceph = userConfig
 	} else {
 		var err error
-		ceph, err = CreateDefaultCephConfig(context, cluster, runDir)
+		ceph, err = CreateDefaultCephConfig(context, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create default ceph config. %+v", err)
 		}

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -197,7 +197,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 		monIP := cephutil.GetIPFromEndpoint(monitor.Endpoint)
 
 		// This tries to detect the current port if the mon already exists
-		// This basically handles the transtion between monitors running on 6790 to msgr2
+		// This basically handles the transition between monitors running on 6790 to msgr2
 		// So whatever the previous monitor port was we keep it
 		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
 
@@ -263,9 +263,9 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo, ru
 	}
 
 	// Everything before 14.2.1
-	// These new flags control Ceph's daemon logging behaviour to files
+	// These new flags control Ceph's daemon logging behavior to files
 	// By default we set them to False so no logs get written on file
-	// However they can be actived at any time via the centralized config store
+	// However they can be activated at any time via the centralized config store
 	if !cluster.CephVersion.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
 		conf.LogFile = "/dev/stderr"
 		conf.MonClusterLogFile = "/dev/stderr"

--- a/pkg/daemon/ceph/config/config_test.go
+++ b/pkg/daemon/ceph/config/config_test.go
@@ -54,7 +54,7 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 		},
 	}
 
-	cephConfig, err := CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1")
+	cephConfig, err := CreateDefaultCephConfig(context, clusterInfo)
 	if err != nil {
 		t.Fatalf("failed to create default ceph config. %+v", err)
 	}
@@ -63,7 +63,7 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 	// now use DEBUG level logging
 	context.LogLevel = capnslog.DEBUG
 
-	cephConfig, err = CreateDefaultCephConfig(context, clusterInfo, "/var/lib/rook1")
+	cephConfig, err = CreateDefaultCephConfig(context, clusterInfo)
 	if err != nil {
 		t.Fatalf("failed to create default ceph config. %+v", err)
 	}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"path"
 	"regexp"
 	"strconv"
 	"syscall"
@@ -177,7 +176,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 	}
 
 	// set the crush location in the osd config file
-	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, agent.cluster, path.Join(context.ConfigDir, agent.cluster.Name))
+	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, agent.cluster)
 	if err != nil {
 		return fmt.Errorf("failed to create default ceph config. %+v", err)
 	}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -498,7 +498,7 @@ func getActiveAndRemovedDirs(
 	return activeDirs, removedDirs
 }
 
-//releaseLVMDevice deativates the LV to release the device.
+//releaseLVMDevice deactivates the LV to release the device.
 func releaseLVMDevice(context *clusterd.Context, volumeGroupName string) error {
 	if err := context.Executor.ExecuteCommand(false, "", "lvchange", "-an", volumeGroupName); err != nil {
 		return fmt.Errorf("failed to deactivate LVM %s. Error: %+v", volumeGroupName, err)

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -506,7 +506,7 @@ func WriteConfigFile(context *clusterd.Context, cluster *cephconfig.ClusterInfo,
 }
 
 func writeConfigFile(cfg *osdConfig, context *clusterd.Context, cluster *cephconfig.ClusterInfo, location string) error {
-	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, cluster, cfg.rootPath)
+	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to create default ceph config. %+v", err)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

 Previously, "run dir" was used to place a number of file and config on
 dataDirHostPath. Now, since a lot of configs and options have moved
 either on the OSD's startup CLI line or remove with bluestore we don't
 need to change the default.
    
 Also, it was confusing for user and difficult to find the socket.
 The is is not breaking any config in dataDirHostPath since all the
 elements (keyrings) are hardcoded in the config file

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/3966

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]