### PR TITLE
ceph: use "github.com/pkg/errors"

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,6 +63,10 @@ ignored = [
   version = "=v1.14.1"
 
 [[constraint]]
+  name = "github.com/pkg/errors"
+  version = "=v0.8.1"
+
+[[constraint]]
   name = "k8s.io/kube-controller-manager"
   version = "kubernetes-1.14.1"
 

--- a/cmd/rook/ceph/agent.go
+++ b/cmd/rook/ceph/agent.go
@@ -17,8 +17,7 @@ limitations under the License.
 package ceph
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/daemon/ceph/agent"
 	"github.com/rook/rook/pkg/util/flags"
@@ -46,7 +45,7 @@ func startAgent(cmd *cobra.Command, args []string) error {
 	agent := agent.New(context)
 	err := agent.Run()
 	if err != nil {
-		rook.TerminateFatal(fmt.Errorf("failed to run rook ceph agent. %+v\n", err))
+		rook.TerminateFatal(errors.Wrapf(err, "failed to run rook ceph agent\n"))
 	}
 
 	return nil

--- a/cmd/rook/ceph/config.go
+++ b/cmd/rook/ceph/config.go
@@ -17,10 +17,10 @@ limitations under the License.
 package ceph
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/util"
@@ -60,15 +60,15 @@ func initConfig(cmd *cobra.Command, args []string) error {
 	rook.LogStartupInfo(configCmd.Flags())
 
 	if keyring == "" {
-		rook.TerminateFatal(fmt.Errorf("keyring is empty string"))
+		rook.TerminateFatal(errors.New("keyring is empty string"))
 	}
 	if username == "" {
-		rook.TerminateFatal(fmt.Errorf("username is empty string"))
+		rook.TerminateFatal(errors.New("username is empty string"))
 	}
 
 	monHost := os.Getenv("ROOK_CEPH_MON_HOST")
 	if monHost == "" {
-		rook.TerminateFatal(fmt.Errorf("ROOK_CEPH_MON_HOST is not set or is empty string"))
+		rook.TerminateFatal(errors.New("ROOK_CEPH_MON_HOST is not set or is empty string"))
 	}
 
 	cfg := `
@@ -82,7 +82,7 @@ keyring = ` + keyring + `
 	var fileMode os.FileMode = 0444 // read-only
 	err := ioutil.WriteFile(cephconfig.DefaultConfigFilePath(), []byte(cfg), fileMode)
 	if err != nil {
-		rook.TerminateFatal(fmt.Errorf("failed to write config file. %+v", err))
+		rook.TerminateFatal(errors.Wrapf(err, "failed to write config file"))
 	}
 
 	util.WriteFileToLog(logger, cephconfig.DefaultConfigFilePath())

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -17,8 +17,7 @@ limitations under the License.
 package ceph
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
@@ -97,7 +96,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	op := operator.New(context, volumeAttachment, rookImage, serviceAccountName)
 	err = op.Run()
 	if err != nil {
-		rook.TerminateFatal(fmt.Errorf("failed to run operator. %+v\n", err))
+		rook.TerminateFatal(errors.Wrapf(err, "failed to run operator\n"))
 	}
 
 	return nil

--- a/pkg/daemon/ceph/agent/cluster/controller_test.go
+++ b/pkg/daemon/ceph/agent/cluster/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
@@ -261,7 +262,7 @@ func TestClusterDeleteMultiAttachmentRace(t *testing.T) {
 			if removeCount%2 == 0 {
 				// every other time, simulate a failure to remove the attachment, e.g., someone else
 				// updated it before we could.
-				return fmt.Errorf("mock error for failing to remove the volume attachment")
+				return errors.New("mock error for failing to remove the volume attachment")
 			}
 
 			return nil

--- a/pkg/daemon/ceph/agent/flexvolume/controller.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller.go
@@ -18,7 +18,6 @@ limitations under the License.
 package flexvolume
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/util/display"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
@@ -35,7 +35,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -97,8 +97,8 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 	// Check if this volume has been attached
 	volumeattachObj, err := c.volumeAttachment.Get(namespace, crdName)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get volume CRD %s. %+v", crdName, err)
+		if !kerrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to get volume CRD %s", crdName)
 		}
 		// No volumeattach CRD for this volume found. Create one
 		volumeattachObj = rookalpha.NewVolume(
@@ -114,11 +114,11 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 		logger.Infof("creating Volume attach Resource %s/%s: %+v", volumeattachObj.Namespace, volumeattachObj.Name, attachOpts)
 		err = c.volumeAttachment.Create(volumeattachObj)
 		if err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return fmt.Errorf("failed to create volume CRD %s. %+v", crdName, err)
+			if !kerrors.IsAlreadyExists(err) {
+				return errors.Wrapf(err, "failed to create volume CRD %s", crdName)
 			}
 			// Some other attacher beat us in this race. Kubernetes will retry again.
-			return fmt.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by a different pod",
+			return errors.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by a different pod",
 				crdName, attachOpts.PodNamespace, attachOpts.Pod)
 		}
 	} else {
@@ -146,8 +146,8 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 				allowAttach := false
 				pod, err := c.context.Clientset.CoreV1().Pods(attachment.PodNamespace).Get(attachment.PodName, metav1.GetOptions{})
 				if err != nil {
-					if !errors.IsNotFound(err) {
-						return fmt.Errorf("failed to get pod CRD %s/%s. %+v", attachment.PodNamespace, attachment.PodName, err)
+					if !kerrors.IsNotFound(err) {
+						return errors.Wrapf(err, "failed to get pod CRD %s/%s", attachment.PodNamespace, attachment.PodName)
 					}
 					allowAttach = true
 					logger.Infof("volume attachment record %s/%s is orphaned. Updating record with new attachment information for pod %s/%s", volumeattachObj.Namespace, volumeattachObj.Name, attachOpts.PodNamespace, attachOpts.Pod)
@@ -166,18 +166,18 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 					attachment.ReadOnly = attachOpts.RW == ReadOnly
 					err = c.volumeAttachment.Update(volumeattachObj)
 					if err != nil {
-						return fmt.Errorf("failed to update volume CRD %s. %+v", crdName, err)
+						return errors.Wrapf(err, "failed to update volume CRD %s", crdName)
 					}
 				} else {
 					// Attachment is not orphaned. Original pod still exists. Don't attach.
-					return fmt.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by pod %s/%s. Status %+v",
+					return errors.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by pod %s/%s. Status %+v",
 						crdName, attachOpts.PodNamespace, attachOpts.Pod, attachment.PodNamespace, attachment.PodName, pod.Status.Phase)
 				}
 			} else {
 				// No RW attachment found. Check if this is a RW attachment request.
 				// We only support RW once attachment. No mixing either with RO
 				if attachOpts.RW == "rw" && len(volumeattachObj.Attachments) > 0 {
-					return fmt.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by one or more pods",
+					return errors.Errorf("failed to attach volume %s for pod %s/%s. Volume is already attached by one or more pods",
 						crdName, attachOpts.PodNamespace, attachOpts.Pod)
 				}
 
@@ -193,14 +193,14 @@ func (c *Controller) Attach(attachOpts AttachOptions, devicePath *string) error 
 				volumeattachObj.Attachments = append(volumeattachObj.Attachments, newAttach)
 				err = c.volumeAttachment.Update(volumeattachObj)
 				if err != nil {
-					return fmt.Errorf("failed to update volume CRD %s. %+v", crdName, err)
+					return errors.Wrapf(err, "failed to update volume CRD %s", crdName)
 				}
 			}
 		}
 	}
 	*devicePath, err = c.volumeManager.Attach(attachOpts.Image, attachOpts.BlockPool, attachOpts.MountUser, attachOpts.MountSecret, attachOpts.ClusterNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to attach volume %s/%s: %+v", attachOpts.BlockPool, attachOpts.Image, err)
+		return errors.Wrapf(err, "failed to attach volume %s/%s", attachOpts.BlockPool, attachOpts.Image)
 	}
 	return nil
 }
@@ -211,7 +211,7 @@ func (c *Controller) Expand(expandArgs ExpandArgs, _ *struct{}) error {
 	sizeInMb := display.BToMb(expandArgs.Size)
 	err := c.volumeManager.Expand(expandOpts.Image, expandOpts.Pool, expandOpts.ClusterNamespace, sizeInMb)
 	if err != nil {
-		return fmt.Errorf("failed to resize volume %s/%s: %+v", expandOpts.Pool, expandOpts.Image, err)
+		return errors.Wrapf(err, "failed to resize volume %s/%s", expandOpts.Pool, expandOpts.Image)
 	}
 	return nil
 }
@@ -235,14 +235,14 @@ func (c *Controller) doDetach(detachOpts AttachOptions, force bool) error {
 		detachOpts.ClusterNamespace,
 		force,
 	); err != nil {
-		return fmt.Errorf("failed to detach volume %s/%s: %+v", detachOpts.BlockPool, detachOpts.Image, err)
+		return errors.Wrapf(err, "failed to detach volume %s/%s", detachOpts.BlockPool, detachOpts.Image)
 	}
 
 	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
 	crdName := detachOpts.VolumeName
 	volumeAttach, err := c.volumeAttachment.Get(namespace, crdName)
 	if err != nil {
-		return fmt.Errorf("failed to get VolumeAttachment for %s in namespace %s. %+v", crdName, namespace, err)
+		return errors.Wrapf(err, "failed to get VolumeAttachment for %s in namespace %s", crdName, namespace)
 	}
 	if len(volumeAttach.Attachments) == 0 {
 		logger.Infof("Deleting Volume CRD %s/%s", namespace, crdName)
@@ -258,7 +258,7 @@ func (c *Controller) RemoveAttachmentObject(detachOpts AttachOptions, safeToDeta
 	logger.Infof("deleting attachment for mountDir %s from Volume attach CRD %s/%s", detachOpts.MountDir, namespace, crdName)
 	volumeAttach, err := c.volumeAttachment.Get(namespace, crdName)
 	if err != nil {
-		return fmt.Errorf("failed to get Volume attach CRD %s/%s: %+v", namespace, crdName, err)
+		return errors.Wrapf(err, "failed to get Volume attach CRD %s/%s", namespace, crdName)
 	}
 	node := os.Getenv(k8sutil.NodeNameEnvVar)
 	nodeAttachmentCount := 0
@@ -281,7 +281,7 @@ func (c *Controller) RemoveAttachmentObject(detachOpts AttachOptions, safeToDeta
 		}
 		return c.volumeAttachment.Update(volumeAttach)
 	}
-	return fmt.Errorf("volume CRD %s found but attachment to the mountDir %s was not found", crdName, detachOpts.MountDir)
+	return errors.Errorf("volume CRD %s found but attachment to the mountDir %s was not found", crdName, detachOpts.MountDir)
 }
 
 // Log logs messages from the driver
@@ -329,7 +329,7 @@ func (c *Controller) GetAttachInfoFromMountDir(mountDir string, attachOptions *A
 
 	pv, err := c.context.Clientset.CoreV1().PersistentVolumes().Get(attachOptions.VolumeName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get persistent volume %s: %+v", attachOptions.VolumeName, err)
+		return errors.Wrapf(err, "failed to get persistent volume %s", attachOptions.VolumeName)
 	}
 
 	if attachOptions.PodNamespace == "" {
@@ -345,7 +345,7 @@ func (c *Controller) GetAttachInfoFromMountDir(mountDir string, attachOptions *A
 		}
 		pods, err := c.context.Clientset.CoreV1().Pods(attachOptions.PodNamespace).List(opts)
 		if err != nil {
-			return fmt.Errorf("failed to get pods in namespace %s: %+v", attachOptions.PodNamespace, err)
+			return errors.Wrapf(err, "failed to get pods in namespace %s", attachOptions.PodNamespace)
 		}
 
 		pod := findPodByID(pods, types.UID(attachOptions.PodID))
@@ -372,7 +372,7 @@ func (c *Controller) GetAttachInfoFromMountDir(mountDir string, attachOptions *A
 	}
 	attachOptions.ClusterNamespace, err = c.parseClusterNamespace(attachOptions.StorageClass)
 	if err != nil {
-		return fmt.Errorf("failed to parse clusterNamespace from storageClass %s: %+v", attachOptions.StorageClass, err)
+		return errors.Wrapf(err, "failed to parse clusterNamespace from storageClass %s", attachOptions.StorageClass)
 	}
 	return nil
 }
@@ -395,7 +395,7 @@ func (c *Controller) GetClientAccessInfo(args []string, clientAccessInfo *Client
 	clusterNamespace := args[0]
 	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, clusterNamespace)
 	if err != nil {
-		return fmt.Errorf("failed to load cluster information from clusters namespace %s: %+v", clusterNamespace, err)
+		return errors.Wrapf(err, "failed to load cluster information from clusters namespace %s", clusterNamespace)
 	}
 
 	monEndpoints := make([]string, 0, len(clusterInfo.Monitors))
@@ -410,7 +410,7 @@ func (c *Controller) GetClientAccessInfo(args []string, clientAccessInfo *Client
 	clientAccessInfo.SecretKey = args[3]
 
 	if c.mountSecurityMode == agent.MountSecurityModeRestricted && (clientAccessInfo.UserName == "" || clientAccessInfo.SecretKey == "") {
-		return fmt.Errorf("no mount user and/or mount secret given")
+		return errors.New("no mount user and/or mount secret given")
 	}
 
 	if c.mountSecurityMode == agent.MountSecurityModeAny && clientAccessInfo.UserName == "" {
@@ -420,10 +420,10 @@ func (c *Controller) GetClientAccessInfo(args []string, clientAccessInfo *Client
 	if clientAccessInfo.SecretKey != "" {
 		secret, err := c.context.Clientset.CoreV1().Secrets(podNamespace).Get(clientAccessInfo.SecretKey, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("unable to get mount secret %s from pod namespace %s. %+v", clientAccessInfo.SecretKey, podNamespace, err)
+			return errors.Wrapf(err, "unable to get mount secret %s from pod namespace %s", clientAccessInfo.SecretKey, podNamespace)
 		}
 		if len(secret.Data) == 0 || len(secret.Data) > 1 {
-			return fmt.Errorf("no data or more than one data (length %d) in mount secret %s in namespace %s", len(secret.Data), clientAccessInfo.SecretKey, podNamespace)
+			return errors.Errorf("no data or more than one data (length %d) in mount secret %s in namespace %s", len(secret.Data), clientAccessInfo.SecretKey, podNamespace)
 		}
 		var secretValue string
 		for _, value := range secret.Data {
@@ -443,7 +443,7 @@ func (c *Controller) GetKernelVersion(_ *struct{} /* no inputs */, kernelVersion
 	nodeName := os.Getenv(k8sutil.NodeNameEnvVar)
 	node, err := c.context.Clientset.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get kernel version from node information for node %s: %+v", nodeName, err)
+		return errors.Wrapf(err, "failed to get kernel version from node information for node %s", nodeName)
 	}
 	*kernelVersion = node.Status.NodeInfo.KernelVersion
 	return nil
@@ -464,7 +464,7 @@ func getPodAndPVNameFromMountDir(mountDir string) (string, string, error) {
 	// token length should at least size 5
 	length := len(token)
 	if length < 5 {
-		return "", "", fmt.Errorf("failed to parse mountDir %s for CRD name and podID", mountDir)
+		return "", "", errors.Errorf("failed to parse mountDir %s for CRD name and podID", mountDir)
 	}
 	return token[length-4], token[length-1], nil
 }

--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -17,8 +17,8 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -28,7 +28,7 @@ func AuthAdd(context *clusterd.Context, clusterName, name, keyringPath string, c
 	args := append([]string{"auth", "add", name, "-i", keyringPath}, caps...)
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return fmt.Errorf("failed to auth add for %s: %+v", name, err)
+		return errors.Wrapf(err, "failed to auth add for %s", name)
 	}
 
 	return nil
@@ -44,7 +44,7 @@ func AuthGetOrCreate(context *clusterd.Context, clusterName, name, keyringPath s
 	cmd.OutputFile = false
 	_, err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to auth get-or-create for %s: %+v", name, err)
+		return errors.Wrapf(err, "failed to auth get-or-create for %s", name)
 	}
 
 	return nil
@@ -55,7 +55,7 @@ func AuthGetKey(context *clusterd.Context, clusterName, name string) (string, er
 	args := []string{"auth", "get-key", name}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return "", fmt.Errorf("failed to get key for %s: %+v", name, err)
+		return "", errors.Wrapf(err, "failed to get key for %s", name)
 	}
 
 	return parseAuthKey(buf)
@@ -66,7 +66,7 @@ func AuthGetOrCreateKey(context *clusterd.Context, clusterName, name string, cap
 	args := append([]string{"auth", "get-or-create-key", name}, caps...)
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return "", fmt.Errorf("failed get-or-create-key %s: %+v", name, err)
+		return "", errors.Wrapf(err, "failed get-or-create-key %s", name)
 	}
 
 	return parseAuthKey(buf)
@@ -77,7 +77,7 @@ func AuthUpdateCaps(context *clusterd.Context, clusterName, name string, caps []
 	args := append([]string{"auth", "caps", name}, caps...)
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return fmt.Errorf("failed to update caps for %s. %+v", name, err)
+		return errors.Wrapf(err, "failed to update caps for %s", name)
 	}
 	return err
 }
@@ -87,13 +87,13 @@ func AuthGetCaps(context *clusterd.Context, clusterName, name string) (caps map[
 	args := append([]string{"auth", "get", name})
 	output, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get caps for %s. %+v", name, err)
+		return nil, errors.Wrapf(err, "failed to get caps for %q", name)
 	}
 
 	var data []map[string]interface{}
 	err = json.Unmarshal(output, &data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal auth get response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal auth get response")
 	}
 	caps = make(map[string]string)
 
@@ -118,7 +118,7 @@ func AuthDelete(context *clusterd.Context, clusterName, name string) error {
 	args := []string{"auth", "del", name}
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return fmt.Errorf("failed to delete auth for %s. %v", name, err)
+		return errors.Wrapf(err, "failed to delete auth for %s", name)
 	}
 	return nil
 }
@@ -126,7 +126,7 @@ func AuthDelete(context *clusterd.Context, clusterName, name string) error {
 func parseAuthKey(buf []byte) (string, error) {
 	var resp map[string]interface{}
 	if err := json.Unmarshal(buf, &resp); err != nil {
-		return "", fmt.Errorf("failed to unmarshal get/create key response: %+v", err)
+		return "", errors.Wrapf(err, "failed to unmarshal get/create key response")
 	}
 	return resp["key"].(string), nil
 }

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -196,12 +197,12 @@ func ExecuteCephCommandWithRetry(
 					continue
 				}
 			}
-			return nil, fmt.Errorf("failed to complete command %+v", err)
+			return nil, errors.Wrapf(err, "failed to complete command")
 		}
 		if i > 0 {
 			logger.Infof("command succeeded on attempt %d", i)
 		}
 		return data, nil
 	}
-	return nil, fmt.Errorf("max command retries exceeded")
+	return nil, errors.New("max command retries exceeded")
 }

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -81,12 +82,12 @@ func GetCrushMap(context *clusterd.Context, clusterName string) (CrushMap, error
 	args := []string{"osd", "crush", "dump"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return c, fmt.Errorf("failed to get crush map. %v", err)
+		return c, errors.Wrapf(err, "failed to get crush map")
 	}
 
 	err = json.Unmarshal(buf, &c)
 	if err != nil {
-		return c, fmt.Errorf("failed to unmarshal crush map. %+v", err)
+		return c, errors.Wrapf(err, "failed to unmarshal crush map")
 	}
 
 	return c, nil
@@ -103,7 +104,7 @@ func CrushRemove(context *clusterd.Context, clusterName, name string) (string, e
 	args := []string{"osd", "crush", "rm", name}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return "", fmt.Errorf("failed to crush rm: %+v, %s", err, string(buf))
+		return "", errors.Wrapf(err, "failed to crush rm. %s", string(buf))
 	}
 
 	return string(buf), nil
@@ -113,12 +114,12 @@ func FindOSDInCrushMap(context *clusterd.Context, clusterName string, osdID int)
 	args := []string{"osd", "find", strconv.Itoa(osdID)}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to find osd.%d in crush map: %+v, %s", osdID, err, string(buf))
+		return nil, errors.Wrapf(err, "failed to find osd.%d in crush map: %s", osdID, string(buf))
 	}
 
 	var result CrushFindResult
 	if err := json.Unmarshal(buf, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal crush find result: %+v. raw: %s", err, string(buf))
+		return nil, errors.Wrapf(err, "failed to unmarshal crush find result: %s", string(buf))
 	}
 
 	return &result, nil

--- a/pkg/daemon/ceph/client/crush_test.go
+++ b/pkg/daemon/ceph/client/crush_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -233,7 +234,7 @@ func TestGetCrushMap(t *testing.T) {
 		if args[1] == "crush" && args[2] == "dump" {
 			return testCrushMap, nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command '%v'", args)
 	}
 	crush, err := GetCrushMap(&clusterd.Context{Executor: executor}, "rook")
 

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/ceph/model"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 				return "", nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	err := CreateErasureCodeProfile(context, "myns", cfg, "myapp", failureDomain, crushRoot, deviceClass)

--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -18,9 +18,9 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -147,7 +147,7 @@ func TestFilesystemRemove(t *testing.T) {
 				return "", nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
@@ -157,7 +157,7 @@ func TestFilesystemRemove(t *testing.T) {
 				return emptyPool, nil
 			}
 		}
-		return "", fmt.Errorf("unexpected rbd command '%v'", args)
+		return "", errors.Errorf("unexpected rbd command %q", args)
 	}
 
 	err := RemoveFilesystem(context, "ns", fs.MDSMap.FilesystemName, false)

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -22,6 +22,7 @@ import (
 
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -40,9 +41,9 @@ func TestCreateImage(t *testing.T) {
 	executor.MockExecuteCommandWithOutput = func(debug bool, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
-			return "mocked detailed ceph error output stream", fmt.Errorf("some mocked error")
+			return "mocked detailed ceph error output stream", errors.New("some mocked error")
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	image, err := CreateImage(context, "foocluster", "image1", "pool1", "", uint64(sizeMB)) // 1MB
 	assert.NotNil(t, err)
@@ -63,7 +64,7 @@ func TestCreateImage(t *testing.T) {
 			return `{"name":"image1","size":1048576,"objects":1,"order":20,"object_size":1048576,"block_name_prefix":"pool1_data.229226b8b4567",` +
 				`"format":2,"features":["layering"],"op_features":[],"flags":[],"create_timestamp":"Fri Oct  5 19:46:20 2018"}`, nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	// 0 byte --> 0 MB
@@ -148,12 +149,12 @@ func TestExpandImage(t *testing.T) {
 	executor.MockExecuteCommandWithTimeout = func(debug bool, timeout time.Duration, actionName string, command string, args ...string) (string, error) {
 		switch {
 		case args[1] != "kube/some-image":
-			return "", fmt.Errorf("no image %s", args[1])
+			return "", errors.Errorf("no image %s", args[1])
 
 		case command == "rbd" && args[0] == "resize":
 			return "everything is okay", nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	err := ExpandImage(context, "default", "error-name", "kube", "mon1,mon2,mon3", "/tmp/keyring", 1000000)
 	assert.Error(t, err)
@@ -181,7 +182,7 @@ func TestListImageLogLevelInfo(t *testing.T) {
 
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	images, err = ListImages(context, "foocluster", "pool1")
@@ -244,7 +245,7 @@ func TestListImageLogLevelDebug(t *testing.T) {
 				return fmt.Sprintf(`%s[{"image":"image1","size":1048576,"format":2},{"image":"image2","size":2048576,"format":2},{"image":"image3","size":3048576,"format":2}]`, libradosDebugOut), nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	images, err = ListImages(context, "foocluster", "pool1")

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 )
@@ -56,7 +57,7 @@ func MgrSetConfig(context *clusterd.Context, clusterName, mgrName string, cephVe
 	}
 
 	if _, err := NewCephCommand(context, clusterName, setArgs).Run(); err != nil {
-		return false, fmt.Errorf("failed to set mgr config key %s to \"%s\": %+v", key, val, err)
+		return false, errors.Wrapf(err, "failed to set mgr config key %s to \"%s\"", key, val)
 	}
 
 	hasChanged := prevVal != val
@@ -70,7 +71,7 @@ func enableModule(context *clusterd.Context, clusterName, name string, force boo
 	}
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return fmt.Errorf("failed to mgr module enable for %s: %+v", name, err)
+		return errors.Wrapf(err, "failed to mgr module enable for %s", name)
 	}
 
 	return nil

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -17,8 +17,8 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -67,13 +67,13 @@ func GetMonQuorumStatus(context *clusterd.Context, clusterName string, debug boo
 	cmd.Debug = debug
 	buf, err := cmd.Run()
 	if err != nil {
-		return MonStatusResponse{}, fmt.Errorf("mon quorum status failed. %+v", err)
+		return MonStatusResponse{}, errors.Wrapf(err, "mon quorum status failed")
 	}
 
 	var resp MonStatusResponse
 	err = json.Unmarshal(buf, &resp)
 	if err != nil {
-		return MonStatusResponse{}, fmt.Errorf("unmarshal failed: %+v.  raw buffer response: %s", err, buf)
+		return MonStatusResponse{}, errors.Wrapf(err, "unmarshal failed. raw buffer response: %s", buf)
 	}
 
 	return resp, nil
@@ -98,12 +98,12 @@ func GetMonTimeStatus(context *clusterd.Context, clusterName string) (*MonTimeSt
 	args := []string{"time-sync-status"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get time sync status: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get time sync status")
 	}
 
 	var timeStatus MonTimeStatus
 	if err := json.Unmarshal(buf, &timeStatus); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal time sync status response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal time sync status response")
 	}
 
 	return &timeStatus, nil

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -17,10 +17,10 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -120,7 +120,7 @@ func SetFlagOnCrushUnit(context *clusterd.Context, clusterName, crushUnit, flag 
 	cmd := NewCephCommand(context, clusterName, args)
 	_, err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to set flag %s on %s: %+v", crushUnit, flag, err)
+		return errors.Wrapf(err, "failed to set flag %s on %s", crushUnit, flag)
 	}
 	return nil
 }
@@ -131,7 +131,7 @@ func UnsetFlagOnCrushUnit(context *clusterd.Context, clusterName, crushUnit, fla
 	cmd := NewCephCommand(context, clusterName, args)
 	_, err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to unset flag %s on %s: %+v", crushUnit, flag, err)
+		return errors.Wrapf(err, "failed to unset flag %s on %s", crushUnit, flag)
 	}
 	return nil
 }
@@ -197,19 +197,19 @@ func (dump *OSDDump) StatusByID(id int64) (int64, int64, error) {
 		}
 	}
 
-	return 0, 0, fmt.Errorf("not found osd.%d in OSDDump", id)
+	return 0, 0, errors.Errorf("not found osd.%d in OSDDump", id)
 }
 
 func GetOSDUsage(context *clusterd.Context, clusterName string) (*OSDUsage, error) {
 	args := []string{"osd", "df"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get osd df: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get osd df")
 	}
 
 	var osdUsage OSDUsage
 	if err := json.Unmarshal(buf, &osdUsage); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal osd df response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal osd df response")
 	}
 
 	return &osdUsage, nil
@@ -219,12 +219,12 @@ func GetOSDPerfStats(context *clusterd.Context, clusterName string) (*OSDPerfSta
 	args := []string{"osd", "perf"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get osd perf: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get osd perf")
 	}
 
 	var osdPerfStats OSDPerfStats
 	if err := json.Unmarshal(buf, &osdPerfStats); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal osd perf response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal osd perf response")
 	}
 
 	return &osdPerfStats, nil
@@ -236,12 +236,12 @@ func GetOSDDump(context *clusterd.Context, clusterName string) (*OSDDump, error)
 	cmd.Debug = true
 	buf, err := cmd.Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get osd dump: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get osd dump")
 	}
 
 	var osdDump OSDDump
 	if err := json.Unmarshal(buf, &osdDump); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal osd dump response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal osd dump response")
 	}
 
 	return &osdDump, nil
@@ -264,12 +264,12 @@ func OsdSafeToDestroy(context *clusterd.Context, clusterName string, osdID int) 
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()
 	if err != nil {
-		return false, fmt.Errorf("failed to get safe-to-destroy status: %+v", err)
+		return false, errors.Wrapf(err, "failed to get safe-to-destroy status")
 	}
 
 	var output SafeToDestroyStatus
 	if err := json.Unmarshal(buf, &output); err != nil {
-		return false, fmt.Errorf("failed to unmarshal safe-to-destroy response: %+v", err)
+		return false, errors.Wrapf(err, "failed to unmarshal safe-to-destroy response")
 	}
 	if len(output.SafeToDestroy) != 0 && output.SafeToDestroy[0] == osdID {
 		return true, nil
@@ -294,12 +294,12 @@ func HostTree(context *clusterd.Context, clusterName string) (OsdTree, error) {
 	args := []string{"osd", "tree"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return output, fmt.Errorf("failed to get osd tree: %+v", err)
+		return output, errors.Wrapf(err, "failed to get osd tree")
 	}
 
 	err = json.Unmarshal(buf, &output)
 	if err != nil {
-		return output, fmt.Errorf("failed to unmarshal 'osd tree' response: %+v", err)
+		return output, errors.Wrapf(err, "failed to unmarshal 'osd tree' response")
 	}
 
 	return output, nil
@@ -312,12 +312,12 @@ func OsdListNum(context *clusterd.Context, clusterName string) (OsdList, error) 
 	args := []string{"osd", "ls"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return output, fmt.Errorf("failed to get osd list: %+v", err)
+		return output, errors.Wrapf(err, "failed to get osd list")
 	}
 
 	err = json.Unmarshal(buf, &output)
 	if err != nil {
-		return output, fmt.Errorf("failed to unmarshal 'osd ls' response: %+v", err)
+		return output, errors.Wrapf(err, "failed to unmarshal 'osd ls' response")
 	}
 
 	return output, nil

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +70,7 @@ func TestHostTree(t *testing.T) {
 			}
 			return fakeOsdTree, nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	tree, err := HostTree(&clusterd.Context{Executor: executor}, "rook")
@@ -98,7 +98,7 @@ func TestOsdListNum(t *testing.T) {
 			}
 			return fakeOSdList, nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	list, err := OsdListNum(&clusterd.Context{Executor: executor}, "rook")

--- a/pkg/daemon/ceph/client/pg.go
+++ b/pkg/daemon/ceph/client/pg.go
@@ -17,8 +17,8 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -41,12 +41,12 @@ func GetPGDumpBrief(context *clusterd.Context, clusterName string, isNautilusOrN
 	args := []string{"pg", "dump", "pgs_brief"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pg dump: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get pg dump")
 	}
 
 	if !isNautilusOrNewer {
 		if err := json.Unmarshal(buf, &pgStats); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal pg dump response: %+v", err)
+			return nil, errors.Wrapf(err, "failed to unmarshal pg dump response")
 		}
 		pgDump = PGDumpBrief{
 			PgStats: pgStats,
@@ -55,7 +55,7 @@ func GetPGDumpBrief(context *clusterd.Context, clusterName string, isNautilusOrN
 	}
 
 	if err := json.Unmarshal(buf, &pgDump); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal pg dump response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal pg dump response")
 	}
 
 	return &pgDump, nil

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/ceph/model"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -58,7 +58,7 @@ func TestCreateECPoolWithOverwrites(t *testing.T) {
 				return "", nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	err := CreateECPoolForApp(context, "myns", p, "myapp", true, model.ErasureCodedPoolConfig{DataChunkCount: 1})
@@ -91,7 +91,7 @@ func TestCreateECPoolWithoutOverwrites(t *testing.T) {
 				return "", nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	err := CreateECPoolForApp(context, "myns", p, "myapp", false, model.ErasureCodedPoolConfig{DataChunkCount: 1})
@@ -156,7 +156,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass s
 			}
 			return "", nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	p := CephStoragePoolDetails{Name: "mypool", Size: 12345, FailureDomain: failureDomain, CrushRoot: crushRoot, DeviceClass: deviceClass}
@@ -193,11 +193,11 @@ func TestGetPoolStatistics(t *testing.T) {
 				if args[2] == "replicapool" {
 					return a, nil
 				}
-				return "", fmt.Errorf("rbd:error opening pool '%s': (2) No such file or directory", args[3])
+				return "", errors.Errorf("rbd:error opening pool '%s': (2) No such file or directory", args[3])
 
 			}
 		}
-		return "", fmt.Errorf("unexpected rbd command '%v'", args)
+		return "", errors.Errorf("unexpected rbd command %q", args)
 	}
 
 	stats, err := GetPoolStatistics(context, "replicapool", "cluster")

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -18,9 +18,9 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -85,7 +85,7 @@ func TestOkToStopDaemon(t *testing.T) {
 		case args[0] == "mon" && args[1] == "ok-to-stop" && args[2] == "a":
 			return "", nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	context := &clusterd.Context{Executor: executor}
 

--- a/pkg/daemon/ceph/client/usage.go
+++ b/pkg/daemon/ceph/client/usage.go
@@ -17,8 +17,8 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 )
 
@@ -35,12 +35,12 @@ func Usage(context *clusterd.Context, clusterName string) (*CephUsage, error) {
 	args := []string{"df", "detail"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get usage: %+v", err)
+		return nil, errors.Wrapf(err, "failed to get usage")
 	}
 
 	var usage CephUsage
 	if err := json.Unmarshal(buf, &usage); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal usage response: %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal usage response")
 	}
 
 	return &usage, nil

--- a/pkg/daemon/ceph/config/keyring.go
+++ b/pkg/daemon/ceph/config/keyring.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 )
@@ -63,13 +64,13 @@ func CreateKeyring(context *clusterd.Context, clusterName, username, keyringPath
 		return nil
 	} else if !os.IsNotExist(err) {
 		// some other error besides "does not exist", bail out with error
-		return fmt.Errorf("failed to stat %s: %+v", keyringPath, err)
+		return errors.Wrapf(err, "failed to stat %s", keyringPath)
 	}
 
 	// get-or-create-key for the user account
 	key, err := client.AuthGetOrCreateKey(context, clusterName, username, access)
 	if err != nil {
-		return fmt.Errorf("failed to get or create auth key for %s. %+v", username, err)
+		return errors.Wrapf(err, "failed to get or create auth key for %s", username)
 	}
 
 	return WriteKeyring(keyringPath, key, generateContents)
@@ -80,10 +81,10 @@ func CreateKeyring(context *clusterd.Context, clusterName, username, keyringPath
 func writeKeyring(keyring, keyringPath string) error {
 	// save the keyring to the given path
 	if err := os.MkdirAll(filepath.Dir(keyringPath), 0744); err != nil {
-		return fmt.Errorf("failed to create keyring directory for %s: %+v", keyringPath, err)
+		return errors.Wrapf(err, "failed to create keyring directory for %s", keyringPath)
 	}
 	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0644); err != nil {
-		return fmt.Errorf("failed to write monitor keyring to %s: %+v", keyringPath, err)
+		return errors.Wrapf(err, "failed to write monitor keyring to %s", keyringPath)
 	}
 	return nil
 }

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/test"
@@ -229,7 +230,7 @@ func testOSDAgentWithDevicesHelper(t *testing.T, storeConfig config.StoreConfig,
 			}
 			if len(args) == 3 && args[2] == "--prepare" && legacyProvisioner {
 				// return an error for ceph-volume so we use the legacy provisioner
-				return ``, fmt.Errorf("ceph-volume not supported")
+				return ``, errors.New("ceph-volume not supported")
 			}
 		}
 		return "", nil
@@ -396,7 +397,7 @@ func createTestAgent(t *testing.T, devices, configDir, nodeName string, storeCon
 			if command == "ceph-volume" {
 				if len(args) == 3 && args[0] == "lvm" && args[1] == "batch" && args[2] == "--prepare" {
 					logger.Infof("test c-v not supported")
-					return "", fmt.Errorf("c-v not supported")
+					return "", errors.New("c-v not supported")
 				}
 			}
 			return "", nil
@@ -446,7 +447,7 @@ func TestGetPartitionPerfScheme(t *testing.T) {
 				currOsdID++
 				return fmt.Sprintf(`{"osdid": %d}`, currOsdID), nil
 			}
-			return "", fmt.Errorf("unexpected command '%+v'", args)
+			return "", errors.Errorf("unexpected command '%+v'", args)
 		},
 		MockExecuteCommandWithOutput: func(debug bool, actionName string, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %+v", command, args)
@@ -467,7 +468,7 @@ func TestGetPartitionPerfScheme(t *testing.T) {
 			if command == "udevadm" {
 				return "", nil
 			}
-			return "", fmt.Errorf("unexpected command %s %+v", command, args)
+			return "", errors.Errorf("unexpected command %s %s", command, args)
 		},
 	}
 	context.Executor = executor
@@ -532,7 +533,7 @@ func TestGetPartitionSchemeDiskInUse(t *testing.T) {
 			if command == "udevadm" {
 				return "", nil
 			}
-			return "", fmt.Errorf("unexpected command %s %+v", command, args)
+			return "", errors.Errorf("unexpected command %s %s", command, args)
 		},
 	}
 	context := &clusterd.Context{
@@ -597,7 +598,7 @@ func TestGetPartitionSchemeDiskNameChanged(t *testing.T) {
 			if command == "udevadm" {
 				return "", nil
 			}
-			return "", fmt.Errorf("unexpected command %s %+v", command, args)
+			return "", errors.Errorf("unexpected command %s %s", command, args)
 		},
 	}
 	context := &clusterd.Context{

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -28,13 +28,14 @@ import (
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/sys"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -53,30 +54,30 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 	// Update LVM config at runtime
 	if err := updateLVMConfig(context, pvcBackedOSD, lvBackedPV); err != nil {
-		return fmt.Errorf("failed to update lvm configuration file, %+v", err) // fail return here as validation provided by ceph-volume
+		return errors.Wrapf(err, "failed to update lvm configuration file") // fail return here as validation provided by ceph-volume
 	}
 
 	var volumeGroupName string
 	if pvcBackedOSD && !lvBackedPV {
 		volumeGroupName, err = getVolumeGroupName(lvPath)
 		if err != nil {
-			return fmt.Errorf("error fetching volume group name for OSD %s. %+v", osdID, err)
+			return errors.Wrapf(err, "error fetching volume group name for OSD %s", osdID)
 		}
 		go handleTerminate(context, lvPath, volumeGroupName)
 
 		if err := context.Executor.ExecuteCommand(false, "", "vgchange", "-an", volumeGroupName); err != nil {
-			return fmt.Errorf("failed to deactivate volume group for lv %+v. Error: %+v", lvPath, err)
+			return errors.Wrapf(err, "failed to deactivate volume group for lv %q", lvPath)
 		}
 
 		if err := context.Executor.ExecuteCommand(false, "", "vgchange", "-ay", volumeGroupName); err != nil {
-			return fmt.Errorf("failed to activate volume group for lv %+v. Error: %+v", lvPath, err)
+			return errors.Wrapf(err, "failed to activate volume group for lv %q", lvPath)
 		}
 	}
 
 	// activate the osd with ceph-volume
 	storeFlag := "--" + osdType
 	if err := context.Executor.ExecuteCommand(false, "", "stdbuf", "-oL", "ceph-volume", "lvm", "activate", "--no-systemd", storeFlag, osdID, osdUUID); err != nil {
-		return fmt.Errorf("failed to activate osd. %+v", err)
+		return errors.Wrapf(err, "failed to activate osd")
 	}
 
 	// run the ceph-osd daemon
@@ -87,7 +88,7 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 	if pvcBackedOSD && !lvBackedPV {
 		if err := releaseLVMDevice(context, volumeGroupName); err != nil {
-			return fmt.Errorf("failed to release device from lvm. %+v", err)
+			return errors.Wrapf(err, "failed to release device from lvm")
 		}
 	}
 
@@ -103,7 +104,7 @@ func handleTerminate(context *clusterd.Context, lvPath, volumeGroupName string) 
 			logger.Infof("shutdown signal received, exiting...")
 			err := killCephOSDProcess(context, lvPath)
 			if err != nil {
-				return fmt.Errorf("failed to kill ceph-osd process. %+v", err)
+				return errors.Wrapf(err, "failed to kill ceph-osd process")
 			}
 			return nil
 		}
@@ -114,7 +115,7 @@ func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
 
 	pid, err := context.Executor.ExecuteCommandWithOutput(false, "", "fuser", "-a", lvPath)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve process ID for - %s. Error %+v", lvPath, err)
+		return errors.Wrapf(err, "failed to retrieve process ID for %s", lvPath)
 	}
 
 	logger.Infof("process ID for ceph-osd: %s", pid)
@@ -128,7 +129,7 @@ func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
 		// improve the shutdown time of the OSD. For cleanliness we should consider removing the -9
 		// once it is backported to Nautilus: https://github.com/ceph/ceph/pull/31677.
 		if err := context.Executor.ExecuteCommand(false, "", "kill", "-9", pid); err != nil {
-			return fmt.Errorf("failed to kill ceph-osd process. %+v", err)
+			return errors.Wrapf(err, "failed to kill ceph-osd process")
 		}
 	}
 
@@ -140,14 +141,14 @@ func RunFilestoreOnDevice(context *clusterd.Context, mountSourcePath, mountPath 
 	logger.Infof("starting filestore osd on a device")
 
 	if err := sys.MountDevice(mountSourcePath, mountPath, context.Executor); err != nil {
-		return fmt.Errorf("failed to mount device. %+v", err)
+		return errors.Wrapf(err, "failed to mount device")
 	}
 	// unmount the device before exit
 	defer sys.UnmountDevice(mountPath, context.Executor)
 
 	// run the ceph-osd daemon
 	if err := context.Executor.ExecuteCommand(false, "", "ceph-osd", cephArgs...); err != nil {
-		return fmt.Errorf("failed to start osd. %+v", err)
+		return errors.Wrapf(err, "failed to start osd")
 	}
 
 	return nil
@@ -164,21 +165,21 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	// create the ceph.conf with the default settings
 	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, agent.cluster)
 	if err != nil {
-		return fmt.Errorf("failed to create default ceph config. %+v", err)
+		return errors.Wrapf(err, "failed to create default ceph config")
 	}
 
 	// write the latest config to the config dir
 	confFilePath, err := cephconfig.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig)
 	if err != nil {
-		return fmt.Errorf("failed to write connection config. %+v", err)
+		return errors.Wrapf(err, "failed to write connection config")
 	}
 	src, err := ioutil.ReadFile(confFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to copy connection config to /etc/ceph. failed to read the connection config. %+v", err)
+		return errors.Wrapf(err, "failed to copy connection config to /etc/ceph. failed to read the connection config")
 	}
 	err = ioutil.WriteFile(cephconfig.DefaultConfigFilePath(), src, 0444)
 	if err != nil {
-		return fmt.Errorf("failed to copy connection config to /etc/ceph. failed to write %s. %+v", cephconfig.DefaultConfigFilePath(), err)
+		return errors.Wrapf(err, "failed to copy connection config to /etc/ceph. failed to write %s", cephconfig.DefaultConfigFilePath())
 	}
 	dst, err := ioutil.ReadFile(cephconfig.DefaultConfigFilePath())
 	if err == nil {
@@ -191,17 +192,17 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	var rawDevices []*sys.LocalDisk
 	if agent.pvcBacked {
 		if len(agent.devices) > 1 {
-			return fmt.Errorf("more than one desired device found in case of PVC backed OSDs. we expect exactly one device")
+			return errors.New("more than one desired device found in case of PVC backed OSDs. we expect exactly one device")
 		}
 		rawDevice, err := clusterd.PopulateDeviceInfo(agent.devices[0].Name, context.Executor)
 		if err != nil {
-			return fmt.Errorf("failed to get device info for %s. %+v", agent.devices[0].Name, err)
+			return errors.Wrapf(err, "failed to get device info for %q", agent.devices[0].Name)
 		}
 		rawDevices = append(rawDevices, rawDevice)
 	} else {
 		rawDevices, err = clusterd.DiscoverDevices(context.Executor)
 		if err != nil {
-			return fmt.Errorf("failed initial hardware discovery. %+v", err)
+			return errors.Wrapf(err, "failed initial hardware discovery")
 		}
 	}
 
@@ -212,13 +213,13 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	// determine the set of devices that can/should be used for OSDs.
 	devices, err := getAvailableDevices(context, agent.devices, agent.metadataDevice, agent.pvcBacked)
 	if err != nil {
-		return fmt.Errorf("failed to get available devices. %+v", err)
+		return errors.Wrapf(err, "failed to get available devices")
 	}
 
 	// determine the set of removed OSDs and the node's crush name (if needed)
 	removedDevicesScheme, _, err := getRemovedDevices(agent)
 	if err != nil {
-		return fmt.Errorf("failed to get removed devices: %+v", err)
+		return errors.Wrapf(err, "failed to get removed devices")
 	}
 
 	// orchestration is about to start, update the status
@@ -231,7 +232,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	logger.Infof("configuring osd devices: %+v", devices)
 	deviceOSDs, err := agent.configureDevices(context, devices)
 	if err != nil {
-		return fmt.Errorf("failed to configure devices. %+v", err)
+		return errors.Wrapf(err, "failed to configure devices")
 	}
 
 	// Populate CRUSH location for each OSD on the host
@@ -244,30 +245,30 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	devicesConfigured := len(deviceOSDs) > 0
 	dirs, removedDirs, err := getDataDirs(context, agent.kv, agent.directories, devicesConfigured, agent.nodeName)
 	if err != nil {
-		return fmt.Errorf("failed to get data dirs. %+v", err)
+		return errors.Wrapf(err, "failed to get data dirs")
 	}
 
 	// start up the OSDs for directories
 	logger.Infof("configuring osd dirs: %+v", dirs)
 	dirOSDs, err := agent.configureDirs(context, dirs)
 	if err != nil {
-		return fmt.Errorf("failed to configure dirs %+v. %+v", dirs, err)
+		return errors.Wrapf(err, "failed to configure dirs %+v", dirs)
 	}
 
 	// now we can start removing OSDs from devices and directories
 	logger.Infof("removing osd devices: %+v", removedDevicesScheme)
 	if err := agent.removeDevices(context, removedDevicesScheme); err != nil {
-		return fmt.Errorf("failed to remove devices. %+v", err)
+		return errors.Wrapf(err, "failed to remove devices")
 	}
 
 	logger.Infof("removing osd dirs: %+v", removedDirs)
 	if err := agent.removeDirs(context, removedDirs); err != nil {
-		return fmt.Errorf("failed to remove dirs. %+v", err)
+		return errors.Wrapf(err, "failed to remove dirs")
 	}
 
 	logger.Info("saving osd dir map")
 	if err := config.SaveOSDDirMap(agent.kv, agent.nodeName, dirs); err != nil {
-		return fmt.Errorf("failed to save osd dir map. %+v", err)
+		return errors.Wrapf(err, "failed to save osd dir map")
 	}
 
 	logger.Infof("device osds:%+v\ndir osds: %+v", deviceOSDs, dirOSDs)
@@ -275,10 +276,10 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	if agent.pvcBacked && !deviceOSDs[0].SkipLVRelease && !deviceOSDs[0].LVBackedPV {
 		volumeGroupName, err := getVolumeGroupName(deviceOSDs[0].LVPath)
 		if err != nil {
-			return fmt.Errorf("error fetching volume group name. %+v", err)
+			return errors.Wrapf(err, "error fetching volume group name")
 		}
 		if err := releaseLVMDevice(context, volumeGroupName); err != nil {
-			return fmt.Errorf("failed to release device from lvm. %+v", err)
+			return errors.Wrapf(err, "failed to release device from lvm")
 		}
 	}
 
@@ -308,7 +309,7 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 		}
 		partCount, ownPartitions, fs, err := sys.CheckIfDeviceAvailable(context.Executor, device.Name, pvcBacked)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get device %q info. %+v", device.Name, err)
+			return nil, errors.Wrapf(err, "failed to get device %q info", device.Name)
 		}
 
 		if fs != "" || !ownPartitions {
@@ -414,9 +415,9 @@ func getDataDirs(context *clusterd.Context, kv *k8sutil.ConfigMapKVStore, desire
 		return activeDirs, removedDirs, nil
 	}
 
-	if !errors.IsNotFound(err) {
+	if !kerrors.IsNotFound(err) {
 		// real error when trying to load the osd dir map, return the err
-		return nil, nil, fmt.Errorf("failed to load OSD dir map: %+v", err)
+		return nil, nil, errors.Wrapf(err, "failed to load OSD dir map")
 	}
 
 	// the osd dirs map doesn't exist yet
@@ -452,14 +453,14 @@ func getRemovedDevices(agent *OsdAgent) (*config.PerfScheme, *DeviceOsdMapping, 
 
 	scheme, err := config.LoadScheme(agent.kv, config.GetConfigStoreName(agent.nodeName))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load agent's partition scheme: %+v", err)
+		return nil, nil, errors.Wrapf(err, "failed to load agent's partition scheme")
 	}
 
 	for _, entry := range scheme.Entries {
 		// determine which partition the data lives on for this entry
 		dataDetails, ok := entry.Partitions[entry.GetDataPartitionType()]
 		if !ok || dataDetails == nil {
-			return nil, nil, fmt.Errorf("failed to find data partition for entry %+v", entry)
+			return nil, nil, errors.Errorf("failed to find data partition for entry %+v", entry)
 		}
 
 		// add the current scheme entry to the removed devices scheme and its device to the removed
@@ -508,7 +509,7 @@ func getActiveAndRemovedDirs(
 //releaseLVMDevice deactivates the LV to release the device.
 func releaseLVMDevice(context *clusterd.Context, volumeGroupName string) error {
 	if err := context.Executor.ExecuteCommand(false, "", "lvchange", "-an", volumeGroupName); err != nil {
-		return fmt.Errorf("failed to deactivate LVM %s. Error: %+v", volumeGroupName, err)
+		return errors.Wrapf(err, "failed to deactivate LVM %s", volumeGroupName)
 	}
 	logger.Info("Successfully released device from lvm")
 	return nil
@@ -517,13 +518,13 @@ func releaseLVMDevice(context *clusterd.Context, volumeGroupName string) error {
 //getVolumeGroupName returns the Volume group name from the given Logical Volume Path
 func getVolumeGroupName(lvPath string) (string, error) {
 	if lvPath == "" {
-		return "", fmt.Errorf("empty LV Path : %s", lvPath)
+		return "", errors.Errorf("empty LV Path : %s", lvPath)
 	}
 
 	vgSlice := strings.Split(lvPath, "/")
 	//Assert that lvpath is in correct format `/dev/<vg name>/<lv name>` before extracting the vg name
 	if len(vgSlice) != 4 || vgSlice[2] == "" {
-		return "", fmt.Errorf("invalid LV Path : %s", lvPath)
+		return "", errors.Errorf("invalid LV Path : %s", lvPath)
 	}
 
 	return vgSlice[2], nil

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -16,12 +16,12 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
@@ -202,7 +202,7 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 			return "", nil
 		}
 
-		return "", fmt.Errorf("unknown command %s %+v", command, args)
+		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
 
 	context := &clusterd.Context{Executor: executor}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -248,7 +248,7 @@ func TestParseCephVolumeResult(t *testing.T) {
 			return cephVolumeTestResult, nil
 		}
 
-		return "", fmt.Errorf("unknown command %s %+v", command, args)
+		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
 
 	context := &clusterd.Context{Executor: executor}
@@ -268,7 +268,7 @@ func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 			return cephVolumeTestResultMultiCluster, nil
 		}
 
-		return "", fmt.Errorf("unknown command %s %+v", command, args)
+		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
 
 	context := &clusterd.Context{Executor: executor}
@@ -289,7 +289,7 @@ func TestCephVolumeResultMultiClusterMultiOSD(t *testing.T) {
 			return cephVolumeTestResultMultiClusterMultiOSD, nil
 		}
 
-		return "", fmt.Errorf("unknown command %s %+v", command, args)
+		return "", errors.Errorf("unknown command %s% s", command, args)
 	}
 
 	context := &clusterd.Context{Executor: executor}

--- a/pkg/daemon/ceph/util/util.go
+++ b/pkg/daemon/ceph/util/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -47,7 +47,7 @@ func FindRBDMappedFile(imageName, poolName, sysBusDir string) (string, error) {
 
 	files, err := ioutil.ReadDir(sysBusDeviceDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to read rbd device dir: %+v", err)
+		return "", errors.Wrapf(err, "failed to read rbd device dir")
 	}
 
 	for _, idFile := range files {

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -18,10 +18,10 @@ package client
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -107,7 +107,7 @@ func TestCreateClient(t *testing.T) {
 			if command == "ceph" && args[1] == "get-or-create-key" {
 				return `{"key":"AQC7ilJdAPijOBAABp+YAzg2QupRAWdnIh7w/Q=="}`, nil
 			}
-			return "", fmt.Errorf("unexpected ceph command '%v'", args)
+			return "", errors.Errorf("unexpected ceph command '%v'", args)
 		},
 	}
 	context := &clusterd.Context{Executor: executor, Clientset: clientset}
@@ -188,7 +188,7 @@ func TestDeleteClient(t *testing.T) {
 			if command == "ceph" && args[1] == "del" {
 				return "updated", nil
 			}
-			return "", fmt.Errorf("unexpected ceph command '%v'", args)
+			return "", errors.Errorf("unexpected ceph command '%v'", args)
 		},
 	}
 	context := &clusterd.Context{Executor: executor, Clientset: clientset}

--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -18,10 +18,10 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -99,13 +99,13 @@ func (c *cephStatusChecker) updateCephStatus(status *client.CephStatus) error {
 	// get the most recent cluster CRD object
 	cluster, err := c.context.RookClientset.CephV1().CephClusters(c.namespace).Get(c.resourceName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get cluster from namespace %s prior to updating its status: %+v", c.namespace, err)
+		return errors.Wrapf(err, "failed to get cluster from namespace %s prior to updating its status", c.namespace)
 	}
 
 	// translate the ceph status struct to the crd status
 	cluster.Status.CephStatus = toCustomResourceStatus(cluster.Status, status)
 	if _, err := c.context.RookClientset.CephV1().CephClusters(c.namespace).Update(cluster); err != nil {
-		return fmt.Errorf("failed to update cluster %s status: %+v", c.namespace, err)
+		return errors.Wrapf(err, "failed to update cluster %s status", c.namespace)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -48,9 +48,10 @@ import (
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -271,7 +272,7 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	// Make sure the spec contains all the information we need
 	err := validateExternalClusterSpec(cluster)
 	if err != nil {
-		return fmt.Errorf("failed to validate external cluster specs. %+v", err)
+		return errors.Wrapf(err, "failed to validate external cluster specs")
 	}
 
 	c.updateClusterStatus(namespace, name, cephv1.ClusterStateConnecting, "")
@@ -293,7 +294,7 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	if cluster.Spec.CephVersion.Image != "" {
 		_, _, err = c.detectAndValidateCephVersion(cluster, cluster.Spec.CephVersion.Image)
 		if err != nil {
-			return fmt.Errorf("failed to detect and validate ceph version. %+v", err)
+			return errors.Wrapf(err, "failed to detect and validate ceph version")
 		}
 
 		// Write the rook-ceph-config configmap (used by various daemons to apply config overrides)
@@ -302,13 +303,13 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 		// Only do this when doing a bit of management...
 		err = config.GetStore(cluster.context, namespace, &cluster.ownerRef).CreateOrUpdate(cluster.Info)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to set config store")
 		}
 	}
 
 	// The cluster Identity must be established at this point
 	if !cluster.Info.IsInitialized() {
-		return fmt.Errorf("the cluster identity was not established: %+v", cluster.Info)
+		return errors.Errorf("the cluster identity was not established: %+v", cluster.Info)
 	}
 	logger.Info("cluster identity established.")
 
@@ -318,7 +319,7 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	// Create CSI Secrets
 	err = csi.CreateCSISecrets(c.context, namespace, &cluster.ownerRef)
 	if err != nil {
-		return fmt.Errorf("failed to create csi kubernetes secrets. %+v", err)
+		return errors.Wrapf(err, "failed to create csi kubernetes secrets")
 	}
 
 	// Mark initialization has done
@@ -338,7 +339,7 @@ func (c *ClusterController) configureLocalCephCluster(namespace, name string, cl
 
 	if c.devicesInUse && cluster.Spec.Storage.AnyUseAllDevices() {
 		c.updateClusterStatus(clusterObj.Namespace, clusterObj.Name, cephv1.ClusterStateError, "using all devices in more than one namespace is not supported")
-		return fmt.Errorf("using all devices in more than one namespace is not supported")
+		return errors.New("using all devices in more than one namespace is not supported")
 	}
 
 	if cluster.Spec.Storage.AnyUseAllDevices() {
@@ -377,14 +378,14 @@ func (c *ClusterController) configureLocalCephCluster(namespace, name string, cl
 		})
 
 	if err != nil {
-		return fmt.Errorf("giving up waiting for cluster creating. %+v", err)
+		return errors.Wrapf(err, "giving up waiting for cluster creating")
 	}
 
 	c.updateClusterStatus(clusterObj.Namespace, clusterObj.Name, state, failedMessage)
 
 	if state == cephv1.ClusterStateError {
 		// the cluster could not be initialized
-		return fmt.Errorf("failed to initialized the cluster")
+		return errors.New("failed to initialized the cluster")
 	}
 
 	return nil
@@ -813,7 +814,7 @@ func (c *ClusterController) waitForFlexVolumeCleanup(cluster *cephv1.CephCluster
 		// TODO: filter this List operation by cluster namespace on the server side
 		vols, err := c.volumeAttachment.List(operatorNamespace)
 		if err != nil {
-			return fmt.Errorf("failed to get volume attachments for operator namespace %s: %+v", operatorNamespace, err)
+			return errors.Wrapf(err, "failed to get volume attachments for operator namespace %s", operatorNamespace)
 		}
 
 		// find volume attachments in the deleted cluster
@@ -853,7 +854,7 @@ func (c *ClusterController) waitForFlexVolumeCleanup(cluster *cephv1.CephCluster
 func (c *ClusterController) checkPVPresentInCluster(drivers []string, clusterID string) (bool, error) {
 	pv, err := c.context.Clientset.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to list PV. %+v", err)
+		return false, errors.Wrapf(err, "failed to list PV")
 	}
 
 	for _, p := range pv.Items {
@@ -882,7 +883,7 @@ func (c *ClusterController) waitForCSIVolumeCleanup(cluster *cephv1.CephCluster,
 		// check any PV is created in this cluster
 		attachmentsExist, err := c.checkPVPresentInCluster(drivers, cluster.Namespace)
 		if err != nil {
-			return fmt.Errorf("failed to list PersistentVolumes. %+v", err)
+			return errors.Wrapf(err, "failed to list PersistentVolumes")
 		}
 		// no PVC created in this cluster
 		if !attachmentsExist {
@@ -908,7 +909,7 @@ func (c *ClusterController) handleDelete(cluster *cephv1.CephCluster, retryInter
 	if csi.CSIEnabled() {
 		err := c.waitForCSIVolumeCleanup(cluster, retryInterval)
 		if err != nil {
-			return fmt.Errorf("failed to wait for the csi volume cleanup. %+v", err)
+			return errors.Wrapf(err, "failed to wait for the csi volume cleanup")
 		}
 	}
 	operatorNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
@@ -925,26 +926,26 @@ func (c *ClusterController) handleDelete(cluster *cephv1.CephCluster, retryInter
 func purgeExternalCluster(clientset kubernetes.Interface, namespace string) error {
 	// purge the mon endpoint config map
 	err := clientset.CoreV1().ConfigMaps(namespace).Delete(mon.EndpointConfigMapName, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 
 	// purge the config flag overrides
 	err = clientset.CoreV1().ConfigMaps(namespace).Delete(config.StoreName, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 
 	// purge config override configmap?
 	err = clientset.CoreV1().ConfigMaps(namespace).Delete(k8sutil.ConfigOverrideName, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 
 	// Now delete secret
 	err = clientset.CoreV1().Secrets(namespace).Delete(mon.AppName, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete secret %+v. %+v", mon.AppName, err)
+		return errors.Wrapf(err, "failed to delete secret %+v", mon.AppName)
 	}
 
 	return nil
@@ -975,7 +976,7 @@ func (c *ClusterController) addFinalizer(namespace, name string) error {
 	// update the crd
 	_, err = c.context.RookClientset.CephV1().CephClusters(clust.Namespace).Update(clust)
 	if err != nil {
-		return fmt.Errorf("failed to add finalizer to cluster. %+v", err)
+		return errors.Wrapf(err, "failed to add finalizer to cluster")
 	}
 
 	logger.Infof("added finalizer to cluster %s", clust.Name)
@@ -1085,7 +1086,7 @@ func printOverallCephVersion(context *clusterd.Context, namespace string) {
 
 func validateExternalClusterSpec(cluster *cluster) error {
 	if cluster.Spec.DataDirHostPath == "" {
-		return fmt.Errorf("dataDirHostPath must be specified")
+		return errors.New("dataDirHostPath must be specified")
 	}
 
 	return nil
@@ -1124,8 +1125,8 @@ func populateConfigOverrideConfigMap(context *clusterd.Context, namespace string
 
 	k8sutil.SetOwnerRef(&cm.ObjectMeta, &ownerRef)
 	_, err := context.Clientset.CoreV1().ConfigMaps(namespace).Create(cm)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create override configmap %s. %+v", namespace, err)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "failed to create override configmap %s", namespace)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	rookfake "github.com/rook/rook/pkg/client/clientset/versioned/fake"
@@ -216,7 +216,7 @@ func TestRemoveFinalizer(t *testing.T) {
 	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
 		func(clusterSpec *cephv1.ClusterSpec) error {
 			logger.Infof("test success callback")
-			return fmt.Errorf("test failed callback")
+			return errors.New("test failed callback")
 		},
 	}
 	removeCallbacks := []func() error{

--- a/pkg/operator/ceph/cluster/crash/add.go
+++ b/pkg/operator/ceph/cluster/crash/add.go
@@ -17,10 +17,10 @@ limitations under the License.
 package crash
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -54,7 +54,7 @@ func Add(mgr manager.Manager) error {
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
-		return fmt.Errorf("failed to create a new %q. %+v", controllerName, err)
+		return errors.Wrapf(err, "failed to create a new %q", controllerName)
 	}
 
 	// Watch for changes to the nodes
@@ -68,7 +68,7 @@ func Add(mgr manager.Manager) error {
 	logger.Debugf("watch for changes to the nodes")
 	err = c.Watch(&source.Kind{Type: &corev1.Node{}}, &handler.EnqueueRequestForObject{}, specChangePredicate)
 	if err != nil {
-		return fmt.Errorf("failed to watch for node changes. %+v", err)
+		return errors.Wrapf(err, "failed to watch for node changes")
 	}
 
 	// Watch for changes to the ceph-crash deployments
@@ -96,7 +96,7 @@ func Add(mgr manager.Manager) error {
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to watch for changes on the ceph-crash deployment. %+v", err)
+		return errors.Wrapf(err, "failed to watch for changes on the ceph-crash deployment")
 	}
 
 	// Watch for changes to the ceph pod nodename and enqueue their nodes
@@ -141,7 +141,7 @@ func Add(mgr manager.Manager) error {
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("failed to watch for changes on the ceph pod nodename and enqueue their nodes. %+v", err)
+		return errors.Wrapf(err, "failed to watch for changes on the ceph pod nodename and enqueue their nodes")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"reflect"
 
+	"github.com/pkg/errors"
 	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
@@ -53,7 +54,7 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 	// Create or Update the deployment default/foo
 	nodeHostnameLabel, ok := node.ObjectMeta.Labels[corev1.LabelHostname]
 	if !ok {
-		return controllerutil.OperationResultNone, fmt.Errorf("label key %q does not exist on node %q", corev1.LabelHostname, node.GetName())
+		return controllerutil.OperationResultNone, errors.Errorf("label key %q does not exist on node %q", corev1.LabelHostname, node.GetName())
 	}
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package mgr
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -28,7 +28,7 @@ import (
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,7 +48,7 @@ func TestGeneratePassword(t *testing.T) {
 func TestGetOrGeneratePassword(t *testing.T) {
 	c := &Cluster{context: &clusterd.Context{Clientset: test.New(3)}, Namespace: "myns"}
 	_, err := c.context.Clientset.CoreV1().Secrets(c.Namespace).Get(dashboardPasswordName, metav1.GetOptions{})
-	assert.True(t, errors.IsNotFound(err))
+	assert.True(t, kerrors.IsNotFound(err))
 
 	// Generate a password
 	password, err := c.getOrGenerateDashboardPassword()
@@ -88,7 +88,7 @@ func TestStartSecureDashboard(t *testing.T) {
 					logger.Infof("simulating retry...")
 					exitCodeResponse = invalidArgErrorCode
 					moduleRetries++
-					return "", fmt.Errorf("test failure")
+					return "", errors.New("test failure")
 				}
 			}
 			return "", nil
@@ -136,6 +136,6 @@ func TestStartSecureDashboard(t *testing.T) {
 
 	svc, err = c.context.Clientset.CoreV1().Services(c.Namespace).Get("rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	assert.NotNil(t, err)
-	assert.True(t, errors.IsNotFound(err))
+	assert.True(t, kerrors.IsNotFound(err))
 	assert.Nil(t, svc)
 }

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -18,9 +18,9 @@ limitations under the License.
 package mgr
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 )
 
@@ -41,13 +41,13 @@ func (c *Cluster) configureOrchestratorModules() error {
 	}
 
 	if err := client.MgrEnableModule(c.context, c.Namespace, rookModuleName, true); err != nil {
-		return fmt.Errorf("failed to enable mgr rook module. %+v", err)
+		return errors.Wrapf(err, "failed to enable mgr rook module")
 	}
 	if err := client.MgrEnableModule(c.context, c.Namespace, orchestratorModuleName, true); err != nil {
-		return fmt.Errorf("failed to enable mgr orchestrator module. %+v", err)
+		return errors.Wrapf(err, "failed to enable mgr orchestrator module")
 	}
 	if err := c.setRookOrchestratorBackend(); err != nil {
-		return fmt.Errorf("failed to set rook orchestrator backend. %+v", err)
+		return errors.Wrapf(err, "failed to set rook orchestrator backend")
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func (c *Cluster) setRookOrchestratorBackend() error {
 		return client.NewCephCommand(c.context, c.Namespace, args).RunWithTimeout(client.CmdExecuteTimeout)
 	}, c.exitCode, 5, invalidArgErrorCode, orchestratorInitWaitTime)
 	if err != nil {
-		return fmt.Errorf("failed to set rook as the orchestrator backend. %+v", err)
+		return errors.Wrapf(err, "failed to set rook as the orchestrator backend")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package mgr
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -46,19 +46,19 @@ func TestOrchestratorModules(t *testing.T) {
 				return "", nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command '%v'", args)
 	}
 	executor.MockExecuteCommandWithOutputFileTimeout = func(debug bool, timeout time.Duration, actionName, command, outputFile string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "orchestrator" && args[1] == "set" && args[2] == "backend" && args[3] == "rook" {
 			if backendErrorCount < 5 {
 				backendErrorCount++
-				return "", fmt.Errorf("test simulation failure")
+				return "", errors.New("test simulation failure")
 			}
 			rookBackendSet = true
 			return "", nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	clusterInfo := &cephconfig.ClusterInfo{

--- a/pkg/operator/ceph/cluster/migration.go
+++ b/pkg/operator/ceph/cluster/migration.go
@@ -18,8 +18,7 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
 
@@ -32,5 +31,5 @@ func getClusterObject(obj interface{}) (cluster *cephv1.CephCluster, err error) 
 		return cluster, nil
 	}
 
-	return nil, fmt.Errorf("not a known cluster object: %+v", obj)
+	return nil, errors.Errorf("not a known cluster object: %+v", obj)
 }

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -33,7 +34,7 @@ import (
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -85,16 +86,16 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 
 	secrets, err := context.Clientset.CoreV1().Secrets(namespace).Get(AppName, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, maxMonID, monMapping, fmt.Errorf("failed to get mon secrets. %+v", err)
+		if !kerrors.IsNotFound(err) {
+			return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to get mon secrets")
 		}
 		if ownerRef == nil {
-			return nil, maxMonID, monMapping, fmt.Errorf("not expected to create new cluster info and did not find existing secret")
+			return nil, maxMonID, monMapping, errors.New("not expected to create new cluster info and did not find existing secret")
 		}
 
 		clusterInfo, err = createNamedClusterInfo(context, namespace)
 		if err != nil {
-			return nil, maxMonID, monMapping, fmt.Errorf("failed to create mon secrets. %+v", err)
+			return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to create mon secrets")
 		}
 
 		err = createClusterAccessSecret(context.Clientset, namespace, clusterInfo, ownerRef)
@@ -114,7 +115,7 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 	// get the existing monitor config
 	clusterInfo.Monitors, maxMonID, monMapping, err = loadMonConfig(context.Clientset, namespace)
 	if err != nil {
-		return nil, maxMonID, monMapping, fmt.Errorf("failed to get mon config. %+v", err)
+		return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to get mon config")
 	}
 
 	return clusterInfo, maxMonID, monMapping, nil
@@ -124,7 +125,7 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo) error {
 	// write the latest config to the config dir
 	if _, err := cephconfig.GenerateAdminConnectionConfig(context, clusterInfo); err != nil {
-		return fmt.Errorf("failed to write connection config. %+v", err)
+		return errors.Wrapf(err, "failed to write connection config")
 	}
 
 	return nil
@@ -140,7 +141,7 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string
 
 	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(EndpointConfigMapName, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !kerrors.IsNotFound(err) {
 			return nil, maxMonID, monMapping, err
 		}
 		// If the config map was not found, initialize the empty set of monitors
@@ -198,7 +199,7 @@ func createClusterAccessSecret(clientset kubernetes.Interface, namespace string,
 	}
 	k8sutil.SetOwnerRef(&secret.ObjectMeta, ownerRef)
 	if _, err = clientset.CoreV1().Secrets(namespace).Create(secret); err != nil {
-		return fmt.Errorf("failed to save mon secrets. %+v", err)
+		return errors.Wrapf(err, "failed to save mon secrets")
 	}
 
 	return nil
@@ -213,7 +214,7 @@ func createNamedClusterInfo(context *clusterd.Context, clusterName string) (*cep
 
 	dir := path.Join(context.ConfigDir, clusterName)
 	if err = os.MkdirAll(dir, 0744); err != nil {
-		return nil, fmt.Errorf("failed to create dir %s. %+v", dir, err)
+		return nil, errors.Wrapf(err, "failed to create dir %s", dir)
 	}
 
 	// generate the mon secret
@@ -249,12 +250,12 @@ func genSecret(executor exec.Executor, configDir, name string, args []string) (s
 	args = append(base, args...)
 	_, err := executor.ExecuteCommandWithOutput(false, "gen secret", "ceph-authtool", args...)
 	if err != nil {
-		return "", fmt.Errorf("failed to gen secret. %+v", err)
+		return "", errors.Wrapf(err, "failed to gen secret")
 	}
 
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to read secret file. %+v", err)
+		return "", errors.Wrapf(err, "failed to read secret file")
 	}
 	return extractKey(string(contents))
 }
@@ -266,7 +267,7 @@ func extractKey(contents string) (string, error) {
 		secret = slice[2]
 	}
 	if secret == "" {
-		return "", fmt.Errorf("failed to parse secret")
+		return "", errors.New("failed to parse secret")
 	}
 	return secret, nil
 }

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -305,7 +306,7 @@ func TestWaitForQuorum(t *testing.T) {
 		quorumChecks++
 		if quorumChecks == 1 {
 			// return an error the first time while we're waiting for the mon to join quorum
-			return "", fmt.Errorf("test error")
+			return "", errors.New("test error")
 		}
 		// a successful response indicates that we have quorum, even if we didn't check which specific mons were in quorum
 		return clienttest.MonInQuorumResponseFromMons(mons), nil

--- a/pkg/operator/ceph/cluster/mon/node.go
+++ b/pkg/operator/ceph/cluster/mon/node.go
@@ -17,9 +17,8 @@ limitations under the License.
 package mon
 
 import (
-	"fmt"
-
-	"k8s.io/api/core/v1"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 )
 
 // NodeUsage is a mapping between a Node and computed metadata about the node
@@ -60,7 +59,7 @@ func getNodeInfoFromNode(n v1.Node) (*NodeInfo, error) {
 		}
 	}
 	if nr.Address == "" {
-		return nil, fmt.Errorf("couldn't get IP of node %s", nr.Name)
+		return nil, errors.Errorf("couldn't get IP of node %s", nr.Name)
 	}
 	return nr, nil
 }

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -17,9 +17,9 @@ limitations under the License.
 package mon
 
 import (
-	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +56,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 
 	s, err := k8sutil.CreateOrUpdateService(c.context.Clientset, c.Namespace, svcDef)
 	if err != nil {
-		return "", fmt.Errorf("failed to create service for mon %s. %+v", mon.DaemonName, err)
+		return "", errors.Wrapf(err, "failed to create service for mon %s", mon.DaemonName)
 	}
 
 	if s == nil {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
@@ -344,14 +345,14 @@ func UpdateCephDeploymentAndWait(context *clusterd.Context, deployment *apps.Dep
 		if action == "stop" {
 			err := client.OkToStop(context, namespace, deployment.Name, daemonType, daemonName, cephVersion)
 			if err != nil {
-				return fmt.Errorf("failed to check if we can %s the deployment %s: %+v", action, deployment.Name, err)
+				return errors.Wrapf(err, "failed to check if we can %s the deployment %s", action, deployment.Name)
 			}
 		}
 
 		if action == "continue" {
 			err := client.OkToContinue(context, namespace, deployment.Name, daemonType, daemonName)
 			if err != nil {
-				return fmt.Errorf("failed to check if we can %s the deployment %s: %+v", action, deployment.Name, err)
+				return errors.Wrapf(err, "failed to check if we can %s the deployment %s", action, deployment.Name)
 			}
 		}
 

--- a/pkg/operator/ceph/cluster/mon/util.go
+++ b/pkg/operator/ceph/cluster/mon/util.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mon
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
@@ -50,7 +50,7 @@ func fullNameToIndex(name string) (int, error) {
 	// attempt to parse the legacy mon name
 	legacyPrefix := AppName
 	if strings.Index(name, legacyPrefix) == -1 || len(name) < len(AppName) {
-		return -1, fmt.Errorf("unexpected mon name")
+		return -1, errors.New("unexpected mon name")
 	}
 	id, err := strconv.Atoi(name[len(legacyPrefix):])
 	if err != nil {

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -118,15 +119,15 @@ func (m *Monitor) handleOSDMarkedOut(outOSDid int) error {
 	label := fmt.Sprintf("ceph-osd-id=%d", outOSDid)
 	dp, err := k8sutil.GetDeployments(m.context.Clientset, m.clusterName, label)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get osd deployment of osd id %d: %+v", outOSDid, err)
+		return errors.Wrapf(err, "failed to get osd deployment of osd id %d", outOSDid)
 	}
 	if len(dp.Items) != 0 {
 		safeToDestroyOSD, err := client.OsdSafeToDestroy(m.context, m.clusterName, outOSDid)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to get osd deployment of osd id %d", outOSDid)
 		}
 
 		if safeToDestroyOSD {
@@ -136,7 +137,7 @@ func (m *Monitor) handleOSDMarkedOut(outOSDid int) error {
 			if podDeletionTimeStamp.Before(currentTime) {
 				logger.Infof("osd.%d is 'safe-to-destroy'. removing the osd deployment.", outOSDid)
 				if err := k8sutil.DeleteDeployment(m.context.Clientset, dp.Items[0].Namespace, dp.Items[0].Name); err != nil {
-					return fmt.Errorf("failed to delete osd deployment %s: %+v", dp.Items[0].Name, err)
+					return errors.Wrapf(err, "failed to delete osd deployment %s", dp.Items[0].Name)
 				}
 			}
 		}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
@@ -211,7 +211,7 @@ func TestAddRemoveNode(t *testing.T) {
 				assert.Equal(t, "osd.1", args[2])
 				return "", nil
 			}
-			return "", fmt.Errorf("unexpected ceph command '%v'", args)
+			return "", errors.Errorf("unexpected ceph command %q", args)
 		},
 	}
 
@@ -346,7 +346,7 @@ func TestAddNodeFailure(t *testing.T) {
 	// create a fake clientset that will return an error when the operator tries to create a job
 	clientset := fake.NewSimpleClientset()
 	clientset.PrependReactor("create", "jobs", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, fmt.Errorf("mock failed to create jobs")
+		return true, nil, errors.New("mock failed to create jobs")
 	})
 	nodeErr := createNode(nodeName, v1.NodeReady, clientset)
 	assert.Nil(t, nodeErr)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
@@ -173,7 +174,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 
 	if len(volumes) == 0 {
-		return nil, fmt.Errorf("empty volumes")
+		return nil, errors.New("empty volumes")
 	}
 
 	storeType := config.Bluestore
@@ -574,7 +575,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	}
 
 	if len(volumes) == 0 {
-		return nil, fmt.Errorf("empty volumes")
+		return nil, errors.New("empty volumes")
 	}
 
 	podSpec := v1.PodSpec{

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 )
@@ -111,11 +112,11 @@ func SetDefaultConfigs(
 	monStore := GetMonStore(context, namespace)
 
 	if err := monStore.SetAll(DefaultCentralizedConfigs(clusterInfo.CephVersion)...); err != nil {
-		return fmt.Errorf("failed to apply default Ceph configurations. %+v", err)
+		return errors.Wrapf(err, "failed to apply default Ceph configurations")
 	}
 
 	if err := monStore.SetAll(DefaultLegacyConfigs()...); err != nil {
-		return fmt.Errorf("failed to apply legacy config overrides. %+v", err)
+		return errors.Wrapf(err, "failed to apply legacy config overrides")
 	}
 
 	return nil

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -20,15 +20,14 @@ limitations under the License.
 package keyring
 
 import (
-	"fmt"
-
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -89,11 +88,11 @@ func (k *SecretStore) GenerateKey(user string, access []string) (string, error) 
 			"Attempting to update capabilities in case the user already exists. %+v", user, err)
 		uErr := client.AuthUpdateCaps(k.context, k.namespace, user, access)
 		if uErr != nil {
-			return "", fmt.Errorf("failed to get, create, or update auth key for %s. %+v", user, err)
+			return "", errors.Wrapf(err, "failed to get, create, or update auth key for %s", user)
 		}
 		key, uErr = client.AuthGetKey(k.context, k.namespace, user)
 		if uErr != nil {
-			return "", fmt.Errorf("failed to get key after updating existing auth capabilities for %s. %+v", user, err)
+			return "", errors.Wrapf(err, "failed to get key after updating existing auth capabilities for %s", user)
 		}
 	}
 	return key, nil
@@ -121,7 +120,7 @@ func (k *SecretStore) CreateOrUpdate(resourceName string, keyring string) error 
 func (k *SecretStore) Delete(resourceName string) error {
 	secretName := keyringSecretName(resourceName)
 	err := k.context.Clientset.CoreV1().Secrets(k.namespace).Delete(secretName, &metav1.DeleteOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !kerrors.IsNotFound(err) {
 		logger.Warningf("failed to delete keyring secret for %s. user may need to delete the resource manually. %+v", secretName, err)
 	}
 
@@ -133,19 +132,19 @@ func (k *SecretStore) CreateSecret(secret *v1.Secret) error {
 	secretName := secret.ObjectMeta.Name
 	_, err := k.context.Clientset.CoreV1().Secrets(k.namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			logger.Debugf("creating secret for %s", secretName)
 			if _, err := k.context.Clientset.CoreV1().Secrets(k.namespace).Create(secret); err != nil {
-				return fmt.Errorf("failed to create secret for %s. %+v", secretName, err)
+				return errors.Wrapf(err, "failed to create secret for %s", secretName)
 			}
 			return nil
 		}
-		return fmt.Errorf("failed to get secret for %s. %+v", secretName, err)
+		return errors.Wrapf(err, "failed to get secret for %s", secretName)
 	}
 
 	logger.Debugf("updating secret for %s", secretName)
 	if _, err := k.context.Clientset.CoreV1().Secrets(k.namespace).Update(secret); err != nil {
-		return fmt.Errorf("failed to update secret for %s. %+v", secretName, err)
+		return errors.Wrapf(err, "failed to update secret for %s", secretName)
 	}
 	return nil
 }

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -17,16 +17,16 @@ limitations under the License.
 package keyring
 
 import (
-	"fmt"
 	"path"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -37,7 +37,7 @@ func TestGenerateKey(t *testing.T) {
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
 			if failGenerateKey {
-				return "", fmt.Errorf("test error")
+				return "", errors.New("test error")
 			}
 			return "{\"key\": \"" + generateKey + "\"}", nil
 		},
@@ -88,7 +88,7 @@ func TestKeyringStore(t *testing.T) {
 
 	assertDoesNotExist := func(keyringName string) {
 		_, e := clientset.CoreV1().Secrets(ns).Get(keyringName, metav1.GetOptions{})
-		assert.True(t, errors.IsNotFound(e))
+		assert.True(t, kerrors.IsNotFound(e))
 	}
 
 	// create first key

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -17,8 +17,7 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 )
@@ -57,8 +56,8 @@ func (m *MonStore) Set(who, option, value string) error {
 	cephCmd := client.NewCephCommand(m.context, m.namespace, args)
 	out, err := cephCmd.Run()
 	if err != nil {
-		return fmt.Errorf("failed to set Ceph config in the centralized mon configuration database; "+
-			"you may need to use the rook-config-override ConfigMap. output: %s. %+v", string(out), err)
+		return errors.Wrapf(err, "failed to set ceph config in the centralized mon configuration database; "+
+			"you may need to use the rook-config-override ConfigMap. output: %s", string(out))
 	}
 	return nil
 }
@@ -74,9 +73,9 @@ func (m *MonStore) SetAll(options ...Option) error {
 		}
 	}
 	if len(errs) > 0 {
-		retErr := fmt.Errorf("failed to set one or more Ceph configs")
+		retErr := errors.New("failed to set one or more Ceph configs")
 		for _, err := range errs {
-			retErr = fmt.Errorf("%+v. %+v", retErr, err)
+			retErr = errors.Wrapf(err, "%+v", retErr)
 		}
 		return retErr
 	}

--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -42,7 +42,7 @@ func TestMonStore_Set(t *testing.T) {
 		func(debug bool, actionName string, command string, outfile string, args ...string) (string, error) {
 			execedCmd = command + " " + strings.Join(args, " ")
 			if execInjectErr {
-				return "output from cmd with error", fmt.Errorf("mocked error")
+				return "output from cmd with error", errors.New("mocked error")
 			}
 			return "", nil
 		}
@@ -88,7 +88,7 @@ func TestMonStore_SetAll(t *testing.T) {
 			execedCmds = append(execedCmds, execedCmd)
 			k := execInjectErrOnKeyword
 			if strings.Contains(execedCmd, k) {
-				return "output from cmd with error on keyword: " + k, fmt.Errorf("mocked error on keyword: " + k)
+				return "output from cmd with error on keyword: " + k, errors.Errorf("mocked error on keyword: " + k)
 			}
 			return "", nil
 		}

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -18,11 +18,11 @@ package csi
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
@@ -56,7 +56,7 @@ func FormatCsiClusterConfig(
 
 	ccJson, err := json.Marshal(cc)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal csi cluster config. %+v", err)
+		return "", errors.Wrapf(err, "failed to marshal csi cluster config")
 	}
 	return string(ccJson), nil
 }
@@ -65,7 +65,7 @@ func parseCsiClusterConfig(c string) (csiClusterConfig, error) {
 	var cc csiClusterConfig
 	err := json.Unmarshal([]byte(c), &cc)
 	if err != nil {
-		return cc, fmt.Errorf("failed to parse csi cluster config. %+v", err)
+		return cc, errors.Wrapf(err, "failed to parse csi cluster config")
 	}
 	return cc, nil
 }
@@ -73,7 +73,7 @@ func parseCsiClusterConfig(c string) (csiClusterConfig, error) {
 func formatCsiClusterConfig(cc csiClusterConfig) (string, error) {
 	ccJson, err := json.Marshal(cc)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal csi cluster config. %+v", err)
+		return "", errors.Wrapf(err, "failed to marshal csi cluster config")
 	}
 	return string(ccJson), nil
 }
@@ -98,8 +98,7 @@ func UpdateCsiClusterConfig(
 	)
 	cc, err := parseCsiClusterConfig(curr)
 	if err != nil {
-		return "", fmt.Errorf(
-			"failed to parse current csi cluster config. %+v", err)
+		return "", errors.Wrapf(err, "failed to parse current csi cluster config")
 	}
 
 	for i, centry := range cc {
@@ -135,9 +134,7 @@ func CreateCsiConfigMap(namespace string, clientset kubernetes.Interface) (*v1.C
 	created, err := clientset.CoreV1().ConfigMaps(namespace).Create(configMap)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf(
-				"failed to create initial csi config map %v (in %v). %+v",
-				configMap.Name, namespace, err)
+			return nil, errors.Wrapf(err, "failed to create initial csi config map %v (in %v)", configMap.Name, namespace)
 		}
 		return getCsiConfigMap(namespace, clientset)
 	}
@@ -147,15 +144,15 @@ func CreateCsiConfigMap(namespace string, clientset kubernetes.Interface) (*v1.C
 func getCsiConfigMap(namespace string, clientset kubernetes.Interface) (*v1.ConfigMap, error) {
 	found, err := clientset.CoreV1().ConfigMaps(namespace).Get(ConfigName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pre-existing csi config map %v (in %v). %+v",
-			ConfigName, namespace, err)
+		return nil, errors.Wrapf(err, "failed to get pre-existing csi config map %q (in %q)",
+			ConfigName, namespace)
 	}
 	return found, err
 }
 
 func DeleteCsiConfigMap(namespace string, clientset kubernetes.Interface) error {
 	if err := clientset.CoreV1().ConfigMaps(namespace).Delete(ConfigName, &metav1.DeleteOptions{}); err != nil {
-		return fmt.Errorf("failed to delete CSI driver configuration and deployments: %v", err)
+		return errors.Wrapf(err, "failed to delete CSI driver configuration and deployments")
 	}
 	return nil
 }
@@ -179,8 +176,7 @@ func SaveClusterConfig(
 	// csi is deployed into the same namespace as the operator
 	csiNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
 	if csiNamespace == "" {
-		return fmt.Errorf("namespace value missing (for %+v)",
-			k8sutil.PodNamespaceEnvVar)
+		return errors.Errorf("namespace value missing for %s", k8sutil.PodNamespaceEnvVar)
 	}
 	logger.Debugf("Using %+v for CSI ConfigMap Namespace", csiNamespace)
 
@@ -188,7 +184,7 @@ func SaveClusterConfig(
 	configMap, err := clientset.CoreV1().ConfigMaps(csiNamespace).Get(
 		ConfigName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to fetch current csi config map: %+v", err)
+		return errors.Wrapf(err, "failed to fetch current csi config map")
 	}
 
 	// update ConfigMap contents for current cluster
@@ -199,13 +195,13 @@ func SaveClusterConfig(
 	newData, err := UpdateCsiClusterConfig(
 		currData, clusterNamespace, clusterInfo.Monitors)
 	if err != nil {
-		return fmt.Errorf("failed to update csi config map data: %+v", err)
+		return errors.Wrapf(err, "failed to update csi config map data")
 	}
 	configMap.Data[ConfigKey] = newData
 
 	// update ConfigMap with new contents
 	if _, err := clientset.CoreV1().ConfigMaps(csiNamespace).Update(configMap); err != nil {
-		return fmt.Errorf("failed to update csi config map: %+v", err)
+		return errors.Wrapf(err, "failed to update csi config map")
 	}
 	return nil
 }

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -17,8 +17,7 @@ limitations under the License.
 package csi
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -152,7 +151,7 @@ func createOrUpdateCSISecret(namespace, csiRBDProvisionerSecretKey, csiRBDNodeSe
 		// Create Kubernetes Secret
 		err := k.CreateSecret(s)
 		if err != nil {
-			return fmt.Errorf("failed to create kubernetes secret %q for cluster %q", secret, namespace)
+			return errors.Errorf("failed to create kubernetes secret %q for cluster %q", secret, namespace)
 		}
 
 	}
@@ -168,30 +167,30 @@ func CreateCSISecrets(context *clusterd.Context, clusterName string, ownerRef *m
 	// Create CSI RBD Provisioner Ceph key
 	csiRBDProvisionerSecretKey, err := createCSIKeyringRBDProvisioner(k)
 	if err != nil {
-		return fmt.Errorf("failed to create csi rbd provisioner ceph keyring. %+v", err)
+		return errors.Wrapf(err, "failed to create csi rbd provisioner ceph keyring")
 	}
 
 	// Create CSI RBD Node Ceph key
 	csiRBDNodeSecretKey, err := createCSIKeyringRBDNode(k)
 	if err != nil {
-		return fmt.Errorf("failed to create csi rbd node ceph keyring. %+v", err)
+		return errors.Wrapf(err, "failed to create csi rbd node ceph keyring")
 	}
 
 	// Create CSI Cephfs provisioner Ceph key
 	csiCephFSProvisionerSecretKey, err := createCSIKeyringCephFSProvisioner(k)
 	if err != nil {
-		return fmt.Errorf("failed to create csi cephfs provisioner ceph keyring. %+v", err)
+		return errors.Wrapf(err, "failed to create csi cephfs provisioner ceph keyring")
 	}
 
 	// Create CSI Cephfs node Ceph key
 	csiCephFSNodeSecretKey, err := createCSIKeyringCephFSNode(k)
 	if err != nil {
-		return fmt.Errorf("failed to create csi cephfs node ceph keyring. %+v", err)
+		return errors.Wrapf(err, "failed to create csi cephfs node ceph keyring")
 	}
 
 	// Create or update Kubernetes CSI secret
 	if err := createOrUpdateCSISecret(clusterName, csiRBDProvisionerSecretKey, csiRBDNodeSecretKey, csiCephFSProvisionerSecretKey, csiCephFSNodeSecretKey, k); err != nil {
-		return fmt.Errorf("failed to create kubernetes csi secret. %+v", err)
+		return errors.Wrapf(err, "failed to create kubernetes csi secret")
 	}
 
 	return nil

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -18,13 +18,13 @@ package csi
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 	"text/template"
 
+	"github.com/pkg/errors"
 	k8sutil "github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/ghodss/yaml"
@@ -42,7 +42,7 @@ func loadTemplate(name, templatePath string, p templateParam) (string, error) {
 	t := template.New(name)
 	t, err = t.Parse(data)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse template %v. %+v", name, err)
+		return "", errors.Wrapf(err, "failed to parse template %v", name)
 	}
 	err = t.Execute(&writer, p)
 	return writer.String(), err
@@ -52,12 +52,12 @@ func templateToService(name, templatePath string, p templateParam) (*corev1.Serv
 	var svc corev1.Service
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load service template. %+v", err)
+		return nil, errors.Wrapf(err, "failed to load service template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &svc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal service template %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal service template")
 	}
 	return &svc, nil
 }
@@ -66,12 +66,12 @@ func templateToStatefulSet(name, templatePath string, p templateParam) (*apps.St
 	var ss apps.StatefulSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load statefulset template. %+v", err)
+		return nil, errors.Wrapf(err, "failed to load statefulset template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ss)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal statefulset template %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal statefulset template")
 	}
 	return &ss, nil
 }
@@ -80,12 +80,12 @@ func templateToDaemonSet(name, templatePath string, p templateParam) (*apps.Daem
 	var ds apps.DaemonSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load daemonset template. %+v", err)
+		return nil, errors.Wrapf(err, "failed to load daemonset template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal daemonset template %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal daemonset template")
 	}
 	return &ds, nil
 }
@@ -94,12 +94,12 @@ func templateToDeployment(name, templatePath string, p templateParam) (*apps.Dep
 	var ds apps.Deployment
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load deployment template. %+v", err)
+		return nil, errors.Wrapf(err, "failed to load deployment template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal deployment template %+v", err)
+		return nil, errors.Wrapf(err, "failed to unmarshal deployment template")
 	}
 	return &ds, nil
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/mon.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/mon.go
@@ -17,9 +17,9 @@ limitations under the License.
 package clusterdisruption
 
 import (
-	"fmt"
 	"math"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -65,7 +65,7 @@ func (r *ReconcileClusterDisruption) reconcileMonPDB(cephCluster *cephv1.CephClu
 	}
 	err := r.reconcileStaticPDB(pdbRequest, pdb)
 	if err != nil {
-		return fmt.Errorf("could not reconcile mon pdb: %+v", err)
+		return errors.Wrapf(err, "could not reconcile mon pdb")
 	}
 	return nil
 }

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rook/rook/pkg/operator/ceph/disruption/nodedrain"
-
+	"github.com/pkg/errors"
 	cephClient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	"github.com/rook/rook/pkg/operator/ceph/disruption/nodedrain"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -56,11 +56,11 @@ func (r *ReconcileClusterDisruption) createPDBForOSD(deployment appsv1.Deploymen
 	namespace := deployment.ObjectMeta.Namespace
 	osdIDLabel, ok := deploymentLabels[osd.OsdIdLabelKey]
 	if !ok {
-		return fmt.Errorf("could not find id label on osd %s/%s", namespace, deploymentName)
+		return errors.Errorf("could not find id label on osd %s/%s", namespace, deploymentName)
 	}
 	cephCluster, ok := r.clusterMap.GetCluster(namespace)
 	if !ok {
-		return fmt.Errorf("the namespace %s was not found in the clustermap", namespace)
+		return errors.Errorf("the namespace %s was not found in the clustermap", namespace)
 	}
 
 	pdb := &policyv1beta1.PodDisruptionBudget{
@@ -87,8 +87,8 @@ func (r *ReconcileClusterDisruption) createPDBForOSD(deployment appsv1.Deploymen
 	}
 
 	err := r.client.Create(context.TODO(), pdb)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("could not create pdb for osd: %s in namespace %s: %+v", osdIDLabel, namespace, err)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "could not create pdb for osd: %s in namespace %s", osdIDLabel, namespace)
 	}
 	return nil
 }
@@ -100,7 +100,7 @@ func (r *ReconcileClusterDisruption) deletePDB(deployment appsv1.Deployment) err
 
 	osdIDLabel, ok := deploymentLabels[osd.OsdIdLabelKey]
 	if !ok {
-		return fmt.Errorf("could not find id label on osd %s/%s", namespace, deploymentName)
+		return errors.Errorf("could not find id label on osd %s/%s", namespace, deploymentName)
 	}
 	pdb := &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,8 +109,8 @@ func (r *ReconcileClusterDisruption) deletePDB(deployment appsv1.Deployment) err
 		},
 	}
 	err := r.client.Delete(context.TODO(), pdb)
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("could not delete pdb for osd: %s in namespace %s: %+v", osdIDLabel, namespace, err)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return errors.Wrapf(err, "could not delete pdb for osd: %s in namespace %s", osdIDLabel, namespace)
 	}
 	return nil
 }
@@ -128,24 +128,24 @@ func (r *ReconcileClusterDisruption) initializePDBState(request reconcile.Reques
 	}
 	err := r.client.Get(context.TODO(), pdbStateMapRequest, pdbStateMap)
 
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		// create configmap and PDBs for all nodes labeled by failuredomain
 		logger.Infof("inititalizing pod disruption budgets for osds")
 		// one pdb is created per OSD, but after initialization they are created/deleted in failuredomain groups
 		for _, osdData := range osdDataList {
 			err := r.createPDBForOSD(osdData.Deployment)
 			if err != nil {
-				return pdbStateMap, fmt.Errorf("failed to create pdb for osd deployment %s. %+v", osdData.Deployment.ObjectMeta.GetName(), err)
+				return pdbStateMap, errors.Wrapf(err, "failed to create pdb for osd deployment %s. %+v", osdData.Deployment.ObjectMeta.GetName(), err)
 			}
 		}
 		pdbStateMap.Data = map[string]string{disabledPDBKey: ""}
 		// create configmap
 		err := r.client.Create(context.TODO(), pdbStateMap)
 		if err != nil {
-			return pdbStateMap, fmt.Errorf("could not create the PDB state map %s, %+v", pdbStateMapRequest, err)
+			return pdbStateMap, errors.Wrapf(err, "could not create the PDB state map %s", pdbStateMapRequest)
 		}
 	} else if err != nil {
-		return pdbStateMap, fmt.Errorf("could not get the pdbStateMap %s", pdbStateMapRequest)
+		return pdbStateMap, errors.Wrapf(err, "could not get the pdbStateMap %s", pdbStateMapRequest)
 	}
 	return pdbStateMap, nil
 }
@@ -167,7 +167,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 			logger.Debugf("Ceph %q cluster not ready, cannot check Ceph status yet.", request.Namespace)
 			return nil
 		}
-		return fmt.Errorf("could not check cluster health: %+v", err)
+		return errors.Wrapf(err, "could not check cluster health")
 	}
 	if pdbStateMap.Data == nil {
 		pdbStateMap.Data = make(map[string]string)
@@ -209,7 +209,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 
 	err = r.client.Update(context.TODO(), pdbStateMap)
 	if err != nil {
-		return fmt.Errorf("could not update %s in cluster %s: %+v", pdbStateMapName, request, err)
+		return errors.Wrapf(err, "could not update %s in cluster %s", pdbStateMapName, request)
 	}
 	drainingFailureDomain, ok := pdbStateMap.Data[disabledPDBKey]
 	if ok && clean && len(drainingFailureDomain) > 0 {
@@ -220,7 +220,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 		drainingCanaryList := &appsv1.DeploymentList{}
 		err := r.client.List(context.TODO(), drainingCanaryList, canaryLabels, client.InNamespace(r.context.OperatorNamespace))
 		if err != nil {
-			return fmt.Errorf("could not list canary pods by labels %q: %+v", canaryLabels, err)
+			return errors.Wrapf(err, "could not list canary pods by labels %q", canaryLabels)
 		}
 		// refresh old canaries in draining failure domain
 		for _, drainingCanary := range drainingCanaryList.Items {
@@ -241,7 +241,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 				err = r.createPDBForOSD(osdData.Deployment)
 			}
 			if err != nil {
-				return fmt.Errorf("failed to reconcile pdb for osd deployment %s. %+v", osdData.Deployment.ObjectMeta.GetName(), err)
+				return errors.Wrapf(err, "failed to reconcile pdb for osd deployment %s. %+v", osdData.Deployment.ObjectMeta.GetName(), err)
 			}
 		}
 	}
@@ -254,7 +254,7 @@ func (r *ReconcileClusterDisruption) updateNoout(pdbStateMap *corev1.ConfigMap, 
 	namespace := pdbStateMap.ObjectMeta.Namespace
 	osdDump, err := cephClient.GetOSDDump(r.context.ClusterdContext, namespace)
 	if err != nil {
-		return fmt.Errorf("could not get osddump for reconciling maintenance noout in namespace %s: %+v", namespace, err)
+		return errors.Wrapf(err, "could not get osddump for reconciling maintenance noout in namespace %s", namespace)
 	}
 	for failureDomain := range allFailureDomainsMap {
 		disabledFailureDomainTimeStampKey := fmt.Sprintf("%s-noout-last-set-at", failureDomain)
@@ -269,7 +269,7 @@ func (r *ReconcileClusterDisruption) updateNoout(pdbStateMap *corev1.ConfigMap, 
 			// parse the timestamp
 			nooutSetTime, err := time.Parse(time.RFC3339, pdbStateMap.Data[disabledFailureDomainTimeStampKey])
 			if err != nil {
-				return fmt.Errorf("could not parse timestamp %s for failureDomain %s", pdbStateMap.Data[disabledFailureDomainTimeStampKey], nooutSetTime)
+				return errors.Wrapf(err, "could not parse timestamp %s for failureDomain %s", pdbStateMap.Data[disabledFailureDomainTimeStampKey], nooutSetTime)
 			}
 			if time.Since(nooutSetTime) >= r.maintenanceTimeout {
 				// noout expired

--- a/pkg/operator/ceph/disruption/register_controllers.go
+++ b/pkg/operator/ceph/disruption/register_controllers.go
@@ -19,7 +19,7 @@ limitations under the License.
 package disruption
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/rook/rook/pkg/operator/ceph/disruption/clusterdisruption"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
@@ -51,7 +51,7 @@ var MachineDisruptionBudgetAddToManagerFuncs = []func(manager.Manager, *controll
 // which will setup all the necessary watch
 func AddToManager(m manager.Manager, c *controllerconfig.Context) error {
 	if c == nil {
-		return fmt.Errorf("nil controllercontext passed")
+		return errors.New("nil controllercontext passed")
 	}
 	for _, f := range AddToManagerFuncs {
 		if err := f(m, c); err != nil {

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -256,7 +257,7 @@ func getFilesystemObject(obj interface{}) (filesystem *cephv1.CephFilesystem, er
 		return filesystem.DeepCopy(), nil
 	}
 
-	return nil, fmt.Errorf("not a known filesystem object: %+v", obj)
+	return nil, errors.Errorf("not a known filesystem object: %+v", obj)
 }
 
 func (c *FilesystemController) acquireOrchestrationLock() {

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -143,7 +143,7 @@ func TestCreateFilesystem(t *testing.T) {
 
 	//Create another filesystem which should fail
 	err = createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", false)
-	assert.Equal(t, "failed to create filesystem myfs: Cannot create multiple filesystems. Enable ROOK_ALLOW_MULTIPLE_FILESYSTEMS env variable to create more than one", err.Error())
+	assert.Equal(t, "failed to create filesystem myfs: cannot create multiple filesystems. enable ROOK_ALLOW_MULTIPLE_FILESYSTEMS env variable to create more than one", err.Error())
 }
 
 func TestCreateNopoolFilesystem(t *testing.T) {

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -22,9 +22,10 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -53,7 +54,7 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 	// Delete legacy key store for upgrade from Rook v0.9.x to v1.0.x
 	err = c.context.Clientset.CoreV1().Secrets(c.fs.Namespace).Delete(m.ResourceName, &metav1.DeleteOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			logger.Debugf("legacy mds key %s is already removed", m.ResourceName)
 		} else {
 			logger.Warningf("legacy mds key %s could not be removed: %+v", m.ResourceName, err)
@@ -89,7 +90,7 @@ func (c *Cluster) setDefaultFlagsMonConfigStore(mdsID string) error {
 	for flag, val := range configOptions {
 		err := monStore.Set(who, flag, val)
 		if err != nil {
-			return fmt.Errorf("failed to set %q to %q on %q. %+v", flag, val, who, err)
+			return errors.Wrapf(err, "failed to set %q to %q on %q", flag, val, who)
 		}
 	}
 

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -19,6 +19,7 @@ package mds
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
@@ -130,7 +131,7 @@ func getMdsDeployments(context *clusterd.Context, namespace, fsName string) (*ap
 	fsLabelSelector := fmt.Sprintf("rook_file_system=%s", fsName)
 	deps, err := k8sutil.GetDeployments(context.Clientset, namespace, fsLabelSelector)
 	if err != nil {
-		return nil, fmt.Errorf("could not get deployments for filesystem %s (matching label selector '%s'): %+v", fsName, fsLabelSelector, err)
+		return nil, errors.Wrapf(err, "could not get deployments for filesystem %s (matching label selector %q)", fsName, fsLabelSelector)
 	}
 	return deps, nil
 }
@@ -142,7 +143,7 @@ func deleteMdsDeployment(context *clusterd.Context, namespace string, deployment
 	propagation := metav1.DeletePropagationForeground
 	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
 	if err := context.Clientset.AppsV1().Deployments(namespace).Delete(deployment.GetName(), options); err != nil {
-		return fmt.Errorf("failed to delete mds deployment %s: %+v", deployment.GetName(), err)
+		return errors.Wrapf(err, "failed to delete mds deployment %s", deployment.GetName())
 	}
 	return nil
 }

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -17,8 +17,7 @@ limitations under the License.
 package nfs
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
@@ -27,7 +26,7 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -65,8 +64,8 @@ func (c *CephNFSController) createCephNFSService(nfs cephv1.CephNFS, cfg daemonC
 
 	svc, err := c.context.Clientset.CoreV1().Services(nfs.Namespace).Create(svc)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create ganesha service. %+v", err)
+		if !kerrors.IsAlreadyExists(err) {
+			return errors.Wrapf(err, "failed to create ganesha service")
 		}
 		logger.Infof("ceph nfs service already created")
 		return nil

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -19,6 +19,7 @@ package object
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 )
@@ -41,7 +42,7 @@ func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
 	if err != nil {
-		return "", fmt.Errorf("failed to run radosgw-admin: %+v", err)
+		return "", errors.Wrapf(err, "failed to run radosgw-admin")
 	}
 
 	return output, nil

--- a/pkg/operator/ceph/object/bucket/s3-handlers.go
+++ b/pkg/operator/ceph/object/bucket/s3-handlers.go
@@ -24,7 +24,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api/errors"
+	oerrors "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api/errors"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
@@ -67,14 +68,14 @@ func (s S3Agent) CreateBucket(name string) error {
 			case s3.ErrCodeBucketAlreadyExists:
 				msg := fmt.Sprintf("Bucket %q already exists", name)
 				logger.Errorf(msg)
-				return errors.NewBucketExistsError(msg)
+				return oerrors.NewBucketExistsError(msg)
 			case s3.ErrCodeBucketAlreadyOwnedByYou:
 				msg := fmt.Sprintf("Bucket %q already owned by you", name)
 				logger.Errorf(msg)
-				return errors.NewBucketExistsError(msg)
+				return oerrors.NewBucketExistsError(msg)
 			}
 		}
-		return fmt.Errorf("Bucket %q could not be created: %v", name, err)
+		return errors.Wrapf(err, "bucket %q could not be created", name)
 	}
 
 	logger.Infof("successfully created bucket %q", name)

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -17,16 +17,16 @@ limitations under the License.
 package bucket
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner"
-	"k8s.io/api/core/v1"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -98,10 +98,10 @@ func getObjectStore(c cephclientset.CephV1Interface, namespace, name string) (*c
 	// Verify the object store API object actually exists
 	store, err := c.CephObjectStores(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("cephObjectStore not found: %v", err)
+		if kerrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "cephObjectStore not found")
 		}
-		return nil, fmt.Errorf("error getting cephObjectStore: %v", err)
+		return nil, errors.Wrapf(err, "error getting cephObjectStore")
 	}
 	return store, err
 }
@@ -110,10 +110,10 @@ func getService(c kubernetes.Interface, namespace, name string) (*v1.Service, er
 	// Verify the object store's service actually exists
 	svc, err := c.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("cephObjectStore service not found: %v", err)
+		if kerrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "cephObjectStore service not found")
 		}
-		return nil, fmt.Errorf("error getting cephObjectStore service: %v", err)
+		return nil, errors.Wrapf(err, "error getting cephObjectStore service")
 	}
 	return svc, nil
 }

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -135,7 +136,7 @@ func (c *clusterConfig) setDefaultFlagsMonConfigStore(rgwName string) error {
 	for flag, val := range configOptions {
 		err := monStore.Set(who, flag, val)
 		if err != nil {
-			return fmt.Errorf("failed to set %q to %q on %q. %+v", flag, val, who, err)
+			return errors.Wrapf(err, "failed to set %q to %q on %q", flag, val, who)
 		}
 	}
 

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -270,7 +271,7 @@ func getObjectStoreObject(obj interface{}) (objectstore *cephv1.CephObjectStore,
 		return objectstore.DeepCopy(), nil
 	}
 
-	return nil, fmt.Errorf("not a known objectstore object: %+v", obj)
+	return nil, errors.Errorf("not a known objectstore object %+v", obj)
 }
 
 func (c *ObjectStoreController) acquireOrchestrationLock() {

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,13 +47,13 @@ func mimeTypesMountPath() string {
 // store mime.types file in a config map
 func (c *clusterConfig) generateMimeTypes(ownerRef *metav1.OwnerReference) error {
 	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, *ownerRef)
-	if _, err := k.GetValue(c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !errors.IsNotFound(err) {
+	if _, err := k.GetValue(c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
 		logger.Infof("config map for object pool %s already exists, not overwriting", c.store.Name)
 		return nil
 	}
 	// is not found
 	if err := k.SetValue(c.mimeTypesConfigMapName(), mimeTypesFileName, mimeTypes); err != nil {
-		return fmt.Errorf("failed to create config map for object pool %s. %+v", c.store.Name, err)
+		return errors.Wrapf(err, "failed to create config map for object pool %s", c.store.Name)
 	}
 	return nil
 }

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,7 @@ func TestCreateRealm(t *testing.T) {
 		idResponse := `{"id":"test-id"}`
 		logger.Infof("Execute: %s %v", command, args)
 		if args[1] == "get" {
-			return "", fmt.Errorf("induce a create")
+			return "", errors.New("induce a create")
 		} else if args[1] == "create" {
 			for _, arg := range args {
 				if arg == "--default" {
@@ -42,7 +43,7 @@ func TestCreateRealm(t *testing.T) {
 			assert.False(t, defaultStore, "did not find --default flag in %v", args)
 		} else if args[0] == "realm" && args[1] == "list" {
 			if defaultStore {
-				return "", fmt.Errorf("failed to run radosgw-admin: Failed to complete : exit status 2")
+				return "", errors.New("failed to run radosgw-admin: Failed to complete : exit status 2")
 			}
 			return `{"realms": ["myobj"]}`, nil
 		}
@@ -115,7 +116,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 				}
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	executorFunc := func(debug bool, actionName, command string, args ...string) (string, error) {
 		//logger.Infof("Command: %s %v", command, args)
@@ -145,7 +146,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 				return emptyPool, nil
 			}
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 	executor.MockExecuteCommandWithOutput = executorFunc
 	executor.MockExecuteCommandWithCombinedOutput = executorFunc

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -30,7 +31,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/pool"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -60,7 +61,7 @@ var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 func (c *clusterConfig) createOrUpdate() error {
 	// validate the object store settings
 	if err := validateStore(c.context, c.store); err != nil {
-		return fmt.Errorf("invalid object store %s arguments. %+v", c.store.Name, err)
+		return errors.Wrapf(err, "invalid object store %s arguments", c.store.Name)
 	}
 
 	logger.Infof("creating object store %s in namespace %s", c.store.Name, c.store.Namespace)
@@ -68,18 +69,18 @@ func (c *clusterConfig) createOrUpdate() error {
 	// start the service
 	serviceIP, err := c.startService()
 	if err != nil {
-		return fmt.Errorf("failed to start rgw service. %+v", err)
+		return errors.Wrapf(err, "failed to start rgw service")
 	}
 
 	// create the ceph artifacts for the object store
 	objContext := NewContext(c.context, c.store.Name, c.store.Namespace)
 	err = createObjectStore(objContext, *c.store.Spec.MetadataPool.ToModel(""), *c.store.Spec.DataPool.ToModel(""), serviceIP, c.store.Spec.Gateway.Port)
 	if err != nil {
-		return fmt.Errorf("failed to create pools. %+v", err)
+		return errors.Wrapf(err, "failed to create pools")
 	}
 
 	if err := c.startRGWPods(); err != nil {
-		return fmt.Errorf("failed to start pods. %+v", err)
+		return errors.Wrapf(err, "failed to start pods")
 	}
 
 	logger.Infof("created object store %s", c.store.Name)
@@ -120,7 +121,7 @@ func (c *clusterConfig) startRGWPods() error {
 		// the controller as its owner reference; the keyring is deleted with the controller
 		keyring, err := c.generateKeyring(rgwConfig)
 		if err != nil {
-			return fmt.Errorf("failed to create rgw keyring. %+v", err)
+			return errors.Wrapf(err, "failed to create rgw keyring")
 		}
 
 		// Check for existing deployment and set the daemon config flags
@@ -128,11 +129,11 @@ func (c *clusterConfig) startRGWPods() error {
 		// We don't need to handle any error here
 		if err != nil {
 			// Apply the flag only when the deployment is not found
-			if errors.IsNotFound(err) {
+			if kerrors.IsNotFound(err) {
 				logger.Info("setting rgw config flags")
 				err = c.setDefaultFlagsMonConfigStore(rgwConfig.ResourceName)
 				if err != nil {
-					return fmt.Errorf("failed to set default rgw config options. %+v", err)
+					return errors.Wrapf(err, "failed to set default rgw config options")
 				}
 			}
 		}
@@ -142,13 +143,13 @@ func (c *clusterConfig) startRGWPods() error {
 		logger.Infof("object store %s deployment %s started", c.store.Name, deployment.Name)
 		createdDeployment, createErr := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Create(deployment)
 		if createErr != nil {
-			if !errors.IsAlreadyExists(createErr) {
-				return fmt.Errorf("failed to create rgw deployment. %+v", createErr)
+			if !kerrors.IsAlreadyExists(createErr) {
+				return errors.Wrapf(createErr, "failed to create rgw deployment")
 			}
 			logger.Infof("object store %s deployment %s already exists. updating if needed", c.store.Name, deployment.Name)
 			createdDeployment, err = c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Get(deployment.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("failed to get existing rgw deployment %s for update: %+v", deployment.Name, err)
+				return errors.Wrapf(err, "failed to get existing rgw deployment %s for update", deployment.Name)
 			}
 		}
 
@@ -165,7 +166,7 @@ func (c *clusterConfig) startRGWPods() error {
 		}
 
 		// Generate the mime.types file after the rep. controller as well for the same reason as keyring
-		if createErr != nil && errors.IsAlreadyExists(createErr) {
+		if createErr != nil && kerrors.IsAlreadyExists(createErr) {
 			// Always invoke ceph version before an upgrade so we are sure to be up-to-date
 			daemon := string(config.RgwType)
 			var cephVersionToUse cephver.CephVersion
@@ -180,12 +181,12 @@ func (c *clusterConfig) startRGWPods() error {
 				cephVersionToUse = currentCephVersion
 			}
 			if err := updateDeploymentAndWait(c.context, deployment, c.store.Namespace, daemon, daemonLetterID, cephVersionToUse, c.isUpgrade, c.skipUpgradeChecks); err != nil {
-				return fmt.Errorf("failed to update object store %s deployment %s. %+v", c.store.Name, deployment.Name, err)
+				return errors.Wrapf(err, "failed to update object store %s deployment %s", c.store.Name, deployment.Name)
 			}
 		}
 
 		if err := c.generateMimeTypes(resourceControllerOwnerRef); err != nil {
-			return fmt.Errorf("failed to generate the rgw mime.types config. %+v", err)
+			return errors.Wrapf(err, "failed to generate the rgw mime.types config")
 		}
 	}
 
@@ -277,6 +278,33 @@ func (c *clusterConfig) deleteLegacyDaemons() {
 func (c *clusterConfig) deleteStore() error {
 	logger.Infof("Deleting object store %s from namespace %s", c.store.Name, c.store.Namespace)
 
+	var gracePeriod int64
+	propagation := metav1.DeletePropagationForeground
+	options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
+
+	// Delete the rgw service
+	err := c.context.Clientset.CoreV1().Services(c.store.Namespace).Delete(c.instanceName(), options)
+	if err != nil && !kerrors.IsNotFound(err) {
+		logger.Warningf("failed to delete rgw service. %+v", err)
+	}
+
+	// Make a best effort to delete the rgw pods deployments
+	deps, err := k8sutil.GetDeployments(c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
+	if err != nil {
+		logger.Warning("could not get deployments for object store %s (matching label selector '%s'): %+v", c.store.Namespace, c.storeLabelSelector(), err)
+	}
+	for _, d := range deps.Items {
+		if err := k8sutil.DeleteDeployment(c.context.Clientset, c.store.Namespace, d.Name); err != nil {
+			logger.Warning("error during deletion of deployment %s resource: %+v", d.Name, err)
+		}
+	}
+
+	// Delete the rgw config map keyrings
+	err = c.context.Clientset.CoreV1().Secrets(c.store.Namespace).Delete(c.instanceName(), options)
+	if err != nil && !kerrors.IsNotFound(err) {
+		logger.Warningf("failed to delete rgw secret. %+v", err)
+	}
+
 	// Delete rgw CephX keys
 	for i := 0; i < int(c.store.Spec.Gateway.Instances); i++ {
 		daemonLetterID := k8sutil.IndexToName(i)
@@ -289,9 +317,9 @@ func (c *clusterConfig) deleteStore() error {
 
 	// Delete the realm and pools
 	objContext := NewContext(c.context, c.store.Name, c.store.Namespace)
-	err := deleteRealmAndPools(objContext, c.store.Spec.PreservePoolsOnDelete)
+	err = deleteRealmAndPools(objContext, c.store.Spec.PreservePoolsOnDelete)
 	if err != nil {
-		return fmt.Errorf("failed to delete the realm and pools. %+v", err)
+		return errors.Wrapf(err, "failed to delete the realm and pools")
 	}
 
 	logger.Infof("Completed deleting object store %s", c.store.Name)
@@ -309,16 +337,16 @@ func (c *clusterConfig) storeLabelSelector() string {
 // Validate the object store arguments
 func validateStore(context *clusterd.Context, s cephv1.CephObjectStore) error {
 	if s.Name == "" {
-		return fmt.Errorf("missing name")
+		return errors.New("missing name")
 	}
 	if s.Namespace == "" {
-		return fmt.Errorf("missing namespace")
+		return errors.New("missing namespace")
 	}
 	if err := pool.ValidatePoolSpec(context, s.Namespace, &s.Spec.MetadataPool); err != nil {
-		return fmt.Errorf("invalid metadata pool spec. %+v", err)
+		return errors.Wrapf(err, "invalid metadata pool spec")
 	}
 	if err := pool.ValidatePoolSpec(context, s.Namespace, &s.Spec.DataPool); err != nil {
-		return fmt.Errorf("invalid data pool spec. %+v", err)
+		return errors.Wrapf(err, "invalid data pool spec")
 	}
 
 	return nil

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -17,15 +17,14 @@ limitations under the License.
 package object
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -181,12 +180,12 @@ func (c *clusterConfig) startService() (string, error) {
 
 	svc, err := c.context.Clientset.CoreV1().Services(c.store.Namespace).Create(svc)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("failed to create rgw service. %+v", err)
+		if !kerrors.IsAlreadyExists(err) {
+			return "", errors.Wrapf(err, "failed to create rgw service")
 		}
 		svc, err = c.context.Clientset.CoreV1().Services(c.store.Namespace).Get(c.instanceName(), metav1.GetOptions{})
 		if err != nil {
-			return "", fmt.Errorf("failed to get existing service IP. %+v", err)
+			return "", errors.Wrapf(err, "failed to get existing service IP")
 		}
 		return svc.Spec.ClusterIP, nil
 	}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package pool
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -75,7 +75,7 @@ func TestValidateCrushProperties(t *testing.T) {
 		if args[1] == "crush" && args[2] == "dump" {
 			return `{"types":[{"type_id": 0,"name": "osd"}],"buckets":[{"id": -1,"name":"default"},{"id": -2,"name":"good"}]}`, nil
 		}
-		return "", fmt.Errorf("unexpected ceph command '%v'", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	// succeed with a failure domain that exists
@@ -177,10 +177,10 @@ func TestDeletePool(t *testing.T) {
 					return p, nil
 
 				}
-				return "", fmt.Errorf("rbd: error opening pool '%s': (2) No such file or directory", args[3])
+				return "", errors.Errorf("rbd: error opening pool %q: (2) No such file or directory", args[3])
 
 			}
-			return "", fmt.Errorf("unexpected rbd command '%v'", args)
+			return "", errors.Errorf("unexpected rbd command %q", args)
 		},
 	}
 	context := &clusterd.Context{Executor: executor}

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
@@ -325,7 +326,7 @@ func CheckPodMemory(resources v1.ResourceRequirements, cephPodMinimumMemory uint
 	if !podMemoryLimit.IsZero() {
 		// This means LIMIT and REQUEST are either identical or different but still we use LIMIT as a reference
 		if uint64(podMemoryLimit.Value()) < display.MbTob(cephPodMinimumMemory) {
-			return fmt.Errorf(errorMessage, display.BToMb(uint64(podMemoryLimit.Value())), cephPodMinimumMemory)
+			return errors.Errorf(errorMessage, display.BToMb(uint64(podMemoryLimit.Value())), cephPodMinimumMemory)
 		}
 
 		// This means LIMIT < REQUEST
@@ -335,7 +336,7 @@ func CheckPodMemory(resources v1.ResourceRequirements, cephPodMinimumMemory uint
 			User has specified a pod memory limit %dmb below the pod memory request %dmb in the cluster CR.\n
 			Rook will create pods that are expected to fail to serve as a more apparent error indicator to the user.`
 
-			return fmt.Errorf(extraErrorLine, display.BToMb(uint64(podMemoryLimit.Value())), display.BToMb(uint64(podMemoryRequest.Value())))
+			return errors.Errorf(extraErrorLine, display.BToMb(uint64(podMemoryLimit.Value())), display.BToMb(uint64(podMemoryRequest.Value())))
 		}
 	}
 

--- a/pkg/operator/ceph/spec/version.go
+++ b/pkg/operator/ceph/spec/version.go
@@ -17,8 +17,7 @@ limitations under the License.
 package spec
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -30,7 +29,7 @@ func ValidateCephVersionsBetweenLocalAndExternalClusters(context *clusterd.Conte
 	// health check should tell us if the external cluster has been upgraded and display a message
 	externalVersion, err := client.GetCephMonVersion(context, namespace)
 	if err != nil {
-		return cephver.CephVersion{}, fmt.Errorf("failed to get ceph mon version. %+v", err)
+		return cephver.CephVersion{}, errors.Wrapf(err, "failed to get ceph mon version")
 	}
 
 	return *externalVersion, cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, *externalVersion)

--- a/pkg/operator/ceph/test/spec.go
+++ b/pkg/operator/ceph/test/spec.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	e "github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
@@ -33,10 +34,10 @@ const (
 func checkLabel(key, value string, labels map[string]string) error {
 	v, ok := labels[key]
 	if !ok {
-		return fmt.Errorf("label not present: expected={%s: %s}", key, value)
+		return e.Errorf("label not present: expected={%s: %s}", key, value)
 	}
 	if v != value {
-		return fmt.Errorf("label mismatch: expected={%s: %s} present={%s: %s}", key, value, key, v)
+		return e.Errorf("label mismatch: expected={%s: %s} present={%s: %s}", key, value, key, v)
 	}
 	return nil
 }
@@ -52,7 +53,7 @@ func combineErrors(errors ...error) error {
 	}
 	if failure {
 		errText = strings.TrimRight(errText, ": ") // Remove ": " from end
-		return fmt.Errorf("%s", errText)
+		return e.Errorf("%s", errText)
 	}
 	return nil
 }


### PR DESCRIPTION
We now use the error package.
Kubernetes errors have been renamed kerrors since they are lower than
'errors'.

Closes: https://github.com/rook/rook/issues/4054
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #4054

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


[test ceph]