### PR TITLE
Set default FS to "ext4" on RBD device

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
@@ -35,7 +35,7 @@ parameters:
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.
-    csi.storage.k8s.io/fstype: xfs
+    csi.storage.k8s.io/fstype: ext4
 # uncomment the following to use rbd-nbd as mounter on supported nodes
 #mounter: rbd-nbd
 reclaimPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -35,7 +35,7 @@ parameters:
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.
-    csi.storage.k8s.io/fstype: xfs
+    csi.storage.k8s.io/fstype: ext4
 # uncomment the following to use rbd-nbd as mounter on supported nodes
 #mounter: rbd-nbd
 reclaimPolicy: Delete


### PR DESCRIPTION
We were defaulting to `ext4` at first and then moved to`xfs`. 
However further testing shows that, ext4 should be
the default or preferred fs for RBD devices.

This patch bring that change

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[skip ci]