### PR TITLE
ceph: add CR flag to tune slow device class for OSD on PVC in the Cloud

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -39,6 +39,7 @@ To remove OSDs manually, see the new doc on [OSD Management](Documentation/ceph-
       - New OSDs created in directories are always `Filestore` type
       - New OSDs created on disks are always `Bluestore` type
     - Preexisting disks provisioned as `Filestore` OSDs will remain as `Filestore` OSDs
+  - When running on PVC, the OSD can be on a slow device class, Rook can adapt to that by tuning the OSD. This can be enabled by the CR setting `tuneSlowDeviceClass`
 - RGWs:
   - Ceph Object Gateway are automatically configured to not run on the same host if hostNetwork is activated
 
@@ -52,10 +53,10 @@ To remove OSDs manually, see the new doc on [OSD Management](Documentation/ceph-
 
 ### YugabyteDB
 
-
 ## Breaking Changes
 
 ### Ceph
+
 - The `topology` setting has been removed from the CephCluster CR. To configure the OSD topology, node labels must be applied.
 See the [OSD topology topic](ceph-cluster-crd.md#osd-topology). This setting only affects OSDs when they are first created, thus OSDs will not be impacted during upgrade.
 The topology settings only apply to bluestore OSDs on raw devices. The topology labels are not applied to directory-based OSDs.

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -48,6 +48,10 @@ spec:
       # this needs to be set to false. For example, if using the local storage provisioner
       # this should be false.
       portable: true
+      # Certain storage class in the Cloud are slow
+      # Rook can configure the OSD running on PVC to accommodate that by tuning some of the Ceph internal
+      # Currently, "gp2" has been identified as such
+      tuneSlowDeviceClass: true
       # Since the OSDs could end up on any node, an effort needs to be made to spread the OSDs
       # across nodes as much as possible. Unfortunately the pod anti-affinity breaks down
       # as soon as you have more than one OSD per node. If you have more OSDs than nodes, K8s may

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1alpha2
 
 import (
@@ -135,7 +136,7 @@ type StorageClassDeviceSet struct {
 	Placement            Placement                  `json:"placement,omitempty"`            // Placement constraints for the devices
 	Config               map[string]string          `json:"config,omitempty"`               // Provider-specific device configuration
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"` // List of PVC templates for the underlying storage devices
-	Portable             bool                       `json:"portable,omitempty"`             // OSD portablity across the hosts
+	Portable             bool                       `json:"portable,omitempty"`             // OSD portability across the hosts
 }
 
 type VolumeSource struct {
@@ -144,5 +145,6 @@ type VolumeSource struct {
 	Resources                   v1.ResourceRequirements              `json:"resources,omitempty"`
 	Placement                   Placement                            `json:"placement,omitempty"`
 	Config                      map[string]string                    `json:"config,omitempty"`
-	Portable                    bool                                 `json:"portable,omitempty"` // OSD portablity across the hosts
+	Portable                    bool                                 `json:"portable,omitempty"`        // OSD portability across the hosts
+	TuneSlowDeviceClass         bool                                 `json:"tuneDeviceClass,omitempty"` // Tune the OSD when running on a slow Device Class
 }


### PR DESCRIPTION
**Description of your changes:**

gp2 devices present themselves as SSDs,
but have much more variable performance.
Ceph attempts to adjust some settings based on the drive type,
HDD/SSD
In this case client I/O can be impacted too much by assuming gp2 devices are like other SSDs
(an example is https://bugzilla.redhat.com/show_bug.cgi?id=1765923#c6)

In order to prevent this, rook can set the following for OSDs on gp2 devices:

```
osd_recovery_sleep = 0.1
osd_snap_trim_sleep = 2
osd_delete_sleep = 2
```

Closes: https://github.com/rook/rook/issues/4298 and https://bugzilla.redhat.com/show_bug.cgi?id=1771047
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4298

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]