### PR TITLE
Backport: Allow setting affinity on the ceph version job

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -59,6 +59,7 @@ an example usage
 - Rook now has a new config CRD `mgr` to enable ceph manager modules
 - Flexvolume plugin now supports dynamic PVC expansion.
 - The Rook-enforced minimum memory for OSD pods has been reduced from 4096M to 2048M
+- The job for detecting the Ceph version can be started with node affinity or tolerations according to the same settings in the Cluster CR as the mons.
 - A new CR property `skipUpgradeChecks` has been added, which allows you force an upgrade by skipping daemon checks. Use this at **YOUR OWN RISK**, only if you know what you're doing. To understand Rook's upgrade process of Ceph, read the [upgrade doc](Documentation/ceph-upgrade.html#ceph-version-upgrades).
 - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -104,6 +104,9 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 	job := versionReporter.Job()
 	job.Spec.Template.Spec.ServiceAccountName = "rook-ceph-cmd-reporter"
 
+	// Apply the same node selector and tolerations for the ceph version detection as the mon daemons
+	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)
+
 	stdout, stderr, retcode, err := versionReporter.Run(timeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to complete ceph version job. %+v", err)


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>
(cherry picked from commit 0f5f2a81d74d5f02ac176816de2d16b84751ca8c)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
A job is started to detect the Ceph version. This job now allows setting the node affinity and tolerations with the same setting that is specified for the mon placement. No new placement spec is required, but we will simply use the same spec that the mons use.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]