### PR TITLE
Clean up block integration tests more reliably

### DIFF
--- a/tests/integration/ceph_block_test.go
+++ b/tests/integration/ceph_block_test.go
@@ -159,7 +159,8 @@ func (s *CephBlockSuite) statefulSetDataCleanup(namespace, poolName, storageClas
 	// Delete all PVCs
 	s.kh.DeletePvcWithLabel(defaultNamespace, statefulSetName)
 	// Delete storageclass and pool
-	s.testClient.PoolClient.DeleteStorageClass(s.namespace, poolName, storageClassName, reclaimPolicy)
+	s.testClient.PoolClient.DeletePool(s.testClient.BlockClient, s.namespace, poolName)
+	s.testClient.PoolClient.DeleteStorageClass(storageClassName)
 }
 
 func (s *CephBlockSuite) setupPVCs() {
@@ -218,10 +219,13 @@ func (s *CephBlockSuite) TearDownSuite() {
 	s.kh.DeletePods(
 		"setup-block-rwo", "setup-block-rwx", "rwo-block-rw-one", "rwo-block-rw-two", "rwo-block-ro-one",
 		"rwo-block-ro-two", "rwx-block-rw-one", "rwx-block-rw-two", "rwx-block-ro-one", "rwx-block-ro-two")
-	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwo", "rook-ceph-block-rwo", "Delete", s.pvcNameRWO, "ReadWriteOnce")
-	s.testClient.PoolClient.DeleteStorageClassAndPvc(s.namespace, "block-pool-rwx", "rook-ceph-block-rwx", "Delete", s.pvcNameRWX, "ReadWriteMany")
 
-	cleanupDynamicBlockStorage(s.testClient, s.namespace)
+	s.testClient.PoolClient.DeletePvc(s.namespace, s.pvcNameRWO)
+	s.testClient.PoolClient.DeletePvc(s.namespace, s.pvcNameRWX)
+	s.testClient.PoolClient.DeleteStorageClass("rook-ceph-block-rwo")
+	s.testClient.PoolClient.DeleteStorageClass("rook-ceph-block-rwx")
+	s.testClient.PoolClient.DeletePool(s.testClient.BlockClient, s.namespace, "block-pool-rwo")
+	s.testClient.PoolClient.DeletePool(s.testClient.BlockClient, s.namespace, "block-pool-rwx")
 	s.op.Teardown()
 }
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -83,7 +83,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	logger.Infof("Initializing block before the upgrade")
 	setupBlockLite(s.helper, s.k8sh, s.Suite, s.namespace, poolName, storageClassName, blockName, podName, s.op.installer.CephVersion)
 	createPodWithBlock(s.helper, s.k8sh, s.Suite, s.namespace, blockName, podName)
-	defer blockTestDataCleanUp(s.helper, s.k8sh, s.namespace, poolName, storageClassName, blockName, podName)
+	defer blockTestDataCleanUp(s.helper, s.k8sh, s.Suite, s.namespace, poolName, storageClassName, blockName, podName)
 
 	logger.Infof("Initializing file before the upgrade")
 	filesystemName := "upgrade-test-fs"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The block integration tests are a source of intermittent failures in the CI. The PVCs were not being confirmed as removed before the pools were deleted. Then the pool would not be removed since there might still be a block image from the PVC that wasn't deleted yet. Now the tests will ensure the PVCs and their block images are removed before the pool is deleted.

K8s APIs are also called to delete resources during the test instead of recreating entire yaml snippets in order to delete the resources.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]