### PR TITLE
ceph: use quorum_status instead of mon_status

### DIFF
--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -27,9 +27,9 @@ func TestFinalizeCephCommandArgs(t *testing.T) {
 	clusterName := "rook"
 	configDir := "/var/lib/rook/rook-ceph"
 	expectedCommand := "ceph"
-	args := []string{"mon_status"}
+	args := []string{"quorum_status"}
 	expectedArgs := []string{
-		"mon_status",
+		"quorum_status",
 		"--connect-timeout=15",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
@@ -98,9 +98,9 @@ func TestFinalizeCephCommandArgsClusterDefaultName(t *testing.T) {
 	clusterName := "ceph"
 	configDir := "/etc"
 	expectedCommand := "ceph"
-	args := []string{"mon_status"}
+	args := []string{"quorum_status"}
 	expectedArgs := []string{
-		"mon_status",
+		"quorum_status",
 		"--connect-timeout=15",
 	}
 

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 )
 
-// represents the response from a mon_status mon_command (subset of all available fields, only
+// MonStatusResponse represents the response from a quorum_status mon_command (subset of all available fields, only
 // marshal ones we care about)
 type MonStatusResponse struct {
 	Quorum []int `json:"quorum"`
@@ -60,14 +60,14 @@ type AddrvecEntry struct {
 	Nonce int    `json:"nonce"`
 }
 
-// GetMonStatus calls mon_status mon_command
-func GetMonStatus(context *clusterd.Context, clusterName string, debug bool) (MonStatusResponse, error) {
-	args := []string{"mon_status"}
+// GetMonQuorumStatus calls quorum_status mon_command
+func GetMonQuorumStatus(context *clusterd.Context, clusterName string, debug bool) (MonStatusResponse, error) {
+	args := []string{"quorum_status"}
 	cmd := NewCephCommand(context, clusterName, args)
 	cmd.Debug = debug
 	buf, err := cmd.Run()
 	if err != nil {
-		return MonStatusResponse{}, fmt.Errorf("mon status failed. %+v", err)
+		return MonStatusResponse{}, fmt.Errorf("mon quorum status failed. %+v", err)
 	}
 
 	var resp MonStatusResponse


### PR DESCRIPTION
**Description of your changes:**

In Octopus, this commit
https://github.com/ceph/ceph/pull/30859/commits/c09b82a80a392ccd0da7677c7b424ce5cd3fa5d6
moved the quorum_status command to a socket call. Thus, the `ceph
quorum_status` command does not exist anymore, to use it we need to do
`ceph daemon mon.$ID quorum_status`. However, this command only works
locally so it won't work if we run it from the operator.
The `ceph mon_status` command is a general command that run from
anywhere and returns the mon map, let's use this one on the operator
code.
This is not a breaking change.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
