### PR TITLE
Issue 4073 configure rgw non ec pool as metadata

### DIFF
--- a/design/object-bucket.md
+++ b/design/object-bucket.md
@@ -62,7 +62,7 @@ kubectl create -f object-store.yaml
 ```
 
 At this point the Rook operator recognizes that a new object store resource needs to be configured. The operator will create all of the resources to start the object store.
-1. Metadata pools are created (`.rgw.root`, `my-store.rgw.control`, `my-store.rgw.meta`, `my-store.rgw.log`, `my-store.rgw.buckets.index`)
+1. Metadata pools are created (`.rgw.root`, `my-store.rgw.control`, `my-store.rgw.meta`, `my-store.rgw.log`, `my-store.rgw.buckets.index`, `my-store.rgw.buckets.non-ec`)
 1. The data pool is created (`my-store.rgw.buckets.data`)
 1. A Ceph realm is created
 1. A Ceph zone group is created in the new realm

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -39,6 +39,7 @@ var (
 		"rgw.meta",
 		"rgw.log",
 		"rgw.buckets.index",
+		"rgw.buckets.non-ec",
 	}
 	dataPools = []string{
 		"rgw.buckets.data",

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -154,7 +154,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 	// Delete an object store
 	err := deleteRealmAndPools(context, false)
 	assert.Nil(t, err)
-	expectedPoolsDeleted := 5
+	expectedPoolsDeleted := 6
 	if expectedDeleteRootPool {
 		expectedPoolsDeleted++
 	}


### PR DESCRIPTION
This is used for S3 multipart uploads and should be configured in the same way as other metadata pools.

**Description of your changes:**
Added the `non-ec` pool to the list of metadata pools to be configured, and updated the list of metadata pools in the design doc.

I haven't added tests as bucket creation is already covered in unit testing by `TestCreateObjectStore` in `pkg/operator/ceph/object/rgw_test.go`. 

The only other tests I could think that may be worth adding were: 
- An S3 multipart upload as part of the smoke suite. As per #4073 this would still have passed without this fix (because the replication factor in the integration testing environment is high enough to support the default pool size), so maybe this is a separate issue?
- Some kind of test for the edge case where a cluster only has one OSD.

I'm happy to take advice on tests for this and update the PR as needed.

**Which issue is resolved by this Pull Request:**
Resolves #4073

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [N/A] Unit tests have been added, if necessary.
- [N/A] Integration tests have been added, if necessary.
- [N/A] Pending release notes updated with breaking and/or notable changes, if necessary.
- [N/A] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [N/A] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [N/A ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]