### PR TITLE
ceph: expose prepare pod resource limits

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -287,6 +287,7 @@ You can set resource requests/limits for Rook components through the [Resource R
 - `mon`: Set resource requests/limits for mons
 - `osd`: Set resource requests/limits for OSDs
 - `rbdmirror`: Set resource requests/limits for RBD Mirrors
+- `prepareosd`: Set resource requests/limits for OSD prepare job
 
 In order to provide the best possible experience running Ceph in containers, Rook internally enforces minimum memory limits if resource limits are passed.
 If a user configures a limit or request value that is too low, Rook will refuse to run the pod(s).
@@ -297,6 +298,8 @@ Here are the current minimum amounts of memory in MB to apply so that Rook will 
 - `osd`: 2048MB
 - `mds`: 4096MB
 - `rbdmirror`: 512MB
+
+Rook does not enforce any minimum limit nor request on the prepare OSD pod. We have seen that pod taking up to 50 MB, but depending on the OSD scenario, that value might need to be higher. So setting a value to at least 50 MB should be a good start, but 100 MB might be safer.
 
 ### Resource Requirements/Limits
 For more information on resource requests/limits see the official Kubernetes documentation: [Kubernetes - Managing Compute Resources for Containers](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container)

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -114,6 +114,7 @@ spec:
 # The above example requests/limits can also be added to the mon and osd components
 #    mon:
 #    osd:
+#    prepareosd:
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true

--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -17,13 +17,19 @@ package v1
 
 import (
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
-	ResourcesKeyMgr       = "mgr"
-	ResourcesKeyMon       = "mon"
-	ResourcesKeyOSD       = "osd"
+	// ResourcesKeyMon represents the name of resource in the CR for a mon
+	ResourcesKeyMon = "mon"
+	// ResourcesKeyMgr represents the name of resource in the CR for a mgr
+	ResourcesKeyMgr = "mgr"
+	// ResourcesKeyOSD represents the name of resource in the CR for an osd
+	ResourcesKeyOSD = "osd"
+	// ResourcesKeyPrepareOSD represents the name of resource in the CR for the osd prepare job
+	ResourcesKeyPrepareOSD = "prepareosd"
+	// ResourcesKeyRBDMirror represents the name of resource in the CR for the rbdmirror
 	ResourcesKeyRBDMirror = "rbdmirror"
 )
 
@@ -40,6 +46,11 @@ func GetMonResources(p rook.ResourceSpec) v1.ResourceRequirements {
 // GetOSDResources returns the placement for the OSDs
 func GetOSDResources(p rook.ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyOSD]
+}
+
+// GetPrepareOSDResources returns the placement for the OSDs prepare job
+func GetPrepareOSDResources(p rook.ResourceSpec) v1.ResourceRequirements {
+	return p[ResourcesKeyPrepareOSD]
 }
 
 // GetRBDMirrorResources returns the placement for the RBD Mirrors

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -280,7 +280,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 		// Start the OSDs
 		osds := osd.New(c.Info, c.context, c.Namespace, rookImage, spec.CephVersion, spec.Storage, spec.DataDirHostPath,
 			cephv1.GetOSDPlacement(spec.Placement), cephv1.GetOSDAnnotations(spec.Annotations), spec.Network,
-			cephv1.GetOSDResources(spec.Resources), c.ownerRef, c.isUpgrade, c.Spec.SkipUpgradeChecks)
+			cephv1.GetOSDResources(spec.Resources), cephv1.GetPrepareOSDResources(spec.Resources), c.ownerRef, c.isUpgrade, c.Spec.SkipUpgradeChecks)
 		err = osds.Start()
 		if err != nil {
 			return fmt.Errorf("failed to start the osds. %+v", err)

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -79,6 +79,7 @@ type Cluster struct {
 	dataDirHostPath   string
 	Network           cephv1.NetworkSpec
 	resources         v1.ResourceRequirements
+	prepareResources  v1.ResourceRequirements
 	ownerRef          metav1.OwnerReference
 	kv                *k8sutil.ConfigMapKVStore
 	isUpgrade         bool
@@ -98,6 +99,7 @@ func New(
 	annotations rookalpha.Annotations,
 	network cephv1.NetworkSpec,
 	resources v1.ResourceRequirements,
+	prepareResources v1.ResourceRequirements,
 	ownerRef metav1.OwnerReference,
 	isUpgrade bool,
 	skipUpgradeChecks bool,
@@ -114,6 +116,7 @@ func New(
 		dataDirHostPath:   dataDirHostPath,
 		Network:           network,
 		resources:         resources,
+		prepareResources:  resources,
 		ownerRef:          ownerRef,
 		kv:                k8sutil.NewConfigMapKVStore(namespace, context.Clientset, ownerRef),
 		isUpgrade:         isUpgrade,

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -47,7 +47,7 @@ func TestStart(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "myversion", cephv1.CephVersionSpec{},
-		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// Start the first time
 	err := c.Start()
@@ -125,7 +125,7 @@ func TestAddRemoveNode(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
-		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// kick off the start of the orchestration in a goroutine
 	var startErr error
@@ -210,7 +210,7 @@ func TestAddRemoveNode(t *testing.T) {
 	// modify the storage spec to remove the node from the cluster
 	storageSpec.Nodes = []rookalpha.Node{}
 	c = New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: mockExec}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
-		storageSpec, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		storageSpec, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// reset the orchestration status watcher
 	statusMapWatcher = watch.NewFake()
@@ -262,7 +262,7 @@ func TestDiscoverOSDs(t *testing.T) {
 		Executor: executor,
 	}
 	c := New(clusterInfo, context, "ns", "myversion", cephv1.CephVersionSpec{},
-		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 	node1 := "n1"
 	node2 := "n2"
 
@@ -345,7 +345,7 @@ func TestAddNodeFailure(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
-		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// kick off the start of the orchestration in a goroutine
 	var startErr error

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -37,6 +37,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -727,7 +728,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 			RunAsNonRoot:           &runAsNonRoot,
 			ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 		},
-		Resources: osdProps.resources,
+		Resources: c.osdPrepareResources(osdProps.pvc.ClaimName),
 	}
 
 	return osdProvisionContainer
@@ -881,4 +882,24 @@ func getCRUSHLocation(p osdProperties) (string, error) {
 		return "", err
 	}
 	return strings.Join(locs, " "), nil
+}
+
+func (c *Cluster) osdPrepareResources(osdClaimName string) v1.ResourceRequirements {
+	var cpuLimit, cpuRequest, memoryLimit, memoryRequest int64
+
+	cpuLimit = c.prepareResources.Limits.Cpu().Value()
+	cpuRequest = c.prepareResources.Requests.Cpu().Value()
+	memoryLimit = c.prepareResources.Limits.Memory().Value()
+	memoryRequest = c.prepareResources.Requests.Memory().Value()
+
+	return v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuLimit, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(memoryLimit, resource.BinarySI),
+		},
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuRequest, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(memoryRequest, resource.BinarySI),
+		},
+	}
 }

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -42,7 +42,7 @@ func TestOrchestrationStatus(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "myversion", cephv1.CephVersionSpec{},
-		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
+		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 	kv := k8sutil.NewConfigMapKVStore(c.Namespace, clientset, metav1.OwnerReference{})
 	nodeName := "mynode"
 	cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)


### PR DESCRIPTION
The osd-prepare jobs should not inherit osd resources since this might
cause scheduling issues.
Instead, we can now use the new CRD property `prepareosd` in the resource section.

Refer to the documentation for more details.

Closes: https://github.com/rook/rook/issues/2502
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]