### PR TITLE
Ceph: fix the config overrides for osds

### DIFF
--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -155,6 +155,15 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 		return "", fmt.Errorf("failed to add admin client config section, %+v", err)
 	}
 
+	// if there's a config file override path given, process the given config file
+	if context.ConfigFileOverride != "" {
+		err := configFile.Append(context.ConfigFileOverride)
+		if err != nil {
+			// log the config file override failure as a warning, but proceed without it
+			logger.Warningf("failed to add config file override from '%s': %+v", context.ConfigFileOverride, err)
+		}
+	}
+
 	// write the entire config to disk
 	filePath := GetConfFilePath(pathRoot, cluster.Name)
 	logger.Infof("writing config file %s", filePath)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -244,6 +244,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			"--id", osdID,
 			"--fsid", c.clusterInfo.FSID,
 			"--cluster", "ceph",
+			"--conf", osd.Config,
 			"--setuser", "ceph",
 			"--setgroup", "ceph",
 			// Set '--setuser-match-path' so that existing directory owned by root won't affect the daemon startup.

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -48,8 +48,8 @@ const (
 	// ConfigOverrideVal config override value
 	ConfigOverrideVal = "config"
 	defaultVersion    = "rook/rook:latest"
-	configMountDir    = "/etc/rook/config"
-	overrideFilename  = "override.conf"
+	configMountDir    = "/etc/ceph"
+	overrideFilename  = "ceph.conf"
 )
 
 // ConfigOverrideMount is an override mount


### PR DESCRIPTION
Signed-off-by: travisn <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD daemons configured with `ceph-volume` were not picking up the config overrides from /etc/ceph/ceph.conf as expected. This change applies the overrides into /var/lib/rook/osd<id>/rook-ceph.config and then instructs the osd to load the config from that path. Even with this change I'm still not clear if the overrides were properly picked up by the osd or if the osd configured by c-v is finding it somewhere else.

But the expectation was that the osds configured with ceph-volume would pick up the config from /etc/ceph/ceph.conf. That's where the overrides are stored.
@leseb Can you take a closer look at why c-v wasn't loading the overrides from the expected path? The --conf option was removed in [this commit](https://github.com/rook/rook/commit/a4a180b8fb3efba113435b8baedd793aae2f01d9#diff-715ffbe3e68cc184a213d04310c8e811) and it was expected to not be necessary then.

**Which issue is resolved by this Pull Request:**
Resolves #4063 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]