### PR TITLE
New setting to avoid delete pools on <filesystem>/<object store> deletion

### DIFF
--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -39,6 +39,7 @@ spec:
     - failureDomain: host
       replicated:
         size: 3
+  preservePoolsOnDelete: true
   metadataServer:
     activeCount: 1
     activeStandby: true
@@ -113,6 +114,7 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 
 - `metadataPool`: The settings used to create the file system metadata pool. Must use replication.
 - `dataPools`: The settings to create the file system data pools. If multiple pools are specified, Rook will add the pools to the file system. Assigning users or files to a pool is left as an exercise for the reader with the [CephFS documentation](http://docs.ceph.com/docs/master/cephfs/file-layouts/). The data pools can use replication or erasure coding. If erasure coding pools are specified, the cluster must be running with bluestore enabled on the OSDs.
+- `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the filesystem will remain when the filesystem will be deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'.
 
 ## Metadata Server Settings
 

--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -46,6 +46,7 @@ spec:
   dataPools:
     - replicated:
         size: 3
+  preservePoolsOnDelete: true
   metadataServer:
     activeCount: 1
     activeStandby: true
@@ -219,10 +220,12 @@ To clean up all the artifacts created by the file system demo:
 kubectl delete -f kube-registry.yaml
 ```
 
-To delete the filesystem components and backing data, delete the Filesystem CRD. **Warning: Data will be deleted**
+To delete the filesystem components and backing data, delete the Filesystem CRD. **Warning: Data will be deleted if preservePoolsOnDelete=false**
 ```
 kubectl -n rook-ceph delete cephfilesystem myfs
 ```
+
+Note: If the "preservePoolsOnDelete" filesystem attribute is set to true, the above command won't delete the pools. Creating again the filesystem with the same CRD will reuse again the previous pools.
 
 ## Flex Driver
 

--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -34,6 +34,7 @@ spec:
     erasureCoded:
       dataChunks: 2
       codingChunks: 1
+  preservePoolsOnDelete: true
   gateway:
     type: s3
     sslCertificateRef:
@@ -79,6 +80,8 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 
 - `metadataPool`: The settings used to create all of the object store metadata pools. Must use replication.
 - `dataPool`: The settings to create the object store data pool. Can use replication or erasure coding.
+- `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the object store will remain when the object store will be deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'.
+
 
 ## Gateway Settings
 

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -20,7 +20,7 @@ The below sample will create a `CephObjectStore` that starts the RGW service in 
 
 The OSDs must be located on different nodes, because the [`failureDomain`](ceph-pool-crd.md#spec) is set to `host` and the `erasureCoded` chunk settings require at least 3 different OSDs (2 `dataChunks` + 1 `codingChunks`).
 
-See the [Object Store CRD](ceph-object-store-crd.md#object-store-settings), for more detail on the settings availabe for a `CephObjectStore`. 
+See the [Object Store CRD](ceph-object-store-crd.md#object-store-settings), for more detail on the settings available for a `CephObjectStore`.
 
 ```yaml
 apiVersion: ceph.rook.io/v1
@@ -38,6 +38,7 @@ spec:
     erasureCoded:
       dataChunks: 2
       codingChunks: 1
+  preservePoolsOnDelete: true
   gateway:
     type: s3
     sslCertificateRef:

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,6 +11,7 @@
 - A new CR property `skipUpgradeChecks` has been added, which allows you force an upgrade by skipping daemon checks. Use this at **YOUR OWN RISK**, only if you know what you're doing. To understand Rook's upgrade process of Ceph, read the [upgrade doc](Documentation/ceph-upgrade.html#ceph-version-upgrades).
 - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
 - Mon Quorum Disaster Recovery guide has been updated to work with the latest Rook and Ceph release.
+- A new CRD property `PreservePoolsOnDelete` has been added to Filesystem(fs) and Object Store(os) resources in order to increase protection against data loss. if it is set to `true`, associated pools won't be deleted when the main resource(fs/os) is deleted. Creating again the deleted fs/os with the same name will reuse the preserved pools.
 
 ### EdgeFS
 

--- a/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
@@ -21,6 +21,8 @@ spec:
     - erasureCoded:
         dataChunks: 2
         codingChunks: 1
+  # Whether to preserve metadata and data pools on filesystem deletion
+  preservePoolsOnDelete: true
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/ceph/filesystem-test.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-test.yaml
@@ -16,6 +16,7 @@ spec:
     - failureDomain: osd
       replicated:
         size: 1
+  preservePoolsOnDelete: false
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -19,6 +19,8 @@ spec:
     - failureDomain: host
       replicated:
         size: 3
+  # Whether to preserve metadata and data pools on filesystem deletion
+  preservePoolsOnDelete: true
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -21,6 +21,8 @@ spec:
     erasureCoded:
       dataChunks: 2
       codingChunks: 1
+  # Whether to preserve metadata and data pools on object store deletion
+  preservePoolsOnDelete: true
   # The gaeteway service configuration
   gateway:
     # type of the gateway (s3)

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -20,6 +20,8 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+  # Whether to preserve metadata and data pools on object store deletion
+  preservePoolsOnDelete: true
   # The gaeteway service configuration
   gateway:
     # type of the gateway (s3)

--- a/cluster/examples/kubernetes/ceph/object-test.yaml
+++ b/cluster/examples/kubernetes/ceph/object-test.yaml
@@ -15,6 +15,7 @@ spec:
   dataPool:
     replicated:
       size: 1
+  preservePoolsOnDelete: false
   gateway:
     type: s3
     port: 80

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -20,6 +20,8 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+  # Whether to preserve metadata and data pools on object store deletion
+  preservePoolsOnDelete: false
   # The gaeteway service configuration
   gateway:
     # type of the gateway (s3)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -267,6 +267,9 @@ type FilesystemSpec struct {
 	// The data pool settings
 	DataPools []PoolSpec `json:"dataPools,omitempty"`
 
+	// Preserve pools on filesystem deletion
+	PreservePoolsOnDelete bool `json:"preservePoolsOnDelete"`
+
 	// The mds pod info
 	MetadataServer MetadataServerSpec `json:"metadataServer"`
 }
@@ -314,6 +317,9 @@ type ObjectStoreSpec struct {
 
 	// The data pool settings
 	DataPool PoolSpec `json:"dataPool"`
+
+	// Preserve pools on object store deletion
+	PreservePoolsOnDelete bool `json:"preservePoolsOnDelete"`
 
 	// The rgw pod info
 	Gateway GatewaySpec `json:"gateway"`

--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -160,7 +160,7 @@ func TestFilesystemRemove(t *testing.T) {
 		return "", fmt.Errorf("unexpected rbd command '%v'", args)
 	}
 
-	err := RemoveFilesystem(context, "ns", fs.MDSMap.FilesystemName)
+	err := RemoveFilesystem(context, "ns", fs.MDSMap.FilesystemName, false)
 	assert.Nil(t, err)
 	assert.True(t, metadataDeleted)
 	assert.True(t, dataDeleted)

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -218,6 +218,11 @@ func filesystemChanged(oldFS, newFS cephv1.FilesystemSpec) bool {
 		logger.Infof("mds active standby changed from %t to %t", oldFS.MetadataServer.ActiveStandby, newFS.MetadataServer.ActiveStandby)
 		return true
 	}
+	if oldFS.PreservePoolsOnDelete != newFS.PreservePoolsOnDelete {
+		logger.Infof("value of Preserve pools setting changed from %t to %t", oldFS.PreservePoolsOnDelete, newFS.PreservePoolsOnDelete)
+		// This setting only will be used when the filesystem will be deleted
+		return false
+	}
 	return false
 }
 

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -66,7 +66,7 @@ func createObjectStore(context *Context, metadataSpec, dataSpec model.Pool, serv
 	return nil
 }
 
-func deleteRealmAndPools(context *Context) error {
+func deleteRealmAndPools(context *Context, preservePoolsOnDelete bool) error {
 	stores, err := getObjectStores(context)
 	if err != nil {
 		return fmt.Errorf("failed to detect object stores during deletion. %+v", err)
@@ -83,9 +83,13 @@ func deleteRealmAndPools(context *Context) error {
 		lastStore = true
 	}
 
-	err = deletePools(context, lastStore)
-	if err != nil {
-		return fmt.Errorf("failed to delete object store pools. %+v", err)
+	if !preservePoolsOnDelete {
+		err = deletePools(context, lastStore)
+		if err != nil {
+			return fmt.Errorf("failed to delete object store pools. %+v", err)
+		}
+	} else {
+		logger.Infof("PreservePoolsOnDelete is set in object store %s. Pools not deleted", context.Name)
 	}
 	return nil
 }

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -152,7 +152,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 	context := &Context{Context: &clusterd.Context{Executor: executor}, Name: "myobj", ClusterName: "ns"}
 
 	// Delete an object store
-	err := deleteRealmAndPools(context)
+	err := deleteRealmAndPools(context, false)
 	assert.Nil(t, err)
 	expectedPoolsDeleted := 5
 	if expectedDeleteRootPool {

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -296,7 +296,7 @@ func (c *clusterConfig) deleteStore() error {
 
 	// Delete the realm and pools
 	objContext := NewContext(c.context, c.store.Name, c.store.Namespace)
-	err = deleteRealmAndPools(objContext)
+	err = deleteRealmAndPools(objContext, c.store.Spec.PreservePoolsOnDelete)
 	if err != nil {
 		return fmt.Errorf("failed to delete the realm and pools. %+v", err)
 	}


### PR DESCRIPTION
**Description of your changes:**
New setting to avoid delete pools on <filesystem>/<object store> deletion

Despite of the suggestion of @travisn  i have preferred to include a new "preservePools" attribute in the Ceph filesytem and Ceph Object store k8 objects.
My decision is based in the fact that these objects need several pools to keep their integrity healthy. So if we want to avoid to delete the pools storing the information in a filesystem/onject store we must be sure that all the pools are preserved always.
To have the "reclaimpolicy" (retain/delete) attribute at pool level , implies to specify this attribute for each pool, and therefore this increase the probability of error and make less comfortable to set this type of change

In any case, we also can include the "reclaim policy" attribute in pools. By the moment,  i think is not needed, but probably I cannot see all the implications. So if i miss something please indicate it.

Below the details about the verification of the fix/enhancement:

**Which issue is resolved by this Pull Request:**
Resolves #2206 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

Signed-off-by: Juan Miguel Olmo Martínez jolmomar@redhat.com



### **Details about verification:**

**FILESYSTEM:**

Delete a filesystem preserving pools

1. In the filesystem CRD the "Preserve Pools" Attribute must be set to true. Create the filesystem:

`$ kubectl create -f filesystem.yaml`

2. Filesystem "myfs" has been created using "myfs-data0" and "myfs-metadata" pools:

```
root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_WARN
            too few PGs per OSD (16 < min 30)

  services:
    mon: 3 daemons, quorum a,b,c (age 17h)
    mgr: a(active, since 91s)
    mds: myfs:1 {0=myfs-a=up:active} 1 up:standby-replay
    osd: 3 osds: 3 up (since 17h), 3 in (since 17h)

  data:
    pools:   2 pools, 16 pgs
    objects: 22 objects, 2.2 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     16 active+clean

  io:
    client:   852 B/s rd, 1 op/s rd, 0 op/s wr


[root@node3 /]# rados df
POOL_NAME        USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS     RD WR_OPS     WR USED COMPR UNDER COMPR
myfs-data0        0 B       0      0      0                  0       0        0      0    0 B      0    0 B        0 B         0 B
myfs-metadata 1.5 MiB      22      0     66                  0       0        0    120 64 KiB     45 13 KiB        0 B         0 B

total_objects    22
total_used       3.1 GiB
total_avail      69 GiB
total_space      72 GiB

```

3. Check value of "Preserve Pools" attribute in "myfs" k8 filesystem object:

```
$ kubectl -n rook-ceph get cephfilesystems myfs
NAME      ACTIVEMDS   AGE
myfs      1           20m

$ kubectl -n rook-ceph describe cephfilesystems myfs
Name:         myfs
Namespace:    rook-ceph
Labels:       <none>
Annotations:  <none>
API Version:  ceph.rook.io/v1
Kind:         CephFilesystem
Metadata:
  Creation Timestamp:  2019-09-24T09:43:37Z
  Generation:          1
  Resource Version:    227581
  Self Link:           /apis/ceph.rook.io/v1/namespaces/rook-ceph/cephfilesystems/myfs
  UID:                 57d497e7-daf9-432d-8a04-159d15a2a0bd
Spec:
  Data Pools:
    Failure Domain:  host
    Replicated:
      Size:  3
  Metadata Pool:
    Replicated:
      Size:  3
  Metadata Server:
    Active Count:    1
    Active Standby:  true
    Annotations:     <nil>
    Placement:
      Pod Anti Affinity:
        Required During Scheduling Ignored During Execution:
          Label Selector:
            Match Expressions:
              Key:       app
              Operator:  In
              Values:
                rook-ceph-mds
          Topology Key:  kubernetes.io/hostname
    Resources:           <nil>
  Preserve Pools:        true
Events:                  <none>

```
4. Delete the Filesystem

```
$ kubectl -n rook-ceph delete cephfilesystem myfs
cephfilesystem.ceph.rook.io "myfs" deleted

```

Using Ceph toolbox:

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_WARN
            too few PGs per OSD (16 < min 30)

  services:
    mon: 3 daemons, quorum a,b,c (age 17h)
    mgr: a(active, since 9m)
    osd: 3 osds: 3 up (since 17h), 3 in (since 17h)

  data:
    pools:   2 pools, 16 pgs
    objects: 22 objects, 2.2 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     16 active+clean

[root@node3 /]# rados df
POOL_NAME        USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS      RD WR_OPS     WR USED COMPR UNDER COMPR
myfs-data0        0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
myfs-metadata 1.5 MiB      22      0     66                  0       0        0    842 425 KiB     45 13 KiB        0 B         0 B

total_objects    22
total_used       3.1 GiB
total_avail      69 GiB
total_space      72 GiB


```
In the operator log file we can see:

```
...
2019-09-24 10:10:30.391771 I | op-file: Downing filesystem myfs
2019-09-24 10:10:30.393017 I | exec: Running command: ceph fs fail myfs --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/472395614
2019-09-24 10:10:31.165975 I | exec: myfs marked not joinable; MDS cannot join the cluster. All MDS ranks marked failed.
2019-09-24 10:10:31.166061 I | op-file: Downed filesystem myfs
2019-09-24 10:10:31.166069 I | op-file: GO TO DELETE FILESYSTEM
2019-09-24 10:10:31.166164 I | exec: Running command: ceph fs get myfs --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/300680485
2019-09-24 10:10:31.672102 I | exec: Running command: ceph fs rm myfs --yes-i-really-mean-it --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/493696576
2019-09-24 10:10:33.109234 I | cephclient: <PreservePools> is set in filesystem <myfs>. Pools not deleted
2019-09-24 10:10:33.116488 I | op-mds: deleting mds deployment rook-ceph-mds-myfs-a
2019-09-24 10:10:33.125196 I | op-mds: deleting mds deployment rook-ceph-mds-myfs-b
...
```

**OBJECT STORE:**
The object store CRD has been modified to allow also preserve pools. It can be achieved setting the "preservePools" attribute in the object store CRD to true.

Verification:

1. Create a object store with the "preservePools" attribute set to "true"

```
$ cat object.yaml | grep preservePools
  preservePools: true

$ kubectl create -f object.yaml
cephobjectstore.ceph.rook.io/my-store created
```

2. Using ceph toolbox, verify Ceph and Pools status:

```
root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 19h)
    mgr: a(active, since 2m)
    osd: 3 osds: 3 up (since 19h), 3 in (since 19h)
    rgw: 1 daemon active (my.store.a)

  data:
    pools:   6 pools, 48 pgs
    objects: 201 objects, 3.8 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     48 active+clean

  io:
    client:   7.8 KiB/s rd, 0 B/s wr, 11 op/s rd, 7 op/s wr

[root@node3 /]# rados df
POOL_NAME                     USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS      RD WR_OPS     WR USED COMPR UNDER COMPR
.rgw.root                  2.8 MiB      16      0     48                  0       0        0     46  46 KiB     32 23 KiB        0 B         0 B
my-store.rgw.buckets.data      0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.buckets.index     0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.control           0 B       8      0     24                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.log           192 KiB     177      0    531                  0       0        0    526 350 KiB    353  1 KiB        0 B         0 B
my-store.rgw.meta              0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B

total_objects    201
total_used       3.1 GiB
total_avail      69 GiB
total_space      72 GiB
```

3. Delete Object store

```
$ kubectl -n rook-ceph delete CephObjectStore my-store
cephobjectstore.ceph.rook.io "my-store" deleted

```
4. Verify Ceph and pool status

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 19h)
    mgr: a(active, since 3m)
    osd: 3 osds: 3 up (since 19h), 3 in (since 19h)

  data:
    pools:   6 pools, 48 pgs
    objects: 193 objects, 2.2 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     48 active+clean

  io:
    client:   767 B/s rd, 0 B/s wr, 0 op/s rd, 0 op/s wr

[root@node3 /]# rados df
POOL_NAME                     USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS      RD WR_OPS     WR USED COMPR UNDER COMPR
.rgw.root                  1.3 MiB       7      0     21                  0       0        0     55  55 KiB     41 23 KiB        0 B         0 B
my-store.rgw.buckets.data      0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.buckets.index     0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.control           0 B       8      0     24                  0       0        0      0     0 B      0    0 B        0 B         0 B
my-store.rgw.log           192 KiB     178      0    534                  0       0        0    528 352 KiB    357  5 KiB        0 B         0 B
my-store.rgw.meta              0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B

total_objects    193
total_used       3.1 GiB
total_avail      69 GiB
total_space      72 GiB
```

5. Check operator logs:
```
...
2019-09-24 11:25:41.713460 I | op-object: Deleting object store my-store from namespace rook-ceph
2019-09-24 11:25:41.762358 I | op-k8sutil: removing deployment rook-ceph-rgw-my-store-a if it exists
2019-09-24 11:25:41.778529 I | op-k8sutil: Removed deployment rook-ceph-rgw-my-store-a
2019-09-24 11:25:41.785292 I | op-k8sutil: rook-ceph-rgw-my-store-a still found. waiting...
2019-09-24 11:25:43.793416 I | op-k8sutil: rook-ceph-rgw-my-store-a still found. waiting...
2019-09-24 11:25:45.798573 I | op-k8sutil: confirmed rook-ceph-rgw-my-store-a does not exist
2019-09-24 11:25:45.804315 I | exec: Running command: ceph auth del client.my.store.a --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/067910445
2019-09-24 11:25:46.250311 I | exec: updated
2019-09-24 11:25:46.250451 I | exec: Running command: radosgw-admin realm list --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2019-09-24 11:25:46.489530 I | op-object: Found stores [my-store] when deleting store my-store
2019-09-24 11:25:46.489601 I | exec: Running command: radosgw-admin realm delete --rgw-realm my-store --rgw-realm=my-store --rgw-zonegroup=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2019-09-24 11:25:46.726192 I | exec: Running command: radosgw-admin zonegroup delete --rgw-zonegroup my-store --rgw-realm=my-store --rgw-zonegroup=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2019-09-24 11:25:46.950101 I | exec: Running command: radosgw-admin zone delete --rgw-zone my-store --rgw-realm=my-store --rgw-zonegroup=my-store --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring
2019-09-24 11:25:47.173069 I | op-object: <PreservePools> is set in object store <my-store>. Pools not deleted
2019-09-24 11:25:47.173124 I | op-object: Completed deleting object store my-store
...

```

==================================================================

**FILESYSTEM**

**verify that deleting a filesystem , pools are deleted**

1. In the filesystem CRD the "Preserve Pools" Attribute must be set to false, or not included.

```
$ cat filesystem.yaml | grep preservePools
  preservePools: false

```
Create the filesystem:

`$ kubectl create -f filesystem.yaml`

Once the filesystem is created we have:

```
$ kubectl -n rook-ceph get cephfilesystems myfs
NAME      ACTIVEMDS   AGE
myfs      1           23s

$ kubectl -n rook-ceph describe cephfilesystems myfs | grep Preserve
  Preserve Pools:        false
```

Using the ceph toolbox:

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_WARN
            too few PGs per OSD (16 < min 30)

  services:
    mon: 3 daemons, quorum a,b,c (age 17h)
    mgr: a(active, since 18m)
    mds: myfs:1 {0=myfs-a=up:active} 1 up:standby-replay
    osd: 3 osds: 3 up (since 17h), 3 in (since 17h)

  data:
    pools:   4 pools, 16 pgs
    objects: 22 objects, 2.2 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     16 active+clean

  io:
    client:   1.2 KiB/s rd, 2 op/s rd, 0 op/s wr

    [root@node3 /]# rados df
    POOL_NAME        USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS      RD WR_OPS     WR USED COMPR UNDER COMPR
    myfs-data0        0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
    myfs-metadata 1.5 MiB      22      0     66                  0       0        0    230 119 KiB     45 13 KiB        0 B         0 B

    total_objects    22
    total_used       3.1 GiB
    total_avail      69 GiB
    total_space      72 GiB
```

2. Delete the filesystem and verify ceph and pools STATUS

```
$ kubectl -n rook-ceph delete cephfilesystem myfs
cephfilesystem.ceph.rook.io "myfs" deleted
```

Using the Ceph toolbox:

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 18h)
    mgr: a(active, since 24m)
    osd: 3 osds: 3 up (since 17h), 3 in (since 17h)

  data:
    pools:   3 pools, 0 pgs
    objects: 0 objects, 0 B
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:

    [root@node3 /]# rados df
    POOL_NAME USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS RD WR_OPS WR USED COMPR UNDER COMPR

    total_objects    0
    total_used       3.1 GiB
    total_avail      69 GiB
    total_space      72 GiB

```
and in the operator log we can see:

```
...
2019-09-24 10:25:32.607202 I | op-file: Downing filesystem myfs
2019-09-24 10:25:32.608043 I | exec: Running command: ceph fs fail myfs --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/804323567
2019-09-24 10:25:33.343347 I | exec: myfs marked not joinable; MDS cannot join the cluster. All MDS ranks marked failed.
2019-09-24 10:25:33.343458 I | op-file: Downed filesystem myfs
2019-09-24 10:25:33.343467 I | op-file: GO TO DELETE FILESYSTEM
2019-09-24 10:25:33.343532 I | exec: Running command: ceph fs get myfs --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/752691586
2019-09-24 10:25:33.863220 I | exec: Running command: ceph fs rm myfs --yes-i-really-mean-it --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/325110521
2019-09-24 10:25:35.265936 I | exec: Running command: ceph osd lspools --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/983511556
2019-09-24 10:25:35.766810 I | exec: Running command: ceph osd pool get myfs-metadata all --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/096677779
2019-09-24 10:25:36.280598 I | cephclient: purging pool myfs-metadata (id=21)
2019-09-24 10:25:36.280754 I | exec: Running command: ceph osd pool delete myfs-metadata myfs-metadata --yes-i-really-really-mean-it --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/802382806
2019-09-24 10:25:37.301183 I | exec: pool 'myfs-metadata' removed
2019-09-24 10:25:37.301447 I | exec: Running command: ceph osd crush rule rm myfs-metadata --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/122894653
2019-09-24 10:25:38.388965 I | cephclient: purge completed for pool myfs-metadata
2019-09-24 10:25:38.389055 I | exec: Running command: ceph osd pool get myfs-data0 all --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/907849080
2019-09-24 10:25:38.793918 I | cephclient: purging pool myfs-data0 (id=22)
2019-09-24 10:25:38.793996 I | exec: Running command: ceph osd pool delete myfs-data0 myfs-data0 --yes-i-really-really-mean-it --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/505333879
2019-09-24 10:25:39.398101 I | exec: pool 'myfs-data0' removed
2019-09-24 10:25:39.398365 I | exec: Running command: ceph osd crush rule rm myfs-data0 --connect-timeout=15 --cluster=rook-ceph --conf=/var/lib/rook/rook-ceph/rook-ceph.config --keyring=/var/lib/rook/rook-ceph/client.admin.keyring --format json --out-file /tmp/148229482
2019-09-24 10:25:40.426258 I | cephclient: purge completed for pool myfs-data0
2019-09-24 10:25:40.430637 I | op-mds: deleting mds deployment rook-ceph-mds-myfs-a
2019-09-24 10:25:40.435734 I | op-mds: deleting mds deployment rook-ceph-mds-myfs-b
...
```

**OBJECT STORE**

1. Set the object store attribute  preservePools to False

```
$ cat object.yaml | grep preservePools
  preservePools: false
```

2. Create the object store

```
$ kubectl create -f object.yaml
cephobjectstore.ceph.rook.io/my-store created

```

3. Check Ceph and pool status

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 19h)
    mgr: a(active, since 16m)
    osd: 3 osds: 3 up (since 19h), 3 in (since 19h)
    rgw: 1 daemon active (my.store.a)

  data:
    pools:   9 pools, 48 pgs
    objects: 208 objects, 6.0 KiB
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:     48 active+clean

  io:
    client:   14 KiB/s rd, 0 B/s wr, 21 op/s rd, 14 op/s wr

    [root@node3 /]# rados df
    POOL_NAME                     USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS      RD WR_OPS     WR USED COMPR UNDER COMPR
    .rgw.root                  4.1 MiB      23      0     69                  0       0        0    101 101 KiB     73 46 KiB        0 B         0 B
    my-store.rgw.buckets.data      0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
    my-store.rgw.buckets.index     0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B
    my-store.rgw.control           0 B       8      0     24                  0       0        0      0     0 B      0    0 B        0 B         0 B
    my-store.rgw.log           192 KiB     178      0    534                  0       0        0    527 351 KiB    355  3 KiB        0 B         0 B
    my-store.rgw.meta              0 B       0      0      0                  0       0        0      0     0 B      0    0 B        0 B         0 B

    total_objects    209
    total_used       3.1 GiB
    total_avail      69 GiB
    total_space      72 GiB

```

4. Delete the object store

```
$ kubectl -n rook-ceph delete CephObjectStore my-store
cephobjectstore.ceph.rook.io "my-store" deleted
```

5. Check Ceph and pool status

```
[root@node3 /]# ceph -s
  cluster:
    id:     db6b561a-c2f8-4f07-bc32-728eccdf8c74
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 19h)
    mgr: a(active, since 17m)
    osd: 3 osds: 3 up (since 19h), 3 in (since 19h)

  data:
    pools:   7 pools, 0 pgs
    objects: 0 objects, 0 B
    usage:   3.1 GiB used, 69 GiB / 72 GiB avail
    pgs:

[root@node3 /]# rados df
POOL_NAME USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS RD WR_OPS WR USED COMPR UNDER COMPR

total_objects    0
total_used       3.1 GiB
total_avail      69 GiB
total_space      72 GiB
```


