### PR TITLE
ceph: do not hardcode cmd-reporter service account

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -102,7 +102,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 	}
 
 	job := versionReporter.Job()
-	job.Spec.Template.Spec.ServiceAccountName = "rook-ceph-cmd-reporter"
+	job.Spec.Template.Spec.ServiceAccountName = c.Namespace + "-cmd-reporter"
 
 	// Apply the same node selector and tolerations for the ceph version detection as the mon daemons
 	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)


### PR DESCRIPTION
**Description of your changes:**

Previously, the name of the cmd-reporter service account was hardcoded
with 'rook-ceph', the namespace used by default. Let's use the current
namespace so that we know the permission are correct and can avoid
errors like:

Error creating: pods "rook-ceph-detect-version-" is forbidden: error looking up service account default/rook-ceph-cmd-reporter: serviceaccount "rook-ceph-cmd-reporter" not found

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]
