### PR TITLE
ceph: increase liveness prove check timetout

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -145,6 +145,8 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 				},
 			},
 			InitialDelaySeconds: 10,
+			TimeoutSeconds:      2,
+			PeriodSeconds:       10,
 		},
 		SecurityContext: mon.PodSecurityContext(),
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

During high IOs volume, the rgw might need more time to answer the
liveness probe request.
Let's do a couple of things to mitigate that:

* increase initial delay second to 30, if the container is busy and has
to resume request we should give it more time to initialize
* increase the timeout to 20s, that's really arbitrary
* increase the check interval to 60 to not hammer the rgw too much

Might fix: https://bugzilla.redhat.com/show_bug.cgi?id=1768874
Signed-off-by: Sébastien Han <seb@redhat.com>


**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1768874

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
