### PR TITLE
Clarify docs around the custom ceph.conf settings configmap

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -436,7 +436,9 @@ MDS, and RGW daemons as an `/etc/ceph/ceph.conf` file.
 **WARNING:** Rook performs no validation on the config, so the  validity of the settings is the
 user's responsibility.
 
-Each daemon will need to be restarted where you want the settings applied:
+If the `rook-config-override` ConfigMap is created before the cluster is started, the Ceph daemons
+will automatically pick up the settings. If you add the settings to the ConfigMap after the cluster
+has been initialized, each daemon will need to be restarted where you want the settings applied:
 
 - mons: ensure all three mons are online and healthy before restarting each mon pod, one at a time.
 - mgrs: the pods are stateless and can be restarted as needed, but note that this will disrupt the


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The configmap for advanced configuration can be created before the cluster is created. In that case, the daemons will all pick up the settings the first time they are started. Otherwise, the daemons need to be restarted

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]
