### PR TITLE
rook: Fixing the potential hardcoded credential warnings

### DIFF
--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	crashCollectorKeyringUsername = "client.crash"
-	crashCollectorSecretName      = "rook-ceph-crash-collector-keyring"
+	crashCollectorKeyName         = "rook-ceph-crash-collector-keyring"
 )
 
 // ClusterResource operator-kit Custom Resource Definition

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -80,7 +80,7 @@ func createOrUpdateCrashCollectorSecret(namespace, crashCollectorSecretKey strin
 
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      crashCollectorSecretName,
+			Name:      crashCollectorKeyName,
 			Namespace: namespace,
 		},
 		Data: crashCollectorSecret,

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -34,10 +34,11 @@ import (
 )
 
 const (
-	dashboardModuleName            = "dashboard"
-	dashboardPortHTTPS             = 8443
-	dashboardPortHTTP              = 7000
-	dashboardUsername              = "admin"
+	dashboardModuleName = "dashboard"
+	dashboardPortHTTPS  = 8443
+	dashboardPortHTTP   = 7000
+	dashboardUsername   = "admin"
+	// #nosec because of the word `Password`
 	dashboardPasswordName          = "rook-ceph-dashboard-password"
 	passwordLength                 = 20
 	passwordKeyName                = "password"
@@ -273,6 +274,7 @@ func (c *Cluster) getOrGenerateDashboardPassword() (string, error) {
 }
 
 func generatePassword(length int) (string, error) {
+	// #nosec because of the word password
 	const passwordChars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 	passwd, err := generateRandomBytes(length)
 	if err != nil {

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// #nosec because of the word `Secret`
 const (
 	csiKeyringRBDProvisionerUsername = "client.csi-rbd-provisioner"
 	csiKeyringRBDNodeUsername        = "client.csi-rbd-node"
@@ -32,6 +33,7 @@ const (
 	csiRBDProvisionerSecret          = "rook-csi-rbd-provisioner"
 )
 
+// #nosec because of the word `Secret`
 const (
 	csiKeyringCephFSProvisionerUsername = "client.csi-cephfs-provisioner"
 	csiKeyringCephFSNodeUsername        = "client.csi-cephfs-node"

--- a/pkg/operator/ceph/test/podspec.go
+++ b/pkg/operator/ceph/test/podspec.go
@@ -67,9 +67,11 @@ func NewPodSpecTester(t *testing.T, spec *v1.PodSpec) *PodSpecTester {
 func (ps *PodSpecTester) AssertVolumesMeetCephRequirements(
 	daemonType config.DaemonType, daemonID string,
 ) {
+	// #nosec because of the word `Secret`
 	keyringSecretName := fmt.Sprintf("rook-ceph-%s-%s-keyring", daemonType, daemonID)
 	if daemonType == config.MonType {
-		keyringSecretName = "rook-ceph-mons-keyring" // mons share a keyring
+		// #nosec because of the word `Secret`
+		keyringSecretName = "rook-ceph-mons-keyring"
 	}
 	requiredVols := []string{"rook-config-override", keyringSecretName}
 	if daemonType != config.RbdMirrorType {

--- a/pkg/operator/edgefs/cluster/target/layout.go
+++ b/pkg/operator/edgefs/cluster/target/layout.go
@@ -32,7 +32,8 @@ import (
 const (
 	// DefaultContainerMaxCapacity - max allowed container disks capacity, if exeeded then new new container will be added
 	DefaultContainerMaxCapacity = "132Ti"
-	S3PayloadSecretsPath        = "/opt/nedge/etc/secrets/"
+	// #nosec because of the word `Secret`
+	S3PayloadSecretsPath = "/opt/nedge/etc/secrets/"
 )
 
 // CreateQualifiedHeadlessServiceName creates a qualified name of the headless service for a given replica id and namespace,


### PR DESCRIPTION
This commit fixes the gosec warning
G101: Potential hardcoded credential variable by adding a #nosec tag and relavant comment

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
