### PR TITLE
ceph: remove last bits of osd min_size

### DIFF
--- a/design/ceph/ceph-config-updates.md
+++ b/design/ceph/ceph-config-updates.md
@@ -127,7 +127,6 @@ spec:
       # The below "osd_pool_default..." settings make the default pools created have no replication
       # and should be removed for production clusters, as this could impact data fault tolerance.
       osd_pool_default_size: 1
-      osd_pool_default_min_size: 1
     # mon will add/override config for all mons
     mon:
       mon_cluster_log_file: "/dev/stderr"

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -233,10 +233,6 @@ func CreateECPoolForApp(context *clusterd.Context, clusterName string, newPool C
 		return errors.Wrapf(err, "failed to create EC pool %s", newPool.Name)
 	}
 
-	if err = SetPoolProperty(context, clusterName, newPool.Name, "min_size", strconv.FormatUint(uint64(erasureCodedConfig.DataChunkCount), 10)); err != nil {
-		return errors.Wrapf(err, "failed to set min size to %d for pool %s", erasureCodedConfig.DataChunkCount, newPool.Name)
-	}
-
 	if enableECOverwrite {
 		if err = SetPoolProperty(context, clusterName, newPool.Name, "allow_ec_overwrites", "true"); err != nil {
 			return errors.Wrapf(err, "failed to allow EC overwrite for pool %s", newPool.Name)

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -45,10 +45,6 @@ func TestCreateECPoolWithOverwrites(t *testing.T) {
 					assert.Equal(t, "mypool", args[3])
 					assert.Equal(t, "true", args[5])
 					return "", nil
-				} else if args[4] == "min_size" {
-					assert.Equal(t, "mypool", args[3])
-					assert.Equal(t, "1", args[5])
-					return "", nil
 				}
 			}
 			if args[2] == "application" {
@@ -80,8 +76,7 @@ func TestCreateECPoolWithoutOverwrites(t *testing.T) {
 			}
 			if args[2] == "set" {
 				assert.Equal(t, "mypool", args[3])
-				assert.Equal(t, "min_size", args[4])
-				assert.Equal(t, "1", args[5])
+				assert.Equal(t, "1", args[4])
 				return "", nil
 			}
 			if args[2] == "application" {

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -82,7 +82,6 @@ type GlobalConfig struct {
 	OsdPgBits                int    `ini:"osd pg bits,omitempty"`
 	OsdPgpBits               int    `ini:"osd pgp bits,omitempty"`
 	OsdPoolDefaultSize       int    `ini:"osd pool default size,omitempty"`
-	OsdPoolDefaultMinSize    int    `ini:"osd pool default min size,omitempty"`
 	OsdPoolDefaultPgNum      int    `ini:"osd pool default pg num,omitempty"`
 	OsdPoolDefaultPgpNum     int    `ini:"osd pool default pgp num,omitempty"`
 	OsdMaxObjectNameLen      int    `ini:"osd max object name len,omitempty"`
@@ -252,7 +251,6 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 			OsdPgBits:              11,
 			OsdPgpBits:             11,
 			OsdPoolDefaultSize:     1,
-			OsdPoolDefaultMinSize:  1,
 			OsdPoolDefaultPgNum:    100,
 			OsdPoolDefaultPgpNum:   100,
 			RbdDefaultFeatures:     3,


### PR DESCRIPTION
**Description of your changes:**

As agreed in https://github.com/rook/rook/issues/2543, Rook must not set
min_size for a pool and should let Ceph handle that calculation.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]