### PR TITLE
CSI: Add ENV variable to use ceph kernel client

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -425,15 +425,6 @@ located.
         value: "quay.io/k8scsi/csi-attacher:v1.2.0"
 ```
 
-If you want to enable Ceph Kernel clients on kernel < 4.17 which support quotas
-for Cephfs please add below to the operator `env` variables.
-
-```yaml
-  env:
-    - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
-      value: "true"
-```
-
 ### Verifying updates
 You can use the below command to see the CSI images currently being used in the cluster. Once there
 is only a single version of each image and the version is the latest one you expect, the CSI pods

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -425,6 +425,15 @@ located.
         value: "quay.io/k8scsi/csi-attacher:v1.2.0"
 ```
 
+If you want to enable Ceph Kernel clients on kernel < 4.17 which support quotas
+for Cephfs please add below to the operator `env` variables.
+
+```yaml
+  env:
+    - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+      value: "true"
+```
+
 ### Verifying updates
 You can use the below command to see the CSI images currently being used in the cluster. Once there
 is only a single version of each image and the version is the latest one you expect, the CSI pods

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -128,6 +128,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `csi.rbdGrpcMetricsPort`        | Ceph CSI RBD driver GRPC metrics port.                                                                  | `9090`                                                 |
 | `csi.rbdLivenessMetricsPort`    | Ceph CSI RBD driver metrics port.                                                                       | `8080`                                                 |
 | `csi.enableSnapshotter`         | Enable deployment of snapshotter container in ceph-csi provisioner.                                     | `true`                                                 |
+| `csi.forceCephFSKernelClient`   | Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs.                            | `true`                                                 |
 | `csi.kubeletDirPath`            | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
 | `csi.cephcsi.image`             | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.2`                       |
 | `csi.registrar.image`           | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |

--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -21,9 +21,20 @@ setting up Rook in a Kubernetes cluster with Pod Security Policies enabled.
 The Rook agent requires setup as a Flex volume plugin to manage the storage attachments in your cluster.
 See the [Flex Volume Configuration](flexvolume.md) topic to configure your Kubernetes deployment to load the Rook volume plugin.
 
-## Kernel with RBD module
+## Kernel
 
-Rook Ceph requires a Linux kernel built with the RBD module. Many distributions of Linux have this module but some don't, e.g. the GKE Container-Optimised OS (COS) does not have RBD. You can test your Kubernetes nodes by running `modprobe rbd`. If it says 'not found', you may have to [rebuild your kernel](https://rook.io/docs/rook/master/common-issues.html#rook-agent-rbd-module-missing-error) or choose a different Linux distribution.
+### RBD
+
+Rook Ceph requires a Linux kernel built with the RBD module. Many distributions of Linux have this module but some don't,
+e.g. the GKE Container-Optimised OS (COS) does not have RBD. You can test your Kubernetes nodes by running `modprobe rbd`.
+If it says 'not found', you may have to [rebuild your kernel](https://rook.io/docs/rook/master/common-issues.html#rook-agent-rbd-module-missing-error)
+or choose a different Linux distribution.
+
+### CephFS
+
+If you will be creating volumes from a Ceph shared file system (CephFS), the recommended minimum kernel version is 4.17.
+If you have a kernel version less than 4.17, the requested PVC sizes will not be enforced. Storage quotas will only be
+enforced on newer kernels.
 
 ## Kernel modules directory configuration
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -176,6 +176,10 @@ spec:
         - name: CSI_RBD_LIVENESS_METRICS_PORT
           value: {{ .Values.csi.rbdLivenessMetricsPort | quote }}
 {{- end }}
+{{- if .Values.csi.forceCephFSKernelClient }}
+        - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+          value: {{ .Values.csi.forceCephFSKernelClient | quote }}
+{{- end }}
 {{- end }}
         - name: ROOK_ENABLE_FLEX_DRIVER
           value: "{{ .Values.enableFlexDriver }}"

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -72,6 +72,8 @@ csi:
   #cephfsGrpcMetricsPort: 9091
   #cephfsLivenessMetricsPort: 9081
   #rbdGrpcMetricsPort: 9090
+  # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
+  #forceCephFSKernelClient: true
   #rbdLivenessMetricsPort: 9080
   #kubeletDirPath: /var/lib/kubelet
   #cephcsi:

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -72,8 +72,10 @@ csi:
   #cephfsGrpcMetricsPort: 9091
   #cephfsLivenessMetricsPort: 9081
   #rbdGrpcMetricsPort: 9090
-  # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
-  #forceCephFSKernelClient: true
+  # Enable Ceph Kernel clients on kernel < 4.17. If your kernel does not support quotas for CephFS
+  # you may want to disable this setting. However, this will cause an issue during upgrades
+  # with the FUSE client. See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
+  forceCephFSKernelClient: true
   #rbdLivenessMetricsPort: 9080
   #kubeletDirPath: /var/lib/kubelet
   #cephcsi:
@@ -140,8 +142,8 @@ hostpathRequiresPrivileged: false
 # Disable automatic orchestration when new devices are discovered.
 disableDeviceHotplug: false
 
-# Blacklist certain disks according to the regex provided. 
-discoverDaemonUdev: 
+# Blacklist certain disks according to the regex provided.
+discoverDaemonUdev:
 
 # imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 # imagePullSecrets:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -65,6 +65,7 @@ spec:
             - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
+            - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -60,6 +60,7 @@ spec:
             - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
+            - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -57,6 +57,7 @@ spec:
             - "--mountcachedir=/mount-cache-dir"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
+            - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"
             - "--metricspath=/metrics"
             - "--enablegrpcmetrics={{ .EnableCSIGRPCMetrics }}"
           env:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -236,8 +236,10 @@ spec:
         - name: CSI_ENABLE_SNAPSHOTTER
           value: "true"
         # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
-        # - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
-        #  value: "true"
+        # If you disable the kernel client, your application may be disrupted during upgrade.
+        # See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
+        - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+          value: "true"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -235,6 +235,9 @@ spec:
         # Enable deployment of snapshotter container in ceph-csi provisioner
         - name: CSI_ENABLE_SNAPSHOTTER
           value: "true"
+        # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
+        # - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+        #  value: "true"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -185,6 +185,9 @@ spec:
         # Enable deployment of snapshotter container in ceph-csi provisioner.
         - name: CSI_ENABLE_SNAPSHOTTER
           value: "true"
+        # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
+        # - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+        #  value: "true"
         # The default version of CSI supported by Rook will be started. To change the version
         # of the CSI driver to something other than what is officially supported, change
         # these images to the desired release of the CSI driver.

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -186,8 +186,10 @@ spec:
         - name: CSI_ENABLE_SNAPSHOTTER
           value: "true"
         # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
-        # - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
-        #  value: "true"
+        # If you disable the kernel client, your application may be disrupted during upgrade.
+        # See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
+        - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+          value: "true"
         # The default version of CSI supported by Rook will be started. To change the version
         # of the CSI driver to something other than what is officially supported, change
         # these images to the desired release of the CSI driver.
@@ -255,7 +257,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      # Uncomment it to run rook operator on the host network 
+      # Uncomment it to run rook operator on the host network
       #hostNetwork: true
       volumes:
       - name: rook-config

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -204,11 +204,12 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 
 	tp.EnableCSIGRPCMetrics = fmt.Sprintf("%t", EnableCSIGRPCMetrics)
 
+	// If not set or set to anything but "false", the kernel client will be enabled
 	kClinet := os.Getenv("CSI_FORCE_CEPHFS_KERNEL_CLIENT")
-	if strings.EqualFold(kClinet, "true") {
-		tp.ForceCephFSKernelClient = "true"
-	} else {
+	if strings.EqualFold(kClinet, "false") {
 		tp.ForceCephFSKernelClient = "false"
+	} else {
+		tp.ForceCephFSKernelClient = "true"
 	}
 	// parse GRPC and Liveness ports
 	tp.CephFSGRPCMetricsPort = getPortFromENV("CSI_CEPHFS_GRPC_METRICS_PORT", DefaultCephFSGRPCMerticsPort)

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -44,6 +44,7 @@ type Param struct {
 	EnableSnapshotter         string
 	EnableCSIGRPCMetrics      string
 	KubeletDirPath            string
+	ForceCephFSKernelClient   string
 	CephFSGRPCMetricsPort     uint16
 	CephFSLivenessMetricsPort uint16
 	RBDGRPCMetricsPort        uint16
@@ -203,6 +204,12 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 
 	tp.EnableCSIGRPCMetrics = fmt.Sprintf("%t", EnableCSIGRPCMetrics)
 
+	kClinet := os.Getenv("CSI_FORCE_CEPHFS_KERNEL_CLIENT")
+	if strings.EqualFold(kClinet, "true") {
+		tp.ForceCephFSKernelClient = "true"
+	} else {
+		tp.ForceCephFSKernelClient = "false"
+	}
 	// parse GRPC and Liveness ports
 	tp.CephFSGRPCMetricsPort = getPortFromENV("CSI_CEPHFS_GRPC_METRICS_PORT", DefaultCephFSGRPCMerticsPort)
 	tp.CephFSLivenessMetricsPort = getPortFromENV("CSI_CEPHFS_LIVENESS_METRICS_PORT", DefaultCephFSLivenessMerticsPort)


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In ceph-csi v1.2.2 we have added a flag `forcecephkernelclient` to force use Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves #4055

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]