### PR TITLE
Get <ceph-volume inventory> data in dev. configmaps

### DIFF
--- a/cmd/rook/discover.go
+++ b/cmd/rook/discover.go
@@ -32,10 +32,14 @@ var (
 
 	// interval between discovering devices
 	discoverDevicesInterval time.Duration
+
+	// Uses ceph-volume inventory to extend devices information
+	usesCVInventory bool
 )
 
 func init() {
 	discoverCmd.Flags().DurationVar(&discoverDevicesInterval, "discover-interval", 60*time.Minute, "interval between discovering devices (default 60m)")
+	discoverCmd.Flags().BoolVar(&usesCVInventory, "use-ceph-volume", false, "Use ceph-volume inventory to extend storage devices information (default false)")
 
 	flags.SetFlagsFromEnv(discoverCmd.Flags(), rook.RookEnvVarPrefix)
 	discoverCmd.RunE = startDiscover
@@ -48,7 +52,7 @@ func startDiscover(cmd *cobra.Command, args []string) error {
 
 	context := rook.NewContext()
 
-	err := discover.Run(context, discoverDevicesInterval)
+	err := discover.Run(context, discoverDevicesInterval, usesCVInventory)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -43,7 +43,6 @@ func ignoreDevice(d string) bool {
 
 // Discover all the details of devices available on the local node
 func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
-
 	var disks []*sys.LocalDisk
 	devices, err := sys.ListDevices(executor)
 	if err != nil {

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -106,7 +106,7 @@ func (o *Operator) Run() error {
 
 	if EnableDiscoveryDaemon {
 		rookDiscover := discover.New(o.context.Clientset)
-		if err := rookDiscover.Start(o.operatorNamespace, o.rookImage, o.securityAccount); err != nil {
+		if err := rookDiscover.Start(o.operatorNamespace, o.rookImage, o.securityAccount, true); err != nil {
 			return fmt.Errorf("error starting device discovery daemonset. %+v", err)
 		}
 	}

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -46,7 +46,7 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	a := New(clientset)
 
 	// start a basic cluster
-	err := a.Start(namespace, "rook/rook:myversion", "mysa")
+	err := a.Start(namespace, "rook/rook:myversion", "mysa", false)
 	assert.Nil(t, err)
 
 	// check daemonset parameters

--- a/pkg/operator/edgefs/operator.go
+++ b/pkg/operator/edgefs/operator.go
@@ -29,7 +29,7 @@ import (
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/edgefs/cluster"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-operator")
@@ -65,7 +65,7 @@ func (o *Operator) Run() error {
 	}
 
 	rookDiscover := discover.New(o.context.Clientset)
-	if err := rookDiscover.Start(namespace, o.rookImage, o.securityAccount); err != nil {
+	if err := rookDiscover.Start(namespace, o.rookImage, o.securityAccount, false); err != nil {
 		return fmt.Errorf("Error starting device discovery daemonset: %v", err)
 	}
 

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -79,6 +79,8 @@ type LocalDisk struct {
 	WWNVendorExtension string `json:"wwnVendorExtension"`
 	// Empty checks whether the device is completely empty
 	Empty bool `json:"empty"`
+	// Information provided by Ceph Volume Inventory
+	CephVolumeData string `json:"cephVolumeData,omitempty"`
 }
 
 func ListDevices(executor exec.Executor) ([]string, error) {


### PR DESCRIPTION
**Description of your changes:**
This modification adds the information extracted from 'ceph-volume inventory':
command to the device configmaps generated by the discovery daemon when "rook discover" starts with the new boolean "--use-cv" parameter. 
This parameter is set if the new env. var "ROOK_DISCOVER_USES_CEPH_VOLUME" is
set to 'true' in the operator CRD.

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

Resolves #
https://github.com/rook/rook/issues/2606

**Manual verification:**

_1. Use ceph-volume inventory_

```
$ grep "ROOK_DISCOVER_USES_CEPH_VOLUME" operator.yaml -a2
        # Rook-discover daemonset will use "ceph-volume inventory" command to extend
        # information about storage devices in each node.
        - name: ROOK_DISCOVER_USES_CEPH_VOLUME
          value: "true"

$ kubectl  get nodes
NAME      STATUS    ROLES     AGE       VERSION
master    Ready     master    5d18h     v1.16.0
node1     Ready     <none>    5d18h     v1.16.0
node2     Ready     <none>    5d18h     v1.16.0
node3     Ready     <none>    5d18h     v1.16.0

$ kubectl create -f operator.yaml

$ kubectl -n rook-ceph get pod
NAME                                 READY     STATUS    RESTARTS   AGE
rook-ceph-operator-c78c99ff9-m7mb4   1/1       Running   0          98s
rook-discover-942zg                  1/1       Running   0          92s
rook-discover-jknbj                  1/1       Running   0          92s
rook-discover-t88jc                  1/1       Running   0          92s


$ kubectl -n rook-ceph logs rook-discover-942zg
2019-10-07 08:24:03.193161 I | rookcmd: starting Rook v1.1.0-beta.0.222.g418cbb94-dirty with arguments '/usr/local/bin/rook discover --discover-interval 60m --use-cv'
2019-10-07 08:24:03.193348 I | rookcmd: flag values: --discover-interval=1h0m0s, --help=false, --log-flush-frequency=5s, --log-level=INFO, --operator-image=, --service-account=, --use-cv=true
2019-10-07 08:24:03.195657 I | rook-discover: device discovery interval is 1h0m0s
2019-10-07 08:24:03.195672 I | rook-discover: use ceph volume inventory is true
2019-10-07 08:24:03.206028 I | rook-discover: updating device configmap
...
2019-10-07 08:24:03.265212 I | rook-discover: localdevices - [0xc0004700f0 0xc0004701e0 0xc0004702d0 0xc0004703c0]
2019-10-07 08:24:03.265236 I | rook-discover: Getting ceph-volume inventory information
2019-10-07 08:24:03.265244 I | exec: Running command: ceph-volume inventory --format json
2019-10-07 08:24:14.175077 I | exec: Running command: lsblk /dev/sda --bytes --pairs --output NAME,SIZE,TYPE,PKNAME
2019-10-07 08:24:14.184935 I | sys: Output: NAME="sda" SIZE="34359738368" TYPE="disk" PKNAME=""
...
2019-10-07 08:24:14.228839 I | rook-discover: available devices: [{Name:sda Parent: HasChildren:false DevLinks:/dev/disk/by-id/ata-VBOX_HARDDISK_VB49b8145a-f4f18659 /dev/disk/by-path/pci-0000:00:01.1-ata-1.0 Size:34359738368 UUID:576ddc72-9bea-439b-b846-2dcb2340636c Serial:VBOX_HARDDISK_VB49b8145a-f4f18659 Type:disk Rotational:true Readonly:false Partitions:[{Name:sda1 Size:1073741824 Label: Filesystem:xfs} {Name:sda2 Size:33284947968 Label: Filesystem:LVM2_member}] Filesystem: Vendor: Model:VBOX_HARDDISK WWN: WWNVendorExtension: Empty:false CephVolumeData:0xc0003d34c0} {Name:sdb Parent: HasChildren:false DevLinks:/dev/disk/by-id/ata-VBOX_HARDDISK_VBd298841f-d5521468 /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0 Size:26843545600 UUID:27f9d277-a757-4387-b57e-8a0fb154adce Serial:VBOX_HARDDISK_VBd298841f-d5521468 Type:disk Rotational:true Readonly:false Partitions:[] Filesystem: Vendor: Model:VBOX_HARDDISK WWN: WWNVendorExtension: Empty:true CephVolumeData:0xc0003d3c00}]

$ kubectl -n rook-ceph  describe configmap  local-device-node1
Name:         local-device-node1
Namespace:    rook-ceph
Labels:       app=rook-discover
              rook.io/node=node1
Annotations:  <none>

Data
====
devices:
----
[{"name":"sda","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/ata-VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac /dev/disk/by-path/pci-0000:00:01.1-ata-1.0","size":34359738368,"uuid":"57e28869-1d69-481d-8fd8-9ca394ef8451","serial":"VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac","type":"disk","rotational":true,"readOnly":false,"Partitions":[{"Name":"sda1","Size":1073741824,"Label":"","Filesystem":"xfs"},{"Name":"sda2","Size":33284947968,"Label":"","Filesystem":"LVM2_member"}],"filesystem":"","vendor":"","model":"VBOX_HARDDISK","wwn":"","wwnVendorExtension":"","empty":false,"cephVolumeData":{"DevicePath":"/dev/sda","Size":"32.00 GB","Rotates":true,"Available":false,"ModelName":"VBOX HARDDISK"}},{"name":"sdb","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/ata-VBOX_HARDDISK_VB496d0bf5-7937a495 /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0","size":26843545600,"uuid":"bc041c8b-e0b4-42fd-bae4-428b047b0670","serial":"VBOX_HARDDISK_VB496d0bf5-7937a495","type":"disk","rotational":true,"readOnly":false,"Partitions":null,"filesystem":"","vendor":"","model":"VBOX_HARDDISK","wwn":"","wwnVendorExtension":"","empty":true,"cephVolumeData":{"DevicePath":"/dev/sdb","Size":"25.00 GB","Rotates":true,"Available":true,"ModelName":"VBOX HARDDISK"}}]
Events:  <none>
```

_2. Not use ceph-volume inventory_

```

$ grep "ROOK_DISCOVER_USES_CEPH_VOLUME" operator.yaml -a2
        # Rook-discover daemonset will use "ceph-volume inventory" command to extend
        # information about storage devices in each node.
        - name: ROOK_DISCOVER_USES_CEPH_VOLUME
          value: "false"

$ kubectl create -f operator.yaml

$ kubectl -n rook-ceph get pod
NAME                                  READY     STATUS    RESTARTS   AGE
rook-ceph-operator-8545ff9478-q86pw   1/1       Running   0          10s
rook-discover-5tlqv                   1/1       Running   0          6s
rook-discover-gpb6t                   1/1       Running   0          6s
rook-discover-t95q5                   1/1       Running   0          6s

$ k -n rook-ceph logs rook-discover-5tlqv
2019-10-07 08:31:42.272009 I | rookcmd: starting Rook v1.1.0-beta.0.222.g418cbb94-dirty with arguments '/usr/local/bin/rook discover --discover-interval 60m'
2019-10-07 08:31:42.272122 I | rookcmd: flag values: --discover-interval=1h0m0s, --help=false, --log-flush-frequency=5s, --log-level=INFO, --operator-image=, --service-account=, --use-cv=false
2019-10-07 08:31:42.274477 I | rook-discover: device discovery interval is 1h0m0s
2019-10-07 08:31:42.274498 I | rook-discover: use ceph volume inventory is false
2019-10-07 08:31:42.296625 I | rook-discover: updating device configmap

2019-10-07 08:31:42.372999 I | rook-discover: available devices: [{Name:sda Parent: HasChildren:false DevLinks:/dev/disk/by-id/ata-VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac /dev/disk/by-path/pci-0000:00:01.1-ata-1.0 Size:34359738368 UUID:c132d3ca-702b-4b23-a0ca-9fdb15f426f4 Serial:VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac Type:disk Rotational:true Readonly:false Partitions:[{Name:sda1 Size:1073741824 Label: Filesystem:xfs} {Name:sda2 Size:33284947968 Label: Filesystem:LVM2_member}] Filesystem: Vendor: Model:VBOX_HARDDISK WWN: WWNVendorExtension: Empty:false CephVolumeData:<nil>} {Name:sdb Parent: HasChildren:false DevLinks:/dev/disk/by-id/ata-VBOX_HARDDISK_VB496d0bf5-7937a495 /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0 Size:26843545600 UUID:b470245d-04a5-45ec-ade8-b869ecf4872a Serial:VBOX_HARDDISK_VB496d0bf5-7937a495 Type:disk Rotational:true Readonly:false Partitions:[] Filesystem: Vendor: Model:VBOX_HARDDISK WWN: WWNVendorExtension: Empty:true CephVolumeData:<nil>}]


$ kubectl -n rook-ceph  describe configmap  local-device-node1
Name:         local-device-node1
Namespace:    rook-ceph
Labels:       app=rook-discover
              rook.io/node=node1
Annotations:  <none>

Data
====
devices:
----
[{"name":"sda","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/ata-VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac /dev/disk/by-path/pci-0000:00:01.1-ata-1.0","size":34359738368,"uuid":"c132d3ca-702b-4b23-a0ca-9fdb15f426f4","serial":"VBOX_HARDDISK_VB22f2f3b1-f3d2a2ac","type":"disk","rotational":true,"readOnly":false,"Partitions":[{"Name":"sda1","Size":1073741824,"Label":"","Filesystem":"xfs"},{"Name":"sda2","Size":33284947968,"Label":"","Filesystem":"LVM2_member"}],"filesystem":"","vendor":"","model":"VBOX_HARDDISK","wwn":"","wwnVendorExtension":"","empty":false},{"name":"sdb","parent":"","hasChildren":false,"devLinks":"/dev/disk/by-id/ata-VBOX_HARDDISK_VB496d0bf5-7937a495 /dev/disk/by-path/pci-0000:00:0d.0-ata-1.0","size":26843545600,"uuid":"b470245d-04a5-45ec-ade8-b869ecf4872a","serial":"VBOX_HARDDISK_VB496d0bf5-7937a495","type":"disk","rotational":true,"readOnly":false,"Partitions":null,"filesystem":"","vendor":"","model":"VBOX_HARDDISK","wwn":"","wwnVendorExtension":"","empty":true}]
Events:  <none>

```

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
