### PR TITLE
Set discover ownerrefs without blocking parent deletion

### DIFF
--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -19,7 +19,7 @@ package k8sutil
 
 // MergeResourceRequirements merges two resource requirements together (first overrides second values)
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,6 +65,25 @@ func SetOwnerRef(object *metav1.ObjectMeta, ownerRef *metav1.OwnerReference) {
 		return
 	}
 	SetOwnerRefs(object, []metav1.OwnerReference{*ownerRef})
+}
+
+func SetOwnerRefsWithoutBlockOwner(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+	if ownerRefs == nil {
+		return
+	}
+	newOwners := []metav1.OwnerReference{}
+	for _, ownerRef := range ownerRefs {
+		// Make a new copy of the owner ref so we don't impact existing references to it
+		// but don't add the Controller or BlockOwnerDeletion properties
+		newRef := metav1.OwnerReference{
+			APIVersion: ownerRef.APIVersion,
+			Kind:       ownerRef.Kind,
+			Name:       ownerRef.Name,
+			UID:        ownerRef.UID,
+		}
+		newOwners = append(newOwners, newRef)
+	}
+	SetOwnerRefs(object, newOwners)
 }
 
 func SetOwnerRefs(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
An owner reference cannot be set with `BlockOwnerDeletion: true` if the operator does not have privs to add a finalizer to the parent. The discover resources don't need to block deletion based on the parent so we remove that property from the owner reference.

This issue was causing the following error when running on OpenShift:
```
 2019-12-13 06:29:56.309823 I | cephcmd: starting operator
failed to run operator
: error starting device discovery daemonset: Error starting discover daemonset: failed to create rook-discover daemon set. daemonsets.apps "rook-discover" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]