### PR TITLE
Edgefs: Rtlfs devices should be more then 3 on all nodes fix

### DIFF
--- a/pkg/operator/edgefs/cluster/cluster_deployment_config.go
+++ b/pkg/operator/edgefs/cluster/cluster_deployment_config.go
@@ -311,7 +311,6 @@ func (c *cluster) validateDeploymentConfig(deploymentConfig edgefsv1.ClusterDepl
 		return err
 	}
 
-	deploymentNodesCount := len(deploymentConfig.DevConfig)
 	if deploymentConfig.TransportKey == edgefsv1.DeploymentRtkvs {
 		if len(c.Spec.Storage.Directories) == 0 {
 			return fmt.Errorf("RTKVS configuration error: storage.directory has to " +
@@ -322,9 +321,12 @@ func (c *cluster) validateDeploymentConfig(deploymentConfig edgefsv1.ClusterDepl
 				" A per-node NVME KVSSD disks list is expected")
 		}
 	} else if deploymentConfig.TransportKey == edgefsv1.DeploymentRtlfs {
-		// Check directories devices count on all nodes
-		if len(c.Spec.Storage.Directories)*deploymentNodesCount < 3 {
-			return fmt.Errorf("Rtlfs devices should be more then 3 on all nodes summary")
+		// Check directories devices count on all nodes for autoRtlfs mode
+		deploymentNodesCount := len(deploymentConfig.DevConfig)
+		if len(c.Spec.Storage.Directories) > 0 {
+			if len(c.Spec.Storage.Directories)*deploymentNodesCount < 3 {
+				return fmt.Errorf("Rtlfs devices should be more then 3 on all nodes summary")
+			}
 		}
 	} else if deploymentConfig.TransportKey == edgefsv1.DeploymentRtrd {
 		// Check all deployment nodes has available disk devices


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If no devices specified in cluster.yaml then autoRtlfs mode should be selected and 4 folders should be created on each node
**Which issue is resolved by this Pull Request:**
Resolves #4103 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
