### PR TITLE
Ceph: use the rook image for drain-canaries.

### DIFF
--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -38,6 +38,7 @@ func (o *Operator) startManager(stopCh <-chan struct{}) {
 	}
 	// options to pass to the controllers
 	controllerOpts := &controllerconfig.Context{
+		RookImage:         o.rookImage,
 		ClusterdContext:   o.context,
 		OperatorNamespace: o.operatorNamespace,
 		ReconcileCanaries: &controllerconfig.LockingBool{},

--- a/pkg/operator/ceph/disruption/controllerconfig/context.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/context.go
@@ -25,6 +25,7 @@ import (
 // Context passed to the controller when associating it with the manager.
 type Context struct {
 	ClusterdContext   *clusterd.Context
+	RookImage         string
 	OperatorNamespace string
 	ReconcileCanaries *LockingBool
 }

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -146,7 +146,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			ObjectMeta: metav1.ObjectMeta{Labels: deploymentLabels},
 			Spec: corev1.PodSpec{
 				NodeSelector: nodeSelector,
-				Containers:   newDoNothingContainers(),
+				Containers:   newDoNothingContainers(r.context.RookImage),
 				Tolerations:  tolerationMapToList(uniqueTolerations),
 			},
 		}
@@ -174,11 +174,11 @@ func tolerationMapToList(tolerationMap map[corev1.Toleration]struct{}) []corev1.
 }
 
 // returns a container that does nothing
-func newDoNothingContainers() []corev1.Container {
+func newDoNothingContainers(rookImage string) []corev1.Container {
 	return []corev1.Container{{
-		Image:   "busybox",
-		Name:    "busybox",
-		Command: []string{"bin/sh"},
-		Args:    []string{"-c", "sleep infinity"},
+		Image:   rookImage,
+		Name:    "sleep",
+		Command: []string{"/tini"},
+		Args:    []string{"--", "sleep", "infinity"},
 	}}
 }


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Previously, the drain-canary used the busybox image. This changes that to the rook/ceph image. This is so that we don't needlessly consume another image that we don't control.

The footprint of running the image should remain small. Even though the image itself is so large, its runtime footprint would be reasonable if it's just loading tini and sleep. The image is necessary on all the nodes running rook/ceph anyway.