### PR TITLE
Ceph-volume skip restorecon

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -57,11 +57,6 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 		return fmt.Errorf("failed to update lvm configuration file, %+v", err) // fail return here as validation provided by ceph-volume
 	}
 
-	// Hide restorecon command, only when hostnetworking is enabled
-	if err := replaceRestoreconCommand(); err != nil {
-		return fmt.Errorf("failed to hide 'restorecon' command. %+v", err)
-	}
-
 	var volumeGroupName string
 	if pvcBackedOSD {
 		volumeGroupName, err = getVolumeGroupName(lvPath)

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -38,11 +37,8 @@ import (
 
 // These are not constants because they are used by the tests
 var (
-	cephConfigDir         = "/var/lib/ceph"
-	lvmConfPath           = "/etc/lvm/lvm.conf"
-	restoreconPath        = "/usr/sbin/restorecon"
-	restoreconPathNewPath = restoreconPath + ".old"
-	redHatReleaseFile     = "/etc/redhat-release"
+	cephConfigDir = "/var/lib/ceph"
+	lvmConfPath   = "/etc/lvm/lvm.conf"
 )
 
 const (
@@ -53,10 +49,6 @@ const (
 	dbDeviceFlag         = "--db-devices"
 	cephVolumeCmd        = "ceph-volume"
 	cephVolumeMinDBSize  = 1024 // 1GB
-	restoreconNewContent = `#!/usr/bin/env bash
-echo "restorecon command was replaced with a no-op."
-echo "original restorecon command is now at %s"
-`
 )
 
 func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *DeviceOsdMapping) ([]oposd.OSDInfo, error) {
@@ -80,10 +72,6 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	// Update LVM configuration file
 	if err := updateLVMConfig(context, a.pvcBacked); err != nil {
 		return nil, fmt.Errorf("failed to update lvm configuration file, %+v", err) // fail return here as validation provided by ceph-volume
-	}
-	// Hide restorecon command, only when hostnetworking is enabled
-	if err := replaceRestoreconCommand(); err != nil {
-		return nil, fmt.Errorf("failed to hide 'restorecon' command. %+v", err)
 	}
 	if a.pvcBacked {
 		if lv, err = a.initializeBlockPVC(context, devices); err != nil {
@@ -175,38 +163,6 @@ func updateLVMConfig(context *clusterd.Context, onPVC bool) error {
 	}
 
 	logger.Info("Successfully updated lvm config file")
-	return nil
-}
-
-func replaceRestoreconCommand() error {
-	// Check if Host Networking is enabled
-	hostnetworking := os.Getenv("ROOK_HOST_NETWORKING")
-	if hostnetworking == "false" {
-		logger.Debugf("ROOK_HOST_NETWORKING is %q, not replacing 'restorecon' command", hostnetworking)
-		return nil
-	}
-
-	// Check whether we are running on RHEL
-	// The existence of /etc/redhat-release should be enough
-	_, err := os.Stat(redHatReleaseFile)
-	if os.IsNotExist(err) {
-		logger.Debugf("%q does not exist, not replacing 'restorecon' command, only doing this on red hat systems", redHatReleaseFile)
-		return nil
-	}
-
-	logger.Debugf("renaming %q to %q", restoreconPath, restoreconPathNewPath)
-	err = os.Rename(restoreconPath, restoreconPathNewPath)
-	if err != nil {
-		return fmt.Errorf("failed to rename %q to %q. %+v", restoreconPath, restoreconPathNewPath, err)
-	}
-
-	logger.Debugf("writing new content to %q", restoreconPath)
-	err = ioutil.WriteFile(restoreconPath, []byte(fmt.Sprintf(restoreconNewContent, restoreconPathNewPath)), 0755)
-	if err != nil {
-		return fmt.Errorf("failed to write new content of restorecon to %q. %+v", restoreconPath, err)
-	}
-
-	logger.Infof("Successfully replaced restorecon command to %q", restoreconPathNewPath)
 	return nil
 }
 

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -16,11 +16,7 @@ limitations under the License.
 
 package mon
 
-import (
-	"strconv"
-
-	v1 "k8s.io/api/core/v1"
-)
+import v1 "k8s.io/api/core/v1"
 
 // ClusterNameEnvVar is the cluster name environment var
 func ClusterNameEnvVar(name string) v1.EnvVar {
@@ -43,9 +39,4 @@ func SecretEnvVar() v1.EnvVar {
 func AdminSecretEnvVar() v1.EnvVar {
 	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: adminSecretName}
 	return v1.EnvVar{Name: "ROOK_ADMIN_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
-}
-
-// ClusterHostNetworking is the value of the hostnetworking spec
-func ClusterHostNetworking(name bool) v1.EnvVar {
-	return v1.EnvVar{Name: "ROOK_HOST_NETWORKING", Value: strconv.FormatBool(name)}
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -555,7 +555,6 @@ func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, node
 		opmon.EndpointEnvVar(),
 		opmon.SecretEnvVar(),
 		opmon.AdminSecretEnvVar(),
-		opmon.ClusterHostNetworking(c.Network.IsHost()),
 		k8sutil.ConfigDirEnvVar(dataDir),
 		k8sutil.ConfigOverrideEnvVar(),
 		{Name: "ROOK_FSID", ValueFrom: &v1.EnvVarSource{

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -260,11 +260,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo) (*apps.Dep
 			Name:      "run-udev",
 			MountPath: "/run/udev"})
 
-		// Activate verbose mode for ceph-volume on activate
-		envVars = append(envVars, []v1.EnvVar{
-			{Name: "CEPH_VOLUME_DEBUG", Value: "1"},
-		}...)
-
 	} else if osd.IsDirectory {
 		// config for dir-based osds is gotten from the commandline or from the mon database
 		doConfigInit = false
@@ -563,9 +558,12 @@ func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, node
 				Key:                  "fsid",
 			},
 		}},
-		{Name: "CEPH_VOLUME_DEBUG", Value: "1"},
 		k8sutil.NodeEnvVar(),
 	}
+
+	// Append ceph-volume environment variables
+	envVars = append(envVars, cephVolumeEnvVar()...)
+
 	if storeConfig.StoreType != "" {
 		envVars = append(envVars, v1.EnvVar{Name: osdStoreEnvVarName, Value: storeConfig.StoreType})
 	}
@@ -866,5 +864,12 @@ func (c *Cluster) osdPrepareResources(osdClaimName string) v1.ResourceRequiremen
 			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuRequest, resource.DecimalSI),
 			v1.ResourceMemory: *resource.NewQuantity(memoryRequest, resource.BinarySI),
 		},
+	}
+}
+
+func cephVolumeEnvVar() []v1.EnvVar {
+	return []v1.EnvVar{
+		{Name: "CEPH_VOLUME_DEBUG", Value: "1"},
+		{Name: "CEPH_VOLUME_SKIP_RESTORECON", Value: "1"},
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -365,3 +365,11 @@ func TestOsdPrepareResources(t *testing.T) {
 	assert.Equal(t, "0", r.Limits.Memory().String())
 	assert.Equal(t, "250", r.Requests.Memory().String())
 }
+
+func TestCephVolumeEnvVar(t *testing.T) {
+	cvEnv := cephVolumeEnvVar()
+	assert.Equal(t, "CEPH_VOLUME_DEBUG", cvEnv[0].Name)
+	assert.Equal(t, "1", cvEnv[0].Value)
+	assert.Equal(t, "CEPH_VOLUME_SKIP_RESTORECON", cvEnv[1].Name)
+	assert.Equal(t, "1", cvEnv[1].Value)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This reverts commit d224fbd.
Since ceph/ceph#31421, the monkey patching of
'restorecon' is not needed anymore.

This will tell ceph-volume not to run any restorecon commands by using the new environment variable `CEPH_VOLUME_SKIP_RESTORECON`.
This relies on ceph/ceph#31421

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]