### PR TITLE
ceph: force enabling balancer module with older clients

### DIFF
--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -128,7 +128,7 @@ func setBalancerMode(context *clusterd.Context, clusterName, mode string) error 
 
 // SetMinCompatClientLuminous set the minimum compatibility for clients to Luminous
 func SetMinCompatClientLuminous(context *clusterd.Context, clusterName string) error {
-	args := []string{"osd", "set-require-min-compat-client", "luminous"}
+	args := []string{"osd", "set-require-min-compat-client", "luminous", "--yes-i-really-mean-it"}
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return errors.Wrap(err, "failed to set set-require-min-compat-client to luminous")


### PR DESCRIPTION
**Description of your changes:**

When running old client version, we must force the compatibility
features so that the orchestration does not fail in a loop.

Closes: https://github.com/rook/rook/issues/4842
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4842

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]