### PR TITLE
Remove operator kit dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -565,14 +565,6 @@
   revision = "bf6a532e95b1f7a62adf0ab5050a5bb2237ad2f4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1ae8472d770851e687463105821ccddad62766c66202f95693dc6970cd1269ab"
-  name = "github.com/rook/operator-kit"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "5ae9623aed20e249092e0ba99e0dd126c3173a29"
-
-[[projects]]
   digest = "1:d707dbc1330c0ed177d4642d6ae102d5e2c847ebd0eb84562d0dc4f024531cfc"
   name = "github.com/spf13/afero"
   packages = [
@@ -1511,7 +1503,6 @@
     "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1",
     "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1",
     "github.com/pkg/errors",
-    "github.com/rook/operator-kit",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
@@ -1524,7 +1515,6 @@
     "k8s.io/api/policy/v1beta1",
     "k8s.io/api/storage/v1",
     "k8s.io/api/storage/v1beta1",
-    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/pkg/daemon/ceph/agent/cluster/controller.go
+++ b/pkg/daemon/ceph/agent/cluster/controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
@@ -68,8 +67,7 @@ func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) e
 	}
 
 	logger.Infof("start watching cluster resources")
-	watcher := opkit.NewWatcher(opcluster.ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephCluster{}, stopCh)
+	go k8sutil.WatchCR(opcluster.ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephCluster{}, stopCh)
 	return nil
 }
 

--- a/pkg/daemon/ceph/agent/flexvolume/attachment/resource.go
+++ b/pkg/daemon/ceph/agent/flexvolume/attachment/resource.go
@@ -20,9 +20,8 @@ package attachment
 import (
 	"reflect"
 
-	opkit "github.com/rook/operator-kit"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
 const (
@@ -31,11 +30,10 @@ const (
 )
 
 // VolumeResource represents the Volume custom resource object
-var VolumeResource = opkit.CustomResource{
+var VolumeResource = k8sutil.CustomResource{
 	Name:    CustomResourceName,
 	Plural:  CustomResourceNamePlural,
 	Group:   rookalpha.CustomResourceGroup,
 	Version: rookalpha.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(rookalpha.Volume{}).Name(),
 }

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -25,14 +25,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	ceph "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -43,12 +41,11 @@ const ClientSecretName = "-client-key"
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-client")
 
 // ClientResource represents the Client custom resource object
-var ClientResource = opkit.CustomResource{
+var ClientResource = k8sutil.CustomResource{
 	Name:    "cephclient",
 	Plural:  "cephclients",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephClient{}).Name(),
 }
 
@@ -76,8 +73,7 @@ func (c *ClientController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching client resources in namespace %q", c.namespace)
-	watcher := opkit.NewWatcher(ClientResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephClient{}, stopCh)
+	go k8sutil.WatchCR(ClientResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephClient{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -28,7 +28,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
@@ -50,7 +49,6 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -89,12 +87,11 @@ var (
 )
 
 // ClusterResource operator-kit Custom Resource Definition
-var ClusterResource = opkit.CustomResource{
+var ClusterResource = k8sutil.CustomResource{
 	Name:    "cephcluster",
 	Plural:  "cephclusters",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephCluster{}).Name(),
 }
 
@@ -138,8 +135,7 @@ func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) e
 	} else {
 		logger.Infof("start watching clusters in namespace: %v", namespace)
 	}
-	watcher := opkit.NewWatcher(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephCluster{}, stopCh)
+	go k8sutil.WatchCR(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephCluster{}, stopCh)
 
 	// Watch for events on new/updated K8s Nodes objects
 

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -23,25 +23,19 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/ceph/version"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -50,10 +44,9 @@ const (
 )
 
 // ClusterResource operator-kit Custom Resource Definition
-var clusterResource = opkit.CustomResource{
+var clusterResource = k8sutil.CustomResource{
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephCluster{}).Name(),
 }
 

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -24,13 +24,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -38,12 +36,11 @@ import (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-file")
 
 // FilesystemResource represents the filesystem custom resource
-var FilesystemResource = opkit.CustomResource{
+var FilesystemResource = k8sutil.CustomResource{
 	Name:    "cephfilesystem",
 	Plural:  "cephfilesystems",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephFilesystem{}).Name(),
 }
 
@@ -93,8 +90,7 @@ func (c *FilesystemController) StartWatch(namespace string, stopCh chan struct{}
 	}
 
 	logger.Infof("start watching filesystem resource in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(FilesystemResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephFilesystem{}, stopCh)
+	go k8sutil.WatchCR(FilesystemResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephFilesystem{}, stopCh)
 	return nil
 }
 

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -22,12 +22,10 @@ import (
 	"sync"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -35,12 +33,11 @@ import (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-nfs")
 
 // CephNFSResource represents the file system custom resource
-var CephNFSResource = opkit.CustomResource{
+var CephNFSResource = k8sutil.CustomResource{
 	Name:    "cephnfs",
 	Plural:  "cephnfses",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephNFS{}).Name(),
 }
 
@@ -78,8 +75,7 @@ func (c *CephNFSController) StartWatch(namespace string, stopCh chan struct{}) e
 	}
 
 	logger.Infof("start watching ceph nfs resource in namespace %s", namespace)
-	watcher := opkit.NewWatcher(CephNFSResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephNFS{}, stopCh)
+	go k8sutil.WatchCR(CephNFSResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephNFS{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -23,14 +23,12 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	daemonconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -38,12 +36,11 @@ import (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-object")
 
 // ObjectStoreResource represents the object store custom resource
-var ObjectStoreResource = opkit.CustomResource{
+var ObjectStoreResource = k8sutil.CustomResource{
 	Name:    "cephobjectstore",
 	Plural:  "cephobjectstores",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephObjectStore{}).Name(),
 }
 
@@ -92,8 +89,7 @@ func (c *ObjectStoreController) StartWatch(namespace string, stopCh chan struct{
 	}
 
 	logger.Infof("start watching object store resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(ObjectStoreResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephObjectStore{}, stopCh)
+	go k8sutil.WatchCR(ObjectStoreResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephObjectStore{}, stopCh)
 	return nil
 }
 

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -26,14 +26,12 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -46,12 +44,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-object")
 
 // ObjectStoreUserResource represents the object store user custom resource
-var ObjectStoreUserResource = opkit.CustomResource{
+var ObjectStoreUserResource = k8sutil.CustomResource{
 	Name:    "cephobjectstoreuser",
 	Plural:  "cephobjectstoreusers",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephObjectStoreUser{}).Name(),
 }
 
@@ -83,8 +80,7 @@ func (c *ObjectStoreUserController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching object store user resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(ObjectStoreUserResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephObjectStoreUser{}, stopCh)
+	go k8sutil.WatchCR(ObjectStoreUserResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephObjectStoreUser{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
@@ -67,7 +66,7 @@ var (
 // Operator type for managing storage
 type Operator struct {
 	context           *clusterd.Context
-	resources         []opkit.CustomResource
+	resources         []k8sutil.CustomResource
 	operatorNamespace string
 	rookImage         string
 	securityAccount   string
@@ -79,7 +78,7 @@ type Operator struct {
 
 // New creates an operator instance
 func New(context *clusterd.Context, volumeAttachmentWrapper attachment.Attachment, rookImage, securityAccount string) *Operator {
-	schemes := []opkit.CustomResource{cluster.ClusterResource, pool.PoolResource, object.ObjectStoreResource, objectuser.ObjectStoreUserResource,
+	schemes := []k8sutil.CustomResource{cluster.ClusterResource, pool.PoolResource, object.ObjectStoreResource, objectuser.ObjectStoreUserResource,
 		file.FilesystemResource, attachment.VolumeResource}
 
 	operatorNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -22,14 +22,12 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
-	opkit "github.com/rook/operator-kit"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	ceph "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/daemon/ceph/model"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -43,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-pool")
 
 // PoolResource represents the Pool custom resource object
-var PoolResource = opkit.CustomResource{
+var PoolResource = k8sutil.CustomResource{
 	Name:    "cephblockpool",
 	Plural:  "cephblockpools",
 	Group:   cephv1.CustomResourceGroup,
 	Version: cephv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cephv1.CephBlockPool{}).Name(),
 }
 
@@ -76,8 +73,7 @@ func (c *PoolController) StartWatch(namespace string, stopCh chan struct{}) erro
 	}
 
 	logger.Infof("start watching pools in namespace %q", namespace)
-	watcher := opkit.NewWatcher(PoolResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient())
-	go watcher.Watch(&cephv1.CephBlockPool{}, stopCh)
+	go k8sutil.WatchCR(PoolResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephBlockPool{}, stopCh)
 	return nil
 }
 

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	opkit "github.com/rook/operator-kit"
 	cockroachdbv1alpha1 "github.com/rook/rook/pkg/apis/cockroachdb.rook.io/v1alpha1"
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
@@ -34,7 +33,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,12 +59,11 @@ const (
 	envVarValChannelInsecure       = "kubernetes-insecure"
 )
 
-var ClusterResource = opkit.CustomResource{
+var ClusterResource = k8sutil.CustomResource{
 	Name:    CustomResourceName,
 	Plural:  CustomResourceNamePlural,
 	Group:   cockroachdbv1alpha1.CustomResourceGroup,
 	Version: cockroachdbv1alpha1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(cockroachdbv1alpha1.Cluster{}).Name(),
 }
 
@@ -121,8 +118,7 @@ func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) e
 	}
 
 	logger.Infof("start watching cockroachdb clusters in all namespaces")
-	watcher := opkit.NewWatcher(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CockroachdbV1alpha1().RESTClient())
-	go watcher.Watch(&cockroachdbv1alpha1.Cluster{}, stopCh)
+	go k8sutil.WatchCR(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CockroachdbV1alpha1().RESTClient(), &cockroachdbv1alpha1.Cluster{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/cockroachdb/operator.go
+++ b/pkg/operator/cockroachdb/operator.go
@@ -23,16 +23,16 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
-	"k8s.io/api/core/v1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	v1 "k8s.io/api/core/v1"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cockroachdb-operator")
 
 type Operator struct {
 	context           *clusterd.Context
-	resources         []opkit.CustomResource
+	resources         []k8sutil.CustomResource
 	rookImage         string
 	clusterController *ClusterController
 }
@@ -41,7 +41,7 @@ type Operator struct {
 func New(context *clusterd.Context, rookImage string) *Operator {
 	clusterController := NewClusterController(context, rookImage)
 
-	schemes := []opkit.CustomResource{ClusterResource}
+	schemes := []k8sutil.CustomResource{ClusterResource}
 	return &Operator{
 		context:           context,
 		clusterController: clusterController,

--- a/pkg/operator/edgefs/cluster/controller.go
+++ b/pkg/operator/edgefs/cluster/controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/edgefs/iscsi"
@@ -34,7 +33,7 @@ import (
 	"github.com/rook/rook/pkg/operator/edgefs/s3"
 	"github.com/rook/rook/pkg/operator/edgefs/s3x"
 	"github.com/rook/rook/pkg/operator/edgefs/swift"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -59,12 +58,11 @@ const (
 	defaultEdgefsImageName     = "edgefs/edgefs:latest"
 )
 
-var ClusterResource = opkit.CustomResource{
+var ClusterResource = k8sutil.CustomResource{
 	Name:    CustomResourceName,
 	Plural:  CustomResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.Cluster{}).Name(),
 }
 
@@ -103,8 +101,7 @@ func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) e
 	}
 
 	logger.Infof("start watching edgefs clusters in all namespaces")
-	watcher := opkit.NewWatcher(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.Cluster{}, stopCh)
+	go k8sutil.WatchCR(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.Cluster{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/iscsi/controller.go
+++ b/pkg/operator/edgefs/iscsi/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-iscsi")
 
 // ISCSIResource represents the iscsi custom resource
-var ISCSIResource = opkit.CustomResource{
+var ISCSIResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.ISCSI{}).Name(),
 }
 
@@ -106,8 +104,7 @@ func (c *ISCSIController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching iscsi resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(ISCSIResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.ISCSI{}, stopCh)
+	go k8sutil.WatchCR(ISCSIResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.ISCSI{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/isgw/controller.go
+++ b/pkg/operator/edgefs/isgw/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-isgw")
 
 // ISGWResource represents the isgw custom resource
-var ISGWResource = opkit.CustomResource{
+var ISGWResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.ISGW{}).Name(),
 }
 
@@ -106,8 +104,7 @@ func (c *ISGWController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching isgw resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(ISGWResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.ISGW{}, stopCh)
+	go k8sutil.WatchCR(ISGWResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.ISGW{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/nfs/controller.go
+++ b/pkg/operator/edgefs/nfs/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-nfs")
 
 // NFSResource represents the nfs custom resource
-var NFSResource = opkit.CustomResource{
+var NFSResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.NFS{}).Name(),
 }
 
@@ -106,8 +104,7 @@ func (c *NFSController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching nfs resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(NFSResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.NFS{}, stopCh)
+	go k8sutil.WatchCR(NFSResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.NFS{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/operator.go
+++ b/pkg/operator/edgefs/operator.go
@@ -24,7 +24,6 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/edgefs/cluster"
@@ -36,7 +35,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-operator"
 
 type Operator struct {
 	context           *clusterd.Context
-	resources         []opkit.CustomResource
+	resources         []k8sutil.CustomResource
 	rookImage         string
 	securityAccount   string
 	clusterController *cluster.ClusterController
@@ -46,7 +45,7 @@ type Operator struct {
 func New(context *clusterd.Context, rookImage string, securityAccount string) *Operator {
 	clusterController := cluster.NewClusterController(context, rookImage)
 
-	schemes := []opkit.CustomResource{cluster.ClusterResource}
+	schemes := []k8sutil.CustomResource{cluster.ClusterResource}
 	return &Operator{
 		context:           context,
 		clusterController: clusterController,

--- a/pkg/operator/edgefs/s3/controller.go
+++ b/pkg/operator/edgefs/s3/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-s3")
 
 // S3Resource represents the s3 custom resource
-var S3Resource = opkit.CustomResource{
+var S3Resource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.S3{}).Name(),
 }
 
@@ -106,8 +104,7 @@ func (c *S3Controller) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching s3 resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(S3Resource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.S3{}, stopCh)
+	go k8sutil.WatchCR(S3Resource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.S3{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/s3x/controller.go
+++ b/pkg/operator/edgefs/s3x/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-s3x")
 
 // S3XResource represents the s3x custom resource
-var S3XResource = opkit.CustomResource{
+var S3XResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.S3X{}).Name(),
 }
 
@@ -106,8 +104,7 @@ func (c *S3XController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching s3x resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(S3XResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.S3X{}, stopCh)
+	go k8sutil.WatchCR(S3XResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.S3X{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/edgefs/swift/controller.go
+++ b/pkg/operator/edgefs/swift/controller.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/google/go-cmp/cmp"
-	opkit "github.com/rook/operator-kit"
 	edgefsv1 "github.com/rook/rook/pkg/apis/edgefs.rook.io/v1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -42,12 +41,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "edgefs-op-swift")
 
 // SWIFTResource represents the swift custom resource
-var SWIFTResource = opkit.CustomResource{
+var SWIFTResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   edgefsv1.CustomResourceGroup,
 	Version: edgefsv1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(edgefsv1.SWIFT{}).Name(),
 }
 
@@ -105,8 +103,7 @@ func (c *SWIFTController) StartWatch(stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching swift resources in namespace %s", c.namespace)
-	watcher := opkit.NewWatcher(SWIFTResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient())
-	go watcher.Watch(&edgefsv1.SWIFT{}, stopCh)
+	go k8sutil.WatchCR(SWIFTResource, c.namespace, resourceHandlerFuncs, c.context.RookClientset.EdgefsV1().RESTClient(), &edgefsv1.SWIFT{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/k8sutil/customresource.go
+++ b/pkg/operator/k8sutil/customresource.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kit for Kubernetes operators
+package k8sutil
+
+import (
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// CustomResource is for creating a Kubernetes TPR/CRD
+type CustomResource struct {
+	// Name of the custom resource
+	Name string
+
+	// Plural of the custom resource in plural
+	Plural string
+
+	// Group the custom resource belongs to
+	Group string
+
+	// Version which should be defined in a const above
+	Version string
+
+	// Kind is the serialized interface of the resource.
+	Kind string
+}
+
+// WatchCR begins watching the custom resource (CRD). The call will block until a Done signal is raised during in the context.
+// When the watch has detected a create, update, or delete event, it will handled by the functions in the resourceEventHandlers. After the callback returns, the watch loop will continue for the next event.
+// If the callback returns an error, the error will be logged.
+func WatchCR(resource CustomResource, namespace string, handlers cache.ResourceEventHandlerFuncs, client rest.Interface, objType runtime.Object, done <-chan struct{}) error {
+	source := cache.NewListWatchFromClient(
+		client,
+		resource.Plural,
+		namespace,
+		fields.Everything())
+	_, controller := cache.NewInformer(
+		source,
+
+		// The object type.
+		objType,
+
+		// resyncPeriod
+		// Every resyncPeriod, all resources in the cache will retrigger events.
+		// Set to 0 to disable the resync.
+		0,
+
+		// Your custom resource event handlers.
+		handlers)
+
+	go controller.Run(done)
+	<-done
+	return nil
+}

--- a/pkg/operator/minio/controller.go
+++ b/pkg/operator/minio/controller.go
@@ -22,14 +22,12 @@ import (
 	"reflect"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	miniov1alpha1 "github.com/rook/rook/pkg/apis/minio.rook.io/v1alpha1"
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,12 +53,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "minio-op-object")
 
 // ObjectStoreResource represents the object store custom resource
-var ObjectStoreResource = opkit.CustomResource{
+var ObjectStoreResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   miniov1alpha1.CustomResourceGroup,
 	Version: miniov1alpha1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(miniov1alpha1.ObjectStore{}).Name(),
 }
 
@@ -87,9 +84,7 @@ func (c *Controller) StartWatch(namespace string, stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching object store resources in namespace %s", namespace)
-	watcher := opkit.NewWatcher(ObjectStoreResource, namespace, resourceHandlerFuncs, c.context.RookClientset.MinioV1alpha1().RESTClient())
-	go watcher.Watch(&miniov1alpha1.ObjectStore{}, stopCh)
-
+	go k8sutil.WatchCR(ObjectStoreResource, namespace, resourceHandlerFuncs, c.context.RookClientset.MinioV1alpha1().RESTClient(), &miniov1alpha1.ObjectStore{}, stopCh)
 	return nil
 }
 

--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -23,13 +23,11 @@ import (
 	s "strings"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	nfsv1alpha1 "github.com/rook/rook/pkg/apis/nfs.rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,12 +47,11 @@ const (
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "nfs-operator")
 
 // NFSResource represents the nfs export custom resource
-var NFSResource = opkit.CustomResource{
+var NFSResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   nfsv1alpha1.CustomResourceGroup,
 	Version: nfsv1alpha1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(nfsv1alpha1.NFSServer{}).Name(),
 }
 
@@ -81,8 +78,7 @@ func (c *Controller) StartWatch(namespace string, stopCh chan struct{}) error {
 	}
 
 	logger.Infof("start watching nfs server resources in namespace %s", namespace)
-	watcher := opkit.NewWatcher(NFSResource, namespace, resourceHandlerFuncs, c.context.RookClientset.NfsV1alpha1().RESTClient())
-	go watcher.Watch(&nfsv1alpha1.NFSServer{}, stopCh)
+	go k8sutil.WatchCR(NFSResource, namespace, resourceHandlerFuncs, c.context.RookClientset.NfsV1alpha1().RESTClient(), &nfsv1alpha1.NFSServer{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/yugabytedb/controller.go
+++ b/pkg/operator/yugabytedb/controller.go
@@ -20,13 +20,11 @@ import (
 	"fmt"
 	"reflect"
 
-	opkit "github.com/rook/operator-kit"
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	yugabytedbv1alpha1 "github.com/rook/rook/pkg/apis/yugabytedb.rook.io/v1alpha1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -75,12 +73,11 @@ const (
 	yugabyteDBImageName         = "yugabytedb/yugabyte:1.3.1.0-b16"
 )
 
-var ClusterResource = opkit.CustomResource{
+var ClusterResource = k8sutil.CustomResource{
 	Name:    customResourceName,
 	Plural:  customResourceNamePlural,
 	Group:   yugabytedbv1alpha1.CustomResourceGroup,
 	Version: yugabytedbv1alpha1.Version,
-	Scope:   apiextensionsv1beta1.NamespaceScoped,
 	Kind:    reflect.TypeOf(yugabytedbv1alpha1.YBCluster{}).Name(),
 }
 
@@ -143,8 +140,7 @@ func (c *ClusterController) StartWatch(namespace string, stopCh chan struct{}) e
 	}
 
 	logger.Infof("start watching yugabytedb clusters in all namespaces")
-	watcher := opkit.NewWatcher(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.YugabytedbV1alpha1().RESTClient())
-	go watcher.Watch(&yugabytedbv1alpha1.YBCluster{}, stopCh)
+	go k8sutil.WatchCR(ClusterResource, namespace, resourceHandlerFuncs, c.context.RookClientset.YugabytedbV1alpha1().RESTClient(), &yugabytedbv1alpha1.YBCluster{}, stopCh)
 
 	return nil
 }

--- a/pkg/operator/yugabytedb/operator.go
+++ b/pkg/operator/yugabytedb/operator.go
@@ -23,8 +23,8 @@ import (
 	"syscall"
 
 	"github.com/coreos/pkg/capnslog"
-	opkit "github.com/rook/operator-kit"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -32,7 +32,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "yugabytedb-opera
 
 type Operator struct {
 	context           *clusterd.Context
-	resources         []opkit.CustomResource
+	resources         []k8sutil.CustomResource
 	rookImage         string
 	clusterController *ClusterController
 }
@@ -41,7 +41,7 @@ type Operator struct {
 func New(context *clusterd.Context, rookImage string) *Operator {
 	clusterController := NewClusterController(context, rookImage)
 
-	schemes := []opkit.CustomResource{ClusterResource}
+	schemes := []k8sutil.CustomResource{ClusterResource}
 	return &Operator{
 		context:           context,
 		clusterController: clusterController,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator kit had more utility originally when the operator was creating and managing the TPRs and CRDs directly. Since the CRDs are now created from a manifest and no longer by the operators, the utility of operator kit is limited to the controller watcher. Since we are moving to the controller runtime, this PR first removes the dependency to make the transition smoother. Now there is only a simple WatchCR method that will need to be replaced as we make that transition.

**Which issue is resolved by this Pull Request:**
Related to #1981 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
