### PR TITLE
Allow for empty "all" annotations

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/annotations.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations.go
@@ -22,25 +22,33 @@ import (
 
 // GetMgrAnnotations returns the Annotations for the MGR service
 func GetMgrAnnotations(a rook.AnnotationsSpec) rook.Annotations {
-	return a.All().Merge(a[KeyMgr])
+	return mergeAllAnnotationsWithKey(a, KeyMgr)
 }
 
 // GetMonAnnotations returns the Annotations for the MON service
 func GetMonAnnotations(a rook.AnnotationsSpec) rook.Annotations {
-	return a.All().Merge(a[KeyMon])
+	return mergeAllAnnotationsWithKey(a, KeyMon)
 }
 
 // GetOSDAnnotations returns the annotations for the OSD service
 func GetOSDAnnotations(a rook.AnnotationsSpec) rook.Annotations {
-	return a.All().Merge(a[KeyOSD])
+	return mergeAllAnnotationsWithKey(a, KeyOSD)
 }
 
 // GetRGWAnnotations returns the Annotations for the RBD mirrors
 func GetRGWAnnotations(a rook.AnnotationsSpec) rook.Annotations {
-	return a.All().Merge(a[KeyRGWMirror])
+	return mergeAllAnnotationsWithKey(a, KeyRGW)
 }
 
 // GetRBDMirrorAnnotations returns the Annotations for the RBD mirrors
 func GetRBDMirrorAnnotations(a rook.AnnotationsSpec) rook.Annotations {
-	return a.All().Merge(a[KeyRBDMirror])
+	return mergeAllAnnotationsWithKey(a, KeyRBDMirror)
+}
+
+func mergeAllAnnotationsWithKey(a rook.AnnotationsSpec, name rook.KeyType) rook.Annotations {
+	all := a.All()
+	if all != nil {
+		return all.Merge(a[name])
+	}
+	return a[name]
 }

--- a/pkg/apis/ceph.rook.io/v1/annotations_test.go
+++ b/pkg/apis/ceph.rook.io/v1/annotations_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnnotationMerge(t *testing.T) {
+	// No annotations defined
+	testAnnotations := rook.AnnotationsSpec{}
+	a := GetOSDAnnotations(testAnnotations)
+	assert.Nil(t, a)
+
+	// Only a specific component annotation without "all"
+	testAnnotations = rook.AnnotationsSpec{
+		"mgr":       {"mgrkey": "mgrval"},
+		"mon":       {"monkey": "monval"},
+		"osd":       {"osdkey": "osdval"},
+		"rgw":       {"rgwkey": "rgwval"},
+		"rbdmirror": {"rbdmirrorkey": "rbdmirrorval"},
+	}
+	a = GetMgrAnnotations(testAnnotations)
+	assert.Equal(t, "mgrval", a["mgrkey"])
+	assert.Equal(t, 1, len(a))
+	a = GetMonAnnotations(testAnnotations)
+	assert.Equal(t, "monval", a["monkey"])
+	assert.Equal(t, 1, len(a))
+	a = GetOSDAnnotations(testAnnotations)
+	assert.Equal(t, "osdval", a["osdkey"])
+	assert.Equal(t, 1, len(a))
+	a = GetRGWAnnotations(testAnnotations)
+	assert.Equal(t, "rgwval", a["rgwkey"])
+	assert.Equal(t, 1, len(a))
+	a = GetRBDMirrorAnnotations(testAnnotations)
+	assert.Equal(t, "rbdmirrorval", a["rbdmirrorkey"])
+	assert.Equal(t, 1, len(a))
+
+	// No annotations matching the component
+	testAnnotations = rook.AnnotationsSpec{
+		"mgr": {"mgrkey": "mgrval"},
+	}
+	a = GetMonAnnotations(testAnnotations)
+	assert.Nil(t, a)
+
+	// Merge with "all"
+	testAnnotations = rook.AnnotationsSpec{
+		"all": {"allkey1": "allval1", "allkey2": "allval2"},
+		"mgr": {"mgrkey": "mgrval"},
+	}
+	a = GetMonAnnotations(testAnnotations)
+	assert.Equal(t, "allval1", a["allkey1"])
+	assert.Equal(t, "allval2", a["allkey2"])
+	assert.Equal(t, 2, len(a))
+	a = GetMgrAnnotations(testAnnotations)
+	assert.Equal(t, "mgrval", a["mgrkey"])
+	assert.Equal(t, "allval1", a["allkey1"])
+	assert.Equal(t, "allval2", a["allkey2"])
+	assert.Equal(t, 3, len(a))
+}

--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -25,5 +25,5 @@ const (
 	KeyMgr       rook.KeyType = "mgr"
 	KeyOSD       rook.KeyType = "osd"
 	KeyRBDMirror rook.KeyType = "rbdmirror"
-	KeyRGWMirror rook.KeyType = "rgw"
+	KeyRGW       rook.KeyType = "rgw"
 )


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the annotations are generated for a ceph daemon, the `all` annotations are merged with the component annotations. If there are no `all` annotations, the component annotation calculation was crashing. Now we check for the case where the `all` annotations are not defined.

**Which issue is resolved by this Pull Request:**
Resolves #4351

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]