### PR TITLE
ceph: helm: fix operator chart rbdGrpcMetricsPort

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -95,40 +95,57 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter                    | Description                                                                                             | Default                                                |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`           | Image                                                                                                   | `rook/ceph`                                            |
-| `image.tag`                  | Image tag                                                                                               | `master`                                               |
-| `image.pullPolicy`           | Image pull policy                                                                                       | `IfNotPresent`                                         |
-| `rbacEnable`                 | If true, create & use RBAC resources                                                                    | `true`                                                 |
-| `pspEnable`                  | If true, create & use PSP resources                                                                     | `true`                                                 |
-| `resources`                  | Pod resource requests & limits                                                                          | `{}`                                                   |
-| `annotations`                | Pod annotations                                                                                         | `{}`                                                   |
-| `logLevel`                   | Global log level                                                                                        | `INFO`                                                 |
-| `nodeSelector`               | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
-| `tolerations`                | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
-| `currentNamespaceOnly`   | Whether the operator should watch cluster CRD in its own namespace or not                               | `false`                                                 |
-| `hostpathRequiresPrivileged` | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
-| `agent.flexVolumeDirPath`    | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
-| `agent.libModulesDirPath`    | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |
-| `agent.mounts`               | Additional paths to be mounted in the agent container (**)                                              | <none>                                                 |
-| `agent.mountSecurityMode`    | Mount Security Mode for the agent.                                                                      | `Any`                                                  |
-| `agent.toleration`           | Toleration for the agent pods                                                                           | <none>                                                 |
-| `agent.tolerationKey`        | The specific key of the taint to tolerate                                                               | <none>                                                 |
-| `agent.tolerations`          | Array of tolerations in YAML format which will be added to agent deployment                             | <none>                                                 |
-| `agent.nodeAffinity`         | The node labels for affinity of `rook-agent` (***)                                                      | <none>                                                 |
-| `discover.toleration`        | Toleration for the discover pods                                                                        | <none>                                                 |
-| `discover.tolerationKey`     | The specific key of the taint to tolerate                                                               | <none>                                                 |
-| `discover.tolerations`       | Array of tolerations in YAML format which will be added to discover deployment                          | <none>                                                 |
-| `discover.nodeAffinity`      | The node labels for affinity of `discover-agent` (***)                                                  | <none>                                                 |
-| `mon.healthCheckInterval`    | The frequency for the operator to check the mon health                                                  | `45s`                                                  |
-| `mon.monOutTimeout`          | The time to wait before failing over an unhealthy mon                                                   | `600s`                                                 |
+| Parameter                       | Description                                                                                             | Default                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `image.repository`              | Image                                                                                                   | `rook/ceph`                                            |
+| `image.tag`                     | Image tag                                                                                               | `master`                                               |
+| `image.pullPolicy`              | Image pull policy                                                                                       | `IfNotPresent`                                         |
+| `rbacEnable`                    | If true, create & use RBAC resources                                                                    | `true`                                                 |
+| `pspEnable`                     | If true, create & use PSP resources                                                                     | `true`                                                 |
+| `resources`                     | Pod resource requests & limits                                                                          | `{}`                                                   |
+| `annotations`                   | Pod annotations                                                                                         | `{}`                                                   |
+| `logLevel`                      | Global log level                                                                                        | `INFO`                                                 |
+| `nodeSelector`                  | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
+| `tolerations`                   | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
+| `currentNamespaceOnly`          | Whether the operator should watch cluster CRD in its own namespace or not                               | `false`                                                |
+| `hostpathRequiresPrivileged`    | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
+| `mon.healthCheckInterval`       | The frequency for the operator to check the mon health                                                  | `45s`                                                  |
+| `mon.monOutTimeout`             | The time to wait before failing over an unhealthy mon                                                   | `600s`                                                 |
+| `discover.toleration`           | Toleration for the discover pods                                                                        | <none>                                                 |
+| `discover.tolerationKey`        | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `discover.tolerations`          | Array of tolerations in YAML format which will be added to discover deployment                          | <none>                                                 |
+| `discover.nodeAffinity`         | The node labels for affinity of `discover-agent` (***)                                                  | <none>                                                 |
+| `csi.enableRbdDriver`           | Enable Ceph CSI RBD driver.                                                                             | `true`                                                 |
+| `csi.enableCephfsDriver`        | Enable Ceph CSI CephFS driver.                                                                          | `true`                                                 |
+| `csi.enableGrpcMetrics`         | Enable Ceph CSI GRPC Metrics.                                                                           | `true`                                                 |
+| `csi.provisionerTolerations`    | Array of tolerations in YAML format which will be added to CSI provisioner deployment.                  | <none>                                                 |
+| `csi.provisionerNodeAffinity`   | The node labels for affinity of the CSI provisioner deployment (***)                                    | <none>                                                 |
+| `csi.pluginTolerations`         | Array of tolerations in YAML format which will be added to Ceph CSI plugin DaemonSet                    | <none>                                                 |
+| `csi.pluginNodeAffinity`        | The node labels for affinity of the Ceph CSI plugin DaemonSet (***)                                     | <none>                                                 |
+| `csi.cephfsGrpcMetricsPort`     | CSI CephFS driver GRPC metrics port.                                                                    | `9091`                                                 |
+| `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port.                                                                         | `9081`                                                 |
+| `csi.rbdGrpcMetricsPort`        | Ceph CSI RBD driver GRPC metrics port.                                                                  | `9090`                                                 |
+| `csi.rbdLivenessMetricsPort`    | Ceph CSI RBD driver metrics port.                                                                       | `8080`                                                 |
+| `csi.kubeletDirPath`            | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
+| `csi.cephcsi.image`             | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.1`                       |
+| `csi.registrar.image`           | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |
+| `csi.provisioner.image`         | Kubernetes CSI provisioner image.                                                                       | `quay.io/k8scsi/csi-provisioner:v1.3.0`                |
+| `csi.snapshotter.image`         | Kubernetes CSI snapshotter image.                                                                       | `quay.io/k8scsi/csi-snapshotter:v1.2.0`                |
+| `csi.attacher.image`            | Kubernetes CSI Attacher image.                                                                          | `quay.io/k8scsi/csi-attacher:v1.2.0`                   |
+| `agent.flexVolumeDirPath`       | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
+| `agent.libModulesDirPath`       | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |
+| `agent.mounts`                  | Additional paths to be mounted in the agent container (**)                                              | <none>                                                 |
+| `agent.mountSecurityMode`       | Mount Security Mode for the agent.                                                                      | `Any`                                                  |
+| `agent.toleration`              | Toleration for the agent pods                                                                           | <none>                                                 |
+| `agent.tolerationKey`           | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `agent.tolerations`             | Array of tolerations in YAML format which will be added to agent deployment                             | <none>                                                 |
+| `agent.nodeAffinity`            | The node labels for affinity of `rook-agent` (***)                                                      | <none>                                                 |
 
 &ast; For information on what to set `agent.flexVolumeDirPath` to, please refer to the [Rook flexvolume documentation](flexvolume.md)
 
 &ast; &ast; `agent.mounts` should have this format `mountname1=/host/path:/container/path,mountname2=/host/path2:/container/path2`
 
-&ast; &ast; &ast; `agent.nodeAffinity` and `discover.nodeAffinity` should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
+&ast; &ast; &ast; `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
 
 ### Command Line
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
         - name: CSI_CEPHFS_LIVENESS_METRICS_PORT
           value: {{ .Values.csi.cephfsLivenessMetricsPort | quote }}
 {{- end }}
-{{- if .Values.csi.cephfsrbdGrpcMetricsPort }}
+{{- if .Values.csi.rbdGrpcMetricsPort }}
         - name: CSI_RBD_GRPC_METRICS_PORT
           value: {{ .Values.csi.rbdGrpcMetricsPort | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of your changes:**

ceph: helm: fix operator chart rbdGrpcMetricsPort

This fixes the conditional for the `rbdGrpcMetricsPort` option.
Previously the `rbdGrpcMetricsPort` was useless as it was not used,
instead the Helm chart looked for `cephfsrbdGrpcMetricsPort` option.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

docs: added missing Rook Ceph operator helm values

Added missing csi values of the Rook Ceph operator helm chart to the
documentation.

**Which issue is resolved by this Pull Request:**
Resolves #4177 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]