### PR TITLE
ceph: set ssl to true in cluster-test.yaml

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -36,6 +36,7 @@ spec:
     allowUnsupported: false
   dashboard:
     enabled: true
+    ssl: true
   network:
     hostNetwork: false
   storage:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -23,6 +23,7 @@ spec:
     allowMultiplePerNode: true
   dashboard:
     enabled: true
+    ssl: true
   monitoring:
     enabled: false  # requires Prometheus to be pre-installed
     rulesNamespace: rook-ceph


### PR DESCRIPTION
Dashboard requires ssl to be turned on for running backend requests in rook.

Fixes: https://tracker.ceph.com/issues/42089
Signed-off-by: Varsha Rao <varao@redhat.com>

[skip ci]
