### PR TITLE
doc: fix CephFS CSI StorageClass name

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -87,7 +87,7 @@ Save this storage class definition as `storageclass.yaml`:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: csi-cephfs
+  name: rook-cephfs
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
@@ -153,7 +153,7 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: csi-cephfs
+  storageClassName: rook-cephfs
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/kube-registry.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/kube-registry.yaml
@@ -9,7 +9,7 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: csi-cephfs
+  storageClassName: rook-cephfs
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: csi-cephfs
+  storageClassName: rook-cephfs

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: csi-cephfs
+  name: rook-cephfs
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   # clusterID is the namespace where operator is deployed.


### PR DESCRIPTION
**Description of your changes:**

This fixes the StorageClass name example and doc to be `rook-cephfs`
instead of just `csi-cephfs`.

Closes #4130.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]