### PR TITLE
Ceph: Fix topology logic for drains.

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -141,6 +141,7 @@ rules:
   - poddisruptionbudgets
   #this is for both clusterdisruption and nodedrain controllers
   - deployments
+  - replicasets
   verbs:
   - "*"
 - apiGroups:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -674,6 +674,7 @@ rules:
   - poddisruptionbudgets
   #this is for both clusterdisruption and nodedrain controllers
   - deployments
+  - replicasets
   verbs:
   - "*"
 - apiGroups:

--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -106,16 +106,23 @@ func TestDetectCrushLocation(t *testing.T) {
 		"topology.rook.io/rack":                    "rack1",
 		"topology.rook.io/row":                     "row1",
 	}
+	expected := map[string]string{
+		"host":   "foo",
+		"region": "region1",
+		"zone":   "zone1",
+		"rack":   "rack1",
+		"row":    "row1",
+	}
 	updateLocationWithNodeLabels(&location, nodeLabels)
 	assert.Equal(t, 5, len(location))
-	assert.Equal(t, "host=foo", location[0])
-	assert.Equal(t, "zone=zone1", location[1])
-	assert.Equal(t, "region=region1", location[2])
-	if strings.HasPrefix(location[3], "rack") {
-		assert.Equal(t, "rack=rack1", location[3])
-		assert.Equal(t, "row=row1", location[4])
-	} else {
-		assert.Equal(t, "rack=rack1", location[4])
-		assert.Equal(t, "row=row1", location[3])
+	for _, locString := range location {
+		split := strings.Split(locString, "=")
+		assert.Len(t, split, 2)
+		prefix := split[0]
+		value := split[1]
+		expectedValue, ok := expected[prefix]
+		assert.True(t, ok)
+		assert.Equal(t, expectedValue, value)
 	}
+
 }

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -43,7 +43,7 @@ var (
 )
 
 // ExtractRookTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value,
-// and a bool indicating if there any invalid labels with a  topology prefix.
+// and an array of any invalid labels with a topology prefix.
 func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string, []string) {
 	topology := make(map[string]string)
 

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -19,7 +19,18 @@ limitations under the License.
 // flags.
 package osd
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
 var (
+
 	// The labels that can be specified with the K8s labels such as failure-domain.beta.kubernetes.io/zone
 	// These are all at the top layers of the CRUSH map.
 	KubernetesTopologyLabels = []string{"zone", "region"}
@@ -30,3 +41,46 @@ var (
 	// The list of supported failure domains in the CRUSH map, ordered from lowest to highest
 	CRUSHMapLevelsOrdered = append([]string{"host"}, append(CRUSHTopologyLabels, KubernetesTopologyLabels...)...)
 )
+
+// ExtractRookTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value,
+// and a bool indicating if there any invalid labels with a  topology prefix.
+func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string, []string) {
+	topology := make(map[string]string)
+
+	// get zone
+	zone, ok := labels[corev1.LabelZoneFailureDomain]
+	if ok {
+		topology["zone"] = client.NormalizeCrushName(zone)
+	}
+	// get region
+	region, ok := labels[corev1.LabelZoneRegion]
+	if ok {
+		topology["region"] = client.NormalizeCrushName(region)
+	}
+
+	// get host
+	host, ok := labels[corev1.LabelHostname]
+	if ok {
+		topology["host"] = client.NormalizeCrushName(host)
+	}
+
+	invalidEncountered := make([]string, 0)
+	for labelKey, labelValue := range labels {
+		for _, validTopologyType := range CRUSHTopologyLabels {
+			if strings.HasPrefix(labelKey, k8sutil.TopologyLabelPrefix) {
+				s := strings.Split(labelKey, "/")
+				if len(s) != 2 {
+					invalidEncountered = append(invalidEncountered, fmt.Sprintf("%s=%s", labelKey, labelValue))
+					continue
+				}
+				topologyType := s[1]
+				if topologyType == validTopologyType {
+					topology[validTopologyType] = client.NormalizeCrushName(labelValue)
+				}
+
+			}
+
+		}
+	}
+	return topology, invalidEncountered
+}

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -77,9 +77,7 @@ func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string,
 				if topologyType == validTopologyType {
 					topology[validTopologyType] = client.NormalizeCrushName(labelValue)
 				}
-
 			}
-
 		}
 	}
 	return topology, invalidEncountered

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -169,29 +169,25 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			logger.Warningf("node in nodelist was nil")
 			continue
 		}
-		topologyLabelMap := map[string]string{
-			"host":   corev1.LabelHostname,
-			"zone":   corev1.LabelZoneFailureDomain,
-			"region": corev1.LabelZoneRegion,
-		}
-		failureDomainLabel, ok := topologyLabelMap[failureDomainType]
-		if !ok {
-			return nil, fmt.Errorf("invalid failure domain %q cannot manage PDBs for OSDs", failureDomainType)
-		}
-		nodeLabels := node.ObjectMeta.GetLabels()
+		nodeTopologyMap, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+
 		for _, osdData := range osdDataList {
-			secondaryCrushHostname := osdData.CrushMeta.Host
+			// get the crush location of the osd
 			crushFailureDomain, ok := osdData.CrushMeta.Location[failureDomainType]
-			if !ok && secondaryCrushHostname == "" {
-				return nil, fmt.Errorf("could not find the CrushFindResult.Location[%q] for %q", failureDomainType, osdData.Deployment.ObjectMeta.Name)
-			}
-			nodeFailureDomain, ok := nodeLabels[failureDomainLabel]
 			if !ok {
-				return nil, fmt.Errorf("could not find the %q label on node %q", failureDomainLabel, node.ObjectMeta.Name)
+				return nil, fmt.Errorf("could not find the CrushFindResult.Location[%q] for %s", failureDomainType, osdData.Deployment.GetName())
 			}
-			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) || cephClient.IsNormalizedCrushNameEqual(secondaryCrushHostname, crushFailureDomain) {
+			// get the crush location of the node
+			nodeFailureDomain, ok := nodeTopologyMap[failureDomainType]
+			if !ok {
+				return nil, fmt.Errorf("could not find the %q failure domain on node %q", failureDomainType, node.GetName())
+			}
+
+			// check if the node and osd have the same crush location value for this particular crush location type
+			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) {
 				nodeOsdDataList = append(nodeOsdDataList, osdData)
 			}
+
 		}
 	}
 	return nodeOsdDataList, nil

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -184,7 +184,7 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			}
 
 			// check if the node and osd have the same crush location value for this particular crush location type
-			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) {
+			if cephClient.IsNormalizedCrushNameEqual(nodeFailureDomain, crushFailureDomain) || (failureDomainType == "host" && cephClient.IsNormalizedCrushNameEqual(node.GetName(), crushFailureDomain)) {
 				nodeOsdDataList = append(nodeOsdDataList, osdData)
 			}
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -50,7 +50,7 @@ func (r *ReconcileClusterDisruption) getOsdDataList(request reconcile.Request, p
 		labels := deployment.Spec.Template.ObjectMeta.GetLabels()
 		osdID, ok := labels[osd.OsdIdLabelKey]
 		if !ok {
-			return nil, fmt.Errorf("osd %q was not labeled", deployment.ObjectMeta.Name)
+			return nil, fmt.Errorf("osd %q was not labeled with %q", deployment.GetName(), osd.OsdIdLabelKey)
 		}
 		osdIDInt, err := strconv.Atoi(osdID)
 		if err != nil {
@@ -175,7 +175,7 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			// get the crush location of the osd
 			crushFailureDomain, ok := osdData.CrushMeta.Location[failureDomainType]
 			if !ok {
-				return nil, fmt.Errorf("could not find the CrushFindResult.Location[%q] for %s", failureDomainType, osdData.Deployment.GetName())
+				return nil, fmt.Errorf("could not find the CrushFindResult.Location[%q] for %q", failureDomainType, osdData.Deployment.GetName())
 			}
 			// get the crush location of the node
 			nodeFailureDomain, ok := nodeTopologyMap[failureDomainType]
@@ -200,7 +200,7 @@ func getFailureDomainMapForOsds(osdDataList []OsdData, failureDomainType string)
 	for _, osdData := range osdDataList {
 		failureDomainValue, ok := osdData.CrushMeta.Location[failureDomainType]
 		if !ok {
-			logger.Errorf("failureDomain type %q not associated with %q", failureDomainType, osdData.Deployment.ObjectMeta.Name)
+			logger.Errorf("failureDomain type %q not associated with %q", failureDomainType, osdData.Deployment.GetName())
 			unfoundOSDs = append(unfoundOSDs, osdData.Deployment.ObjectMeta.Name)
 		} else {
 			if len(failureDomainMap[failureDomainValue]) == 0 {
@@ -210,7 +210,7 @@ func getFailureDomainMapForOsds(osdDataList []OsdData, failureDomainType string)
 		}
 	}
 	if len(unfoundOSDs) > 0 {
-		err = fmt.Errorf("failure domain type %q not associated with osds: %q", failureDomainType, strings.Join(unfoundOSDs, ","))
+		err = fmt.Errorf("failure domain type %q not associated with osds: [%q]", failureDomainType, strings.Join(unfoundOSDs, ","))
 	}
 	return failureDomainMap, err
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -697,6 +697,7 @@ rules:
   - poddisruptionbudgets
   #this is for both clusterdisruption and nodedrain controllers
   - deployments
+  - replicasets
   verbs:
   - "*"
 - apiGroups:


### PR DESCRIPTION
[test ceph]
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Fix bug where not cleaning up drain-canaries was leading to a drain deadlock.
- Add an owner reference from the drain-canary to the node.
- As a prerequisite to fixing that, fix some topologyAware issues:
  - In a discussion, I forgot to mention one place where topologyAware changes had to be brought, so parts of the clusterdisruption controller had to be updated to support the newly supported crush types.
  - Label the drain canaries to make them selectable by crush type.



**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
