### PR TITLE
ceph: Add range validation to port in CRDs 

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -316,7 +316,13 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                securePort: {}
+                  minimum: 1
+                  maximum: 65535
+                securePort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  nullable: true
                 instances:
                   type: integer
                 annotations: {}

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -370,7 +370,13 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                securePort: {}
+                  minimum: 1
+                  maximum: 65535
+                securePort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  nullable: true
                 instances:
                   type: integer
                 annotations: {}

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.1-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.1-crds.yaml
@@ -288,7 +288,13 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                securePort: {}
+                  minimum: 1
+                  maximum: 65535
+                securePort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  nullable: true
                 instances:
                   type: integer
                 annotations: {}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -389,7 +389,13 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                securePort: {}
+                  minimum: 1
+                  maximum: 65535
+                securePort:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  nullable: true
                 instances:
                   type: integer
                 annotations: {}


### PR DESCRIPTION
Kubernetes Service fail to be created when specified rgw ports are invalid.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Add range validation to port in following CRD fields
* `CephObjectStore.Gateway.Port` / `CephObjectStore.Gateway.SecurePort` 1~65535
* `CephCluster.Spec.Dashboard.Port` 0~65535 when `CephCluster.Spec.Dashboard.Enabled`

**Which issue is resolved by this Pull Request:**
Resolves #4574

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]