### PR TITLE
edgeFS: Took care of the Variable shadowing in ConfigMap

### DIFF
--- a/pkg/operator/edgefs/cluster/configmap.go
+++ b/pkg/operator/edgefs/cluster/configmap.go
@@ -38,14 +38,13 @@ const (
 // to all the nodes in the cluster. This way configuration is simplified and
 // available to all subcomponents at any point it time.
 func (c *cluster) createClusterConfigMap(deploymentConfig edgefsv1.ClusterDeploymentConfig, resurrect bool) error {
-
+	var err error
 	cm := make(map[string]edgefsv1.SetupNode)
 
 	dnsRecords := make([]string, len(deploymentConfig.DevConfig))
 	for i := 0; i < len(deploymentConfig.DevConfig); i++ {
 		dnsRecords[i] = target.CreateQualifiedHeadlessServiceName(i, c.Namespace)
 	}
-
 	serverIfName := defaultServerIfName
 	brokerIfName := defaultBrokerIfName
 
@@ -65,7 +64,6 @@ func (c *cluster) createClusterConfigMap(deploymentConfig edgefsv1.ClusterDeploy
 		}
 	} else if c.Spec.Network.IsMultus() {
 		if serverDefined && brokerDefined {
-			var err error
 			serverIfName, err = k8sutil.GetMultusIfName(serverSelector)
 			if err != nil {
 				return err
@@ -76,14 +74,14 @@ func (c *cluster) createClusterConfigMap(deploymentConfig edgefsv1.ClusterDeploy
 				return err
 			}
 		} else if serverDefined {
-			serverIfName, err := k8sutil.GetMultusIfName(serverSelector)
+			serverIfName, err = k8sutil.GetMultusIfName(serverSelector)
 			if err != nil {
 				return err
 			}
 
 			brokerIfName = serverIfName
 		} else if brokerDefined {
-			serverIfName, err := k8sutil.GetMultusIfName(brokerSelector)
+			serverIfName, err = k8sutil.GetMultusIfName(brokerSelector)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This commit fixes the variable shadowing in configMap which leads to a potential misconfiguration.

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #4563 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
