### PR TITLE
ceph: fix upgrade of mds/rgw on build release

### DIFF
--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -164,7 +164,7 @@ func (c *FilesystemController) onUpdate(oldObj, newObj interface{}) {
 // ParentClusterChanged determines wether or not a CR update has been sent
 func (c *FilesystemController) ParentClusterChanged(cluster cephv1.ClusterSpec, clusterInfo *cephconfig.ClusterInfo, isUpgrade bool) {
 	c.clusterInfo = clusterInfo
-	if !isUpgrade {
+	if cluster.CephVersion.Image == c.clusterSpec.CephVersion.Image {
 		logger.Debugf("No need to update the file system after the parent cluster changed")
 		return
 	}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -192,7 +192,7 @@ func (c *ObjectStoreController) onDelete(obj interface{}) {
 // ParentClusterChanged determines wether or not a CR update has been sent
 func (c *ObjectStoreController) ParentClusterChanged(cluster cephv1.ClusterSpec, clusterInfo *daemonconfig.ClusterInfo, isUpgrade bool) {
 	c.clusterInfo = clusterInfo
-	if !isUpgrade {
+	if cluster.CephVersion.Image == c.clusterSpec.CephVersion.Image {
 		logger.Debugf("No need to update the object store after the parent cluster changed")
 		return
 	}

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -29,6 +29,7 @@ type CephVersion struct {
 	Major int
 	Minor int
 	Extra int
+	Build int
 }
 
 const (
@@ -37,15 +38,15 @@ const (
 
 var (
 	// Minimum supported version is 13.2.4 where ceph-volume is supported
-	Minimum = CephVersion{13, 2, 4}
+	Minimum = CephVersion{13, 2, 4, 0}
 	// Luminous Ceph version
-	Luminous = CephVersion{12, 0, 0}
+	Luminous = CephVersion{12, 0, 0, 0}
 	// Mimic Ceph version
-	Mimic = CephVersion{13, 0, 0}
+	Mimic = CephVersion{13, 0, 0, 0}
 	// Nautilus Ceph version
-	Nautilus = CephVersion{14, 0, 0}
+	Nautilus = CephVersion{14, 0, 0, 0}
 	// Octopus Ceph version
-	Octopus = CephVersion{15, 0, 0}
+	Octopus = CephVersion{15, 0, 0, 0}
 
 	// supportedVersions are production-ready versions that rook supports
 	supportedVersions   = []CephVersion{Mimic, Nautilus}
@@ -55,6 +56,10 @@ var (
 
 	// for parsing the output of `ceph --version`
 	versionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)`)
+
+	// For a build release the output is "ceph version 14.2.4-64.el8cp"
+	// So we need to detect the build version change
+	buildVersionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)\-(\d+)`)
 
 	logger = capnslog.NewPackageLogger("github.com/rook/rook", "cephver")
 )
@@ -86,9 +91,10 @@ func (v *CephVersion) ReleaseName() string {
 
 // ExtractCephVersion extracts the major, minor and extra digit of a Ceph release
 func ExtractCephVersion(src string) (*CephVersion, error) {
+	var build int
 	m := versionPattern.FindStringSubmatch(src)
 	if m == nil {
-		return nil, fmt.Errorf("failed to parse version from: %s", src)
+		return nil, fmt.Errorf("failed to parse version from: %q", src)
 	}
 
 	major, err := strconv.Atoi(m[1])
@@ -106,7 +112,17 @@ func ExtractCephVersion(src string) (*CephVersion, error) {
 		return nil, fmt.Errorf("failed to parse version extra part: %s", m[2])
 	}
 
-	return &CephVersion{major, minor, extra}, nil
+	// See if we are running on a build release
+	mm := buildVersionPattern.FindStringSubmatch(src)
+	// We don't need to handle any error here, so let's jump in only when "mm" has content
+	if mm != nil {
+		build, err = strconv.Atoi(mm[4])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version build number part: %q", mm[3])
+		}
+	}
+
+	return &CephVersion{major, minor, extra, build}, nil
 }
 
 // Supported checks if a given release is supported
@@ -171,7 +187,9 @@ func IsIdentical(a, b CephVersion) bool {
 	if a.Major == b.Major {
 		if a.Minor == b.Minor {
 			if a.Extra == b.Extra {
-				return true
+				if a.Build == b.Build {
+					return true
+				}
 			}
 		}
 	}
@@ -196,6 +214,15 @@ func IsSuperior(a, b CephVersion) bool {
 			}
 		}
 	}
+	if a.Major == b.Major {
+		if a.Minor == b.Minor {
+			if a.Extra == b.Extra {
+				if a.Build > b.Build {
+					return true
+				}
+			}
+		}
+	}
 
 	return false
 }
@@ -214,6 +241,15 @@ func IsInferior(a, b CephVersion) bool {
 		if a.Minor == b.Minor {
 			if a.Extra < b.Extra {
 				return true
+			}
+		}
+	}
+	if a.Major == b.Major {
+		if a.Minor == b.Minor {
+			if a.Extra == b.Extra {
+				if a.Build < b.Build {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -118,7 +118,7 @@ func ExtractCephVersion(src string) (*CephVersion, error) {
 	if mm != nil {
 		build, err = strconv.Atoi(mm[4])
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse version build number part: %q", mm[3])
+			logger.Warningf("failed to convert version build number part %q to an integer, ignoring", mm[4])
 		}
 	}
 

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -99,17 +99,17 @@ func ExtractCephVersion(src string) (*CephVersion, error) {
 
 	major, err := strconv.Atoi(m[1])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse version major part: %s", m[0])
+		return nil, fmt.Errorf("failed to convert version major part %q to an integer", m[1])
 	}
 
 	minor, err := strconv.Atoi(m[2])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse version minor part: %s", m[1])
+		return nil, fmt.Errorf("failed to convert version minor part %q to an integer", m[2])
 	}
 
 	extra, err := strconv.Atoi(m[3])
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse version extra part: %s", m[2])
+		return nil, fmt.Errorf("failed to convert version extra part %q to an integer", m[3])
 	}
 
 	// See if we are running on a build release

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -28,7 +28,7 @@ func TestToString(t *testing.T) {
 	assert.Equal(t, "13.0.0 mimic", fmt.Sprintf("%s", &Mimic))
 
 	expected := fmt.Sprintf("-1.0.0 %s", unknownVersionString)
-	assert.Equal(t, expected, fmt.Sprintf("%s", &CephVersion{-1, 0, 0}))
+	assert.Equal(t, expected, fmt.Sprintf("%s", &CephVersion{-1, 0, 0, 0}))
 }
 
 func TestCephVersionFormatted(t *testing.T) {
@@ -39,14 +39,14 @@ func TestCephVersionFormatted(t *testing.T) {
 func TestReleaseName(t *testing.T) {
 	assert.Equal(t, "nautilus", Nautilus.ReleaseName())
 	assert.Equal(t, "mimic", Mimic.ReleaseName())
-	ver := CephVersion{-1, 0, 0}
+	ver := CephVersion{-1, 0, 0, 0}
 	assert.Equal(t, unknownVersionString, ver.ReleaseName())
 }
 
-func extractVersionHelper(t *testing.T, text string, major, minor, extra int) {
+func extractVersionHelper(t *testing.T, text string, major, minor, extra, build int) {
 	v, err := ExtractCephVersion(text)
 	if assert.NoError(t, err) {
-		assert.Equal(t, *v, CephVersion{major, minor, extra})
+		assert.Equal(t, *v, CephVersion{major, minor, extra, build})
 	}
 }
 
@@ -57,8 +57,8 @@ func TestExtractVersion(t *testing.T) {
 root@7a97f5a78bc6:/# ceph --version
 ceph version 13.2.6 (ae699615bac534ea496ee965ac6192cb7e0e07c1) mimic (stable)
 `
-	extractVersionHelper(t, v0c, 13, 2, 6)
-	extractVersionHelper(t, v0d, 13, 2, 6)
+	extractVersionHelper(t, v0c, 13, 2, 6, 0)
+	extractVersionHelper(t, v0d, 13, 2, 6, 0)
 
 	// development build
 	v1c := "ceph version 14.1.33-403-g7ba6bece41"
@@ -68,8 +68,8 @@ bin/ceph --version
 ceph version 14.1.33-403-g7ba6bece41
 (7ba6bece4187eda5d05a9b84211fe6ba8dd287bd) nautilus (rc)
 `
-	extractVersionHelper(t, v1c, 14, 1, 33)
-	extractVersionHelper(t, v1d, 14, 1, 33)
+	extractVersionHelper(t, v1c, 14, 1, 33, 403)
+	extractVersionHelper(t, v1d, 14, 1, 33, 403)
 
 	// build without git version info. it is possible to build the ceph tree
 	// without a version number, but none of the container builds do this.
@@ -135,13 +135,13 @@ func TestVersionAtLeast(t *testing.T) {
 	assert.True(t, Octopus.IsAtLeast(Nautilus))
 	assert.True(t, Octopus.IsAtLeast(Octopus))
 
-	assert.True(t, (&CephVersion{1, 0, 0}).IsAtLeast(CephVersion{0, 0, 0}))
-	assert.False(t, (&CephVersion{0, 0, 0}).IsAtLeast(CephVersion{1, 0, 0}))
-	assert.True(t, (&CephVersion{1, 1, 0}).IsAtLeast(CephVersion{1, 0, 0}))
-	assert.False(t, (&CephVersion{1, 0, 0}).IsAtLeast(CephVersion{1, 1, 0}))
-	assert.True(t, (&CephVersion{1, 1, 1}).IsAtLeast(CephVersion{1, 1, 0}))
-	assert.False(t, (&CephVersion{1, 1, 0}).IsAtLeast(CephVersion{1, 1, 1}))
-	assert.True(t, (&CephVersion{1, 1, 1}).IsAtLeast(CephVersion{1, 1, 1}))
+	assert.True(t, (&CephVersion{1, 0, 0, 0}).IsAtLeast(CephVersion{0, 0, 0, 0}))
+	assert.False(t, (&CephVersion{0, 0, 0, 0}).IsAtLeast(CephVersion{1, 0, 0, 0}))
+	assert.True(t, (&CephVersion{1, 1, 0, 0}).IsAtLeast(CephVersion{1, 0, 0, 0}))
+	assert.False(t, (&CephVersion{1, 0, 0, 0}).IsAtLeast(CephVersion{1, 1, 0, 0}))
+	assert.True(t, (&CephVersion{1, 1, 1, 0}).IsAtLeast(CephVersion{1, 1, 0, 0}))
+	assert.False(t, (&CephVersion{1, 1, 0, 0}).IsAtLeast(CephVersion{1, 1, 1, 0}))
+	assert.True(t, (&CephVersion{1, 1, 1, 0}).IsAtLeast(CephVersion{1, 1, 1, 0}))
 }
 
 func TestVersionAtLeastX(t *testing.T) {
@@ -156,24 +156,26 @@ func TestVersionAtLeastX(t *testing.T) {
 }
 
 func TestIsIdentical(t *testing.T) {
-	assert.True(t, IsIdentical(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
-	assert.False(t, IsIdentical(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
+	assert.True(t, IsIdentical(CephVersion{14, 2, 2, 0}, CephVersion{14, 2, 2, 0}))
+	assert.False(t, IsIdentical(CephVersion{14, 2, 2, 0}, CephVersion{15, 2, 2, 0}))
 }
 
 func TestIsSuperior(t *testing.T) {
-	assert.False(t, IsSuperior(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
-	assert.False(t, IsSuperior(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
-	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{14, 2, 2}))
-	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{15, 1, 3}))
-	assert.True(t, IsSuperior(CephVersion{15, 2, 2}, CephVersion{15, 2, 1}))
+	assert.False(t, IsSuperior(CephVersion{14, 2, 2, 0}, CephVersion{14, 2, 2, 0}))
+	assert.False(t, IsSuperior(CephVersion{14, 2, 2, 0}, CephVersion{15, 2, 2, 0}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2, 0}, CephVersion{14, 2, 2, 0}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2, 0}, CephVersion{15, 1, 3, 0}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2, 0}, CephVersion{15, 2, 1, 0}))
+	assert.True(t, IsSuperior(CephVersion{15, 2, 2, 1}, CephVersion{15, 2, 1, 0}))
 }
 
 func TestIsInferior(t *testing.T) {
-	assert.False(t, IsInferior(CephVersion{14, 2, 2}, CephVersion{14, 2, 2}))
-	assert.False(t, IsInferior(CephVersion{15, 2, 2}, CephVersion{14, 2, 2}))
-	assert.True(t, IsInferior(CephVersion{14, 2, 2}, CephVersion{15, 2, 2}))
-	assert.True(t, IsInferior(CephVersion{15, 1, 3}, CephVersion{15, 2, 2}))
-	assert.True(t, IsInferior(CephVersion{15, 2, 1}, CephVersion{15, 2, 2}))
+	assert.False(t, IsInferior(CephVersion{14, 2, 2, 0}, CephVersion{14, 2, 2, 0}))
+	assert.False(t, IsInferior(CephVersion{15, 2, 2, 0}, CephVersion{14, 2, 2, 0}))
+	assert.True(t, IsInferior(CephVersion{14, 2, 2, 0}, CephVersion{15, 2, 2, 0}))
+	assert.True(t, IsInferior(CephVersion{15, 1, 3, 0}, CephVersion{15, 2, 2, 0}))
+	assert.True(t, IsInferior(CephVersion{15, 2, 1, 0}, CephVersion{15, 2, 2, 0}))
+	assert.True(t, IsInferior(CephVersion{15, 2, 1, 0}, CephVersion{15, 2, 2, 1}))
 }
 
 func TestValidateCephVersionsBetweenLocalAndExternalClusters(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Look at the commits for more details but essentially:

* add support for build release with a ceph version output of 14.2.4-64
* update the deployment for rgw/mds even if this is not an upgrade


**Which issue is resolved by this Pull Request:**
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1775624

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]