### PR TITLE
ceph : Change in operator-openshift.yaml the env variable ROOK_CURREN…

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -120,7 +120,7 @@ spec:
           name: default-config-dir
         env:
         - name: ROOK_CURRENT_NAMESPACE_ONLY
-          value: "true"
+          value: "false"
         # To disable RBAC, uncomment the following:
         # - name: RBAC_ENABLED
         #  value: "false"


### PR DESCRIPTION
…T_NAMESPACE_ONLY to false

   When configuring a cephcluster CRD on a different namespace than rook-ceph, like for example when deploying a external cluster, we need to set ROOK_CURRENT_NAMESPACE_ONLY to true so the operator can watch for CRD modifications on other namespaces.

Closes: https://github.com/rook/rook/issues/4667
Signed-off-by: Daniel Parkes <dparkes@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]