### PR TITLE
cassandra: reconciliation mechanism for JMX Exporter ConfigMap

### DIFF
--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -85,6 +85,7 @@ In the Cassandra model, each cluster contains datacenters and each datacenter co
 * `name`: Name of the rack. Usually, a rack corresponds to an availability zone.
 * `members`: Number of Cassandra members for the specific rack. (In Cassandra documentation, they are called nodes. We don't call them nodes to avoid confusion as a Cassandra Node corresponds to a Kubernetes Pod, not a Kubernetes Node).
 * `storage`: Defines the volumes to use for each Cassandra member. Currently, only 1 volume is supported.
+* `jmxExporterConfigMapName`: Name of configmap that will be used for [jmx_exporter](https://github.com/prometheus/jmx_exporter). Exporter listens on port 9180. If the name not specified, the exporter will not be run. 
 * `resources`: Defines the CPU and RAM resources for the Cassandra Pods.
 * `annotations`: Key value pair list of annotations to add.
 * `placement`: Defines the placement of Cassandra Pods. Has the following subfields:

--- a/Documentation/cassandra.md
+++ b/Documentation/cassandra.md
@@ -148,3 +148,59 @@ If everything looks OK in the operator logs, you can also look in the logs for o
 ```console
 kubectl -n rook-cassandra logs rook-cassandra-0
 ```
+
+## Cassandra Monitoring
+
+To enable jmx_exporter for cassandra rack, you should specify `jmxExporterConfigMapName` option for rack in CassandraCluster CRD.
+
+For example:
+```yaml
+apiVersion: cassandra.rook.io/v1alpha1
+kind: Cluster
+metadata:
+  name: my-cassandra
+  namespace: rook-cassandra
+spec:
+  ...
+  datacenter:
+    name: my-datacenter
+    racks:
+    - name: my-rack
+      members: 3
+      jmxExporterConfigMapName: jmx-exporter-settings
+      storage:
+        volumeClaimTemplates:
+        - metadata:
+            name: rook-cassandra-data
+          spec:
+            storageClassName: my-storage-class
+            resources:
+              requests:
+                storage: 200Gi
+```
+
+Simple config map example to get all metrics:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jmx-exporter-settings
+  namespace: rook-cassandra
+data:
+  jmx_exporter_config.yaml: |
+    lowercaseOutputLabelNames: true
+    lowercaseOutputName: true
+    whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
+```
+
+ConfigMap's data field must contain `jmx_exporter_config.yaml` key with jmx exporter settings.
+
+There is no automatic reloading mechanism for pods when the config map updated.
+After the configmap changed, you should restart all rack pods manually:
+
+```bash
+NAMESPACE=<namespace>
+CLUSTER=<cluster_name>
+RACKS=$(kubectl get sts -n ${NAMESPACE} -l "cassandra.rook.io/cluster=${CLUSTER}")
+echo ${RACKS} | xargs -n1 kubectl rollout restart -n ${NAMESPACE}
+```

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,8 @@
 
 ### YugabyteDB
 
+### Cassandra
+- Added [JMX Prometheus exporter](https://github.com/prometheus/jmx_exporter) support.
 
 ## Breaking Changes
 

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -45,6 +45,8 @@ spec:
                       type: integer
                     configMapName:
                       type: string
+                    jmxExporterConfigMapName:
+                      type: string
                     storage:
                       type: object
                       properties:

--- a/cmd/rook/cassandra/operator.go
+++ b/cmd/rook/cassandra/operator.go
@@ -75,6 +75,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		kubeInformerFactory.Apps().V1().StatefulSets(),
 		kubeInformerFactory.Core().V1().Services(),
 		kubeInformerFactory.Core().V1().Pods(),
+		kubeInformerFactory.Core().V1().ConfigMaps(),
 	)
 
 	// Create a channel to receive OS signals

--- a/design/cassandra/cluster-creation.md
+++ b/design/cassandra/cluster-creation.md
@@ -30,6 +30,9 @@ spec:
       # Optional: configMapName references a user's custom configuration for
       # a specific Cassandra Rack 
       configMapName: "cassandra-config"
+      # Optional: configMapName with single jmx_exporter_config.yaml file 
+      # reference a custom jmx prometheus exporter configuration for CassandraRack
+      jmxExporterConfigMapName: "jmx-prometheus-config"
       # Rook Common Type: StorageSpec
       storage:
         volumeClaims:

--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -26,6 +26,8 @@ RUN mkdir -p /sidecar/plugins
 ADD rook /sidecar/
 # Jolokia plugin for JMX<->HTTP
 ADD "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.0/jolokia-jvm-1.6.0-agent.jar" /sidecar/plugins/jolokia.jar
+# JMX exporter for prometheus metrics
+ADD "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar" /sidecar/plugins/jmx_prometheus.jar
 
 # Run tini as PID 1 and avoid signal handling issues
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${ARCH} /sidecar/tini

--- a/pkg/apis/cassandra.rook.io/v1alpha1/types.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/types.go
@@ -95,6 +95,8 @@ type RackSpec struct {
 	Members int32 `json:"members"`
 	// User-provided ConfigMap applied to the specific statefulset.
 	ConfigMapName *string `json:"configMapName,omitempty"`
+	// User-provided ConfigMap for jmx prometheus exporter
+	JMXExporterConfigMapName *string `json:"jmxExporterConfigMapName,omitempty"`
 	// Storage describes the underlying storage that Cassandra will consume.
 	Storage rook.StorageScopeSpec `json:"storage"`
 	// The annotations-related configuration to add/set on each Pod related object.

--- a/pkg/apis/cassandra.rook.io/v1alpha1/types.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/types.go
@@ -128,6 +128,9 @@ type RackStatus struct {
 	ReadyMembers int32 `json:"readyMembers"`
 	// Conditions are the latest available observations of a rack's state.
 	Conditions []RackCondition `json:"conditions,omitempty"`
+
+	CurrentJMXExporterConfigMapHash string `json:"currentJMXExporterConfigMapHash"`
+	DesiredJMXExporterConfigMapHash string `json:"desiredJMXExporterConfigMapHash"`
 }
 
 // RackCondition is an observation about the state of a rack.

--- a/pkg/apis/cassandra.rook.io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/zz_generated.deepcopy.go
@@ -214,6 +214,11 @@ func (in *RackSpec) DeepCopyInto(out *RackSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.JMXExporterConfigMapName != nil {
+		in, out := &in.JMXExporterConfigMapName, &out.JMXExporterConfigMapName
+		*out = new(string)
+		**out = **in
+	}
 	in.Storage.DeepCopyInto(&out.Storage)
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations

--- a/pkg/operator/cassandra/constants/constants.go
+++ b/pkg/operator/cassandra/constants/constants.go
@@ -35,6 +35,9 @@ const (
 	// Values: {true, false}
 	DecommissionLabel = "cassandra.rook.io/decommissioned"
 
+	// ConfigMapHash
+	JMXExporterConfigMapHashAnnotation = "cassandra.rook.io/jmx-exporter-configmap-sha256"
+
 	// DeveloperModeAnnotation is present when the user wishes
 	// to bypass production-readiness checks and start the database
 	// either way. Currently useful for scylla, may get removed
@@ -78,4 +81,6 @@ const (
 	ReadinessProbePath = "/readyz"
 	LivenessProbePath  = "/healthz"
 	ProbePort          = 8080
+
+	JMXConfigMapVolume = "jmx-config"
 )

--- a/pkg/operator/cassandra/controller/configmap.go
+++ b/pkg/operator/cassandra/controller/configmap.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	cassandrav1alpha1 "github.com/rook/rook/pkg/apis/cassandra.rook.io/v1alpha1"
+	"github.com/rook/rook/pkg/operator/cassandra/controller/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (cc *ClusterController) syncClusterConfigMapOwnerRefs(c *cassandrav1alpha1.Cluster) error {
+	for _, r := range c.Spec.Datacenter.Racks {
+		if r.JMXExporterConfigMapName == nil || *r.JMXExporterConfigMapName == "" {
+			continue
+		}
+		configMap, err := cc.kubeClient.CoreV1().ConfigMaps(c.Namespace).Get(*r.JMXExporterConfigMapName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		err = util.AddOwnerRef(configMap, c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/operator/cassandra/controller/sync.go
+++ b/pkg/operator/cassandra/controller/sync.go
@@ -32,6 +32,7 @@ const (
 	ErrSyncFailed = "ErrSyncFailed"
 
 	MessageRackCreated             = "Rack %s created"
+	MessageRackUpdated             = "Rack %s updated"
 	MessageRackScaledUp            = "Rack %s scaled up to %d members"
 	MessageRackScaleDownInProgress = "Rack %s scaling down to %d members"
 	MessageRackScaledDown          = "Rack %s scaled down to %d members"
@@ -86,6 +87,11 @@ func (cc *ClusterController) Sync(c *cassandrav1alpha1.Cluster) error {
 			ErrSyncFailed,
 			MessageMemberServicesSyncFailed,
 		)
+		return err
+	}
+
+	// Sync ConfigMap Refs related to Cluster
+	if err := cc.syncClusterConfigMapOwnerRefs(c); err != nil {
 		return err
 	}
 

--- a/pkg/operator/cassandra/controller/util/labels.go
+++ b/pkg/operator/cassandra/controller/util/labels.go
@@ -51,6 +51,17 @@ func RackLabels(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Cluster) map[
 	return mergeLabels(rackLabels, recLabels)
 }
 
+// RackAnnotations returns a map of annotation keys and values
+// for the given Rack.
+func RackAnnotations(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Cluster) map[string]string {
+	prometheusAnnotations := map[string]string{
+		"prometheus.io/scrape":                       "true",
+		"prometheus.io/port":                         "9180",
+		constants.JMXExporterConfigMapHashAnnotation: c.Status.Racks[r.Name].CurrentJMXExporterConfigMapHash,
+	}
+	return c.Spec.Annotations.Merge(prometheusAnnotations).GetMapStringString()
+}
+
 // StatefulSetPodLabel returns a map of labels to uniquely
 // identify a StatefulSet Pod with the given name
 func StatefulSetPodLabel(name string) map[string]string {

--- a/pkg/operator/cassandra/controller/util/patch.go
+++ b/pkg/operator/cassandra/controller/util/patch.go
@@ -73,6 +73,29 @@ func PatchStatefulSet(old, new *appsv1.StatefulSet, kubeClient kubernetes.Interf
 	return err
 }
 
+// PatchConfigMap patches the old ConfigMap so that it matches the
+// new ConfigMap.
+func PatchConfigMap(old, new *corev1.ConfigMap, kubeClient kubernetes.Interface) error {
+
+	oldJSON, err := json.Marshal(old)
+	if err != nil {
+		return err
+	}
+
+	newJSON, err := json.Marshal(new)
+	if err != nil {
+		return err
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldJSON, newJSON, corev1.ConfigMap{})
+	if err != nil {
+		return err
+	}
+
+	_, err = kubeClient.CoreV1().ConfigMaps(old.Namespace).Patch(old.Name, types.StrategicMergePatchType, patchBytes)
+	return err
+}
+
 // PatchCluster patches the old Cluster so that it matches the new Cluster.
 func PatchClusterStatus(c *cassandrav1alpha1.Cluster, rookClient versioned.Interface) error {
 

--- a/pkg/operator/cassandra/controller/util/resource.go
+++ b/pkg/operator/cassandra/controller/util/resource.go
@@ -83,16 +83,13 @@ func StatefulSetForRack(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Clust
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: rackLabels,
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "9180",
+					},
 				},
 				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "shared",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
+					Volumes: volumesForRack(r),
 					InitContainers: []corev1.Container{
 						{
 							Name:            "rook-install",
@@ -293,7 +290,13 @@ func volumeMountsForRack(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Clus
 			ReadOnly:  true,
 		},
 	}
-
+	if *r.JMXExporterConfigMapName != "" {
+		vm = append(vm, corev1.VolumeMount{
+			Name:      "jmx-config",
+			MountPath: "/etc/cassandra/jmx_exporter_config.yaml",
+			SubPath:   "jmx_exporter_config.yaml",
+		})
+	}
 	if len(r.Storage.VolumeClaimTemplates) > 0 {
 		vm = append(vm, corev1.VolumeMount{
 			Name:      r.Storage.VolumeClaimTemplates[0].Name,
@@ -301,6 +304,26 @@ func volumeMountsForRack(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Clus
 		})
 	}
 	return vm
+}
+
+func volumesForRack(r cassandrav1alpha1.RackSpec) []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: "shared",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	if *r.JMXExporterConfigMapName != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: "jmx-config",
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: *r.JMXExporterConfigMapName},
+			}},
+		})
+	}
+	return volumes
 }
 
 func tolerationsForRack(r cassandrav1alpha1.RackSpec) []corev1.Toleration {

--- a/pkg/operator/cassandra/controller/util/resource.go
+++ b/pkg/operator/cassandra/controller/util/resource.go
@@ -82,11 +82,8 @@ func StatefulSetForRack(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Clust
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: rackLabels,
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "9180",
-					},
+					Labels:      rackLabels,
+					Annotations: RackAnnotations(r, c),
 				},
 				Spec: corev1.PodSpec{
 					Volumes: volumesForRack(r),
@@ -292,7 +289,7 @@ func volumeMountsForRack(r cassandrav1alpha1.RackSpec, c *cassandrav1alpha1.Clus
 	}
 	if *r.JMXExporterConfigMapName != "" {
 		vm = append(vm, corev1.VolumeMount{
-			Name:      "jmx-config",
+			Name:      constants.JMXConfigMapVolume,
 			MountPath: "/etc/cassandra/jmx_exporter_config.yaml",
 			SubPath:   "jmx_exporter_config.yaml",
 		})
@@ -317,7 +314,7 @@ func volumesForRack(r cassandrav1alpha1.RackSpec) []corev1.Volume {
 	}
 	if *r.JMXExporterConfigMapName != "" {
 		volumes = append(volumes, corev1.Volume{
-			Name: "jmx-config",
+			Name: constants.JMXConfigMapVolume,
 			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: *r.JMXExporterConfigMapName},
 			}},

--- a/pkg/operator/cassandra/sidecar/config.go
+++ b/pkg/operator/cassandra/sidecar/config.go
@@ -45,7 +45,12 @@ const (
 	scyllaJMXPath              = "/usr/lib/scylla/jmx/scylla-jmx"
 
 	// Common
-	jolokiaPath            = constants.PluginDirName + "/" + "jolokia.jar"
+	jolokiaPath = constants.PluginDirName + "/" + "jolokia.jar"
+
+	jmxExporterPath       = constants.PluginDirName + "/" + "jmx_prometheus.jar"
+	jmxExporterConfigPath = configDirCassandra + "/" + "jmx_exporter_config.yaml"
+	jmxExporterPort       = "9180"
+
 	entrypointPath         = "/entrypoint.sh"
 	rackDCPropertiesFormat = "dc=%s" + "\n" + "rack=%s" + "\n" + "prefer_local=false" + "\n"
 )
@@ -134,11 +139,15 @@ func (m *MemberController) generateCassandraConfigFiles() error {
 		return fmt.Errorf("error setting HEAP_NEWSIZE: %s", err.Error())
 	}
 
-	// Add jolokia javaagent
-	jolokiaConfig := []byte(fmt.Sprintf(`JVM_OPTS="$JVM_OPTS %s"`,
-		getJolokiaConfig()))
+	// Generate jmx_agent_config
+	jmxConfig := ""
+	if _, err := os.Stat(jmxExporterConfigPath); !os.IsNotExist(err) {
+		jmxConfig = getJmxExporterConfig()
+	}
 
-	err = ioutil.WriteFile(cassandraEnvPath, append(cassandraEnv, jolokiaConfig...), os.ModePerm)
+	agentsConfig := []byte(fmt.Sprintf(`JVM_OPTS="$JVM_OPTS %s %s"`, getJolokiaConfig(), jmxConfig))
+
+	err = ioutil.WriteFile(cassandraEnvPath, append(cassandraEnv, agentsConfig...), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error trying to write cassandra-env.sh: %s", err.Error())
 	}
@@ -365,7 +374,6 @@ func (m *MemberController) getSeeds() (string, error) {
 	sel := fmt.Sprintf("%s,%s=%s", constants.SeedLabel, constants.ClusterNameLabel, m.cluster)
 
 	for {
-
 		services, err = m.kubeClient.CoreV1().Services(m.namespace).List(metav1.ListOptions{LabelSelector: sel})
 		if err != nil {
 			return "", err
@@ -411,6 +419,10 @@ func getJolokiaConfig() string {
 		cmd = append(cmd, fmt.Sprintf("%s=%s", opt.flag, opt.value))
 	}
 	return fmt.Sprintf("-javaagent:%s=%s", jolokiaPath, strings.Join(cmd, ","))
+}
+
+func getJmxExporterConfig() string {
+	return fmt.Sprintf("-javaagent:%s=%s:%s", jmxExporterPath, jmxExporterPort, jmxExporterConfigPath)
 }
 
 // Merge YAMLs merges two arbitrary YAML structures on the top level.


### PR DESCRIPTION
**Description of your changes:**
This PR adds a reconciliation mechanism for the ConfigMaps used by a Cassandra Cluster.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
