### PR TITLE
ceph: add crash key

### DIFF
--- a/pkg/operator/ceph/cluster/crash/crash_test.go
+++ b/pkg/operator/ceph/cluster/crash/crash_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crash
+
+import (
+	"testing"
+
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateCrashEnvVar(t *testing.T) {
+	v := cephver.Nautilus
+	env := generateCrashEnvVar(v)
+	assert.Equal(t, "CEPH_ARGS", env.Name)
+	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/admin-keyring-store/keyring", env.Value)
+
+	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
+	env = generateCrashEnvVar(v)
+	assert.Equal(t, "CEPH_ARGS", env.Name)
+	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring", env.Value)
+}
+
+func TestGetVolumes(t *testing.T) {
+	v := cephver.Nautilus
+	vol := getVolumes(v)
+	assert.Equal(t, "rook-ceph-admin-keyring", vol.Name)
+
+	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
+	vol = getVolumes(v)
+	assert.Equal(t, "rook-ceph-crash-collector-keyring", vol.Name)
+}
+
+func TestGetVolumeMount(t *testing.T) {
+	v := cephver.Nautilus
+	volMounts := getVolumeMounts(v)
+	assert.Equal(t, "rook-ceph-admin-keyring", volMounts.Name)
+
+	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
+	volMounts = getVolumeMounts(v)
+	assert.Equal(t, "rook-ceph-crash-collector-keyring", volMounts.Name)
+}

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crash
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	crashKeyringTemplate = `
+[client.crash]
+	key = %s
+	caps mon = "allow profile crash"
+	caps mgr = "allow profile crash"
+`
+)
+
+// CreateCrashCollectorSecret creates the Kubernetes Crash Collector Secret
+func CreateCrashCollectorSecret(context *clusterd.Context, clusterName string, ownerRef *metav1.OwnerReference) error {
+	k := keyring.GetSecretStore(context, clusterName, ownerRef)
+
+	// Create CrashCollector Ceph key
+	crashCollectorSecretKey, err := createCrashCollectorKeyring(k)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create %q ceph keyring", crashCollectorKeyringUsername)
+	}
+
+	// Create or update Kubernetes CSI secret
+	if err := createOrUpdateCrashCollectorSecret(clusterName, crashCollectorSecretKey, k, ownerRef); err != nil {
+		return errors.Wrapf(err, "failed to create kubernetes csi secret")
+	}
+
+	return nil
+}
+
+func cephCrashCollectorKeyringCaps() []string {
+	return []string{
+		"mon", "allow profile crash",
+		"mgr", "allow profile crash",
+	}
+}
+
+func createCrashCollectorKeyring(s *keyring.SecretStore) (string, error) {
+	key, err := s.GenerateKey(crashCollectorKeyringUsername, cephCrashCollectorKeyringCaps())
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func createOrUpdateCrashCollectorSecret(namespace, crashCollectorSecretKey string, k *keyring.SecretStore, ownerRef *metav1.OwnerReference) error {
+
+	keyring := fmt.Sprintf(crashKeyringTemplate, crashCollectorSecretKey)
+
+	crashCollectorSecret := map[string][]byte{
+		"keyring": []byte(keyring),
+	}
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crashCollectorSecretName,
+			Namespace: namespace,
+		},
+		Data: crashCollectorSecret,
+		Type: k8sutil.RookType,
+	}
+	k8sutil.SetOwnerRef(&s.ObjectMeta, ownerRef)
+
+	// Create Kubernetes Secret
+	err := k.CreateSecret(s)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", crashCollectorSecret, namespace)
+	}
+
+	logger.Infof("created kubernetes crash collector secret for cluster %q", namespace)
+	return nil
+}

--- a/pkg/operator/ceph/cluster/crash/keyring_test.go
+++ b/pkg/operator/ceph/cluster/crash/keyring_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCephCrashCollectorKeyringCaps(t *testing.T) {
+	caps := cephCrashCollectorKeyringCaps()
+	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow profile crash"})
+}

--- a/pkg/operator/ceph/config/keyring/admin.go
+++ b/pkg/operator/ceph/config/keyring/admin.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	adminKeyringResourceName = "rook-ceph-admin"
-	adminKeyringFileName     = "ceph.client.admin.keyring"
+	adminKeyringResourceName          = "rook-ceph-admin"
+	crashCollectorKeyringResourceName = "rook-ceph-crash-collector"
 
 	adminKeyringTemplate = `
 [client.admin]

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -152,7 +152,7 @@ func createOrUpdateCSISecret(namespace, csiRBDProvisionerSecretKey, csiRBDNodeSe
 		// Create Kubernetes Secret
 		err := k.CreateSecret(s)
 		if err != nil {
-			return errors.Errorf("failed to create kubernetes secret %q for cluster %q", secret, namespace)
+			return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", secret, namespace)
 		}
 
 	}


### PR DESCRIPTION
**Description of your changes:**

Add client.crash key for the crash-collector controller so it does not use the admin key.

Closes: https://github.com/rook/rook/issues/4388
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4388

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]