### PR TITLE
ceph: set default Ceph CSI images as var not const

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -74,17 +74,23 @@ var (
 	ConfigKey  = "csi-cluster-config-json"
 )
 
-const (
-	KubeMinMajor              = "1"
-	KubeMinMinor              = "13"
-	provDeploymentSuppVersion = "14"
-
+// Specify default images as var instead of const so that they can be overridden with the Go
+// linker's -X flag. This allows users to easily build images with a different opinionated set of
+// images without having to specify them manually in charts/manifests which can make upgrades more
+// manually challenging.
+var (
 	// image names
 	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v1.2.1"
 	DefaultRegistrarImage   = "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.3.0"
 	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
 	DefaultSnapshotterImage = "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+)
+
+const (
+	KubeMinMajor              = "1"
+	KubeMinMinor              = "13"
+	provDeploymentSuppVersion = "14"
 
 	// toleration and node affinity
 	provisionerTolerationsEnv  = "CSI_PROVISIONER_TOLERATIONS"


### PR DESCRIPTION
Set the default Ceph CSI images as vars in the code instead of consts.
This allows these values to be overridden at build time with Go linker
-X flags. This allows users to build Rook in such a way that it will
automatically update the CSI images to a custom opinionated default
without having to manually manage the environment variable-based
overrides at upgrade time.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]