### PR TITLE
docs: change default recommendation to 4:3 coding

### DIFF
--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -76,9 +76,9 @@ spec:
 
 Erasure coded pools require the OSDs to use `bluestore` for the configured [`storeType`](ceph-cluster-crd.md#osd-configuration-settings). Additionally, erasure coded pools can only be used with `dataPools`. The `metadataPool` must use a replicated pool.
 
-> **NOTE**: This sample requires *at least 3 bluestore OSDs*, with each OSD located on a *different node*.
+> **NOTE**: This sample requires *at least 8 bluestore OSDs*, with each OSD located on a *different node*. If you only have 3-7 nodes, you can set `{dataChunks: 2, codingChunks: 1}` instead.
 
-The OSDs must be located on different nodes, because the [`failureDomain`](ceph-pool-crd.md#spec) will be set to `host` by default, and the `erasureCoded` chunk settings require at least 3 different OSDs (2 `dataChunks` + 1 `codingChunks`).
+The OSDs must be located on different nodes, because the [`failureDomain`](ceph-pool-crd.md#spec) will be set to `host` by default, and the `erasureCoded` chunk settings require at least 8 different OSDs (4 `dataChunks` + 3 `codingChunks` + 1 allowed unhealthy node).
 
 ```yaml
 apiVersion: ceph.rook.io/v1
@@ -92,8 +92,8 @@ spec:
       size: 3
   dataPools:
     - erasureCoded:
-        dataChunks: 2
-        codingChunks: 1
+        dataChunks: 4
+        codingChunks: 3
   metadataServer:
     activeCount: 1
     activeStandby: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Change the documented default erasure coding setting to 4:3 from 2:1.

 This achieves much higher durability than 2:1 coding at a reasonable node count.
4:3 coding has a modest 75% space penalty (versus 50% for 2:1 or 200% for x3), while not requiring as many nodes as other recommendations such as 10:4.

10:4 comes from the [Red Hat documentation](https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/1.3/html/storage_strategies_guide/erasure_code_pools#erasure-code-profiles).

**Which issue is resolved by this Pull Request:**
No issue filed

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]