### PR TITLE
Continue orchestration on osd update errors

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -192,7 +192,7 @@ func (c *Cluster) Start() error {
 			}
 
 			if err := updateDeploymentAndWait(c.context, d, c.Namespace, daemon, mgrConfig.DaemonID, cephVersionToUse, c.isUpgrade, c.skipUpgradeChecks); err != nil {
-				return fmt.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
+				logger.Errorf("failed to update mgr deployment %s. %+v", resourceName, err)
 			}
 		}
 		if existingDeployment, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(d.GetName(), metav1.GetOptions{}); err != nil {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -352,11 +352,10 @@ func (c *Cluster) startProvisioningOverNodes(config *provisionConfig) {
 
 	// no valid node is ready to run an osd
 	if len(validNodes) == 0 {
-		logger.Warningf("no valid nodes available to run an osd in namespace %s. "+
-			"Rook will not create any new OSD nodes and will skip checking for removed nodes since "+
-			"removing all OSD nodes without destroying the Rook cluster is unlikely to be intentional", c.Namespace)
+		logger.Warningf("no valid nodes available to run osds on nodes in namespace %s", c.Namespace)
 		return
 	}
+
 	// start with nodes currently in the storage spec
 	for _, node := range c.ValidStorage.Nodes {
 		// fully resolve the storage config and resources for this node
@@ -481,8 +480,7 @@ func (c *Cluster) startOSDDaemonsOnPVC(pvcName string, config *provisionConfig, 
 
 		err = c.associateKeyring(keyring, createdDeployment)
 		if err != nil {
-			errMsg := fmt.Sprintf("failed to associate keyring for pvc %s, osd %v: %+v", osdProps.pvc.ClaimName, osd, err)
-			config.addError(errMsg)
+			logger.Errorf("failed to associate keyring for pvc %s, osd %v: %+v", osdProps.pvc.ClaimName, osd, err)
 		}
 
 		if createErr != nil && errors.IsAlreadyExists(createErr) {
@@ -504,7 +502,7 @@ func (c *Cluster) startOSDDaemonsOnPVC(pvcName string, config *provisionConfig, 
 			}
 
 			if err = updateDeploymentAndWait(c.context, dp, c.Namespace, daemon, strconv.Itoa(osd.ID), cephVersionToUse, c.isUpgrade, c.skipUpgradeChecks); err != nil {
-				config.addError(fmt.Sprintf("failed to update osd deployment %d. %+v", osd.ID, err))
+				logger.Errorf("failed to update osd deployment %d. %+v", osd.ID, err)
 			}
 		}
 		logger.Infof("started deployment for osd %d (dir=%t, type=%s)", osd.ID, osd.IsDirectory, storeConfig.StoreType)
@@ -571,8 +569,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 
 		err = c.associateKeyring(keyring, createdDeployment)
 		if err != nil {
-			errMsg := fmt.Sprintf("failed to associate keyring for node %s, osd %v: %+v", n.Name, osd, err)
-			config.addError(errMsg)
+			logger.Errorf("failed to associate keyring for node %s, osd %v: %+v", n.Name, osd, err)
 		}
 
 		if createErr != nil && errors.IsAlreadyExists(createErr) {
@@ -594,7 +591,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 			}
 
 			if err = updateDeploymentAndWait(c.context, dp, c.Namespace, daemon, strconv.Itoa(osd.ID), cephVersionToUse, c.isUpgrade, c.skipUpgradeChecks); err != nil {
-				config.addError(fmt.Sprintf("failed to update osd deployment %d. %+v", osd.ID, err))
+				logger.Errorf("failed to update osd deployment %d. %+v", osd.ID, err)
 			}
 		}
 		logger.Infof("started deployment for osd %d (dir=%t, type=%s)", osd.ID, osd.IsDirectory, storeConfig.StoreType)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
During an orchestration if there were failures to update any OSD deployment, the orchestration would fail and continue trying again. If the OSD(s) continued failing, the operator would be stuck in a loop and never respond to other CR updates.

Now the operator will log the OSD errors, if any, and complete the orchestration. We will rely on K8s to continue to attempt to start the OSD pods instead of the operator being stuck in the loop.

This will result in the cluster CR controller behaving similarly to the other controllers that will simply log the errors instead of being stuck in a loop. Overall we need to improve this when we update to the controller runtime so we can continue retrying upon failure, while not blocking other operations.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
