### PR TITLE
Ceph: PV provisioning fails upon upgrade

### DIFF
--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -34,7 +34,6 @@ import (
 const (
 	dataPoolSuffix     = "data"
 	metaDataPoolSuffix = "metadata"
-	appName            = "cephfs"
 )
 
 // Filesystem represents an instance of a Ceph filesystem (CephFS)
@@ -144,7 +143,7 @@ func newFS(name, namespace string) *Filesystem {
 func SetPoolSize(f *Filesystem, context *clusterd.Context, spec cephv1.FilesystemSpec) error {
 	// generating the metadata pool's name
 	metadataPoolName := generateMetaDataPoolName(f)
-	err := client.CreatePoolWithProfile(context, f.Namespace, metadataPoolName, spec.MetadataPool, appName)
+	err := client.CreatePoolWithProfile(context, f.Namespace, metadataPoolName, spec.MetadataPool, "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to update metadata pool %q", metadataPoolName)
 	}
@@ -152,7 +151,7 @@ func SetPoolSize(f *Filesystem, context *clusterd.Context, spec cephv1.Filesyste
 	dataPoolNames := generateDataPoolNames(f, spec)
 	for i, pool := range spec.DataPools {
 		poolName := dataPoolNames[i]
-		err := client.CreatePoolWithProfile(context, f.Namespace, poolName, pool, appName)
+		err := client.CreatePoolWithProfile(context, f.Namespace, poolName, pool, "")
 		if err != nil {
 			return errors.Wrapf(err, "failed to update datapool  %q", poolName)
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
CSI CephFS provisioner fails to provision a Persistent Volume after upgrading from Rook Ceph Operator 1.1.2 to 1.1.7.
This issue can be fixed by removing givePoolAppTag function call if the `fsname` is not `cephfs`.

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #4494 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]