### PR TITLE
Ceph: Generate new client config for controller-runtime

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1414,13 +1414,14 @@
 
 [[projects]]
   branch = "release-0.2"
-  digest = "1:9f0ef29c01f23bbd2913084e7d9c692115c6c480ef6d1d5807773f077a1c57d3"
+  digest = "1:a8b792e14d6900b58c297ad1d754b8c0d677ba692a04d707594b00bf0cf7a936"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
     "pkg/cache/internal",
     "pkg/client",
     "pkg/client/apiutil",
+    "pkg/client/config",
     "pkg/controller",
     "pkg/controller/controllerutil",
     "pkg/event",
@@ -1575,6 +1576,7 @@
     "k8s.io/kubernetes/pkg/util/mount",
     "k8s.io/kubernetes/pkg/volume/flexvolume",
     "sigs.k8s.io/controller-runtime/pkg/client",
+    "sigs.k8s.io/controller-runtime/pkg/client/config",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/event",

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -21,6 +21,7 @@ import (
 	controllers "github.com/rook/rook/pkg/operator/ceph/disruption"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
 
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -32,7 +33,12 @@ func (o *Operator) startManager(stopCh <-chan struct{}) {
 	}
 
 	logger.Info("setting up the controller-runtime manager")
-	mgr, err := manager.New(o.context.KubeConfig, mgrOpts)
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		logger.Errorf("unable to get client config for controller-runtime manager: %+v", err)
+		return
+	}
+	mgr, err := manager.New(kubeConfig, mgrOpts)
 	if err != nil {
 		logger.Errorf("unable to set up overall controller-runtime manager: %+v", err)
 		return


### PR DESCRIPTION
Reusing the kubeconfig was resulting in concurrent access issues.

There is no DeepCopy function for rest.Config, so I just generated a new one.

Signed-off-by: Rohan CJ <rohantmp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #4350 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]