### PR TITLE
WIP: Document for cluster recovery when running on PVCs

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -113,7 +113,6 @@ func (c *Cluster) makeDeploymentPVC(m *monConfig, canary bool) (*v1.PersistentVo
 	k8sutil.AddRookVersionLabelToObjectMeta(&pvc.ObjectMeta)
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&pvc.ObjectMeta)
 	opspec.AddCephVersionLabelToObjectMeta(c.ClusterInfo.CephVersion, &pvc.ObjectMeta)
-	k8sutil.SetOwnerRef(&pvc.ObjectMeta, &c.ownerRef)
 
 	// k8s uses limit as the resource request fallback
 	if _, ok := pvc.Spec.Resources.Limits[v1.ResourceStorage]; ok {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -833,6 +833,7 @@ func makeStorageClassDeviceSetPVCID(storageClassDeviceSetName string, setIndex, 
 
 func makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId string, pvcIndex, setIndex int) map[string]string {
 	return map[string]string{
+		k8sutil.AppAttr:            AppName,
 		CephDeviceSetLabelKey:      storageClassDeviceSetName,
 		CephSetIndexLabelKey:       fmt.Sprintf("%v", setIndex),
 		CephDeviceSetPVCIDLabelKey: pvcStorageClassDeviceSetPVCId,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When catastrophe strikes and an entire kubernetes cluster is destroyed, it is still possible to restore Rook in a new Kubernetes cluster as long as the PVs underneath the MONs and OSDs are still available and some critical metadata was backed up before the loss. This guide walks through the restoration of such a cluster.

My testing has not yet included loss of an entire cluster. Thus far it has only been tested on a cluster where the cluster CR was removed and the PVCs and PVs remained intact. 
- There are items marked TODO where we would need to fill in details for full k8s cluster loss. 
- The doc assumes critical metadata is backed up from a cluster before it is lost. I'd still like to explore recovery even if that metadata is not backed up.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]