### PR TITLE
ceph: lvm filter again

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -49,7 +49,6 @@ const (
 	dbDeviceFlag         = "--db-devices"
 	cephVolumeCmd        = "ceph-volume"
 	cephVolumeMinDBSize  = 1024 // 1GB
-	lvmFilter            = `filter = [ "a|^/mnt/.*|", "r|.*|" ]`
 )
 
 func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *DeviceOsdMapping) ([]oposd.OSDInfo, error) {
@@ -154,7 +153,13 @@ func updateLVMConfig(context *clusterd.Context, onPVC bool) error {
 	// When running on PVC
 	if onPVC {
 		output = bytes.Replace(output, []byte(`scan = [ "/dev" ]`), []byte(`scan = [ "/dev", "/mnt" ]`), 1)
-		output = append(output, []byte(lvmFilter)...)
+		// Only filter blocks in /mnt, when running on PVC we copy the PVC claim path to /mnt
+		// And reject everything else
+		// We have 2 different regex depending on the version of LVM present in the container...
+		// Since https://github.com/lvmteam/lvm2/commit/08396b4bce45fb8311979250623f04ec0ddb628c#diff-13c602a6258e57ce666a240e67c44f38
+		// the content changed, so depending which version is installled one of the two replace will work
+		output = bytes.Replace(output, []byte(`# filter = [ "a|.*/|" ]`), []byte(`filter = [ "a|^/mnt/.*|", "r|.*|" ]`), 1)
+		output = bytes.Replace(output, []byte(`# filter = [ "a|.*|" ]`), []byte(`filter = [ "a|^/mnt/.*|", "r|.*|" ]`), 1)
 	}
 
 	if err = ioutil.WriteFile(lvmConfPath, output, 0644); err != nil {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -154,7 +154,7 @@ func updateLVMConfig(context *clusterd.Context, onPVC bool) error {
 	// When running on PVC
 	if onPVC {
 		output = bytes.Replace(output, []byte(`scan = [ "/dev" ]`), []byte(`scan = [ "/dev", "/mnt" ]`), 1)
-		output = append(output, []byte(lvmFilter+"\n")...)
+		output = append(output, []byte(lvmFilter)...)
 	}
 
 	if err = ioutil.WriteFile(lvmConfPath, output, 0644); err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

The append puts the filter at the end of the file and it's out of any
lvm section, so it does not work anymore.

LVM complains with:

Configuration setting "filter" invalid. It's not part of any section.

Hence we revert https://github.com/rook/rook/commit/75533182352f41368363b66e9fbc55765db40f9b and https://github.com/rook/rook/commit/eb908e8959261640b445133cbed9fe5d201cfa93.
Release 1.1 is not impacted since the most recent changes were not backported.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]