### PR TITLE
ceph: remove mimic support, default to nautilus

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -11,6 +11,7 @@
 - OSD refactor: drop support for Rook legacy OSD, directory OSD and Filestore OSD. For more details refer to the [corresponding issue](https://github.com/rook/rook/issues/4724).
 - OSD on PVC now supports a metadata device, [refer to the cluster on PVC section](Documentation/ceph-cluster-crd.html#dedicated-metatada-device) or the [corresponding issue](https://github.com/rook/rook/issues/3852).
 - OSD on PVC now supports PVC expansion, if the size of the underlying block increases the Bluestore main block and the overall storage capacity will grow up.
+- Ceph Nautilus 14.2.5 is the minimum supported version
 
 ### EdgeFS
 

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -192,10 +192,6 @@ func SetNumMDSRanks(context *clusterd.Context, cephVersion cephver.CephVersion, 
 		return errors.Wrapf(err, "failed to set filesystem %s num mds ranks (max_mds) to %d", fsName, activeMDSCount)
 	}
 
-	if cephVersion.IsAtLeastMimic() {
-		return nil
-	}
-
 	// ** Noted section 2 - See note at top of function
 	// Now check the error to see if we can even determine whether we should reduce or not
 	if errAtStart != nil {

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 )
 
 var (
@@ -63,7 +62,7 @@ func MgrDisableModule(context *clusterd.Context, clusterName, name string) error
 }
 
 // MgrSetConfig applies a setting for a single mgr daemon
-func MgrSetConfig(context *clusterd.Context, clusterName, mgrName string, cephVersion cephver.CephVersion, key, val string, force bool) (bool, error) {
+func MgrSetConfig(context *clusterd.Context, clusterName, mgrName string, key, val string, force bool) (bool, error) {
 	var getArgs, setArgs []string
 	mgrID := fmt.Sprintf("mgr.%s", mgrName)
 	getArgs = append(getArgs, "config", "get", mgrID, key)
@@ -72,7 +71,7 @@ func MgrSetConfig(context *clusterd.Context, clusterName, mgrName string, cephVe
 	} else {
 		setArgs = append(setArgs, "config", "set", mgrID, key, val)
 	}
-	if force && cephVersion.IsAtLeastNautilus() {
+	if force {
 		setArgs = append(setArgs, "--force")
 	}
 

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -261,10 +261,6 @@ func OSDRemove(context *clusterd.Context, clusterName string, osdID int) (string
 }
 
 func OsdSafeToDestroy(context *clusterd.Context, clusterName string, osdID int, cephVersion cephver.CephVersion) (bool, error) {
-	if !cephVersion.IsAtLeastNautilus() {
-		logger.Debugf("failed to get safe-to-destroy status: ceph version in lower than Nautilus")
-		return false, nil
-	}
 	args := []string{"osd", "safe-to-destroy", strconv.Itoa(osdID)}
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -130,15 +130,7 @@ func EnableReleaseOSDFunctionality(context *clusterd.Context, clusterName, relea
 }
 
 // OkToStop determines if it's ok to stop an upgrade
-func OkToStop(context *clusterd.Context, namespace, deployment, daemonType, daemonName string, cephVersion cephver.CephVersion) error {
-	// The ok-to-stop command for mon and mds landed on 14.2.1
-	// so we return nil if that Ceph version is not satisfied
-	if !cephVersion.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-		if daemonType != "osd" {
-			return nil
-		}
-	}
-
+func OkToStop(context *clusterd.Context, namespace, deployment, daemonType, daemonName string) error {
 	versions, err := GetAllCephDaemonVersions(context, namespace)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get ceph daemons versions")

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -126,18 +125,6 @@ func TestOkToContinue(t *testing.T) {
 	context := &clusterd.Context{Executor: executor}
 
 	err := OkToContinue(context, "rook-ceph", "rook-ceph-mon-a", "mon", "a") // mon is not checked on ok-to-continue so nil is expected
-	assert.NoError(t, err)
-}
-
-func TestOkToStop(t *testing.T) {
-	executor := &exectest.MockExecutor{}
-	context := &clusterd.Context{Executor: executor}
-	v := cephver.Nautilus
-
-	err := OkToStop(context, "rook-ceph", "rook-ceph-mon-a", "mon", "a", v)
-	assert.NoError(t, err)
-
-	err = OkToStop(context, "rook-ceph", "rook-ceph-mds-a", "mds", "a", v)
 	assert.NoError(t, err)
 }
 

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -184,44 +184,8 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 	}
 
 	// extract a list of just the monitor names, which will populate the "mon initial members"
-	// global config field
-	monMembers := make([]string, len(cluster.Monitors))
-	monHosts := make([]string, len(cluster.Monitors))
-	i := 0
-	for _, monitor := range cluster.Monitors {
-		monMembers[i] = monitor.Name
-		monIP := cephutil.GetIPFromEndpoint(monitor.Endpoint)
-
-		// This tries to detect the current port if the mon already exists
-		// This basically handles the transition between monitors running on 6790 to msgr2
-		// So whatever the previous monitor port was we keep it
-		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
-
-		monPorts := [2]string{strconv.Itoa(int(Msgr2port)), strconv.Itoa(int(currentMonPort))}
-		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
-
-		// Mimic daemons like OSD won't be able to parse this, so only the operator should get this config
-		// they will fail with
-		// 		unable to parse addrs in 'v1:10.104.92.199:6790,v1:10.110.137.107:6790,v1:10.102.38.86:6790'
-		// 		server name not found: v1:10.104.92.199:6790 (Name or service not known)
-		// 		2019-04-25 10:31:08.614 7f5971aae1c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
-		// 		2019-04-25 10:31:08.614 7f5971aae1c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
-		// 		failed to fetch mon config (--no-mon-config to skip)
-		// The operator always fails this test since it does not have the env var 'ROOK_CEPH_VERSION'
-		podName := os.Getenv("POD_NAME")
-		if cluster.CephVersion.IsAtLeastNautilus() {
-			monHosts[i] = msgr1Prefix + msgr1Endpoint
-		} else if podName != "" && strings.Contains(podName, "operator") {
-			// This is an operator and its version is always based on Nautilus
-			// so it knows how to parse both msgr1 and msgr2 syntax
-			prefix := msgrPrefix(currentMonPort)
-			monHosts[i] = prefix + msgr1Endpoint
-		} else {
-			// This is not the operator, it's an OSD and its Ceph version is before Nautilus
-			monHosts[i] = msgr1Endpoint
-		}
-		i++
-	}
+	// and "mon hosts" global config field
+	monMembers, monHosts := PopulateMonHostMembers(cluster.Monitors)
 
 	cephLogLevel := logLevelToCephLogLevel(context.LogLevel)
 
@@ -252,15 +216,6 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 			RbdDefaultFeatures:     3,
 			FatalSignalHandlers:    "false",
 		},
-	}
-
-	// Everything before 14.2.1
-	// These new flags control Ceph's daemon logging behavior to files
-	// By default we set them to False so no logs get written on file
-	// However they can be activated at any time via the centralized config store
-	if !cluster.CephVersion.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-		conf.LogFile = "/dev/stderr"
-		conf.MonClusterLogFile = "/dev/stderr"
 	}
 
 	return conf, nil
@@ -334,4 +289,31 @@ func msgrPrefix(currentMonPort int32) string {
 
 	return msgr1Prefix
 
+}
+
+// PopulateMonHostMembers extracts a list of just the monitor names, which will populate the "mon initial members"
+// and "mon hosts" global config field
+func PopulateMonHostMembers(monitors map[string]*MonInfo) ([]string, []string) {
+	monMembers := make([]string, len(monitors))
+	monHosts := make([]string, len(monitors))
+
+	i := 0
+	for _, monitor := range monitors {
+		monMembers[i] = monitor.Name
+		monIP := cephutil.GetIPFromEndpoint(monitor.Endpoint)
+
+		// This tries to detect the current port if the mon already exists
+		// This basically handles the transition between monitors running on 6790 to msgr2
+		// So whatever the previous monitor port was we keep it
+		currentMonPort := cephutil.GetPortFromEndpoint(monitor.Endpoint)
+
+		monPorts := [2]string{strconv.Itoa(int(Msgr2port)), strconv.Itoa(int(currentMonPort))}
+		msgr2Endpoint := net.JoinHostPort(monIP, monPorts[0])
+		msgr1Endpoint := net.JoinHostPort(monIP, monPorts[1])
+
+		monHosts[i] = "[v2:" + msgr2Endpoint + ",v1:" + msgr1Endpoint + "]"
+		i++
+	}
+
+	return monMembers, monHosts
 }

--- a/pkg/daemon/ceph/config/config_test.go
+++ b/pkg/daemon/ceph/config/config_test.go
@@ -40,7 +40,7 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6789"},
 			"node1": {Name: "mon1", Endpoint: "10.0.0.2:6789"},
 		},
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 
 	// start with INFO level logging
@@ -96,7 +96,7 @@ func TestGenerateConfigFile(t *testing.T) {
 		Monitors: map[string]*MonInfo{
 			"node0": {Name: "mon0", Endpoint: "10.0.0.1:6789"},
 		},
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 
 	// generate the config file to disk now
@@ -127,11 +127,8 @@ func verifyConfig(t *testing.T, cephConfig *CephConfig, cluster *ClusterInfo, lo
 	}
 
 	// Testing mon_host
-	expectedMons := "10.0.0.1:6789,10.0.0.2:6789"
 
-	if cluster.CephVersion.IsAtLeastNautilus() {
-		expectedMons = "[v2:10.0.0.1:3300,v1:10.0.0.1:6789],[v2:10.0.0.2:3300,v1:10.0.0.2:6789]"
-	}
+	expectedMons := "[v2:10.0.0.1:3300,v1:10.0.0.1:6789],[v2:10.0.0.2:3300,v1:10.0.0.2:6789]"
 
 	for _, expectedMon := range strings.Split(expectedMons, ",") {
 		contained := false

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -518,14 +518,10 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		}
 		mdArgs = append(mdArgs, strings.Split(conf["devices"], " ")...)
 
-		if a.cluster.CephVersion.IsAtLeast(cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-			mdArgs = append(mdArgs, []string{
-				dbDeviceFlag,
-				path.Join("/dev", md),
-			}...)
-		} else {
-			mdArgs = append(mdArgs, path.Join("/dev", md))
-		}
+		mdArgs = append(mdArgs, []string{
+			dbDeviceFlag,
+			path.Join("/dev", md),
+		}...)
 
 		// Reporting
 		reportArgs := append(mdArgs, []string{

--- a/pkg/operator/ceph/cluster/cluster_test.go
+++ b/pkg/operator/ceph/cluster/cluster_test.go
@@ -116,16 +116,16 @@ func TestMinVersion(t *testing.T) {
 	c := testSpec()
 	c.Spec.CephVersion.AllowUnsupported = true
 
-	// All versions less than 13.2.4 are invalid
-	v := &cephver.CephVersion{Major: 12, Minor: 2, Extra: 10}
+	// All versions less than 14.2.5 are invalid
+	v := &cephver.CephVersion{Major: 13, Minor: 2, Extra: 3}
 	assert.Error(t, c.validateCephVersion(v))
-	v = &cephver.CephVersion{Major: 13, Minor: 2, Extra: 3}
+	v = &cephver.CephVersion{Major: 14, Minor: 2, Extra: 1}
+	assert.Error(t, c.validateCephVersion(v))
+	v = &cephver.CephVersion{Major: 14}
 	assert.Error(t, c.validateCephVersion(v))
 
-	// All versions at least 13.2.4 are valid
-	v = &cephver.CephVersion{Major: 13, Minor: 2, Extra: 4}
-	assert.NoError(t, c.validateCephVersion(v))
-	v = &cephver.CephVersion{Major: 14}
+	// All versions at least 14.2.5 are valid
+	v = &cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
 	assert.NoError(t, c.validateCephVersion(v))
 	v = &cephver.CephVersion{Major: 15}
 	assert.NoError(t, c.validateCephVersion(v))
@@ -135,11 +135,11 @@ func TestSupportedVersion(t *testing.T) {
 	c := testSpec()
 
 	// Supported versions are valid
-	v := &cephver.CephVersion{Major: 14, Minor: 2, Extra: 0}
+	v := &cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
 	assert.NoError(t, c.validateCephVersion(v))
 
 	// Unsupported versions are not valid
-	v = &cephver.CephVersion{Major: 15, Minor: 2, Extra: 0}
+	v = &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
 	assert.Error(t, c.validateCephVersion(v))
 
 	// Unsupported versions are now valid

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/rook/rook/pkg/operator/ceph/csi"
-	"github.com/rook/rook/pkg/operator/ceph/version"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -340,11 +339,9 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 	// Create Crash Collector Secret
 	// In 14.2.5 the crash daemon will read the client.crash key instead of the admin key
 	if !cluster.Spec.CrashCollector.Disable {
-		if cluster.Info.CephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 5}) {
-			err = crash.CreateCrashCollectorSecret(c.context, namespace, &cluster.ownerRef)
-			if err != nil {
-				return errors.Wrap(err, "failed to create crash collector kubernetes secret")
-			}
+		err = crash.CreateCrashCollectorSecret(c.context, namespace, &cluster.ownerRef)
+		if err != nil {
+			return errors.Wrap(err, "failed to create crash collector kubernetes secret")
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/crash/crash_test.go
+++ b/pkg/operator/ceph/cluster/crash/crash_test.go
@@ -19,38 +19,11 @@ package crash
 import (
 	"testing"
 
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateCrashEnvVar(t *testing.T) {
-	v := cephver.Nautilus
-	env := generateCrashEnvVar(v)
-	assert.Equal(t, "CEPH_ARGS", env.Name)
-	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/admin-keyring-store/keyring", env.Value)
-
-	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
-	env = generateCrashEnvVar(v)
+	env := generateCrashEnvVar()
 	assert.Equal(t, "CEPH_ARGS", env.Name)
 	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/crash-collector-keyring-store/keyring", env.Value)
-}
-
-func TestGetVolumes(t *testing.T) {
-	v := cephver.Nautilus
-	vol := getVolumes(v)
-	assert.Equal(t, "rook-ceph-admin-keyring", vol.Name)
-
-	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
-	vol = getVolumes(v)
-	assert.Equal(t, "rook-ceph-crash-collector-keyring", vol.Name)
-}
-
-func TestGetVolumeMount(t *testing.T) {
-	v := cephver.Nautilus
-	volMounts := getVolumeMounts(v)
-	assert.Equal(t, "rook-ceph-admin-keyring", volMounts.Name)
-
-	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
-	volMounts = getVolumeMounts(v)
-	assert.Equal(t, "rook-ceph-crash-collector-keyring", volMounts.Name)
 }

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -102,7 +102,7 @@ func TestStartSecureDashboard(t *testing.T) {
 	}
 
 	clusterInfo := &cephconfig.ClusterInfo{
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: test.New(3), Executor: executor}, Namespace: "myns",
 		dashboard: cephv1.DashboardSpec{Port: dashboardPortHTTP, Enabled: true, SSL: true}, cephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v13.2.2"}}

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -179,9 +179,6 @@ func TestConfigureModules(t *testing.T) {
 	c.mgrSpec.Modules = []cephv1.Module{
 		{Name: "pg_autoscaler", Enabled: true},
 	}
-	c.clusterInfo.CephVersion = cephver.CephVersion{Major: 13}
-	assert.Error(t, c.configureMgrModules())
-	assert.Equal(t, 0, len(configSettings))
 
 	// one module that has a min version that is met
 	c.mgrSpec.Modules = []cephv1.Module{

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -35,11 +35,6 @@ var (
 
 // Ceph docs about the orchestrator modules: http://docs.ceph.com/docs/master/mgr/orchestrator_cli/
 func (c *Cluster) configureOrchestratorModules() error {
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		logger.Infof("skipping enabling orchestrator modules on releases older than nautilus")
-		return nil
-	}
-
 	if err := client.MgrEnableModule(c.context, c.Namespace, rookModuleName, true); err != nil {
 		return errors.Wrapf(err, "failed to enable mgr rook module")
 	}
@@ -53,10 +48,6 @@ func (c *Cluster) configureOrchestratorModules() error {
 }
 
 func (c *Cluster) setRookOrchestratorBackend() error {
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		return nil
-	}
-
 	// retry a few times in the case that the mgr module is not ready to accept commands
 	_, err := client.ExecuteCephCommandWithRetry(func() ([]byte, error) {
 		args := []string{"orchestrator", "set", "backend", "rook"}

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -62,7 +62,7 @@ func TestOrchestratorModules(t *testing.T) {
 	}
 
 	clusterInfo := &cephconfig.ClusterInfo{
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 
 	c := &Cluster{clusterInfo: clusterInfo, context: context}
@@ -71,21 +71,7 @@ func TestOrchestratorModules(t *testing.T) {
 	}
 	orchestratorInitWaitTime = 0
 
-	// the modules are skipped on mimic
-	c.clusterInfo.CephVersion = cephver.Mimic
 	err := c.configureOrchestratorModules()
-	assert.NoError(t, err)
-	err = c.setRookOrchestratorBackend()
-	assert.NoError(t, err)
-	assert.False(t, orchestratorModuleEnabled)
-	assert.False(t, rookModuleEnabled)
-	assert.False(t, rookBackendSet)
-	assert.Equal(t, 0, backendErrorCount)
-
-	// the modules are configured on nautilus
-	// the rook module will fail to be set
-	c.clusterInfo.CephVersion = cephver.Nautilus
-	err = c.configureOrchestratorModules()
 	assert.Error(t, err)
 	err = c.setRookOrchestratorBackend()
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -174,39 +174,13 @@ func TestHttpBindFix(t *testing.T) {
 		DataPathMap:  config.NewStatelessDaemonDataPathMap(config.MgrType, "a", "rook-ceph", "/var/lib/rook/"),
 	}
 
-	vers := []struct {
-		hasFix bool
-		ver    cephver.CephVersion
-	}{
-		// versions before the fix was introduced
-		{hasFix: false, ver: cephver.CephVersion{Major: 11, Minor: 2, Extra: 1}},
-		{hasFix: false, ver: cephver.CephVersion{Major: 12, Minor: 2, Extra: 11}},
-		{hasFix: false, ver: cephver.CephVersion{Major: 13, Minor: 2, Extra: 5}},
-		{hasFix: false, ver: cephver.CephVersion{Major: 14, Minor: 1, Extra: 0}},
+	c.clusterInfo.CephVersion = cephver.Nautilus
+	expectedInitContainers := 3
+	d := c.makeDeployment(&mgrTestConfig)
+	assert.NotNil(t, d)
+	assert.Equal(t, expectedInitContainers,
+		len(d.Spec.Template.Spec.InitContainers))
 
-		// versions when the fix was introduced
-		{hasFix: true, ver: cephver.CephVersion{Major: 13, Minor: 2, Extra: 6}},
-		{hasFix: true, ver: cephver.CephVersion{Major: 14, Minor: 1, Extra: 1}},
-
-		// versions after the fix
-		{hasFix: true, ver: cephver.CephVersion{Major: 13, Minor: 2, Extra: 7}},
-		{hasFix: true, ver: cephver.CephVersion{Major: 14, Minor: 1, Extra: 2}},
-		{hasFix: true, ver: cephver.CephVersion{Major: 15, Minor: 2, Extra: 0}},
-	}
-
-	for _, test := range vers {
-		c.clusterInfo.CephVersion = test.ver
-
-		expectedInitContainers := 1
-		if !test.hasFix {
-			expectedInitContainers += 2
-		}
-
-		d := c.makeDeployment(&mgrTestConfig)
-		assert.NotNil(t, d)
-		assert.Equal(t, expectedInitContainers,
-			len(d.Spec.Template.Spec.InitContainers))
-	}
 }
 
 func TestApplyPrometheusAnnotations(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -149,13 +149,13 @@ func TestStartMonPods(t *testing.T) {
 	c := newCluster(context, namespace, cephv1.NetworkSpec{}, true, v1.ResourceRequirements{})
 
 	// start a basic cluster
-	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 
 	validateStart(t, c)
 
 	// starting again should be a no-op, but still results in an error
-	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 
 	validateStart(t, c)
@@ -169,7 +169,7 @@ func TestOperatorRestart(t *testing.T) {
 	c.ClusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
-	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 	assert.True(t, info.IsInitialized())
 
@@ -178,7 +178,7 @@ func TestOperatorRestart(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, v1.ResourceRequirements{})
 
 	// starting again should be a no-op, but will not result in an error
-	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 	assert.True(t, info.IsInitialized())
 
@@ -196,7 +196,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	c.ClusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
-	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	info, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 	assert.True(t, info.IsInitialized())
 
@@ -206,7 +206,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{HostNetwork: true}, false, v1.ResourceRequirements{})
 
 	// starting again should be a no-op, but still results in an error
-	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	info, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 	assert.True(t, info.IsInitialized(), info)
 

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -79,7 +79,7 @@ func TestHostNetworkSameNode(t *testing.T) {
 	c.ClusterInfo = test.CreateConfigDir(1)
 
 	// start a basic cluster
-	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Error(t, err)
 }
 
@@ -97,7 +97,7 @@ func TestPodMemory(t *testing.T) {
 	c := newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
 	c.ClusterInfo = test.CreateConfigDir(1)
 	// start a basic cluster
-	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err := c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Error(t, err)
 
 	// Test REQUEST == LIMIT
@@ -113,7 +113,7 @@ func TestPodMemory(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
 	c.ClusterInfo = test.CreateConfigDir(1)
 	// start a basic cluster
-	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Error(t, err)
 
 	// Test LIMIT != REQUEST but obviously LIMIT > REQUEST
@@ -129,7 +129,7 @@ func TestPodMemory(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
 	c.ClusterInfo = test.CreateConfigDir(1)
 	// start a basic cluster
-	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Error(t, err)
 
 	// Test valid case where pod resource is set approprietly
@@ -145,7 +145,7 @@ func TestPodMemory(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
 	c.ClusterInfo = test.CreateConfigDir(1)
 	// start a basic cluster
-	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 
 	// Test no resources were specified on the pod
@@ -153,7 +153,7 @@ func TestPodMemory(t *testing.T) {
 	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
 	c.ClusterInfo = test.CreateConfigDir(1)
 	// start a basic cluster
-	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Mimic, c.spec)
+	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
 	assert.Nil(t, err)
 
 }

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -50,9 +50,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	k8sutil.SetOwnerRef(&svcDef.ObjectMeta, &c.ownerRef)
 
 	// If deploying Nautilus or newer we need a new port for the monitor service
-	if c.ClusterInfo.CephVersion.IsAtLeastNautilus() {
-		addServicePort(svcDef, "msgr2", DefaultMsgr2Port)
-	}
+	addServicePort(svcDef, "msgr2", DefaultMsgr2Port)
 
 	s, err := k8sutil.CreateOrUpdateService(c.context.Clientset, c.Namespace, svcDef)
 	if err != nil {
@@ -67,10 +65,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	// mon endpoint are not actually like, they remain with the mgrs1 format
 	// however it's interesting to show that monitors can be addressed via 2 different ports
 	// in the end the service has msgr1 and msgr2 ports configured so it's not entirely wrong
-	if c.ClusterInfo.CephVersion.IsAtLeastNautilus() {
-		logger.Infof("mon %q endpoint are [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(DefaultMsgr2Port)), s.Spec.ClusterIP, mon.Port)
-	} else {
-		logger.Infof("mon %q endpoint is %s:%d", mon.DaemonName, s.Spec.ClusterIP, mon.Port)
-	}
+	logger.Infof("mon %q endpoint are [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(DefaultMsgr2Port)), s.Spec.ClusterIP, mon.Port)
+
 	return s.Spec.ClusterIP, nil
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -282,10 +282,8 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			config.NewFlag("public-bind-addr", opspec.ContainerEnvVarReference(podIPEnvVar)))
 	}
 
-	// If deploying Nautilus and newer we need a new port of the monitor container
-	if c.ClusterInfo.CephVersion.IsAtLeastNautilus() {
-		addContainerPort(container, "msgr2", 3300)
-	}
+	// Add messenger 2 port
+	addContainerPort(container, "msgr2", 3300)
 
 	return container
 }
@@ -303,7 +301,7 @@ func UpdateCephDeploymentAndWait(context *clusterd.Context, deployment *apps.Dep
 		logger.Infof("checking if we can %s the deployment %s", action, deployment.Name)
 
 		if action == "stop" {
-			err := client.OkToStop(context, namespace, deployment.Name, daemonType, daemonName, cephVersion)
+			err := client.OkToStop(context, namespace, deployment.Name, daemonType, daemonName)
 			if err != nil {
 				if continueUpgradeAfterChecksEvenIfNotHealthy {
 					logger.Infof("The %s daemon %s is not ok-to-stop but 'continueUpgradeAfterChecksEvenIfNotHealthy' is true, so proceeding to stop...", daemonType, daemonName)

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -869,11 +869,6 @@ func UpdateLocationWithNodeLabels(location *[]string, nodeLabels map[string]stri
 func (c *Cluster) applyUpgradeOSDFunctionality() {
 	var osdVersion *cephver.CephVersion
 
-	// If mimic, do nothing
-	if c.clusterInfo.CephVersion.IsMimic() {
-		return
-	}
-
 	// Get all the daemons versions
 	versions, err := client.GetAllCephDaemonVersions(c.context, c.clusterInfo.Name)
 	if err != nil {
@@ -892,14 +887,6 @@ func (c *Cluster) applyUpgradeOSDFunctionality() {
 			if err != nil {
 				logger.Warningf("failed to extract ceph version. %v", err)
 				return
-			}
-			// if the version of these OSDs is Nautilus then we run the command
-			if osdVersion.IsNautilus() {
-				err = client.EnableReleaseOSDFunctionality(c.context, c.Namespace, "nautilus")
-				if err != nil {
-					logger.Warningf("failed to enable new osd functionality. %v", err)
-					return
-				}
 			}
 			// if the version of these OSDs is Octopus then we run the command
 			if osdVersion.IsOctopus() {

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -343,17 +343,13 @@ func TestHostNetwork(t *testing.T) {
 
 func TestOsdOnSDNFlag(t *testing.T) {
 	network := cephv1.NetworkSpec{}
-	v := cephver.Mimic
-	args := osdOnSDNFlag(network, v)
+
+	args := osdOnSDNFlag(network)
+	assert.NotEmpty(t, args)
+
+	network.Provider = "host"
+	args = osdOnSDNFlag(network)
 	assert.Empty(t, args)
-
-	v = cephver.CephVersion{Major: 14, Minor: 2, Extra: 2}
-	args = osdOnSDNFlag(network, v)
-	assert.NotEmpty(t, args)
-
-	v = cephver.Octopus
-	args = osdOnSDNFlag(network, v)
-	assert.NotEmpty(t, args)
 }
 
 func TestOsdPrepareResources(t *testing.T) {

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -35,17 +35,8 @@ func DefaultFlags(fsid, mountedKeyringPath string, cephVersion version.CephVersi
 		NewFlag("mon-cluster-log-to-stderr", "true"),
 		// differentiate debug text from audit text, and the space after 'debug' is critical
 		NewFlag("log-stderr-prefix", "debug "),
-	}
-
-	// As of Nautilus 14.2.1 at least
-	// These new flags control Ceph's daemon logging behavior to files
-	// By default we set them to False so no logs get written on file
-	// However they can be activated at any time via the centralized config store
-	if cephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-		flags = append(flags, []string{
-			NewFlag("default-log-to-file", "false"),
-			NewFlag("default-mon-cluster-log-to-file", "false"),
-		}...)
+		NewFlag("default-log-to-file", "false"),
+		NewFlag("default-mon-cluster-log-to-file", "false"),
 	}
 
 	flags = append(flags, StoredMonHostEnvVarFlags()...)
@@ -63,20 +54,8 @@ func configOverride(who, option, value string) Option {
 func DefaultCentralizedConfigs(cephVersion version.CephVersion) []Option {
 	overrides := []Option{
 		configOverride("global", "mon allow pool delete", "true"),
-	}
-
-	// Everything before Nautilus 14.2.1
-	// Prior to Nautilus 14.2.1 certain log flags were not present
-	// so in order to not log anything on files we must set the following flags to null
-	// Since Nautilus 14.2.1 introduced both 'default-log-to-file' and 'default-mon-cluster-log-to-file' (see above defaultFlagConfigs)
-	// these are not needed
-	if !cephVersion.IsAtLeast(version.CephVersion{Major: 14, Minor: 2, Extra: 1}) {
-		// Set the default log files to empty so they don't bloat containers. Can be changed in
-		// Mimic+ by users if needed.
-		overrides = append(overrides, []Option{
-			configOverride("global", "log file", ""),
-			configOverride("global", "mon cluster log file", ""),
-		}...)
+		configOverride("global", "log file", ""),
+		configOverride("global", "mon cluster log file", ""),
 	}
 
 	// We disable "bluestore warn on legacy statfs"

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -41,13 +41,21 @@ func TestStore(t *testing.T) {
 	assertConfigStore := func(ci *cephconfig.ClusterInfo) {
 		sec, e := clientset.CoreV1().Secrets(ns).Get(StoreName, metav1.GetOptions{})
 		assert.NoError(t, e)
-		mh := strings.Split(sec.StringData["mon_host"], ",") // list of mon ip:port pairs in cluster
-		assert.Equal(t, len(ci.Monitors), len(mh))
-		mim := strings.Split(sec.StringData["mon_initial_members"], ",") // list of mon ids in cluster
+		mh := strings.Split(sec.StringData["mon_host"], ",")                    // list of mon ip:port pairs in cluster
+		assert.Equal(t, len(ci.Monitors)*2, len(mh), ci.Monitors["a"].Endpoint) // we need to pass x2 since we split on "," above and that returns msgr1 and msgr2 addresses
+		mim := strings.Split(sec.StringData["mon_initial_members"], ",")        // list of mon ids in cluster
 		assert.Equal(t, len(ci.Monitors), len(mim))
 		// make sure every mon has its id/ip:port in mon_initial_members/mon_host
 		for _, id := range mim {
-			assert.Contains(t, mh, ci.Monitors[id].Endpoint)
+			// cannot use "assert.Contains(t, mh, ci.Monitors[id].Endpoint)"
+			// it looks like the value is not found but if present, it might be confused by the brackets
+			contains := false
+			for _, c := range mh {
+				if strings.Contains(c, ci.Monitors[id].Endpoint) {
+					contains = true
+				}
+			}
+			assert.True(t, contains)
 			assert.Contains(t, mim, ci.Monitors[id].Name)
 		}
 	}

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -81,12 +81,6 @@ func (c *Cluster) setDefaultFlagsMonConfigStore(mdsID string) error {
 		configOptions["mds_cache_memory_limit"] = strconv.Itoa(int(mdsCacheMemoryLimit))
 	}
 
-	// These flags are obsoleted as of Nautilus
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		configOptions["mds_standby_for_fscid"] = c.fsID
-		configOptions["mds_standby_replay"] = strconv.FormatBool(c.fs.Spec.MetadataServer.ActiveStandby)
-	}
-
 	// Set mds_join_fs flag to force mds daemon to join a specific fs
 	if c.clusterInfo.CephVersion.IsAtLeastOctopus() {
 		configOptions["mds_join_fs"] = c.fs.Name

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -59,7 +59,7 @@ func testDeploymentObject(network cephv1.NetworkSpec) *apps.Deployment {
 	}
 	clusterInfo := &cephconfig.ClusterInfo{
 		FSID:        "myfsid",
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 
 	c := NewCluster(

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -86,10 +86,6 @@ func (c *CephNFSController) onAdd(obj interface{}) {
 	}
 
 	nfs := obj.(*cephv1.CephNFS).DeepCopy()
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		logger.Errorf("Ceph NFS is only supported with Nautilus or newer. CRD %q will be ignored.", nfs.Name)
-		return
-	}
 
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
@@ -112,10 +108,6 @@ func (c *CephNFSController) onUpdate(oldObj, newObj interface{}) {
 
 	oldNFS := oldObj.(*cephv1.CephNFS).DeepCopy()
 	newNFS := newObj.(*cephv1.CephNFS).DeepCopy()
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		logger.Errorf("Ceph NFS is only supported with Nautilus or newer. CRD %q will be ignored.", newNFS.Name)
-		return
-	}
 
 	if !nfsChanged(oldNFS.Spec, newNFS.Spec) {
 		logger.Debugf("nfs ganesha %q not updated", newNFS.Name)
@@ -152,10 +144,6 @@ func (c *CephNFSController) onDelete(obj interface{}) {
 	}
 
 	nfs := obj.(*cephv1.CephNFS).DeepCopy()
-	if !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
-		logger.Errorf("Ceph NFS is only supported with Nautilus or newer. CRD %q cleanup will be ignored.", nfs.Name)
-		return
-	}
 
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
@@ -170,7 +158,7 @@ func (c *CephNFSController) onDelete(obj interface{}) {
 // cluster has changed.
 func (c *CephNFSController) ParentClusterChanged(cluster cephv1.ClusterSpec, clusterInfo *cephconfig.ClusterInfo, isUpgrade bool) {
 	c.clusterInfo = clusterInfo
-	if !isUpgrade || !c.clusterInfo.CephVersion.IsAtLeastNautilus() {
+	if !isUpgrade {
 		logger.Debugf("No need to update the nfs daemons after the parent cluster changed")
 		return
 	}

--- a/pkg/operator/ceph/object/config_test.go
+++ b/pkg/operator/ceph/object/config_test.go
@@ -27,7 +27,7 @@ import (
 
 func newConfig() *clusterConfig {
 	clusterInfo := &cephconfig.ClusterInfo{
-		CephVersion: cephver.Mimic,
+		CephVersion: cephver.Nautilus,
 	}
 	return &clusterConfig{
 		store: cephv1.CephObjectStore{
@@ -38,95 +38,37 @@ func newConfig() *clusterConfig {
 }
 
 func TestPortString(t *testing.T) {
-	// No port or secure port on civetweb
-	cfg := newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-	result := cfg.portString(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "", result)
-
 	// No port or secure port on beast
-	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	cfg := newConfig()
+	result := cfg.portString()
 	assert.Equal(t, "", result)
-
-	// Insecure port on civetweb
-	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-	cfg.store.Spec.Gateway.Port = 80
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "port=80", result)
 
 	// Insecure port on beast
 	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
 	cfg.store.Spec.Gateway.Port = 80
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	result = cfg.portString()
 	assert.Equal(t, "port=80", result)
-
-	// Secure port on civetweb
-	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-	cfg.store.Spec.Gateway.SecurePort = 443
-	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "port=443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
-
-	// Both ports on civetweb
-	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-	cfg.store.Spec.Gateway.Port = 80
-	cfg.store.Spec.Gateway.SecurePort = 443
-	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "port=80+443s ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
 	// Secure port on beast
 	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	result = cfg.portString()
 	assert.Equal(t, "ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
 
 	// Both ports on beast
 	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
 	cfg.store.Spec.Gateway.Port = 80
 	cfg.store.Spec.Gateway.SecurePort = 443
 	cfg.store.Spec.Gateway.SSLCertificateRef = "some-k8s-key-secret"
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	result = cfg.portString()
 	assert.Equal(t, "port=80 ssl_port=443 ssl_certificate=/etc/ceph/private/rgw-cert.pem", result)
-
-	// Secure port requires the cert on civetweb
-	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-	cfg.store.Spec.Gateway.SecurePort = 443
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "", result)
 
 	// Secure port requires the cert on beast
 	cfg = newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
 	cfg.store.Spec.Gateway.SecurePort = 443
-	result = cfg.portString(cfg.clusterInfo.CephVersion)
+	result = cfg.portString()
 	assert.Equal(t, "", result)
-}
-
-func TestFrontend(t *testing.T) {
-	cfg := newConfig()
-	cfg.clusterInfo.CephVersion = cephver.Mimic
-
-	result := rgwFrontend(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "civetweb", result)
-
-	cfg.clusterInfo.CephVersion = cephver.Nautilus
-	result = rgwFrontend(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "beast", result)
-
-	cfg.clusterInfo.CephVersion = cephver.Octopus
-	result = rgwFrontend(cfg.clusterInfo.CephVersion)
-	assert.Equal(t, "beast", result)
 }
 
 func TestGenerateCephXUser(t *testing.T) {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -134,7 +134,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 			append(
 				opspec.DaemonFlags(c.clusterInfo, strings.TrimPrefix(generateCephXUser(rgwConfig.ResourceName), "client.")),
 				"--foreground",
-				cephconfig.NewFlag("rgw frontends", fmt.Sprintf("%s %s", rgwFrontend(c.clusterInfo.CephVersion), c.portString(c.clusterInfo.CephVersion))),
+				cephconfig.NewFlag("rgw frontends", fmt.Sprintf("%s %s", rgwFrontendName, c.portString())),
 				cephconfig.NewFlag("host", opspec.ContainerEnvVarReference("POD_NAME")),
 				cephconfig.NewFlag("rgw-mime-types-file", mimeTypesMountPath()),
 			),

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -46,7 +46,7 @@ func TestPodSpecs(t *testing.T) {
 	}
 	store.Spec.Gateway.PriorityClassName = "my-priority-class"
 	info := testop.CreateConfigDir(1)
-	info.CephVersion = cephver.Mimic
+	info.CephVersion = cephver.Nautilus
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
 
 	c := &clusterConfig{
@@ -97,7 +97,7 @@ func TestSSLPodSpec(t *testing.T) {
 	}
 	store.Spec.Gateway.PriorityClassName = "my-priority-class"
 	info := testop.CreateConfigDir(1)
-	info.CephVersion = cephver.Mimic
+	info.CephVersion = cephver.Nautilus
 	data := cephconfig.NewStatelessDaemonDataPathMap(cephconfig.RgwType, "default", "rook-ceph", "/var/lib/rook/")
 	store.Spec.Gateway.SSLCertificateRef = "mycert"
 	store.Spec.Gateway.SecurePort = 443

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -38,12 +38,8 @@ const (
 )
 
 var (
-	// Minimum supported version is 13.2.4 where ceph-volume is supported
-	Minimum = CephVersion{13, 2, 4, 0}
-	// Luminous Ceph version
-	Luminous = CephVersion{12, 0, 0, 0}
-	// Mimic Ceph version
-	Mimic = CephVersion{13, 0, 0, 0}
+	// Minimum supported version is 14.2.5
+	Minimum = CephVersion{14, 2, 5, 0}
 	// Nautilus Ceph version
 	Nautilus = CephVersion{14, 0, 0, 0}
 	// Octopus Ceph version
@@ -52,8 +48,8 @@ var (
 	Pacific = CephVersion{16, 0, 0, 0}
 
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions   = []CephVersion{Mimic, Nautilus}
-	unsupportedVersions = []CephVersion{Octopus, Pacific}
+	supportedVersions   = []CephVersion{Nautilus, Octopus}
+	unsupportedVersions = []CephVersion{Pacific}
 	// allVersions includes all supportedVersions as well as unreleased versions that are being tested with rook
 	allVersions = append(supportedVersions, unsupportedVersions...)
 
@@ -85,8 +81,6 @@ func (v *CephVersion) ReleaseName() string {
 		return "octopus"
 	case Nautilus.Major:
 		return "nautilus"
-	case Mimic.Major:
-		return "mimic"
 	default:
 		return unknownVersionString
 	}
@@ -142,11 +136,6 @@ func (v *CephVersion) isRelease(other CephVersion) bool {
 	return v.Major == other.Major
 }
 
-// IsMimic checks if the Ceph version is Mimic
-func (v *CephVersion) IsMimic() bool {
-	return v.isRelease(Mimic)
-}
-
 // IsNautilus checks if the Ceph version is Nautilus
 func (v *CephVersion) IsNautilus() bool {
 	return v.isRelease(Nautilus)
@@ -198,11 +187,6 @@ func (v *CephVersion) IsAtLeastOctopus() bool {
 // IsAtLeastNautilus check that the Ceph version is at least Nautilus
 func (v *CephVersion) IsAtLeastNautilus() bool {
 	return v.IsAtLeast(Nautilus)
-}
-
-// IsAtLeastMimic check that the Ceph version is at least Mimic
-func (v *CephVersion) IsAtLeastMimic() bool {
-	return v.IsAtLeast(Mimic)
 }
 
 // IsIdentical checks if Ceph versions are identical

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestToString(t *testing.T) {
 	assert.Equal(t, "14.0.0-0 nautilus", fmt.Sprintf("%s", &Nautilus))
-	assert.Equal(t, "13.0.0-0 mimic", fmt.Sprintf("%s", &Mimic))
+	assert.Equal(t, "15.0.0-0 octopus", fmt.Sprintf("%s", &Octopus))
 
 	expected := fmt.Sprintf("-1.0.0-0 %s", unknownVersionString)
 	assert.Equal(t, expected, fmt.Sprintf("%s", &CephVersion{-1, 0, 0, 0}))
@@ -33,12 +33,12 @@ func TestToString(t *testing.T) {
 
 func TestCephVersionFormatted(t *testing.T) {
 	assert.Equal(t, "ceph version 14.0.0-0 nautilus", Nautilus.CephVersionFormatted())
-	assert.Equal(t, "ceph version 13.0.0-0 mimic", Mimic.CephVersionFormatted())
+	assert.Equal(t, "ceph version 15.0.0-0 octopus", Octopus.CephVersionFormatted())
 }
 
 func TestReleaseName(t *testing.T) {
 	assert.Equal(t, "nautilus", Nautilus.ReleaseName())
-	assert.Equal(t, "mimic", Mimic.ReleaseName())
+	assert.Equal(t, "octopus", Octopus.ReleaseName())
 	ver := CephVersion{-1, 0, 0, 0}
 	assert.Equal(t, unknownVersionString, ver.ReleaseName())
 }
@@ -102,15 +102,15 @@ func TestSupported(t *testing.T) {
 }
 
 func TestIsRelease(t *testing.T) {
-	assert.True(t, Mimic.isRelease(Mimic))
 	assert.True(t, Nautilus.isRelease(Nautilus))
+	assert.True(t, Octopus.isRelease(Octopus))
 
-	assert.False(t, Mimic.isRelease(Nautilus))
+	assert.False(t, Octopus.isRelease(Nautilus))
 
-	MimicUpdate := Mimic
-	MimicUpdate.Minor = 33
-	MimicUpdate.Extra = 4
-	assert.True(t, MimicUpdate.isRelease(Mimic))
+	OctopusUpdate := Octopus
+	OctopusUpdate.Minor = 33
+	OctopusUpdate.Extra = 4
+	assert.True(t, OctopusUpdate.isRelease(Octopus))
 
 	NautilusUpdate := Nautilus
 	NautilusUpdate.Minor = 33
@@ -119,19 +119,13 @@ func TestIsRelease(t *testing.T) {
 }
 
 func TestIsReleaseX(t *testing.T) {
-	assert.True(t, Mimic.IsMimic())
-	assert.False(t, Nautilus.IsMimic())
-	assert.False(t, Octopus.IsMimic())
+	assert.True(t, Nautilus.IsNautilus())
+	assert.False(t, Octopus.IsNautilus())
 }
 
 func TestVersionAtLeast(t *testing.T) {
-	assert.True(t, Mimic.IsAtLeast(Mimic))
-	assert.False(t, Mimic.IsAtLeast(Nautilus))
-	assert.False(t, Mimic.IsAtLeast(Octopus))
-	assert.True(t, Nautilus.IsAtLeast(Mimic))
 	assert.True(t, Nautilus.IsAtLeast(Nautilus))
 	assert.False(t, Nautilus.IsAtLeast(Octopus))
-	assert.True(t, Octopus.IsAtLeast(Mimic))
 	assert.True(t, Octopus.IsAtLeast(Nautilus))
 	assert.True(t, Octopus.IsAtLeast(Octopus))
 
@@ -147,12 +141,8 @@ func TestVersionAtLeast(t *testing.T) {
 func TestVersionAtLeastX(t *testing.T) {
 	assert.True(t, Octopus.IsAtLeastOctopus())
 	assert.True(t, Octopus.IsAtLeastNautilus())
-	assert.True(t, Octopus.IsAtLeastMimic())
 	assert.True(t, Nautilus.IsAtLeastNautilus())
-	assert.True(t, Nautilus.IsAtLeastMimic())
-	assert.True(t, Mimic.IsAtLeastMimic())
 	assert.True(t, Pacific.IsAtLeastPacific())
-	assert.False(t, Mimic.IsAtLeastNautilus())
 	assert.False(t, Nautilus.IsAtLeastOctopus())
 	assert.False(t, Nautilus.IsAtLeastPacific())
 }

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -152,6 +152,17 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	logger.Infof("Verified upgrade from v1.1 to v1.2")
 
 	//
+	// Upgrade from mimic to nautilus
+	//
+	logger.Infof("*** UPGRADING CEPH FROM Mimic TO Nautilus ***")
+	s.gatherLogs(systemNamespace, "_before_ceph_upgrade")
+	s.upgradeCephVersion(installer.NautilusVersion.Image, numOSDs)
+	newFile = "post-ceph-upgrade-file"
+	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, oldFilesToRead)
+	oldFilesToRead = append(oldFilesToRead, newFile)
+	logger.Infof("Verified upgrade from mimic to nautilus")
+
+	//
 	// Upgrade Rook from v1.2 to master
 	//
 	logger.Infof("*** UPGRADING ROOK FROM v1.2 to master ***")
@@ -165,17 +176,6 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, oldFilesToRead)
 	oldFilesToRead = append(oldFilesToRead, newFile)
 	logger.Infof("Verified upgrade from v1.2 to master")
-
-	//
-	// Upgrade from mimic to nautilus
-	//
-	logger.Infof("*** UPGRADING CEPH FROM Mimic TO Nautilus ***")
-	s.gatherLogs(systemNamespace, "_before_ceph_upgrade")
-	s.upgradeCephVersion(installer.NautilusVersion.Image, numOSDs)
-	newFile = "post-ceph-upgrade-file"
-	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, oldFilesToRead)
-	oldFilesToRead = append(oldFilesToRead, newFile)
-	logger.Infof("Verified upgrade from mimic to nautilus")
 }
 
 func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {


### PR DESCRIPTION
**Description of your changes:**

As of 1.3, Rook will only support Ceph Nautilus 14.2.5.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]