### PR TITLE
ceph example: remove non-existent topologyAware CRD option

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -40,7 +40,6 @@ spec:
   network:
     hostNetwork: false
   storage:
-    topologyAware: true
     storageClassDeviceSets:
     - name: set1
       # The number of OSDs to create from this device set

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -126,7 +126,6 @@ spec:
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true
-    topologyAware: true
     deviceFilter:
     config:
       # The default and recommended storeType is dynamically set to bluestore for devices and filestore for directories.


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

Remove non-existent topologyAware CRD option from Ceph example. This option was removed by the following commit.

commit ef6815ebfa95a9be1b7b5809268a1cfdfb573fab

**Which issue is resolved by this Pull Request:**
Resolves #4384 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
