### PR TITLE
ceph: rework csi keys and secrets

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -60,9 +60,9 @@ parameters:
     imageFeatures: layering
 
     # The secrets contain Ceph admin credentials.
-    csi.storage.k8s.io/provisioner-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
     csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-    csi.storage.k8s.io/node-stage-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 
     # Specify the filesystem type of the volume. If not specified, csi-provisioner

--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -106,9 +106,9 @@ parameters:
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
-  csi.storage.k8s.io/provisioner-secret-name: rook-ceph-csi
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-  csi.storage.k8s.io/node-stage-secret-name: rook-ceph-csi
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
   csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 
 reclaimPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -20,9 +20,9 @@ parameters:
 
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
-  csi.storage.k8s.io/provisioner-secret-name: rook-ceph-csi
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-  csi.storage.k8s.io/node-stage-secret-name: rook-ceph-csi
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
   csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 
   # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)

--- a/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
@@ -9,5 +9,5 @@ parameters:
   # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
   # for example "rook-ceph".
   clusterID: rook-ceph
-  csi.storage.k8s.io/snapshotter-secret-name: rook-ceph-csi
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
   csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
@@ -29,9 +29,9 @@ parameters:
 
     # The secrets contain Ceph admin credentials. These are generated automatically by the operator
     # in the same namespace as the cluster.
-    csi.storage.k8s.io/provisioner-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
     csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-    csi.storage.k8s.io/node-stage-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -29,9 +29,9 @@ parameters:
 
     # The secrets contain Ceph admin credentials. These are generated automatically by the operator
     # in the same namespace as the cluster.
-    csi.storage.k8s.io/provisioner-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
     csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-    csi.storage.k8s.io/node-stage-secret-name: rook-ceph-csi
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -113,11 +113,12 @@ func DeleteErasureCodeProfile(context *clusterd.Context, clusterName string, era
 
 func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 	pool := CephStoragePoolDetails{
-		Name:          modelPool.Name,
-		Number:        modelPool.Number,
-		FailureDomain: modelPool.FailureDomain,
-		CrushRoot:     modelPool.CrushRoot,
-		DeviceClass:   modelPool.DeviceClass,
+		Name:             modelPool.Name,
+		Number:           modelPool.Number,
+		FailureDomain:    modelPool.FailureDomain,
+		CrushRoot:        modelPool.CrushRoot,
+		DeviceClass:      modelPool.DeviceClass,
+		NotEnableAppPool: modelPool.NotEnableAppPool,
 	}
 
 	if modelPool.Type == model.Replicated {

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -44,6 +44,7 @@ type CephStoragePoolDetails struct {
 	FailureDomain      string `json:"failureDomain"`
 	CrushRoot          string `json:"crushRoot"`
 	DeviceClass        string `json:"deviceClass"`
+	NotEnableAppPool   bool   `json:"notEnableAppPool"`
 }
 
 type CephStoragePoolStats struct {
@@ -241,9 +242,11 @@ func CreateECPoolForApp(context *clusterd.Context, clusterName string, newPool C
 		}
 	}
 
-	err = givePoolAppTag(context, clusterName, newPool.Name, appName)
-	if err != nil {
-		return err
+	if !newPool.NotEnableAppPool {
+		err = givePoolAppTag(context, clusterName, newPool.Name, appName)
+		if err != nil {
+			return err
+		}
 	}
 
 	logger.Infof("creating EC pool %s succeeded, buf: %s", newPool.Name, string(buf))
@@ -269,9 +272,11 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, clusterName string, n
 	}
 
 	// ensure that the newly created pool gets an application tag
-	err = givePoolAppTag(context, clusterName, newPool.Name, appName)
-	if err != nil {
-		return err
+	if !newPool.NotEnableAppPool {
+		err = givePoolAppTag(context, clusterName, newPool.Name, appName)
+		if err != nil {
+			return err
+		}
 	}
 
 	logger.Infof("creating replicated pool %s succeeded, buf: %s", newPool.Name, string(buf))

--- a/pkg/daemon/ceph/model/pool.go
+++ b/pkg/daemon/ceph/model/pool.go
@@ -42,4 +42,5 @@ type Pool struct {
 	DeviceClass        string                 `json:"deviceClass"`
 	ReplicatedConfig   ReplicatedPoolConfig   `json:"replicatedConfig"`
 	ErasureCodedConfig ErasureCodedPoolConfig `json:"erasureCodedConfig"`
+	NotEnableAppPool   bool                   `json:"notEnableAppPool"`
 }

--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -65,20 +65,4 @@ func TestCreateClusterSecrets(t *testing.T) {
 	secret, err := clientset.CoreV1().Secrets(namespace).Get("rook-ceph-mon", metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, adminSecret, string(secret.Data["admin-secret"]))
-
-	// check for the csi secret
-	secret, err = clientset.CoreV1().Secrets(namespace).Get("rook-ceph-csi", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, adminSecret, string(secret.Data["adminKey"]))
-
-	// delete the csi secret and confirm it is created again
-	opts := &metav1.DeleteOptions{}
-	err = clientset.CoreV1().Secrets(namespace).Delete("rook-ceph-csi", opts)
-	assert.NoError(t, err)
-
-	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
-	require.NoError(t, err)
-	secret, err = clientset.CoreV1().Secrets(namespace).Get("rook-ceph-csi", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, adminSecret, string(secret.Data["adminKey"]))
 }

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -217,10 +217,6 @@ func validateStart(t *testing.T, c *Cluster) {
 	assert.NoError(t, err) // there shouldn't be an error due the secret existing
 	assert.Equal(t, 4, len(s.Data))
 
-	s, err = c.context.Clientset.CoreV1().Secrets(c.Namespace).Get("rook-ceph-csi", metav1.GetOptions{})
-	assert.NoError(t, err) // there shouldn't be an error due the secret existing
-	assert.Equal(t, 4, len(s.Data))
-
 	// there is only one pod created. the other two won't be created since the first one doesn't start
 	_, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get("rook-ceph-mon-a", metav1.GetOptions{})
 	assert.Nil(t, err)

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -98,7 +98,7 @@ func (k *SecretStore) CreateOrUpdate(resourceName, keyring string) error {
 	}
 	k8sutil.SetOwnerRef(&secret.ObjectMeta, k.ownerRef)
 
-	return k.createSecret(secret)
+	return k.CreateSecret(secret)
 }
 
 // Delete deletes the keyring secret for the resource.
@@ -112,7 +112,8 @@ func (k *SecretStore) Delete(resourceName string) error {
 	return nil
 }
 
-func (k *SecretStore) createSecret(secret *v1.Secret) error {
+// CreateSecret creates or update a kubernetes secret
+func (k *SecretStore) CreateSecret(secret *v1.Secret) error {
 	secretName := secret.ObjectMeta.Name
 	_, err := k.context.Clientset.CoreV1().Secrets(k.namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"fmt"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	csiKeyringRBDProvisionerUsername = "client.csi-rbd-provisioner"
+	csiKeyringRBDNodeUsername        = "client.csi-rbd-node"
+	csiRBDNodeSecret                 = "rook-csi-rbd-node"
+	csiRBDProvisionerSecret          = "rook-csi-rbd-provisioner"
+)
+
+const (
+	csiKeyringCephFSProvisionerUsername = "client.csi-cephfs-provisioner"
+	csiKeyringCephFSNodeUsername        = "client.csi-cephfs-node"
+	csiCephFSNodeSecret                 = "rook-csi-cephfs-node"
+	csiCephFSProvisionerSecret          = "rook-csi-cephfs-provisioner"
+)
+
+func createCSIKeyringRBDNode(s *keyring.SecretStore) (string, error) {
+	key, err := s.GenerateKey(csiKeyringRBDNodeUsername, cephCSIKeyringRBDNodeCaps())
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func createCSIKeyringRBDProvisioner(s *keyring.SecretStore) (string, error) {
+	key, err := s.GenerateKey(csiKeyringRBDProvisionerUsername, cephCSIKeyringRBDProvisionerCaps())
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func createCSIKeyringCephFSNode(s *keyring.SecretStore) (string, error) {
+	key, err := s.GenerateKey(csiKeyringCephFSNodeUsername, cephCSIKeyringCephFSNodeCaps())
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func createCSIKeyringCephFSProvisioner(s *keyring.SecretStore) (string, error) {
+	key, err := s.GenerateKey(csiKeyringCephFSProvisionerUsername, cephCSIKeyringCephFSProvisionerCaps())
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func cephCSIKeyringRBDNodeCaps() []string {
+	return []string{
+		"mon", "profile rbd",
+		"osd", "profile rbd",
+	}
+}
+
+func cephCSIKeyringRBDProvisionerCaps() []string {
+	return []string{
+		"mon", "profile rbd",
+		"mgr", "allow rw",
+		"osd", "profile rbd",
+	}
+}
+
+func cephCSIKeyringCephFSNodeCaps() []string {
+	return []string{
+		"mon", "allow r",
+		"mgr", "allow rw",
+		"osd", "allow rw tag cephfs *=*",
+		"mds", "allow rw",
+	}
+}
+
+func cephCSIKeyringCephFSProvisionerCaps() []string {
+	return []string{
+		"mon", "allow r",
+		"mgr", "allow rw",
+		"osd", "allow rw tag cephfs metadata=*",
+	}
+}
+
+func createOrUpdateCSISecret(namespace, csiRBDProvisionerSecretKey, csiRBDNodeSecretKey, csiCephFSProvisionerSecretKey, csiCephFSNodeSecretKey string, k *keyring.SecretStore) error {
+	csiRBDProvisionerSecrets := map[string][]byte{
+		// userID is expected for the rbd provisioner driver
+		"userID":  []byte("csi-rbd-provisioner"),
+		"userKey": []byte(csiRBDProvisionerSecretKey),
+	}
+
+	csiRBDNodeSecrets := map[string][]byte{
+		// userID is expected for the rbd node driver
+		"userID":  []byte("csi-rbd-node"),
+		"userKey": []byte(csiRBDNodeSecretKey),
+	}
+
+	csiCephFSProvisionerSecrets := map[string][]byte{
+		// adminID is expected for the cephfs provisioner driver
+		"adminID":  []byte("csi-cephfs-provisioner"),
+		"adminKey": []byte(csiCephFSProvisionerSecretKey),
+	}
+
+	csiCephFSNodeSecrets := map[string][]byte{
+		// adminID is expected for the cephfs node driver
+		"adminID":  []byte("csi-cephfs-node"),
+		"adminKey": []byte(csiCephFSNodeSecretKey),
+	}
+
+	keyringSecretMap := make(map[string]map[string][]byte)
+	keyringSecretMap[csiRBDProvisionerSecret] = csiRBDProvisionerSecrets
+	keyringSecretMap[csiRBDNodeSecret] = csiRBDNodeSecrets
+	keyringSecretMap[csiCephFSProvisionerSecret] = csiCephFSProvisionerSecrets
+	keyringSecretMap[csiCephFSNodeSecret] = csiCephFSNodeSecrets
+
+	for secretName, secret := range keyringSecretMap {
+		s := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: secret,
+			Type: k8sutil.RookType,
+		}
+
+		// Create Kubernetes Secret
+		err := k.CreateSecret(s)
+		if err != nil {
+			return fmt.Errorf("failed to create kubernetes secret %q for cluster %q", secret, namespace)
+		}
+
+	}
+
+	logger.Infof("created kubernetes csi secrets for cluster %q", namespace)
+	return nil
+}
+
+// CreateCSISecrets creates all the Kubernetes CSI Secrets
+func CreateCSISecrets(context *clusterd.Context, clusterName string, ownerRef *metav1.OwnerReference) error {
+	k := keyring.GetSecretStore(context, clusterName, ownerRef)
+
+	// Create CSI RBD Provisioner Ceph key
+	csiRBDProvisionerSecretKey, err := createCSIKeyringRBDProvisioner(k)
+	if err != nil {
+		return fmt.Errorf("failed to create csi rbd provisioner ceph keyring. %+v", err)
+	}
+
+	// Create CSI RBD Node Ceph key
+	csiRBDNodeSecretKey, err := createCSIKeyringRBDNode(k)
+	if err != nil {
+		return fmt.Errorf("failed to create csi rbd node ceph keyring. %+v", err)
+	}
+
+	// Create CSI Cephfs provisioner Ceph key
+	csiCephFSProvisionerSecretKey, err := createCSIKeyringCephFSProvisioner(k)
+	if err != nil {
+		return fmt.Errorf("failed to create csi cephfs provisioner ceph keyring. %+v", err)
+	}
+
+	// Create CSI Cephfs node Ceph key
+	csiCephFSNodeSecretKey, err := createCSIKeyringCephFSNode(k)
+	if err != nil {
+		return fmt.Errorf("failed to create csi cephfs node ceph keyring. %+v", err)
+	}
+
+	// Create or update Kubernetes CSI secret
+	if err := createOrUpdateCSISecret(clusterName, csiRBDProvisionerSecretKey, csiRBDNodeSecretKey, csiCephFSProvisionerSecretKey, csiCephFSNodeSecretKey, k); err != nil {
+		return fmt.Errorf("failed to create kubernetes csi secret. %+v", err)
+	}
+
+	return nil
+}

--- a/pkg/operator/ceph/csi/secrets_test.go
+++ b/pkg/operator/ceph/csi/secrets_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCephCSIKeyringRBDNodeCaps(t *testing.T) {
+	caps := cephCSIKeyringRBDNodeCaps()
+	assert.Equal(t, caps, []string{"mon", "profile rbd", "osd", "profile rbd"})
+}
+
+func TestCephCSIKeyringRBDProvisionerCaps(t *testing.T) {
+	caps := cephCSIKeyringRBDProvisionerCaps()
+	assert.Equal(t, caps, []string{"mon", "profile rbd", "mgr", "allow rw", "osd", "profile rbd"})
+}
+
+func TestCephCSIKeyringCephFSNodeCaps(t *testing.T) {
+	caps := cephCSIKeyringCephFSNodeCaps()
+	assert.Equal(t, caps, []string{"mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs *=*", "mds", "allow rw"})
+}
+
+func TestCephCSIKeyringCephFSProvisionerCaps(t *testing.T) {
+	caps := cephCSIKeyringCephFSProvisionerCaps()
+	assert.Equal(t, caps, []string{"mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"})
+}

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -152,6 +152,10 @@ func newFS(name string, metadataPool *model.Pool, dataPools []*model.Pool, activ
 		pool.Name = fmt.Sprintf("%s-%s%d", name, dataPoolSuffix, i)
 	}
 
+	// For the filesystem pool we don't want to enable the application pool
+	// since it's being done via 'fs new' already
+	metadataPool.NotEnableAppPool = true
+
 	return &Filesystem{
 		Name:           name,
 		metadataPool:   metadataPool,

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -206,9 +206,9 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 		reversedPoolMap[value] = key
 	}
 
-	pools_created := false
-	if _, pool_found := reversedPoolMap[f.metadataPool.Name]; !pool_found {
-		pools_created = true
+	poolsCreated := false
+	if _, poolFound := reversedPoolMap[f.metadataPool.Name]; !poolFound {
+		poolsCreated = true
 		err = client.CreatePoolWithProfile(context, clusterName, *f.metadataPool, appName)
 		if err != nil {
 			return fmt.Errorf("failed to create metadata pool '%s': %+v", f.metadataPool.Name, err)
@@ -218,8 +218,8 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 	var dataPoolNames []string
 	for _, pool := range f.dataPools {
 		dataPoolNames = append(dataPoolNames, pool.Name)
-		if _, pool_found := reversedPoolMap[pool.Name]; !pool_found {
-			pools_created = true
+		if _, poolFound := reversedPoolMap[pool.Name]; !poolFound {
+			poolsCreated = true
 			err = client.CreatePoolWithProfile(context, clusterName, *pool, appName)
 			if err != nil {
 				return fmt.Errorf("failed to create data pool %s: %+v", pool.Name, err)
@@ -235,7 +235,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 
 	// create the filesystem ('fs new' needs to be forced in order to reuse pre-existing pools)
 	// if only one pool is created new it wont work (to avoid inconsistencies).
-	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames, !pools_created); err != nil {
+	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames, !poolsCreated); err != nil {
 		return err
 	}
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -597,6 +597,8 @@ func (k8sh *K8sHelper) IsPodRunning(name string, namespace string) bool {
 		logger.Infof("waiting for pod %s in namespace %s to be running", name, namespace)
 
 	}
+	pod, _ := k8sh.Clientset.CoreV1().Pods(namespace).Get(name, getOpts)
+	k8sh.PrintPodDescribe(namespace, pod.Name)
 	logger.Infof("Giving up waiting for pod %s in namespace %s to be running", name, namespace)
 	return false
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

We know create 4 secrets containing 4 ceph keys where each of them have
limited permissions to access the cluster.

Closes: https://github.com/rook/rook/issues/4074
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4074

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
