### PR TITLE
ceph: add label for CSI deployments/daemonsets/statefulsets

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -254,6 +254,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		if err != nil {
 			return fmt.Errorf("failed to start rbdplugin daemonset: %+v\n%+v", err, rbdPlugin)
 		}
+		k8sutil.AddRookVersionLabelToDaemonSet(rbdPlugin)
 	}
 
 	if rbdProvisionerSTS != nil {
@@ -262,12 +263,14 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		if err != nil {
 			return fmt.Errorf("failed to start rbd provisioner statefulset: %+v\n%+v", err, rbdProvisionerSTS)
 		}
+		k8sutil.AddRookVersionLabelToStatefulSet(rbdProvisionerSTS)
 	} else if rbdProvisionerDeployment != nil {
 		applyToPodSpec(&rbdProvisionerDeployment.Spec.Template.Spec, provisionerNodeAffinity, provisionerTolerations)
 		err = k8sutil.CreateDeployment("csi-rbdplugin-provisioner", namespace, clientset, rbdProvisionerDeployment)
 		if err != nil {
 			return fmt.Errorf("failed to start rbd provisioner deployment: %+v\n%+v", err, rbdProvisionerDeployment)
 		}
+		k8sutil.AddRookVersionLabelToDeployment(rbdProvisionerDeployment)
 	}
 
 	if rbdService != nil {
@@ -283,6 +286,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		if err != nil {
 			return fmt.Errorf("failed to start cephfs plugin daemonset: %+v\n%+v", err, cephfsPlugin)
 		}
+		k8sutil.AddRookVersionLabelToDaemonSet(cephfsPlugin)
 	}
 
 	if cephfsProvisionerSTS != nil {
@@ -291,6 +295,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		if err != nil {
 			return fmt.Errorf("failed to start cephfs provisioner statefulset: %+v\n%+v", err, cephfsProvisionerSTS)
 		}
+		k8sutil.AddRookVersionLabelToStatefulSet(cephfsProvisionerSTS)
 
 	} else if cephfsProvisionerDeployment != nil {
 		applyToPodSpec(&cephfsProvisionerDeployment.Spec.Template.Spec, provisionerNodeAffinity, provisionerTolerations)
@@ -298,6 +303,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		if err != nil {
 			return fmt.Errorf("failed to start cephfs provisioner deployment: %+v\n%+v", err, cephfsProvisionerDeployment)
 		}
+		k8sutil.AddRookVersionLabelToDeployment(cephfsProvisionerDeployment)
 	}
 	if cephfsService != nil {
 		_, err = k8sutil.CreateOrUpdateService(clientset, namespace, cephfsService)

--- a/pkg/operator/k8sutil/statefulset.go
+++ b/pkg/operator/k8sutil/statefulset.go
@@ -37,3 +37,15 @@ func CreateStatefulSet(name, namespace string, clientset kubernetes.Interface, s
 	}
 	return nil
 }
+
+// AddRookVersionLabelToStatefulSet adds or updates a label reporting the Rook version which last
+// modified a apps.statefulset.
+func AddRookVersionLabelToStatefulSet(ss *apps.StatefulSet) {
+	if ss == nil {
+		return
+	}
+	if ss.Labels == nil {
+		ss.Labels = map[string]string{}
+	}
+	addRookVersionLabel(ss.Labels)
+}


### PR DESCRIPTION
Add rook version label to CSI deployments/daemonsets/statefulsets just as the Ceph daemons.

Signed-off-by: Song Gao <2695690803@qq.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Description of your changes:
Add rook-version label for CSI deployments/daemonsets/statefulsets.

Which issue is resolved by this Pull Request:
Resolves #4120

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[test ceph]

