### PR TITLE
[OSD on PVC] add kubernetes version check.

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -43,6 +43,7 @@ spec:
 
 ## PVC-based Cluster
 
+**NOTE** Kubernetes version 1.13.0 or greater is required to provision OSDs on PVCs.
 ```yaml
 apiVersion: ceph.rook.io/v1
 kind: CephCluster

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -40,6 +40,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 var (
@@ -233,13 +234,23 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 
 	// no validVolumeSource is ready to run an osd
 	if len(c.DesiredStorage.VolumeSources) == 0 && len(c.DesiredStorage.StorageClassDeviceSets) == 0 {
-		logger.Warningf("no valid volumeSource available to run an osd in namespace %s. "+
-			"Rook will not create any new OSD nodes and will skip checking for removed pvcs "+
-			"removing all OSD nodes without destroying the Rook cluster is unlikely to be intentional", c.Namespace)
+		logger.Warningf("no volume sources specified for creating OSDs on PVCs.")
 		return
 	}
 
 	logger.Infof("%d of the %d volumeSources are valid", len(validVolumeSources), len(c.DesiredStorage.VolumeSources))
+
+	//check k8s version
+	k8sVersion, err := k8sutil.GetK8SVersion(c.context.Clientset)
+	if err != nil {
+		config.addError("error finding Kubernetes version. %+v", err)
+		return
+	}
+	if !k8sVersion.AtLeast(version.MustParseSemantic("v1.13.0")) {
+		logger.Warningf("skipping OSD on PVC provisioning. Minimum Kubernetes version required: 1.13.0. Actual version: %s", k8sVersion.String())
+		return
+	}
+
 	for _, volume := range c.ValidStorage.VolumeSources {
 		osdProps := osdProperties{
 			crushHostname: volume.PersistentVolumeClaimSource.ClaimName,


### PR DESCRIPTION
Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
 OSD on PVC provisioning fails if k8s version is less than 1.13.0
  - updated document to reflect minimum k8s version required.
  - Added check to skip OSD on pvc provisoning if the minimum k8s version requirement is not met.

**Which issue is resolved by this Pull Request:**
Resolves #4008

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]