### PR TITLE
docs: fix storageclass name used

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -87,7 +87,7 @@ Save this storage class definition as `storageclass.yaml`:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: rook-cephfs
+  name: csi-cephfs
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:

--- a/Documentation/ceph-teardown.md
+++ b/Documentation/ceph-teardown.md
@@ -29,7 +29,7 @@ kubectl delete -f ../mysql.yaml
 kubectl delete -n rook-ceph cephblockpool replicapool
 kubectl delete storageclass rook-ceph-block
 kubectl delete -f csi/cephfs/kube-registry.yaml
-kubectl delete storageclass rook-cephfs
+kubectl delete storageclass csi-cephfs
 ```
 
 ## Delete the CephCluster CRD


### PR DESCRIPTION
**Description of your changes:**

This corrects the used StorageClass name in the docs and example
snippets shown in the docs.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]