### PR TITLE
ceph: relax cr block requirements

### DIFF
--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -143,10 +143,10 @@ func TestValidateSpec(t *testing.T) {
 	err = validateStore(context, s)
 	assert.Nil(t, err)
 
-	// no replication or EC
+	// no replication or EC is valid
 	s.Spec.MetadataPool.Replicated.Size = 0
 	err = validateStore(context, s)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	s.Spec.MetadataPool.Replicated.Size = 1
 	err = validateStore(context, s)
 	assert.Nil(t, err)

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -229,12 +229,10 @@ func ValidatePool(context *clusterd.Context, p *cephv1.CephBlockPool) error {
 	return nil
 }
 
+// ValidatePoolSpec validates the Ceph block pool spec CR
 func ValidatePoolSpec(context *clusterd.Context, namespace string, p *cephv1.PoolSpec) error {
 	if p.Replication() != nil && p.ErasureCode() != nil {
 		return fmt.Errorf("both replication and erasure code settings cannot be specified")
-	}
-	if p.Replication() == nil && p.ErasureCode() == nil {
-		return fmt.Errorf("neither replication nor erasure code settings were specified")
 	}
 
 	var crush ceph.CrushMap

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -30,10 +30,10 @@ import (
 func TestValidatePool(t *testing.T) {
 	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
 
-	// must specify some replication or EC settings
+	// not specifying some replication or EC settings is fine
 	p := cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Name: "mypool", Namespace: "myns"}}
 	err := ValidatePool(context, &p)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 
 	// must specify name
 	p = cephv1.CephBlockPool{ObjectMeta: metav1.ObjectMeta{Namespace: "myns"}}


### PR DESCRIPTION
**Description of your changes:**

The only things that should be required are the name of the pool and the
namespace. We don't need to enforce the replication type as a
requirement.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1767249
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1767249

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
