### PR TITLE
yugabytedb: fixed replication factor flag and the master addresses.

### DIFF
--- a/pkg/operator/yugabytedb/controller.go
+++ b/pkg/operator/yugabytedb/controller.go
@@ -19,6 +19,7 @@ package yugabytedb
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	rookv1alpha2 "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	yugabytedbv1alpha1 "github.com/rook/rook/pkg/apis/yugabytedb.rook.io/v1alpha1"
@@ -70,7 +71,7 @@ const (
 	envPodIPVal                 = "status.podIP"
 	envPodName                  = "POD_NAME"
 	envPodNameVal               = "metadata.name"
-	yugabyteDBImageName         = "yugabytedb/yugabyte:1.3.1.0-b16"
+	yugabyteDBImageName         = "yugabytedb/yugabyte:2.0.10.0-b4"
 )
 
 var ClusterResource = k8sutil.CustomResource{
@@ -329,35 +330,42 @@ func getPortsFromSpec(networkSpec yugabytedbv1alpha1.NetworkSpec) (clusterPort *
 	return &ports, nil
 }
 
-func createMasterContainerCommand(namespace, serviceName string, grpcPort, replicas int32) []string {
+func createMasterContainerCommand(namespace, serviceName string, masterCompleteName string, grpcPort, replicas int32) []string {
 	command := []string{
 		"/home/yugabyte/bin/yb-master",
 		fmt.Sprintf("--fs_data_dirs=%s", volumeMountPath),
 		fmt.Sprintf("--rpc_bind_addresses=$(POD_IP):%d", grpcPort),
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).%s:%d", serviceName, grpcPort),
 		"--use_private_ip=never",
-		fmt.Sprintf("--master_addresses=%s.%s.svc.cluster.local:%d", serviceName, namespace, grpcPort),
-		"--use_initial_sys_catalog_snapshot=true",
-		fmt.Sprintf("--master_replication_factor=%d", replicas),
+		fmt.Sprintf("--master_addresses=%s", getMasterAddresses(masterCompleteName, serviceName, namespace, replicas, grpcPort)),
+		"--enable_ysql=true",
+		fmt.Sprintf("--replication_factor=%d", replicas),
 		"--logtostderr",
 	}
 	return command
 }
 
-func createTServerContainerCommand(namespace, serviceName, masterServiceName string, masterGRPCPort, tserverGRPCPort, pgsqlPort, replicas int32) []string {
+func createTServerContainerCommand(namespace, serviceName, masterServiceName string, masterCompleteName string, masterGRPCPort, tserverGRPCPort, pgsqlPort, replicas int32) []string {
 	command := []string{
 		"/home/yugabyte/bin/yb-tserver",
 		fmt.Sprintf("--fs_data_dirs=%s", volumeMountPath),
 		fmt.Sprintf("--rpc_bind_addresses=$(POD_IP):%d", tserverGRPCPort),
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).%s:%d", serviceName, tserverGRPCPort),
-		"--start_pgsql_proxy",
 		fmt.Sprintf("--pgsql_proxy_bind_address=$(POD_IP):%d", pgsqlPort),
 		"--use_private_ip=never",
-		fmt.Sprintf("--tserver_master_addrs=%s.%s.svc.cluster.local:%d", masterServiceName, namespace, masterGRPCPort),
-		fmt.Sprintf("--tserver_master_replication_factor=%d", replicas),
+		fmt.Sprintf("--tserver_master_addrs=%s", getMasterAddresses(masterCompleteName, masterServiceName, namespace, replicas, masterGRPCPort)),
+		"--enable_ysql=true",
 		"--logtostderr",
 	}
 	return command
+}
+
+func getMasterAddresses(masterCompleteName string, serviceName string, namespace string, replicas int32, masterGRPCPort int32) string {
+	masterAddrs := []string{}
+	for i := int32(0); i < replicas; i++ {
+		masterAddrs = append(masterAddrs, fmt.Sprintf("%s-%d.%s.%s.svc.cluster.local:%d", masterCompleteName, i, serviceName, namespace, masterGRPCPort))
+	}
+	return strings.Join(masterAddrs, ",")
 }
 
 func createMasterContainerPortsList(clusterPortsSpec *clusterPorts) []v1.ContainerPort {

--- a/pkg/operator/yugabytedb/controller_test.go
+++ b/pkg/operator/yugabytedb/controller_test.go
@@ -261,6 +261,40 @@ func TestGetPortsFromSpec(t *testing.T) {
 func TestCreateMasterContainerCommand(t *testing.T) {
 	replicationFactor := int32(3)
 
+	expectedCommand := getMasterContainerCommand(replicationFactor)
+	actualCommand := createMasterContainerCommand("default", masterNamePlural, masterName, int32(7100), replicationFactor)
+
+	assert.Equal(t, expectedCommand, actualCommand)
+}
+
+func TestCreateTServerContainerCommand(t *testing.T) {
+	replicationFactor := int32(3)
+
+	expectedCommand := getTserverContainerCommand(replicationFactor)
+	actualCommand := createTServerContainerCommand("default", tserverNamePlural, masterNamePlural, masterName, int32(7100), int32(9100), int32(5433), replicationFactor)
+
+	assert.Equal(t, expectedCommand, actualCommand)
+}
+
+func TestCreateMasterContainerCommandRF1(t *testing.T) {
+	replicationFactor := int32(1)
+
+	expectedCommand := getMasterContainerCommand(replicationFactor)
+	actualCommand := createMasterContainerCommand("default", masterNamePlural, masterName, int32(7100), replicationFactor)
+
+	assert.Equal(t, expectedCommand, actualCommand)
+}
+
+func TestCreateTServerContainerCommandRF1(t *testing.T) {
+	replicationFactor := int32(1)
+
+	expectedCommand := getTserverContainerCommand(replicationFactor)
+	actualCommand := createTServerContainerCommand("default", tserverNamePlural, masterNamePlural, masterName, int32(7100), int32(9100), int32(5433), replicationFactor)
+
+	assert.Equal(t, expectedCommand, actualCommand)
+}
+
+func getMasterContainerCommand(replicationFactor int32) []string {
 	expectedCommand := []string{
 		"/home/yugabyte/bin/yb-master",
 		"--fs_data_dirs=/mnt/data0",
@@ -272,15 +306,10 @@ func TestCreateMasterContainerCommand(t *testing.T) {
 		fmt.Sprintf("--replication_factor=%d", replicationFactor),
 		"--logtostderr",
 	}
-
-	actualCommand := createMasterContainerCommand("default", masterNamePlural, masterName, int32(7100), replicationFactor)
-
-	assert.Equal(t, expectedCommand, actualCommand)
+	return expectedCommand
 }
 
-func TestCreateTServerContainerCommand(t *testing.T) {
-	replicationFactor := int32(3)
-
+func getTserverContainerCommand(replicationFactor int32) []string {
 	expectedCommand := []string{
 		"/home/yugabyte/bin/yb-tserver",
 		"--fs_data_dirs=/mnt/data0",
@@ -292,10 +321,7 @@ func TestCreateTServerContainerCommand(t *testing.T) {
 		"--enable_ysql=true",
 		"--logtostderr",
 	}
-
-	actualCommand := createTServerContainerCommand("default", tserverNamePlural, masterNamePlural, masterName, int32(7100), int32(9100), int32(5433), replicationFactor)
-
-	assert.Equal(t, expectedCommand, actualCommand)
+	return expectedCommand
 }
 
 func TestOnAdd(t *testing.T) {

--- a/pkg/operator/yugabytedb/controller_test.go
+++ b/pkg/operator/yugabytedb/controller_test.go
@@ -259,7 +259,7 @@ func TestGetPortsFromSpec(t *testing.T) {
 }
 
 func TestCreateMasterContainerCommand(t *testing.T) {
-	replicationFactor := 3
+	replicationFactor := int32(3)
 
 	expectedCommand := []string{
 		"/home/yugabyte/bin/yb-master",
@@ -267,34 +267,33 @@ func TestCreateMasterContainerCommand(t *testing.T) {
 		fmt.Sprintf("--rpc_bind_addresses=$(POD_IP):%d", masterRPCPortDefault),
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).yb-masters:%d", masterRPCPortDefault),
 		"--use_private_ip=never",
-		fmt.Sprintf("--master_addresses=yb-masters.default.svc.cluster.local:%d", masterRPCPortDefault),
-		"--use_initial_sys_catalog_snapshot=true",
-		fmt.Sprintf("--master_replication_factor=%d", replicationFactor),
+		fmt.Sprintf("--master_addresses=%s", getMasterAddresses(masterName, masterNamePlural, "default", replicationFactor, int32(7100))),
+		"--enable_ysql=true",
+		fmt.Sprintf("--replication_factor=%d", replicationFactor),
 		"--logtostderr",
 	}
 
-	actualCommand := createMasterContainerCommand("default", masterNamePlural, int32(7100), int32(3))
+	actualCommand := createMasterContainerCommand("default", masterNamePlural, masterName, int32(7100), replicationFactor)
 
 	assert.Equal(t, expectedCommand, actualCommand)
 }
 
 func TestCreateTServerContainerCommand(t *testing.T) {
-	replicationFactor := 3
+	replicationFactor := int32(3)
 
 	expectedCommand := []string{
 		"/home/yugabyte/bin/yb-tserver",
 		"--fs_data_dirs=/mnt/data0",
 		fmt.Sprintf("--rpc_bind_addresses=$(POD_IP):%d", tserverRPCPortDefault),
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).yb-tservers:%d", tserverRPCPortDefault),
-		"--start_pgsql_proxy",
 		fmt.Sprintf("--pgsql_proxy_bind_address=$(POD_IP):%d", tserverPostgresPortDefault),
 		"--use_private_ip=never",
-		fmt.Sprintf("--tserver_master_addrs=yb-masters.default.svc.cluster.local:%d", masterRPCPortDefault),
-		fmt.Sprintf("--tserver_master_replication_factor=%d", replicationFactor),
+		fmt.Sprintf("--tserver_master_addrs=%s", getMasterAddresses(masterName, masterNamePlural, "default", replicationFactor, int32(7100))),
+		"--enable_ysql=true",
 		"--logtostderr",
 	}
 
-	actualCommand := createTServerContainerCommand("default", tserverNamePlural, masterNamePlural, int32(7100), int32(9100), int32(5433), int32(3))
+	actualCommand := createTServerContainerCommand("default", tserverNamePlural, masterNamePlural, masterName, int32(7100), int32(9100), int32(5433), replicationFactor)
 
 	assert.Equal(t, expectedCommand, actualCommand)
 }
@@ -411,9 +410,9 @@ func TestOnAdd(t *testing.T) {
 		"--rpc_bind_addresses=$(POD_IP):7100",
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).%s:7100", addCRNameSuffix(masterNamePlural)),
 		"--use_private_ip=never",
-		fmt.Sprintf("--master_addresses=%s.%s.svc.cluster.local:7100", addCRNameSuffix(masterNamePlural), namespace),
-		"--use_initial_sys_catalog_snapshot=true",
-		"--master_replication_factor=3",
+		fmt.Sprintf("--master_addresses=%s", getMasterAddresses(addCRNameSuffix(masterName), addCRNameSuffix(masterNamePlural), namespace, int32(3), int32(7100))),
+		"--enable_ysql=true",
+		"--replication_factor=3",
 		"--logtostderr",
 	}
 	assert.Equal(t, expectedCommand, container.Command)
@@ -481,11 +480,10 @@ func TestOnAdd(t *testing.T) {
 		"--fs_data_dirs=/mnt/data0",
 		"--rpc_bind_addresses=$(POD_IP):9100",
 		fmt.Sprintf("--server_broadcast_addresses=$(POD_NAME).%s:9100", addCRNameSuffix(tserverNamePlural)),
-		"--start_pgsql_proxy",
 		"--pgsql_proxy_bind_address=$(POD_IP):5433",
 		"--use_private_ip=never",
-		fmt.Sprintf("--tserver_master_addrs=%s.%s.svc.cluster.local:7100", addCRNameSuffix(masterNamePlural), namespace),
-		"--tserver_master_replication_factor=3",
+		fmt.Sprintf("--tserver_master_addrs=%s", getMasterAddresses(addCRNameSuffix(masterName), addCRNameSuffix(masterNamePlural), namespace, int32(3), int32(7100))),
+		"--enable_ysql=true",
 		"--logtostderr",
 	}
 	assert.Equal(t, expectedCommand, container.Command)

--- a/pkg/operator/yugabytedb/create_controller.go
+++ b/pkg/operator/yugabytedb/create_controller.go
@@ -292,15 +292,17 @@ func createPodSpec(cluster *cluster, containerImage string, isTServerStatefulset
 
 func createContainer(cluster *cluster, containerImage string, isTServerStatefulset bool, name, serviceName string) v1.Container {
 	ports, _ := getPortsFromSpec(cluster.spec.Master.Network)
-	command := createMasterContainerCommand(cluster.namespace, serviceName, ports.masterPorts.rpc, cluster.spec.Master.Replicas)
+	masterCompleteName := cluster.addCRNameSuffix(masterName)
+	command := createMasterContainerCommand(cluster.namespace, serviceName, masterCompleteName, ports.masterPorts.rpc, cluster.spec.Master.Replicas)
 	containerPorts := createMasterContainerPortsList(ports)
 	volumeMountName := cluster.addCRNameSuffix(cluster.spec.Master.VolumeClaimTemplate.Name)
 
 	if isTServerStatefulset {
 		masterServiceName := cluster.addCRNameSuffix(masterNamePlural)
+		masterCompleteName := cluster.addCRNameSuffix(masterName)
 		masterRPCPort := ports.masterPorts.rpc
 		ports, _ = getPortsFromSpec(cluster.spec.TServer.Network)
-		command = createTServerContainerCommand(cluster.namespace, serviceName, masterServiceName, masterRPCPort, ports.tserverPorts.rpc, ports.tserverPorts.postgres, cluster.spec.TServer.Replicas)
+		command = createTServerContainerCommand(cluster.namespace, serviceName, masterServiceName, masterCompleteName, masterRPCPort, ports.tserverPorts.rpc, ports.tserverPorts.postgres, cluster.spec.TServer.Replicas)
 		containerPorts = createTServerContainerPortsList(ports)
 		volumeMountName = cluster.addCRNameSuffix(cluster.spec.TServer.VolumeClaimTemplate.Name)
 	}

--- a/pkg/operator/yugabytedb/update_controller.go
+++ b/pkg/operator/yugabytedb/update_controller.go
@@ -192,10 +192,11 @@ func (c *ClusterController) updateStatefulSet(newCluster *cluster, isTServerStat
 	replicas := int32(newCluster.spec.Master.Replicas)
 	sfsName := newCluster.addCRNameSuffix(masterName)
 	masterServiceName := newCluster.addCRNameSuffix(masterNamePlural)
+	masterCompleteName := newCluster.addCRNameSuffix(masterName)
 	vct := *newCluster.spec.Master.VolumeClaimTemplate.DeepCopy()
 	vct.Name = newCluster.addCRNameSuffix(vct.Name)
 	volumeClaimTemplates := []v1.PersistentVolumeClaim{vct}
-	command := createMasterContainerCommand(newCluster.namespace, masterServiceName, ports.masterPorts.rpc, newCluster.spec.Master.Replicas)
+	command := createMasterContainerCommand(newCluster.namespace, masterServiceName, masterCompleteName, ports.masterPorts.rpc, newCluster.spec.Master.Replicas)
 	containerPorts := createMasterContainerPortsList(ports)
 
 	if isTServerStatefulset {
@@ -209,11 +210,12 @@ func (c *ClusterController) updateStatefulSet(newCluster *cluster, isTServerStat
 		replicas = int32(newCluster.spec.TServer.Replicas)
 		sfsName = newCluster.addCRNameSuffix(tserverName)
 		masterServiceName = newCluster.addCRNameSuffix(masterNamePlural)
+		masterCompleteName := newCluster.addCRNameSuffix(masterName)
 		tserverServiceName := newCluster.addCRNameSuffix(tserverNamePlural)
 		vct = *newCluster.spec.TServer.VolumeClaimTemplate.DeepCopy()
 		vct.Name = newCluster.addCRNameSuffix(vct.Name)
 		volumeClaimTemplates = []v1.PersistentVolumeClaim{vct}
-		command = createTServerContainerCommand(newCluster.namespace, tserverServiceName, masterServiceName,
+		command = createTServerContainerCommand(newCluster.namespace, tserverServiceName, masterServiceName, masterCompleteName,
 			masterRPCPort, ports.tserverPorts.rpc, ports.tserverPorts.postgres, newCluster.spec.TServer.Replicas)
 		containerPorts = createTServerContainerPortsList(ports)
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR takes care of the following things:
1) Fixes the issue of the replication factor not being honored in Yugabyte due to the incorrect flag being set.
2) Hardens the discovery of master servers by passing in the FQDNs as the addresses rather than just the headless service.
3) Bumps the version of Yugabyte to 2.0.10.0-b4.

**Which issue is resolved by this Pull Request:**
Resolves #4625 

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test yugabytedb]