### PR TITLE
ceph: set ssl to true in cluster-minimal.yaml

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -24,6 +24,7 @@ spec:
     allowMultiplePerNode: false
   dashboard:
     enabled: true
+    ssl: true
   monitoring:
     enabled: false  # requires Prometheus to be pre-installed
     rulesNamespace: rook-ceph


### PR DESCRIPTION
The scripts for running backend dashboard requests in rook expect this
to be an SSL-enabled port. Ensure that it is.

https://tracker.ceph.com/issues/42089
Signed-off-by: Jeff Layton <jlayton@redhat.com>

[skip ci]