### PR TITLE
CSI: cephfs and rbd daemonset upgrade strategy

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -27,6 +27,11 @@ Before Rook can provision storage, a [`StorageClass`](https://kubernetes.io/docs
 
 Each OSD must be located on a different node, because the [`failureDomain`](ceph-pool-crd.md#spec) is set to `host` and the `replicated.size` is set to `3`.
 
+> **IMPORTANT**: If you are using rbd-nbd as a mounter in storageclass. During upgrade you will be hitting a ceph-csi
+[bug](https://github.com/ceph/ceph-csi/issues/703) you need to follow
+> [upgrade steps](ceph-upgrade.md#1.-Update-the-Rook-Operator) which requires
+> node draining.
+
 > **NOTE**: This example uses the CSI driver, which is the preferred driver going forward for K8s 1.13 and newer. Examples are found in the [CSI RBD](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/rbd) directory. For an example of a storage class using the flex driver (required for K8s 1.12 or earlier), see the [Flex Driver](#flex-driver) section below, which has examples in the [flex](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/flex) directory.
 
 Save this `StorageClass` definition as `storageclass.yaml`:

--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -27,11 +27,6 @@ Before Rook can provision storage, a [`StorageClass`](https://kubernetes.io/docs
 
 Each OSD must be located on a different node, because the [`failureDomain`](ceph-pool-crd.md#spec) is set to `host` and the `replicated.size` is set to `3`.
 
-> **IMPORTANT**: If you are using rbd-nbd as a mounter in storageclass. During upgrade you will be hitting a ceph-csi
-[bug](https://github.com/ceph/ceph-csi/issues/703) you need to follow
-> [upgrade steps](ceph-upgrade.md#1.-Update-the-Rook-Operator) which requires
-> node draining.
-
 > **NOTE**: This example uses the CSI driver, which is the preferred driver going forward for K8s 1.13 and newer. Examples are found in the [CSI RBD](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/rbd) directory. For an example of a storage class using the flex driver (required for K8s 1.12 or earlier), see the [Flex Driver](#flex-driver) section below, which has examples in the [flex](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/flex) directory.
 
 Save this `StorageClass` definition as `storageclass.yaml`:

--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -79,6 +79,12 @@ $ ceph status
 Before Rook can start provisioning storage, a StorageClass needs to be created based on the filesystem. This is needed for Kubernetes to interoperate
 with the CSI driver to create persistent volumes.
 
+> **IMPORTANT**: Do not use CephFS CSI driver, if the kernel is not
+supporting ceph quotas (kernel version <4.17)
+ceph-fuse client will be used as the default mounter. During upgrade you will be hitting a ceph-csi
+[bug](https://github.com/ceph/ceph-csi/issues/703). you need to follow
+[upgrade steps](ceph-upgrade.md#1.-Update-the-Rook-Operator) which requires node draining.
+
 > **NOTE**: This example uses the CSI driver, which is the preferred driver going forward for K8s 1.13 and newer. Examples are found in the [CSI CephFS](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/cephfs) directory. For an example of a volume using the flex driver (required for K8s 1.12 and earlier), see the [Flex Driver](#flex-driver) section below.
 
 Save this storage class definition as `storageclass.yaml`:

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -239,6 +239,20 @@ kubectl apply -f upgrade-from-v1.1-apply.yaml
 The largest portion of the upgrade is triggered when the operator's image is updated to `v1.2.x`.
 When the operator is updated, it will proceed to update all of the Ceph daemons.
 
+If you are using ceph-fuse or nbd-rbd mounter. when upgraded, will cause
+existing mounts to become stale/not-rechable. please add below to the operator
+`env` variables by editing operator deployment.
+
+```yaml
+  env:
+    #  Add CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY env if you are using ceph-fuse mounter in storageclass or kernel is not supporting ceph quota(<4.17)
+    - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
+      value: "OnDelete"
+     #  Add CSI_RBD_PLUGIN_UPDATE_STRATEGY env if you are using rbd-nbd mounter
+    - name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
+      value: "OnDelete"
+```
+
 ```sh
 kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.0
 ```

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -234,30 +234,61 @@ A new `CephClient` CRD is included in v1.2 and the CSI driver privileges changed
 kubectl apply -f upgrade-from-v1.1-apply.yaml
 ```
 
-### 2. Update the Operator
+### 2. CSI upgrade pre-requisites
+
+In some scenarios there is an issue in the CSI driver that will cause application pods to be
+disconnected from their mounts when the CSI driver is restarted. Since the upgrade would cause the CSI
+driver to restart if it is updated, you need to be aware of whether this affects your applications.
+This issue will happen when using the Ceph `fuse` client or `rbd-nbd`:
+- CephFS: If you are provision volumes for CephFS and have a kernel less than version 4.17,
+The CSI driver will fall back to use the FUSE client.
+- RBD: If you have set the `mounter: rbd-nbd` option in the
+[RBD storage class](https://github.com/rook/rook/blob/release-1.2/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml#L40),
+the NBD mounter will have this issue. This setting is **not** enabled by default.
+
+If you are affected by this issue, you will need to proceed carefully during the upgrade to restart
+your application pods. The first recommended step is to modify the update strategy of the
+CSI driver so that you can control when the CSI driver pods are restarted on each node.
+As seen in the example below, set `CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY` and `CSI_RBD_PLUGIN_UPDATE_STRATEGY`
+values to `OnDelete`.
+
+To avoid this issue in future upgrades, we recommend that you **do not** use the `fuse` client or `rbd-nbd`.
+The `fuse` client can be avoided by setting the following environment variables in the operator now before this upgrade.
+The side effect of this setting is that the PVC size will not be enforced if the CephFS quotas are not supported in your kernel version.
+To enable this option and avoid this upgrade issue in the future, set `CSI_FORCE_CEPHFS_KERNEL_CLIENT` to `true`.
+
+```console
+kubectl -n $ROOK_SYSTEM_NAMESPACE edit deploy rook-ceph-operator
+```
+```yaml
+  # If you set this image at the same time as the env variables, you can skip step 3 of this guide and avoid a second operator restart
+  image: rook/ceph:v1.2.0
+  env:
+    # Change the update strategy for the CephFS driver if your cluster is affected
+    - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
+      value: "OnDelete"
+    # Change the update strategy for the RBD driver if your cluster is affected
+    - name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
+      value: "OnDelete"
+    # To avoid this upgrade issue in the future for CephFS, force enable the kernel client
+    - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
+      value: "true"
+```
+
+After the operator and cluster are updated, we will continue with the CSI and application
+pod restarts in Step 5.
+
+### 3. Update the Rook Operator
 
 The largest portion of the upgrade is triggered when the operator's image is updated to `v1.2.x`.
 When the operator is updated, it will proceed to update all of the Ceph daemons.
-
-If you are using ceph-fuse or nbd-rbd mounter. when upgraded, will cause
-existing mounts to become stale/not-rechable. please add below to the operator
-`env` variables by editing operator deployment.
-
-```yaml
-  env:
-    #  Add CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY env if you are using ceph-fuse mounter in storageclass or kernel is not supporting ceph quota(<4.17)
-    - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
-      value: "OnDelete"
-     #  Add CSI_RBD_PLUGIN_UPDATE_STRATEGY env if you are using rbd-nbd mounter
-    - name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
-      value: "OnDelete"
-```
+(If step 1 was completed, this change has already been applied.)
 
 ```sh
 kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.0
 ```
 
-### 3. Wait for the upgrade to complete
+### 4. Wait for the upgrade to complete
 
 Watch now in amazement as the Ceph mons, mgrs, OSDs, rbd-mirrors, MDSes and RGWs are terminated and
 replaced with updated versions in sequence. The cluster may be offline very briefly as mons update,
@@ -300,13 +331,30 @@ This cluster is finished:
   rook-version=v1.2.0
 ```
 
-### 4. Verify the updated cluster
+### 5. Verify the updated cluster
 
 At this point, your Rook operator should be running version `rook/ceph:v1.2.0`.
 
 Verify the Ceph cluster's health using the [health verification section](#health-verification).
 
-### 5. Update Rook-Ceph custom resource definitions
+### 6. CSI Manual Update (optional)
+
+If you determined in step 1 that you were affected by the CSI driver restart issue that disconnects
+the application pods from their mounts, continue with this section. Otherwise, you can skip to step 7.
+
+Your cluster should now be in a state where Rook has upgraded everything except the CSI driver.
+The CSI driver pods will not be updated until you delete them manually. This allows you to control
+when your application pods will be affected by the CSI driver restart.
+
+For each node:
+- Drain your application pods from the node
+- Delete the CSI driver pods on the node
+  - The pods to delete will be named with a `csi-cephfsplugin` or `csi-rbdplugin` prefix and have a random suffix on each node.
+    However, no need to delete the provisioner pods: `csi-cephfsplugin-provisioner-*` or `csi-rbdplugin-provisioner-*`
+  - The pod deletion causes the pods to be restarted and updated automatically on the node
+
+
+### 7. Update Rook-Ceph custom resource definitions
 
 > **IMPORTANT**: Do not perform this step until ALL existing Rook-Ceph clusters are updated!
 

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -95,55 +95,57 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter                       | Description                                                                                             | Default                                                |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`              | Image                                                                                                   | `rook/ceph`                                            |
-| `image.tag`                     | Image tag                                                                                               | `master`                                               |
-| `image.pullPolicy`              | Image pull policy                                                                                       | `IfNotPresent`                                         |
-| `rbacEnable`                    | If true, create & use RBAC resources                                                                    | `true`                                                 |
-| `pspEnable`                     | If true, create & use PSP resources                                                                     | `true`                                                 |
-| `resources`                     | Pod resource requests & limits                                                                          | `{}`                                                   |
-| `annotations`                   | Pod annotations                                                                                         | `{}`                                                   |
-| `logLevel`                      | Global log level                                                                                        | `INFO`                                                 |
-| `nodeSelector`                  | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
-| `tolerations`                   | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
-| `currentNamespaceOnly`          | Whether the operator should watch cluster CRD in its own namespace or not                               | `false`                                                |
-| `hostpathRequiresPrivileged`    | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
-| `mon.healthCheckInterval`       | The frequency for the operator to check the mon health                                                  | `45s`                                                  |
-| `mon.monOutTimeout`             | The time to wait before failing over an unhealthy mon                                                   | `600s`                                                 |
-| `discover.priorityClassName`    | The priority class name to add to the discover pods                                                     | <none>                                                 |
-| `discover.toleration`           | Toleration for the discover pods                                                                        | <none>                                                 |
-| `discover.tolerationKey`        | The specific key of the taint to tolerate                                                               | <none>                                                 |
-| `discover.tolerations`          | Array of tolerations in YAML format which will be added to discover deployment                          | <none>                                                 |
-| `discover.nodeAffinity`         | The node labels for affinity of `discover-agent` (***)                                                  | <none>                                                 |
-| `csi.enableRbdDriver`           | Enable Ceph CSI RBD driver.                                                                             | `true`                                                 |
-| `csi.enableCephfsDriver`        | Enable Ceph CSI CephFS driver.                                                                          | `true`                                                 |
-| `csi.enableGrpcMetrics`         | Enable Ceph CSI GRPC Metrics.                                                                           | `true`                                                 |
-| `csi.provisionerTolerations`    | Array of tolerations in YAML format which will be added to CSI provisioner deployment.                  | <none>                                                 |
-| `csi.provisionerNodeAffinity`   | The node labels for affinity of the CSI provisioner deployment (***)                                    | <none>                                                 |
-| `csi.pluginTolerations`         | Array of tolerations in YAML format which will be added to Ceph CSI plugin DaemonSet                    | <none>                                                 |
-| `csi.pluginNodeAffinity`        | The node labels for affinity of the Ceph CSI plugin DaemonSet (***)                                     | <none>                                                 |
-| `csi.cephfsGrpcMetricsPort`     | CSI CephFS driver GRPC metrics port.                                                                    | `9091`                                                 |
-| `csi.cephfsLivenessMetricsPort` | CSI CephFS driver metrics port.                                                                         | `9081`                                                 |
-| `csi.rbdGrpcMetricsPort`        | Ceph CSI RBD driver GRPC metrics port.                                                                  | `9090`                                                 |
-| `csi.rbdLivenessMetricsPort`    | Ceph CSI RBD driver metrics port.                                                                       | `8080`                                                 |
-| `csi.enableSnapshotter`         | Enable deployment of snapshotter container in ceph-csi provisioner.                                     | `true`                                                 |
-| `csi.forceCephFSKernelClient`   | Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs.                            | `true`                                                 |
-| `csi.kubeletDirPath`            | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
-| `csi.cephcsi.image`             | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.2`                       |
-| `csi.registrar.image`           | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |
-| `csi.provisioner.image`         | Kubernetes CSI provisioner image.                                                                       | `quay.io/k8scsi/csi-provisioner:v1.4.0`                |
-| `csi.snapshotter.image`         | Kubernetes CSI snapshotter image.                                                                       | `quay.io/k8scsi/csi-snapshotter:v1.2.2`                |
-| `csi.attacher.image`            | Kubernetes CSI Attacher image.                                                                          | `quay.io/k8scsi/csi-attacher:v1.2.0`                   |
-| `agent.flexVolumeDirPath`       | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
-| `agent.libModulesDirPath`       | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |
-| `agent.mounts`                  | Additional paths to be mounted in the agent container (**)                                              | <none>                                                 |
-| `agent.mountSecurityMode`       | Mount Security Mode for the agent.                                                                      | `Any`                                                  |
-| `agent.priorityClassName`       | The priority class name to add to the agent pods                                                        | <none>                                                 |
-| `agent.toleration`              | Toleration for the agent pods                                                                           | <none>                                                 |
-| `agent.tolerationKey`           | The specific key of the taint to tolerate                                                               | <none>                                                 |
-| `agent.tolerations`             | Array of tolerations in YAML format which will be added to agent deployment                             | <none>                                                 |
-| `agent.nodeAffinity`            | The node labels for affinity of `rook-agent` (***)                                                      | <none>                                                 |
+| Parameter                        | Description                                                                                             | Default                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `image.repository`               | Image                                                                                                   | `rook/ceph`                                            |
+| `image.tag`                      | Image tag                                                                                               | `master`                                               |
+| `image.pullPolicy`               | Image pull policy                                                                                       | `IfNotPresent`                                         |
+| `rbacEnable`                     | If true, create & use RBAC resources                                                                    | `true`                                                 |
+| `pspEnable`                      | If true, create & use PSP resources                                                                     | `true`                                                 |
+| `resources`                      | Pod resource requests & limits                                                                          | `{}`                                                   |
+| `annotations`                    | Pod annotations                                                                                         | `{}`                                                   |
+| `logLevel`                       | Global log level                                                                                        | `INFO`                                                 |
+| `nodeSelector`                   | Kubernetes `nodeSelector` to add to the Deployment.                                                     | <none>                                                 |
+| `tolerations`                    | List of Kubernetes `tolerations` to add to the Deployment.                                              | `[]`                                                   |
+| `currentNamespaceOnly`           | Whether the operator should watch cluster CRD in its own namespace or not                               | `false`                                                |
+| `hostpathRequiresPrivileged`     | Runs Ceph Pods as privileged to be able to write to `hostPath`s in OpenShift with SELinux restrictions. | `false`                                                |
+| `mon.healthCheckInterval`        | The frequency for the operator to check the mon health                                                  | `45s`                                                  |
+| `mon.monOutTimeout`              | The time to wait before failing over an unhealthy mon                                                   | `600s`                                                 |
+| `discover.priorityClassName`     | The priority class name to add to the discover pods                                                     | <none>                                                 |
+| `discover.toleration`            | Toleration for the discover pods                                                                        | <none>                                                 |
+| `discover.tolerationKey`         | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `discover.tolerations`           | Array of tolerations in YAML format which will be added to discover deployment                          | <none>                                                 |
+| `discover.nodeAffinity`          | The node labels for affinity of `discover-agent` (***)                                                  | <none>                                                 |
+| `csi.enableRbdDriver`            | Enable Ceph CSI RBD driver.                                                                             | `true`                                                 |
+| `csi.enableCephfsDriver`         | Enable Ceph CSI CephFS driver.                                                                          | `true`                                                 |
+| `csi.enableGrpcMetrics`          | Enable Ceph CSI GRPC Metrics.                                                                           | `true`                                                 |
+| `csi.provisionerTolerations`     | Array of tolerations in YAML format which will be added to CSI provisioner deployment.                  | <none>                                                 |
+| `csi.provisionerNodeAffinity`    | The node labels for affinity of the CSI provisioner deployment (***)                                    | <none>                                                 |
+| `csi.pluginTolerations`          | Array of tolerations in YAML format which will be added to Ceph CSI plugin DaemonSet                    | <none>                                                 |
+| `csi.pluginNodeAffinity`         | The node labels for affinity of the Ceph CSI plugin DaemonSet (***)                                     | <none>                                                 |
+| `csi.cephfsGrpcMetricsPort`      | CSI CephFS driver GRPC metrics port.                                                                    | `9091`                                                 |
+| `csi.cephfsLivenessMetricsPort`  | CSI CephFS driver metrics port.                                                                         | `9081`                                                 |
+| `csi.rbdGrpcMetricsPort`         | Ceph CSI RBD driver GRPC metrics port.                                                                  | `9090`                                                 |
+| `csi.rbdLivenessMetricsPort`     | Ceph CSI RBD driver metrics port.                                                                       | `8080`                                                 |
+| `csi.enableSnapshotter`          | Enable deployment of snapshotter container in ceph-csi provisioner.                                     | `true`                                                 |
+| `csi.forceCephFSKernelClient`    | Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs.                            | `true`                                                 |
+| `csi.kubeletDirPath`             | Kubelet root directory path (if the Kubelet uses a different path for the `--root-dir` flag)            | `/var/lib/kubelet`                                     |
+| `csi.cephcsi.image`              | Ceph CSI image.                                                                                         | `quay.io/cephcsi/cephcsi:v1.2.2`                       |
+| `csi.rbdPluginUpdateStrategy`    | CSI Rbd plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.              | `OnDelete`                                             |
+| `csi.cephFSPluginUpdateStrategy` | CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.           | `OnDelete`                                             |
+| `csi.registrar.image`            | Kubernetes CSI registrar image.                                                                         | `quay.io/k8scsi/csi-node-driver-registrar:v1.1.0`      |
+| `csi.provisioner.image`          | Kubernetes CSI provisioner image.                                                                       | `quay.io/k8scsi/csi-provisioner:v1.4.0`                |
+| `csi.snapshotter.image`          | Kubernetes CSI snapshotter image.                                                                       | `quay.io/k8scsi/csi-snapshotter:v1.2.2`                |
+| `csi.attacher.image`             | Kubernetes CSI Attacher image.                                                                          | `quay.io/k8scsi/csi-attacher:v1.2.0`                   |
+| `agent.flexVolumeDirPath`        | Path where the Rook agent discovers the flex volume plugins (*)                                         | `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` |
+| `agent.libModulesDirPath`        | Path where the Rook agent should look for kernel modules (*)                                            | `/lib/modules`                                         |
+| `agent.mounts`                   | Additional paths to be mounted in the agent container (**)                                              | <none>                                                 |
+| `agent.mountSecurityMode`        | Mount Security Mode for the agent.                                                                      | `Any`                                                  |
+| `agent.priorityClassName`        | The priority class name to add to the agent pods                                                        | <none>                                                 |
+| `agent.toleration`               | Toleration for the agent pods                                                                           | <none>                                                 |
+| `agent.tolerationKey`            | The specific key of the taint to tolerate                                                               | <none>                                                 |
+| `agent.tolerations`              | Array of tolerations in YAML format which will be added to agent deployment                             | <none>                                                 |
+| `agent.nodeAffinity`             | The node labels for affinity of `rook-agent` (***)                                                      | <none>                                                 |
 
 &ast; For information on what to set `agent.flexVolumeDirPath` to, please refer to the [Rook flexvolume documentation](flexvolume.md)
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -108,6 +108,14 @@ spec:
           value: {{ .Values.csi.enableCephfsDriver | quote }}
         - name: CSI_ENABLE_SNAPSHOTTER
           value: {{ .Values.csi.enableSnapshotter | quote }}
+{{- if .Values.csi.cephFSPluginUpdateStrategy }}
+        - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
+          value: {{ .Values.csi.cephFSPluginUpdateStrategy | quote }}
+{{- end }}
+{{- if .Values.csi.rbdPluginUpdateStrategy }}
+        - name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
+          value: {{ .Values.csi.rbdPluginUpdateStrategy | quote }}
+{{- end }}
 {{- if .Values.csi.kubeletDirPath }}
         - name: ROOK_CSI_KUBELET_DIR_PATH
           value: {{ .Values.csi.kubeletDirPath | quote }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -58,6 +58,13 @@ csi:
   enableCephfsDriver: true
   enableGrpcMetrics: true
   enableSnapshotter: true
+  # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+  # Default value is RollingUpdate.
+  #rbdPluginUpdateStrategy: OnDelete
+  # CSI Rbd plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+  # Default value is RollingUpdate.
+  #cephFSPluginUpdateStrategy: OnDelete
+
   # Set provisonerTolerations and provisionerNodeAffinity for provisioner pod.
   # The CSI provisioner would be best to start on the same nodes as other ceph daemons.
   # provisionerTolerations:

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -37,5 +37,8 @@ parameters:
     # will set default as `ext4`.
     csi.storage.k8s.io/fstype: ext4
 # uncomment the following to use rbd-nbd as mounter on supported nodes
+# **IMPORTANT**: If you are using rbd-nbd as the mounter, during upgrade you will be hit a ceph-csi
+# issue that causes the mount to be disconnected. You will need to follow special upgrade steps
+# to restart your application pods. Therefore, this option is not recommended.
 #mounter: rbd-nbd
 reclaimPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       app: csi-cephfsplugin
+  updateStrategy:
+    type: {{ .CephFSPluginUpdateStrategy }}
   template:
     metadata:
       labels:

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       app: csi-rbdplugin
+  updateStrategy:
+    type: {{ .RBDPluginUpdateStrategy }}
   template:
     metadata:
       labels:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -240,6 +240,14 @@ spec:
         # See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
         - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
           value: "true"
+        # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+        # Default value is RollingUpdate.
+        #- name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
+        #  value: "OnDelete"
+        # CSI Rbd plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+        # Default value is RollingUpdate.
+        #- name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
+        #  value: "OnDelete"
         # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
         #- name: ROOK_CSI_KUBELET_DIR_PATH
         #  value: "/var/lib/kubelet"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -190,6 +190,14 @@ spec:
         # See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
         - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
           value: "true"
+        # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+        # Default value is RollingUpdate.
+        #- name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
+        #  value: "OnDelete"
+        # CSI Rbd plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
+        # Default value is RollingUpdate.
+        #- name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
+        #  value: "OnDelete"
         # The default version of CSI supported by Rook will be started. To change the version
         # of the CSI driver to something other than what is officially supported, change
         # these images to the desired release of the CSI driver.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -35,20 +35,22 @@ import (
 )
 
 type Param struct {
-	CSIPluginImage            string
-	RegistrarImage            string
-	ProvisionerImage          string
-	AttacherImage             string
-	SnapshotterImage          string
-	DriverNamePrefix          string
-	EnableSnapshotter         string
-	EnableCSIGRPCMetrics      string
-	KubeletDirPath            string
-	ForceCephFSKernelClient   string
-	CephFSGRPCMetricsPort     uint16
-	CephFSLivenessMetricsPort uint16
-	RBDGRPCMetricsPort        uint16
-	RBDLivenessMetricsPort    uint16
+	CSIPluginImage             string
+	RegistrarImage             string
+	ProvisionerImage           string
+	AttacherImage              string
+	SnapshotterImage           string
+	DriverNamePrefix           string
+	EnableSnapshotter          string
+	EnableCSIGRPCMetrics       string
+	KubeletDirPath             string
+	ForceCephFSKernelClient    string
+	CephFSPluginUpdateStrategy string
+	RBDPluginUpdateStrategy    string
+	CephFSGRPCMetricsPort      uint16
+	CephFSLivenessMetricsPort  uint16
+	RBDGRPCMetricsPort         uint16
+	RBDLivenessMetricsPort     uint16
 }
 
 type templateParam struct {
@@ -222,6 +224,21 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if !strings.EqualFold(enableSnap, "false") {
 		tp.EnableSnapshotter = "true"
 	}
+
+	updateStrategy := os.Getenv("CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY")
+	if strings.EqualFold(updateStrategy, "ondelete") {
+		tp.CephFSPluginUpdateStrategy = "OnDelete"
+	} else {
+		tp.CephFSPluginUpdateStrategy = "RollingUpdate"
+	}
+
+	updateStrategy = os.Getenv("CSI_RBD_PLUGIN_UPDATE_STRATEGY")
+	if strings.EqualFold(updateStrategy, "ondelete") {
+		tp.RBDPluginUpdateStrategy = "OnDelete"
+	} else {
+		tp.RBDPluginUpdateStrategy = "RollingUpdate"
+	}
+
 	if ver.Major > KubeMinMajor || (ver.Major == KubeMinMajor && ver.Minor < provDeploymentSuppVersion) {
 		deployProvSTS = true
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
CSI nodeplugins, specifically when using cephfs FUSE or rbd-nbd as the mounters, when upgraded, will cause existing mounts to become stale/not-rechable (usually connection timeout errors).

This is due to losing the mount processes running within the CSI nodeplugin pods.

This PR adds updated the Daemonset update strategy based on the ENV variable to take care of the above issue with some manual steps

Moreinfo: https://github.com/ceph/ceph-csi/issues/703
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4248

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]