### PR TITLE
ceph: Generate keyrings before OSD deployment

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -124,7 +124,14 @@ func TestAddRemoveNode(t *testing.T) {
 	clusterInfo := &cephconfig.ClusterInfo{
 		CephVersion: cephver.Nautilus,
 	}
-	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
+	generateKey := "expected key"
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName string, command string, outFileArg string, args ...string) (string, error) {
+			return "{\"key\": \"" + generateKey + "\"}", nil
+		},
+	}
+
+	c := New(clusterInfo, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: executor}, "ns-add-remove", "myversion", cephv1.CephVersionSpec{},
 		storageSpec, "/foo", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, metav1.OwnerReference{}, false, false)
 
 	// kick off the start of the orchestration in a goroutine

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -85,7 +85,7 @@ func (k *SecretStore) GenerateKey(user string, access []string) (string, error) 
 
 // CreateOrUpdate creates or updates the keyring secret for the resource with the keyring specified.
 // WARNING: Do not use "rook-ceph-admin" as the resource name; conflicts with the AdminStore.
-func (k *SecretStore) CreateOrUpdate(resourceName, keyring string) error {
+func (k *SecretStore) CreateOrUpdate(resourceName string, keyring string) error {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keyringSecretName(resourceName),
@@ -126,6 +126,7 @@ func (k *SecretStore) CreateSecret(secret *v1.Secret) error {
 		}
 		return fmt.Errorf("failed to get secret for %s. %+v", secretName, err)
 	}
+
 	logger.Debugf("updating secret for %s", secretName)
 	if _, err := k.context.Clientset.CoreV1().Secrets(k.namespace).Update(secret); err != nil {
 		return fmt.Errorf("failed to update secret for %s. %+v", secretName, err)


### PR DESCRIPTION
**Description of your changes:**

Generating keyrings after deployments created a race condition
resulting in intermittent OSD pod failure on the first attempt.
This change creates keyrings prior to creation of OSD deployments
and updates the owner after the creation of a deployment.

Signed-off-by: Elise Gafford <egafford@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #4089

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
