### PR TITLE
ceph: reject ceph dm devices

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -26,14 +26,15 @@ import (
 )
 
 const (
-	DiskType   = "disk"
-	SSDType    = "ssd"
-	PartType   = "part"
-	CryptType  = "crypt"
-	LVMType    = "lvm"
-	LinearType = "linear"
-	sgdisk     = "sgdisk"
-	mountCmd   = "mount"
+	DiskType     = "disk"
+	SSDType      = "ssd"
+	PartType     = "part"
+	CryptType    = "crypt"
+	LVMType      = "lvm"
+	LinearType   = "linear"
+	sgdisk       = "sgdisk"
+	mountCmd     = "mount"
+	cephLVPrefix = "ceph--"
 )
 
 type Partition struct {
@@ -146,6 +147,9 @@ func GetDevicePartitions(device string, executor exec.Executor) (partitions []Pa
 				p.Filesystem = v
 			}
 
+			partitions = append(partitions, p)
+		} else if strings.HasPrefix(name, cephLVPrefix) && props["TYPE"] == LVMType {
+			p := Partition{Name: name}
 			partitions = append(partitions, p)
 		}
 	}

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -170,6 +170,9 @@ NAME="sda3" SIZE="1073741824" TYPE="part" PKNAME="sda"
 NAME="usr" SIZE="1065345024" TYPE="crypt" PKNAME="sda3"
 NAME="sda1" SIZE="134217728" TYPE="part" PKNAME="sda"
 NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda"`, nil
+			case run == 14:
+				return `NAME="dm-0" SIZE="100000" TYPE="lvm" PKNAME=""
+NAME="ceph--89fa04fa--b93a--4874--9364--c95be3ec01c6-osd--data--70847bdb--2ec1--4874--98ba--d87d4860a70d" SIZE="31138512896" TYPE="lvm" PKNAME=""`, nil
 			}
 			return "", nil
 		},
@@ -192,6 +195,10 @@ NAME="sda6" SIZE="134217728" TYPE="part" PKNAME="sda"`, nil
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(0x400000), unused)
 	assert.Equal(t, 7, len(partitions))
+
+	partitions, unused, err = GetDevicePartitions("dm-0", executor)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(partitions))
 
 	partitions, unused, err = GetDevicePartitions("sdx", executor)
 	assert.Nil(t, err)


### PR DESCRIPTION
**Description of your changes:**

Since https://github.com/rook/rook/pull/4219, lv devices are now
presented to ceph-volume when preparing the device.
So on this initial run, this won't fail because the dm hasn't been
created yet but if an orchestration is re-triggered, the prepare pod
ensures idempotency with the ceph-volume batch command.
Unfortunately, c-v seems to have a bug where it doesn't read the dm to
detect whether or not they are ceph members already.
Ceph bug: https://tracker.ceph.com/issues/43209

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
