### PR TITLE
ceph: Standardize association of keyrings with deployments

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -55,16 +56,15 @@ func (c *Cluster) dashboardPort() int {
 	return c.dashboard.Port
 }
 
-func (c *Cluster) generateKeyring(m *mgrConfig) error {
+func (c *Cluster) generateKeyring(m *mgrConfig) (string, error) {
 	user := fmt.Sprintf("mgr.%s", m.DaemonID)
 	/* TODO: the access string here does not match the access from the keyring template. should they match? */
 	access := []string{"mon", "allow *", "mds", "allow *", "osd", "allow *"}
-	/* TODO: can we change this ownerref to be the deployment or service? */
 	s := keyring.GetSecretStore(c.context, c.Namespace, &c.ownerRef)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Delete legacy key store for upgrade from Rook v0.9.x to v1.0.x
@@ -78,5 +78,10 @@ func (c *Cluster) generateKeyring(m *mgrConfig) error {
 	}
 
 	keyring := fmt.Sprintf(keyringTemplate, m.DaemonID, key)
-	return s.CreateOrUpdate(m.ResourceName, keyring)
+	return keyring, s.CreateOrUpdate(m.ResourceName, keyring)
+}
+
+func (c *Cluster) associateKeyring(existingKeyring string, d *apps.Deployment) error {
+	s := keyring.GetSecretStoreForDeployment(c.context, d)
+	return s.CreateOrUpdate(d.GetName(), existingKeyring)
 }

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	apps "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -51,15 +50,6 @@ func (c *Cluster) generateKeyring(osdID int) (string, error) {
 }
 
 func (c *Cluster) associateKeyring(existingKeyring string, d *apps.Deployment) error {
-	resourceName := d.GetName()
-
-	ownerRef := &metav1.OwnerReference{
-		UID:        d.UID,
-		APIVersion: "v1",
-		Kind:       "deployment",
-		Name:       resourceName,
-	}
-	s := keyring.GetSecretStore(c.context, c.Namespace, ownerRef)
-
-	return s.CreateOrUpdate(resourceName, existingKeyring)
+	s := keyring.GetSecretStoreForDeployment(c.context, d)
+	return s.CreateOrUpdate(d.GetName(), existingKeyring)
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -443,7 +443,7 @@ func (c *Cluster) startOSDDaemonsOnPVC(pvcName string, config *provisionConfig, 
 			logger.Infof("deployment for osd %d already exists. updating if needed", osd.ID)
 			createdDeployment, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(dp.Name, metav1.GetOptions{})
 			if err != nil {
-				logger.Warningf("failed to get existing OSD deployment %s for update: %+v", dp.Name, err)
+				logger.Warningf("failed to get existing OSD deployment %q for update: %+v", dp.Name, err)
 				continue
 			}
 		}

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,6 +51,21 @@ func GetSecretStore(context *clusterd.Context, namespace string, ownerRef *metav
 	return &SecretStore{
 		context:   context,
 		namespace: namespace,
+		ownerRef:  ownerRef,
+	}
+}
+
+// GetSecretStoreForDeployment returns a new SecretStore struct owned by the provided Deployment.
+func GetSecretStoreForDeployment(context *clusterd.Context, d *apps.Deployment) *SecretStore {
+	ownerRef := &metav1.OwnerReference{
+		UID:        d.UID,
+		APIVersion: "v1",
+		Kind:       "deployment",
+		Name:       d.GetName(),
+	}
+	return &SecretStore{
+		context:   context,
+		namespace: d.GetNamespace(),
 		ownerRef:  ownerRef,
 	}
 }

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -63,15 +63,6 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 }
 
 func (c *Cluster) associateKeyring(existingKeyring string, d *apps.Deployment) error {
-	resourceName := d.GetName()
-
-	ownerRef := &metav1.OwnerReference{
-		UID:        d.UID,
-		APIVersion: "v1",
-		Kind:       "deployment",
-		Name:       resourceName,
-	}
-	s := keyring.GetSecretStore(c.context, c.fs.Namespace, ownerRef)
-
-	return s.CreateOrUpdate(resourceName, existingKeyring)
+	s := keyring.GetSecretStoreForDeployment(c.context, d)
+	return s.CreateOrUpdate(d.GetName(), existingKeyring)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This change standardizes the ownerRefs of Ceph keyrings to
k8s Deployment resources across all daemons and refactors a
bit of duplicate code on keyring association for ease of
maintenance.

**Which issue is resolved by this Pull Request:**
Resolves #4089
Signed-off-by: egafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
