### PR TITLE
NFS: Set correct owner reference for garbage collection

### DIFF
--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -101,16 +101,16 @@ func newNfsServer(c *nfsv1alpha1.NFSServer, context *clusterd.Context) *nfsServe
 		context:   context,
 		namespace: c.Namespace,
 		spec:      c.Spec,
-		ownerRef:  nfsOwnerRef(c.Namespace, string(c.UID)),
+		ownerRef:  nfsOwnerRef(c.Name, string(c.UID)),
 	}
 }
 
-func nfsOwnerRef(namespace, nfsServerID string) metav1.OwnerReference {
+func nfsOwnerRef(name, nfsServerID string) metav1.OwnerReference {
 	blockOwner := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", NFSResource.Group, NFSResource.Version),
 		Kind:               NFSResource.Kind,
-		Name:               namespace,
+		Name:               name,
 		UID:                types.UID(nfsServerID),
 		BlockOwnerDeletion: &blockOwner,
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The owner reference for the NFS custom resource was using the namespace instead of the name. This causes the k8s garbage collector to remove the nfs resources in some scenarios such as restarting etcd. There were related changes in #4090, but nfs was missed at that time.

**Which issue is resolved by this Pull Request:**
Resolves #4142 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
