### PR TITLE
ceph: finalizer for OBC cleanup

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -20,8 +20,10 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	bktclient "github.com/kube-object-storage/lib-bucket-provisioner/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -44,8 +46,15 @@ var ObjectStoreResource = k8sutil.CustomResource{
 	Kind:    reflect.TypeOf(cephv1.CephObjectStore{}).Name(),
 }
 
+var (
+	finalizerName                  = fmt.Sprintf("%s.%s", ObjectStoreResource.Name, ObjectStoreResource.Group)
+	objectstoreDeleteRetryInterval = 2 * time.Second
+	objectstoreDeleteMaxRetries    = 15
+)
+
 // ObjectStoreController represents a controller object for object store custom resources
 type ObjectStoreController struct {
+	bktclient          bktclient.Interface
 	clusterInfo        *daemonconfig.ClusterInfo
 	clusterSpec        *cephv1.ClusterSpec
 	context            *clusterd.Context
@@ -117,6 +126,11 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 	}
 	c.createOrUpdateStore(objectStore)
 	updateCephObjectStoreStatus(objectStore.GetName(), objectStore.GetNamespace(), k8sutil.ReadyStatus, c.context)
+	err = c.addFinalizer(objectStore.GetNamespace(), objectStore.GetName())
+	if err != nil {
+		logger.Errorf("failed to add finalizer to objectStore crd. %v", err)
+		return
+	}
 }
 
 func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
@@ -135,6 +149,29 @@ func (c *ObjectStoreController) onUpdate(oldObj, newObj interface{}) {
 	if err != nil {
 		logger.Errorf("failed to get new objectstore object. %v", err)
 		return
+	}
+
+	// Check if the objectstore is being deleted. This code path is called when a finalizer is specified in the crd.
+	// When an objectstore is requested for deletion, K8s will only set the deletion timestamp if there are any finalizers in the list.
+	// K8s will only delete the crd and child resources when the finalizers have been removed from the crd.
+	if !newStore.DeletionTimestamp.IsZero() {
+		logger.Infof("objectstore %q has a deletion timestamp", newStore.Namespace)
+		err := c.handleDelete(newStore)
+		if err != nil {
+			logger.Errorf("failed finalizer for objectstore. %v", err)
+			return
+		}
+		// remove the finalizer from the crd, which indicates to k8s that the resource can safely be deleted
+		c.removeFinalizer(newStore)
+		return
+	} else {
+		if !c.hasFinalizer(newStore) {
+			err := c.addFinalizer(newStore.GetNamespace(), newStore.GetName())
+			if err != nil {
+				logger.Errorf("failed to add finalizer to objectStore crd. %v", err)
+				return
+			}
+		}
 	}
 
 	if !storeChanged(oldStore.Spec, newStore.Spec) {
@@ -181,10 +218,48 @@ func (c *ObjectStoreController) onDelete(obj interface{}) {
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
 
+	err = c.handleDelete(objectstore)
+	if err != nil {
+		logger.Errorf("failed to delete objectstore. %v", err)
+	}
+
 	cfg := clusterConfig{context: c.context, store: *objectstore}
 	if err = cfg.deleteStore(); err != nil {
 		logger.Errorf("failed to delete object store %q. %v", objectstore.Name, err)
 	}
+}
+
+func (c *ObjectStoreController) handleDelete(objectstore *cephv1.CephObjectStore) error {
+	for retryCount := 0; retryCount < objectstoreDeleteMaxRetries; retryCount++ {
+
+		selector := fmt.Sprintf("metadata.namespace=%s", objectstore.Namespace)
+		objectBuckets, err := c.bktclient.ObjectbucketV1alpha1().ObjectBuckets().List(metav1.ListOptions{FieldSelector: selector})
+		if err != nil {
+			return errors.Wrapf(err, "failed to get buckets for objectstore %q in namespace %q", objectstore.Name, objectstore.Namespace)
+		}
+		if len(objectBuckets.Items) == 0 {
+			logger.Infof("no objectbuckets for objectstore %q to clean up.", objectstore.Namespace)
+			break
+		}
+
+		retryCount++
+		if retryCount == objectstoreDeleteMaxRetries {
+			bucketNames := make([]string, 0)
+			for _, bucket := range objectBuckets.Items {
+				bucketNames = append(bucketNames, bucket.Name)
+			}
+			logger.Warningf(
+				"exceeded retry count while waiting for buckets for objectstore %q to be cleaned up. buckets: %+v",
+				objectstore.Namespace,
+				bucketNames)
+			break
+		}
+
+		logger.Infof("waiting for buckets in objectstore %q to be cleaned up. Retrying in %q.",
+			objectstore.Namespace, objectstoreDeleteRetryInterval.String())
+		<-time.After(objectstoreDeleteRetryInterval)
+	}
+	return nil
 }
 
 // ParentClusterChanged determines wether or not a CR update has been sent
@@ -297,4 +372,90 @@ func updateCephObjectStoreStatus(name, namespace, status string, context *cluste
 		logger.Errorf("Unable to update the cephObjectStore %s status %v", updatedCephObjectStore.GetName(), err)
 		return
 	}
+}
+
+// ************************************************************************************************
+// Finalizer functions
+// ************************************************************************************************
+// Returns a bool indicating whether the finalizer (cephobjectstore.ceph.rook.io) is defined on the objectstore CRD
+func (c *ObjectStoreController) hasFinalizer(objectstore *cephv1.CephObjectStore) bool {
+	for _, finalizer := range objectstore.Finalizers {
+		if finalizer == finalizerName {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *ObjectStoreController) addFinalizer(namespace, name string) error {
+
+	// get the latest objectstore object since we probably updated it before we got to this point (e.g. by updating its status)
+	objectstore, err := c.context.RookClientset.CephV1().CephObjectStores(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to find objectstore %q", name)
+	}
+
+	if c.hasFinalizer(objectstore) {
+		return nil
+	}
+
+	// adding finalizer to the objectstore crd
+	objectstore.Finalizers = append(objectstore.Finalizers, finalizerName)
+
+	// update the crd
+	_, err = c.context.RookClientset.CephV1().CephObjectStores(objectstore.Namespace).Update(objectstore)
+	if err != nil {
+		return errors.Wrapf(err, "failed to add finalizer to objectstore %q", name)
+	}
+
+	logger.Infof("added finalizer to objectstore %q", objectstore.Name)
+	return nil
+}
+
+func (c *ObjectStoreController) removeFinalizer(obj interface{}) {
+	// first determine what type/version of cluster we are dealing with
+
+	os, ok := obj.(*cephv1.CephObjectStore)
+	if !ok {
+		logger.Warningf("cannot remove finalizer from object that is not an objectstore. %+v", obj)
+		return
+	}
+
+	// update the crd to remove the finalizer for good. retry several times in case of intermittent failures.
+	maxRetries := 5
+	retrySeconds := 5 * time.Second
+	for i := 0; i < maxRetries; i++ {
+		// Get the latest objectstore instead of using the same instance in case it has been changed
+		objectstore, err := c.context.RookClientset.CephV1().CephObjectStores(os.Namespace).Get(os.Name, metav1.GetOptions{})
+		if err != nil {
+			logger.Errorf("failed to remove finalizer. failed to get cluster. %v", err)
+			return
+		}
+		objectMeta := &objectstore.ObjectMeta
+
+		// remove the finalizer from the slice if it exists
+		found := false
+		for i, finalizer := range objectMeta.Finalizers {
+			if finalizer == finalizerName {
+				objectMeta.Finalizers = append(objectMeta.Finalizers[:i], objectMeta.Finalizers[i+1:]...)
+				found = true
+				break
+			}
+		}
+		if !found {
+			logger.Infof("finalizer %q not found in the objectstore crd %q", finalizerName, objectMeta.Name)
+			return
+		}
+
+		_, err = c.context.RookClientset.CephV1().CephObjectStores(objectstore.Namespace).Update(objectstore)
+		if err != nil {
+			logger.Errorf("failed to remove finalizer %q from objectstore %q. %v", finalizerName, objectMeta.Name, err)
+			time.Sleep(retrySeconds)
+			continue
+		}
+		logger.Infof("removed finalizer %q from objectstore %q", finalizerName, objectMeta.Name)
+		return
+	}
+
+	logger.Warningf("giving up from removing the %q objectstore finalizer", finalizerName)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Rook already has a finalizer to ensure that PVCs are removed
before CephClusters, but lacks a similar mechanism for OBCs
provisioned through RGW. This patch adds a finalizer to ensure
cleanup of these resources before the deletion of an ObjectStore.

Note: WIP; this needs additional testing. Still, posting to check
early impressions on whether this is the right track. I'm also
very happy to consolidate similar code between the
ClusterController and ObjectStoreController; in the end not a
great deal of code could be reasonably centralized but some amount
of duplication could be pushed to ks8util.

**Which issue is resolved by this Pull Request:**
Resolves: #4486
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
