### PR TITLE
Generate keyrings before OSD deployment

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -124,7 +124,14 @@ func TestAddRemoveNode(t *testing.T) {
 	clusterInfo := &cephconfig.ClusterInfo{
 		CephVersion: cephver.Nautilus,
 	}
-	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
+	generateKey := "expected key"
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return "{\"key\": \"" + generateKey + "\"}", nil
+		},
+	}
+
+	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: executor}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
 		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// kick off the start of the orchestration in a goroutine

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -67,6 +67,7 @@ func TestGenerateKey(t *testing.T) {
 	failGenerateKey = true
 	_, e = s.GenerateKey("newuser", []string{"new", "access"})
 	assert.Error(t, e)
+
 }
 
 func TestKeyringStore(t *testing.T) {
@@ -102,6 +103,11 @@ func TestKeyringStore(t *testing.T) {
 
 	// update a key
 	k.CreateOrUpdate("second-resource", "lkjhgfdsa")
+	assertKeyringData("test-resource-keyring", "qwertyuiop")
+	assertKeyringData("second-resource-keyring", "lkjhgfdsa")
+
+	// update a key with a sentinel value to keep the current keyring
+	k.CreateOrUpdate("second-resource", ReplaceKeyring)
 	assertKeyringData("test-resource-keyring", "qwertyuiop")
 	assertKeyringData("second-resource-keyring", "lkjhgfdsa")
 


### PR DESCRIPTION
Generating keyrings after deployments created a race condition
resulting in intermittent OSD pod failure on the first attempt.
This change creates keyrings prior to creation of OSD deployments
and updates the owner after the creation of a deployment.

Fixes: rook#4089
