### PR TITLE
Add NET_ADMIN to corosync container capabilities

### DIFF
--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -57,7 +57,7 @@ func (c *Cluster) makeCorosyncContainer(containerImage string) v1.Container {
 		RunAsUser:              &runAsUser,
 		ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 		Capabilities: &v1.Capabilities{
-			Add: []v1.Capability{"SYS_NICE", "IPC_LOCK"},
+			Add: []v1.Capability{"SYS_NICE", "IPC_LOCK", "NET_ADMIN"},
 		},
 	}
 


### PR DESCRIPTION
**Description of your changes:**

CAP_NET_ADMIN capability added to corosync container in edgefs's operator

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/Nexenta/edgefs/issues/393

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test edgefs]