### PR TITLE
Restore --conf option for filestore osds and config override settings

### DIFF
--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -155,6 +155,15 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 		return "", fmt.Errorf("failed to add admin client config section, %+v", err)
 	}
 
+	// if there's a config file override path given, process the given config file
+	if context.ConfigFileOverride != "" {
+		err := configFile.Append(context.ConfigFileOverride)
+		if err != nil {
+			// log the config file override failure as a warning, but proceed without it
+			logger.Warningf("failed to add config file override from '%s': %+v", context.ConfigFileOverride, err)
+		}
+	}
+
 	// write the entire config to disk
 	filePath := GetConfFilePath(pathRoot, cluster.Name)
 	logger.Infof("writing config file %s", filePath)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -177,6 +177,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 	defaultArgs := []string{
 		"--foreground",
 		"--id", osdID,
+		"--conf", osd.Config,
 		"--osd-data", osd.DataPath,
 		"--keyring", osd.KeyringPath,
 		"--cluster", osd.Cluster,

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -48,8 +48,8 @@ const (
 	// ConfigOverrideVal config override value
 	ConfigOverrideVal = "config"
 	defaultVersion    = "rook/rook:latest"
-	configMountDir    = "/etc/rook/config"
-	overrideFilename  = "override.conf"
+	configMountDir    = "/etc/ceph"
+	overrideFilename  = "ceph.conf"
 )
 
 // ConfigOverrideMount is an override mount


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The filestore OSDs in the 1.1 release require the --conf option. In master this was not necessary due to the changes to OSD configuration in #3554. In the release branch we still need to merge the config overrides and specify --conf.

**Which issue is resolved by this Pull Request:**
Resolves #4164 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph min]