### PR TITLE
ceph: Simplification of addOrRemoveMonitor()

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -247,7 +247,7 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 	// both clusterInfo and mon map are identical so nil is expected
 	changed, err = c.addOrRemoveExternalMonitor(fakeResp)
 	assert.NoError(t, err)
-	assert.False(t, changed)
+	assert.True(t, changed)
 	assert.Equal(t, 1, len(c.ClusterInfo.Monitors))
 
 	//
@@ -283,94 +283,4 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 	assert.True(t, changed)
 	// ClusterInfo should now have 2 monitors
 	assert.Equal(t, 2, len(c.ClusterInfo.Monitors))
-
-	//
-	// TEST 4
-	//
-	// Now let's test the case where the mon is in clusterInfo, part of the monmap but not in quorum!
-	c.ClusterInfo = test.CreateConfigDir(1)
-	fakeResp2 := client.MonStatusResponse{Quorum: []int{1}} // quorum is owned by the mon with the rank 1 and our mon rank is 0
-
-	fakeResp2.MonMap.Mons = []client.MonMapEntry{
-		{
-			Name: "a",
-			Rank: 0,
-		},
-	}
-	fakeResp2.MonMap.Mons[0].PublicAddr = "172.17.0.4:3300"
-	changed, err = c.addOrRemoveExternalMonitor(fakeResp2)
-	assert.NoError(t, err)
-	assert.True(t, changed)
-	assert.Equal(t, 0, len(c.ClusterInfo.Monitors))
-
-}
-
-func TestIsMonInMonMapt(t *testing.T) {
-	fakeResp := client.MonStatusResponse{}
-	fakeResp.MonMap.Mons = []client.MonMapEntry{
-		{
-			Name: "a",
-		},
-		{
-			Name: "b",
-		},
-		{
-			Name: "c",
-		},
-	}
-
-	isIT := isMonInMonMap("a", fakeResp.MonMap.Mons)
-	assert.True(t, isIT)
-	isIT = isMonInMonMap("z", fakeResp.MonMap.Mons)
-	assert.False(t, isIT)
-}
-
-func TestGetMonRankt(t *testing.T) {
-	fakeResp := client.MonStatusResponse{}
-	fakeResp.MonMap.Mons = []client.MonMapEntry{
-		{
-			Name: "a",
-			Rank: 0,
-		},
-		{
-			Name: "b",
-			Rank: 1,
-		},
-		{
-			Name: "c",
-			Rank: 2,
-		},
-	}
-
-	isIT := getMonRank("a", fakeResp.MonMap.Mons)
-	assert.Equal(t, 0, isIT)
-	isIT = getMonRank("b", fakeResp.MonMap.Mons)
-	assert.Equal(t, 1, isIT)
-	isIT = getMonRank("z", fakeResp.MonMap.Mons)
-	assert.Equal(t, -1, isIT)
-}
-
-func TestIsMonInQuorum(t *testing.T) {
-	fakeResp := client.MonStatusResponse{Quorum: []int{0, 1}}
-	fakeResp.MonMap.Mons = []client.MonMapEntry{
-		{
-			Name: "a",
-			Rank: 0,
-		},
-		{
-			Name: "b",
-			Rank: 1,
-		},
-		{
-			Name: "c",
-			Rank: 2,
-		},
-	}
-
-	isIT := isMonInQuorum("a", fakeResp.MonMap.Mons, fakeResp.Quorum)
-	assert.True(t, isIT)
-	isIT = isMonInQuorum("c", fakeResp.MonMap.Mons, fakeResp.Quorum)
-	assert.False(t, isIT)
-	isIT = isMonInQuorum("z", fakeResp.MonMap.Mons, fakeResp.Quorum)
-	assert.False(t, isIT)
 }


### PR DESCRIPTION
Signed-off-by: Rajat Singh  rajasing@redhat.com

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
ceph: Simplification of addOrRemoveMonitor() 
Modified `addOrRemoveMonitor()` such a way that `clusterInfo` will get cleaned every time the function is being called and then get populated with `status.MonMap.Mons`
**Which issue is resolved by this Pull Request:**
Resolves #3692 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.