### PR TITLE
docs: added toc to Ceph advanced configuration page

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -9,6 +9,19 @@ indent: true
 These examples show how to perform advanced configuration tasks on your Rook
 storage cluster.
 
+* [Prerequisites](#prerequisites)
+* [Use custom Ceph user and secret for mounting](#use-custom-ceph-user-and-secret-for-mounting)
+* [Log Collection](#log-collection)
+* [OSD Information](#osd-information)
+* [Separate Storage Groups](#separate-storage-groups)
+* [Configuring Pools](#configuring-pools)
+* [Custom ceph.conf Settings](#custom-cephconf-settings)
+* [OSD CRUSH Settings](#osd-crush-settings)
+* [OSD Dedicated Network](#osd-dedicated-network)
+* [Phantom OSD Removal](#phantom-osd-removal)
+* [Change Failure Domain](#change-failure-domain)
+* [Monitor placement](#monitor-placement)
+
 ## Prerequisites
 
 Most of the examples make use of the `ceph` client command.  A quick way to use
@@ -37,6 +50,7 @@ kubectl create secret generic ceph-user1-secret --from-literal=key=YOUR_CEPH_KEY
 ```
 
 > **NOTE**: This secret with the same name must be created in each namespace where the StorageClass will be used.
+
 In addition to this Secret you must create a RoleBinding to allow the Rook Ceph agent to get the secret from each namespace.
 The RoleBinding is optional if you are using a ClusterRoleBinding for the Rook Ceph agent secret access.
 A ClusterRole which contains the permissions which are needed and used for the Bindings are shown as an example after the next step.


### PR DESCRIPTION
**Description of your changes:**

Added table of contents to the Ceph advanced configuration page to make
it easier to find the right section till the theme / layout of the
homepage can autogenerate a toc if enabled.

/cc @travisn 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]