### PR TITLE
Ceph: move csi placements to cephCluster.placement

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	KeyMon       rook.KeyType = "mon"
-	KeyMgr       rook.KeyType = "mgr"
-	KeyOSD       rook.KeyType = "osd"
-	KeyRBDMirror rook.KeyType = "rbdmirror"
-	KeyRGW       rook.KeyType = "rgw"
+	KeyMon            rook.KeyType = "mon"
+	KeyMgr            rook.KeyType = "mgr"
+	KeyOSD            rook.KeyType = "osd"
+	KeyRBDMirror      rook.KeyType = "rbdmirror"
+	KeyRGW            rook.KeyType = "rgw"
+	KeyCSIProvisioner rook.KeyType = "csi-provisioner"
+	KeyCSIPlugin      rook.KeyType = "csi-plugin"
 )

--- a/pkg/apis/ceph.rook.io/v1/placement.go
+++ b/pkg/apis/ceph.rook.io/v1/placement.go
@@ -38,3 +38,13 @@ func GetOSDPlacement(p rook.PlacementSpec) rook.Placement {
 func GetRBDMirrorPlacement(p rook.PlacementSpec) rook.Placement {
 	return p.All().Merge(p[KeyRBDMirror])
 }
+
+// GetCSIProvisionerPlacement returns the placement for CSI Provisioners
+func GetCSIProvisionerPlacement(p rook.PlacementSpec) rook.Placement {
+	return p.All().Merge(p[KeyCSIProvisioner])
+}
+
+// GetCSIPluginPlacement returns the placement for CSI Plugins
+func GetCSIPluginPlacement(p rook.PlacementSpec) rook.Placement {
+	return p.All().Merge(p[KeyCSIPlugin])
+}

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rook/rook/pkg/operator/test"
 
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,6 +45,7 @@ func TestStartCSI(t *testing.T) {
 	if err != nil {
 		assert.Nil(t, err)
 	}
-	err = StartCSIDrivers("ns", clientset, serverVersion)
+	clusterSpec := &cephv1.ClusterSpec{}
+	err = StartCSIDrivers("ns", clusterSpec, clientset, serverVersion)
 	assert.Nil(t, err)
 }

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -199,7 +199,7 @@ func (o *Operator) startSystemDaemons(clusterSpec *cephv1.ClusterSpec) error {
 		return errors.Wrapf(err, "invalid csi params")
 	}
 
-	if err = csi.StartCSIDrivers(o.operatorNamespace, o.context.Clientset, serverVersion); err != nil {
+	if err = csi.StartCSIDrivers(o.operatorNamespace, clusterSpec, o.context.Clientset, serverVersion); err != nil {
 		return errors.Wrapf(err, "failed to start Ceph csi drivers")
 	}
 	logger.Infof("successfully started Ceph CSI driver(s)")


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- ceph-csi starts when CephCluster is created. So it makes
more sense to have csi placements within the CephCluster spec
rather than the rook operator. This also allows modification of
csi placement without restarting operator.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
