### PR TITLE
FailureDomain/SysRepCount validation

### DIFF
--- a/cluster/examples/kubernetes/edgefs/cluster.yaml
+++ b/cluster/examples/kubernetes/edgefs/cluster.yaml
@@ -142,6 +142,8 @@ spec:
   #    broker: "enp2s0f0"
   #skipHostPrepare: true
   #maxContainerCapacity: 132Ti
+  #sysRepCount: 1                  # SystemReplicationCount [1..n](default is 3)
+  #failureDomain: "device"         # Cluster's failureDomain ["device", "host", "zone"] (default is "host")
   #trlogProcessingInterval: 2      # set transaction log processing interval to 2s to speed up ISGW Link delivery
   #trlogKeepDays: 2                # keep up to 2 days of transaction log interval batches to reduce local storage overhead
   #useHostLocalTime: true

--- a/pkg/apis/edgefs.rook.io/v1/cluster.go
+++ b/pkg/apis/edgefs.rook.io/v1/cluster.go
@@ -47,6 +47,55 @@ func (deploymentConfig *ClusterDeploymentConfig) GetRtlfsDevices() []RtlfsDevice
 	return rtlfsDevices
 }
 
+func (deploymentConfig *ClusterDeploymentConfig) GetRtkvsDevicesCount() int {
+	rtkvsDevicesCount := 0
+	for _, devConfig := range deploymentConfig.DevConfig {
+		if devConfig.IsGatewayNode {
+			continue
+		}
+		rtkvsDevicesCount += len(devConfig.Rtkvs.Devices)
+	}
+	return rtkvsDevicesCount
+}
+
+func (deploymentConfig *ClusterDeploymentConfig) GetRtrdDevicesCount() int {
+	rtrdsDevicesCount := 0
+	for _, devConfig := range deploymentConfig.DevConfig {
+		if devConfig.IsGatewayNode {
+			continue
+		}
+		rtrdsDevicesCount += len(devConfig.Rtrd.Devices)
+		for _, slave := range devConfig.RtrdSlaves {
+			rtrdsDevicesCount += len(slave.Devices)
+		}
+	}
+	return rtrdsDevicesCount
+}
+
+func (deploymentConfig *ClusterDeploymentConfig) GetTargetsCount() int {
+	targets := 0
+	for _, devConfig := range deploymentConfig.DevConfig {
+		if devConfig.IsGatewayNode {
+			continue
+		}
+		targets++
+	}
+	return targets
+}
+
+func (deploymentConfig *ClusterDeploymentConfig) GetRtrdContainersCount() int {
+
+	containers := 0
+	for _, devConfig := range deploymentConfig.DevConfig {
+		if devConfig.IsGatewayNode {
+			continue
+		}
+		// 1 is main target container
+		containers += 1 + len(devConfig.RtrdSlaves)
+	}
+	return containers
+}
+
 func (deploymentConfig *ClusterDeploymentConfig) CompatibleWith(newConfig ClusterDeploymentConfig) (bool, error) {
 	if deploymentConfig.DeploymentType != newConfig.DeploymentType {
 		return false, fmt.Errorf("DeploymentType `%s` != `%s` for updated cluster configuration", deploymentConfig.DeploymentType, newConfig.DeploymentType)

--- a/pkg/operator/edgefs/cluster/utils.go
+++ b/pkg/operator/edgefs/cluster/utils.go
@@ -246,6 +246,7 @@ func (c *cluster) PrintDeploymentConfig(deploymentConfig *edgefsv1.ClusterDeploy
 			logger.Infof("\t\tContainer[0] Path: /mnt/disks/disk0")
 			logger.Infof("\t\tContainer[0] Path: /mnt/disks/disk1")
 			logger.Infof("\t\tContainer[0] Path: /mnt/disks/disk2")
+			logger.Infof("\t\tContainer[0] Path: /mnt/disks/disk3")
 		default:
 			logger.Errorf("[%s] Unknown DeploymentType '%s'", c.Namespace, deploymentConfig.DeploymentType)
 		}


### PR DESCRIPTION
Signed-off-by: Anton Skriptsov <sabbotagge@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add advanced validation for fialureDomain,sysRepCount cluster spec props during applayng it to current cluster configuration
**Which issue is resolved by this Pull Request:**
Resolves #4181

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
