### PR TITLE
Implemented update for ClusterRole rook-ceph-system in case of update from 1.0.6 to 1.1.0

### DIFF
--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.0-apply.yaml
@@ -135,3 +135,51 @@ rules:
       - create
       - update
       - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: rook-ceph-system
+  labels:
+    operator: rook
+    storage-backend: ceph
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - statefulsets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+


### PR DESCRIPTION
According to upgrade manual https://rook.io/docs/rook/v1.1/ceph-upgrade.html, you need to update RBAC thins for rook, but there are missed update for ClusterRole `rook-ceph-system`, because of  you'll can get such messages in rook-ceph-operator:

```
E1219 15:07:01.720941       7 reflector.go:126] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1beta1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:rook-ceph-system:rook-ceph-system" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope
E1219 15:07:01.720946       7 reflector.go:126] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:rook-ceph-system:rook-ceph-system" cannot list resource "deployments" in API group "apps" at the cluster scope
```

All this true when you made update from 0.9.3 to 1.0.6, and then update from 1.0.6 to 1.1.0