### PR TITLE
Ceph: OSD: refactor config for filestore OSDs

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,7 +15,7 @@
   - Ceph OSD's admin socket is now placed under Ceph's default system location `/run/ceph`.
   - The on-host log directory for OSDs was set incorrectly to `<dataDirHostPath>/<namespace>/log`;
     fix this to be `<dataDirHostPath>/log/<namespace>`, the same as other daemons.
-  - Use the mon configuration database for directory-based OSDs, and do not generate a config
+  - Do not generate a config (during pod init) for directory-based or legacy filestore OSDs
   - Add a new CRD property `devicePathFilter` to support device filtering with path names, e.g. `/dev/disk/by-path/pci-.*-sas-.*`.
   - Support PersistentVolume backed by LVM Logical Volume for "OSD on PVC".
 - A new ceph-crashcollector controller has been added, that new pod will run on any node where a Ceph pod is running. Read more about this in the [doc](Documentation/ceph-cluster-crd.html#cluster-wide-resources-configuration-settings)

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -52,12 +52,12 @@ func TestStoreTypeDefaults(t *testing.T) {
 
 	// A bluestore dir
 	cfg = &osdConfig{dir: true, storeConfig: config.StoreConfig{StoreType: "bluestore"}}
-	assert.False(t, isFilestore(cfg))
+	assert.True(t, isFilestore(cfg)) // all dir osds are filestore
 	assert.False(t, isFilestoreDevice(cfg))
-	assert.False(t, isFilestoreDir(cfg))
-	assert.True(t, isBluestore(cfg))
+	assert.True(t, isFilestoreDir(cfg)) // all dir osds are filestore
+	assert.False(t, isBluestore(cfg))   // all dir osds are filestore
 	assert.False(t, isBluestoreDevice(cfg))
-	assert.True(t, isBluestoreDir(cfg))
+	assert.False(t, isBluestoreDir(cfg)) // all dir osds are filestore
 
 	// a bluestore device
 	cfg = &osdConfig{dir: false, partitionScheme: &config.PerfSchemeEntry{StoreType: ""}}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -23,9 +23,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
-	"syscall"
-
 	"strings"
+	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
@@ -135,6 +134,9 @@ func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
 	return nil
 }
 
+// RunFilestoreOnDevice runs a Ceph filestore OSD on a device. For filestore devices, Rook must
+// first mount the filesystem on disk (source path) to a path (mount path) from which the OSD will
+// be run.
 func RunFilestoreOnDevice(context *clusterd.Context, mountSourcePath, mountPath string, cephArgs []string) error {
 	// start the OSD daemon in the foreground with the given config
 	logger.Infof("starting filestore osd on a device")

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -231,7 +231,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 
 	if osd.IsFileStore {
-		commonArgs = append(commonArgs, fmt.Sprintf("--osd-journal=%s", osd.Journal))
+		commonArgs = append(commonArgs,
+			"--osd-journal", osd.Journal,
+			"--osd-max-object-name-len", "256",
+			"--osd-max-object-namespace-len", "64",
+		)
 	}
 
 	if c.clusterInfo.CephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 1}) {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -143,8 +143,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	doConfigInit := true       // initialize ceph.conf in init container?
 	doBinaryCopyInit := true   // copy tini and rook binaries in an init container?
 	doActivateOSDInit := false // run an init container to activate the osd?
+	doChownDataPath := true    // chown the data path in an init container?
 
 	var dataDir string
+	var sourcePath string
 	if osd.IsDirectory {
 		// Mount the path to the directory-based osd
 		// osd.DataPath includes the osd subdirectory, so we want to mount the parent directory
@@ -154,6 +156,16 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		// for directory osds, we completely overwrite the starting point from above.
 		provisionConfig.DataPathMap.HostDataDir = dataDir
 		provisionConfig.DataPathMap.ContainerDataDir = dataDir
+
+		volumes = opspec.DaemonVolumes(provisionConfig.DataPathMap, deploymentName)
+		volumeMounts = opspec.DaemonVolumeMounts(provisionConfig.DataPathMap, deploymentName)
+		configVolumeMounts = opspec.DaemonVolumeMounts(provisionConfig.DataPathMap, deploymentName)
+	} else if !osd.IsDirectory && osd.IsFileStore && !osd.CephVolumeInitiated {
+		// for legacy filestore osds, sourcePath is mounted to the dataDir in the container.
+		dataDir = osd.DataPath
+		sourcePath = path.Join("/dev/disk/by-partuuid", osd.DevicePartUUID)
+		provisionConfig.DataPathMap.HostDataDir = sourcePath
+		provisionConfig.DataPathMap.ContainerDataDir = sourcePath
 
 		volumes = opspec.DaemonVolumes(provisionConfig.DataPathMap, deploymentName)
 		volumeMounts = opspec.DaemonVolumeMounts(provisionConfig.DataPathMap, deploymentName)
@@ -230,14 +242,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		}
 	}
 
-	if osd.IsFileStore {
-		commonArgs = append(commonArgs,
-			"--osd-journal", osd.Journal,
-			"--osd-max-object-name-len", "256",
-			"--osd-max-object-namespace-len", "64",
-		)
-	}
-
 	if c.clusterInfo.CephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
 		commonArgs = append(commonArgs, "--default-log-to-file", "false")
 	}
@@ -247,20 +251,39 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	var command []string
 	var args []string
 	if !osd.IsDirectory && osd.IsFileStore && !osd.CephVolumeInitiated {
+		doConfigInit = false
 		// All scenarios except one can call the ceph-osd daemon directly. The one different scenario is when
 		// filestore is running on a device. Rook needs to mount the device, run the ceph-osd daemon, and then
 		// when the daemon exits, rook needs to unmount the device. Since rook needs to be in the container
 		// for this scenario, we will copy the binaries necessary to a mount, which will then be mounted
 		// to the daemon container.
-		sourcePath := path.Join("/dev/disk/by-partuuid", osd.DevicePartUUID)
+		doBinaryCopyInit = true
+		// Since the data path is mounted from a different source for filestore disks, don't chown it
+		doChownDataPath = false
+
 		command = []string{path.Join(k8sutil.BinariesMountPath, "tini")}
-		args = append([]string{
+		args = []string{
 			"--", path.Join(k8sutil.BinariesMountPath, "rook"),
 			"ceph", "osd", "filestore-device",
 			"--source-path", sourcePath,
 			"--mount-path", osd.DataPath,
-			"--"},
-			defaultArgs...)
+			"--",
+		}
+		args = append(args,
+			opspec.DaemonFlags(c.clusterInfo, osdID)...,
+		)
+		args = append(args,
+			"--foreground",
+			"--osd-data", osd.DataPath,
+			"--osd-uuid", osd.UUID,
+			"--osd-objectstore", storeType,
+			"--osd-max-object-name-len", "256",
+			"--osd-max-object-namespace-len", "64",
+			"--crush-location", fmt.Sprintf("root=default host=%s", osdProps.crushHostname),
+			// Set '--setuser-match-path' so that existing directory owned by root won't affect the daemon startup.
+			// For existing data store owned by root, the daemon will continue to run as root
+			"--setuser-match-path", osd.DataPath,
+		)
 
 		// If the Bluestore OSD was prepared with ceph-volume and not running on PVC
 	} else if osd.CephVolumeInitiated && osdProps.pvc.ClaimName == "" && !osd.IsFileStore {
@@ -339,6 +362,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		args = defaultArgs
 	}
 
+	if osd.IsFileStore {
+		args = append(args, fmt.Sprintf("--osd-journal=%s", osd.Journal))
+	}
+
 	// Add the volume to the spec and the mount to the daemon container
 	copyBinariesVolume, copyBinariesContainer := c.getCopyBinariesContainer()
 	if doBinaryCopyInit {
@@ -406,9 +433,13 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	// completing. It can take an arbitrarily long time for a pod restart to successfully chown the
 	// directory. This is a race condition for all OSDs; therefore, do this in an init container.
 	// See more discussion here: https://github.com/rook/rook/pull/3594#discussion_r312279176
+	dataPath := ""
+	if doChownDataPath {
+		dataPath = osd.DataPath
+	}
 	initContainers = append(initContainers,
 		opspec.ChownCephDataDirsInitContainer(
-			opconfig.DataPathMap{ContainerDataDir: osd.DataPath},
+			opconfig.DataPathMap{ContainerDataDir: dataPath},
 			c.cephVersion.Image,
 			volumeMounts,
 			osdProps.resources,

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -707,9 +707,8 @@ func (c *Cluster) getConfigEnvVars(storeConfig config.StoreConfig, dataDir, node
 	// Append ceph-volume environment variables
 	envVars = append(envVars, cephVolumeEnvVar()...)
 
-	if storeConfig.StoreType != "" {
-		envVars = append(envVars, v1.EnvVar{Name: osdStoreEnvVarName, Value: storeConfig.StoreType})
-	}
+	// deliberately skip setting osdStoreEnvVarName (ROOK_OSD_STORE) as a quick means to deprecate
+	// creating new disk-based Filestore OSDs
 
 	if storeConfig.DatabaseSizeMB != 0 {
 		envVars = append(envVars, v1.EnvVar{Name: osdDatabaseSizeEnvVarName, Value: strconv.Itoa(storeConfig.DatabaseSizeMB)})

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -233,7 +233,6 @@ func TestStorageSpecConfig(t *testing.T) {
 			{
 				Name: "node1",
 				Config: map[string]string{
-					"storeType":      "bluestore",
 					"databaseSizeMB": "10",
 					"walSizeMB":      "20",
 					"journalSizeMB":  "30",
@@ -288,7 +287,6 @@ func TestStorageSpecConfig(t *testing.T) {
 	assert.NotNil(t, container)
 	container = job.Spec.Template.Spec.Containers[0]
 	assert.NotNil(t, container)
-	verifyEnvVar(t, container.Env, "ROOK_OSD_STORE", "bluestore", true)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_DATABASE_SIZE", "10", true)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_WAL_SIZE", "20", true)
 	verifyEnvVar(t, container.Env, "ROOK_OSD_JOURNAL_SIZE", "30", true)
@@ -307,7 +305,6 @@ func TestHostNetwork(t *testing.T) {
 			{
 				Name: "node1",
 				Config: map[string]string{
-					"storeType":      "bluestore",
 					"databaseSizeMB": "10",
 					"walSizeMB":      "20",
 					"journalSizeMB":  "30",


### PR DESCRIPTION
**Description of your changes:**
Just as with the mon, mgr, mds, rgw, and rbd-mirror daemons, do not
generate a ceph.conf in an init container for filestore OSDs.
Instead use the commandline to supply all the needed arguments for
running these OSDs.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
