### PR TITLE
ceph: relax pre-requisite for external cluster

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -89,7 +89,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 ### Cluster Settings
 
 - `external`:
-  - `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster).
+  - `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs if an image is provided and will refuse otherwise. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster). If `cephVersion.image` is left blank, Rook will refuse the creation of extra CRs like object, file and nfs.
 - `cephVersion`: The version information for launching the ceph daemons.
   - `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v13.2.6-20190604` or `ceph/ceph:v14.2.4-20190917`.
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
@@ -672,6 +672,18 @@ spec:
 
 ### External cluster
 
+**The minimum supported Ceph version for the External Cluster is Luminous 12.2.x.**
+
+The features available from the external cluster will vary depending on the version of Ceph. The following table shows the minimum version of Ceph for some of the features:
+
+| FEATURE                                      | CEPH VERSION |
+|----------------------------------------------|--------------|
+| Dynamic provisioning RBD                     | 12.2.X       |
+| Configure extra CRDs (object, file, nfs)[^1] | 13.2.3       |
+| Dynamic provisioning CephFS                  | 14.2.3       |
+
+[^1]: Configure an object store, shared file system, or NFS resources in the local cluster to connect to the external Ceph cluster
+
 #### Pre-requisites
 
 In order to configure an external Ceph cluster with Rook, we need to inject some information in order to connect to that cluster.
@@ -712,12 +724,13 @@ spec:
   external:
     enable: true
   dataDirHostPath: /var/lib/rook
+  # providing an image is optional, do this if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v14.2.4-20190917 # the image version **must** match the version of the external Ceph cluster
+    image: ceph/ceph:v14.2.4-20190917 # MUST match external cluster version
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.
-Additionnally, you now need to inject `common-external.yaml` too.
+Additionally, you now need to inject `common-external.yaml` too.
 
 You can now create it like this:
 

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -19,5 +19,6 @@ spec:
   external:
     enable: true
   dataDirHostPath: /var/lib/rook
+  # providing an image is optional, do this if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
     image: ceph/ceph:v14.2.4-20190917 # MUST match external cluster version

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -432,16 +432,16 @@ type NetworkSpec struct {
 	HostNetwork bool `json:"hostNetwork"`
 }
 
-// DisruptionManagementSpec configures mangement of daemon disruptions
+// DisruptionManagementSpec configures management of daemon disruptions
 type DisruptionManagementSpec struct {
 
 	// This enables management of poddisruptionbudgets
 	ManagePodBudgets bool `json:"managePodBudgets,omitempty"`
 
-	// OSDMaintenenceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure domains
+	// OSDMaintenanceTimeout sets how many additional minutes the DOWN/OUT interval is for drained failure domains
 	// it only works if managePodBudgetss is true.
 	// the default is 30 minutes
-	OSDMaintenenceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
+	OSDMaintenanceTimeout time.Duration `json:"osdMaintenanceTimeout,omitempty"`
 
 	// This enables management of machinedisruptionbudgets
 	ManageMachineDisruptionBudgets bool `json:"manageMachineDisruptionBudgets,omitempty"`

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -47,6 +47,7 @@ type MonMapEntry struct {
 	Name        string `json:"name"`
 	Rank        int    `json:"rank"`
 	Address     string `json:"addr"`
+	PublicAddr  string `json:"public_addr"`
 	PublicAddrs struct {
 		Addrvec []AddrvecEntry `json:"addrvec"`
 	} `json:"public_addrs"`

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -213,7 +213,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 		// The operator always fails this test since it does not have the env var 'ROOK_CEPH_VERSION'
 		podName := os.Getenv("POD_NAME")
 		if cluster.CephVersion.IsAtLeastNautilus() {
-			monHosts[i] = "v1:" + msgr1Endpoint
+			monHosts[i] = msgr1Prefix + msgr1Endpoint
 		} else if podName != "" && strings.Contains(podName, "operator") {
 			// This is an operator and its version is always based on Nautilus
 			// so it knows how to parse both msgr1 and msgr2 syntax

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -293,7 +293,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 	}
 
 	// Notify the child controllers that the cluster spec might have changed
-	logger.Debug("notifying CR childs of the potential upgrade")
+	logger.Debug("notifying CR child of the potential upgrade")
 	for _, child := range c.childControllers {
 		child.ParentClusterChanged(*c.Spec, c.Info, c.isUpgrade)
 	}
@@ -362,12 +362,12 @@ func (c *cluster) checkSetOrchestrationStatus() bool {
 func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion, runningVersions client.CephDaemonsVersions) (bool, error) {
 	numberOfCephVersions := len(runningVersions.Overall)
 	if numberOfCephVersions == 0 {
-		// let's return immediatly
+		// let's return immediately
 		return false, fmt.Errorf("no 'overall' section in the ceph versions. %+v", runningVersions.Overall)
 	}
 
 	if numberOfCephVersions > 1 {
-		// let's return immediatly
+		// let's return immediately
 		logger.Warningf("it looks like we have more than one ceph version running. triggering upgrade. %+v:", runningVersions.Overall)
 		return true, nil
 	}

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -243,7 +243,7 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 
 	c.Spec.DataDirHostPath = "path"
 	err = validateExternalClusterSpec(c)
-	assert.Error(t, err)
+	assert.NoError(t, err, err)
 
 	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.4-20190917"
 	err = validateExternalClusterSpec(c)

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -229,17 +229,13 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 
 	// populate fake monmap
 	fakeResp := client.MonStatusResponse{Quorum: []int{0}}
-	fakeAddrvecEntry := []client.AddrvecEntry{
-		{
-			Addr: "172.17.0.4:3300",
-		},
-	}
+
 	fakeResp.MonMap.Mons = []client.MonMapEntry{
 		{
 			Name: "a",
 		},
 	}
-	fakeResp.MonMap.Mons[0].PublicAddrs.Addrvec = fakeAddrvecEntry
+	fakeResp.MonMap.Mons[0].PublicAddr = "172.17.0.4:3300"
 
 	// populate fake ClusterInfo
 	c := &Cluster{ClusterInfo: &cephconfig.ClusterInfo{}}
@@ -280,12 +276,7 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 			Name: "b",
 		},
 	}
-	fakeAddrvecEntry2 := []client.AddrvecEntry{
-		{
-			Addr: "172.17.0.5:3300",
-		},
-	}
-	fakeResp.MonMap.Mons[1].PublicAddrs.Addrvec = fakeAddrvecEntry2
+	fakeResp.MonMap.Mons[1].PublicAddr = "172.17.0.5:3300"
 	c.ClusterInfo = test.CreateConfigDir(1)
 	changed, err = c.addOrRemoveExternalMonitor(fakeResp)
 	assert.NoError(t, err)
@@ -299,18 +290,14 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 	// Now let's test the case where the mon is in clusterInfo, part of the monmap but not in quorum!
 	c.ClusterInfo = test.CreateConfigDir(1)
 	fakeResp2 := client.MonStatusResponse{Quorum: []int{1}} // quorum is owned by the mon with the rank 1 and our mon rank is 0
-	fakeAddrvecEntry3 := []client.AddrvecEntry{
-		{
-			Addr: "172.17.0.4:3300",
-		},
-	}
+
 	fakeResp2.MonMap.Mons = []client.MonMapEntry{
 		{
 			Name: "a",
 			Rank: 0,
 		},
 	}
-	fakeResp2.MonMap.Mons[0].PublicAddrs.Addrvec = fakeAddrvecEntry3
+	fakeResp2.MonMap.Mons[0].PublicAddr = "172.17.0.4:3300"
 	changed, err = c.addOrRemoveExternalMonitor(fakeResp2)
 	assert.NoError(t, err)
 	assert.True(t, changed)

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -113,7 +113,7 @@ func (r *ReconcileClusterDisruption) reconcile(request reconcile.Request) (recon
 	}
 	//signal to the nodedrain controller to start
 	r.context.ReconcileCanaries.Update(true)
-	r.maintenanceTimeout = cephCluster.Spec.DisruptionManagement.OSDMaintenenceTimeout
+	r.maintenanceTimeout = cephCluster.Spec.DisruptionManagement.OSDMaintenanceTimeout
 	if r.maintenanceTimeout == 0 {
 		r.maintenanceTimeout = DefaultMaintenanceTimeout
 	}

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -97,6 +97,12 @@ func (c *FilesystemController) StartWatch(namespace string, stopCh chan struct{}
 }
 
 func (c *FilesystemController) onAdd(obj interface{}) {
+
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Creating filesystems for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	filesystem, err := getFilesystemObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get filesystem object: %+v", err)
@@ -123,6 +129,11 @@ func (c *FilesystemController) onAdd(obj interface{}) {
 }
 
 func (c *FilesystemController) onUpdate(oldObj, newObj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Updating filesystems for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	oldFS, err := getFilesystemObject(oldObj)
 	if err != nil {
 		logger.Errorf("failed to get old filesystem object: %+v", err)
@@ -182,6 +193,11 @@ func (c *FilesystemController) ParentClusterChanged(cluster cephv1.ClusterSpec, 
 }
 
 func (c *FilesystemController) onDelete(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Deleting filesystems for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	filesystem, err := getFilesystemObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get filesystem object: %+v", err)

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -85,6 +85,11 @@ func (c *CephNFSController) StartWatch(namespace string, stopCh chan struct{}) e
 }
 
 func (c *CephNFSController) onAdd(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Creating nfs for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	nfs := obj.(*cephv1.CephNFS).DeepCopy()
 	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
 		logger.Errorf("Ceph NFS is only supported with Nautilus or newer. CRD %s will be ignored.", nfs.Name)
@@ -101,6 +106,11 @@ func (c *CephNFSController) onAdd(obj interface{}) {
 }
 
 func (c *CephNFSController) onUpdate(oldObj, newObj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Updating nfs for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	oldNFS := oldObj.(*cephv1.CephNFS).DeepCopy()
 	newNFS := newObj.(*cephv1.CephNFS).DeepCopy()
 	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
@@ -132,6 +142,11 @@ func (c *CephNFSController) onUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *CephNFSController) onDelete(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Deleting nfs for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	nfs := obj.(*cephv1.CephNFS).DeepCopy()
 	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
 		logger.Errorf("Ceph NFS is only supported with Nautilus or newer. CRD %s cleanup will be ignored.", nfs.Name)

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -96,6 +96,11 @@ func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{
 }
 
 func (c *ObjectStoreController) onAdd(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Creating object store for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	objectstore, err := getObjectStoreObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get objectstore object: %+v", err)
@@ -118,6 +123,11 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 }
 
 func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Updating object store for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	// if the object store spec is modified, update the object store
 	oldStore, err := getObjectStoreObject(oldObj)
 	if err != nil {
@@ -159,6 +169,11 @@ func (c *ObjectStoreController) createOrUpdateStore(objectstore *cephv1.CephObje
 }
 
 func (c *ObjectStoreController) onDelete(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Deleting object store for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	objectstore, err := getObjectStoreObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get objectstore object: %+v", err)

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -89,6 +89,11 @@ func (c *ObjectStoreUserController) StartWatch(stopCh chan struct{}) error {
 }
 
 func (c *ObjectStoreUserController) onAdd(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Creating object store user for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	user, err := getObjectStoreUserObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get objectstoreuser object: %+v", err)
@@ -101,10 +106,19 @@ func (c *ObjectStoreUserController) onAdd(obj interface{}) {
 }
 
 func (c *ObjectStoreUserController) onUpdate(oldObj, newObj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Updating object store user for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
 	// TODO: Add update code here after features are added which require updates.
 }
 
 func (c *ObjectStoreUserController) onDelete(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Deleting object store user for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	user, err := getObjectStoreUserObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get objectstoreuser object: %+v", err)

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -80,6 +80,11 @@ func (c *PoolController) StartWatch(namespace string, stopCh chan struct{}) erro
 }
 
 func (c *PoolController) onAdd(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Creating pools for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	pool, err := getPoolObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get pool object: %+v", err)
@@ -93,6 +98,11 @@ func (c *PoolController) onAdd(obj interface{}) {
 }
 
 func (c *PoolController) onUpdate(oldObj, newObj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Updating pools for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	oldPool, err := getPoolObject(oldObj)
 	if err != nil {
 		logger.Errorf("failed to get old pool object: %+v", err)
@@ -138,6 +148,11 @@ func poolChanged(old, new cephv1.PoolSpec) bool {
 }
 
 func (c *PoolController) onDelete(obj interface{}) {
+	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
+		logger.Warningf("Deleting pools for an external ceph cluster is disabled because no Ceph image is specified")
+		return
+	}
+
 	pool, err := getPoolObject(obj)
 	if err != nil {
 		logger.Errorf("failed to get pool object: %+v", err)

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -38,6 +38,8 @@ const (
 var (
 	// Minimum supported version is 13.2.4 where ceph-volume is supported
 	Minimum = CephVersion{13, 2, 4}
+	// Luminous Ceph version
+	Luminous = CephVersion{12, 0, 0}
 	// Mimic Ceph version
 	Mimic = CephVersion{13, 0, 0}
 	// Nautilus Ceph version
@@ -224,9 +226,9 @@ func IsInferior(a, b CephVersion) bool {
 func ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, externalVersion CephVersion) error {
 	logger.Debugf("local version is %s, external version is %s", localVersion.String(), externalVersion.String())
 
-	// We only support Nautilus or newer
-	if !externalVersion.IsAtLeastNautilus() {
-		return fmt.Errorf("unsupported ceph version %s, need at least nautilus, delete your cluster CR and create a new one with a correct ceph version", externalVersion.String())
+	// We only support Luminous or newer
+	if !externalVersion.IsAtLeast(Luminous) {
+		return fmt.Errorf("unsupported external ceph version %s, need at least luminous", externalVersion.String())
 	}
 
 	// Identical version, regardless if other CRs are running, it's ok!


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
   
We now differentiate the cases where:

* we only consume the external cluster
* we consume the external cluster as well as creating stateless
resources in Kubernetes (bootstrap mds,rgw, nfs)

This is mostly controlled via the image property spec. If not defined,
not extra CRs won't be able to be created.

Now the external cluster feature supports cluster as of Luminous 12.2.
    
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]