### PR TITLE
doc: update doc for PG count

### DIFF
--- a/Documentation/ceph-configuration.md
+++ b/Documentation/ceph-configuration.md
@@ -30,7 +30,7 @@ docs](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#a-pre
 provide detailed information about how to tune these parameters: `osd_pool_default_pg_num` and `osd_pool_default_pgp_num`.
 
 Pools created prior to v1.1 will have a default PG count of 100. Pools created after v1.1
-will have a default PG count of 8.
+will have Ceph's default PG count.
 
 An easier option exists for Rook-Ceph clusters running Ceph Nautilus (v14.2.x) or newer. Nautilus
 [introduced the PG auto-scaler mgr module](https://ceph.com/rados/new-in-nautilus-pg-merging-and-autotuning/)


### PR DESCRIPTION
**Description of your changes:**

Ceph recently changed its default PG count in
https://github.com/ceph/ceph/pull/32788, it also changed from 8 to 16
then 16 to 32. So let's remove the 8 PGs mention which is incorrect.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


[skip ci]