### PR TITLE
Ceph: Ensure draining state is set and checked correctly. 

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -236,16 +236,17 @@ func (r *ReconcileClusterDisruption) updateNoout(pdbStateMap *corev1.ConfigMap, 
 	if err != nil {
 		return fmt.Errorf("could not get osddump for reconciling maintenance noout in namespace %s: %+v", namespace, err)
 	}
-	disabledFailureDomainTimeStampKey := fmt.Sprintf("%s-noout-set-at", disabledFailureDomain)
 	for failureDomain := range allFailureDomainsMap {
+		disabledFailureDomainTimeStampKey := fmt.Sprintf("%s-noout-last-set-at", failureDomain)
 		if disabledFailureDomain == failureDomain {
+
+			// get the time stamp
 			nooutSetTimeString, ok := pdbStateMap.Data[disabledFailureDomainTimeStampKey]
-			if !ok {
-				pdbStateMap.Data[disabledFailureDomainTimeStampKey] = time.Now().Format(time.RFC3339)
-			} else if len(nooutSetTimeString) == 0 {
+			if !ok || len(nooutSetTimeString) == 0 {
+				// initialize it if it's not set
 				pdbStateMap.Data[disabledFailureDomainTimeStampKey] = time.Now().Format(time.RFC3339)
 			}
-
+			// parse the timestamp
 			nooutSetTime, err := time.Parse(time.RFC3339, pdbStateMap.Data[disabledFailureDomainTimeStampKey])
 			if err != nil {
 				return fmt.Errorf("could not parse timestamp %s for failureDomain %s", pdbStateMap.Data[disabledFailureDomainTimeStampKey], nooutSetTime)
@@ -259,15 +260,10 @@ func (r *ReconcileClusterDisruption) updateNoout(pdbStateMap *corev1.ConfigMap, 
 			}
 
 		} else {
-			delete(pdbStateMap.Data, disabledFailureDomainTimeStampKey)
 			// ensure noout unset
 			osdDump.UpdateFlagOnCrushUnit(r.context.ClusterdContext, false, namespace, failureDomain, nooutFlag)
-		}
-		// cleanup
-		for key := range pdbStateMap.Data {
-			if key != disabledPDBKey && key != disabledFailureDomainTimeStampKey {
-				delete(pdbStateMap.Data, key)
-			}
+			// delete the timestamp
+			delete(pdbStateMap.Data, disabledFailureDomainTimeStampKey)
 		}
 	}
 	return nil

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -178,7 +178,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 		if clean {
 			pdbStateMap.Data[disabledPDBKey] = drainingFailureDomains[0]
 		}
-	} else {
+	} else if clean {
 		pdbStateMap.Data[disabledPDBKey] = ""
 	}
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -183,8 +183,8 @@ func (r *ReconcileClusterDisruption) reconcile(request reconcile.Request) (recon
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	_, ok := pdbStateMap.Data[disabledPDBKey]
-	if ok {
+	disabledPDB, ok := pdbStateMap.Data[disabledPDBKey]
+	if ok && len(disabledPDB) > 0 {
 		return reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
 	}
 	return reconcile.Result{}, nil

--- a/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/reconcile.go
@@ -116,6 +116,7 @@ func (r *ReconcileClusterDisruption) reconcile(request reconcile.Request) (recon
 	r.maintenanceTimeout = cephCluster.Spec.DisruptionManagement.OSDMaintenanceTimeout
 	if r.maintenanceTimeout == 0 {
 		r.maintenanceTimeout = DefaultMaintenanceTimeout
+		logger.Debugf("Using default maintenance timeout: %v", r.maintenanceTimeout)
 	}
 
 	//  reconcile the pools and get the failure domain


### PR DESCRIPTION
- Checking whether drain was incorrectly checked map instead of string length.
- Unsetting drain did not check if the cluster was clean.
- Fix: noout timestamp was being periodically reset.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Been stress testing the drain logic and noticed that a deleted node with nowhere for the OSD to go resulted in ceph NOOUT being revoked prematurely.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]