### PR TITLE
Enable restoring a cluster after disaster recovery

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -163,7 +163,7 @@ func Status(context *clusterd.Context, clusterName string, debug bool) (CephStat
 // clean is true if the cluster is clean
 // err is not nil if getting the status failed.
 func IsClusterClean(context *clusterd.Context, clusterName string) (string, bool, error) {
-	status, err := Status(context, clusterName, false)
+	status, err := Status(context, clusterName, true)
 	if err != nil {
 		return "unable to get PG health", false, err
 	}
@@ -203,7 +203,7 @@ func isClusterClean(status CephStatus) (string, bool) {
 	}
 	if cleanPGs == status.PgMap.NumPgs {
 		// all PGs in the cluster are in a clean state
-		logger.Infof("all placement groups have reached a clean state: %+v", status.PgMap.PgsByState)
+		logger.Debugf("all placement groups have reached a clean state: %+v", status.PgMap.PgsByState)
 		return "all PGs in cluster are clean", true
 	}
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -231,7 +231,7 @@ func (c *Cluster) setLoginCredentials(password string) error {
 		args := []string{"dashboard", "set-login-credentials", dashboardUsername, password}
 		cmd := client.NewCephCommand(c.context, c.Namespace, args)
 		cmd.Debug = true
-		return cmd.Run()
+		return cmd.RunWithTimeout(client.CmdExecuteTimeout)
 	}, c.exitCode, 5, invalidArgErrorCode, dashboardInitWaitTime)
 	if err != nil {
 		return fmt.Errorf("failed to set login creds on mgr. %+v", err)

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -49,11 +49,10 @@ func (c *Cluster) configureOrchestratorModules() error {
 	// retry a few times in the case that the mgr module is not ready to accept commands
 	_, err := client.ExecuteCephCommandWithRetry(func() ([]byte, error) {
 		args := []string{"orchestrator", "set", "backend", "rook"}
-		return client.NewCephCommand(c.context, c.Namespace, args).Run()
+		return client.NewCephCommand(c.context, c.Namespace, args).RunWithTimeout(client.CmdExecuteTimeout)
 	}, c.exitCode, 5, invalidArgErrorCode, orchestratorInitWaitTime)
 	if err != nil {
 		return fmt.Errorf("failed to set rook as the orchestrator backend. %+v", err)
-
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -18,6 +18,7 @@ package mgr
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -32,6 +33,7 @@ func TestOrchestratorModules(t *testing.T) {
 	orchestratorModuleEnabled := false
 	rookModuleEnabled := false
 	rookBackendSet := false
+	backendErrorCount := 0
 	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "mgr" && args[1] == "module" && args[2] == "enable" {
@@ -44,7 +46,15 @@ func TestOrchestratorModules(t *testing.T) {
 				return "", nil
 			}
 		}
+		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+	}
+	executor.MockExecuteCommandWithOutputFileTimeout = func(debug bool, timeout time.Duration, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "orchestrator" && args[1] == "set" && args[2] == "backend" && args[3] == "rook" {
+			if backendErrorCount < 5 {
+				backendErrorCount++
+				return "", fmt.Errorf("test simulation failure")
+			}
 			rookBackendSet = true
 			return "", nil
 		}
@@ -56,6 +66,10 @@ func TestOrchestratorModules(t *testing.T) {
 	}
 
 	c := &Cluster{clusterInfo: clusterInfo, context: context}
+	c.exitCode = func(err error) (int, bool) {
+		return invalidArgErrorCode, true
+	}
+	orchestratorInitWaitTime = 0
 
 	// the modules are skipped on mimic
 	c.clusterInfo.CephVersion = cephver.Mimic
@@ -66,9 +80,17 @@ func TestOrchestratorModules(t *testing.T) {
 	assert.False(t, rookBackendSet)
 
 	// the modules are configured on nautilus
+	// the rook module will fail to be set
 	c.clusterInfo.CephVersion = cephver.Nautilus
 	err = c.configureOrchestratorModules()
-	assert.Nil(t, err)
+	assert.Error(t, err)
+	assert.True(t, orchestratorModuleEnabled)
+	assert.True(t, rookModuleEnabled)
+	assert.False(t, rookBackendSet)
+
+	// the rook module will succeed
+	err = c.configureOrchestratorModules()
+	assert.NoError(t, err)
 	assert.True(t, orchestratorModuleEnabled)
 	assert.True(t, rookModuleEnabled)
 	assert.True(t, rookBackendSet)

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -654,6 +654,24 @@ func (c *Cluster) startDeployments(mons []*monConfig, requireAllInQuorum bool) e
 		return fmt.Errorf("cannot start 0 mons")
 	}
 
+	// If all the mon deployments don't exist, allow the mon deployments to all be started without checking for quorum.
+	// This will be the case where:
+	// 1) New clusters where we are starting one deployment at a time. We only need to check for quorum once when we add a new mon.
+	// 2) Clusters being restored where no mon deployments are running. We need to start all the deployments before checking quorum.
+	onlyCheckQuorumOnce := false
+	deployments, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", AppName)})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Infof("0 of %d expected mon deployments exist. creating new deployment(s).", len(mons))
+			onlyCheckQuorumOnce = true
+		} else {
+			logger.Warningf("failed to list mon deployments. attempting to continue. %+v", err)
+		}
+	} else if len(deployments.Items) < len(mons) {
+		logger.Infof("%d of %d expected mon deployments exist. creating new deployment(s).", len(deployments.Items), len(mons))
+		onlyCheckQuorumOnce = true
+	}
+
 	// Ensure each of the mons have been created. If already created, it will be a no-op.
 	for i := 0; i < len(mons); i++ {
 		node, _ := c.mapping.Node[mons[i].DaemonName]
@@ -664,10 +682,12 @@ func (c *Cluster) startDeployments(mons []*monConfig, requireAllInQuorum bool) e
 		// For the initial deployment (first creation) it's expected to not have all the monitors in quorum
 		// However, in an event of an update, it's crucial to proceed monitors by monitors
 		// At the end of the method we perform one last check where all the monitors must be in quorum
-		requireAllInQuorum := false
-		err = c.waitForMonsToJoin(mons, requireAllInQuorum)
-		if err != nil {
-			return fmt.Errorf("failed to check mon quorum %s. %+v", mons[i].DaemonName, err)
+		if !onlyCheckQuorumOnce || (onlyCheckQuorumOnce && i == len(mons)-1) {
+			requireAllInQuorum := false
+			err = c.waitForMonsToJoin(mons, requireAllInQuorum)
+			if err != nil {
+				return fmt.Errorf("failed to check mon quorum %s. %+v", mons[i].DaemonName, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When testing the scenario of restoring a cluster after rebuilding k8s (described [here](https://github.com/rook/rook/issues/1653#issuecomment-536696481)), there are some small fixes to enable the scenario:
1. When creating mon quorum, immediately create all mon deployments. The operator was waiting for quorum after starting the first one, but at least two mons needed to be up. After starting all mons, then check for quorum.
1. Certain requests to mgr modules are hanging while the OSDs are still down. Changed this to timeout when these requests are not responsive. 
1. Unrelated change to reduce operator verbose logging around checking for clean PGs.

**Which issue is resolved by this Pull Request:**
Related to #1653 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
