### PR TITLE
Flex driver should not allow attach before detach on a different node

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/controller_test.go
+++ b/pkg/daemon/ceph/agent/flexvolume/controller_test.go
@@ -503,10 +503,16 @@ func TestOrphanAttachOriginalPodNameSame(t *testing.T) {
 		volumeManager:    &manager.FakeVolumeManager{},
 	}
 
-	// Attach should succeed and the stale volumeattachment record should be updated to reflect the new pod information
+	// Attach should fail because the pod is on a different node
 	devicePath := ""
 	err = controller.Attach(opts, &devicePath)
-	assert.Nil(t, err)
+	assert.Error(t, err)
+
+	// Attach should succeed and the stale volumeattachment record should be updated to reflect the new pod information
+	// since the pod is restarting on the same node
+	os.Setenv(k8sutil.NodeNameEnvVar, "otherNode")
+	err = controller.Attach(opts, &devicePath)
+	assert.NoError(t, err)
 
 	volAtt, err := context.RookClientset.RookV1alpha2().Volumes("rook-system").Get("pvc-123", metav1.GetOptions{})
 	assert.Nil(t, err)
@@ -518,7 +524,7 @@ func TestOrphanAttachOriginalPodNameSame(t *testing.T) {
 			PodName:      opts.Pod,
 			MountDir:     opts.MountDir,
 			ReadOnly:     false,
-			Node:         "node1",
+			Node:         "otherNode",
 		}, volAtt.Attachments,
 	), "Volume crd does not contain expected attachment")
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If a volume is being attached, it should be verified that the volume is safe to attach. The volume was assumed to be safe to attach if it was for the same pod. But this was assuming the pod of the same name would be on the same node. This is true for pods created from deployments, but not for pods that are part of a stateful set. A stateful set will maintain the pod name even as the pod is failed over to a new node. Therefore, the fencing must check if the pod is from the same node before allowing the attach to continue. Otherwise, we need to wait for the volume to be detached from the other node.

The critical part of this change is adding the check for `&& attachment.Node == node`. The other changes are just for readability.

**Which issue is resolved by this Pull Request:**
Resolves #3580 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]