### PR TITLE
ceph: do not restart the osds when upgrading the operator

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,8 +20,9 @@
 - PriorityClassNames can now be added to the Rook/Ceph components to influence the scheduler's pod preemption.
   - mgr/mon/osd/rbdmirror: [priority class names configuration settings](Documentation/ceph-cluster-crd.md#priority-class-names-configuration-settings)
   - filesystem: [metadata server settings](Documentation/ceph-filesystem-crd.md#metadata-server-settings)
-  - rgw: [gateway settings](Documentation/ceph-object-store-crd.md#gateway-settings)    
+  - rgw: [gateway settings](Documentation/ceph-object-store-crd.md#gateway-settings)
   - nfs: [samples](Documentation/ceph-nfs-crd.md#samples)
+- When the operator is upgraded, the mgr and osd (not running on PVC) won't be restarted if the Rook binary version changes
 
 ### EdgeFS
 

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -149,14 +149,8 @@ func startOSD(cmd *cobra.Command, args []string) error {
 
 	context := createContext()
 
-	crushLocation, err := getLocation(context.Clientset)
-	if err != nil {
-		rook.TerminateFatal(err)
-	}
-	args = append(args, fmt.Sprintf("--crush-location=%s", crushLocation))
-
 	// Run OSD start sequence
-	err = osddaemon.StartOSD(context, osdStoreType, osdStringID, osdUUID, lvPath, pvcBackedOSD, args)
+	err := osddaemon.StartOSD(context, osdStoreType, osdStringID, osdUUID, lvPath, pvcBackedOSD, args)
 	if err != nil {
 		rook.TerminateFatal(err)
 	}
@@ -257,7 +251,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, cfg.directories, forceFormat,
 		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, cfg.pvcBacked)
 
-	err = osddaemon.Provision(context, agent)
+	err = osddaemon.Provision(context, agent, crushLocation)
 	if err != nil {
 		// something failed in the OSD orchestration, update the status map with failure details
 		status := oposd.OrchestrationStatus{

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -152,7 +152,8 @@ func RunFilestoreOnDevice(context *clusterd.Context, mountSourcePath, mountPath 
 	return nil
 }
 
-func Provision(context *clusterd.Context, agent *OsdAgent) error {
+// Provision provisions an OSD
+func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string) error {
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
 	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
@@ -230,6 +231,11 @@ func Provision(context *clusterd.Context, agent *OsdAgent) error {
 	deviceOSDs, err := agent.configureDevices(context, devices)
 	if err != nil {
 		return fmt.Errorf("failed to configure devices. %+v", err)
+	}
+
+	// Populate CRUSH location for each OSD on the host
+	for i := range deviceOSDs {
+		deviceOSDs[i].Location = crushLocation
 	}
 
 	// determine the set of directories that can/should be used for OSDs, with the default dir if no devices were specified. save off the node's crush name if needed.

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -77,7 +77,8 @@ func TestRunDaemon(t *testing.T) {
 
 	agent.pvcBacked = false
 	logger.Infof("Agent %+v", agent)
-	err := Provision(context, agent)
+	crushLocation := "root=default host=foo"
+	err := Provision(context, agent, crushLocation)
 	assert.Nil(t, err)
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -143,6 +143,7 @@ type OSDInfo struct {
 	//LVPath is the logical Volume path for an OSD created by Ceph-volume with format '/dev/<Volume Group>/<Logical Volume>'
 	LVPath        string `json:"lv-path"`
 	SkipLVRelease bool   `json:"skip-lv-release"`
+	Location      string `json:"location"`
 }
 
 type OrchestrationStatus struct {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -245,6 +245,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			// Set '--setuser-match-path' so that existing directory owned by root won't affect the daemon startup.
 			// For existing data store owned by root, the daemon will continue to run as root
 			"--setuser-match-path", osd.DataPath,
+			fmt.Sprintf("--crush-location=%s", osd.Location),
 		}
 
 		// mount /run/udev in the container so ceph-volume (via `lvs`)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -53,12 +53,46 @@ const (
 	lvPathVarName                       = "ROOK_LV_PATH"
 	rookBinariesMountPath               = "/rook"
 	rookBinariesVolumeName              = "rook-binaries"
+	activateOSDVolumeName               = "activate-osd"
+	activateOSDMountPath                = "/var/lib/ceph/osd/ceph-"
 	blockPVCMapperInitContainer         = "blkdevmapper"
 	osdMemoryTargetSafetyFactor float32 = 0.8
 	CephDeviceSetLabelKey               = "ceph.rook.io/DeviceSet"
 	CephSetIndexLabelKey                = "ceph.rook.io/setIndex"
 	CephDeviceSetPVCIDLabelKey          = "ceph.rook.io/DeviceSetPVCId"
 	OSDOverPVCLabelKey                  = "ceph.rook.io/pvc"
+)
+
+const (
+	activateOSDCode = `
+set -ex
+
+OSD_ID=%s
+OSD_UUID=%s
+OSD_STORE_FLAG="%s"
+TMP_DIR=$(mktemp -d)
+OSD_DATA_DIR=/var/lib/ceph/osd/ceph-"$OSD_ID"
+
+# active the osd with ceph-volume
+ceph-volume lvm activate --no-systemd "$OSD_STORE_FLAG" "$OSD_ID" "$OSD_UUID"
+
+# copy the tmpfs directory to a temporary directory
+# this is needed because when the init container exits, the tmpfs goes away and its content with it
+# this will result in the emptydir to be empty when accessed by the main osd container
+cp --verbose --no-dereference "$OSD_DATA_DIR"/* "$TMP_DIR"/
+
+# unmount the tmpfs since we don't need it anymore
+umount "$OSD_DATA_DIR"
+
+# copy back the content of the tmpfs into the original osd directory
+cp --verbose --no-dereference "$TMP_DIR"/* "$OSD_DATA_DIR"
+
+# retain ownership of files to the ceph user/group
+chown --verbose --recursive ceph:ceph "$OSD_DATA_DIR"
+
+# remove the temporary directory
+rm --recursive --force "$TMP_DIR"
+`
 )
 
 func (c *Cluster) makeJob(osdProps osdProperties, provisionConfig *provisionConfig) (*batch.Job, error) {
@@ -105,8 +139,9 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	configVolumeMounts := opspec.RookVolumeMounts(provisionConfig.DataPathMap, false)
 	volumes := opspec.PodVolumes(provisionConfig.DataPathMap, c.dataDirHostPath, false)
 	failureDomainValue := osdProps.crushHostname
-	doConfigInit := true     // initialize ceph.conf in init container?
-	doBinaryCopyInit := true // copy tini and rook binaries in an init container?
+	doConfigInit := true       // initialize ceph.conf in init container?
+	doBinaryCopyInit := true   // copy tini and rook binaries in an init container?
+	doActivateOSDInit := false // run an init container to activate the osd?
 
 	var dataDir string
 	if osd.IsDirectory {
@@ -204,13 +239,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 
 	commonArgs = append(commonArgs, osdOnSDNFlag(c.Network, c.clusterInfo.CephVersion)...)
 
-	// Add the volume to the spec and the mount to the daemon container
-	copyBinariesVolume, copyBinariesContainer := c.getCopyBinariesContainer()
-	if doBinaryCopyInit {
-		volumes = append(volumes, copyBinariesVolume)
-		volumeMounts = append(volumeMounts, copyBinariesContainer.VolumeMounts[0])
-	}
-
 	var command []string
 	var args []string
 	if !osd.IsDirectory && osd.IsFileStore && !osd.CephVolumeInitiated {
@@ -229,7 +257,27 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			"--"},
 			defaultArgs...)
 
-	} else if osd.CephVolumeInitiated {
+		// If the Bluestore OSD was prepared with ceph-volume and not running on PVC
+	} else if osd.CephVolumeInitiated && osdProps.pvc.ClaimName == "" && !osd.IsFileStore {
+		doBinaryCopyInit = false
+		doConfigInit = false
+		doActivateOSDInit = true
+		command = []string{"ceph-osd"}
+		args = []string{
+			"--foreground",
+			"--id", osdID,
+			"--fsid", c.clusterInfo.FSID,
+			"--setuser", "ceph",
+			"--setgroup", "ceph",
+			fmt.Sprintf("--crush-location=%s", osd.Location),
+		}
+
+		// Needed so that the init chown container won't chown something that does not exist
+		// We don't need this directory, it's empty
+		osd.DataPath = ""
+
+		// If the OSD was prepared with ceph-volume and running on PVC
+	} else if osd.CephVolumeInitiated && osdProps.pvc.ClaimName != "" {
 		// if the osd was provisioned by ceph-volume, we need to launch it with rook as the parent process
 		command = []string{path.Join(rookBinariesMountPath, "tini")}
 		args = []string{
@@ -286,6 +334,23 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		args = defaultArgs
 	}
 
+	// Add the volume to the spec and the mount to the daemon container
+	copyBinariesVolume, copyBinariesContainer := c.getCopyBinariesContainer()
+	if doBinaryCopyInit {
+		volumes = append(volumes, copyBinariesVolume)
+		volumeMounts = append(volumeMounts, copyBinariesContainer.VolumeMounts[0])
+	}
+
+	// Add the volume to the spec and the mount to the daemon container
+	// so that it can pick the already mounted/activated osd metadata path
+	// This container will activate the OSD and place the activated filesinto an empty dir
+	// The empty dir will be shared by the "activate-osd" pod and the "osd" main pod
+	activateOSDVolume, activateOSDContainer := c.getActivateOSDInitContainer(osdID, osd.UUID, osd.IsFileStore, osdProps)
+	if doActivateOSDInit {
+		volumes = append(volumes, activateOSDVolume)
+		volumeMounts = append(volumeMounts, activateOSDContainer.VolumeMounts[0])
+	}
+
 	args = append(args, commonArgs...)
 
 	if osdProps.pvc.ClaimName != "" {
@@ -325,6 +390,9 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 	if doBinaryCopyInit {
 		initContainers = append(initContainers, *copyBinariesContainer)
+	}
+	if doActivateOSDInit {
+		initContainers = append(initContainers, *activateOSDContainer)
 	}
 
 	// Doing a chown in a post start lifecycle hook does not reliably complete before the OSD
@@ -428,6 +496,43 @@ func (c *Cluster) getCopyBinariesContainer() (v1.Volume, *v1.Container) {
 		Name:         "copy-bins",
 		Image:        k8sutil.MakeRookImage(c.rookVersion),
 		VolumeMounts: []v1.VolumeMount{mount},
+	}
+}
+
+// This container runs all the actions needed to activate an OSD before we can run the OSD process
+func (c *Cluster) getActivateOSDInitContainer(osdID, osdUUID string, isFilestore bool, osdProps osdProperties) (v1.Volume, *v1.Container) {
+	volume := v1.Volume{Name: activateOSDVolumeName, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}
+	envVars := cephVolumeEnvVar()
+	osdStore := "--bluestore"
+	if isFilestore {
+		osdStore = "--filestore"
+	}
+
+	// Build empty dir osd path to something like "/var/lib/ceph/osd/ceph-0"
+	activateOSDMountPathID := activateOSDMountPath + osdID
+
+	volMounts := []v1.VolumeMount{
+		{Name: activateOSDVolumeName, MountPath: activateOSDMountPathID},
+		{Name: "devices", MountPath: "/dev"},
+	}
+
+	privileged := true
+	securityContext := &v1.SecurityContext{
+		Privileged: &privileged,
+	}
+
+	return volume, &v1.Container{
+		Command: []string{
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(activateOSDCode, osdID, osdUUID, osdStore),
+		},
+		Name:            "activate-osd",
+		Image:           c.cephVersion.Image,
+		VolumeMounts:    volMounts,
+		SecurityContext: securityContext,
+		Env:             envVars,
+		Resources:       osdProps.resources,
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Essentially, this commits allows us to upgrade the operator image without having to restart the OSDs.
See commits for more details.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4362 and https://github.com/rook/rook/issues/4363

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]