### PR TITLE
doc: Flexvolume is not prerequisite for everyone

### DIFF
--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -18,6 +18,8 @@ setting up Rook in a Kubernetes cluster with Pod Security Policies enabled.
 
 ## Flexvolume Configuration
 
+**NOTE** This configuration is only needed when using the FlexVolume driver (required for Kubernetes 1.12 or earlier). The Ceph-CSI RBD driver or the Ceph-CSI CephFS driver are recommended for Kubernetes 1.13 and newer, making FlexVolume configuration redundant.  
+
 The Rook agent requires setup as a Flex volume plugin to manage the storage attachments in your cluster.
 See the [Flex Volume Configuration](flexvolume.md) topic to configure your Kubernetes deployment to load the Rook volume plugin.
 


### PR DESCRIPTION

**Description of your changes:**

Flexvolume configuration is listed as a prerequisite. However, if choosing to go with the CSI RBD driver there is no need to configure Flexvolume. 

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]
