### PR TITLE
ceph: Do not log sensitive information in debug mode

### DIFF
--- a/pkg/util/sys/parse.go
+++ b/pkg/util/sys/parse.go
@@ -22,13 +22,11 @@ import (
 
 // grep finds the *first* line that matches, rather than multiple lines
 func Grep(input, searchFor string) string {
-	logger.Debugf("grep. search=%s, input=%s", searchFor, input)
 	if input == "" || searchFor == "" {
 		return ""
 	}
 	for _, line := range strings.Split(input, "\n") {
 		if matched, _ := regexp.MatchString(searchFor, line); matched {
-			logger.Debugf("grep found line: %s", line)
 			return line
 		}
 	}


### PR DESCRIPTION
**Description of your changes:**

Fix security issues identified by TrailOfBits:
Logging of sensitive information in debug mode

In this case, instead of removing the log lines I have preferred to leave them
but without printing sensitive information.
I think it could be useful when debug to know if the function has been called
and if it has found any matching line.

**Which issue is resolved by this Pull Request:**
Resolves #4568 

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
