### PR TITLE
Ceph: fix the deduplication of tolerations collected for the drain-canary

### DIFF
--- a/pkg/operator/ceph/disruption/controllerconfig/toleration.go
+++ b/pkg/operator/ceph/disruption/controllerconfig/toleration.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerconfig
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TolerationSet is a set of unique tolerations.
+type TolerationSet struct {
+	tolerations map[string]corev1.Toleration
+}
+
+// Add adds a toleration to the TolerationSet
+func (t *TolerationSet) Add(toleration corev1.Toleration) {
+	key := getKey(toleration)
+	if len(t.tolerations) == 0 {
+		t.tolerations = make(map[string]corev1.Toleration)
+	}
+	t.tolerations[key] = toleration
+}
+
+func getKey(toleration corev1.Toleration) string {
+	return fmt.Sprintf("%s-%s-%s-%s", toleration.Key, toleration.Operator, toleration.Effect, toleration.Value)
+}
+
+// ToList returns a list of all tolerations in the set. The order will always be the same for the same set.
+func (t *TolerationSet) ToList() []corev1.Toleration {
+	tolerationList := make([]corev1.Toleration, 0)
+	for _, toleration := range t.tolerations {
+		tolerationList = append(tolerationList, toleration)
+	}
+	sort.SliceStable(tolerationList, func(i, j int) bool {
+		a := getKey(tolerationList[i])
+		b := getKey(tolerationList[j])
+		return strings.Compare(a, b) == -1
+	})
+	return tolerationList
+}


### PR DESCRIPTION
The drain canary collects tolerations from OSDs as there are multiple sources
of tolerations and the canary needs to follow the OSD. There was an issue with
the deduplication that caused very frequent updates to the drain-canary toleration.
This rendered it unusable is some scenarios.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Change map key to a string to ensure it is deterministic. The old key was a struct that included a pointer. 
- Sort the outputted list by this key to ensure the order is deterministic.
- Get the tolerations from the deployment instead of the pod as pod tolerations are sometimes modified by the system. We only want user provided tolerations in our deployment.


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]