### PR TITLE
ceph: match cli timeout to authentication timeout

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -41,7 +41,7 @@ const (
 	// CrushTool is the name of the CLI tool for 'crushtool'
 	CrushTool             = "crushtool"
 	CmdExecuteTimeout     = 1 * time.Minute
-	cephConnectionTimeout = "15" // in seconds
+	cephConnectionTimeout = "600" // in seconds
 )
 
 // CephConfFilePath returns the location to the cluster's config file in the operator container.

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -30,7 +30,7 @@ func TestFinalizeCephCommandArgs(t *testing.T) {
 	args := []string{"quorum_status"}
 	expectedArgs := []string{
 		"quorum_status",
-		"--connect-timeout=15",
+		"--connect-timeout=600",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
 		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
@@ -85,7 +85,7 @@ func TestFinalizeCephCommandArgsToolBox(t *testing.T) {
 		"--",
 		"ceph",
 		"health",
-		"--connect-timeout=15",
+		"--connect-timeout=600",
 	}
 
 	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)
@@ -101,7 +101,7 @@ func TestFinalizeCephCommandArgsClusterDefaultName(t *testing.T) {
 	args := []string{"quorum_status"}
 	expectedArgs := []string{
 		"quorum_status",
-		"--connect-timeout=15",
+		"--connect-timeout=600",
 	}
 
 	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -29,7 +29,7 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, CephTool, command)
 	assert.Equal(t, 4, len(args))
 	assert.Equal(t, 4, len(args))
-	assert.Equal(t, "--connect-timeout=15", args[0])
+	assert.Equal(t, "--connect-timeout=600", args[0])
 	assert.Equal(t, "--cluster=a", args[1])
 	assert.Equal(t, "--conf=/etc/a/a.config", args[2])
 	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", args[3])
@@ -46,7 +46,7 @@ func TestCephArgs(t *testing.T) {
 	assert.Equal(t, "a", args[4])
 	assert.Equal(t, "--", args[5])
 	assert.Equal(t, CephTool, args[6])
-	assert.Equal(t, "--connect-timeout=15", args[7])
+	assert.Equal(t, "--connect-timeout=600", args[7])
 	RunAllCephCommandsInToolbox = false
 
 	// cluster under /var/lib/rook


### PR DESCRIPTION
**Description of your changes:**

The CLI timeout shouldn't be lower than authentication one as well as
the client_mount_timeout.
Also, we double it since we have seen network flakiness impacting the
orchestration.

See the following note and recommendation from Josh Durgin:

```
2019-10-31 06:53:55.783 7fb595579700  0 monclient: authenticate timed out after 300
```

Looking at the cluster log (lines containing ' cluster ' in the mon pod output), it appears there were some network connectivity issues among the monitors a few times - all the monitor processes were running as expected during this time, but there were several elections:

```
2019-10-31T06:46:39.384359384Z mon.1) 51 : cluster [INF] mon.b is new leader, mons b,c in quorum (ranks 1,2)
2019-10-31T06:47:39.887442505Z  mon.a (mon.0) 3 : cluster [INF] mon.a is new leader, mons a,b,c in quorum (ranks 0,1,2)
2019-10-31T06:48:20.182847716Z 12 : cluster [INF] mon.a is new leader, mons a,c in quorum (ranks 0,2)
2019-10-31T06:49:11.913724522Z  : cluster [INF] mon.b is new leader, mons b,c in quorum (ranks 1,2)
2019-10-31T06:49:11.913896783Z mon.a (mon.0) 39 : cluster [INF] mon.a is new leader, mons a,b,c in quorum (ranks 0,1,2)
```

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1767390
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]