### PR TITLE
Governance updates including a steering committee

### DIFF
--- a/CODE-OWNERS
+++ b/CODE-OWNERS
@@ -1,8 +1,9 @@
-# Code ownership file that specifies approvers and reviewers for all areas of the Rook codebase.
+# Code ownership file that specifies maintainers and reviewers for all areas of the Rook codebase.
 # all: These members have the given role for all areas of the codebase.
-# common: The rook.io common types, specs, logic, etc.
-# build: The top level makefile, as well as the scripts and makefiles in the `build` directory.
-# All other areas are for specific storage providers and covers all portions of code that is specific to their project.
+# Specific storage provider ownership and covers all portions of code that is specific to their project.
+# Maintainers have push access to merge PRs after approved by another maintainer or reviewer.
+# With the intention of using the Prow bot in the future, the term "approver" is used below.
+# An approver is equivalent to a Rook maintainer for all intents and purposes as described in the Rook governance.
 
 areas:
   all:
@@ -10,18 +11,11 @@ areas:
     - travisn
     - galexrt
     - jbw976
-  common:
-    approvers:
-    - bassam
-  build:
-    approvers:
-    - bassam
   ceph:
     approvers:
+    - travisn
     - BlaineEXE
     - leseb
-    reviewers:
-    - noahdesu
   edgefs:
     approvers:
     - dyusupov
@@ -33,4 +27,7 @@ areas:
   nfs:
     reviewers:
     - rohan47
-  cockroachdb:
+  yugabytedb:
+    approvers:
+    - Arnav15
+    - samkulkarni20

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ The model for approving changes is largely based on the [Kubernetes code review 
 where a set of roles are defined for different portions of the code base and have different responsibilities:
 
 * **Reviewers** are able to review code for quality and correctness on some part of the project, but cannot merge changes.
-* **Approvers** are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution. Approvers can merge changes.
+* **Maintainers** are able to both review and approve code contributions. While code review is focused on code quality and correctness, approval is focused on holistic acceptance of a contribution. Maintainers can merge changes. (A Rook maintainer is similar in scope to a K8s approver in the link above.)
 
 Both of these roles will require a time commitment to the project in order to keep the change approval process moving forward at a reasonable pace.
 When automation is implemented to auto assign members to review pull requests, it will be done in a round-robin fashion, so all members must be able to dedicate the time needed.
@@ -130,11 +130,11 @@ Note that neither of these roles have voting powers in conflict resolution, thes
 The general flow for a pull request approval process is as follows:
 
 1. Author submits the pull request
-1. Reviewers and approvers for the applicable code areas review the pull request and provide feedback that the author integrates
-1. Reviewers and/or approvers signify their LGTM on the pull request
-1. An approver approves the pull request based on at least one LGTM from the previous step
-    1. Note that the approver can heavily lean on the reviewer for examining the pull request at a finely grained detailed level. The reviewers are trusted members and approvers can leverage their efforts to reduce their own review burden.
-1. An approver merges the pull request into the target branch (master, release, etc.)
+1. Reviewers and maintainers for the applicable code areas review the pull request and provide feedback that the author integrates
+1. Reviewers and/or maintainers signify their LGTM on the pull request
+1. A maintainer approves the pull request based on at least one LGTM from the previous step
+    1. Note that the maintainer can heavily lean on the reviewer for examining the pull request at a finely grained detailed level. The reviewers are trusted members and maintainers can leverage their efforts to reduce their own review burden.
+1. A maintainer merges the pull request into the target branch (master, release, etc.)
 
 ### Role Assignments
 
@@ -144,12 +144,12 @@ All roles will be assigned by the usage of [`CODE-OWNERS`](CODE-OWNERS) files co
 These assignments will be initially be defined in a single file at the root of the repo and it will describe all assigned roles for the entire code base.
 As we incorporate automation (i.e. bots) into this change acceptance process in the future, we can reorganize this initial single owners file into separate files amongst the codebase as the automation necessitates.
 
-The format of the file can start with simply listing the reviewers and approvers for areas of the code base using a YAML format:
+The format of the file can start with simply listing the reviewers and maintainers for areas of the code base using a YAML format:
 
 ```yaml
 areas:
   feature-foo:
-    approvers:
+    maintainers:
     - alice
     - bob
     reviewers:
@@ -158,22 +158,22 @@ areas:
 
 #### Update Process
 
-The process for adding or removing reviewers/approvers is described in the [project governance](GOVERNANCE.md#updating-change-approval-roles).
+The process for adding or removing reviewers/maintainers is described in the [project governance](GOVERNANCE.md#updating-change-approval-roles).
 
 ### Permissions
 
 Role assignees will be made part of the following Rook organization teams with the given permissions:
 
 * **Reviewers:** added to a new Reviewers team so they have write permissions to the repo to assign issues, add labels to issues, add issues to milestones and projects, etc. but cannot merge to protected branches such as `master` and `release-*`.
-* **Approvers:** added to a new Approvers team that will have access to merge to protected branches.
+* **Maintainers:** added to a Maintainers team that has access to merge to protected branches.
 
 ### Automation
 
-This process can be further improved by automation and bots to automatically assign the PR to reviewers/approvers, add labels to the PR, and merge the PR.
+This process can be further improved by automation and bots to automatically assign the PR to reviewers/maintainers, add labels to the PR, and merge the PR.
 We should explore this further with some experimentation and potentially leveraging what Kubernetes has done, but automation isn’t strictly required to adopt and implement this model.
 
 ### Alternatives Considered
 
 The built in support in Github for [`CODEOWNERS`](https://help.github.com/en/articles/about-code-owners) files was considered.
 However, this only supports the automated assignment of reviewers to pull requests.
-It has no tiering or differentiation between roles like the proposed approvers/reviewers model has and is therefore not a good fit.
+It has no tiering or differentiation between roles like the proposed maintainers/reviewers model has and is therefore not a good fit.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,133 +2,140 @@
 
 This document defines governance policies for the Rook project.
 
-## Maintainer Roles
+## Steering Committee
 
-Rook uses a two-tiered system of maintainer roles:
+Steering committee members demonstrate a strong commitment to the project with views in the interest of the broader Rook project.
 
-* Senior Maintainers
-  * Have the most experience with the Rook project and are expected to have the knowledge and insight to lead the project's growth and improvement
-  * Represent their organization within the Rook community
-  * Oversee the process for adding new maintainers and provides guidance for the standard maintainers
-  * Receive **two votes** in the [conflict resolution and voting process](#conflict-resolution-and-voting) described below
-* Standard Maintainers
-  * Have less experience with the Rook project than senior maintainers, but are also expected to provide significant value to the project, helping it grow and improve
-  * Receive **one vote** in the voting process
+Responsibilities include:
 
-## Becoming a maintainer
+* Own the overall direction of the Rook project
+* Provide guidance for the project maintainers and oversee the process for adding new maintainers
+* Participate in the [conflict resolution and voting process](#conflict-resolution-and-voting) when necessary
+* Actively participate in the regularly scheduled steering committee meetings
+* Regularly attend the recurring [community meetings](README.md#community-meeting)
 
-The current list of maintainers is published and updated in [OWNERS.md](OWNERS.md).
+The current list of steering committee members is published and updated in [OWNERS.md](OWNERS.md#steering-committee).
 
-### Maintainer Pre-requisites
+### Becoming a Steering Committee Member
+
+* Each storage provider has at most a single member on the steering committee.
+* Storage providers declared as stable in Rook should have a representative on the steering committee.
+* Storage providers that are on track to be declared stable soon may have a representative on the steering committee.
+* Steering committee members are likely members of the Rook maintainers group and are contributing consistently to Rook.
+  If the member (or proposed member) is not a maintainer, they must have demonstrated consistent vision and input
+  for the good of the project with the big picture in mind.
+* No company may hold the majority seats on the steering committee. If this happens due to changing companies,
+  a member of the committee from that company must be replaced.
+
+If you meet these requirements, express interest to the steering committee directly that your organization is interested in joining the steering committee.
+
+### Removing a steering committee member
+
+If a steering committee member is no longer interested or cannot perform the duties listed above, they
+should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of
+the steering committee members per the voting process below.
+
+## Maintainer Role
+
+Maintainers have the most experience with the Rook project and are expected to have the knowledge
+and insight to lead the project's growth and improvement.
+
+Responsibilities include:
+
+* Represent their organization and storage provider within the Rook community
+* Strong commitment to the project
+* Participate in design and technical discussions
+* Contribute non-trivial pull requests
+* Perform code reviews on other's pull requests
+* Regularly triage GitHub issues. The areas of specialization listed in [OWNERS.md](OWNERS.md) can be used to help with routing
+  an issue/question to the right person.
+* Make sure that ongoing PRs are moving forward at the right pace or closing them
+* Monitor Rook email aliases
+* Monitor Rook Slack (delayed response is perfectly acceptable), particularly for the area of your
+  storage provider
+* Regularly attend the recurring [community meetings](README.md#community-meeting)
+* Periodically attend the recurring steering committee meetings to provide input
+* In general continue to be willing to spend at least 25% of ones time working on Rook (~1.25
+  business days per week)
+
+The current list of maintainers is published and updated in [OWNERS.md](OWNERS.md#maintainers).
+
+### Reviewer Role
+
+Reviewers have similar responsibilities as maintainers, with the differences listed in the [Change Approval](CONTRIBUTING.md#change-approval)
+roles of the developer guide. Rules for adding and removing reviewers will follow the same guidelines as
+adding and removing maintainers as described below.
+
+### Becoming a maintainer
 
 To become a maintainer you need to demonstrate the following:
 
-* A strong commitment to the project
-  * Participate in design and technical discussions
-  * Contribute non-trivial pull requests
-  * Perform code reviews on other's pull requests
-  * Answer user questions and troubleshoot issues in the field
-* Ability to write good solid code
-* Ability to collaborate with the team
-* Understanding of how the team works (policies, processes for testing and code review, etc.)
-* Understanding of the project's code base and coding style
+* Consistently be seen as a leader in the Rook community by fulfilling the Maintainer responsibilities
+  listed above to some degree.
+* Domain expertise for at least one of the Rook storage providers
+* Be extremely proficient with Kubernetes and Golang
+* Consistently demonstrate:
+  * Ability to write good solid code
+  * Ability to collaborate with the team
+  * Understanding of how the team works (policies, processes for testing and code review, etc.)
+  * Understanding of the project's code base and coding style
 
-### Your organization is not yet a maintainer
+Beyond your contributions to the project, consider:
 
-* Express interest to the [senior maintainers](OWNERS.md#senior-maintainers) directly that your
-  organization is interested in becoming a maintainer. Becoming a maintainer generally means that
-  you are going to be spending substantial time (>25%) on Rook for the foreseeable future. You
-  should have domain expertise and be extremely proficient with Kubernetes and Golang.  Ultimately
-  your goal is to become a senior maintainer that will represent your organization.
-* You should likely have already been commenting on pull requests and issues with the intent of solving
-  user problems and improving the overall quality of the project.
-* We will expect you to start contributing increasingly complicated PRs, under the guidance
-  of the existing senior maintainers.
+* If your storage provider or organization already have a Rook maintainer, more maintainers may not be needed.
+  A valid reason is "blast radius" for a large storage provider or organization
+* Becoming a maintainer generally means that you are going to be spending substantial time (>25%)
+  on Rook for the foreseeable future.
+
+If you are meeting these requirements, express interest to the [steering committee](OWNERS.md#steering-committee) directly that your
+organization is interested in adding a maintainer.
+
 * We may ask you to do some PRs from our backlog.
 * As you gain experience with the code base and our standards, we will ask you to do code reviews
   for incoming PRs (i.e., all maintainers are expected to shoulder a proportional share of
   community reviews).
 * After a period of approximately 2-3 months of working together and making sure we see eye to eye,
-  the existing senior maintainers will confer and decide whether to grant maintainer status or not.
+  the steering committee will confer and decide whether to grant maintainer status or not.
   We make no guarantees on the length of time this will take, but 2-3 months is the approximate
   goal.
 
-### Your organization is currently a maintainer
-
-* First decide whether your organization really needs more people with maintainer access. Valid
-  reasons are "blast radius", a large organization that is working on multiple unrelated projects,
-  etc.
-* Contact a senior maintainer for your organization and express interest.
-* Start doing PRs and code reviews under the guidance of your senior maintainer.
-* After a period of 1-2 months the existing senior maintainers will discuss granting "standard"
-  maintainer access.
-* "Standard" maintainer access can be upgraded to "senior" maintainer access after another 1-2
-  months of work and another conference of the existing senior committers.
-
-## Removing a maintainer
+### Removing a maintainer
 
 If a maintainer is no longer interested or cannot perform the maintainer duties listed above, they
 should volunteer to be moved to emeritus status. In extreme cases this can also occur by a vote of
 the maintainers per the voting process below.
 
-## Maintainer responsibilities
-
-* Monitor email aliases.
-* Monitor Slack (delayed response is perfectly acceptable).
-* Attend the regularly recurring [community meetings](README.md#community-meeting).
-* Triage GitHub issues and perform pull request reviews for other maintainers and the community.
-  The areas of specialization listed in [OWNERS.md](OWNERS.md) can be used to help with routing
-  an issue/question to the right person.
-* During GitHub issue triage, apply all applicable [labels](https://github.com/rook/rook/labels)
-  to each new issue. Labels are extremely useful for future issue follow up. Which labels to apply
-  is somewhat subjective so just use your best judgment. A few of the most important labels that are
-  not self explanatory are:
-  * **beginner**: Mark any issue that can reasonably be accomplished by a new contributor with
-    this label.
-  * **help wanted**: Unless it is immediately obvious that someone is going to work on an issue (and
-    if so assign it), mark it help wanted.
-  * **question**: If it's unclear if an issue is immediately actionable, mark it with the
-    question label. Questions are easy to search for and close out at a later time. Questions
-    can be promoted to other issue types once it's clear they are actionable (at which point the
-    question label should be removed).
-* Make sure that ongoing PRs are moving forward at the right pace or closing them.
-* In general continue to be willing to spend at least 25% of ones time working on Rook (~1.25
-  business days per week).
 
 ### Github Project Administration
 
 Maintainers will be added to the Rook GitHub organization (if they are not already) and added to
 the GitHub Maintainers team.
 
-After 6 months, **senior** maintainers will be made an "owner" of the Rook GitHub organization.
-
 ## Updating Change Approval Roles
 
 The full change approval process is described in the [contributing guide](CONTRIBUTING.md#change-approval).
 
-All new reviewers and approvers must be nominated by someone (anyone) opening a pull request that adds the nominated person’s name to the appropriate [`CODE-OWNERS`](CODE-OWNERS) files in the appropriate roles.
-Similarly, to remove a reviewer or approver, a pull request should be opened that removes their name from the appropriate [`CODE-OWNERS`](CODE-OWNERS) files.
+All new steering committee members and maintainers must be nominated by someone (anyone) opening a pull request that adds the nominated person’s name to the appropriate [`CODE-OWNERS`](CODE-OWNERS) files in the appropriate roles.
+Similarly, to remove a steering committee member or maintainer, a pull request should be opened that removes their name from the appropriate [`CODE-OWNERS`](CODE-OWNERS) files.
 
-The maintainer team will approve this update in the standard voting and conflict resolution process.
-Note that new reviewer/approver nominations do not go through the standard pull request approval described in the [contributing guide](CONTRIBUTING.md#change-approval), only the maintainer team can approve updates of members to the change approval roles.
+The steering committee will approve this update in the standard voting and conflict resolution process.
+Note that new nominations do not go through the standard pull request approval described in the [contributing guide](CONTRIBUTING.md#change-approval).
+Only the steering committee team can approve updates of members to the steering committee or maintainer roles.
 
 ## Conflict resolution and voting
 
-As previously mentioned, senior maintainers receive **2 votes** each and standard maintainers
-receive 1 vote each.
-
 In general, we prefer that technical issues and maintainer membership are amicably worked out
-between the persons involved. If a dispute cannot be decided independently, the maintainers can be
-called in to decide an issue. If the maintainers themselves cannot decide an issue, the issue will
-be resolved by voting. The voting process is a simple majority (except for maintainer changes,
-which require 2/3 majority as described below) in which each senior maintainer receives two votes
-and each standard maintainer receives one vote.
+between the persons involved. If a dispute cannot be decided independently, the steering committee can be
+called in to decide an issue. If the steering committee members themselves cannot decide an issue, the issue will
+be resolved by voting. The voting process is a simple majority in which each steering committee member gets a single vote,
+except as noted below. Maintainers do not have a vote in conflict resolution, although steering committee members
+should consider their input.
 
 For formal votes, a specific statement of what is being voted on should be added to the relevant
-GitHub issue or PR. Maintainers should indicate their yes/no vote on that issue or PR, and after a
+GitHub issue or PR. Steering committee members should indicate their yes/no vote on that issue or PR, and after a
 suitable period of time (goal is by 5 business days), the votes will be tallied and the outcome
-noted. If any maintainers are unreachable during the voting period, postponing the completion of
+noted. If any steering committee members are unreachable during the voting period, postponing the completion of
 the voting process should be considered.
 
-Additions and removals of maintainers require a **2/3 majority**, while other decisions and changes
+Additions and removals of steering committee members or maintainers require a **2/3 majority**, while other decisions and changes
 require only a simple majority.

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,29 +1,44 @@
-# Rook Maintainers
+# Rook Contributors
 
-This page lists all active maintainers and their areas of expertise. This can be used for routing PRs, questions, etc. to the right place.
+This page lists all active contributors and their areas of expertise. This can be used for routing PRs, questions, etc. to the right place.
 
 * See [CONTRIBUTING.md](CONTRIBUTING.md) for general contribution guidelines.
-* See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and maintainer responsibilities.
+* See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and steering committee and maintainer responsibilities.
 
-## Senior maintainers
+## Steering Committee
 
-* Bassam Tabbara <bassam@upbound.io> ([bassam](https://github.com/bassam))
-  * Catch-all, architecture, strategy, build and packaging
-* Travis Nielsen <tnielsen@redhat.com> ([travisn](https://github.com/travisn))
-  * Ceph, Operators/Orchestration, Test automation
-* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-  * Framework, APIs, CockroachDB
+Steering committee members will be added according to the [process for adding a steering committee member](GOVERNANCE.md#becoming-a-steering-committee-member) in the [governance](GOVERNANCE.md).
+
+| Name                                      | Represents  | Github                                  |
+| ----------------------------------------- | ----------- | --------------------------------------- |
+| Travis Nielsen <tnielsen@redhat.com>      | Ceph        | [travisn](https://github.com/travisn)   |
+| Jared Watts <jared@upbound.io>            | Independent | [jbw976](https://github.com/jbw976)     |
+| Dmitry Yusupov <dmitry.yusupov@gmail.com> | EdgeFS      | [dyusupov](https://github.com/dyusupov) |
 
 ## Maintainers
 
 Maintainers will be added according to the [process for adding a maintainer](GOVERNANCE.md#becoming-a-maintainer) in the [governance](GOVERNANCE.md).
 
+* Travis Nielsen <tnielsen@redhat.com> ([travisn](https://github.com/travisn))
+  * Ceph, Operators/Orchestration
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+  * Framework, APIs, CockroachDB
 * Alexander Trost <galexrt@googlemail.com> ([galexrt](https://github.com/galexrt))
   * Ceph, Operators/Orchestration, User support
+* Dmitry Yusupov <dmitry.yusupov@gmail.com> ([dyusupov](https://github.com/dyusupov))
+  * EdgeFS
+* Sebastien Han <shan@redhat.com> ([leseb](https://github.com/leseb))
+  * Ceph
+* Blaine Gardner <blaine.gardner@suse.com> ([BlaineEXE](https://github.com/BlaineEXE))
+  * Ceph
+* Yannis Zarkadas <yanniszarkadas@gmail.com> ([yanniszark](https://github.com/yanniszark))
+  * Cassandra
 
 ## Emeritus maintainers
 
-There are currently no emeritus maintainers.  This list will be updated according to the [process for removing a maintainer](GOVERNANCE.md#removing-a-maintainer) in the [governance](GOVERNANCE.md).
+This list will be updated according to the [process for removing a maintainer](GOVERNANCE.md#removing-a-maintainer) in the [governance](GOVERNANCE.md).
+
+* Bassam Tabbara <bassam@upbound.io> ([bassam](https://github.com/bassam))
 
 ## Code Owners
 
@@ -35,7 +50,6 @@ This section lists people that are not currently maintainers but have demonstrat
 They typically help out with technical, code and design reviews and also with support and troubleshooting.
 Feel free to loop them in as needed.
 
-* Blaine Gardner <blaine.gardner@suse.com> ([BlaineEXE](https://github.com/BlaineEXE))
 * Christian Hüning ([christianhuening](https://github.com/christianhuening))
 * Dan Kerns <kerns@pobox.com> ([DanKerns](https://github.com/DanKerns))
 * Dan Mick <dan.mick@redhat.com> ([dmick](https://github.com/dmick))
@@ -51,4 +65,3 @@ Feel free to loop them in as needed.
 * Rohan Gupta <rohanrgupta1996@gmail.com> ([rohan47](https://github.com/rohan47))
 * Sage Weil <sage@redhat.com> ([liewegas](https://github.com/liewegas))
 * Steve Leon <kokhang@gmail.com> ([kokhang](https://github.com/kokhang))
-* Tony Allen <tallen@lyft.com> ([tonya11en](https://github.com/tonya11en))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Updates and clarifications to the Rook governance including:
- Add a steering committee to oversee the project starting with three members: @jbw976 @dyusupov @travisn 
- Rename approvers to maintainers, who have push access to the repo
- Clarify process for adding and removing maintainers
- Move @bassam to emeritus maintainer
- Add reviewers for YugabyteDB
- Remove inactive reviewers
- Other clarifications for maintainer and reviewer responsibilities

Per requirements for current Rook governance, this must be approved by majority of current Rook maintainers before this is merged or the changes take effect.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]