### PR TITLE
Run the distributed test matrix in PRs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,12 +184,11 @@ These options should **not** be used if there are any changes to code which is s
 storage providers. If there is any risk of affecting another storage provider, all tests should
 be executed in the CI.
 
-### [test ceph min]
+### [test full]
 
-By default all the ceph test suites run on all versions of K8s. For more efficient
-CI times, we can choose to run each test suite on only one K8s version by using the tag:
+In master and release builds, all test suites will run on all supported versions of K8s.
+In PR builds, all the test suites will run on some version of K8s. For bigger changes,
+it is recommended to run all test suites on all versions of K8s by using the tag:
 ```
-[test ceph min]
+[test full]
 ```
-
-This option should only be used for changes with lower risk.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,14 +30,18 @@ pipeline {
                     if (body.contains("[all logs]")) {
                           env.getLogs = "all"
                     }
+
+                    if (!body.contains("[test full]")) {
+                        // By default run the min test matrix (all tests run, but will be distributed on different versions of K8s).
+                        // This only affects the PR builds. The master and release builds will always run the full matrix.
+                        env.testArgs = "min-test-matrix"
+                    }
+
                     // extract which specific storage provider to test
                     if (body.contains("[test cassandra]")) {
                         env.testProvider = "cassandra"
                     } else if (body.contains("[test ceph]")) {
                         env.testProvider = "ceph"
-                    } else if (body.contains("[test ceph min]")) {
-                        env.testProvider = "ceph"
-                        env.testArgs = "min-test-matrix"
                     } else if (body.contains("[test cockroachdb]")) {
                         env.testProvider = "cockroachdb"
                     } else if (body.contains("[test edgefs]")) {


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CI runs the integration tests on several versions of K8s. By default the integration tests have all been running on all versions of K8s. With the recent option to run a minimum matrix for ceph tests it has shown to be reliable for PRs and is much faster to have the test distribution. So we will make this the default to run the tests in a distributed way.

Larger or riskier PRs should run the full test suite by the new option:
```
test full
```

Master and release builds will still always run the full set of test suites on all versions of K8s.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
