### PR TITLE
ceph: add retry while enabling mgr modules

### DIFF
--- a/pkg/daemon/ceph/client/mgr_test.go
+++ b/pkg/daemon/ceph/client/mgr_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnableModuleRetries(t *testing.T) {
+	moduleEnableRetries := 0
+	moduleEnableWaitTime = 0
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		switch {
+		case args[0] == "mgr" && args[1] == "module" && args[2] == "enable":
+			if args[3] == "prometheus" || args[3] == "pg_autoscaler" || args[3] == "crash" {
+				return "", nil
+			}
+
+		case args[0] == "mgr" && args[1] == "module" && args[2] == "disable":
+			if args[3] == "prometheus" || args[3] == "pg_autoscaler" || args[3] == "crash" {
+				return "", nil
+			}
+		}
+
+		moduleEnableRetries = moduleEnableRetries + 1
+		return "", errors.Errorf("unexpected ceph command %q", args)
+
+	}
+
+	_ = MgrEnableModule(&clusterd.Context{Executor: executor}, "clusterName", "invalidModuleName", false)
+	assert.Equal(t, 5, moduleEnableRetries)
+
+	moduleEnableRetries = 0
+	_ = MgrEnableModule(&clusterd.Context{Executor: executor}, "clusterName", "pg_autoscaler", false)
+	assert.Equal(t, 0, moduleEnableRetries)
+
+}
+
+func TestEnableModule(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutputFile = func(debug bool, actionName, command, outputFile string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
+		switch {
+		case args[0] == "mgr" && args[1] == "module" && args[2] == "enable":
+			if args[3] == "prometheus" || args[3] == "pg_autoscaler" || args[3] == "crash" {
+				return "", nil
+			}
+
+		case args[0] == "mgr" && args[1] == "module" && args[2] == "disable":
+			if args[3] == "prometheus" || args[3] == "pg_autoscaler" || args[3] == "crash" {
+				return "", nil
+			}
+		}
+
+		return "", errors.Errorf("unexpected ceph command %q", args)
+	}
+
+	err := enableModule(&clusterd.Context{Executor: executor}, "clusterName", "pg_autoscaler", true, "enable")
+	assert.NoError(t, err)
+
+	err = enableModule(&clusterd.Context{Executor: executor}, "clusterName", "prometheus", true, "disable")
+	assert.NoError(t, err)
+
+	err = enableModule(&clusterd.Context{Executor: executor}, "clusterName", "invalidModuleName", false, "enable")
+	assert.Error(t, err)
+
+	err = enableModule(&clusterd.Context{Executor: executor}, "clusterName", "pg_autoscaler", false, "invalidCommandArgs")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Enabling pg_autoscalar module fails most probably becasue `ceph mgr module enable <>` is happening very quickly after ceph mgr starts.
This PR adds a retry (5 times) with a sleep interval of 5 seconds (for each interval) to handle failure while enabling mgr modules.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Add a retry (5 times) when trying to enable mgr modules. 
- Add a wait for 5 seconds for reach retry iteration. 

**Which issue is resolved by this Pull Request:**
Resolves #4497

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]