### PR TITLE
ceph: fix resources for prepare job

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -37,7 +37,6 @@ import (
 	apps "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -879,7 +878,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 			RunAsNonRoot:           &runAsNonRoot,
 			ReadOnlyRootFilesystem: &readOnlyRootFilesystem,
 		},
-		Resources: c.osdPrepareResources(osdProps.pvc.ClaimName),
+		Resources: c.prepareResources,
 	}
 
 	return osdProvisionContainer
@@ -1028,26 +1027,6 @@ func (c *Cluster) getOSDLabels(osdID int, failureDomainValue string, portable bo
 		OsdIdLabelKey:       fmt.Sprintf("%d", osdID),
 		FailureDomainKey:    failureDomainValue,
 		portableKey:         strconv.FormatBool(portable),
-	}
-}
-
-func (c *Cluster) osdPrepareResources(osdClaimName string) v1.ResourceRequirements {
-	var cpuLimit, cpuRequest, memoryLimit, memoryRequest int64
-
-	cpuLimit = c.prepareResources.Limits.Cpu().Value()
-	cpuRequest = c.prepareResources.Requests.Cpu().Value()
-	memoryLimit = c.prepareResources.Limits.Memory().Value()
-	memoryRequest = c.prepareResources.Requests.Memory().Value()
-
-	return v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuLimit, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(memoryLimit, resource.BinarySI),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuRequest, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(memoryRequest, resource.BinarySI),
-		},
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -362,8 +362,6 @@ func TestOsdOnSDNFlag(t *testing.T) {
 }
 
 func TestOsdPrepareResources(t *testing.T) {
-	var osdClaimName string
-
 	clientset := fake.NewSimpleClientset()
 	c := New(&cephconfig.ClusterInfo{}, &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}, "ns", "myversion", cephv1.CephVersionSpec{},
 		rookalpha.StorageScopeSpec{}, "", rookalpha.Placement{}, rookalpha.Annotations{}, cephv1.NetworkSpec{}, v1.ResourceRequirements{}, v1.ResourceRequirements{}, "my-priority-class", metav1.OwnerReference{}, false, false, false)
@@ -379,8 +377,8 @@ func TestOsdPrepareResources(t *testing.T) {
 	}
 
 	c.prepareResources = rr
-	r := c.osdPrepareResources(osdClaimName)
-	assert.Equal(t, "2", r.Limits.Cpu().String(), rr.Limits.Cpu().String())
+	r := c.prepareResources
+	assert.Equal(t, "2000", r.Limits.Cpu().String(), rr.Limits.Cpu().String())
 	assert.Equal(t, "0", r.Requests.Cpu().String())
 	assert.Equal(t, "0", r.Limits.Memory().String())
 	assert.Equal(t, "250", r.Requests.Memory().String())


### PR DESCRIPTION
**Description of your changes:**

Now, we purely rely on what the user puts in the CR and apply it.
Prior to this commit we were putting 0 if not declared, this was not the
intentional.

Closes: https://github.com/rook/rook/issues/4713
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4713

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]