### PR TITLE
Check Pools is in use before deleting it

### DIFF
--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -149,6 +149,17 @@ func TestFilesystemRemove(t *testing.T) {
 		}
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
+	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
+		emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
+
+		if args[0] == "pool" {
+			if args[1] == "stats" {
+				return emptyPool, nil
+			}
+		}
+		return "", fmt.Errorf("unexpected rbd command '%v'", args)
+	}
+
 	err := RemoveFilesystem(context, "ns", fs.MDSMap.FilesystemName)
 	assert.Nil(t, err)
 	assert.True(t, metadataDeleted)

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -138,6 +138,13 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 			zoneDeleted = true
 			return "", nil
 		}
+
+		if args[0] == "pool" {
+			if args[1] == "stats" {
+				emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
+				return emptyPool, nil
+			}
+		}
 		return "", fmt.Errorf("unexpected ceph command '%v'", args)
 	}
 	executor.MockExecuteCommandWithOutput = executorFunc

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -143,7 +143,6 @@ func (c *PoolController) onDelete(obj interface{}) {
 		logger.Errorf("failed to get pool object: %+v", err)
 		return
 	}
-
 	if err := deletePool(c.context, pool); err != nil {
 		logger.Errorf("failed to delete pool %s. %+v", pool.ObjectMeta.Name, err)
 	}


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
currently, we are not checking the pool is empty or not before deleting, This PR adds a check to check
if any images/snapshots using the pool, if yes it will not delete the pool

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[test ceph min]