### PR TITLE
Run integration tests on K8s 1.17

### DIFF
--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -5,11 +5,13 @@ weight: 1000
 
 # Prerequisites
 
-Rook can be installed on any existing Kubernetes clusters as long as it meets the minimum version and have the required privilege to run in the cluster (see below for more information). If you dont have a Kubernetes cluster, you can quickly set one up using [Minikube](#minikube), [Kubeadm](#kubeadm) or [CoreOS/Vagrant](#new-local-kubernetes-cluster-with-vagrant).
+Rook can be installed on any existing Kubernetes cluster as long as it meets the minimum version
+and Rook is granted the required privileges (see below for more information). If you don't have a Kubernetes cluster,
+you can quickly set one up using [Minikube](#minikube), [Kubeadm](#kubeadm) or [CoreOS/Vagrant](#new-local-kubernetes-cluster-with-vagrant).
 
 ## Minimum Version
 
-Kubernetes v1.10 or higher is supported by Rook.
+Kubernetes v1.13 or higher is supported by Rook.
 
 ## Privileges and RBAC
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,11 +108,11 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,yugabytedb-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
-                        "aws_1.12.x": "v1.12.10",
-                        "aws_1.13.x": "v1.13.11",
-                        "aws_1.14.x": "v1.14.7",
-                        "aws_1.15.x": "v1.15.4",
-                        "aws_1.16.x": "v1.16.0"
+                        "aws_1.13.x": "v1.13.12",
+                        "aws_1.14.x": "v1.14.10",
+                        "aws_1.15.x": "v1.15.7",
+                        "aws_1.16.x": "v1.16.4",
+                        "aws_1.17.x": "v1.17.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -4,6 +4,7 @@
 
 
 ## Notable Features
+- Added K8s 1.17 to the test matrix and removed K8s 1.12 from the test matrix.
 
 ### Ceph
 

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -39,11 +39,11 @@ const (
 	// UPDATE these versions when the integration test matrix changes
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
-	blockMinimalTestVersion        = "1.12.0"
-	multiClusterMinimalTestVersion = "1.13.0"
-	helmMinimalTestVersion         = "1.14.0"
-	upgradeMinimalTestVersion      = "1.15.0"
-	smokeSuiteMinimalTestVersion   = "1.16.0"
+	blockMinimalTestVersion        = "1.13.0"
+	multiClusterMinimalTestVersion = "1.14.0"
+	helmMinimalTestVersion         = "1.15.0"
+	upgradeMinimalTestVersion      = "1.16.0"
+	smokeSuiteMinimalTestVersion   = "1.17.0"
 )
 
 var (


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Since the release of K8s 1.17 this week Rook needs to run the integration tests on 1.17. Following the same pattern as traditional tests, we run the tests on the five most recent releases, thus removing 1.12 from the test matrix.

**Which issue is resolved by this Pull Request:**
Resolves #4488 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test full]