### PR TITLE
ceph: Implementing Conditions on rook-ceph

### DIFF
--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -187,10 +187,14 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-    - name: State
+    - name: Phase
       type: string
-      description: Current State
-      JSONPath: .status.state
+      description: Phase 
+      JSONPath: .status.phase
+    - name: Message
+      type: string
+      description: Message
+      JSONPath: .status.message
     - name: Health
       type: string
       description: Ceph Health

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -142,8 +142,9 @@ type MonitoringSpec struct {
 }
 
 type ClusterStatus struct {
-	State       ClusterState    `json:"state,omitempty"`
+	Phase       ConditionType   `json:"phase,omitempty"`
 	Message     string          `json:"message,omitempty"`
+	Conditions  []Condition     `json:"conditions,omitempty"`
 	CephStatus  *CephStatus     `json:"ceph,omitempty"`
 	CephVersion *ClusterVersion `json:"version,omitempty"`
 }
@@ -166,15 +167,27 @@ type CephHealthMessage struct {
 	Message  string `json:"message"`
 }
 
-type ClusterState string
+type Condition struct {
+	Type               ConditionType      `json:"type,omitempty"`
+	Status             v1.ConditionStatus `json:"status,omitempty"`
+	Reason             string             `json:"reason,omitempty"`
+	Message            string             `json:"message,omitempty"`
+	LastHeartbeatTime  metav1.Time        `json:"lastHeartbeatTime,omitempty"`
+	LastTransitionTime metav1.Time        `json:"lastTransitionTime,omitempty"`
+}
+
+type ConditionType string
 
 const (
-	ClusterStateCreating   ClusterState = "Creating"
-	ClusterStateCreated    ClusterState = "Created"
-	ClusterStateUpdating   ClusterState = "Updating"
-	ClusterStateConnecting ClusterState = "Connecting"
-	ClusterStateConnected  ClusterState = "Connected"
-	ClusterStateError      ClusterState = "Error"
+	ConditionIgnored     ConditionType = "Ignored"
+	ConditionConnecting  ConditionType = "Connecting"
+	ConditionConnected   ConditionType = "Connected"
+	ConditionProgressing ConditionType = "Progressing"
+	ConditionReady       ConditionType = "Ready"
+	ConditionUpdating    ConditionType = "Updating"
+	ConditionFailure     ConditionType = "Failure"
+	ConditionUpgrading   ConditionType = "Upgrading"
+	ConditionDeleting    ConditionType = "Deleting"
 	// DefaultFailureDomain for PoolSpec
 	DefaultFailureDomain = "host"
 )

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -56,6 +56,7 @@ type cluster struct {
 	Namespace            string
 	Spec                 *cephv1.ClusterSpec
 	crdName              string
+	condition            *cephv1.ClusterStatus
 	mons                 *mon.Cluster
 	initCompleted        bool
 	stopCh               chan struct{}

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -49,7 +49,6 @@ func TestClusterDeleteFlexEnabled(t *testing.T) {
 	context := &clusterd.Context{
 		Clientset: clientset,
 	}
-
 	listCount := 0
 	volumeAttachmentController := &attachment.MockAttachment{
 		MockList: func(namespace string) (*rookalpha.VolumeList, error) {
@@ -116,7 +115,6 @@ func TestClusterDeleteFlexDisabled(t *testing.T) {
 	context := &clusterd.Context{
 		Clientset: clientset,
 	}
-
 	listCount := 0
 	volumeAttachmentController := &attachment.MockAttachment{
 		MockList: func(namespace string) (*rookalpha.VolumeList, error) {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -181,7 +181,6 @@ func (c *Cluster) Start() error {
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}
-
 	logger.Infof("start running osds in namespace %s", c.Namespace)
 
 	if c.DesiredStorage.UseAllNodes == false && len(c.DesiredStorage.Nodes) == 0 && len(c.DesiredStorage.VolumeSources) == 0 && len(c.DesiredStorage.StorageClassDeviceSets) == 0 {
@@ -226,7 +225,6 @@ func (c *Cluster) Start() error {
 			}
 		}
 	}
-
 	logger.Infof("completed running osds in namespace %s", c.Namespace)
 	return nil
 }

--- a/pkg/operator/ceph/config/conditions.go
+++ b/pkg/operator/ceph/config/conditions.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config to provide conditions for CephCluster
+package config
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	conditions   *[]cephv1.Condition
+	conditionMap = make(map[cephv1.ConditionType]v1.ConditionStatus)
+)
+
+// ConditionExport function will export each condition into the cluster custom resource
+func ConditionExport(context *clusterd.Context, namespace, name string, conditionType cephv1.ConditionType, status v1.ConditionStatus, reason, message string) {
+	setCondition(context, namespace, name, cephv1.Condition{
+		Type:    conditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
+}
+
+// setCondition updates the conditions of the cluster custom resource
+func setCondition(context *clusterd.Context, namespace, name string, newCondition cephv1.Condition) {
+	cluster, err := context.RookClientset.CephV1().CephClusters(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Errorf("failed to get cluster %v", err)
+	}
+	if conditions == nil {
+		conditions = &cluster.Status.Conditions
+		if cluster.Status.Conditions != nil {
+			conditionMapping(*conditions)
+		}
+	}
+	conditionMap[newCondition.Type] = newCondition.Status
+	existingCondition := findStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		newCondition.LastHeartbeatTime = metav1.NewTime(time.Now())
+		*conditions = append(*conditions, newCondition)
+
+	} else if existingCondition.Status != newCondition.Status || existingCondition.Message != newCondition.Message {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		existingCondition.Status = newCondition.Status
+		existingCondition.Reason = newCondition.Reason
+		existingCondition.Message = newCondition.Message
+		existingCondition.LastHeartbeatTime = metav1.NewTime(time.Now())
+	}
+	cluster.Status.Conditions = *conditions
+
+	if newCondition.Status == v1.ConditionTrue {
+		cluster.Status.Phase = newCondition.Type
+		cluster.Status.Message = newCondition.Message
+		logger.Infof("CephCluster %q status: %q. %q", namespace, cluster.Status.Phase, cluster.Status.Message)
+	}
+
+	if _, err := context.RookClientset.CephV1().CephClusters(namespace).Update(cluster); err != nil {
+		logger.Errorf("failed to update cluster condition %v", err)
+	}
+	if newCondition.Type == cephv1.ConditionReady {
+		checkConditionFalse(context, namespace, name)
+	}
+}
+
+// Updating the status of Progressing, Updating or Upgrading to False once cluster is Ready
+func checkConditionFalse(context *clusterd.Context, namespace, name string) {
+	tempConditionList := []cephv1.ConditionType{cephv1.ConditionUpdating, cephv1.ConditionUpgrading, cephv1.ConditionProgressing}
+	var tempCondition cephv1.ConditionType
+	for _, conditionType := range tempConditionList {
+		if conditionMap[conditionType] == v1.ConditionTrue {
+			tempCondition = conditionType
+		}
+	}
+	reason := ""
+	message := ""
+	if tempCondition == cephv1.ConditionUpdating {
+		reason = "UpdateCompleted"
+		message = "Cluster updating is completed"
+	} else if tempCondition == cephv1.ConditionUpgrading {
+		reason = "UpgradeCompleted"
+		message = "Cluster upgrading is completed"
+	} else {
+		reason = "ProgressingCompleted"
+		message = "Cluster progression is completed"
+	}
+	ConditionExport(context, namespace, name, tempCondition, v1.ConditionFalse, reason, message)
+}
+
+// ConditionInitialize initializes some of the conditions at the beginning of cluster creation
+func ConditionInitialize(context *clusterd.Context, namespace, name string) {
+	setCondition(context, namespace, name, cephv1.Condition{
+		Type:    cephv1.ConditionFailure,
+		Status:  v1.ConditionFalse,
+		Reason:  "",
+		Message: "",
+	})
+	setCondition(context, namespace, name, cephv1.Condition{
+		Type:    cephv1.ConditionIgnored,
+		Status:  v1.ConditionFalse,
+		Reason:  "",
+		Message: "",
+	})
+	setCondition(context, namespace, name, cephv1.Condition{
+		Type:    cephv1.ConditionUpgrading,
+		Status:  v1.ConditionFalse,
+		Reason:  "",
+		Message: "",
+	})
+}
+
+// conditionMapping maps the condition type to its status
+func conditionMapping(conditions []cephv1.Condition) {
+	for i := range conditions {
+		conditionType := conditions[i].Type
+		conditionMap[conditionType] = conditions[i].Status
+	}
+}
+
+// CheckConditionReady checks whether the cluster is Ready and returns the message for the Progressing ConditionType
+func CheckConditionReady(context *clusterd.Context, namespace, name string) string {
+	cluster, err := context.RookClientset.CephV1().CephClusters(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		logger.Errorf("failed to get cluster %v", err)
+	}
+	if cluster.Status.Conditions != nil && len(conditionMap) == 0 {
+		conditionMapping(cluster.Status.Conditions)
+	}
+	if conditionMap[cephv1.ConditionReady] == v1.ConditionTrue {
+		return "Cluster is checking if updates are needed"
+	}
+	return "Cluster is creating"
+}
+
+// ErrorMapping iterate through the Condition Map to see if Failure is True or False
+func ErrorMapping() error {
+	if conditionMap[cephv1.ConditionFailure] == v1.ConditionTrue {
+		return errors.New("failed to initialize the cluster")
+	}
+	return nil
+}
+
+//findStatusCondition is used to find the already existing Condition Type
+func findStatusCondition(conditions []cephv1.Condition, conditionType cephv1.ConditionType) *cephv1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -622,9 +622,9 @@ func (h *CephInstaller) purgeClusters() error {
 func (h *CephInstaller) checkCephHealthStatus(namespace string) {
 	clusterResource, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Get(namespace, metav1.GetOptions{})
 	assert.Nil(h.T(), err)
-	clusterStatus := string(clusterResource.Status.State)
-	if clusterStatus != "Created" && clusterStatus != "Connected" {
-		assert.Equal(h.T(), "Created", string(clusterResource.Status.State))
+	clusterPhase := string(clusterResource.Status.Phase)
+	if clusterPhase != "Ready" && clusterPhase != "Connected" {
+		assert.Equal(h.T(), "Ready", string(clusterResource.Status.Phase))
 	}
 
 	// Depending on the tests, the health may be fluctuating with different components being started or stopped.


### PR DESCRIPTION
Did the changes which required to implement conditions on the rook ceph cluster
Conditions will eliminate the current status.State and incorporates a type which
provides much more description to the current status of the cluster.

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
As per the discussions in #4066 

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]