### PR TITLE
ceph: clean up CSI resources on cluster deletion

### DIFF
--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -80,15 +80,21 @@ func TestClusterDeleteFlexEnabled(t *testing.T) {
 
 		},
 	}
-	callbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
+	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
 		func(clusterSpec *cephv1.ClusterSpec) error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
+	removeCallbacks := []func() error{
+		func() error {
 			logger.Infof("test success callback")
 			return nil
 		},
 	}
 
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, "", volumeAttachmentController, callbacks)
+	controller := NewClusterController(context, "", volumeAttachmentController, addCallbacks, removeCallbacks)
 	clusterToDelete := &cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 
@@ -119,7 +125,7 @@ func TestClusterDeleteFlexDisabled(t *testing.T) {
 
 		},
 	}
-	callbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
+	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
 		func(clusterSpec *cephv1.ClusterSpec) error {
 			logger.Infof("test success callback")
 			os.Setenv("ROOK_ENABLE_FLEX_DRIVER", "true")
@@ -128,9 +134,15 @@ func TestClusterDeleteFlexDisabled(t *testing.T) {
 			return nil
 		},
 	}
+	removeCallbacks := []func() error{
+		func() error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
 
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, "", volumeAttachmentController, callbacks)
+	controller := NewClusterController(context, "", volumeAttachmentController, addCallbacks, removeCallbacks)
 	clusterToDelete := &cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 
@@ -201,14 +213,20 @@ func TestRemoveFinalizer(t *testing.T) {
 		Clientset:     clientset,
 		RookClientset: rookfake.NewSimpleClientset(),
 	}
-	callbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
+	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
 		func(clusterSpec *cephv1.ClusterSpec) error {
 			logger.Infof("test success callback")
 			return fmt.Errorf("test failed callback")
 		},
 	}
+	removeCallbacks := []func() error{
+		func() error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
 
-	controller := NewClusterController(context, "", &attachment.MockAttachment{}, callbacks)
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, addCallbacks, removeCallbacks)
 
 	// *****************************************
 	// start with a current version ceph cluster

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -153,6 +153,13 @@ func getCsiConfigMap(namespace string, clientset kubernetes.Interface) (*v1.Conf
 	return found, err
 }
 
+func DeleteCsiConfigMap(namespace string, clientset kubernetes.Interface) error {
+	if err := clientset.CoreV1().ConfigMaps(namespace).Delete(ConfigName, &metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete CSI driver configuration and deployments: %v", err)
+	}
+	return nil
+}
+
 // SaveClusterConfig updates the config map used to provide ceph-csi with
 // basic cluster configuration. The clusterNamespace and clusterInfo are
 // used to determine what "cluster" in the config map will be updated and

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -343,6 +343,11 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	return nil
 }
 
+func StopCSIDrivers(namespace string, clientset kubernetes.Interface) error {
+	// As we have placed ownerRefs to the ConfigMap for all CSI resources, we delegate entirely to its deletion method.
+	return DeleteCsiConfigMap(namespace, clientset)
+}
+
 // createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
 func createCSIDriverInfo(clientset kubernetes.Interface, name string, ownerRef metav1.OwnerReference) error {
 	attach := true

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -90,10 +90,11 @@ func New(context *clusterd.Context, volumeAttachmentWrapper attachment.Attachmen
 		rookImage:         rookImage,
 		securityAccount:   securityAccount,
 	}
-	callbacks := []func(*cephv1.ClusterSpec) error{
+	addCallbacks := []func(*cephv1.ClusterSpec) error{
 		o.startSystemDaemons,
 	}
-	o.clusterController = cluster.NewClusterController(context, rookImage, volumeAttachmentWrapper, callbacks)
+	var removeCallbacks []func() error
+	o.clusterController = cluster.NewClusterController(context, rookImage, volumeAttachmentWrapper, addCallbacks, removeCallbacks)
 	return o
 }
 

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -93,7 +93,9 @@ func New(context *clusterd.Context, volumeAttachmentWrapper attachment.Attachmen
 	addCallbacks := []func(*cephv1.ClusterSpec) error{
 		o.startSystemDaemons,
 	}
-	var removeCallbacks []func() error
+	removeCallbacks := []func() error{
+		o.stopSystemDaemons,
+	}
 	o.clusterController = cluster.NewClusterController(context, rookImage, volumeAttachmentWrapper, addCallbacks, removeCallbacks)
 	return o
 }
@@ -204,5 +206,27 @@ func (o *Operator) startSystemDaemons(clusterSpec *cephv1.ClusterSpec) error {
 	logger.Infof("successfully started Ceph CSI driver(s)")
 
 	o.delayedDaemonsStarted = true
+	return nil
+}
+
+func (o *Operator) stopSystemDaemons() error {
+	if !o.delayedDaemonsStarted || o.clusterController.GetClusterCount() != 0 {
+		return nil
+	}
+	if o.operatorNamespace == "" {
+		return fmt.Errorf("Rook operator namespace is not provided. Expose it via downward API in the rook operator manifest file using environment variable %s", k8sutil.PodNamespaceEnvVar)
+	}
+	// TODO: Add removal of FlexVolume daemons
+	if !csi.CSIEnabled() {
+		logger.Infof("CSI driver is not enabled")
+		return nil
+	}
+
+	if err := csi.StopCSIDrivers(o.operatorNamespace, o.context.Clientset); err != nil {
+		return fmt.Errorf("failed to start Ceph csi drivers: %v", err)
+	}
+	logger.Infof("successfully stopped Ceph CSI driver(s)")
+
+	o.delayedDaemonsStarted = false
 	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This change:
a) Assigns an ownerRef to the CSI ConfigMap for all CSI resources.
b) Adds callback hooks to the operator for cluster deletion.
c) Deletes all CSI resources if no remaining clusters are managed
   by the ClusterController.

**Which issue is resolved by this Pull Request:**
Resolves #4234 
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
