### PR TITLE
ceph: fix garbage collection for csi driver

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -189,7 +189,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 		return errors.Wrapf(err, "failed creating csi config map")
 	}
 	ownerRef := metav1.OwnerReference{
-		APIVersion: "v1",
+		APIVersion: "core/v1",
 		Kind:       "ConfigMap",
 		Name:       configMap.Name,
 		UID:        configMap.UID,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CSI driver was disappearing in some clusters after certain events such as restarting the operator or master nodes being restarted. This is due to an incorrect owner reference on the csi driver back to the configmap. The owner reference must specify apps/v1 instead of v1 for the APIVersion of the configmap. This issue is only hit when the k8s garbage collector rebuilds its cache, which would happen at indeterminate times from Rook's perspective. This GC behavior was introduced by #4354.

**Which issue is resolved by this Pull Request:**
Resolves #4590 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]