### PR TITLE
Ceph: Fix topologyAware in clusterdisruption package does not respect  the rook topolgy prefix.

### DIFF
--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -106,16 +106,23 @@ func TestDetectCrushLocation(t *testing.T) {
 		"topology.rook.io/rack":                    "rack1",
 		"topology.rook.io/row":                     "row1",
 	}
+	expected := map[string]string{
+		"host":   "foo",
+		"region": "region1",
+		"zone":   "zone1",
+		"rack":   "rack1",
+		"row":    "row1",
+	}
 	updateLocationWithNodeLabels(&location, nodeLabels)
 	assert.Equal(t, 5, len(location))
-	assert.Equal(t, "host=foo", location[0])
-	assert.Equal(t, "zone=zone1", location[1])
-	assert.Equal(t, "region=region1", location[2])
-	if strings.HasPrefix(location[3], "rack") {
-		assert.Equal(t, "rack=rack1", location[3])
-		assert.Equal(t, "row=row1", location[4])
-	} else {
-		assert.Equal(t, "rack=rack1", location[4])
-		assert.Equal(t, "row=row1", location[3])
+	for _, locString := range location {
+		split := strings.Split(locString, "=")
+		assert.Len(t, split, 2)
+		prefix := split[0]
+		value := split[1]
+		expectedValue, ok := expected[prefix]
+		assert.True(t, ok)
+		assert.Equal(t, expectedValue, value)
 	}
+
 }

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -19,7 +19,18 @@ limitations under the License.
 // flags.
 package osd
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
 var (
+
 	// The labels that can be specified with the K8s labels such as failure-domain.beta.kubernetes.io/zone
 	// These are all at the top layers of the CRUSH map.
 	KubernetesTopologyLabels = []string{"zone", "region"}
@@ -30,3 +41,46 @@ var (
 	// The list of supported failure domains in the CRUSH map, ordered from lowest to highest
 	CRUSHMapLevelsOrdered = append([]string{"host"}, append(CRUSHTopologyLabels, KubernetesTopologyLabels...)...)
 )
+
+// ExtractRookTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value,
+// and a bool indicating if there any invalid labels with a  topology prefix.
+func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string, []string) {
+	topology := make(map[string]string)
+
+	// get zone
+	zone, ok := labels[corev1.LabelZoneFailureDomain]
+	if ok {
+		topology["zone"] = client.NormalizeCrushName(zone)
+	}
+	// get region
+	region, ok := labels[corev1.LabelZoneRegion]
+	if ok {
+		topology["region"] = client.NormalizeCrushName(region)
+	}
+
+	// get host
+	host, ok := labels[corev1.LabelHostname]
+	if ok {
+		topology["host"] = client.NormalizeCrushName(host)
+	}
+
+	invalidEncountered := make([]string, 0)
+	for labelKey, labelValue := range labels {
+		for _, validTopologyType := range CRUSHTopologyLabels {
+			if strings.HasPrefix(labelKey, k8sutil.TopologyLabelPrefix) {
+				s := strings.Split(labelKey, "/")
+				if len(s) != 2 {
+					invalidEncountered = append(invalidEncountered, fmt.Sprintf("%s=%s", labelKey, labelValue))
+					continue
+				}
+				topologyType := s[1]
+				if topologyType == validTopologyType {
+					topology[validTopologyType] = client.NormalizeCrushName(labelValue)
+				}
+
+			}
+
+		}
+	}
+	return topology, invalidEncountered
+}

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -160,29 +160,25 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			logger.Warningf("node in nodelist was nil")
 			continue
 		}
-		topologyLabelMap := map[string]string{
-			"host":   corev1.LabelHostname,
-			"zone":   corev1.LabelZoneFailureDomain,
-			"region": corev1.LabelZoneRegion,
-		}
-		failureDomainLabel, ok := topologyLabelMap[failureDomainType]
-		if !ok {
-			return nil, fmt.Errorf("invalid failure domain %s cannot manage PDBs for OSDs", failureDomainType)
-		}
-		nodeLabels := node.ObjectMeta.GetLabels()
+		nodeTopologyMap, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+
 		for _, osdData := range osdDataList {
-			secondaryCrushHostname := osdData.CrushMeta.Host
+			// get the crush location of the osd
 			crushFailureDomain, ok := osdData.CrushMeta.Location[failureDomainType]
-			if !ok && secondaryCrushHostname == "" {
-				return nil, fmt.Errorf("could not find the CrushFindResult.Location['%s'] for %s", failureDomainType, osdData.Deployment.ObjectMeta.Name)
-			}
-			nodeFailureDomain, ok := nodeLabels[failureDomainLabel]
 			if !ok {
-				return nil, fmt.Errorf("could not find the %s label on node %s", failureDomainLabel, node.ObjectMeta.Name)
+				return nil, fmt.Errorf("could not find the CrushFindResult.Location['%s'] for %s", failureDomainType, osdData.Deployment.GetName())
 			}
-			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) || cephClient.IsNormalizedCrushNameEqual(secondaryCrushHostname, crushFailureDomain) {
+			// get the crush location of the node
+			nodeFailureDomain, ok := nodeTopologyMap[failureDomainType]
+			if !ok {
+				return nil, fmt.Errorf("could not find the %s failure domain on node %s", failureDomainType, node.GetName())
+			}
+
+			// check if the node and osd have the same crush location value for this particular crush location type
+			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) {
 				nodeOsdDataList = append(nodeOsdDataList, osdData)
 			}
+
 		}
 	}
 	return nodeOsdDataList, nil

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -139,7 +139,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 	mutateFunc := func() error {
 
 		// lablels for the pod, the deployment, and the deploymentSelector
-		deploymentLabels := map[string]string{
+		selectorLabels := map[string]string{
 			corev1.LabelHostname: nodeHostnameLabel,
 			k8sutil.AppAttr:      CanaryAppName,
 			NodeNameLabel:        node.GetName(),
@@ -151,16 +151,24 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		// a new object is going to be created
 		if deploy.ObjectMeta.CreationTimestamp.IsZero() {
 			deploy.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: deploymentLabels,
+				MatchLabels: selectorLabels,
 			}
 		}
 
-		// update
-		deploy.ObjectMeta.Labels = deploymentLabels
+		// update the deployment labels
+		objectLabels := make(map[string]string, 0)
+		for key, value := range selectorLabels {
+			objectLabels[key] = value
+		}
+		topology, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+		for key, value := range topology {
+			objectLabels[key] = value
+		}
+		deploy.ObjectMeta.Labels = objectLabels
 
 		// update the Deployment pod template
 		deploy.Spec.Template = corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{Labels: deploymentLabels},
+			ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
 			Spec: corev1.PodSpec{
 				NodeSelector: nodeSelector,
 				Containers:   newDoNothingContainers(r.context.RookImage),


### PR DESCRIPTION
…

Allow the clusterdisruption package to recognize node topologies other than zone.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
