### PR TITLE
ceph: osd hide 'restorecon' when necessary

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -58,7 +58,7 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 	}
 
 	// Hide restorecon command, only when hostnetworking is enabled
-	if err := hideRestoreconCommand(context); err != nil {
+	if err := replaceRestoreconCommand(); err != nil {
 		return fmt.Errorf("failed to hide 'restorecon' command. %+v", err)
 	}
 

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -54,7 +54,12 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 	// Update LVM config at runtime
 	if err := updateLVMConfig(context, pvcBackedOSD); err != nil {
-		return fmt.Errorf("sed failure, %+v", err) // fail return here as validation provided by ceph-volume
+		return fmt.Errorf("failed to update lvm configuration file, %+v", err) // fail return here as validation provided by ceph-volume
+	}
+
+	// Hide restorecon command, only when hostnetworking is enabled
+	if err := hideRestoreconCommand(context); err != nil {
+		return fmt.Errorf("failed to hide 'restorecon' command. %+v", err)
 	}
 
 	var volumeGroupName string

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -18,6 +18,9 @@ package osd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
@@ -310,4 +313,47 @@ func TestSanitizeOSDsPerDevice(t *testing.T) {
 func TestGetDatabaseSize(t *testing.T) {
 	assert.Equal(t, 0, getDatabaseSize(0, 0))
 	assert.Equal(t, 2048, getDatabaseSize(4096, 2048))
+}
+
+func TestHideRestoreconCommand(t *testing.T) {
+	os.Setenv("ROOK_HOST_NETWORKING", "false")
+	defer os.Setenv("ROOK_HOST_NETWORKING", "")
+
+	// Should not run if ROOK_HOST_NETWORKING is false
+	err := replaceRestoreconCommand()
+	assert.NoError(t, err)
+
+	// Should not run if /etc/redhat-release does not exist
+	os.Setenv("ROOK_HOST_NETWORKING", "true")
+	err = replaceRestoreconCommand()
+	assert.NoError(t, err)
+
+	// Should run now
+	// Fake redhat-release file
+	f, err := ioutil.TempFile("", "redhat-release")
+	assert.NoError(t, err)
+	defer f.Close()
+	defer os.Remove(f.Name())
+	redHatReleaseFile = f.Name()
+	assert.FileExists(t, redHatReleaseFile)
+
+	// Fake restorecon command
+	ff, err := ioutil.TempFile("", "restorecon")
+	defer ff.Close()
+	defer os.Remove(ff.Name())
+	assert.NoError(t, err)
+	restoreconPath = ff.Name()
+	assert.FileExists(t, restoreconPath)
+
+	restoreconPathNewPath = restoreconPath + ".old"
+	defer os.Remove(restoreconPathNewPath)
+	err = replaceRestoreconCommand()
+	assert.NoError(t, err)
+	assert.FileExists(t, restoreconPathNewPath, "restoreconPath is %q and restoreconPathNewPath is %q", restoreconPath, restoreconPathNewPath)
+
+	r, err := ioutil.ReadFile(restoreconPath)
+	assert.NoError(t, err)
+
+	b := strings.Contains(string(r), "restorecon command was replaced with a no-op")
+	assert.True(t, b, restoreconPath)
 }

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package mon
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // ClusterNameEnvVar is the cluster name environment var
 func ClusterNameEnvVar(name string) v1.EnvVar {
@@ -39,4 +43,9 @@ func SecretEnvVar() v1.EnvVar {
 func AdminSecretEnvVar() v1.EnvVar {
 	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: adminSecretName}
 	return v1.EnvVar{Name: "ROOK_ADMIN_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
+}
+
+// ClusterHostNetworking is the value of the hostnetworking spec
+func ClusterHostNetworking(name bool) v1.EnvVar {
+	return v1.EnvVar{Name: "ROOK_HOST_NETWORKING", Value: strconv.FormatBool(name)}
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -568,6 +568,7 @@ func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, node
 		opmon.EndpointEnvVar(),
 		opmon.SecretEnvVar(),
 		opmon.AdminSecretEnvVar(),
+		opmon.ClusterHostNetworking(c.Network.IsHost()),
 		k8sutil.ConfigDirEnvVar(dataDir),
 		k8sutil.ConfigOverrideEnvVar(),
 		{Name: "ROOK_FSID", ValueFrom: &v1.EnvVarSource{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Some testing on OpenShift has shown that enabling Hostnetworking causes
issues with ceph-volume creating OSD.
This is a pure Red Hat OpenShift downstream issue.

This is meant to be temporary while we are waiting for the Selinux team
to get back to us.

**Which issue is resolved by this Pull Request:**
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1764275

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
