### PR TITLE
CSI: update kubernetes sidecar images

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -290,9 +290,9 @@ below, which you should change to match where your images are located.
     - name: ROOK_CSI_REGISTRAR_IMAGE
         value: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
     - name: ROOK_CSI_PROVISIONER_IMAGE
-        value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
+        value: "quay.io/k8scsi/csi-provisioner:v1.4.0"
     - name: ROOK_CSI_SNAPSHOTTER_IMAGE
-        value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+        value: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
     - name: ROOK_CSI_ATTACHER_IMAGE
         value: "quay.io/k8scsi/csi-attacher:v1.2.0"
 ```

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -129,8 +129,8 @@ The following tables lists the configurable parameters of the rook-operator char
 | `csi.kubeletDirPath`            | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
 | `csi.cephcsi.image`             | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.1`                       |
 | `csi.registrar.image`           | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |
-| `csi.provisioner.image`         | Kubernetes CSI provisioner image.                                                                       | `quay.io/k8scsi/csi-provisioner:v1.3.0`                |
-| `csi.snapshotter.image`         | Kubernetes CSI snapshotter image.                                                                       | `quay.io/k8scsi/csi-snapshotter:v1.2.0`                |
+| `csi.provisioner.image`         | Kubernetes CSI provisioner image.                                                                       | `quay.io/k8scsi/csi-provisioner:v1.4.0`                |
+| `csi.snapshotter.image`         | Kubernetes CSI snapshotter image.                                                                       | `quay.io/k8scsi/csi-snapshotter:v1.2.2`                |
 | `csi.attacher.image`            | Kubernetes CSI Attacher image.                                                                          | `quay.io/k8scsi/csi-attacher:v1.2.0`                   |
 | `agent.flexVolumeDirPath`       | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
 | `agent.libModulesDirPath`       | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -78,9 +78,9 @@ csi:
   #registrar:
     #image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
   #provisioner:
-    #image: quay.io/k8scsi/csi-provisioner:v1.3.0
+    #image: quay.io/k8scsi/csi-provisioner:v1.4.0
   #snapshotter:
-    #image: quay.io/k8scsi/csi-snapshotter:v1.2.0
+    #image: quay.io/k8scsi/csi-snapshotter:v1.2.2
   #attacher:
     #image: quay.io/k8scsi/csi-attacher:v1.2.0
 

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -176,9 +176,9 @@ spec:
         #- name: ROOK_CSI_REGISTRAR_IMAGE
         #  value: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
         #- name: ROOK_CSI_PROVISIONER_IMAGE
-        #  value: "quay.io/k8scsi/csi-provisioner:v1.3.0"
+        #  value: "quay.io/k8scsi/csi-provisioner:v1.4.0"
         #- name: ROOK_CSI_SNAPSHOTTER_IMAGE
-        #  value: "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+        #  value: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
         #- name: ROOK_CSI_ATTACHER_IMAGE
         #  value: "quay.io/k8scsi/csi-attacher:v1.2.0"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -85,9 +85,9 @@ var (
 	// image names
 	DefaultCSIPluginImage   = "quay.io/cephcsi/cephcsi:v1.2.1"
 	DefaultRegistrarImage   = "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0"
-	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.3.0"
+	DefaultProvisionerImage = "quay.io/k8scsi/csi-provisioner:v1.4.0"
 	DefaultAttacherImage    = "quay.io/k8scsi/csi-attacher:v1.2.0"
-	DefaultSnapshotterImage = "quay.io/k8scsi/csi-snapshotter:v1.2.0"
+	DefaultSnapshotterImage = "quay.io/k8scsi/csi-snapshotter:v1.2.2"
 )
 
 const (


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
update csi sidecar images to fix CVE-2019-11255

more info:
https://github.com/kubernetes/kubernetes/issues/85233
https://github.com/kubernetes-csi/external-snapshotter/issues/193
https://github.com/kubernetes-csi/external-provisioner/issues/380

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
