### PR TITLE
docs: fix typo on ceph cluster crd description

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -463,7 +463,7 @@ spec:
 ### Node Affinity
 
 To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
-The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage' and
+The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
 tolerate taints with a key of 'storage-node'.
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: taeuk_kim <taeuk_kim@tmax.co.kr>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Typo Fix in ceph cluster crd documentation

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]