### PR TITLE
ceph: revert "CSI: Add support for CSIDriver object creation"

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -256,7 +256,7 @@ below, which you should change to match where your images are located.
 ```yaml
     env:
     - name: ROOK_CSI_CEPH_IMAGE
-        value: "quay.io/cephcsi/cephcsi:v1.2.2"
+        value: "quay.io/cephcsi/cephcsi:v1.2.1"
     - name: ROOK_CSI_REGISTRAR_IMAGE
         value: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
     - name: ROOK_CSI_PROVISIONER_IMAGE

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -1367,9 +1367,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
 # OLM: END CSI CEPHFS CLUSTER ROLE
 # OLM: BEGIN CSI CEPHFS CLUSTER ROLEBINDING
 ---
@@ -1565,9 +1562,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
 # OLM: END CSI RBD CLUSTER ROLE
 # OLM: BEGIN CSI RBD CLUSTER ROLEBINDING
 ---

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -67,7 +67,6 @@ spec:
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
-            - "--registercsidriver={{ .CSIDriverRegistration }}"
           env:
             - name: POD_IP
               valueFrom:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -83,7 +83,6 @@ spec:
             - "--metricsport={{ .RBDGRPCMetricsPort }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
-            - "--registercsidriver={{ .CSIDriverRegistration }}"
           env:
             - name: POD_IP
               valueFrom:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -258,9 +258,6 @@ spec:
         #  value: "9090"
         #- name: CSI_RBD_LIVENESS_METRICS_PORT
         #  value: "9080"
-        # CSIDriver object creation in kubernetes.
-        #- name: CSI_DRIVER_REGISTRATION
-        #  value: "false"
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "true"
         # The name of the node to pass with the downward API

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -184,9 +184,6 @@ spec:
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"
-        # CSIDriver object creation in kubernetes.
-        #- name: CSI_DRIVER_REGISTRATION
-        #  value: "false"
         # (Optional) Ceph Provisioner NodeAffinity.
         # - name: CSI_PROVISIONER_NODE_AFFINITY
         #   value: "role=storage-node; storage=rook, ceph"

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-create.yaml
@@ -243,9 +243,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -404,9 +401,6 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["csidrivers"]
-    verbs: ["create", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -19,7 +19,6 @@ package csi
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
@@ -37,7 +36,6 @@ type Param struct {
 	SnapshotterImage          string
 	DriverNamePrefix          string
 	EnableCSIGRPCMetrics      string
-	CSIDriverRegistration     string
 	KubeletDirPath            string
 	CephFSGRPCMetricsPort     uint16
 	CephFSLivenessMetricsPort uint16
@@ -82,7 +80,7 @@ var (
 // manually challenging.
 var (
 	// image names
-	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v1.2.2"
+	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v1.2.1"
 	DefaultRegistrarImage   = "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
 	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.3.0"
 	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
@@ -197,13 +195,10 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 
 	tp.RBDGRPCMetricsPort = getPortFromENV("CSI_RBD_GRPC_METRICS_PORT", DefaultRBDGRPCMerticsPort)
 	tp.RBDLivenessMetricsPort = getPortFromENV("CSI_RBD_LIVENESS_METRICS_PORT", DefaultRBDLivenessMerticsPort)
-	//csi registration requires kubernetes 1.14+ version
-	csiObj := os.Getenv("CSI_DRIVER_REGISTRATION") != "false"
+
 	if ver.Minor < provDeploymentSuppVersion {
 		deployProvSTS = true
-		csiObj = false
 	}
-	tp.CSIDriverRegistration = fmt.Sprintf("%t", csiObj)
 
 	if EnableRBD {
 		rbdPlugin, err = templateToDaemonSet("rbdplugin", RBDPluginTemplatePath, tp)


### PR DESCRIPTION
I merged https://github.com/rook/rook/pull/4169 too quickly and didn't
noticed we were supposed to wait for csi 1.2.2.

This reverts commit 520ad44d71a23342913e8a84862bdd6d85fad01f.

Signed-off-by: Sébastien Han <seb@redhat.com>

[skip ci]