### PR TITLE
test: functional default baseTestDir for remote k8s master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ def RunIntegrationTest(k, v) {
                                   STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
                                   TEST_ARGUMENTS='''+"${env.testArgs}"+'''
                               kubectl config view
-                              _output/tests/linux_amd64/integration -test.v -test.timeout 7200s --host_type '''+"${k}"+''' --logs '''+"${env.getLogs}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
+                              _output/tests/linux_amd64/integration -test.v -test.timeout 7200s --base_test_dir "" --host_type '''+"${k}"+''' --logs '''+"${env.getLogs}"+''' --helm /tmp/rook-tests-scripts-helm/linux-amd64/helm 2>&1 | tee _output/tests/integrationTests.log'''
                     }
                     finally{
                         sh "journalctl -u kubelet > _output/tests/kubelet_${v}.log"

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -26,6 +26,7 @@ type EnvironmentManifest struct {
 	Helm               string
 	RookImageName      string
 	ToolboxImageName   string
+	BaseTestDir        string
 	SkipInstallRook    bool
 	LoadVolumeNumber   int
 	LoadConcurrentRuns int
@@ -43,6 +44,7 @@ func init() {
 	flag.StringVar(&Env.Helm, "helm", "helm", "Path to helm binary")
 	flag.StringVar(&Env.RookImageName, "rook_image", "rook/ceph", "Docker image name for the rook container to install, must be in docker hub or local environment")
 	flag.StringVar(&Env.ToolboxImageName, "toolbox_image", "rook/ceph", "Docker image name of the toolbox container to install, must be in docker hub or local environment")
+	flag.StringVar(&Env.BaseTestDir, "base_test_dir", "/data", "Base test directory, for use only when kubernetes master is running on localhost")
 	flag.BoolVar(&Env.SkipInstallRook, "skip_install_rook", false, "Indicate if Rook need to installed - false if tests are being running at Rook that is pre-installed")
 	flag.IntVar(&Env.LoadConcurrentRuns, "load_parallel_runs", 20, "number of routines for load test")
 	flag.IntVar(&Env.LoadVolumeNumber, "load_volumes", 1, "number of volumes(file,object or block) to be created for load test")
@@ -50,4 +52,5 @@ func init() {
 	flag.StringVar(&Env.LoadSize, "load_size", "medium", "load size for each thread performing operations - small,medium or large.")
 	flag.BoolVar(&Env.EnableChaos, "enable_chaos", false, "used to determine if random pods in a namespace are to be killed during load test.")
 	flag.StringVar(&Env.Logs, "logs", "", "Gather rook logs, eg - all")
+	flag.Parse()
 }

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -19,7 +19,6 @@ package installer
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -77,14 +76,13 @@ func SkipTestSuite(name string) bool {
 }
 
 func init() {
-	// this default will only work if running kubernetes on the local machine
-	baseTestDir, _ = os.Getwd()
-
-	// The following settings could apply to any environment when the kube context is running on the host and the tests are running inside a
-	// VM such as minikube. This is a cheap test for this condition, we need to find a better way to automate these settings.
-	if runtime.GOOS == "darwin" {
+	// If the base test directory is actively set to empty (as in CI), we use the current working directory.
+	baseTestDir = Env.BaseTestDir
+	if baseTestDir == "" {
+		baseTestDir, _ = os.Getwd()
+	}
+	if baseTestDir == "/data" {
 		createBaseTestDir = false
-		baseTestDir = "/data"
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Using the current working directory as the base test directory
fails with an unclear error message when running mkfs for OSDs
if tests are run when the k8s master node is not running on
localhost.

This change creates a new flag for the test suite to set the
base test directory, but uses a default that is safe for
virtualized test environments ("/data").

**Which issue is resolved by this Pull Request:**
Fixes: #4205
Signed-off-by: egafford <egafford@redhat.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
