### PR TITLE
mergify: change config to allow auto-merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,9 +9,8 @@ pull_request_rules:
       - 'status-success=continuous-integration/jenkins/pr-head'
     actions:
       merge:
-        method: rebase
-        rebase_fallback: merge
-        strict: smart
+        method: merge
+        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 # Trigger backport PRs based on label


### PR DESCRIPTION
Let's not do a rebase, but only merge. Rook is configured to refuse the
rebase and mergify fails with the following Github error:

GitHub error message: Rebase merges are not allowed on this repository.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]
