### PR TITLE
Close stale pull requests if no activity

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,5 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-# Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 90
-
-# Number of days of inactivity before a stale Issue or Pull Request is closed.
-# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
-
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - security
@@ -21,19 +14,29 @@ exemptMilestones: false
 # Label to use when marking as stale
 staleLabel: wontfix
 
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-
-# Comment to post when closing a stale Issue or Pull Request.
-closeComment: >
-  This issue has been automatically closed due to inactivity. Please re-open
-  if this still requires investigation.
-
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 30
+limitPerRun: 5
 
-# Limit to only `issues` or `pulls`
-only: issues
+# Specify configuration settings that are specific to issues
+issues:
+  daysUntilStale: 90
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed in a week if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: >
+    This issue has been automatically closed due to inactivity. Please re-open
+    if this still requires investigation.
+
+# Specify configuration settings that are specific to PRs
+pulls:
+  daysUntilStale: 180
+  daysUntilClose: 30
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed in a month if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: >
+    This pull request has been automatically closed due to inactivity. Please re-open
+    if these changes are still required.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Issues are already being marked as stale if there is no activity for 90 days and then closed after a week. Pull requests have not been closed automatically. While all contributions are valued, if a PR is not getting attention for a long period of time, it is not adding any value and requires attention to move forward. 

This change will cause pull requests to be marked as stale after six months of inactivity. If there is no further activity, the PR will be closed after one more month.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]