### PR TITLE
Remove unused commands in minikube helper script

### DIFF
--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -4,58 +4,6 @@ scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck disable=SC1090
 source "${scriptdir}/../../build/common.sh"
 
-function init_flexvolume() {
-    local flexname=$1
-
-    cat <<EOF | ssh -i "$(minikube ssh-key)" "docker@$(minikube ip)" -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet 'cat - > ~/rook'
-#!/bin/bash
-echo -ne '{"status": "Success", "capabilities": {"attach": false}}' >&1
-exit 0
-EOF
-    minikube ssh "chmod +x ~/rook"
-    minikube ssh "sudo chown root:root ~/rook"
-    minikube ssh "sudo mkdir -p /usr/libexec/kubernetes/kubelet-plugins/volume/exec/${flexname}~rook"
-    minikube ssh "sudo mv ~/rook /usr/libexec/kubernetes/kubelet-plugins/volume/exec/${flexname}~rook"
-}
-
-# workaround for kube-dns CrashLoopBackOff issue with RBAC enabled
-#issue https://github.com/kubernetes/minikube/issues/1734 and https://github.com/kubernetes/minikube/issues/1722
-function enable_roles_for_RBAC() {
-    cat <<EOF | kubectl create -f -
-# Wide open access to the cluster (mostly for kubelet)
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cluster-writer
-rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
-  - nonResourceURLs: ["*"]
-    verbs: ["*"]
----
-# Give admin, kubelet, kube-system, kube-proxy god access
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: cluster-write
-subjects:
-  - kind: User
-    name: admin
-  - kind: User
-    name: kubelet
-  - kind: ServiceAccount
-    name: default
-    namespace: kube-system
-  - kind: User
-    name: kube-proxy
-roleRef:
-  kind: ClusterRole
-  name: cluster-writer
-  apiGroup: rbac.authorization.k8s.io
-EOF
-}
-
 function wait_for_ssh() {
     local tries=100
     while (( tries > 0 )) ; do
@@ -73,22 +21,6 @@ function copy_image_to_cluster() {
     local build_image=$1
     local final_image=$2
     docker save "${build_image}" | (eval "$(minikube docker-env --shell bash)" && docker load && docker tag "${build_image}" "${final_image}")
-}
-
-# Deletes pods with 'rook-' prefix. Namespace is expected as the first argument
-function delete_rook_pods() {
-    for P in $(kubectl get pods -n "$1" | awk "/$2/ {print \$1}"); do
-        kubectl delete pod "$P" -n "$1"
-    done
-}
-
-# current kubectl context == minikube, returns boolean
-function check_context() {
-    if [ "$(kubectl config view 2>/dev/null | awk '/current-context/ {print $NF}')" = "minikube" ]; then
-        return 0
-    fi
-
-    return 1
 }
 
 function copy_images() {
@@ -155,17 +87,6 @@ case "${1:-}" in
   update)
     copy_images "$2"
     ;;
-  restart)
-    if check_context; then
-        [ "$2" ] && regex=$2 || regex="^rook-"
-        echo "Restarting Rook pods matching the regex \"$regex\" in \"rook\" namespace."
-        delete_rook_pods "rook" $regex
-        echo "Restarting Rook pods matching the regex \"$regex\" in \"rook-system\" namespace.."
-        delete_rook_pods "rook-system" $regex
-    else
-      echo "To prevent accidental data loss acting only on 'minikube' context. No action is taken."
-    fi
-    ;;
   wordpress)
     echo "copying the wordpress images"
     copy_image_to_cluster mysql:5.6 mysql:5.6
@@ -191,7 +112,6 @@ case "${1:-}" in
     echo "  $0 clean" >&2
     echo "  $0 ssh" >&2
     echo "  $0 update [ceph | cockroachdb | cassandra | minio | nfs | yugabytedb]" >&2
-    echo "  $0 restart <pod-name-regex> (the pod name is a regex to match e.g. restart ^rook-ceph-osd)" >&2
     echo "  $0 wordpress" >&2
     echo "  $0 cockroachdb-loadgen" >&2
     echo "  $0 helm" >&2


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The helper script to start minikube has dead code that is
no longer used. Specifically, the flex driver config isn't needed
anymore and the RBAC rules are all configured in the manifests.
Neither is there a need to have a restart option on minikube.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]