### PR TITLE
CSI: Ability to disable snapshotter from ceph-csi rbd

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -119,6 +119,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port.                                                                         | `9081`                                                 |
 | `csi.rbdGrpcMetricsPort`        | Ceph CSI RBD driver GRPC metrics port.                                                                  | `9090`                                                 |
 | `csi.rbdLivenessMetricsPort`    | Ceph CSI RBD driver metrics port.                                                                       | `8080`                                                 |
+| `csi.enableSnapshotter`         | Enable deployment of snapshotter container in ceph-csi provisioner.                                     | `true`                                                 |
 | `csi.kubeletDirPath`            | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
 | `csi.cephcsi.image`             | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.2`                       |
 | `csi.registrar.image`           | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -98,6 +98,8 @@ spec:
           value: {{ .Values.csi.enableRbdDriver | quote }}
         - name: ROOK_CSI_ENABLE_CEPHFS
           value: {{ .Values.csi.enableCephfsDriver | quote }}
+        - name: CSI_ENABLE_SNAPSHOTTER
+          value: {{ .Values.csi.enableSnapshotter | quote }}
 {{- if .Values.csi.kubeletDirPath }}
         - name: ROOK_CSI_KUBELET_DIR_PATH
           value: {{ .Values.csi.kubeletDirPath | quote }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -59,6 +59,7 @@ csi:
   enableRbdDriver: true
   enableCephfsDriver: true
   enableGrpcMetrics: true
+  enableSnapshotter: true
   # Set provisonerTolerations and provisionerNodeAffinity for provisioner pod.
   # The CSI provisioner would be best to start on the same nodes as other ceph daemons.
   # provisionerTolerations:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -49,6 +49,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{ if .EnableSnapshotter }}
         - name: csi-snapshotter
           image:  {{ .SnapshotterImage }}
           args:
@@ -66,6 +67,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{ end }}
         - name: csi-rbdplugin
           securityContext:
             privileged: true

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-sts.yaml
@@ -44,6 +44,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{ if .EnableSnapshotter }}
         - name: csi-snapshotter
           image:  {{ .SnapshotterImage }}
           args:
@@ -59,6 +60,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{ end }}
         - name: csi-rbdplugin
           securityContext:
             privileged: true

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -219,6 +219,9 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: "true"
+        # Enable deployment of snapshotter container in ceph-csi provisioner
+        - name: CSI_ENABLE_SNAPSHOTTER
+          value: "true"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -168,6 +168,9 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: "true"
+        # Enable deployment of snapshotter container in ceph-csi provisioner.
+        - name: CSI_ENABLE_SNAPSHOTTER
+          value: "true"
         # The default version of CSI supported by Rook will be started. To change the version
         # of the CSI driver to something other than what is officially supported, change
         # these images to the desired release of the CSI driver.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -19,6 +19,8 @@ package csi
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
@@ -35,6 +37,7 @@ type Param struct {
 	AttacherImage             string
 	SnapshotterImage          string
 	DriverNamePrefix          string
+	EnableSnapshotter         string
 	EnableCSIGRPCMetrics      string
 	KubeletDirPath            string
 	CephFSGRPCMetricsPort     uint16
@@ -195,6 +198,11 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 
 	tp.RBDGRPCMetricsPort = getPortFromENV("CSI_RBD_GRPC_METRICS_PORT", DefaultRBDGRPCMerticsPort)
 	tp.RBDLivenessMetricsPort = getPortFromENV("CSI_RBD_LIVENESS_METRICS_PORT", DefaultRBDLivenessMerticsPort)
+
+	enableSnap := os.Getenv("CSI_ENABLE_SNAPSHOTTER")
+	if !strings.EqualFold(enableSnap, "false") {
+		tp.EnableSnapshotter = "true"
+	}
 
 	if ver.Minor < provDeploymentSuppVersion {
 		deployProvSTS = true


### PR DESCRIPTION
we need to set a ENV `CSI_ENABLE_SNAPSHOTTER` variable to "false" in operator template to disable deployment of snapshotter sidecar in ceph-csi rbd provisioner.

Fixes: #4401
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit cc418bce3b41a9be95d3f4961b695c4a5fd90faf)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[test ceph]