### PR TITLE
Always use the version suffix from release build or tag pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,8 +146,8 @@ pipeline {
             }
             steps {
                 sh 'docker login -u="${DOCKER_USR}" -p="${DOCKER_PSW}"'
-                sh 'build/run make -j\$(nproc) -C build/release build BRANCH_NAME=${BRANCH_NAME} GIT_API_TOKEN=${GIT_PSW}'
-                sh 'build/run make -j\$(nproc) -C build/release publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_PSW}'
+                sh 'build/run make -j\$(nproc) -C build/release build BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=true GIT_API_TOKEN=${GIT_PSW}'
+                sh 'build/run make -j\$(nproc) -C build/release publish BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=true AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_PSW}'
             }
         }
     }

--- a/build/release/Jenkinsfile.tag
+++ b/build/release/Jenkinsfile.tag
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 // github credentials are not setup to push over https in jenkins. add the github token to the url
                 sh "git config remote.origin.url https://${GITHUB_USR}:${GITHUB_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')"
-                sh "make -j\$(nproc) -C build/release tag VERSION=${params.version} COMMIT_HASH=${params.commit}"
+                sh "make -j\$(nproc) -C build/release tag VERSION=${params.version} COMMIT_HASH=${params.commit} TAG_WITH_SUFFIX=true"
             }
         }
     }

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -25,10 +25,9 @@ ifeq ($(filter master release,$(CHANNEL)),)
 $(error invalid channel $(CHANNEL))
 endif
 
-# When a release branch is first created, the tag shows up in the master branch build tags.
-# When that tag has the alpha, beta, or rc suffixes, we want to remove it since it is only
-# relevant to the release tags.
-ifeq ($(CHANNEL),master)
+# When running the tag pipeline or release build we always want to add the alpha, beta, or rc suffix
+# if provided. Otherwise, it's a master build where we don't want to apply the suffix.
+ifneq ($(TAG_WITH_SUFFIX),true)
 override VERSION := $(shell echo "$(VERSION)" | sed -e 's/-alpha.0//' -e 's/-beta.0//' -e 's/-rc.0//')
 endif
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The version suffix such as alpha.0, beta.0, or rc.0 only apply
when running the tag pipeline or the release build. Otherwise,
we don't want to use the suffix from the master build.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]