### PR TITLE
Added required permissions to roles for ServiceMonitor and PrometheusRule deployment

### DIFF
--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -35,6 +35,18 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -614,6 +614,18 @@ rules:
   - create
   - update
   - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
 ---
 # The cluster role for managing the Rook CRDs
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR solves the issue when "monitoring" enabled in CephCluster. The operator tries to create ServiceMonitor and PrometheusRule objects but it fails with messages:
```
2020-01-12 22:20:55.169384 E | op-mgr: failed to enable service monitor. service monitor could not
be enabled: failed to create servicemonitor. servicemonitors.monitoring.coreos.com is forbidden: User
"system:serviceaccount:ceph:rook-ceph-system" cannot create resource "servicemonitors" in API
group "monitoring.coreos.com" in the namespace "ceph"

2020-01-12 22:20:55.222053 E | op-mgr: failed to deploy prometheus rule. prometheus rule could
not be deployed: failed to create prometheusRules. prometheusrules.monitoring.coreos.com is
forbidden: User "system:serviceaccount:ceph:rook-ceph-system" cannot create resource
"prometheusrules" in API group "monitoring.coreos.com" in the namespace "ceph"
```
These permissions presented in PR were tested after my adding to the role "rook-ceph-system" and confirmed - the operator was able to create mentioned monitoring objects successfully.

**Which issue is resolved by this Pull Request:**
Resolves N/A

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
