### PR TITLE
ceph: add mds_join_fs option when running mds daemon

### DIFF
--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -87,6 +87,11 @@ func (c *Cluster) setDefaultFlagsMonConfigStore(mdsID string) error {
 		configOptions["mds_standby_replay"] = strconv.FormatBool(c.fs.Spec.MetadataServer.ActiveStandby)
 	}
 
+	// Set mds_join_fs flag to force mds daemon to join a specific fs
+	if c.clusterInfo.CephVersion.IsAtLeastOctopus() {
+		configOptions["mds_join_fs"] = c.fs.Name
+	}
+
 	for flag, val := range configOptions {
 		err := monStore.Set(who, flag, val)
 		if err != nil {

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -49,10 +49,12 @@ var (
 	Nautilus = CephVersion{14, 0, 0, 0}
 	// Octopus Ceph version
 	Octopus = CephVersion{15, 0, 0, 0}
+	// Pacific Ceph version
+	Pacific = CephVersion{16, 0, 0, 0}
 
 	// supportedVersions are production-ready versions that rook supports
 	supportedVersions   = []CephVersion{Mimic, Nautilus}
-	unsupportedVersions = []CephVersion{Octopus}
+	unsupportedVersions = []CephVersion{Octopus, Pacific}
 	// allVersions includes all supportedVersions as well as unreleased versions that are being tested with rook
 	allVersions = append(supportedVersions, unsupportedVersions...)
 
@@ -170,6 +172,11 @@ func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	}
 	// If we arrive here then both versions are identical
 	return true
+}
+
+// IsAtLeastPacific check that the Ceph version is at least Pacific
+func (v *CephVersion) IsAtLeastPacific() bool {
+	return v.IsAtLeast(Pacific)
 }
 
 // IsAtLeastOctopus check that the Ceph version is at least Octopus

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -151,8 +151,10 @@ func TestVersionAtLeastX(t *testing.T) {
 	assert.True(t, Nautilus.IsAtLeastNautilus())
 	assert.True(t, Nautilus.IsAtLeastMimic())
 	assert.True(t, Mimic.IsAtLeastMimic())
+	assert.True(t, Pacific.IsAtLeastPacific())
 	assert.False(t, Mimic.IsAtLeastNautilus())
 	assert.False(t, Nautilus.IsAtLeastOctopus())
+	assert.False(t, Nautilus.IsAtLeastPacific())
 }
 
 func TestIsIdentical(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

We now force the mds daemon to join the fs that was created by Rook.
This can always be changed by using the ceph config store.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4707

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
