### PR TITLE
ceph: fix set mgr annotations

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -103,6 +103,7 @@ func New(
 		context:           context,
 		Namespace:         namespace,
 		placement:         placement,
+		annotations:       annotations,
 		rookVersion:       rookVersion,
 		cephVersion:       cephVersion,
 		Replicas:          1,

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -62,7 +62,7 @@ func TestStartMGR(t *testing.T) {
 		"myversion",
 		cephv1.CephVersionSpec{},
 		rookalpha.Placement{},
-		rookalpha.Annotations{},
+		rookalpha.Annotations{"my": "annotation"},
 		cephv1.NetworkSpec{},
 		cephv1.DashboardSpec{Enabled: true, SSL: true},
 		cephv1.MonitoringSpec{Enabled: true, RulesNamespace: ""},
@@ -108,8 +108,9 @@ func validateStart(t *testing.T, c *Cluster) {
 		}
 		logger.Infof("Looking for cephmgr replica %d", i)
 		daemonName := mgrNames[i]
-		_, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
+		d, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
 		assert.Nil(t, err)
+		assert.Equal(t, map[string]string{"my": "annotation"}, d.Spec.Template.Annotations)
 	}
 
 	_, err := c.context.Clientset.CoreV1().Services(c.Namespace).Get("rook-ceph-mgr", metav1.GetOptions{})


### PR DESCRIPTION
Mgr annotation was previously not being set.

Signed-off-by: d-luu <david@davidluu.info>


**Description of your changes:**
Add setting of annotations in mgr pod that was previously missing.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
