### PR TITLE
build: resolve yq dependency changes for build pipeline

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -31,7 +31,7 @@ INCLUDE_CSV_TEMPLATES = true
 endif
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
-YQ := $(TOOLS_HOST_DIR)/yq.v2
+YQ := $(TOOLS_HOST_DIR)/yq
 
 # ====================================================================================
 # Build Rook
@@ -66,7 +66,7 @@ $(YQ):
 	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		echo === installing yq $(GOHOST);\
 		mkdir -p $(TOOLS_HOST_DIR)/tmp;\
-		GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get gopkg.in/mikefarah/yq.v2;\
+		GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) GO111MODULE=on $(GOHOST) get -u github.com/mikefarah/yq@d1cec1ad;\
 		rm -fr $(TOOLS_HOST_DIR)/tmp;\
 	fi
 
@@ -75,4 +75,3 @@ $(OPERATOR_SDK):
 		curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM) -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION);\
 		chmod +x $(OPERATOR_SDK);\
         fi
-

--- a/images/cross/Dockerfile
+++ b/images/cross/Dockerfile
@@ -18,6 +18,8 @@ FROM ubuntu:16.04
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yy -q --no-install-recommends \
         awscli \
+        build-essential \
+        bzr \
         ca-certificates \
         curl \
         docker.io \


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Recent dependency changes in yq require that:
1) We pin yq at a commit prior to the introduction of Go 1.13
into the build pipeline
2) We install bzr, which is now required by several dependencies
of yq. This patch adds the package to the dependencies of the
cross container.

**Which issue is resolved by this Pull Request:**

This fix should not be counted as a fix for the need to stabilize
our build dependency on yq. It is only intended to fix the current
pipeline issues.

Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
