### PR TITLE
ceph: terminate detect-version if config write fails

### DIFF
--- a/cmd/rook/util/cmdreporter.go
+++ b/cmd/rook/util/cmdreporter.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-
 	"github.com/rook/rook/pkg/daemon/util"
 
 	"github.com/rook/rook/cmd/rook/rook"
@@ -38,13 +37,13 @@ will be overwritten.
 
 If cmd-reporter succeeds in running the command to completion, no error is
 reported, even if the command's return code is nonzero (failure). Run will
-return an error if the command could not be run for any reason or if there was
-an error storing the command results into the ConfigMap. An application label
-is applied to the ConfigMap, and if the label already exists and has a
-different application's name name, this returns an error, as this may indicate
-that it is not safe for cmd-reporter to edit the ConfigMap.`,
+terminate if the command could not be run for any reason or if there was an
+error storing the command results into the ConfigMap. An application label
+is applied to the ConfigMap. Run will also terminate if the label already
+exists and has a different application's name name; this may indicate that
+it is not safe for cmd-reporter to edit the ConfigMap.`,
 	Args: cobra.NoArgs,
-	RunE: runCmdReporter,
+	Run:  runCmdReporter,
 }
 
 var (
@@ -71,7 +70,7 @@ func init() {
 	CmdReporterCmd.MarkFlagRequired("namespace")
 }
 
-func runCmdReporter(cCmd *cobra.Command, cArgs []string) error {
+func runCmdReporter(cCmd *cobra.Command, cArgs []string) {
 	cmd, args, err := util.CmdReporterFlagArgumentToCommand(commandString)
 	if err != nil {
 		rook.TerminateFatal(fmt.Errorf("failed to parse '--command' argument [%s]. %+v", commandString, err))
@@ -82,5 +81,8 @@ func runCmdReporter(cCmd *cobra.Command, cArgs []string) error {
 	if err != nil {
 		rook.TerminateFatal(fmt.Errorf("cannot start command-reporter. %+v", err))
 	}
-	return reporter.Run()
+	err = reporter.Run()
+	if err != nil {
+		rook.TerminateFatal(err)
+	}
 }


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

In some cases in which the rook-ceph-detect-version job fails to
write to the ConfigMap, this should not cause the job to fail.
However, in the case of a temporary network partition, failing
the job improves resiliency.

This change causes the job to fail in the case that the k8s client
cannot read, create, or update the ConfigMap.

**Which issue is resolved by this Pull Request:**

Fixes: #4301
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
