### PR TITLE
Ceph CRD Validation: Add reservePoolsOnDelete

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -246,6 +246,8 @@ spec:
                         type: integer
                       codingChunks:
                         type: integer
+            preservePoolsOnDelete:
+              type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS
       type: string
@@ -348,6 +350,8 @@ spec:
                       type: integer
                     codingChunks:
                       type: integer
+            preservePoolsOnDelete:
+              type: boolean
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -267,6 +267,8 @@ spec:
                         type: integer
                       codingChunks:
                         type: integer
+            preservePoolsOnDelete:
+              type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS
       type: string
@@ -373,6 +375,8 @@ spec:
                       type: integer
                     codingChunks:
                       type: integer
+            preservePoolsOnDelete:
+              type: boolean
 # OLM: END CEPH OBJECT STORE CRD
 # OLM: BEGIN CEPH OBJECT STORE USERS CRD
 ---

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -319,6 +319,8 @@ spec:
                         type: integer
                       codingChunks:
                         type: integer
+            preservePoolsOnDelete:
+              type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS
       type: string
@@ -421,6 +423,8 @@ spec:
                       type: integer
                     codingChunks:
                       type: integer
+            preservePoolsOnDelete:
+              type: boolean
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**

Fixes

```
rook_ceph_client/tests/test_examples.py::test_filesystem[filesystem-ec] FAILED                                                                                                                                                                                                       [ 58%]
rook_ceph_client/tests/test_examples.py::test_filesystem[filesystem-test] FAILED                                                                                                                                                                                                     [ 62%]
rook_ceph_client/tests/test_examples.py::test_filesystem[filesystem] FAILED                                                                                                                                                                                                          [ 65%]
rook_ceph_client/tests/test_examples.py::test_object[object-bucket-claim-delete] FAILED                                                                                                                                                                                              [ 68%]
rook_ceph_client/tests/test_examples.py::test_object[object-bucket-claim-retain] FAILED                                                                                                                                                                                              [ 72%]
rook_ceph_client/tests/test_examples.py::test_object[object-ec] FAILED                                                                                                                                                                                                               [ 75%]
rook_ceph_client/tests/test_examples.py::test_object[object-openshift] FAILED                                                                                                                                                                                                        [ 79%]
rook_ceph_client/tests/test_examples.py::test_object[object-test] FAILED                                                                                                                                                                                                             [ 82%]
rook_ceph_client/tests/test_examples.py::test_object[object-user] FAILED                                                                                                                                                                                                             [ 86%]
rook_ceph_client/tests/test_examples.py::test_object[object] FAILED    
```

```
E       AssertionError: assert {'apiVersion'...elete': True}} == {'apiVersion':.....}]}}, ...}}}
E         Common items:
E         {'apiVersion': 'ceph.rook.io/v1',
E          'kind': 'CephFilesystem',
E          'metadata': {'name': 'myfs-ec', 'namespace': 'rook-ceph'}}
E         Differing items:
E         {'spec': {'dataPools': [{'erasureCoded': {'codingChunks': 1, 'dataChunks': 2}}], 'metadataPool': {'replicated': {'size...{'podAntiAffinity': {'requiredDuringSchedulingIgnoredDuringExecution': [{...}]}}, ...}, 'preservePoolsOnDelete': True}} != {'spec': {'dataPools': [{'erasureCoded': {'codingChunks': 1, 'dataChunks': 2}}], 'metadataPool': {'replicated': {'size...notations': None, 'placement': {'podAntiAffinity': {'requiredDuringSchedulingIgnoredDuringExecution': [{...}]}}, ...}}}
E         Full diff:
E         {'apiVersion': 'ceph.rook.io/v1',
E         'kind': 'CephFilesystem',
E         'metadata': {'name': 'myfs-ec', 'namespace': 'rook-ceph'},
E         'spec': {'dataPools': [{'erasureCoded': {'codingChunks': 1, 'dataChunks': 2}}],
E         'metadataPool': {'replicated': {'size': 3}},
E         'metadataServer': {'activeCount': 1,
E         'activeStandby': True,
E         'annotations': None,
E         'placement': {'podAntiAffinity': {'requiredDuringSchedulingIgnoredDuringExecution': [{'labelSelector': {'matchExpressions': [{'key': 'app',
E         'operator': 'In',
E         'values': ['rook-ceph-mds']}]},
E         'topologyKey': 'kubernetes.io/hostname'}]}},
E         -                              'resources': None},
E         ?                                                ^
E         +                              'resources': None}}}
E         ?                                                ^^
E         -           'preservePoolsOnDelete': True}}

rook_ceph_client/tests/test_examples.py:49: AssertionError

```

See also: https://github.com/sebastian-philipp/rook-ceph-client-python/commit/5c480997a6e12e94fac8e6f2fd782294b5324b12

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
