### PR TITLE
Rehydrate the osd CRUSH location for PVCs

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -719,8 +719,13 @@ func getOSDInfo(d *apps.Deployment) ([]OSDInfo, error) {
 		if strings.HasPrefix(a, "--setuser-match-path") {
 			if len(container.Args) >= i+1 {
 				osd.DataPath = container.Args[i+1]
-				break
 			}
+		}
+		locationPrefix := "--crush-location="
+		if strings.HasPrefix(a, locationPrefix) {
+			// Extract the same CRUSH location as originally determined by the OSD prepare pod
+			// by cutting off the prefix: --crush-location=
+			osd.Location = a[len(locationPrefix):]
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -385,7 +385,8 @@ func TestGetOSDInfo(t *testing.T) {
 		v1.ResourceRequirements{}, v1.ResourceRequirements{}, "my-priority-class", metav1.OwnerReference{}, false, false)
 
 	node := "n1"
-	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", LVPath: "dev/logical-volume-path", DataPath: "/rook/path", CephVolumeInitiated: true}
+	location := "root=default host=myhost zone=myzone"
+	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", LVPath: "dev/logical-volume-path", DataPath: "/rook/path", CephVolumeInitiated: true, Location: location}
 	osd2 := OSDInfo{ID: 3, UUID: "osd-uuid", LVPath: "", DataPath: "/rook/path", CephVolumeInitiated: true}
 	osdProp := osdProperties{
 		crushHostname: node,
@@ -402,10 +403,10 @@ func TestGetOSDInfo(t *testing.T) {
 	assert.Equal(t, 1, len(osds1))
 	assert.Equal(t, osd1.ID, osds1[0].ID)
 	assert.Equal(t, osd1.LVPath, osds1[0].LVPath)
+	assert.Equal(t, location, osds1[0].Location)
 
 	d2, _ := c.makeDeployment(osdProp, osd2, dataPathMap)
 	osds2, err := getOSDInfo(d2)
 	assert.Equal(t, 0, len(osds2))
 	assert.NotNil(t, err)
-
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSDs on PVCs were changing location in the CRUSH hierarchy after an operator restart due to the location property not being re-discovered on the OSD daemon. Since OSDs on PVCs do not run the prepare pod again to discover this property, the operator must read it off the existing osd deployment. The operator was reading other properties, but now will read the location as well.

**Which issue is resolved by this Pull Request:**
Resolves #4543 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]