### PR TITLE
Skip the upgrade checks in integration tests

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1711,6 +1711,7 @@ spec:
     allowMultiplePerNode: true
   dashboard:
     enabled: true
+  skipUpgradeChecks: true
   rbdMirroring:
     workers: ` + strconv.Itoa(settings.RBDMirrorWorkers) + `
   metadataDevice:

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -158,10 +158,11 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	oldCephVersion := d.Labels["ceph-version"] // upgraded OSDs should not have this version label
 
 	//
-	// Upgrade Ceph version from Mimic to Nautilus before upgrading to Rook v1.1
+	// Upgrade Ceph version from Mimic to Nautilus before upgrading to Rook v1.1.
+	// Set the skipUpgradeChecks flag since we're not fully waiting for Ceph health during the tests.
 	//
 	s.k8sh.Kubectl("-n", s.namespace, "patch", "CephCluster", s.namespace, "--type=merge",
-		"-p", fmt.Sprintf(`{"spec": {"cephVersion": {"image": "%s"}}}`, installer.NautilusVersion.Image))
+		"-p", fmt.Sprintf(`{"spec": {"cephVersion": {"image": "%s"}, "skipUpgradeChecks": "true"}}`, installer.NautilusVersion.Image))
 
 	// we need to make sure Ceph is fully updated (including RGWs and MDSes) before proceeding to
 	// upgrade rook; we do not support upgrading Ceph simultaneously with Rook upgrade


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests only have a single node so the upgrade checks do not provide any real safety for the cluster during the upgrade. We will be able to improve the reliability and speed of the tests by disabling these checks. In particular, the filesystem update spends a lot of time waiting for the mds daemons.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]