### PR TITLE
Support all layers of CRUSH map with node labels

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -40,6 +40,7 @@ spec:
   network:
     hostNetwork: false
   storage:
+    topologyAware: true
     storageClassDeviceSets:
     - name: set1
       count: 3

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -120,6 +120,7 @@ spec:
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true
+    topologyAware: true
     deviceFilter:
     location:
     config:

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config provides methods for generating the Ceph config for a Ceph cluster and for
+// producing a "ceph.conf" compatible file from the config as well as Ceph command line-compatible
+// flags.
+package osd
+
+var (
+	// The labels that can be specified with the K8s labels such as failure-domain.beta.kubernetes.io/zone
+	// These are all at the top layers of the CRUSH map.
+	KubernetesTopologyLabels = []string{"zone", "region"}
+
+	// The node labels that are supported with the topology.rook.io prefix such as topology.rook.io/rack
+	CRUSHTopologyLabels = []string{"chassis", "rack", "row", "pdu", "pod", "room", "datacenter"}
+
+	// The list of supported failure domains in the CRUSH map, ordered from lowest to highest
+	CRUSHMapLevelsOrdered = append([]string{"host"}, append(CRUSHTopologyLabels, KubernetesTopologyLabels...)...)
+)

--- a/pkg/operator/ceph/cluster/osd/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config provides methods for generating the Ceph config for a Ceph cluster and for
+// producing a "ceph.conf" compatible file from the config as well as Ceph command line-compatible
+// flags.
+package osd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedCRUSHLabels(t *testing.T) {
+	assert.Equal(t, "host", CRUSHMapLevelsOrdered[0])
+	assert.Equal(t, "chassis", CRUSHMapLevelsOrdered[1])
+	assert.Equal(t, "rack", CRUSHMapLevelsOrdered[2])
+	assert.Equal(t, "row", CRUSHMapLevelsOrdered[3])
+	assert.Equal(t, "pdu", CRUSHMapLevelsOrdered[4])
+	assert.Equal(t, "pod", CRUSHMapLevelsOrdered[5])
+	assert.Equal(t, "room", CRUSHMapLevelsOrdered[6])
+	assert.Equal(t, "datacenter", CRUSHMapLevelsOrdered[7])
+	assert.Equal(t, "zone", CRUSHMapLevelsOrdered[8])
+	assert.Equal(t, "region", CRUSHMapLevelsOrdered[9])
+}

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -31,9 +31,14 @@ import (
 	helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
+const (
+	TopologyLabelPrefix = "topology.rook.io/"
+)
+
 var validTopologyLabelKeys = []string{
 	"failure-domain.beta.kubernetes.io",
 	"failure-domain.kubernetes.io",
+	TopologyLabelPrefix,
 }
 
 // ValidNodeNoSched returns true if the node (1) meets Rook's placement terms,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The node labels were already supported for zones and regions to add to the CRUSH map. Now all layers of the CRUSH map will be supported with the new labels such as `topology.rook.io/rack`. The labels will be detected at the osd startup time similar to the zone and region labels already being detected.

The example cluster.yaml will also have `topologyAware` set to true by default. In the future we should just remove this setting and always use topology labels automatically. This will be done with #4131.  

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[skip ci]