### PR TITLE
osd: fix misleading log messages when matching device filters

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -323,7 +323,10 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 						logger.Errorf("regex failed on device %q and filter %q. %v", device.Name, desiredDevice.Name, err)
 						continue
 					}
-					logger.Infof("device %q matches device filter %q: %t", device.Name, desiredDevice.Name, matched)
+
+					if matched {
+						logger.Infof("device %q matches device filter %q", device.Name, desiredDevice.Name)
+					}
 				} else if desiredDevice.IsDevicePathFilter {
 					pathnames := append(strings.Fields(device.DevLinks), filepath.Join("/dev", device.Name))
 					for _, pathname := range pathnames {
@@ -332,11 +335,12 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 							logger.Errorf("regex failed on device %q and filter %q. %v", device.Name, desiredDevice.Name, err)
 							continue
 						}
+
 						if matched {
+							logger.Infof("device %q (aliases: %q) matches device path filter %q", device.Name, device.DevLinks, desiredDevice.Name)
 							break
 						}
 					}
-					logger.Infof("device %q (aliases: %q) matches device path filter %q: %t", device.Name, device.DevLinks, desiredDevice.Name, matched)
 				} else if device.Name == desiredDevice.Name {
 					logger.Infof("%q found in the desired devices", device.Name)
 					matched = true


### PR DESCRIPTION
Signed-off-by: Dustin Guerrero <dguerrero@twilio.com>

**Description of your changes:**
Changes device filter log messages to only print when a match actually occurs.

**Which issue is resolved by this Pull Request:**
Resolves #4711 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
