### PR TITLE
Dep: Update golang dep to support Arm64

### DIFF
--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -65,7 +65,7 @@ endif
 GOPATH := $(shell go env GOPATH)
 
 # setup tools used during the build
-DEP_VERSION=v0.5.0
+DEP_VERSION=v0.5.4
 DEP := $(TOOLS_HOST_DIR)/dep-$(DEP_VERSION)
 GOLINT := $(TOOLS_HOST_DIR)/golint
 GOJUNIT := $(TOOLS_HOST_DIR)/go-junit-report
@@ -195,12 +195,7 @@ go.vendor.update: $(DEP)
 $(DEP):
 	@echo === installing dep
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@if [ "$(GOHOSTARCH)" = "arm64" ]; then\
-		GOPATH=$(TOOLS_HOST_DIR)/tmp GOBIN=$(TOOLS_HOST_DIR) $(GOHOST) get -u github.com/golang/dep/cmd/dep;\
-		mv $(TOOLS_HOST_DIR)/dep $@;\
-	else \
-		curl -sL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(GOHOSTOS)-$(GOHOSTARCH);\
-	fi
+	@curl -sL -o $(DEP) https://github.com/golang/dep/releases/download/$(DEP_VERSION)/dep-$(GOHOSTOS)-$(GOHOSTARCH)
 	@chmod +x $(DEP)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Current Rook code uses go dep 0.5.0 and separates handling
for Arm and x86. It's because there's no dep 0.5.0 binary for 
arm64.Dep has updated to 0.5.4 and supports arm64. Rook
code can be simplified by upgrading dep to fix gaps of Arm
and x86.

**Which issue is resolved by this Pull Request:**
Resolves #
Signed-off-by: Haichao Li <haichao.li@arm.com>
**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
