### PR TITLE
ceph: allow osd full upgrade to octopus

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -115,16 +115,16 @@ func EnableMessenger2(context *clusterd.Context, clusterName string) error {
 	return nil
 }
 
-// EnableNautilusOSD disallows pre-Nautilus OSDs and enables all new Nautilus-only functionality
-func EnableNautilusOSD(context *clusterd.Context, clusterName string) error {
-	args := []string{"osd", "require-osd-release", "nautilus"}
+// EnableReleaseOSDFunctionality disallows pre-Nautilus OSDs and enables all new Nautilus-only functionality
+func EnableReleaseOSDFunctionality(context *clusterd.Context, clusterName, release string) error {
+	args := []string{"osd", "require-osd-release", release}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to disallow pre-nautilus osds and enable all new nautilus-only functionality")
+		return errors.Wrapf(err, "failed to disallow pre-%s osds and enable all new %s-only functionality", release, release)
 	}
 	output := string(buf)
 	logger.Debug(output)
-	logger.Infof("successfully disallowed pre-nautilus osds and enabled all new nautilus-only functionality")
+	logger.Infof("successfully disallowed pre-%s osds and enabled all new %s-only functionality", release, release)
 
 	return nil
 }

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -64,16 +64,17 @@ func TestEnableMessenger2(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestEnableNautilusOSD(t *testing.T) {
+func TestEnableReleaseOSDFunctionality(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(debug bool, name string, command string, args ...string) (string, error) {
 		assert.Equal(t, "osd", args[0])
 		assert.Equal(t, "require-osd-release", args[1])
+		assert.Equal(t, 3, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
 
-	err := EnableNautilusOSD(context, "rook-ceph")
+	err := EnableReleaseOSDFunctionality(context, "rook-ceph", "nautilus")
 	assert.NoError(t, err)
 }
 

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -147,6 +147,21 @@ func (v *CephVersion) IsMimic() bool {
 	return v.isRelease(Mimic)
 }
 
+// IsNautilus checks if the Ceph version is Nautilus
+func (v *CephVersion) IsNautilus() bool {
+	return v.isRelease(Nautilus)
+}
+
+// IsOctopus checks if the Ceph version is Octopus
+func (v *CephVersion) IsOctopus() bool {
+	return v.isRelease(Octopus)
+}
+
+// IsPacific checks if the Ceph version is Pacific
+func (v *CephVersion) IsPacific() bool {
+	return v.isRelease(Pacific)
+}
+
 // IsAtLeast checks a given Ceph version is at least a given one
 func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	if v.Major > other.Major {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Once osds will run on octopus we will activate the necessary features for these OSDs.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


[test ceph]