### PR TITLE
ceph: increase gateway liveness timeout

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -174,6 +174,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 				},
 			},
 			InitialDelaySeconds: 10,
+			TimeoutSeconds:      10,
 		},
 		SecurityContext: mon.PodSecurityContext(),
 	}

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -78,6 +78,11 @@ func TestPodSpecs(t *testing.T) {
 		c.getLabels(),
 		s.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels)
 
+	// Check liveness timeout
+	assert.Equal(t,
+		int32(10),
+		s.Spec.Containers[0].LivenessProbe.TimeoutSeconds)
+
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Increase the default timeout from 1s to 10s of the gateways liveness check.

**Which issue is resolved by this Pull Request:**
Resolves below issue:
Running a Load test, distcp from hadoop to S3 of 45To with 200 mappers running in //, on our Ceph/S3 platform based on rook 1.1.7 I observed lots of restart of the gateway components.
A first issue was due to a bug in ceph v14.2.4 corrected in v14.2.5 (https://github.com/ceph/ceph/pull/29559).
But most of the restart are due to the liveness probe timeout which is based on the default setting of 1s.
In case of big loads the health checks takes more than a second to be treated and leads to the gateway beeing restarted even if it still responds to queries.
Since I've increased the timeout to 10s this issue doesn't happen anymore and the service is stable.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]