### PR TITLE
Ceph: Toolbox does not need to run privileged

### DIFF
--- a/Documentation/direct-tools.md
+++ b/Documentation/direct-tools.md
@@ -11,12 +11,27 @@ use block and file storage directly from a pod without any of the Kubernetes mag
 although it is not meant to be used in production. All of the benefits of Kubernetes storage including failover, detach, and attach will not be available.
 If your pod dies, your mount will die with it.
 
+## Start the Direct Mount Pod
+
+To test mounting your Ceph volumes, start a pod with the necessary mounts. An example is provided in the examples test directory:
+
+```console
+kubectl create -f cluster/examples/kubernetes/ceph/direct-mount.yaml
+```
+
+After the pod is started, connect to it like this:
+
+```console
+kubectl -n rook-ceph get pod -l app=rook-direct-mount
+kubectl -n rook-ceph exec -it <pod> bash
+```
+
 ## Block Storage Tools
 
 After you have created a pool as described in the [Block Storage](ceph-block.md) topic, you can create a block image and mount it directly in a pod.
-This example will show how the Ceph rbd volume can be mounted in the toolbox pod.
+This example will show how the Ceph rbd volume can be mounted in the direct mount pod.
 
-After you have started and connected to the [Rook toolbox](ceph-toolbox.md), proceed with the following commands in the toolbox.
+Create the [Direct Mount Pod](direct-tools.md#Start-the-Direct-Mount-Pod).
 
 Create a volume image (10MB):
 
@@ -31,7 +46,7 @@ rbd feature disable replicapool/test fast-diff deep-flatten object-map
 Map the block volume and format it and mount it:
 
 ```console
-# Map the rbd device. If the toolbox was started with "hostNetwork: false" this hangs and you have to stop it with Ctrl-C,
+# Map the rbd device. If the Direct Mount Pod was started with "hostNetwork: false" this hangs and you have to stop it with Ctrl-C,
 # however the command still succeeds; see https://github.com/rook/rook/issues/2021
 rbd map replicapool/test
 
@@ -65,10 +80,10 @@ rbd unmap /dev/rbd0
 ## Shared Filesystem Tools
 
 After you have created a filesystem as described in the [Shared Filesystem](ceph-filesystem.md) topic, you can mount the filesystem from multiple pods.
-The the other topic you may have mounted the filesystem already in the registry pod. Now we will mount the same filesystem in the toolbox pod.
+The the other topic you may have mounted the filesystem already in the registry pod. Now we will mount the same filesystem in the Direct Mount pod.
 This is just a simple way to validate the Ceph filesystem and is not recommended for production Kubernetes pods.
 
-After you have started and connected to the [Rook toolbox](ceph-toolbox.md), proceed with the following commands in the toolbox.
+Follow [Direct Mount Pod](direct-tools.md#Start-the-Direct-Mount-Pod) to start a pod with the necessary mounts and then proceed with the following commands after connecting to the pod.
 
 ```console
 # Create the directory
@@ -103,7 +118,7 @@ rm -f /tmp/registry/hello
 
 ### Unmount the Filesystem
 
-To unmount the shared filesystem from the toolbox pod:
+To unmount the shared filesystem from the Direct Mount Pod:
 
 ```console
 umount /tmp/registry

--- a/cluster/examples/kubernetes/ceph/direct-mount.yaml
+++ b/cluster/examples/kubernetes/ceph/direct-mount.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-direct-mount
+  namespace: rook-ceph
+  labels:
+    app: rook-direct-mount
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-direct-mount
+  template:
+    metadata:
+      labels:
+        app: rook-direct-mount
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: rook-direct-mount
+        image: rook/ceph:master
+        command: ["/tini"]
+        args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: ROOK_ADMIN_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-mon
+                key: admin-secret
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /dev
+            name: dev
+          - mountPath: /sys/bus
+            name: sysbus
+          - mountPath: /lib/modules
+            name: libmodules
+          - name: mon-endpoint-volume
+            mountPath: /etc/rook
+      # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
+      hostNetwork: true
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sysbus
+          hostPath:
+            path: /sys/bus
+        - name: libmodules
+          hostPath:
+            path: /lib/modules
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+            - key: data
+              path: mon-endpoints

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -28,32 +28,17 @@ spec:
               secretKeyRef:
                 name: rook-ceph-mon
                 key: admin-secret
-        securityContext:
-          privileged: true
         volumeMounts:
-          - mountPath: /dev
-            name: dev
-          - mountPath: /sys/bus
-            name: sysbus
-          - mountPath: /lib/modules
-            name: libmodules
+          - mountPath: /etc/ceph
+            name: ceph-config
           - name: mon-endpoint-volume
             mountPath: /etc/rook
-      # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
-      hostNetwork: true
       volumes:
-        - name: dev
-          hostPath:
-            path: /dev
-        - name: sysbus
-          hostPath:
-            path: /sys/bus
-        - name: libmodules
-          hostPath:
-            path: /lib/modules
         - name: mon-endpoint-volume
           configMap:
             name: rook-ceph-mon-endpoints
             items:
             - key: data
               path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}


### PR DESCRIPTION
Signed-off-by: RAJAT SINGH <rajasing@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Made changes by modifying the following in `toolbox.yaml`
- Adding an `emptyDir` in `toolbox.yaml`
- Deleting `privileged: true`
- Deleting `hostnetwork: true`
-   Deleting All volume and mounts except `mon-endpoint-volume`

Also Deleted all the occurrences for `direct-tools.md`.
**Which issue is resolved by this Pull Request:**
Resolves #4297 #3706 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]