### PR TITLE
ceph: osd add missing ROOK_CEPH_MON_HOST env

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -395,3 +395,17 @@ func TestCephVolumeEnvVar(t *testing.T) {
 	assert.Equal(t, "DM_DISABLE_UDEV", cvEnv[2].Name)
 	assert.Equal(t, "1", cvEnv[1].Value)
 }
+
+func TestOsdActivateEnvVar(t *testing.T) {
+	osdActivateEnv := osdActivateEnvVar()
+	assert.Equal(t, 5, len(osdActivateEnv))
+	assert.Equal(t, "CEPH_VOLUME_DEBUG", osdActivateEnv[0].Name)
+	assert.Equal(t, "1", osdActivateEnv[0].Value)
+	assert.Equal(t, "CEPH_VOLUME_SKIP_RESTORECON", osdActivateEnv[1].Name)
+	assert.Equal(t, "1", osdActivateEnv[1].Value)
+	assert.Equal(t, "DM_DISABLE_UDEV", osdActivateEnv[2].Name)
+	assert.Equal(t, "1", osdActivateEnv[1].Value)
+	assert.Equal(t, "ROOK_CEPH_MON_HOST", osdActivateEnv[3].Name)
+	assert.Equal(t, "CEPH_ARGS", osdActivateEnv[4].Name)
+	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST)", osdActivateEnv[4].Value)
+}


### PR DESCRIPTION
**Description of your changes:**

The ROOK_CEPH_MON_HOST env var was missing from the pod env so the
CEPH_ARGS won't be populated correctly.

Closes: https://github.com/rook/rook/issues/4558
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4558

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]