### PR TITLE
Ceph: MDS pod placement adheres to fault domain topology

### DIFF
--- a/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
@@ -52,9 +52,21 @@ spec:
                 operator: In
                 values:
                 - rook-ceph-mds
-            # topologyKey: failure-domain.beta.kubernetes.io/zone can be used to spread MDS across different AZ
             # topologyKey: kubernetes.io/hostname will place MDS across different hosts
             topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - rook-ceph-mds
+                # topologyKey: */zone can be used to spread MDS across different AZ
+                # Use <topologyKey: failure-domain.beta.kubernetes.io/zone> in k8s cluster if your cluster is v1.16 or lower
+                # Use <topologyKey: topology.kubernetes.io/zone>  in k8s cluster is v1.17 or upper
+                topologyKey: topology.kubernetes.io/zone
     # A key/value list of annotations
     annotations:
     #  key: value

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -50,9 +50,21 @@ spec:
                 operator: In
                 values:
                 - rook-ceph-mds
-            # topologyKey: failure-domain.beta.kubernetes.io/zone can be used to spread MDS across different AZ
             # topologyKey: kubernetes.io/hostname will place MDS across different hosts
             topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - rook-ceph-mds
+              # topologyKey: */zone can be used to spread MDS across different AZ
+              # Use <topologyKey: failure-domain.beta.kubernetes.io/zone> in k8s cluster if your cluster is v1.16 or lower
+              # Use <topologyKey: topology.kubernetes.io/zone>  in k8s cluster is v1.17 or upper
+              topologyKey: topology.kubernetes.io/zone
     # A key/value list of annotations
     annotations:
     #  key: value

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -120,6 +120,7 @@ func (c *Cluster) Start() error {
 
 	// Always create double the number of metadata servers to have standby mdses available
 	replicas := c.fs.Spec.MetadataServer.ActiveCount * 2
+
 	// keep list of deployments we want so unwanted ones can be deleted later
 	desiredDeployments := map[string]bool{} // improvised set
 	// Create/update deployments


### PR DESCRIPTION
**Description of your changes:**
With this modification is guaranteed that at least 1 MDS pod is going to be
placed in each of the available zones in the k8s cluster.
This would be improved in the future using: "Pod Topology Spread Constraints"
<Pod Topology Spread Constraints> (still in alpha state since kubernetes V.1.16)

This modification obtain the number of zones in the k8s cluster and appends an
<antiaffinity> term using the topologyKey
<topology.kubernetes.io/zone> in the same number of MDS pods.
In the case that will be more MDS pods than zones, the <antiaffinity> term won't
be added in these extra pods.

Important Note:
The antiaffiniy term only will work with nodes labeled using the NEW label:
 <topology.kubernetes.io/zone> present in k8s V.1.17 clusters.
For previous versions of k8s clusters the label used is:
 <failure-domain.beta.kubernetes.io/zone>
And therefore, in this kind of clusters this modification won't work.

Resolves #4641

[test ceph]

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
