### PR TITLE
ceph: populate CSI configmap for external cluster

### DIFF
--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -138,6 +138,8 @@ func CreateCsiConfigMap(namespace string, clientset kubernetes.Interface) (*v1.C
 		}
 		return getCsiConfigMap(namespace, clientset)
 	}
+
+	logger.Infof("successfully created csi config map %q", configMap.Name)
 	return created, nil
 }
 
@@ -160,7 +162,7 @@ func DeleteCsiConfigMap(namespace string, clientset kubernetes.Interface) error 
 // SaveClusterConfig updates the config map used to provide ceph-csi with
 // basic cluster configuration. The clusterNamespace and clusterInfo are
 // used to determine what "cluster" in the config map will be updated and
-// and the clusterNamespace value is epxected to match the clusterID
+// and the clusterNamespace value is expected to match the clusterID
 // value that is provided to ceph-csi uses in the storage class.
 // The locker l is typically a mutex and is used to prevent the config
 // map from being updated for multiple clusters simultaneously.
@@ -203,5 +205,6 @@ func SaveClusterConfig(
 	if _, err := clientset.CoreV1().ConfigMaps(csiNamespace).Update(configMap); err != nil {
 		return errors.Wrapf(err, "failed to update csi config map")
 	}
+
 	return nil
 }


### PR DESCRIPTION
**Description of your changes:**

The configmap for csi wasn't created so csi wasn't working.

Closes: https://github.com/rook/rook/issues/4816
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4816

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]