### PR TITLE
Set hostname properly in the CRUSH map for non-portable OSDs on PVCs

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -730,6 +730,14 @@ func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string) []v1.
 		k8sutil.NodeEnvVar(),
 	}
 
+	// Give a hint to the prepare pod for what the host in the CRUSH map should be
+	crushmapHostname := osdProps.crushHostname
+	if !osdProps.portable && osdProps.pvc.ClaimName != "" {
+		// If it's a pvc that's not portable we only know what the host name should be when inside the osd prepare pod
+		crushmapHostname = ""
+	}
+	envVars = append(envVars, v1.EnvVar{Name: "ROOK_CRUSHMAP_HOSTNAME", Value: crushmapHostname})
+
 	// Append ceph-volume environment variables
 	envVars = append(envVars, cephVolumeEnvVar()...)
 

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -119,6 +119,10 @@ func GetNodeHostName(clientset kubernetes.Interface, nodeName string) (string, e
 	if err != nil {
 		return "", err
 	}
+	return GetNodeHostNameLabel(node)
+}
+
+func GetNodeHostNameLabel(node *v1.Node) (string, error) {
 	hostname, ok := node.Labels[v1.LabelHostname]
 	if !ok {
 		return "", fmt.Errorf("hostname not found on the node")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
For non-portable OSDs on PVCs (e.g. local volumes), the host name of an OSD in the CRUSH map should actually be the host name. It was incorrectly being set to the PVC name, which should only be used for portable OSDs. Now the non-portable OSDs based on PVCs will correctly have the host name set to the node name.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
