### PR TITLE
Continue orchestration on missing node for osd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -519,7 +519,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 	// fully resolve the storage config and resources for this node
 	n := c.resolveNode(nodeName)
 	if n == nil {
-		config.addError("node %s did not resolve to start osds", nodeName)
+		logger.Errorf("node %s did not resolve to start osds", nodeName)
 		return
 	}
 	storeConfig := osdconfig.ToStoreConfig(n.Config)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When a node has been removed, cordoned, or is otherwise missing from the filters that rook uses to evaluate deploying osds on nodes, the orchestration should continue instead of failing. Otherwise, the orchestration will stay stuck in a retry loop if any nodes are cordoned or removed in the middle of an orchestration.

Such an old issue and such a simple fix...

**Which issue is resolved by this Pull Request:**
Resolves: #2587 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]