### PR TITLE
docs: clean-up Ceph NFS Gateway CRD

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -12,7 +12,9 @@ Rook allows exporting NFS shares of the filesystem or object store through the C
 
 ## Samples
 
-This configuration adds a cluster of ganesha gateways that store objects in the pool cephfs.a.meta and the namespace **
+The following sample will create a two-node active-active cluster of NFS Ganesha gateways. A CephFS named `myfs` is used, and the recovery objects are stored in a RADOS pool named `myfs-data0` with a RADOS namespace of `nfs-ns`.
+
+> **NOTE**: For an RGW object store, a data pool of `my-store.rgw.buckets.data` can be used.
 
 ```yaml
 apiVersion: ceph.rook.io/v1
@@ -23,8 +25,6 @@ metadata:
 spec:
   rados:
     # RADOS pool where NFS client recovery data is stored.
-    # In this example the data pool for the "myfs" filesystem is used.
-    # If using the object store example, the data pool would be "my-store.rgw.buckets.data".
     pool: myfs-data0
     # RADOS namespace where NFS client recovery data is stored in the pool.
     namespace: nfs-ns
@@ -84,7 +84,7 @@ When a server is started, it will create the included object if it does not alre
 ## Scaling the active server count
 
 It is possible to scale the size of the cluster up or down by modifying
-the spec.server.active field. Scaling the cluster size up can be done at
+the `spec.server.active` field. Scaling the cluster size up can be done at
 will. Once the new server comes up, clients can be assigned to it
 immediately.
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

- fixup RADOS pool name to match what is used by the CRD
- add missing RADOS namespace to the Sample description
- move/merge description of the RADOS pool/namespace config into the
  sample text instead of inline comments within the CRD yaml
- add inline code block for `spec.server.active` field

Signed-off-by: Michael Fritch <mfritch@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]