### PR TITLE
ceph: mgr do not override annotation

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	rookcephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
@@ -80,16 +81,11 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
 		podSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
 	c.annotations.ApplyToObjectMeta(&podSpec.ObjectMeta)
+	c.applyPrometheusAnnotations(&podSpec.ObjectMeta)
 	c.placement.ApplyToPodSpec(&podSpec.Spec)
 
 	replicas := int32(1)
-	if len(c.annotations) == 0 {
-		prometheusAnnotations := map[string]string{
-			"prometheus.io/scrape": "true",
-			"prometheus.io/port":   strconv.Itoa(metricsPort),
-		}
-		podSpec.ObjectMeta.Annotations = prometheusAnnotations
-	}
+
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mgrConfig.ResourceName,
@@ -327,6 +323,19 @@ func (c *Cluster) getPodLabels(daemonName string) map[string]string {
 	// leave "instance" key for legacy usage
 	labels["instance"] = daemonName
 	return labels
+}
+
+func (c *Cluster) applyPrometheusAnnotations(objectMeta *metav1.ObjectMeta) error {
+	if len(c.annotations) == 0 {
+		t := rookalpha.Annotations{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   strconv.Itoa(metricsPort),
+		}
+
+		t.ApplyToObjectMeta(objectMeta)
+	}
+
+	return nil
 }
 
 func (c *Cluster) cephMgrOrchestratorModuleEnvs() []v1.EnvVar {


### PR DESCRIPTION
**Description of your changes:**

The current implementation was overriding any previous annotations set on
the object meta.
Moving the logic to its own method as well as adding unit tests.

Closes: https://github.com/rook/rook/issues/4106
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4106

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
