### PR TITLE
ceph: fail if no devices found

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -214,6 +214,15 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 		return errors.Wrap(err, "failed to configure devices")
 	}
 
+	// Let's fail if no OSDs were configured
+	// This likely means the filter for available devices passed (in PVC case)
+	// but the resulting device was already configured for another cluster (disk not wiped and leftover)
+	// So we need to make sure the list is filled up, otherwise fail
+	if len(deviceOSDs) == 0 {
+		logger.Warningf("skipping OSD configuration as no devices matched the storage settings for this node %q", agent.nodeName)
+		return nil
+	}
+
 	logger.Infof("devices = %+v", deviceOSDs)
 
 	// Populate CRUSH location for each OSD on the host


### PR DESCRIPTION
**Description of your changes:**

This will likely happen when re-running an orchestration and
bootstrapping a new cluster with unclean drives.
The prepare pod won't prepare nor list existing disks, thus the code
will later fail on reading disks properties.

Closes: https://github.com/rook/rook/issues/4810
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4810

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
