### PR TITLE
Ceph: ObjectStore replica size will not change

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -19,6 +19,7 @@ package object
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -274,7 +275,7 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 	for _, pool := range pools {
 		// create the pool if it doesn't exist yet
 		name := poolName(context.Name, pool)
-		if _, err := ceph.GetPoolDetails(context.Context, context.ClusterName, name); err != nil {
+		if poolDetails, err := ceph.GetPoolDetails(context.Context, context.ClusterName, name); err != nil {
 			cephConfig.Name = name
 			// If the ceph config has an EC profile, an EC pool must be created. Otherwise, it's necessary
 			// to create a replicated pool.
@@ -288,6 +289,17 @@ func createSimilarPools(context *Context, pools []string, poolSpec model.Pool) e
 			}
 			if err != nil {
 				return errors.Errorf("failed to create pool %s for object store %s", name, context.Name)
+			}
+		} else {
+			// pools already exist
+			if !isECPool {
+				// detect if the replication is different from the pool details
+				if poolDetails.Size != poolSpec.ReplicatedConfig.Size {
+					logger.Infof("pool size is changed from %d to %d", poolDetails.Size, poolSpec.ReplicatedConfig.Size)
+					if err := ceph.SetPoolReplicatedSizeProperty(context.Context, context.ClusterName, poolDetails.Name, strconv.FormatUint(uint64(poolDetails.Size), 10), poolDetails.RequireSafeReplicaSize); err != nil {
+						return errors.Wrapf(err, "failed to set size property to replicated pool %q to %d", poolDetails.Name, poolSpec.ReplicatedConfig.Size)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The pool size for cephObjectStore `(object.yaml)` , are not getting updated in the cluster upon changing.

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #4341 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]