### PR TITLE
Ceph: Remove unnecessary field in rook-ceph cluster example

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -41,7 +41,6 @@ spec:
     useAllDevices: false
     deviceFilter:
     config:
-      databaseSizeMB: "1024" # this value can be removed for environments with normal sized disks (100 GB or larger)
       journalSizeMB: "1024"  # this value can be removed for environments with normal sized disks (20 GB or larger)
       osdsPerDevice: "1" # this value can be overridden at the node or device level
     directories:


### PR DESCRIPTION
Signed-off-by: taeuk_kim <taeuk_kim@tmax.co.kr>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

I removed `databaseSizeMB` field from `cluster-test.yaml`, a CephCluster example spec.
 - The `databaseSizeMB` is not effective field in `cluster-test.yaml` since the example creates only filestore-backend OSD in Ceph cluster. That field works when bluestore-backend OSD is configured.
 - Removing `databaseSizeMB` can enhance the readability of ceph-beginners. They may not understand the term database in Ceph cluster intuitively. (Even they do not need to know it)

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


[skip ci]