### PR TITLE
Ceph: Assure mon canary pods deletion

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -89,7 +89,7 @@ const (
 
 	// canary pod scheduling uses retry loops when cleaning up previous canary
 	// pods and waiting for kubernetes scheduling to complete.
-	canaryRetries           = 180
+	canaryRetries           = 30
 	canaryRetryDelaySeconds = 5
 
 	// Fallback pod anti affinity for mon pods to PreferredDuringSchedulingIgnoredDuringExecution
@@ -414,7 +414,7 @@ func realScheduleMonitor(c *Cluster, mon *monConfig) (SchedulingResult, error) {
 	}
 
 	// build the canary deployment.
-	d := c.makeDeployment(mon)
+	d := c.makeDeployment(mon, true)
 	d.Name += "-canary"
 	d.Spec.Template.ObjectMeta.Name += "-canary"
 
@@ -442,7 +442,7 @@ func realScheduleMonitor(c *Cluster, mon *monConfig) (SchedulingResult, error) {
 	} else {
 		// the pvc that is created here won't be deleted: it will be reattached
 		// to the real monitor deployment.
-		pvc, err := c.makeDeploymentPVC(mon)
+		pvc, err := c.makeDeploymentPVC(mon, true)
 		if err != nil {
 			return result, errors.Wrapf(err, "sched-mon: failed to make monitor %s pvc", d.Name)
 		}
@@ -556,33 +556,41 @@ func (c *Cluster) initMonIPs(mons []*monConfig) error {
 	return nil
 }
 
-func (c *Cluster) assignMons(mons []*monConfig) error {
-	// when monitors are scheduling below by invoking scheduleMonitor() a canary
-	// deployment and optional canary PVC are created. in order for the
-	// anti-affinity rules to be effective, we leave the canary pods in place
-	// until all of the canaries have been scheduled. only after the
-	// monitor/node assignment process is complete are the canary deployments
-	// and pvcs removed here.
-	canaryCleanup := []SchedulingResult{}
-	defer func() {
-		for _, result := range canaryCleanup {
-			logger.Infof("assignmon: cleaning up canary deployment %s and canary pvc %s", result.CanaryDeployment, result.CanaryPVC)
-			if result.CanaryDeployment != "" {
-				if err := k8sutil.DeleteDeployment(c.context.Clientset, c.Namespace, result.CanaryDeployment); err != nil {
-					logger.Infof("assignmon: error deleting canary deployment %s. %v", result.CanaryDeployment, err)
-				}
-			}
-			if result.CanaryPVC != "" {
-				var gracePeriod int64 // delete immediately
-				propagation := metav1.DeletePropagationForeground
-				options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-				err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.Namespace).Delete(result.CanaryPVC, options)
-				if err != nil {
-					logger.Infof("assignmon: error removing canary monitor %s pvc %s. %v", result.CanaryDeployment, result.CanaryPVC, err)
-				}
+// Delete mon canary deployments (and associated PVCs) using deployment labels
+// to select this kind of temporary deployments
+func (c *Cluster) removeCanaryDeployments() {
+	canaryDeployments, err := k8sutil.GetDeployments(c.context.Clientset, c.Namespace, "app=rook-ceph-mon,mon_canary=true")
+	if err != nil {
+		logger.Warningf("failed to get the list of monitor canary deployments. %v", err)
+		return
+	}
+
+	for _, canary := range canaryDeployments.Items {
+		logger.Infof("cleaning up canary monitor deployment %q and canary pvc %q.", canary.Name, canary.Labels["pvc_name"])
+		if err := k8sutil.DeleteDeployment(c.context.Clientset, c.Namespace, canary.Name); err != nil {
+			logger.Warningf("failed to delete canary monitor deployment %q. %v", canary.Name, err)
+		}
+
+		if canary.Labels["pvc_name"] != "" {
+			var gracePeriod int64 // delete immediately
+			propagation := metav1.DeletePropagationForeground
+			options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
+			err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.Namespace).Delete(canary.Labels["pvc_name"], options)
+			if err != nil {
+				logger.Warningf("failed to delete canary monitor %q pvc %q. %v", canary.Name, canary.Labels["pvc_name"], err)
 			}
 		}
-	}()
+	}
+}
+
+func (c *Cluster) assignMons(mons []*monConfig) error {
+	// when monitors are scheduling below by invoking scheduleMonitor() a canary
+	// deployment and optional canary PVC are created. In order for the
+	// anti-affinity rules to be effective, we leave the canary pods in place
+	// until all of the canaries have been scheduled. Only after the
+	// monitor/node assignment process is complete are the canary deployments
+	// and pvcs removed here.
+	defer c.removeCanaryDeployments()
 
 	// ensure that all monitors have either (1) a node assignment that will be
 	// enforced using a node selector, or (2) configuration permits k8s to handle
@@ -600,9 +608,6 @@ func (c *Cluster) assignMons(mons []*monConfig) error {
 		// non-optimal, but it is convenient to catch some failures early,
 		// before a decision is stored in the node mapping.
 		result, err := scheduleMonitor(c, mon)
-
-		// even if an error occurs cleanup may be necessary
-		canaryCleanup = append(canaryCleanup, result)
 
 		if err != nil {
 			return errors.Wrapf(err, "assignmon: error scheduling monitor")
@@ -851,7 +856,8 @@ func (c *Cluster) startMon(m *monConfig, node *NodeInfo) error {
 	// exist, also determine if it using pvc storage.
 	pvcExists := false
 	deploymentExists := false
-	d := c.makeDeployment(m)
+
+	d := c.makeDeployment(m, false)
 
 	// Set the deployment hash as an annotation
 	err := patch.DefaultAnnotator.SetLastAppliedAnnotation(d)
@@ -904,7 +910,7 @@ func (c *Cluster) startMon(m *monConfig, node *NodeInfo) error {
 	}
 
 	if c.spec.Mon.VolumeClaimTemplate != nil {
-		pvc, err := c.makeDeploymentPVC(m)
+		pvc, err := c.makeDeploymentPVC(m, false)
 		if err != nil {
 			return errors.Wrapf(err, "failed to make mon %s pvc", d.Name)
 		}

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -166,7 +166,7 @@ func TestHostNetwork(t *testing.T) {
 	c.Network.HostNetwork = true
 
 	monConfig := testGenMonConfig("c")
-	pod := c.makeMonPod(monConfig)
+	pod := c.makeMonPod(monConfig, false, "")
 	assert.NotNil(t, pod)
 	assert.Equal(t, true, pod.Spec.HostNetwork)
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, pod.Spec.DNSPolicy)
@@ -177,7 +177,7 @@ func TestHostNetwork(t *testing.T) {
 	assert.Equal(t, "arg not found: --public-bind-addr", message)
 
 	monConfig.Port = 6790
-	pod = c.makeMonPod(monConfig)
+	pod = c.makeMonPod(monConfig, false, "")
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3:6790", val, message)
 	assert.NotNil(t, pod)

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (c *Cluster) createService(mon *monConfig) (string, error) {
-	labels := c.getLabels(mon.DaemonName)
+	labels := c.getLabels(mon.DaemonName, false, "")
 	svcDef := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   mon.ResourceName,

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -44,21 +44,28 @@ const (
 	monmapFile = "monmap"
 )
 
-func (c *Cluster) getLabels(daemonName string) map[string]string {
+func (c *Cluster) getLabels(daemonName string, canary bool, pvcName string) map[string]string {
 	// Mons have a service for each mon, so the additional pod data is relevant for its services
 	// Use pod labels to keep "mon: id" for legacy
 	labels := opspec.PodLabels(AppName, c.Namespace, "mon", daemonName)
 	// Add "mon_cluster: <namespace>" for legacy
 	labels[monClusterAttr] = c.Namespace
+	if canary {
+		labels["mon_canary"] = "true"
+	}
+	if pvcName != "" {
+		labels["pvc_name"] = pvcName
+	}
+
 	return labels
 }
 
-func (c *Cluster) makeDeployment(monConfig *monConfig) *apps.Deployment {
+func (c *Cluster) makeDeployment(monConfig *monConfig, canary bool) *apps.Deployment {
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      monConfig.ResourceName,
 			Namespace: c.Namespace,
-			Labels:    c.getLabels(monConfig.DaemonName),
+			Labels:    c.getLabels(monConfig.DaemonName, canary, ""),
 		},
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
@@ -66,11 +73,11 @@ func (c *Cluster) makeDeployment(monConfig *monConfig) *apps.Deployment {
 	opspec.AddCephVersionLabelToDeployment(c.ClusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 
-	pod := c.makeMonPod(monConfig)
+	pod := c.makeMonPod(monConfig, canary, "")
 	replicaCount := int32(1)
 	d.Spec = apps.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: c.getLabels(monConfig.DaemonName),
+			MatchLabels: c.getLabels(monConfig.DaemonName, canary, ""),
 		},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: pod.ObjectMeta,
@@ -85,14 +92,14 @@ func (c *Cluster) makeDeployment(monConfig *monConfig) *apps.Deployment {
 	return d
 }
 
-func (c *Cluster) makeDeploymentPVC(m *monConfig) (*v1.PersistentVolumeClaim, error) {
+func (c *Cluster) makeDeploymentPVC(m *monConfig, canary bool) (*v1.PersistentVolumeClaim, error) {
 	template := c.spec.Mon.VolumeClaimTemplate
 	volumeMode := v1.PersistentVolumeFilesystem
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.ResourceName,
 			Namespace: c.Namespace,
-			Labels:    c.getLabels(m.DaemonName),
+			Labels:    c.getLabels(m.DaemonName, canary, m.ResourceName),
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -131,7 +138,7 @@ func (c *Cluster) makeDeploymentPVC(m *monConfig) (*v1.PersistentVolumeClaim, er
 	return pvc, nil
 }
 
-func (c *Cluster) makeMonPod(monConfig *monConfig) *v1.Pod {
+func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool, PVCName string) *v1.Pod {
 	logger.Debugf("monConfig: %+v", monConfig)
 	podSpec := v1.PodSpec{
 		InitContainers: []v1.Container{
@@ -160,7 +167,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      monConfig.ResourceName,
 			Namespace: c.Namespace,
-			Labels:    c.getLabels(monConfig.DaemonName),
+			Labels:    c.getLabels(monConfig.DaemonName, canary, PVCName),
 		},
 		Spec: podSpec,
 	}

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -68,7 +68,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 	}
 	monConfig := testGenMonConfig(monID)
 
-	d := c.makeDeployment(monConfig)
+	d := c.makeDeployment(monConfig, false)
 	assert.NotNil(t, d)
 
 	if pvc {
@@ -116,7 +116,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 
 	// configured with default storage request
 	c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{}
-	pvc, err := c.makeDeploymentPVC(monConfig)
+	pvc, err := c.makeDeploymentPVC(monConfig, false)
 	assert.NoError(t, err)
 	defaultReq, err := resource.ParseQuantity(cephMonDefaultStorageRequest)
 	assert.NoError(t, err)
@@ -132,7 +132,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 			},
 		},
 	}
-	pvc, err = c.makeDeploymentPVC(monConfig)
+	pvc, err = c.makeDeploymentPVC(monConfig, false)
 	assert.NoError(t, err)
 	assert.Equal(t, pvc.Spec.Resources.Limits[v1.ResourceStorage], req)
 
@@ -146,7 +146,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 			},
 		},
 	}
-	pvc, err = c.makeDeploymentPVC(monConfig)
+	pvc, err = c.makeDeploymentPVC(monConfig, false)
 	assert.NoError(t, err)
 	assert.Equal(t, pvc.Spec.Resources.Requests[v1.ResourceStorage], req)
 }


### PR DESCRIPTION
**Description of your changes:**
~With this modification the mon failover process is not executed if there is
no available nodes where to schedule the mon pod.
This avoid to have mon canary pods in Pending state because no nodes
available.~

If for any cause the operator processing a mon failover is restarted, the
mon canary pods created in order to get the right placement for this
kind of pods can remain in <pending> state forever.

The following labels have been added to the mon canary deployments:
"mon_type" = "canary"
"canary_pvc_name" = <PVC name used for the canary pod>

A separate <removeCanaryDeployments> has been implemented for
removing the dependence of the variable <canaryCleanup>.
This function uses the <canary> labels to obtain the <real>
and <existing> list of mon canary deployments in any moment.

This change, by itself, will avoid most of the problems with
pending canary pods, but as second safe guard measure a call to this
function has been added in the health check, to <force> a canary pod
deletion if the cluster of monitors is healthy and complete (this implies
that no canary pods should be present)

Resolves #3764

[test ceph]

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

Resolves #3764
 
**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


**Details about manual testing of this fix:**
Lab used: (4 vms centos 7)

```
# kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:18:23Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.0", GitCommit:"70132b0f130acc0bed193d9ba59dd186f0e634cf", GitTreeState:"clean", BuildDate:"2019-12-07T21:12:17Z", GoVersion:"go1.13.4", Compiler:"gc", Platform:"linux/amd64"}

[root@rook-ceph-operator-77b4b868d8-7jgx6 /]# rook version
rook: v1.1.0-beta.0.661.gdca96729-dirty
go: go1.12.7
```

In first place check wher the operator is running:

```
# kubectl -n rook-ceph describe pod rook-ceph-operator-844c546bb5-rdwps  | grep Node:
Node:         ku-worker-00.karmalabs.com/192.168.122.132
```

Take a look to the vm list:

```
# kcli list vms
Using local libvirt as no client was specified...
+--------------+--------+-----------------+------------------------------------+-----------------+---------+--------+
|     Name     | Status |       Ips       |               Source               |       Plan      | Profile | Report |
+--------------+--------+-----------------+------------------------------------+-----------------+---------+--------+
| ku-master-00 |   up   |  192.168.122.40 | CentOS-7-x86_64-GenericCloud.qcow2 | agitated_muster |  kvirt  |        |
| ku-worker-00 |   up   | 192.168.122.132 | CentOS-7-x86_64-GenericCloud.qcow2 | agitated_muster |  kvirt  |        |
| ku-worker-01 |   up   |  192.168.122.67 | CentOS-7-x86_64-GenericCloud.qcow2 | agitated_muster |  kvirt  |        |
| ku-worker-02 |   up   | 192.168.122.131 | CentOS-7-x86_64-GenericCloud.qcow2 | agitated_muster |  kvirt  |        |
+--------------+--------+-----------------+------------------------------------+-----------------+---------+--------+

```

Stopping a node different from the one where operator is running:

```
# date && kcli stop vm ku-worker-02
jue dic 19 09:41:03 CET 2019
Using local libvirt as no client was specified...
Stopping vm ku-worker-02 in local...
ku-worker-02 stopped
```

In the Operator logs we can see:

```
2019-12-19 09:41:21.676813 W | op-mon: mon c not found in quorum, waiting for timeout before failover
2019-12-19 09:41:52.164022 W | op-mon: mon c not found in quorum, waiting for timeout before failover
2019-12-19 09:42:22.644601 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
```

Once the timeout for the mon is expired, the failover is tried, but is not possible because we do not have enough Nodes "ready"

```
2019-12-19 09:42:22.647447 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 09:42:53.113920 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 09:42:53.117656 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 09:43:23.572786 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 09:43:23.575372 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 09:43:54.045977 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 09:43:54.048877 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 09:44:24.572873 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 09:44:24.575831 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 09:44:55.045390 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
....
```

This will continue while the "lost node" situation persist. If we check the pod status we will see several pods in "Terminating" state, these pods belongs to the stopped node.
Besides that we have a mon "pending" pod. This pending pods has been created by k8s (trying to satisfy the mon deployment and it is scheduled in the stopped node).

```
# kubectl -n rook-ceph get pods
NAME                                                              READY   STATUS        RESTARTS   AGE
csi-cephfsplugin-6cdrp                                            3/3     Running       3          72m
...
csi-cephfsplugin-provisioner-56c8b7ddf4-bj8f8                     4/4     Terminating   0          72m
...
rook-ceph-crashcollector-ku-master-00.karmalabs.com-f4b4d6zlskh   1/1     Running       0          24h
...
rook-ceph-crashcollector-ku-worker-02.karmalabs.com-5895bdkgrsj   1/1     Terminating   0          24h
rook-ceph-crashcollector-ku-worker-02.karmalabs.com-5895bdws8sq   0/1     Pending       0          94s
rook-ceph-mgr-a-57996b5dcc-kstkn                                  1/1     Running       0          24m
rook-ceph-mon-a-5db6888d7b-nvxhv                                  1/1     Running       0          44m
rook-ceph-mon-b-5b84574448-njdg4                                  1/1     Running       0          19m
rook-ceph-mon-c-7d99bcbf5-bf9dz                                   1/1     Terminating   0          24h
rook-ceph-mon-c-7d99bcbf5-w9gp2                                   0/1     Pending       0          94s
rook-ceph-mon-d-8467ff498d-sfxqq                                  1/1     Running       0          24h
rook-ceph-operator-844c546bb5-rdwps                               1/1     Running       0          10m
rook-ceph-osd-0-547ff9fd4d-4dlfl                                  1/1     Running       0          19m
rook-ceph-osd-1-fd4dbcbcf-6jnzt                                   1/1     Running       3          24h
rook-ceph-osd-2-57b95ff546-5v22c                                  1/1     Terminating   1          24h
rook-ceph-osd-2-57b95ff546-ntrss                                  0/1     Pending       0          94s
rook-ceph-osd-3-749ccd686f-ngn9k                                  1/1     Running       0          44m
...

```

The "canary" mon pod is not scheduled/launched because we do not have enough Nodes.

If we start again the stopped k8s node:

```
# date && kcli start vm ku-worker-02
jue dic 19 09:52:08 CET 2019
Using local libvirt as no client was specified...
Starting vm ku-worker-02...
ku-worker-02 started
```

in the operator logs we can see:

```
2019-12-19 09:53:04.111704 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 09:53:04.116220 I | op-mon: Failing over monitor "c"
2019-12-19 09:53:04.116271 I | op-mon: starting new mon: &{ResourceName:rook-ceph-mon-e DaemonName:e PublicIP: Port:6789 DataPathMap:0xc000a034a0}
2019-12-19 09:53:04.122530 I | op-mon: sched-mon: created canary deployment rook-ceph-mon-e-canary
2019-12-19 09:53:04.127777 I | op-mon: sched-mon: waiting for canary pod creation rook-ceph-mon-e-canary
```

Here we can see two different scenarios:

1. If the node stopped never returns to live: it will be needed to add a new k8s Node. The normal operator mon failover procedure will be executed and the "lost" monitor will be scheduled in the completely new node.

2. If the node stopped returns to live:
Kubernetes will restart by itself the "lost" monitor in the "restarted" node. In fact, this mon pod was scheduled (due the mon deployment) in the moment that the node was stopped and remains in "Pending" state during the time the node is stopped. What we can see in the pods state is something like:

```
# kubectl -n rook-ceph get pods
...
rook-ceph-mon-b-78d8b7cff8-jlp8w                                  1/1     Terminating   0          144m
rook-ceph-mon-b-78d8b7cff8-qn5hk                                  0/1     Pending       0          37s
...

```
And the "Pending" mon pod is in this state because the deployment of this pod requires the node that is stopped:

```
# kubectl -n rook-ceph describe pod rook-ceph-mon-b-78d8b7cff8-qn5hk

Events:
  Type     Reason            Age        From               Message
  ----     ------            ----       ----               -------
  Warning  FailedScheduling  <unknown>  default-scheduler  0/4 nodes are available: 1 node(s) had taints that the pod didn't tolerate, 3 node(s) didn't match node selector.
  Warning  FailedScheduling  <unknown>  default-scheduler  0/4 nodes are available: 1 node(s) had taints that the pod didn't tolerate, 3 node(s) didn't match node selector.

```

Once the node is recovered k8s take two actions, 1 delete the old mon pod in "Terminating" state and the other one is to continue with the start of the mon pod in "Pending" state. This allows to recover the mon without the intervention of the operator(mon health check). In this case what we can see in the operator log is:

```
2019-12-19 13:56:15.896037 W | op-mon: mon c NOT found in quorum and timeout exceeded, mon will be failed over
2019-12-19 13:56:15.898963 E | op-mon: Not enough <Ready> nodes(only 3) to schedule the mon "c". It is needed at least 4 nodes. Canceling failover
2019-12-19 13:57:01.354828 I | op-mon: mon c is back in quorum, removed from mon out timeout list
```

[test ceph]

