### PR TITLE
ceph: add the missing newline in lvm.conf's filter configuration line

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -154,7 +154,7 @@ func updateLVMConfig(context *clusterd.Context, onPVC bool) error {
 	// When running on PVC
 	if onPVC {
 		output = bytes.Replace(output, []byte(`scan = [ "/dev" ]`), []byte(`scan = [ "/dev", "/mnt" ]`), 1)
-		output = append(output, []byte(lvmFilter)...)
+		output = append(output, []byte(lvmFilter+"\n")...)
 	}
 
 	if err = ioutil.WriteFile(lvmConfPath, output, 0644); err != nil {


### PR DESCRIPTION
**Description of your changes:**

lvmFilter doesn't contain a newline character. So when we will add more lines after lvm.conf's filter configuration line, lvm.conf will corrupt.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
