### PR TITLE
ceph: fixed RBAC delete\create before upgrade

### DIFF
--- a/cluster/examples/kubernetes/ceph/upgrade-from-v0.9-create.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v0.9-create.yaml
@@ -152,6 +152,43 @@ rules:
 
 ---
 
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - apps  # upgrade note: changed from 'extensions' to 'apps' in Rook 1.0
+    resources:
+      - daemonsets
+      - statefulsets  # upgrade note: added in Rook 1.0 to support CSI
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+
+---
+
 # Aspects of ceph-mgr that require access to the system namespace
 kind: ClusterRole  # upgrade note: changed from a Role to a ClusterRole in 1.0
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -167,6 +204,22 @@ rules:
   - get
   - list
   - watch
+
+---
+
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-system
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: rook-ceph-system
 
 ---
 

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v0.9-delete.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v0.9-delete.yaml
@@ -1,3 +1,9 @@
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-system
+
 ---
 
 # The cluster role for managing all the cluster-specific resources in a namespace


### PR DESCRIPTION
According to upgrade manual https://rook.io/docs/rook/v1.0/ceph-upgrade.html, you need to delete and create some of the RBAC things, because of changes within it. But there was missed needed some parts to delete and create.

Because of this you can get such messages in rook-ceph-operator:

```
2019-12-17 09:46:00.208988 I | cephcmd: starting operator
2019-12-17 09:46:00.284655 I | op-agent: getting flexvolume dir path from FLEXVOLUME_DIR_PATH env var
2019-12-17 09:46:00.285462 I | op-agent: discovered flexvolume dir path from source env var. value: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
2019-12-17 09:46:00.285552 I | op-agent: no agent mount security mode given, defaulting to 'Any' mode
`failed to run operator. Error starting agent daemonset: error starting agent daemonset: failed to create rook-ceph-agent daemon set. daemonsets.apps is forbidden: User "system:serviceaccount:rook-ceph-system:rook-ceph-system" cannot create resource "daemonsets" in API group "apps" in the namespace "rook-ceph-system"`
```

This Pull Request should resolve this problem.

[skip ci]