### PR TITLE
Sanitize the master tag

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -25,6 +25,13 @@ ifeq ($(filter master release,$(CHANNEL)),)
 $(error invalid channel $(CHANNEL))
 endif
 
+# When a release branch is first created, the tag shows up in the master branch build tags.
+# When that tag has the alpha, beta, or rc suffixes, we want to remove it since it is only
+# relevant to the release tags.
+ifeq ($(CHANNEL),master)
+override VERSION := $(shell echo "$(VERSION)" | sed -e 's/-alpha.0//' -e 's/-beta.0//' -e 's/-rc.0//')
+endif
+
 DOCS_VERSION := $(shell echo $(BRANCH_NAME) | sed -E "s/^release\-([0-9]+)\.([0-9]+)$$/v\1.\2/g")
 DOCS_DIR ?= $(ROOT_DIR)/Documentation
 DOCS_WORK_DIR := $(WORK_DIR)/rook.github.io


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The master branch uses the first tag from the last release to create the version tag. Since the 1.1 release this tag can include the alpha, beta, or rc tags, which only make sense for the release tags, but not the master tag. This change removes the suffix from the master tag.

The most recent master tag is `v1.1.0-beta.0.228.gb40321f`. 
With the change, the tag would now be `v1.1.0.228.gb40321f`.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]