### PR TITLE
Revert nfs operator pid location

### DIFF
--- a/pkg/operator/nfs/server.go
+++ b/pkg/operator/nfs/server.go
@@ -25,7 +25,6 @@ import (
 
 const (
 	ganeshaLog     = "/dev/stdout"
-	ganeshaPid     = "/var/run/ganesha/ganesha.pid"
 	ganeshaOptions = "NIV_DEBUG"
 )
 
@@ -67,7 +66,7 @@ func Setup(ganeshaConfig string) error {
 func Run(ganeshaConfig string) error {
 	// Start ganesha.nfsd
 	logger.Infof("Running NFS server!")
-	cmd := exec.Command("ganesha.nfsd", "-p", ganeshaPid, "-F", "-L", ganeshaLog, "-f", ganeshaConfig, "-N", ganeshaOptions)
+	cmd := exec.Command("ganesha.nfsd", "-F", "-L", ganeshaLog, "-f", ganeshaConfig, "-N", ganeshaOptions)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("ganesha.nfsd failed with error: %v, output: %s", err, out)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Integration tests are failing with the ganesha pid location. No need for this argument.

**Which issue is resolved by this Pull Request:**
Resolves #4437 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test nfs]