### PR TITLE
ceph: create csi keys and secrets for external cluster

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -303,6 +303,12 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	// Everything went well so let's update the CR's status to "connected"
 	c.updateClusterStatus(namespace, name, cephv1.ClusterStateConnected, "")
 
+	// Create CSI Secrets
+	err = csi.CreateCSISecrets(c.context, namespace, &cluster.ownerRef)
+	if err != nil {
+		return fmt.Errorf("failed to create csi kubernetes secrets. %+v", err)
+	}
+
 	// Mark initialization has done
 	cluster.initCompleted = true
 


### PR DESCRIPTION
**Description of your changes:**

Once the cluster is connected, we need to create the CSI keys so that we
can provide persistent storage to containers, via ceph csi.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]