### PR TITLE
ceph: ability to set target_size_ratio

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -70,6 +70,7 @@ When creating an erasure-coded pool, it is highly recommended to create the pool
 
 * `replicated`: Settings for a replicated pool. If specified, `erasureCoded` settings must not be specified.
   * `size`: The desired number of copies to make of the data in the pool.
+  * `targetSizeRatio:` gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool, for more info see the [ceph documentation](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size)
 * `erasureCoded`: Settings for an erasure-coded pool. If specified, `replicated` settings must not be specified. See below for more details on [erasure coding](#erasure-coding).
   * `dataChunks`: Number of chunks to divide the original object into
   * `codingChunks`: Number of coding chunks to generate

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -373,6 +373,31 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            failureDomain:
+                type: string
+            replicated:
+              properties:
+                size:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                targetSizeRatio:
+                  type: number
+            erasureCoded:
+              properties:
+                dataChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                codingChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -189,7 +189,7 @@ spec:
       JSONPath: .metadata.creationTimestamp
     - name: Phase
       type: string
-      description: Phase 
+      description: Phase
       JSONPath: .status.phase
     - name: Message
       type: string
@@ -435,6 +435,31 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            failureDomain:
+                type: string
+            replicated:
+              properties:
+                size:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                targetSizeRatio:
+                  type: number
+            erasureCoded:
+              properties:
+                dataChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                codingChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
 # OLM: END CEPH BLOCK POOL CRD
 # OLM: BEGIN CEPH VOLUME POOL CRD
 ---

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -19,6 +19,9 @@ spec:
     - failureDomain: host
       replicated:
         size: 3
+        # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+        # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+        #targetSizeRatio: .5
   # Whether to preserve metadata and data pools on filesystem deletion
   preservePoolsOnDelete: true
   # The metadata service (mds) configuration

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -15,6 +15,10 @@ spec:
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 3
+    # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+    # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+    #targetSizeRatio: .5
+
   # A key/value list of annotations
   annotations:
   #  key: value

--- a/pkg/apis/ceph.rook.io/v1/blockpool.go
+++ b/pkg/apis/ceph.rook.io/v1/blockpool.go
@@ -17,12 +17,14 @@ package v1
 
 import "github.com/rook/rook/pkg/daemon/ceph/model"
 
+// ToModel translates the spec details to an internal data model of a pool
 func (p *PoolSpec) ToModel(name string) *model.Pool {
 	pool := &model.Pool{Name: name, FailureDomain: p.FailureDomain, CrushRoot: p.CrushRoot, DeviceClass: p.DeviceClass}
 	r := p.Replication()
 	if r != nil {
 		pool.ReplicatedConfig.Size = r.Size
 		pool.Type = model.Replicated
+		pool.ReplicatedConfig.TargetSizeRatio = r.TargetSizeRatio
 	} else {
 		ec := p.ErasureCode()
 		if ec != nil {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -263,10 +263,13 @@ type Status struct {
 	Phase string `json:"phase,omitempty"`
 }
 
-// ReplicationSpec represents the spec for replication in a pool
+// ReplicatedSpec represents the spec for replication in a pool
 type ReplicatedSpec struct {
-	// Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
+	// Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
 	Size uint `json:"size"`
+
+	// TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
+	TargetSizeRatio float64 `json:"targetSizeRatio"`
 }
 
 // ErasureCodeSpec represents the spec for erasure code in a pool

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -124,6 +124,7 @@ func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 
 	if modelPool.Type == model.Replicated {
 		pool.Size = modelPool.ReplicatedConfig.Size
+		pool.TargetSizeRatio = modelPool.ReplicatedConfig.TargetSizeRatio
 	} else if modelPool.Type == model.ErasureCoded {
 		pool.ErasureCodeProfile = GetErasureCodeProfileForPool(modelPool.Name)
 	}

--- a/pkg/daemon/ceph/model/pool.go
+++ b/pkg/daemon/ceph/model/pool.go
@@ -24,7 +24,8 @@ const (
 type PoolType int
 
 type ReplicatedPoolConfig struct {
-	Size uint `json:"size"`
+	Size            uint    `json:"size"`
+	TargetSizeRatio float64 `json:"targetSizeRatio"`
 }
 
 type ErasureCodedPoolConfig struct {

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -460,6 +460,31 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            failureDomain:
+                type: string
+            replicated:
+              properties:
+                size:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                targetSizeRatio:
+                  type: number
+            erasureCoded:
+              properties:
+                dataChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                codingChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -1963,7 +1988,8 @@ metadata:
   namespace: ` + namespace + `
 spec:
   replicated:
-    size: ` + replicaSize
+    size: ` + replicaSize + `
+    targetSizeRatio: .5`
 }
 
 func (m *CephManifestsMaster) GetBlockStorageClassDef(poolName string, storageClassName string, reclaimPolicy string, namespace string, varClusterName bool) string {


### PR DESCRIPTION
**Description of your changes:**

target_size_ratio is used the tell the Ceph cluster the excepted
occupancy of a pool in the cluster.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]