### PR TITLE
ceph: add ceph version to cluster status

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -139,9 +139,10 @@ type MonitoringSpec struct {
 }
 
 type ClusterStatus struct {
-	State      ClusterState `json:"state,omitempty"`
-	Message    string       `json:"message,omitempty"`
-	CephStatus *CephStatus  `json:"ceph,omitempty"`
+	State       ClusterState    `json:"state,omitempty"`
+	Message     string          `json:"message,omitempty"`
+	CephStatus  *CephStatus     `json:"ceph,omitempty"`
+	CephVersion *ClusterVersion `json:"version,omitempty"`
 }
 
 type CephStatus struct {
@@ -150,6 +151,11 @@ type CephStatus struct {
 	LastChecked    string                       `json:"lastChecked,omitempty"`
 	LastChanged    string                       `json:"lastChanged,omitempty"`
 	PreviousHealth string                       `json:"previousHealth,omitempty"`
+}
+
+type ClusterVersion struct {
+	Image   string `json:"image,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type CephHealthMessage struct {

--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/rbd"
 	"github.com/rook/rook/pkg/operator/ceph/file/mds"
 	"github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/ceph/version"
 
 	"github.com/coreos/pkg/capnslog"
@@ -125,9 +126,10 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		}
 
 		clusterImage := cephCluster.Spec.CephVersion.Image
-		cephVersion, ok := getImageVersion(clusterImage)
-		if !ok {
-			logger.Warningf("ceph version not found for image %q used by cluster %q", clusterImage, cephCluster.Name)
+		cephVersion, err := getImageVersion(cephCluster)
+		if err != nil {
+			logger.Errorf("ceph version not found for image %q used by cluster %q. %v", clusterImage, cephCluster.Name, err)
+			return reconcile.Result{}, nil
 		}
 
 		uniqueTolerations := controllerconfig.TolerationSet{}
@@ -174,14 +176,15 @@ func (r *ReconcileNode) cephPodList() ([]corev1.Pod, error) {
 }
 
 // getImageVersion returns the CephVersion registered for a specified image (if any) and whether any image was found.
-func getImageVersion(image string) (*version.CephVersion, bool) {
+func getImageVersion(cephCluster cephv1.CephCluster) (*version.CephVersion, error) {
 	for i := 0; i < getVersionMaxRetries; i++ {
-		cephVersion, ok := version.GetImageVersion(image)
-		if ok {
-			logger.Debugf("ceph version found %+v", cephVersion)
-			return cephVersion, true
+		// If the Ceph cluster has not yet recorded the image and version for the current image in its spec, then the Crash
+		// controller should wait for the version to be detected.
+		if cephCluster.Spec.CephVersion.Image == cephCluster.Status.CephVersion.Image {
+			logger.Debugf("ceph version found %q", cephCluster.Status.CephVersion.Version)
+			return spec.ExtractCephVersionFromLabel(cephCluster.Status.CephVersion.Version)
 		}
 		<-time.After(time.Second * getVersionRetryInterval)
 	}
-	return nil, false
+	return nil, errors.New("attempt to determine ceph version for the current cluster image timed out")
 }

--- a/pkg/operator/ceph/spec/label.go
+++ b/pkg/operator/ceph/spec/label.go
@@ -38,8 +38,18 @@ const (
 func addCephVersionLabel(cephVersion version.CephVersion, labels map[string]string) {
 	// cephVersion.String() returns a string with a space in it, and labels in k8s are limited to
 	// alphanum characters plus '-', '_', '.'
-	labels[CephVersionLabelKey] = fmt.Sprintf("%d.%d.%d-%d",
+	labels[CephVersionLabelKey] = GetCephVersionLabel(cephVersion)
+}
+
+// GetCephVersionLabel returns a formatted serialization of a provided CephVersion for use in resource labels.
+func GetCephVersionLabel(cephVersion version.CephVersion) string {
+	return fmt.Sprintf("%d.%d.%d-%d",
 		cephVersion.Major, cephVersion.Minor, cephVersion.Extra, cephVersion.Build)
+}
+
+// ExtractCephVersionFromLabel returns a CephVersion struct deserialized from a provided version label.
+func ExtractCephVersionFromLabel(labelVersion string) (*version.CephVersion, error) {
+	return version.ExtractCephVersion(fmt.Sprintf("ceph version %s", labelVersion))
 }
 
 // AddCephVersionLabelToDeployment adds a label reporting the Ceph version which Rook has detected is

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"sync"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -58,9 +57,6 @@ var (
 
 	// for parsing the output of `ceph --version`
 	versionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)`)
-	// for storage of the versions of images for access in managed reconciliations
-	imageToVersionMap     = map[string]CephVersion{}
-	imageToVersionMapLock = &sync.Mutex{}
 
 	// For a build release the output is "ceph version 14.2.4-64.el8cp"
 	// So we need to detect the build version change
@@ -297,19 +293,4 @@ func ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, externalV
 	}
 
 	return nil
-}
-
-// RegisterImageVersion stores the CephVersion detected for a specified image for global access.
-func RegisterImageVersion(image string, version CephVersion) {
-	imageToVersionMapLock.Lock()
-	imageToVersionMap[image] = version
-	imageToVersionMapLock.Unlock()
-}
-
-// GetImageVersion returns the CephVersion registered for a specified image (if any) and whether any image was found.
-func GetImageVersion(image string) (*CephVersion, bool) {
-	imageToVersionMapLock.Lock()
-	version, ok := imageToVersionMap[image]
-	imageToVersionMapLock.Unlock()
-	return &version, ok
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

In order for deployments managed outside the immediate scope of
the ClusterController to accurately detect the Ceph version of
their images, the ClusterController must store the detected
version. This change records the Ceph version as part of the
cluster status and modifies the crashcollector deployment to
consume this field to record its own Ceph version. This replaces
an earlier solution to this problem in which the Ceph version
for a given image to version mapping was stored in a global
in-memory map by the operator.

**Which issue is resolved by this Pull Request:**
Resolves: rook#4357
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
