### PR TITLE
rook: add missing owner references to the discover daemon

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -3,7 +3,9 @@
 ## Action Required
 
 ## Notable Features
+
 - Added K8s 1.16 to the test matrix and removed K8s 1.11 from the test matrix.
+- When the Storage Operator is deleted, the Discover Daemon will also be deleted, as well as its Config Map
 
 ### Ceph
 

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -145,6 +145,7 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 							Env: []v1.EnvVar{
 								k8sutil.NamespaceEnvVar(),
 								k8sutil.NodeEnvVar(),
+								k8sutil.NameEnvVar(),
 							},
 						},
 					},

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -48,6 +48,23 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	namespace := "ns"
 	a := New(clientset)
 
+	// Create an operator pod
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-operator",
+			Namespace: "rook-system",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "mypodContainer",
+					Image: "rook/test",
+				},
+			},
+		},
+	}
+	clientset.CoreV1().Pods("rook-system").Create(&pod)
+
 	// start a basic cluster
 	err := a.Start(namespace, "rook/rook:myversion", "mysa", false)
 	assert.Nil(t, err)
@@ -65,7 +82,7 @@ func TestStartDiscoveryDaemonset(t *testing.T) {
 	volumeMounts := agentDS.Spec.Template.Spec.Containers[0].VolumeMounts
 	assert.Equal(t, 3, len(volumeMounts))
 	envs := agentDS.Spec.Template.Spec.Containers[0].Env
-	assert.Equal(t, 2, len(envs))
+	assert.Equal(t, 3, len(envs))
 	image := agentDS.Spec.Template.Spec.Containers[0].Image
 	assert.Equal(t, "rook/rook:myversion", image)
 	assert.Nil(t, agentDS.Spec.Template.Spec.Tolerations)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Add owner references to the discover daemon pod as well as the config map. So, when the Operator is deleted both will go away too.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]