### PR TITLE
CSI: Add support for CSIDriver object creation

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -256,7 +256,7 @@ below, which you should change to match where your images are located.
 ```yaml
     env:
     - name: ROOK_CSI_CEPH_IMAGE
-        value: "quay.io/cephcsi/cephcsi:v1.2.1"
+        value: "quay.io/cephcsi/cephcsi:v1.2.2"
     - name: ROOK_CSI_REGISTRAR_IMAGE
         value: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
     - name: ROOK_CSI_PROVISIONER_IMAGE

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -1367,6 +1367,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
 # OLM: END CSI CEPHFS CLUSTER ROLE
 # OLM: BEGIN CSI CEPHFS CLUSTER ROLEBINDING
 ---
@@ -1562,6 +1565,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
 # OLM: END CSI RBD CLUSTER ROLE
 # OLM: BEGIN CSI RBD CLUSTER ROLEBINDING
 ---

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -67,6 +67,7 @@ spec:
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--registercsidriver={{ .CSIDriverRegistration }}"
           env:
             - name: POD_IP
               valueFrom:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -83,6 +83,7 @@ spec:
             - "--metricsport={{ .RBDGRPCMetricsPort }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
+            - "--registercsidriver={{ .CSIDriverRegistration }}"
           env:
             - name: POD_IP
               valueFrom:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -258,6 +258,9 @@ spec:
         #  value: "9090"
         #- name: CSI_RBD_LIVENESS_METRICS_PORT
         #  value: "9080"
+        # CSIDriver object creation in kubernetes.
+        #- name: CSI_DRIVER_REGISTRATION
+        #  value: "false"
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "true"
         # The name of the node to pass with the downward API

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -184,6 +184,9 @@ spec:
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"
+        # CSIDriver object creation in kubernetes.
+        #- name: CSI_DRIVER_REGISTRATION
+        #  value: "false"
         # (Optional) Ceph Provisioner NodeAffinity.
         # - name: CSI_PROVISIONER_NODE_AFFINITY
         #   value: "role=storage-node; storage=rook, ceph"

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
@@ -243,6 +243,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -401,6 +404,9 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This will be helpful to list the CSI drivers deployed in the kubernetes cluster. if we have N number of
CSI drivers deployed in the cluster, the user can query `kubectl get csidriver` and get  the list of
registered CSI drivers and it requires kube 1.14+ and also the functionality is disabled by default

More info here: https://github.com/ceph/ceph-csi/pull/698

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[skip ci]