### PR TITLE
ceph: integration: upgrade: long wait for mgr module - disable dashboard

### DIFF
--- a/tests/framework/installer/ceph_manifests_v1.0.go
+++ b/tests/framework/installer/ceph_manifests_v1.0.go
@@ -1173,6 +1173,8 @@ func (m *CephManifestsV1_0) GetRookCluster(settings *ClusterSettings) string {
 		store = `storeType: "` + settings.StoreType + `"`
 	}
 
+	// disable dashboard of the upgrade test, because upgrading Ceph from Mimic to Nautilus with Rook
+	// v1.0 can stall for a LONG time on updating the mgr module
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -1189,7 +1191,7 @@ spec:
     count: ` + strconv.Itoa(settings.Mons) + `
     allowMultiplePerNode: true
   dashboard:
-    enabled: true
+    enabled: false
   rbdMirroring:
     workers: ` + strconv.Itoa(settings.RBDMirrorWorkers) + `
   metadataDevice:

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -55,7 +55,7 @@ type K8sHelper struct {
 
 const (
 	// RetryLoop params for tests.
-	RetryLoop = 40
+	RetryLoop = 60
 	// RetryInterval param for test - wait time while in RetryLoop
 	RetryInterval = 5
 	// TestMountPath is the path inside a test pod where storage is mounted

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -55,7 +55,7 @@ type K8sHelper struct {
 
 const (
 	// RetryLoop params for tests.
-	RetryLoop = 80
+	RetryLoop = 40
 	// RetryInterval param for test - wait time while in RetryLoop
 	RetryInterval = 5
 	// TestMountPath is the path inside a test pod where storage is mounted
@@ -1602,8 +1602,15 @@ func IsKubectlErrorNotFound(output string, err error) bool {
 // WaitForDeploymentCount waits until the desired number of deployments with the label exist. The
 // deployments are not guaranteed to be running, only existing.
 func (k8sh *K8sHelper) WaitForDeploymentCount(label, namespace string, count int) error {
+	return k8sh.WaitForDeploymentCountWithRetries(label, namespace, count, RetryLoop)
+}
+
+// WaitForDeploymentCountWithRetries waits until the desired number of deployments with the label
+// exist, retrying the specified number of times. The deployments are not guaranteed to be running,
+// only existing.
+func (k8sh *K8sHelper) WaitForDeploymentCountWithRetries(label, namespace string, count, retries int) error {
 	options := metav1.ListOptions{LabelSelector: label}
-	for i := 0; i < RetryLoop; i++ {
+	for i := 0; i < retries; i++ {
 		deps, err := k8sh.Clientset.AppsV1().Deployments(namespace).List(options)
 		numDeps := 0
 		if err == nil {

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -178,16 +178,10 @@ spec:
     image: krallin/ubuntu-tini
     command:
         - "/usr/local/bin/tini"
+        - "-g"
         - "--"
-        - "bash"
-        - "-c"
-        - |
-          pid=
-          trap 'exit 0' SIGTERM
-          trap '[[ $pid ]] && kill "$pid"' EXIT
-          sleep 1800 & pid=$!
-          wait $pid
-          pid=
+        - "sleep"
+        - "1800"
     imagePullPolicy: IfNotPresent
     env:
     volumeMounts:

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -167,7 +167,8 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	require.NoError(s.T(), err)
 
 	osdsNotOldVersion := fmt.Sprintf("app=rook-ceph-osd,ceph-version!=%s", oldCephVersion)
-	err = s.k8sh.WaitForDeploymentCount(osdsNotOldVersion, s.namespace, numOSDs)
+	// It can take a LONG time to update the mgr modules, so wait an extra long time here
+	err = s.k8sh.WaitForDeploymentCountWithRetries(osdsNotOldVersion, s.namespace, numOSDs, utils.RetryLoop*2)
 	require.NoError(s.T(), err)
 	err = s.k8sh.WaitForLabeledDeploymentsToBeReady(osdsNotOldVersion, s.namespace)
 	require.NoError(s.T(), err)


### PR DESCRIPTION
Reset the integration test k8s helper's `RetryLoop` to its original
value, and instead only wait an extra long time to allow the mgr module
updates to take a long time after Ceph is updated from Mimic to Nautilus
as part of Ceph's upgrade integration test.

Updating mgr modules can hang for quite a while, which causes the tests
to time out waiting for the OSDs to be updated. Allow this to take a
long time so the tests aren't as flaky.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test full]
[test ceph]