### PR TITLE
ceph: Add encoders for input and output of ceph

### DIFF
--- a/pkg/daemon/ceph/config/info.go
+++ b/pkg/daemon/ceph/config/info.go
@@ -63,6 +63,7 @@ func NewMonInfo(name, ip string, port int32) *MonInfo {
 func (c *ClusterInfo) Log(logger *capnslog.PackageLogger) {
 	mons := []string{}
 	for _, m := range c.Monitors {
+		// Sprintf formatting is safe as user input isn't being used. Issue https://github.com/rook/rook/issues/4575
 		mons = append(mons, fmt.Sprintf("{Name: %s, Endpoint: %s}", m.Name, m.Endpoint))
 	}
 	monsec := ""

--- a/pkg/operator/edgefs/cluster/utils.go
+++ b/pkg/operator/edgefs/cluster/utils.go
@@ -290,6 +290,7 @@ func (c *cluster) AddLabelsToNode(nodeName string, labels map[string]string) err
 		tokens = append(tokens, "\""+k+"\":\""+v+"\"")
 	}
 	labelString := "{" + strings.Join(tokens, ",") + "}"
+	// Sprintf formatting is safe as user input isn't being used. Issue https://github.com/rook/rook/issues/4575
 	patch := fmt.Sprintf(`{"metadata":{"labels":%v}}`, labelString)
 	var err error
 	for attempt := 0; attempt < labelingRetries; attempt++ {


### PR DESCRIPTION
This commits adds encoders for input and output
of ceph

Closes: https://github.com/rook/rook/issues/4575
Signed-off-by: crombus <pkundra@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
