### PR TITLE
ceph: add rook-version and ceph-version tags to crash deployment

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -682,6 +682,7 @@ func (c *ClusterController) detectAndValidateCephVersion(cluster *cluster, image
 	if err := cluster.validateCephVersion(version); err != nil {
 		return nil, false, err
 	}
+	cephver.RegisterImageVersion(image, *version)
 	return version, false, nil
 }
 

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -50,7 +51,7 @@ var clusterResource = opkit.CustomResource{
 }
 
 // createOrUpdateCephCrash is a wrapper around controllerutil.CreateOrUpdate
-func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []corev1.Toleration, cephCluster cephv1.CephCluster) (controllerutil.OperationResult, error) {
+func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []corev1.Toleration, cephCluster cephv1.CephCluster, cephVersion *version.CephVersion) (controllerutil.OperationResult, error) {
 	// Create or Update the deployment default/foo
 	nodeHostnameLabel, ok := node.ObjectMeta.Labels[corev1.LabelHostname]
 	if !ok {
@@ -86,6 +87,10 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 		}
 
 		deploy.ObjectMeta.Labels = deploymentLabels
+		k8sutil.AddRookVersionLabelToDeployment(deploy)
+		if cephVersion != nil {
+			opspec.AddCephVersionLabelToDeployment(*cephVersion, deploy)
+		}
 		deploy.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: deploymentLabels,

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"sync"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -57,6 +58,9 @@ var (
 
 	// for parsing the output of `ceph --version`
 	versionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)`)
+	// for storage of the versions of images for access in managed reconciliations
+	imageToVersionMap     = map[string]CephVersion{}
+	imageToVersionMapLock = &sync.Mutex{}
 
 	// For a build release the output is "ceph version 14.2.4-64.el8cp"
 	// So we need to detect the build version change
@@ -293,4 +297,19 @@ func ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, externalV
 	}
 
 	return nil
+}
+
+// RegisterImageVersion stores the CephVersion detected for a specified image for global access.
+func RegisterImageVersion(image string, version CephVersion) {
+	imageToVersionMapLock.Lock()
+	imageToVersionMap[image] = version
+	imageToVersionMapLock.Unlock()
+}
+
+// GetImageVersion returns the CephVersion registered for a specified image (if any) and whether any image was found.
+func GetImageVersion(image string) (*CephVersion, bool) {
+	imageToVersionMapLock.Lock()
+	version, ok := imageToVersionMap[image]
+	imageToVersionMapLock.Unlock()
+	return &version, ok
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This change adds rook-version and ceph-version tags to crash
collector deployments, in keeping with other Ceph deployments.

**Which issue is resolved by this Pull Request:**
Resolves #4357
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
