### PR TITLE
test: update k8s versions for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,9 +110,9 @@ pipeline {
                     def data = [
                         "aws_1.13.x": "v1.13.12",
                         "aws_1.14.x": "v1.14.10",
-                        "aws_1.15.x": "v1.15.7",
-                        "aws_1.16.x": "v1.16.4",
-                        "aws_1.17.x": "v1.17.1"
+                        "aws_1.15.x": "v1.15.9",
+                        "aws_1.16.x": "v1.16.6",
+                        "aws_1.17.x": "v1.17.2"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {


### PR DESCRIPTION
**Description of your changes:**

The CI will now use the current latest K8S releases.
v1.15: v1.15.9
v1.16: v1.16.6
v1.17: v1.17.2

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.