### PR TITLE
Ceph: Toleration for <NotReady> nodes set to 5 seconds

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -42,6 +42,8 @@ To remove OSDs manually, see the new doc on [OSD Management](Documentation/ceph-
   - When running on PVC, the OSD can be on a slow device class, Rook can adapt to that by tuning the OSD. This can be enabled by the CR setting `tuneSlowDeviceClass`
 - RGWs:
   - Ceph Object Gateway are automatically configured to not run on the same host if hostNetwork is activated
+- New CR property available in the Operator: `ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS` (5 seconds by default). Represents the time to wait until the node controller will move Rook pods to other nodes after detecting an unreachable node. Pods affected by this setting are: mgr, rbd, mds, rgw, nfs, PVC based mons and osds, and ceph toolbox. The value used in this variable replaces the default value of 300 seconds added automatically by k8s as Pod Toleration for `node.kubernetes.io/unreachable`.
+Now the total amount of time to reschedule Rook pods in healthy nodes before detecting a `not ready node` condition will be the sum of `node-monitor-grace-period` (k8s kube-controller-manager flag, 40 seconds by default) and `ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS` (5 seconds by default)
 
 ### EdgeFS
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -212,6 +212,10 @@ spec:
           value: {{ .Values.mon.monOutTimeout }}
 {{- end }}
 {{- end }}
+{{- if .Values.unreachableNodeTolerationSeconds }}
+        - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
+          value: {{ .Values.unreachableNodeTolerationSeconds | quote }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.useOperatorHostNetwork }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -24,6 +24,9 @@ nodeSelector:
 # Tolerations for the rook-ceph-operator to allow it to run on nodes with particular taints
 tolerations: []
 
+# Delay to use in node.kubernetes.io/unreachable toleration
+unreachableNodeTolerationSeconds: 5
+
 # Whether rook watches its current namespace for CRDs or the entire cluster, defaults to false
 currentNamespaceOnly: false
 

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -281,6 +281,21 @@ spec:
         #  value: "9080"
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "true"
+
+        # Time to wait until the node controller will move Rook pods to other
+        # nodes after detecting an unreachable node.
+        # Pods affected by this setting are:
+        # mgr, rbd, mds, rgw, nfs, PVC based mons and osds, and ceph toolbox
+        # The value used in this variable replaces the default value of 300 secs
+        # added automatically by k8s as Toleration for
+        # <node.kubernetes.io/unreachable>
+        # The total amount of time to reschedule Rook pods in healthy nodes
+        # before detecting a <not ready node> condition will be the sum of:
+        #  --> node-monitor-grace-period: 40 seconds (k8s kube-controller-manager flag)
+        #  --> ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS: 5 seconds
+        - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
+          value: "5"
+
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -242,6 +242,21 @@ spec:
         #  value: "9090"
         #- name: CSI_RBD_LIVENESS_METRICS_PORT
         #  value: "9080"
+
+        # Time to wait until the node controller will move Rook pods to other
+        # nodes after detecting an unreachable node.
+        # Pods affected by this setting are:
+        # mgr, rbd, mds, rgw, nfs, PVC based mons and osds, and ceph toolbox
+        # The value used in this variable replaces the default value of 300 secs
+        # added automatically by k8s as Toleration for
+        # <node.kubernetes.io/unreachable>
+        # The total amount of time to reschedule Rook pods in healthy nodes
+        # before detecting a <not ready node> condition will be the sum of:
+        #  --> node-monitor-grace-period: 40 seconds (k8s kube-controller-manager flag)
+        #  --> ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS: 5 seconds
+        - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
+          value: "5"
+
         # The name of the node to pass with the downward API
         - name: NODE_NAME
           valueFrom:

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -42,3 +42,8 @@ spec:
               path: mon-endpoints
         - name: ceph-config
           emptyDir: {}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 5

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -42,6 +42,7 @@ const (
 )
 
 func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
+	logger.Debugf("mgrConfig: %+v", mgrConfig)
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   mgrConfig.ResourceName,
@@ -61,6 +62,9 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) *apps.Deployment {
 			PriorityClassName:  c.priorityClassName,
 		},
 	}
+
+	// Replace default unreachable node toleration
+	k8sutil.AddUnreachableNodeToleration(&podSpec.Spec)
 
 	// if the fix is needed, then the following init containers are created
 	// which explicitly configure the server_addr Ceph configuration option to

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -198,6 +198,10 @@ func (c *Cluster) makeMonPod(monConfig *monConfig) *v1.Pod {
 	if c.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
+	// Replace default unreachable node toleration
+	if c.spec.Mon.VolumeClaimTemplate != nil {
+		k8sutil.AddUnreachableNodeToleration(&podSpec)
+	}
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -524,6 +524,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	if !osdProps.portable {
 		deployment.Spec.Template.Spec.NodeSelector = map[string]string{v1.LabelHostname: osdProps.crushHostname}
 	}
+	// Replace default unreachable node toleration if the osd pod is portable and based in PVC
+	if osdProps.pvc.ClaimName != "" && osdProps.portable {
+		k8sutil.AddUnreachableNodeToleration(&deployment.Spec.Template.Spec)
+	}
 
 	k8sutil.AddRookVersionLabelToDeployment(deployment)
 	c.annotations.ApplyToObjectMeta(&deployment.ObjectMeta)

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -45,6 +45,9 @@ func (m *Mirroring) makeDeployment(daemonConfig *daemonConfig) *apps.Deployment 
 			PriorityClassName: m.priorityClassName,
 		},
 	}
+	// Replace default unreachable node toleration
+	k8sutil.AddUnreachableNodeToleration(&podSpec.Spec)
+
 	if m.Network.IsHost() {
 		podSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -56,6 +56,9 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 			PriorityClassName: c.fs.Spec.MetadataServer.PriorityClassName,
 		},
 	}
+	// Replace default unreachable node toleration
+	k8sutil.AddUnreachableNodeToleration(&podSpec.Spec)
+
 	if c.clusterSpec.Network.IsHost() {
 		podSpec.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -114,6 +114,9 @@ func (c *CephNFSController) makeDeployment(nfs cephv1.CephNFS, cfg daemonConfig)
 		HostNetwork:       c.clusterSpec.Network.IsHost(),
 		PriorityClassName: nfs.Spec.Server.PriorityClassName,
 	}
+	// Replace default unreachable node toleration
+	k8sutil.AddUnreachableNodeToleration(&podSpec)
+
 	if c.clusterSpec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -76,6 +76,9 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) v1.PodTemplateSpec 
 		HostNetwork:       c.clusterSpec.Network.IsHost(),
 		PriorityClassName: c.store.Spec.Gateway.PriorityClassName,
 	}
+	// Replace default unreachable node toleration
+	k8sutil.AddUnreachableNodeToleration(&podSpec)
+
 	if c.clusterSpec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}


### PR DESCRIPTION
**Description of your changes:**
Reduce from 5 minutes to less than 50 seconds the time needed to restart a mgr,mon, and toolbox pod that was running in a k8 "NotReady" Node.

**Which issue is resolved by this Pull Request:**
Resolves #4342

**Details:**
Kubernetes automatically adds a toleration for node.kubernetes.io/not-ready with tolerationSeconds=300 in each pod if this toleration is not set explicetelly.
I have added it to the pods where the recovery from a situation where we have a "notReady" node can be improved. (mgr, mon, toolbox)

I have done several tests and the time needed to have the new pods running is typically less than 50 seconds:

**Example:** ( using the change included in this PR)
Lab: A k8 cluster with master and three workers, in "ku-worker-01" we have a mgr-a, mon-b and the ceph toolbox.

**At 11:35:06** the node "ku-worker-01" is stopped

**After 43 seconds**, in the kube-controller logs we can see:

`I1119 10:35:49.980025       1 event.go:274] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"ku-worker-01.karmalabs.com", UID:"8b2d63b8-09a9-4f54-b8e7-a45fbc54ed84", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'NodeNotReady' Node ku-worker-01.karmalabs.com status is now: NodeNotReady`

The detection of a "NotReady" node in a k8 cluster is only effective after 40 seconds (default value)
And the node controller checks the state of each node every --node-monitor-period seconds (5 seconds by default) 
This force that the detection of this event take between 40 and 45 seconds:
(see [Node Controller](https://kubernetes.io/docs/concepts/architecture/nodes/#node-controller)).  
I am using the values by default. We cannot  cannot reduce them, cbecause is something out of the scope of the Rook operator.


**After 10 seconds:** ( i guess because this happens only after the second detection of the "notReady node ( Toleration is set to 5 seconds)

```
I1119 10:36:00.171795       1 taint_manager.go:105] NoExecuteTaintManager is deleting Pod: rook-ceph/rook-ceph-mon-b-66bfc8696b-jgd7b
I1119 10:36:00.171824       1 taint_manager.go:105] NoExecuteTaintManager is deleting Pod: rook-ceph/rook-ceph-tools-95ff4ff8b-562sm
I1119 10:36:00.172014       1 taint_manager.go:105] NoExecuteTaintManager is deleting Pod: rook-ceph/rook-ceph-mgr-a-5fc7685b65-7tck8
I1119 10:36:00.172071       1 event.go:274] Event(v1.ObjectReference{Kind:"Pod", Namespace:"rook-ceph", Name:"rook-ceph-tools-95ff4ff8b-562sm", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'TaintManagerEviction' Marking for deletion Pod rook-ceph/rook-ceph-tools-95ff4ff8b-562sm
I1119 10:36:00.172094       1 event.go:274] Event(v1.ObjectReference{Kind:"Pod", Namespace:"rook-ceph", Name:"rook-ceph-mgr-a-5fc7685b65-7tck8", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'TaintManagerEviction' Marking for deletion Pod rook-ceph/rook-ceph-mgr-a-5fc7685b65-7tck8
I1119 10:36:00.172106       1 event.go:274] Event(v1.ObjectReference{Kind:"Pod", Namespace:"rook-ceph", Name:"rook-ceph-mon-b-66bfc8696b-jgd7b", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'TaintManagerEviction' Marking for deletion Pod rook-ceph/rook-ceph-mon-b-66bfc8696b-jgd7b
I1119 10:36:00.218764       1 event.go:274] Event(v1.ObjectReference{Kind:"ReplicaSet", Namespace:"rook-ceph", Name:"rook-ceph-mgr-a-5fc7685b65", UID:"4f0f113f-c8de-48d5-b168-369adbaed991", APIVersion:"apps/v1", ResourceVersion:"14932", FieldPath:""}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: rook-ceph-mgr-a-5fc7685b65-9kdgp
I1119 10:36:00.218786       1 event.go:274] Event(v1.ObjectReference{Kind:"ReplicaSet", Namespace:"rook-ceph", Name:"rook-ceph-tools-95ff4ff8b", UID:"4a3b5628-4565-4654-8288-7aa5b0a89367", APIVersion:"apps/v1", ResourceVersion:"14947", FieldPath:""}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: rook-ceph-tools-95ff4ff8b-c2fcw
I1119 10:36:00.228011       1 event.go:274] Event(v1.ObjectReference{Kind:"ReplicaSet", Namespace:"rook-ceph", Name:"rook-ceph-mon-b-66bfc8696b", UID:"b7182e29-fb1b-4b58-96be-61f09d518126", APIVersion:"apps/v1", ResourceVersion:"14936", FieldPath:""}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: rook-ceph-mon-b-66bfc8696b-2tcbb
```


Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

// known CI issue
[skip ci]