### PR TITLE
Return explicit errors

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -16,6 +16,8 @@ limitations under the License.
 package clusterd
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 
@@ -54,33 +56,37 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 			// skip device
 			continue
 		}
-		disk := PopulateDeviceInfo(d, executor)
-		if disk == nil {
+		disk, err := PopulateDeviceInfo(d, executor)
+		if err != nil {
+			// skip device
+			logger.Warningf("skipping device %s: %+v", d, err)
 			continue
 		}
-		disk = PopulateDeviceUdevInfo(d, executor, disk)
+		disk, err = PopulateDeviceUdevInfo(d, executor, disk)
+		if err != nil {
+			// go on without udev info
+			logger.Warningf("failed to get udev info for device %s: %+v", d, err)
+		}
 		disks = append(disks, disk)
 	}
 
 	return disks, nil
 }
 
-func PopulateDeviceInfo(d string, executor exec.Executor) *sys.LocalDisk {
+// PopulateDeviceInfo returns the information of the specified block device
+func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error) {
 	diskProps, err := sys.GetDeviceProperties(d, executor)
 	if err != nil {
-		logger.Warningf("skipping device %s: %+v", d, err)
-		return nil
+		return nil, err
 	}
 
 	diskType, ok := diskProps["TYPE"]
 	if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType && diskType != sys.LinearType) {
 		if !ok {
-			logger.Warningf("skipping device %s: diskType is empty", d)
+			return nil, errors.New("diskType is empty")
 		} else {
-			logger.Warningf("skipping device %s: unsupported diskType %+s", d, diskType)
+			return nil, fmt.Errorf("unsupported diskType %+s", diskType)
 		}
-		// unsupported disk type, just continue
-		return nil
 	}
 
 	// get the UUID for disks
@@ -88,8 +94,7 @@ func PopulateDeviceInfo(d string, executor exec.Executor) *sys.LocalDisk {
 	if diskType != sys.PartType {
 		diskUUID, err = sys.GetDiskUUID(d, executor)
 		if err != nil {
-			logger.Warningf("device %s has an unknown uuid. %+v", d, err)
-			return nil
+			return nil, err
 		}
 	}
 
@@ -117,14 +122,14 @@ func PopulateDeviceInfo(d string, executor exec.Executor) *sys.LocalDisk {
 		disk.Parent = val
 	}
 
-	return disk
+	return disk, nil
 }
 
-func PopulateDeviceUdevInfo(d string, executor exec.Executor, disk *sys.LocalDisk) *sys.LocalDisk {
+// PopulateDeviceUdevInfo fills the udev info into the block device information
+func PopulateDeviceUdevInfo(d string, executor exec.Executor, disk *sys.LocalDisk) (*sys.LocalDisk, error) {
 	udevInfo, err := sys.GetUdevInfo(d, executor)
 	if err != nil {
-		logger.Warningf("failed to get udev info for device %s: %+v", d, err)
-		return disk
+		return disk, err
 	}
 	// parse udev info output
 	if val, ok := udevInfo["DEVLINKS"]; ok {
@@ -153,5 +158,5 @@ func PopulateDeviceUdevInfo(d string, executor exec.Executor, disk *sys.LocalDis
 		disk.WWN = val
 	}
 
-	return disk
+	return disk, nil
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -210,7 +210,11 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 		if len(agent.devices) > 1 {
 			return fmt.Errorf("more than one desired device found in case of PVC backed OSDs. we expect exactly one device")
 		}
-		rawDevices = append(rawDevices, clusterd.PopulateDeviceInfo(agent.devices[0].Name, context.Executor))
+		rawDevice, err := clusterd.PopulateDeviceInfo(agent.devices[0].Name, context.Executor)
+		if err != nil {
+			return fmt.Errorf("failed to get device info for %s. %+v", agent.devices[0].Name, err)
+		}
+		rawDevices = append(rawDevices, rawDevice)
 	} else {
 		rawDevices, err = clusterd.DiscoverDevices(context.Executor)
 		if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

`PopulateDeviceInfo()` in `pkg/clusterd/disk.go` returns nil as `*sys.LocalDisk` if an error has occurred.
This causes a nil pointer exception at `getAvailableDevices()` in `pkg/daemon/ceph/osd/daemon.go`.
At least the returned value should be checked at the caller.

I added an explicit error to the return value of `PopulateDeviceInfo()`.
This naturally revokes an error check at the caller.

I modified `PopulateDeviceUdevInfo()` in the same file too.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]