### PR TITLE
CSI: Add support for CSIDriver object creation

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -293,6 +293,7 @@ below, which you should change to match where your images are located.
         value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
     - name: ROOK_CSI_SNAPSHOTTER_IMAGE
         value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+    #ROOK_CSI_ATTACHER_IMAGE is required if Kubernetes version is 1.13.x
     - name: ROOK_CSI_ATTACHER_IMAGE
         value: "quay.io/k8scsi/csi-attacher:v1.2.0"
 ```

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -165,6 +165,12 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -81,6 +81,7 @@ csi:
     #image: quay.io/k8scsi/csi-provisioner:v1.3.0
   #snapshotter:
     #image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+  # attacher is required if Kubernetes version is 1.13.x
   #attacher:
     #image: quay.io/k8scsi/csi-attacher:v1.2.0
 

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -702,6 +702,12 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -16,22 +16,6 @@ spec:
     spec:
       serviceAccount: rook-csi-cephfs-provisioner-sa
       containers:
-        - name: csi-attacher
-          image: {{ .AttacherImage }}
-          args:
-            - "--v=5"
-            - "--csi-address=$(ADDRESS)"
-            - "--leader-election=true"
-            - "--timeout=150s"
-            - "--leader-election-type=leases"
-            - "--leader-election-namespace={{ .Namespace }}"
-          env:
-            - name: ADDRESS
-              value: /csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
         - name: csi-provisioner
           image: {{ .ProvisionerImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -33,22 +33,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: csi-rbdplugin-attacher
-          image: {{ .AttacherImage }}
-          args:
-            - "--v=5"
-            - "--timeout=150s"
-            - "--csi-address=$(ADDRESS)"
-            - "--leader-election=true"
-            - "--leader-election-type=leases"
-            - "--leader-election-namespace={{ .Namespace }}"
-          env:
-            - name: ADDRESS
-              value: /csi/csi-provisioner.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
         - name: csi-snapshotter
           image:  {{ .SnapshotterImage }}
           args:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -179,6 +179,7 @@ spec:
         #  value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
         #- name: ROOK_CSI_SNAPSHOTTER_IMAGE
         #  value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+        # ROOK_CSI_ATTACHER_IMAGE is required if Kubernetes version is 1.13.x
         #- name: ROOK_CSI_ATTACHER_IMAGE
         #  value: "quay.io/k8scsi/csi-attacher:v1.2.0"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -24,6 +24,9 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8scsi "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 )
@@ -196,7 +199,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	tp.RBDGRPCMetricsPort = getPortFromENV("CSI_RBD_GRPC_METRICS_PORT", DefaultRBDGRPCMerticsPort)
 	tp.RBDLivenessMetricsPort = getPortFromENV("CSI_RBD_LIVENESS_METRICS_PORT", DefaultRBDLivenessMerticsPort)
 
-	if ver.Minor < provDeploymentSuppVersion {
+	if ver.Major > KubeMinMajor || (ver.Major == KubeMinMajor && ver.Minor < provDeploymentSuppVersion) {
 		deployProvSTS = true
 	}
 
@@ -311,5 +314,44 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 			return fmt.Errorf("failed to create rbd service: %+v\n%+v", err, cephfsService)
 		}
 	}
+
+	if ver.Major > KubeMinMajor || (ver.Major == KubeMinMajor && ver.Minor >= provDeploymentSuppVersion) {
+		err = createCSIDriverInfo(clientset, RBDDriverName)
+		if err != nil {
+			return fmt.Errorf("failed to create CSI driver object for %q: %+v", RBDDriverName, err)
+		}
+		err = createCSIDriverInfo(clientset, CephFSDriverName)
+		if err != nil {
+			return fmt.Errorf("failed to create CSI driver object for %q: %+v", CephFSDriverName, err)
+		}
+	}
 	return nil
+}
+
+// createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
+func createCSIDriverInfo(clientset kubernetes.Interface, name string) error {
+	attach := false
+	mountInfo := false
+	// Create CSIDriver object
+	csiDriver := &k8scsi.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: k8scsi.CSIDriverSpec{
+			AttachRequired: &attach,
+			PodInfoOnMount: &mountInfo,
+		},
+	}
+	csidrivers := clientset.StorageV1beta1().CSIDrivers()
+	_, err := csidrivers.Create(csiDriver)
+	if err == nil {
+		logger.Infof("CSIDriver object created for driver %q", name)
+		return nil
+	}
+	if apierrors.IsAlreadyExists(err) {
+		logger.Info("CSIDriver CRD already had been registered for %q", name)
+		return nil
+	}
+
+	return err
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -725,6 +725,12 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This will be helpful to list the CSI drivers deployed in the kubernetes cluster. if we have N number of
CSI drivers deployed in the cluster, the user can query `kubectl get csidriver` and get the list of
registered CSI drivers and it requires kube 1.14+ and also the functionality is disabled by default

More info here: ceph/ceph-csi#698

Signed-off-by: Madhu Rajanna madhupr007@gmail.com

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.