### PR TITLE
Allow integration tests in minimal config to run on multiple versions

### DIFF
--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -52,5 +52,4 @@ func init() {
 	flag.StringVar(&Env.LoadSize, "load_size", "medium", "load size for each thread performing operations - small,medium or large.")
 	flag.BoolVar(&Env.EnableChaos, "enable_chaos", false, "used to determine if random pods in a namespace are to be killed during load test.")
 	flag.StringVar(&Env.Logs, "logs", "", "Gather rook logs, eg - all")
-	flag.Parse()
 }

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -101,10 +101,11 @@ func (k8sh *K8sHelper) VersionAtLeast(minVersion string) bool {
 	return v.AtLeast(version.MustParseSemantic(minVersion))
 }
 
-func (k8sh *K8sHelper) VersionMinorMatches(minVersion string) bool {
-	v := version.MustParseSemantic(k8sh.GetK8sServerVersion())
+func (k8sh *K8sHelper) VersionMinorMatches(minVersion string) (string, bool) {
+	kubeVersion := k8sh.GetK8sServerVersion()
+	v := version.MustParseSemantic(kubeVersion)
 	requestedVersion := version.MustParseSemantic(minVersion)
-	return v.Major() == requestedVersion.Major() && v.Minor() == requestedVersion.Minor()
+	return kubeVersion, v.Major() == requestedVersion.Major() && v.Minor() == requestedVersion.Minor()
 }
 
 func (k8sh *K8sHelper) MakeContext() *clusterd.Context {

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -39,6 +39,7 @@ const (
 	// UPDATE these versions when the integration test matrix changes
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
+	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
 	blockMinimalTestVersion        = "1.13.0"
 	multiClusterMinimalTestVersion = "1.14.0"
 	helmMinimalTestVersion         = "1.15.0"
@@ -113,11 +114,21 @@ func checkIfShouldRunForMinimalTestMatrix(t func() *testing.T, k8sh *utils.K8sHe
 		logger.Infof("running all tests")
 		return
 	}
-	if !k8sh.VersionMinorMatches(version) {
-		logger.Infof("Skipping test suite since kube version is not minor version %s", version)
+	versions := strings.Split(version, ",")
+	logger.Infof("checking if tests are running on k8s %q", version)
+	matchedVersion := false
+	kubeVersion := ""
+	for _, v := range versions {
+		kubeVersion, matchedVersion = k8sh.VersionMinorMatches(v)
+		if matchedVersion {
+			break
+		}
+	}
+	if !matchedVersion {
+		logger.Infof("Skipping test suite since kube version %q does not match", kubeVersion)
 		t().Skip()
 	}
-	logger.Infof("Running test suite since kube version is minor version %s", version)
+	logger.Infof("Running test suite since kube version is %q", kubeVersion)
 }
 
 // StartTestCluster creates new instance of TestCluster struct


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the tests run in a PR, they can only run against a single version of K8s by default. If more than five k8s versions are supported in the CI, we will need to run some of the suites on multiple versions. The versions are comma-separated in the list.

Running integration tests locally on k8s 1.13 was causing an error with parsing the command line flags. The tests can't call flags.Parse() from an init() method.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
