### PR TITLE
ceph: ceph-csi version detection #3824

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -341,7 +341,7 @@ func ValidateCSIVersion(namespace string, clientset kubernetes.Interface, csiPlu
 	// To get the version of it is necessary to start with no or invalid parameters and parse the stderr
 	_, stderr, _, err := versionReporter.Run(timeout)
 	if err != nil {
-		return false, fmt.Errorf("failed to complete ceph version job. %+v", err)
+		return false, fmt.Errorf("failed to complete ceph CSI version job. %+v", err)
 	}
 
 	version, err := cephver.ExtractCephCSIVersion(stderr)

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -197,6 +197,10 @@ func (o *Operator) startSystemDaemons(clusterSpec *cephv1.ClusterSpec) error {
 		return fmt.Errorf("invalid csi params: %v", err)
 	}
 
+	if _, err = csi.ValidateCSIVersion(o.operatorNamespace, o.context.Clientset, csi.DefaultCSIPluginImage, o.rookImage, o.securityAccount); err != nil {
+		return fmt.Errorf("invalid csi version: %v", err)
+	}
+
 	if err = csi.StartCSIDrivers(o.operatorNamespace, o.context.Clientset, serverVersion); err != nil {
 		return fmt.Errorf("failed to start Ceph csi drivers: %v", err)
 	}


### PR DESCRIPTION
This PR fixes #3824 

This fix adds an additional step to the operator to validate the version of the configured CSI plugin image before the CSI-service gets actually started.