### PR TITLE
ci: add external cluster functional test

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -29,7 +29,9 @@ type CephManifests interface {
 	GetRookCRDs() string
 	GetRookOperator(namespace string) string
 	GetClusterRoles(namespace, systemNamespace string) string
+	GetClusterExternalRoles(namespace, systemNamespace string) string
 	GetRookCluster(settings *ClusterSettings) string
+	GetRookExternalCluster(settings *ClusterExternalSettings) string
 	GetRookToolBox(namespace string) string
 	GetCleanupPod(node, removalDir string) string
 	GetBlockPoolDef(poolName string, namespace string, replicaSize string) string
@@ -54,6 +56,12 @@ type ClusterSettings struct {
 	Mons             int
 	RBDMirrorWorkers int
 	CephVersion      cephv1.CephVersionSpec
+}
+
+// ClusterExternalSettings represents the settings of an external cluster
+type ClusterExternalSettings struct {
+	Namespace       string
+	DataDirHostPath string
 }
 
 // CephManifestsMaster wraps rook yaml definitions
@@ -1438,6 +1446,8 @@ spec:
           value: "true"
         - name: ROOK_CSI_ENABLE_GRPC_METRICS
           value: "true"
+        - name: ROOK_CURRENT_NAMESPACE_ONLY
+          value: "false"
 `
 }
 
@@ -1726,6 +1736,76 @@ spec:
     modules:
     - name: pg_autoscaler
       enabled: true`
+}
+
+// GetClusterExternalRoles returns rook-cluster-external manifest
+func (m *CephManifestsMaster) GetClusterExternalRoles(namespace, firstClusterNamespace string) string {
+	return `apiVersion: v1
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster-mgmt
+  namespace: ` + namespace + `
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: ` + firstClusterNamespace + `
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: ` + namespace + `
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete`
+}
+
+// GetRookExternalCluster returns rook-cluster-external manifest
+func (m *CephManifestsMaster) GetRookExternalCluster(settings *ClusterExternalSettings) string {
+	return `apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: ` + settings.Namespace + `
+  namespace: ` + settings.Namespace + `
+spec:
+  external:
+    enable: true
+  dataDirHostPath: ` + settings.DataDirHostPath + ``
 }
 
 // GetRookToolBox returns rook-toolbox manifest

--- a/tests/framework/installer/ceph_manifests_v1.0.go
+++ b/tests/framework/installer/ceph_manifests_v1.0.go
@@ -1430,3 +1430,13 @@ func (m *CephManifestsV1_0) GetObc(claimName string, storageClassName string, ob
 func (m *CephManifestsV1_0) GetClient(claimName string, namespace string, caps map[string]string) string {
 	panic("upgrade test not supported for client")
 }
+
+// GetClusterExternalRoles get the cluster roles of an external cluster
+func (m *CephManifestsV1_0) GetClusterExternalRoles(namespace, systemNamespace string) string {
+	return ""
+}
+
+// GetRookExternalCluster get an external cluster
+func (m *CephManifestsV1_0) GetRookExternalCluster(settings *ClusterExternalSettings) string {
+	return ""
+}

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -103,7 +103,6 @@ type TestCluster struct {
 	T                func() *testing.T
 	namespace        string
 	storeType        string
-	useDevices       bool
 	mons             int
 	rbdMirrorWorkers int
 }
@@ -132,7 +131,7 @@ func checkIfShouldRunForMinimalTestMatrix(t func() *testing.T, k8sh *utils.K8sHe
 }
 
 // StartTestCluster creates new instance of TestCluster struct
-func StartTestCluster(t func() *testing.T, minimalMatrixK8sVersion, namespace, storeType string, useHelm, useDevices bool, mons,
+func StartTestCluster(t func() *testing.T, minimalMatrixK8sVersion, namespace, storeType string, useHelm bool, mons,
 	rbdMirrorWorkers int, rookVersion string, cephVersion cephv1.CephVersionSpec) (*TestCluster, *utils.K8sHelper) {
 
 	kh, err := utils.CreateK8sHelper(t)
@@ -141,7 +140,7 @@ func StartTestCluster(t func() *testing.T, minimalMatrixK8sVersion, namespace, s
 
 	i := installer.NewCephInstaller(t, kh.Clientset, useHelm, rookVersion, cephVersion)
 
-	op := &TestCluster{i, kh, nil, t, namespace, storeType, useDevices, mons, rbdMirrorWorkers}
+	op := &TestCluster{i, kh, nil, t, namespace, storeType, mons, rbdMirrorWorkers}
 
 	if rookVersion != installer.VersionMaster {
 		// make sure we have the images from a previous release locally so the test doesn't hit a timeout
@@ -157,7 +156,7 @@ func StartTestCluster(t func() *testing.T, minimalMatrixK8sVersion, namespace, s
 // SetUpRook is a wrapper for setting up rook
 func (op *TestCluster) Setup() {
 	isRookInstalled, err := op.installer.InstallRookOnK8sWithHostPathAndDevices(op.namespace, op.storeType,
-		op.useDevices, cephv1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers)
+		cephv1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers)
 
 	if !isRookInstalled || err != nil {
 		logger.Errorf("Rook was not installed successfully: %v", err)

--- a/tests/integration/ceph_block_test.go
+++ b/tests/integration/ceph_block_test.go
@@ -90,10 +90,9 @@ func (s *CephBlockSuite) SetupSuite() {
 	s.pvcNameRWO = "block-persistent-rwo"
 	s.pvcNameRWX = "block-persistent-rwx"
 	useHelm := false
-	useDevices := true
 	mons := 1
 	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, blockMinimalTestVersion, s.namespace, "bluestore", useHelm, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	s.op, s.kh = StartTestCluster(s.T, blockMinimalTestVersion, s.namespace, "bluestore", useHelm, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	s.bc = s.testClient.BlockClient
 }

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -69,7 +69,7 @@ func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
 	mons := 1
 	rbdMirrorWorkers := 1
-	hs.op, hs.kh = StartTestCluster(hs.T, helmMinimalTestVersion, hs.namespace, "bluestore", true, true, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	hs.op, hs.kh = StartTestCluster(hs.T, helmMinimalTestVersion, hs.namespace, "bluestore", true, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	hs.helper = clients.CreateTestClient(hs.kh, hs.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -46,10 +46,9 @@ import (
 // - Create the object store via the CRD
 // *************************************************************
 func TestCephMultiClusterDeploySuite(t *testing.T) {
-	// if installer.SkipTestSuite(installer.CephTestSuite) {
-	logger.Infof("Skipping Ceph Multi Cluster Suite until we decide whether this scenario makes sense or not anymore")
-	t.Skip()
-	// }
+	if installer.SkipTestSuite(installer.CephTestSuite) {
+		t.Skip()
+	}
 
 	s := new(MultiClusterDeploySuite)
 	defer func(s *MultiClusterDeploySuite) {

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -87,11 +87,6 @@ func (mrc *MultiClusterDeploySuite) createPools() {
 	logger.Infof("Creating pool %s", poolName)
 	err := mrc.testClient.PoolClient.Create(poolName, mrc.namespace1, 1)
 	require.Nil(mrc.T(), err)
-
-	poolName = "multi-cluster-pool2"
-	logger.Infof("Creating pool %s", poolName)
-	err = mrc.testClient.PoolClient.Create(poolName, mrc.namespace2, 1)
-	require.Nil(mrc.T(), err)
 }
 
 func (mrc *MultiClusterDeploySuite) TearDownSuite() {
@@ -104,27 +99,9 @@ func (mrc *MultiClusterDeploySuite) TestInstallingMultipleRookClusters() {
 	checkIfRookClusterIsInstalled(mrc.Suite, mrc.k8sh, installer.SystemNamespace(mrc.namespace1), mrc.namespace1, 1)
 	checkIfRookClusterIsHealthy(mrc.Suite, mrc.testClient, mrc.namespace1)
 
-	// Check if Rook cluster 2 is deployed successfully
-	checkIfRookClusterIsInstalled(mrc.Suite, mrc.k8sh, installer.SystemNamespace(mrc.namespace1), mrc.namespace2, 1)
+	// Check if Rook external cluster is deployed successfully
+	// Checking health status is enough to validate the connection
 	checkIfRookClusterIsHealthy(mrc.Suite, mrc.testClient, mrc.namespace2)
-}
-
-// Test Block Store Creation on multiple rook clusters
-func (mrc *MultiClusterDeploySuite) TestBlockStoreOnMultipleRookCluster() {
-	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, mrc.op.installer.CephVersion)
-	runBlockE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, mrc.op.installer.CephVersion)
-}
-
-// Test Filesystem Creation on multiple rook clusters
-func (mrc *MultiClusterDeploySuite) TestFileStoreOnMultiRookCluster() {
-	runFileE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, "test-fs-1")
-	runFileE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, "test-fs-2")
-}
-
-// Test Object Store Creation on multiple rook clusters
-func (mrc *MultiClusterDeploySuite) TestObjectStoreOnMultiRookCluster() {
-	runObjectE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace1, "default-c1", 2)
-	runObjectE2ETestLite(mrc.testClient, mrc.k8sh, mrc.Suite, mrc.namespace2, "default-c2", 1)
 }
 
 // MCTestOperations struct for handling panic and test suite tear down
@@ -166,35 +143,29 @@ func (o MCTestOperations) Setup() {
 	time.Sleep(10 * time.Second)
 
 	// start the two clusters in parallel
-	logger.Infof("starting two clusters in parallel")
+	logger.Infof("starting two clusters, one traditional and one external")
 	err = o.startCluster(o.namespace1, "bluestore")
 	require.NoError(o.T(), err)
+	// Wait for the monitors to be up so that we can fetch the configmap and secrets
+	require.True(o.T(), o.kh.IsPodInExpectedState("rook-ceph-mon", o.namespace1, "Running"),
+		"Make sure rook-ceph-mon is in running state")
 
-	require.True(o.T(), o.kh.IsPodInExpectedState("rook-ceph-agent", o.systemNamespace, "Running"),
-		"Make sure rook-ceph-agent is in running state")
+	// create an external cluster
+	err = o.startExternalCluster(o.namespace2)
+	require.NoError(o.T(), err)
 
 	logger.Infof("finished starting clusters")
 }
 
 // TearDownRook is a wrapper for tearDown after suite
 func (o MCTestOperations) Teardown() {
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Infof("Unexpected Errors while cleaning up MultiCluster test --> %v", r)
-			o.T().FailNow()
-		}
-	}()
-
 	o.installer.UninstallRookFromMultipleNS(true, installer.SystemNamespace(o.namespace1), o.namespace1, o.namespace2)
 }
 
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
-	useDevices := false
-	// do not use disks for this cluster, otherwise the 2 test clusters will each try to use the
-	// same disks.
 	err := o.installer.CreateK8sRookClusterWithHostPathAndDevices(namespace, o.systemNamespace, store,
-		useDevices, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, true, 1, installer.NautilusVersion)
+		cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, true, 1, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
@@ -207,5 +178,25 @@ func (o MCTestOperations) startCluster(namespace, store string) error {
 		return fmt.Errorf("failed to create toolbox for %s. %+v", namespace, err)
 	}
 	logger.Infof("succeeded starting cluster %s", namespace)
+	return nil
+}
+
+func (o MCTestOperations) startExternalCluster(namespace string) error {
+	logger.Infof("starting external cluster %q", namespace)
+	err := o.installer.CreateK8sRookExternalCluster(namespace, o.namespace1)
+	if err != nil {
+		o.T().Fail()
+		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
+		return fmt.Errorf("failed to create external cluster %s. %+v", namespace, err)
+	}
+
+	logger.Infof("running toolbox on namespace %q", namespace)
+	if err := o.installer.CreateK8sRookToolbox(namespace); err != nil {
+		o.T().Fail()
+		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
+		return fmt.Errorf("failed to create toolbox for %s. %+v", namespace, err)
+	}
+
+	logger.Infof("succeeded starting external cluster %s", namespace)
 	return nil
 }

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -71,10 +71,9 @@ type SmokeSuite struct {
 
 func (suite *SmokeSuite) SetupSuite() {
 	suite.namespace = "smoke-ns"
-	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 1
-	suite.op, suite.k8sh = StartTestCluster(suite.T, smokeSuiteMinimalTestVersion, suite.namespace, "bluestore", false, useDevices, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
+	suite.op, suite.k8sh = StartTestCluster(suite.T, smokeSuiteMinimalTestVersion, suite.namespace, "bluestore", false, mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion)
 	suite.helper = clients.CreateTestClient(suite.k8sh, suite.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -70,7 +70,6 @@ type UpgradeSuite struct {
 
 func (s *UpgradeSuite) SetupSuite() {
 	s.namespace = "upgrade-ns"
-	useDevices := true
 	mons := 3
 	rbdMirrorWorkers := 0
 	cephVersion := rookcephv1.CephVersionSpec{
@@ -83,7 +82,6 @@ func (s *UpgradeSuite) SetupSuite() {
 		s.namespace,
 		"",
 		false,
-		useDevices,
 		mons,
 		rbdMirrorWorkers,
 		installer.Version1_0,

--- a/tests/longhaul/base_block_test.go
+++ b/tests/longhaul/base_block_test.go
@@ -157,7 +157,7 @@ func (o LoadTestCluster) Setup() {
 
 	if !o.kh.IsRookInstalled(o.namespace) {
 		isRookInstalled, err := o.installer.InstallRookOnK8sWithHostPathAndDevices(o.namespace, "bluestore",
-			true, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
+			cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true},
 			true, /* startWithAllNodes */
 			1 /*rbd mirror workers*/)
 		require.NoError(o.T(), err)


### PR DESCRIPTION
**Description of your changes:**

Add coverage in the CI for the external cluster feature.

Closes: https://github.com/rook/rook/issues/3691
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/3691

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]