### PR TITLE
ceph: support device selection for OSDs by device path name patterns

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -212,12 +212,15 @@ This feature is only available when `useAllNodes` has been set to `false`.
 Below are the settings available, both at the cluster and individual node level, for selecting which storage resources will be included in the cluster.
 
 * `useAllDevices`: `true` or `false`, indicating whether all devices found on nodes in the cluster should be automatically consumed by OSDs. **Not recommended** unless you have a very controlled environment where you will not risk formatting of devices with existing data. When `true`, all devices will be used except those with partitions created or a local filesystem. Is overridden by `deviceFilter` if specified.
-* `deviceFilter`: A regular expression that allows selection of devices to be consumed by OSDs.  If individual devices have been specified for a node then this filter will be ignored.  This field uses [golang regular expression syntax](https://golang.org/pkg/regexp/syntax/). For example:
+* `deviceFilter`: A regular expression for short kernel names of devices (e.g. `sda`) that allows selection of devices to be consumed by OSDs.  If individual devices have been specified for a node then this filter will be ignored.  This field uses [golang regular expression syntax](https://golang.org/pkg/regexp/syntax/). For example:
   * `sdb`: Only selects the `sdb` device if found
   * `^sd.`: Selects all devices starting with `sd`
   * `^sd[a-d]`: Selects devices starting with `sda`, `sdb`, `sdc`, and `sdd` if found
   * `^s`: Selects all devices that start with `s`
   * `^[^r]`: Selects all devices that do *not* start with `r`
+* `devicePathFilter`: A regular expression for device paths (e.g. `/dev/disk/by-path/pci-0:1:2:3-scsi-1`) that allows selection of devices to be consumed by OSDs.  If individual devices or `deviceFilter` have been specified for a node then this filter will be ignored.  This field uses [golang regular expression syntax](https://golang.org/pkg/regexp/syntax/). For example:
+  * `^/dev/sd.`: Selects all devices starting with `sd`
+  * `^/dev/disk/by-path/pci-.*`: Selects all devices which are connected to PCI bus
 * `devices`: A list of individual device names belonging to this node to include in the storage cluster.
   * `name`: The name of the device (e.g., `sda`)
   * `config`: Device-specific config settings. See the [config settings](#osd-configuration-settings) below

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -16,6 +16,7 @@
   - The on-host log directory for OSDs was set incorrectly to `<dataDirHostPath>/<namespace>/log`;
     fix this to be `<dataDirHostPath>/log/<namespace>`, the same as other daemons.
   - Use the mon configuration database for directory-based OSDs, and do not generate a config
+  - Add a new CRD property `devicePathFilter` to support device filtering with path names, e.g. `/dev/disk/by-path/pci-.*-sas-.*`.
 - A new ceph-crashcollector controller has been added, that new pod will run on any node where a Ceph pod is running. Read more about this in the [doc](Documentation/ceph-cluster-crd.html#cluster-wide-resources-configuration-settings)
 - PriorityClassNames can now be added to the Rook/Ceph components to influence the scheduler's pod preemption.
   - mgr/mon/osd/rbdmirror: [priority class names configuration settings](Documentation/ceph-cluster-crd.md#priority-class-names-configuration-settings)

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -134,7 +134,10 @@ spec:
                             pattern: ^(true|false)$
                       useAllDevices:
                         type: boolean
-                      deviceFilter: {}
+                      deviceFilter:
+                        type: string
+                      devicePathFilter:
+                        type: string
                       directories:
                         type: array
                         items:
@@ -152,7 +155,10 @@ spec:
                   type: array
                 useAllDevices:
                   type: boolean
-                deviceFilter: {}
+                deviceFilter:
+                  type: string
+                devicePathFilter:
+                  type: string
                 directories:
                   type: array
                   items:

--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -37,6 +37,9 @@ func TestParseDesiredDevices(t *testing.T) {
 	assert.False(t, result[0].IsFilter)
 	assert.False(t, result[1].IsFilter)
 	assert.False(t, result[2].IsFilter)
+	assert.False(t, result[0].IsDevicePathFilter)
+	assert.False(t, result[1].IsDevicePathFilter)
+	assert.False(t, result[2].IsDevicePathFilter)
 
 	// negative osd count is not allowed
 	devices = "nvme01:-5"
@@ -77,6 +80,10 @@ func TestParseDesiredDevices(t *testing.T) {
 	assert.False(t, result[1].IsFilter)
 	assert.False(t, result[2].IsFilter)
 	assert.False(t, result[3].IsFilter)
+	assert.False(t, result[0].IsDevicePathFilter)
+	assert.False(t, result[1].IsDevicePathFilter)
+	assert.False(t, result[2].IsDevicePathFilter)
+	assert.False(t, result[3].IsDevicePathFilter)
 
 }
 

--- a/design/ceph/cluster-update.md
+++ b/design/ceph/cluster-update.md
@@ -33,6 +33,7 @@ The following fields will be **supported** for updates:
   * `count`: The number of monitors can be updated and the operator will ensure that as monitors are scaled up or down the cluster remains in quorum.
   * `allowMultiplePerNode`: The policy to allow multiple mons to be placed on one node can be toggled.
 * `deviceFilter`: The regex filter for devices allowed to be used for storage can be updated and OSDs will be added or removed to match the new filter pattern.
+* `devicePathFilter`: The regex filter for paths of devices allowed to be used for storage can be updated and OSDs will be added or removed to match the new filter pattern.
 * `useAllDevices`: If this value is updated to `true`, then OSDs will be added to start using all devices on nodes.
 However, if this value is updated to `false`, the operator will only allow OSDs to be removed if there is a value set for `deviceFilter`.
 This is to prevent an unintentional action by the user that would effectively remove all data in the cluster.

--- a/pkg/apis/ceph.rook.io/v1/spec_test.go
+++ b/pkg/apis/ceph.rook.io/v1/spec_test.go
@@ -38,6 +38,7 @@ storage:
   useAllNodes: false
   useAllDevices: false
   deviceFilter: "^sd."
+  devicePathFilter: "^/dev/disk/by-path/pci-.*"
   location: "region=us-west,datacenter=delmar"
   config:
     metadataDevice: "nvme01"
@@ -52,7 +53,8 @@ storage:
     directories:
     - path: "/rook/dir1"
   - name: "node2"
-    deviceFilter: "^foo*"`)
+    deviceFilter: "^foo*"
+    devicePathFilter: "^/dev/disk/by-id/.*foo.*"`)
 
 	// convert the raw spec yaml into JSON
 	rawJSON, err := yaml.YAMLToJSON(specYaml)
@@ -78,9 +80,10 @@ storage:
 		Storage: rookalpha.StorageScopeSpec{
 			UseAllNodes: false,
 			Selection: rookalpha.Selection{
-				UseAllDevices: &useAllDevices,
-				DeviceFilter:  "^sd.",
-				Directories:   []rookalpha.Directory{{Path: "/rook/dir2"}},
+				UseAllDevices:    &useAllDevices,
+				DeviceFilter:     "^sd.",
+				DevicePathFilter: "^/dev/disk/by-path/pci-.*",
+				Directories:      []rookalpha.Directory{{Path: "/rook/dir2"}},
 			},
 			Config: map[string]string{
 				"metadataDevice": "nvme01",
@@ -100,7 +103,8 @@ storage:
 				{
 					Name: "node2",
 					Selection: rookalpha.Selection{
-						DeviceFilter: "^foo*",
+						DeviceFilter:     "^foo*",
+						DevicePathFilter: "^/dev/disk/by-id/.*foo.*",
 					},
 				},
 			},

--- a/pkg/apis/rook.io/v1alpha2/storage.go
+++ b/pkg/apis/rook.io/v1alpha2/storage.go
@@ -82,6 +82,7 @@ func (s *StorageScopeSpec) resolveNodeSelection(node *Node) {
 	}
 
 	resolveString(&(node.Selection.DeviceFilter), s.Selection.DeviceFilter, "")
+	resolveString(&(node.Selection.DevicePathFilter), s.Selection.DevicePathFilter, "")
 
 	if len(node.Selection.Devices) == 0 {
 		node.Selection.Devices = s.Devices

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -59,6 +59,8 @@ type Selection struct {
 	UseAllDevices *bool `json:"useAllDevices,omitempty"`
 	// A regular expression to allow more fine-grained selection of devices on nodes across the cluster
 	DeviceFilter string `json:"deviceFilter,omitempty"`
+	// A regular expression to allow more fine-grained selection of devices with path names
+	DevicePathFilter string `json:"devicePathFilter,omitempty"`
 	// List of devices to use as storage devices
 	Devices []Device `json:"devices,omitempty"`
 	// List of host directories to use as storage

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -342,7 +342,7 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 
 			if err == nil && matched {
 				// the current device matches the user specifies filter/list, use it for data
-				deviceInfo = &DeviceOsdIDEntry{Data: unassignedOSDID, Config: matchedDevice}
+				deviceInfo = &DeviceOsdIDEntry{Data: unassignedOSDID, Config: matchedDevice, PersistentDevicePaths: strings.Fields(device.DevLinks)}
 			} else {
 				logger.Infof("skipping device %s that does not match the device filter/list (%v). %+v", device.Name, desiredDevices, err)
 			}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"syscall"
 
@@ -301,12 +302,12 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 		}
 		partCount, ownPartitions, fs, err := sys.CheckIfDeviceAvailable(context.Executor, device.Name, pvcBacked)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get device %s info. %+v", device.Name, err)
+			return nil, fmt.Errorf("failed to get device %q info. %+v", device.Name, err)
 		}
 
 		if fs != "" || !ownPartitions {
 			// not OK to use the device because it has a filesystem or rook doesn't own all its partitions
-			logger.Infof("skipping device %s that is in use (not by rook). fs: %s, ownPartitions: %t", device.Name, fs, ownPartitions)
+			logger.Infof("skipping device %q that is in use (not by rook). fs: %s, ownPartitions: %t", device.Name, fs, ownPartitions)
 			continue
 		}
 
@@ -326,12 +327,25 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 					// the desired devices is a regular expression
 					matched, err = regexp.Match(desiredDevice.Name, []byte(device.Name))
 					if err != nil {
-						logger.Errorf("regex failed on device %s and filter %s. %+v", device.Name, desiredDevice.Name, err)
+						logger.Errorf("regex failed on device %q and filter %q. %+v", device.Name, desiredDevice.Name, err)
 						continue
 					}
-					logger.Infof("device %s matches device filter %s: %t", device.Name, desiredDevice.Name, matched)
+					logger.Infof("device %q matches device filter %q: %t", device.Name, desiredDevice.Name, matched)
+				} else if desiredDevice.IsDevicePathFilter {
+					pathnames := append(strings.Fields(device.DevLinks), filepath.Join("/dev", device.Name))
+					for _, pathname := range pathnames {
+						matched, err = regexp.Match(desiredDevice.Name, []byte(pathname))
+						if err != nil {
+							logger.Errorf("regex failed on device %q and filter %q. %+v", device.Name, desiredDevice.Name, err)
+							continue
+						}
+						if matched {
+							break
+						}
+					}
+					logger.Infof("device %q (aliases: %q) matches device path filter %q: %t", device.Name, device.DevLinks, desiredDevice.Name, matched)
 				} else if device.Name == desiredDevice.Name {
-					logger.Infof("%s found in the desired devices", device.Name)
+					logger.Infof("%q found in the desired devices", device.Name)
 					matched = true
 				}
 				matchedDevice = desiredDevice
@@ -342,12 +356,13 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 
 			if err == nil && matched {
 				// the current device matches the user specifies filter/list, use it for data
+				logger.Infof("device %q is selected by the device filter/name %q", device.Name, matchedDevice.Name)
 				deviceInfo = &DeviceOsdIDEntry{Data: unassignedOSDID, Config: matchedDevice, PersistentDevicePaths: strings.Fields(device.DevLinks)}
 			} else {
-				logger.Infof("skipping device %s that does not match the device filter/list (%v). %+v", device.Name, desiredDevices, err)
+				logger.Infof("skipping device %q that does not match the device filter/list (%v). %+v", device.Name, desiredDevices, err)
 			}
 		} else {
-			logger.Infof("skipping device %s until the admin specifies it can be used by an osd", device.Name)
+			logger.Infof("skipping device %q until the admin specifies it can be used by an osd", device.Name)
 		}
 
 		if deviceInfo != nil {

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -72,12 +72,13 @@ type Device struct {
 
 // DesiredDevice keeps track of the desired settings for a device
 type DesiredDevice struct {
-	Name           string
-	OSDsPerDevice  int
-	MetadataDevice string
-	DatabaseSizeMB int
-	DeviceClass    string
-	IsFilter       bool
+	Name               string
+	OSDsPerDevice      int
+	MetadataDevice     string
+	DatabaseSizeMB     int
+	DeviceClass        string
+	IsFilter           bool
+	IsDevicePathFilter bool
 }
 
 type DeviceOsdMapping struct {

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -89,6 +89,7 @@ type DeviceOsdIDEntry struct {
 	Metadata              []int         // OSD IDs (multiple) that have metadata stored here
 	Config                DesiredDevice // Device specific config options
 	LegacyPartitionsFound bool          // Whether legacy rook partitions were found
+	PersistentDevicePaths []string
 }
 
 type devicePartInfo struct {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -192,6 +192,12 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		if device.Data == -1 {
 			logger.Infof("configuring new device %s", name)
 			deviceArg := path.Join("/dev", name)
+			// ceph-volume prefers to use /dev/mapper/<name> if the device has this kind of alias
+			for _, devlink := range device.PersistentDevicePaths {
+				if strings.HasPrefix(devlink, "/dev/mapper") {
+					deviceArg = devlink
+				}
+			}
 
 			deviceOSDCount := osdsPerDeviceCount
 			if device.Config.OSDsPerDevice > 1 {


### PR DESCRIPTION
**Description of your changes:**

Add `devicePathFilter` to Storage Selection Settings which enables device selection
with a regular expression for device path names.
For example, `devicePathFilter: "^/dev/disk/by-path/pci.*-sas-.*"` selects all SAS
devices.

This PR contains a small fix for using `ceph-volume`.
When using `devicePathFilter`, I found some device caused an error in `ceph-volume`.
This is because `ceph-volume` cannot handle a device correctly if the device has an alias
under `/dev/mapper/`.
This PR fixes it by checking whether the device has that kind of alias
and using the alias as an argument for `ceph-volume`.

**Which issue is resolved by this Pull Request:**
Resolves #4275

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
