### PR TITLE
Updated ceph-monitoring.md to K8s 1.16+

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -23,6 +23,8 @@ A full explanation can be found in the [Prometheus operator repository on GitHub
 ```console
 kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml
 ```
+> **NOTE**: If your rook-ceph cluster is deployed on Kubernetes 1.16+ then `v0.26.0/bundle.yaml` of prometheus-operator
+> will not work. Use [v0.34.0/bundle.yaml](https://raw.githubusercontent.com/coreos/prometheus-operator/v0.34.0/bundle.yaml) which supports Kubernetes 1.16+.
 
 This will start the Prometheus operator, but before moving on, wait until the operator is in the `Running` state:
 


### PR DESCRIPTION
Updated references to coreos/prometheus-operator bundle.yaml following the discussion [here](https://github.com/coreos/prometheus-operator/issues/2592)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]