### PR TITLE
Fix NFS document with wrong label

### DIFF
--- a/Documentation/nfs.md
+++ b/Documentation/nfs.md
@@ -201,7 +201,7 @@ We can then use the busybox writer pod we launched before to check that nginx is
 In the below 1-liner command, we use `kubectl exec` to run a command in the busybox writer pod that uses `wget` to retrieve the web page that the web server pod is hosting. As the busybox writer pod continues to write a new timestamp, we should see the returned output also update every ~10 seconds or so.
 
 ```console
-> echo; kubectl exec $(kubectl get pod -l name=nfs-busybox -o jsonpath='{.items[0].metadata.name}') -- wget -qO- http://$(kubectl get services nfs-web -o jsonpath='{.spec.clusterIP}'); echo
+> echo; kubectl exec $(kubectl get pod -l app=nfs-demo,role=busybox -o jsonpath='{.items[0].metadata.name}') -- wget -qO- http://$(kubectl get services nfs-web -o jsonpath='{.spec.clusterIP}'); echo
 
 Thu Oct 22 19:28:55 UTC 2015
 nfs-busybox-w3s4t


### PR DESCRIPTION
**Description of your changes:**
In NFS document, the document example explain with `-l name=nfs-busybox` label, however no corresponding label in previous section. Fix to the label mentioned in the previous section.

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**
- [V] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [V] Documentation has been updated, if necessary.
- [V] Unit tests have been added, if necessary.
- [V] Integration tests have been added, if necessary.
- [V] Pending release notes updated with breaking and/or notable changes, if necessary.
- [V] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [V] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [V] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [V] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]