### PR TITLE
ceph: added a check for triggering the orchestration

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -335,11 +335,13 @@ func clusterChanged(oldCluster, newCluster cephv1.ClusterSpec, clusterRef *clust
 			// resource.Quantity has non-exportable fields, so we use its comparator method
 			resourceQtyComparer := cmp.Comparer(func(x, y resource.Quantity) bool { return x.Cmp(y) == 0 })
 			diff = cmp.Diff(oldCluster, newCluster, resourceQtyComparer)
-			logger.Infof("The Cluster CR has changed. diff=%s", diff)
 		}()
-		return true, diff
-	}
+		if diff != "" {
+			logger.Infof("The Cluster CR has changed. diff=%s", diff)
+			return true, diff
+		}
 
+	}
 	return false, ""
 }
 


### PR DESCRIPTION
Fix for automatic orchestration triggering even if the cluster CRD is unchanged.

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Added a condition to check if there is any difference while comparing the new and old cluster CRD, the only returns the `true` value.

**Which issue is resolved by this Pull Request:**
Resolves #4201 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
