### PR TITLE
kubectl edit should be kubectl patch

### DIFF
--- a/Documentation/disaster-recovery.md
+++ b/Documentation/disaster-recovery.md
@@ -196,7 +196,7 @@ The following `kubectl patch` command is an easy way to do that. In the end it p
 
 ```console
 mon_host=$(kubectl -n rook-ceph get svc rook-ceph-mon-b -o jsonpath='{.spec.clusterIP}')
-kubectl -n rook-ceph edit secret rook-ceph-config -p '{"stringData": {"mon_host": "[v2:'"${mon_host}"':3300,v1:'"${mon_host}"':6789]", "mon_initial_members": "'"${good_mon_id}"'"}}'
+kubectl -n rook-ceph patch secret rook-ceph-config -p '{"stringData": {"mon_host": "[v2:'"${mon_host}"':3300,v1:'"${mon_host}"':6789]", "mon_initial_members": "'"${good_mon_id}"'"}}'
 ```
 
 > **NOTE**: If you are using `hostNetwork: true`, you need to replace the `mon_host` var with the node IP the mon is pinned to (`nodeSelector`). This is because there is no `rook-ceph-mon-*` service created in that "mode".


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

As mentioned in title, the `kubectl edit` command should be `kubectl patch`

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [X] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
