### PR TITLE
ceph: fix external cluster config override cm creation

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -295,13 +295,14 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 			return errors.Wrapf(err, "failed to detect and validate ceph version")
 		}
 
-		// Write the rook-ceph-config configmap (used by various daemons to apply config overrides)
+		// Write the rook-config-override configmap (used by various daemons to apply config overrides)
 		// If we don't do this, daemons will never start, waiting forever for this configmap to be present
 		//
 		// Only do this when doing a bit of management...
-		err = config.GetStore(cluster.context, namespace, &cluster.ownerRef).CreateOrUpdate(cluster.Info)
+		logger.Info("creating 'rook-ceph-config' configmap.")
+		err = populateConfigOverrideConfigMap(cluster.context, namespace, cluster.ownerRef)
 		if err != nil {
-			return errors.Wrapf(err, "failed to set config store")
+			return errors.Wrapf(err, "failed to populate config override config map")
 		}
 	}
 


### PR DESCRIPTION
**Description of your changes:**

If an image is specified in the external cluster CR, the
'rook-ceph-config' config map will be created and then child CRs like
rgw/mds/nfs can be created.

Also, calling config.GetStore() was a mistake since it's calling by the
health check if new mons are being added to clusterInfo.

Closes: https://github.com/rook/rook/issues/4686
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4686

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]