### PR TITLE
ceph: Generating a strong ceph dashboard password

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -33,14 +33,17 @@ import (
 )
 
 func TestGeneratePassword(t *testing.T) {
-	password := generatePassword(0)
+	password, err := generatePassword(0)
+	require.Nil(t, err)
 	assert.Equal(t, "", password)
 
-	password = generatePassword(1)
+	password, err = generatePassword(1)
+	require.Nil(t, err)
 	assert.Equal(t, 1, len(password))
 	logger.Infof("password: %s", password)
 
-	password = generatePassword(10)
+	password, err = generatePassword(10)
+	require.Nil(t, err)
 	assert.Equal(t, 10, len(password))
 	logger.Infof("password: %s", password)
 }


### PR DESCRIPTION
Replaced `math/rand` with more secure `crypto/rand` which will generate CSPRNG.
Changed the length of dashboard password from 10 to 20 and included more special characters that can strengthen password.

Passwords before this change: QoMmqLkaOf
Passwords after this change: L{QZ@_c'Rl7$uvW:UHU1

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #4571 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
