### PR TITLE
ceph: docs: added a note around snapshot CRD cleanup

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -270,6 +270,14 @@ below, which you should change to match where your images are located.
 You can also remove the `ROOK_CSI_CEPHFS_IMAGE` and `ROOK_CSI_RBD_IMAGE` `env` variables that are
 no longer used in Rook.
 
+You should also delete outdated `*.snapshot.storage.io` CRDs that may have been created by the previous version. If they are not cleaned up, there may be an error in preventing the VolumeSnapshots from ever being "Ready-To-Use: true":
+
+```console
+kubectl delete crd volumesnapshotclasses.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io volumesnapshots.snapshot.storage.k8s.io
+```
+
+The new versions of the CRDs will be created when the `csi-rbdplugin-provisioner-0` pod is started following the operator upgrade.
+
 If you have configured the kubelet to use other than `/var/lib/kubelet` please
 add below to the operator `env` variables.
 


### PR DESCRIPTION
Older CRDs from previous versions prevented VolumeSnapshots from working correctly

**Description of your changes:**
This PR updates the docs for upgrades that may happen from Rook v1.0 to v1.1+. The snapshot CRDs will be outdated if the CSI drivers were used which will prevent the VolumeSnapshots to be taken successfully. Retargeting to `release-1.1` as per https://github.com/rook/rook/pull/4292#issuecomment-553032019

**Which issue is resolved by this Pull Request:**
Resolves #4178 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]