### PR TITLE
Ceph: Fix drain-canary cleanup.

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -22,11 +22,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rook/rook/pkg/operator/ceph/disruption/nodedrain"
+
 	cephClient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -187,6 +190,27 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 	err = r.client.Update(context.TODO(), pdbStateMap)
 	if err != nil {
 		return fmt.Errorf("could not update %s in cluster %s: %+v", pdbStateMapName, request, err)
+	}
+	drainingFailureDomain, ok := pdbStateMap.Data[disabledPDBKey]
+	if ok && clean && len(drainingFailureDomain) > 0 {
+
+		canaryLabels := client.MatchingLabels{k8sutil.AppAttr: nodedrain.CanaryAppName, poolFailureDomain: drainingFailureDomain}
+
+		// list and delete only if it's old
+		drainingCanaryList := &appsv1.DeploymentList{}
+		err := r.client.List(context.TODO(), drainingCanaryList, canaryLabels, client.InNamespace(r.context.OperatorNamespace))
+		if err != nil {
+			return fmt.Errorf("could not list canary pods by labels %s: %+v", canaryLabels, err)
+		}
+		// refresh old canaries in draining failure domain
+		for _, drainingCanary := range drainingCanaryList.Items {
+			if time.Since(drainingCanary.GetCreationTimestamp().Time) > time.Minute && drainingCanary.Status.ReadyReplicas < 1 {
+				err := r.client.Delete(context.TODO(), &drainingCanary)
+				if err != nil {
+					logger.Warningf("could not delete canary deployment %s/%s: %+v", drainingCanary.GetName(), drainingCanary.GetNamespace(), err)
+				}
+			}
+		}
 	}
 	for failureDomain, osdDataList := range allFailureDomainsMap {
 		for _, osdData := range osdDataList {

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -127,11 +127,23 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 	}
+	controllerBool := false
+	blockOwnerDeletionBool := false
 	// Create or Update the deployment default/foo
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sutil.TruncateNodeName(fmt.Sprintf("%s-%%s", CanaryAppName), nodeHostnameLabel),
 			Namespace: r.context.OperatorNamespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         node.APIVersion,
+					Kind:               node.Kind,
+					UID:                node.GetUID(),
+					Name:               node.GetName(),
+					Controller:         &controllerBool,
+					BlockOwnerDeletion: &blockOwnerDeletionBool,
+				},
+			},
 		},
 	}
 

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -127,6 +127,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 			}
 		}
 	}
+
 	controllerBool := false
 	blockOwnerDeletionBool := false
 	// Create or Update the deployment default/foo


### PR DESCRIPTION
The drain canary was not being garbage collected when the node object was deleted. This sometimes prevented drains from proceeding after a node had been deleted.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
