### PR TITLE
Set manifest versions to v1.2.4

### DIFF
--- a/Documentation/ceph-toolbox.md
+++ b/Documentation/ceph-toolbox.md
@@ -37,7 +37,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -49,11 +49,11 @@ With this upgrade guide, there are a few notes to consider:
 ## Patch Release Upgrades
 
 Unless otherwise noted due to extenuating requirements, upgrades from one patch release of Rook to
-another are as simple as updating the image of the Rook operator. For example, when Rook v1.2.3 is
+another are as simple as updating the image of the Rook operator. For example, when Rook v1.2.4 is
 released, the process of updating from v1.2.0 is as simple as running the following:
 
 ```console
-kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.3
+kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.4
 ```
 
 If you want to enable the CSI v2.0 driver, additional steps are needed in the
@@ -245,7 +245,7 @@ Any pod that is using a Rook volume should also remain healthy:
 ## Rook Operator Upgrade Process
 
 In the examples given in this guide, we will be upgrading a live Rook cluster running `v1.1.9` to
-the version `v1.2.3`. This upgrade should work from any official patch release of Rook v1.1 to any
+the version `v1.2.4`. This upgrade should work from any official patch release of Rook v1.1 to any
 official patch release of v1.2. We will further assume that your previous cluster was created using
 an earlier version of this guide and manifests. If you have created custom manifests, these steps
 may not work as written.
@@ -295,7 +295,7 @@ kubectl -n $ROOK_SYSTEM_NAMESPACE edit deploy rook-ceph-operator
 ```
 ```yaml
   # If you set this image at the same time as the env variables, you can skip step 3 of this guide and avoid a second operator restart
-  image: rook/ceph:v1.2.3
+  image: rook/ceph:v1.2.4
   env:
     # Change the update strategy for the CephFS driver if your cluster is affected
     - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
@@ -318,7 +318,7 @@ When the operator is updated, it will proceed to update all of the Ceph daemons.
 (If step 1 was completed, this change has already been applied.)
 
 ```sh
-kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.3
+kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.2.4
 ```
 
 ## 4. Wait for the upgrade to complete
@@ -336,17 +336,17 @@ watch --exec kubectl -n $ROOK_NAMESPACE get deployments -l rook_cluster=$ROOK_NA
 ```
 
 As an example, this cluster is midway through updating the OSDs from v1.1 to v1.2. When all
-deployments report `1/1/1` availability and `rook-version=v1.2.3`, the Ceph cluster's core
+deployments report `1/1/1` availability and `rook-version=v1.2.4`, the Ceph cluster's core
 components are fully updated.
 
 ```console
 Every 2.0s: kubectl -n rook-ceph get deployment -o j...
 
-rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.2.3
-rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.2.3
-rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.2.3
-rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.2.3
-rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.2.3
+rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.2.4
+rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.2.4
+rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.2.4
+rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.2.4
+rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.2.4
 rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.1.9
 rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.1.9
 ```
@@ -359,14 +359,14 @@ to proceed with the next step before the MDSes and RGWs are finished updating.
 # kubectl -n $ROOK_NAMESPACE get deployment -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
   rook-version=v1.1.9
-  rook-version=v1.2.3
+  rook-version=v1.2.4
 This cluster is finished:
-  rook-version=v1.2.3
+  rook-version=v1.2.4
 ```
 
 ## 5. Verify the updated cluster
 
-At this point, your Rook operator should be running version `rook/ceph:v1.2.3`.
+At this point, your Rook operator should be running version `rook/ceph:v1.2.4`.
 
 Verify the Ceph cluster's health using the [health verification section](#health-verification).
 

--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-after-reboot-check
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-before-reboot-check
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -186,7 +186,7 @@ subjects:
        serviceAccountName: rook-cassandra-operator
        containers:
        - name: rook-cassandra-operator
-         image: rook/cassandra:v1.2.3
+         image: rook/cassandra:v1.2.4
          imagePullPolicy: "Always"
          args: ["cassandra", "operator"]
          env:

--- a/cluster/examples/kubernetes/ceph/direct-mount.yaml
+++ b/cluster/examples/kubernetes/ceph/direct-mount.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-direct-mount
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -111,7 +111,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.2.3
+        image: rook/ceph:v1.2.4
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -94,7 +94,7 @@ spec:
       serviceAccountName: rook-cockroachdb-operator
       containers:
       - name: rook-cockroachdb-operator
-        image: rook/cockroachdb:v1.2.3
+        image: rook/cockroachdb:v1.2.4
         args: ["cockroachdb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -386,7 +386,7 @@ spec:
       serviceAccountName: rook-edgefs-system
       containers:
       - name: rook-edgefs-operator
-        image: rook/edgefs:v1.2.3
+        image: rook/edgefs:v1.2.4
         imagePullPolicy: "Always"
         args: ["edgefs", "operator"]
         env:

--- a/cluster/examples/kubernetes/minio/operator.yaml
+++ b/cluster/examples/kubernetes/minio/operator.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: rook-minio-operator
       containers:
       - name: rook-minio-operator
-        image: rook/minio:v1.2.3
+        image: rook/minio:v1.2.4
         args: ["minio", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -103,7 +103,7 @@ spec:
       serviceAccountName: rook-nfs-operator
       containers:
       - name: rook-nfs-operator
-        image: rook/nfs:v1.2.3
+        image: rook/nfs:v1.2.4
         imagePullPolicy: IfNotPresent
         args: ["nfs", "operator"]
         env:
@@ -192,7 +192,7 @@ spec:
       serviceAccount: rook-nfs-provisioner
       containers:
       - name: rook-nfs-provisioner
-        image: rook/nfs:v1.2.3
+        image: rook/nfs:v1.2.4
         imagePullPolicy: IfNotPresent
         args: ["nfs", "provisioner","--provisioner=rook.io/nfs-provisioner"]
         env:

--- a/cluster/examples/kubernetes/yugabytedb/operator.yaml
+++ b/cluster/examples/kubernetes/yugabytedb/operator.yaml
@@ -100,7 +100,7 @@ spec:
       serviceAccountName: rook-yugabytedb-operator
       containers:
       - name: rook-yugabytedb-operator
-        image: rook/yugabytedb:v1.2.3
+        image: rook/yugabytedb:v1.2.4
         args: ["yugabytedb", "operator"]
         env:
         - name: POD_NAME


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
For the patch release, set the manifest versions to v1.2.4.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]