### PR TITLE
ceph: Remove ineffectual assignments

### DIFF
--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -199,9 +199,7 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 					logger.Infof("orchestration status config map result channel closed, will restart watch.")
 					w.Stop()
 					<-time.After(5 * time.Second)
-					leftNodes := 0
-					leftRemainingNodes := util.NewSet()
-					leftNodes, leftRemainingNodes, completed, statuses, err = c.checkNodesCompleted(selector, config, configOSDs)
+					leftNodes, leftRemainingNodes, completed, _, err := c.checkNodesCompleted(selector, config, configOSDs)
 					if err == nil {
 						if completed {
 							logger.Infof("additional %d/%d node(s) completed osd provisioning", leftNodes, originalNodes)


### PR DESCRIPTION
**Description of your changes:**
Fix security issues identified by TrailOfBits

**Modifications in `osd/status.go:`**
I opted by remove the offending variables because "c.checkNodesCompleted" provides this variables always, so no need to initialize them.
<statuses> var was not used, so i have replaced it by the blank identifier.

**Modifications in `machinelabel/add.go:`**
I have followed the same criteria used in other disruption packages, and return the error if it is produced when we try to "_watch_" machines.

**Which issue is resolved by this Pull Request:**
Resolves #4565 

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]