### PR TITLE
ceph: add securePort values for objectstore integration tests

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -318,11 +318,7 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 65535
-                securePort:
-                  type: integer
-                  minimum: 1
-                  maximum: 65535
-                  nullable: true
+                securePort: {}
                 instances:
                   type: integer
                 annotations: {}

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -372,11 +372,7 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 65535
-                securePort:
-                  type: integer
-                  minimum: 1
-                  maximum: 65535
-                  nullable: true
+                securePort: {}
                 instances:
                   type: integer
                 annotations: {}

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.1-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.1-crds.yaml
@@ -290,11 +290,7 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 65535
-                securePort:
-                  type: integer
-                  minimum: 1
-                  maximum: 65535
-                  nullable: true
+                securePort: {}
                 instances:
                   type: integer
                 annotations: {}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -342,6 +342,10 @@ func validateStore(context *clusterd.Context, s cephv1.CephObjectStore) error {
 	if s.Namespace == "" {
 		return errors.New("missing namespace")
 	}
+	securePort := s.Spec.Gateway.SecurePort
+	if securePort < 0 || securePort > 65535 {
+		return errors.Errorf("securePort value of %d must be between 0 and 65535", securePort)
+	}
 	if err := pool.ValidatePoolSpec(context, s.Namespace, &s.Spec.MetadataPool); err != nil {
 		return errors.Wrapf(err, "invalid metadata pool spec")
 	}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -391,11 +391,7 @@ spec:
                   type: integer
                   minimum: 1
                   maximum: 65535
-                securePort:
-                  type: integer
-                  minimum: 1
-                  maximum: 65535
-                  nullable: true
+                securePort: {}
                 instances:
                   type: integer
                 annotations: {}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Recent integration tests have failed due to a null value in the
securePort field in their CephObjectStore manifests. This patch
adds a standard 443 value for these fields.

**Which issue is resolved by this Pull Request:**
Fixes: #4693
Signed-off-by: Elise Gafford <egafford@redhat.com>

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]