### PR TITLE
k8sutil: speed up UpdateDeploymentAndWait()

### DIFF
--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -79,11 +79,11 @@ func UpdateDeploymentAndWait(context *clusterd.Context, deployment *apps.Deploym
 	}
 
 	// wait for the deployment to be restarted
-	sleepTime := 2
-	attempts := 30
+	sleepTime := 1
+	attempts := 60
 	if original.Spec.ProgressDeadlineSeconds != nil {
 		// make the attempts double the progress deadline since the pod is both stopping and starting
-		attempts = 2 * (int(*original.Spec.ProgressDeadlineSeconds) / sleepTime)
+		attempts = 2 * (int(*original.Spec.ProgressDeadlineSeconds) / 2)
 	}
 	for i := 0; i < attempts; i++ {
 		// check for the status of the deployment


### PR DESCRIPTION
**Description of your changes:**

Instead of waiting for 2 seconds, let's check every second up to 60
times.
This should speed up the function if nothing changed in the deployment
object.

Closes: https://github.com/rook/rook/issues/4642
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4642

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
