### PR TITLE
ceph: create a generic setPodPlacement used by mon and gateways

### DIFF
--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -18,7 +18,6 @@ package object
 
 import (
 	"fmt"
-	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -163,54 +162,4 @@ func TestValidateSpec(t *testing.T) {
 	s.Spec.MetadataPool.Replicated.Size = 1
 	err = validateStore(context, s)
 	assert.Nil(t, err)
-}
-
-func testPodSpecPlacement(t *testing.T, hostNet bool, req int, placement *rook.Placement) {
-	c := newConfig()
-	c.clusterSpec = &cephv1.ClusterSpec{
-		Network: cephv1.NetworkSpec{HostNetwork: hostNet},
-	}
-
-	d := v1.PodSpec{
-		InitContainers:    []v1.Container{},
-		Containers:        []v1.Container{},
-		RestartPolicy:     v1.RestartPolicyAlways,
-		HostNetwork:       hostNet,
-		PriorityClassName: c.store.Spec.Gateway.PriorityClassName,
-	}
-
-	if placement != nil {
-		c.store.Spec.Gateway.Placement = *placement
-	}
-
-	c.setPodPlacement(&d, c.store.Spec.Gateway.Placement)
-
-	// should have a required anti-affnity
-	assert.Equal(t,
-		req,
-		len(d.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
-}
-
-func makePlacement() rook.Placement {
-	return rook.Placement{
-		PodAntiAffinity: &v1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
-				{
-					TopologyKey: v1.LabelZoneFailureDomain,
-				},
-			},
-		},
-	}
-}
-
-func TestPodSpecPlacement(t *testing.T) {
-	// no placement settings in the crd
-	testPodSpecPlacement(t, true, 1, nil)
-	testPodSpecPlacement(t, false, 0, nil)
-
-	// crd has other preferred and required anti-affinity setting
-	p := makePlacement()
-	testPodSpecPlacement(t, true, 2, &p)
-	p = makePlacement()
-	testPodSpecPlacement(t, false, 1, &p)
 }

--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -19,7 +19,6 @@ package spec
 
 import (
 	"fmt"
-
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package k8sutil
 
 import (
+	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"os"
 	"testing"
 
@@ -173,4 +174,60 @@ func TestAddUnreachableNodeToleration(t *testing.T) {
 	assert.Equal(t, 1, len(podSpec.Tolerations))
 	assert.Equal(t, expectedURToleration, podSpec.Tolerations[0])
 
+}
+
+func testPodSpecPlacement(t *testing.T, requiredDuringScheduling, preferredDuringScheduling bool, req, pref int, placement *rook.Placement) {
+	spec := v1.PodSpec{
+		InitContainers: []v1.Container{},
+		Containers:     []v1.Container{},
+		RestartPolicy:  v1.RestartPolicyAlways,
+	}
+
+	SetNodeAntiAffinityForPod(&spec, *placement, requiredDuringScheduling, preferredDuringScheduling, map[string]string{"app": "mon"}, nil)
+
+	// should have a required anti-affinity and no preferred anti-affinity
+	assert.Equal(t,
+		req,
+		len(spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	assert.Equal(t,
+		pref,
+		len(spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
+}
+
+func makePlacement() rook.Placement {
+	return rook.Placement{
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					TopologyKey: v1.LabelZoneFailureDomain,
+				},
+			},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
+				{
+					PodAffinityTerm: v1.PodAffinityTerm{
+						TopologyKey: v1.LabelZoneFailureDomain,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPodSpecPlacement(t *testing.T) {
+	// no placement settings in the crd
+	p := rook.Placement{}
+	testPodSpecPlacement(t, true, true, 1, 0, &p)
+	testPodSpecPlacement(t, true, false, 1, 0, &p)
+	testPodSpecPlacement(t, false, true, 0, 1, &p)
+	testPodSpecPlacement(t, false, false, 0, 0, &p)
+
+	// crd has other preferred and required anti-affinity setting
+	p = makePlacement()
+	testPodSpecPlacement(t, true, true, 2, 1, &p)
+	p = makePlacement()
+	testPodSpecPlacement(t, true, false, 2, 1, &p)
+	p = makePlacement()
+	testPodSpecPlacement(t, false, true, 1, 2, &p)
+	p = makePlacement()
+	testPodSpecPlacement(t, false, false, 1, 1, &p)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Refacto setPodPlacement for ceph mon and gateways to use a common one

**Which issue is resolved by this Pull Request:**
Resolves #4473

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
