### PR TITLE
Add K8s 1.11 to the integration tests for Rook v1.2 

### DIFF
--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -14,7 +14,7 @@ from other pods running in your cluster.
 
 ## Minimum Version
 
-Kubernetes **v1.10** or higher is supported by Rook.
+Kubernetes **v1.11** or higher is supported by Rook.
 
 ## Prerequisites
 

--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -9,7 +9,7 @@ Rook can be installed on any existing Kubernetes clusters as long as it meets th
 
 ## Minimum Version
 
-Kubernetes v1.10 or higher is supported by Rook.
+Kubernetes v1.11 or higher is supported by Rook.
 
 ## Privileges and RBAC
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,11 +108,12 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,yugabytedb-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script{
                     def data = [
+                        "aws_1.11.x": "v1.11.10",
                         "aws_1.12.x": "v1.12.10",
-                        "aws_1.13.x": "v1.13.11",
-                        "aws_1.14.x": "v1.14.7",
-                        "aws_1.15.x": "v1.15.4",
-                        "aws_1.16.x": "v1.16.0"
+                        "aws_1.13.x": "v1.13.12",
+                        "aws_1.14.x": "v1.14.10",
+                        "aws_1.15.x": "v1.15.7",
+                        "aws_1.16.x": "v1.16.4"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -40,7 +40,7 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	blockMinimalTestVersion        = "1.12.0"
+	blockMinimalTestVersion        = "1.11.0,1.12.0"
 	multiClusterMinimalTestVersion = "1.13.0"
 	helmMinimalTestVersion         = "1.14.0"
 	upgradeMinimalTestVersion      = "1.15.0"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With production environments remaining up for much longer than the lifetime of upstream k8s releases due to the downstream releases of k8s, let's keep running more versions of k8s in the integration tests to give some assurance that Rook will continue to run in those older K8s versions. If an older release of K8s hits an issue with a Rook change we will evaluate whether we can continue to support that version. But there is no technical reason that Rook wouldn't currently run at least back to 1.11.

**Which issue is resolved by this Pull Request:**
Resolves #4548 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
