### PR TITLE
osd: Added check for `--crush-location`

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -399,14 +399,14 @@ func TestGetOSDInfo(t *testing.T) {
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.Namespace, c.dataDirHostPath),
 	}
 	d1, _ := c.makeDeployment(osdProp, osd1, dataPathMap)
-	osds1, _ := getOSDInfo(d1)
+	osds1, _ := c.getOSDInfo(d1)
 	assert.Equal(t, 1, len(osds1))
 	assert.Equal(t, osd1.ID, osds1[0].ID)
 	assert.Equal(t, osd1.LVPath, osds1[0].LVPath)
 	assert.Equal(t, location, osds1[0].Location)
 
 	d2, _ := c.makeDeployment(osdProp, osd2, dataPathMap)
-	osds2, err := getOSDInfo(d2)
+	osds2, err := c.getOSDInfo(d2)
 	assert.Equal(t, 0, len(osds2))
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Signed-off-by: rohan47 <rohgupta@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Added a check for `--crush-location`, if `--crush-location` is not present,
the node topology is not applied and the operator will need to determine
the value based on the node labels instead of skipping this setting.

**Which issue is resolved by this Pull Request:**
Resolves #4616 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]