### PR TITLE
ceph: ensure crush-location osd command args is always the same to avoid useless osds restart

### DIFF
--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ceph
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,23 +112,18 @@ func TestDetectCrushLocation(t *testing.T) {
 		"topology.rook.io/rack":                    "rack1",
 		"topology.rook.io/row":                     "row1",
 	}
-	expected := map[string]string{
-		"host":   "foo",
-		"region": "region1",
-		"zone":   "zone1",
-		"rack":   "rack1",
-		"row":    "row1",
+
+	expected := []string{
+		"host=foo",
+		"rack=rack1",
+		"region=region1",
+		"row=row1",
+		"zone=zone1",
 	}
 	updateLocationWithNodeLabels(&location, nodeLabels)
-	assert.Equal(t, 5, len(location))
-	for _, locString := range location {
-		split := strings.Split(locString, "=")
-		assert.Len(t, split, 2)
-		prefix := split[0]
-		value := split[1]
-		expectedValue, ok := expected[prefix]
-		assert.True(t, ok)
-		assert.Equal(t, expectedValue, value)
-	}
 
+	assert.Equal(t, 5, len(location))
+	for i, locString := range location {
+		assert.Equal(t, locString, expected[i])
+	}
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -19,6 +19,7 @@ package osd
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -831,9 +832,16 @@ func UpdateLocationWithNodeLabels(location *[]string, nodeLabels map[string]stri
 	if len(invalidLabels) > 0 {
 		logger.Warningf("ignored invalid node topology labels: %v", invalidLabels)
 	}
-	for topologyType, value := range topology {
+
+	keys := make([]string, 0, len(topology))
+	for k := range topology {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, topologyType := range keys {
 		if topologyType != "host" {
-			client.UpdateCrushMapValue(location, topologyType, value)
+			client.UpdateCrushMapValue(location, topologyType, topology[topologyType])
 		}
 	}
 }


### PR DESCRIPTION
Currently each time the ceph operator restart, osds also restart.
This is due to a change in the crush-location args with location not ordered
At each restart the location order can change and lead to that kind of change in the osd deployment
```
104c105
<                             "--crush-location=root=default host=hostname datacenter=PAR pod=2 rack=2",
---
>                             "--crush-location=root=default host=hostname pod=2 rack=2 datacenter=PAR",
```
Sorting the topology to ensure stability of this command arg

Signed-off-by: n.fraison <n.fraison@criteo.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
