### PR TITLE
adds retry to ObjectUser creation

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -191,7 +191,19 @@ func (c *ObjectStoreUserController) createUser(context *clusterd.Context, u *cep
 
 	user, rgwerr, err := object.CreateUser(objContext, userConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create user %s. RadosGW returned error %d: %+v", u.Name, rgwerr, err)
+		pollErr := wait.Poll(time.Second*15, time.Minute*5, func() (ok bool, err error) {
+			user, rgwerr, err = object.CreateUser(objContext, userConfig)
+			if err != nil {
+				if rgwerr == object.RGWErrorBadData {
+					return true, fmt.Errorf("failed to create rgw user %q. error code %d. %+v", u.Name, rgwerr, err)
+				}
+				return false, nil
+			}
+			return true, nil
+		})
+		if pollErr != nil {
+			return fmt.Errorf("err or timed out while waiting for objectuser %q to be created. %+v", u.Name, pollErr)
+		}
 	}
 
 	// Store the keys in a secret

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -51,13 +51,17 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Object Storage End To End Integration Test - Create Object Store, User,Bucket and read/write to bucket")
 	logger.Infof("Running on Rook Cluster %s", namespace)
 
-	logger.Infof("Step 0 : Create Object Store")
+	logger.Infof("Step 0 : Create Object Store User")
+	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
+
+	logger.Infof("Step 1 : Create Object Store")
 	cobsErr := helper.ObjectClient.Create(namespace, storeName, 3)
+
+	// check that ObjectStore is created
 	require.Nil(s.T(), cobsErr)
 	logger.Infof("Object store created successfully")
 
-	logger.Infof("Step 1 : Create Object Store User")
-	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
+	// check that ObjectUser is created
 	require.Nil(s.T(), cosuErr)
 	logger.Infof("Waiting 10 seconds to ensure user was created")
 	time.Sleep(10 * time.Second)

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -51,16 +51,14 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Object Storage End To End Integration Test - Create Object Store, User,Bucket and read/write to bucket")
 	logger.Infof("Running on Rook Cluster %s", namespace)
 
-	logger.Infof("Step 0 : Create Object Store User")
-	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
-
-	logger.Infof("Step 1 : Create Object Store")
+	logger.Infof("Step 0 : Create Object Store")
 	cobsErr := helper.ObjectClient.Create(namespace, storeName, 3)
-
 	// check that ObjectStore is created
 	require.Nil(s.T(), cobsErr)
 	logger.Infof("Object store created successfully")
 
+	logger.Infof("Step 1 : Create Object Store User")
+	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
 	// check that ObjectUser is created
 	require.Nil(s.T(), cosuErr)
 	logger.Infof("Waiting 10 seconds to ensure user was created")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- retry ObjectUser creation as long as valid input is provided
or it times out. Retry every 15sec for 5min.

- integration test creates ObjectUser before ObjectStore to
ensure that ObjectUser waits for ObjectStore to be created
and available

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/3937

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]