### PR TITLE
rook: Changing the file and directory permissions to most narrow poss…

### DIFF
--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -242,7 +242,7 @@ func getClusterInfo(context *clusterd.Context, clusterNamespace string) (string,
 	}
 
 	keyring := cephclient.CephKeyring(clusterInfo.CephCred)
-	if err := ioutil.WriteFile(keyringFile.Name(), []byte(keyring), 0644); err != nil {
+	if err := ioutil.WriteFile(keyringFile.Name(), []byte(keyring), 0600); err != nil {
 		return "", "", errors.Errorf("failed to write monitor keyring to %s", keyringFile.Name())
 	}
 

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -241,6 +241,7 @@ func configureFlexVolume(driverFile, driverDir, driverName string) error {
 	if err != nil {
 		logger.Errorf("invalid flex settings. %v", err)
 	} else {
+		// #nosec since the flex settings need read permissions
 		if err := ioutil.WriteFile(path.Join(driverDir, settingsFilename), settings, 0644); err != nil {
 			logger.Errorf("failed to write settings file %q. %v", settingsFilename, err)
 		} else {

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -101,7 +101,8 @@ func (s *FlexvolumeServer) Start(driverVendor, driverName string) error {
 	}
 	s.listeners[unixSocketFile] = listener
 
-	if err := os.Chmod(unixSocketFile, 0770); err != nil {
+	// #nosec since unixSocketFile needs the permission to execute
+	if err := os.Chmod(unixSocketFile, 0750); err != nil {
 		return errors.Wrapf(err, "unable to set file permission to unix socket %q", unixSocketFile)
 	}
 
@@ -198,7 +199,7 @@ func LoadFlexSettings(directory string) []byte {
 func configureFlexVolume(driverFile, driverDir, driverName string) error {
 	// copying flex volume
 	if _, err := os.Stat(driverDir); os.IsNotExist(err) {
-		err := os.Mkdir(driverDir, 0755)
+		err := os.Mkdir(driverDir, 0750)
 		if err != nil {
 			logger.Errorf("failed to create dir %q. %v", driverDir, err)
 		}
@@ -258,8 +259,8 @@ func copyFile(src, dest string) error {
 	}
 	defer srcFile.Close()
 
-	// #nosec G304 Rook controls the File path provided as input
-	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755) // creates if file doesn't exist
+	// #nosec G304 since destFile needs the permission to execute
+	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0750) // creates if file doesn't exist
 	if err != nil {
 		return errors.Wrapf(err, "error creating destination file %s", dest)
 	}

--- a/pkg/daemon/ceph/client/keyring.go
+++ b/pkg/daemon/ceph/client/keyring.go
@@ -89,10 +89,10 @@ func CreateKeyring(context *clusterd.Context, clusterInfo *ClusterInfo, username
 // TODO: Write keyring only to the default ceph config location since we are in a container
 func writeKeyring(keyring, keyringPath string) error {
 	// save the keyring to the given path
-	if err := os.MkdirAll(filepath.Dir(keyringPath), 0744); err != nil {
+	if err := os.MkdirAll(filepath.Dir(keyringPath), 0700); err != nil {
 		return errors.Wrapf(err, "failed to create keyring directory for %s", keyringPath)
 	}
-	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0644); err != nil {
+	if err := ioutil.WriteFile(keyringPath, []byte(keyring), 0600); err != nil {
 		return errors.Wrapf(err, "failed to write monitor keyring to %s", keyringPath)
 	}
 	return nil

--- a/pkg/daemon/ceph/client/test/info.go
+++ b/pkg/daemon/ceph/client/test/info.go
@@ -27,13 +27,13 @@ import (
 )
 
 func CreateConfigDir(configDir string) error {
-	if err := os.MkdirAll(configDir, 0744); err != nil {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return errors.Wrap(err, "error while creating directory")
 	}
-	if err := ioutil.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0600); err != nil {
 		return errors.Wrap(err, "admin writefile error")
 	}
-	if err := ioutil.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0600); err != nil {
 		return errors.Wrap(err, "mon writefile error")
 	}
 	return nil

--- a/pkg/daemon/ceph/osd/agent_test.go
+++ b/pkg/daemon/ceph/osd/agent_test.go
@@ -31,9 +31,9 @@ func createTestKeyring(t *testing.T, configRoot string, args []string) {
 	var configDir string
 	if len(args) > 5 && strings.HasPrefix(args[5], "--id") {
 		configDir = filepath.Join(configRoot, "osd") + args[5][5:]
-		err := os.MkdirAll(configDir, 0744)
+		err := os.MkdirAll(configDir, 0700)
 		assert.Nil(t, err)
-		err = ioutil.WriteFile(path.Join(configDir, "keyring"), []byte("mykeyring"), 0644)
+		err = ioutil.WriteFile(path.Join(configDir, "keyring"), []byte("mykeyring"), 0600)
 		assert.Nil(t, err)
 	}
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -49,7 +49,7 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 	// ensure the config mount point exists
 	configDir := fmt.Sprintf("/var/lib/ceph/osd/ceph-%s", osdID)
-	err := os.Mkdir(configDir, 0755)
+	err := os.Mkdir(configDir, 0750)
 	if err != nil {
 		logger.Errorf("failed to create config dir %q. %v", configDir, err)
 	}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -376,7 +376,7 @@ func UpdateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
 		}
 	}
 
-	if err = ioutil.WriteFile(lvmConfPath, output, 0644); err != nil {
+	if err = ioutil.WriteFile(lvmConfPath, output, 0600); err != nil {
 		return errors.Wrapf(err, "failed to update lvm config file %q", lvmConfPath)
 	}
 
@@ -739,7 +739,7 @@ func callCephVolume(context *clusterd.Context, args ...string) (string, error) {
 	// failure log later without also printing out past failures
 	// TODO: does this mess up expectations from the ceph log collector daemon?
 	logPath := "/tmp/ceph-log"
-	if err := os.MkdirAll(logPath, 0644); err != nil {
+	if err := os.MkdirAll(logPath, 0700); err != nil {
 		return "", errors.Wrapf(err, "failed to create dir %q", logPath)
 	}
 	baseArgs := []string{"-oL", cephVolumeCmd, "--log-path", logPath}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -229,7 +230,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 	// Create a specific log directory so that each prepare command will have its own log
 	// Only do this if nothing is present so that we don't override existing logs
 	cvLogDir = path.Join(cephLogDir, a.nodeName)
-	err := os.MkdirAll(cvLogDir, 0755)
+	err := os.MkdirAll(cvLogDir, 0750)
 	if err != nil {
 		logger.Errorf("failed to create ceph-volume log directory %q, continue with default %q. %v", cvLogDir, cephLogDir, err)
 		baseArgs = []string{"-oL", cephVolumeCmd, cephVolumeMode, "prepare", "--bluestore"}
@@ -649,8 +650,7 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 func readCVLogContent(cvLogFilePath string) string {
 	// Open c-v log file
-	// #nosec G304 Rook controls File path provided as input
-	cvLogFile, err := os.Open(cvLogFilePath)
+	cvLogFile, err := os.Open(filepath.Clean(cvLogFilePath))
 	if err != nil {
 		logger.Errorf("failed to open ceph-volume log file %q. %v", cvLogFilePath, err)
 		return ""

--- a/pkg/daemon/util/copybins.go
+++ b/pkg/daemon/util/copybins.go
@@ -68,6 +68,6 @@ func copyBinary(sourceDir, targetDir, filename string) error {
 	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
 		return err
 	}
-
-	return os.Chmod(targetPath, 0755)
+	// #nosec targetPath requires the permission to execute
+	return os.Chmod(targetPath, 0700)
 }

--- a/pkg/daemon/util/copybins_test.go
+++ b/pkg/daemon/util/copybins_test.go
@@ -33,13 +33,13 @@ func TestCopyBinaries(t *testing.T) {
 		// the binary should just be the text showing where it was copied from so we can verify it
 		_, err = f.WriteString(binPath)
 		assert.NoError(t, err)
-		err = os.Chmod(binPath, 0755)
+		err = os.Chmod(binPath, 0700)
 		assert.NoError(t, err)
 		f.Close()
 	}
 
 	mkdir := func(dir string) {
-		err := os.MkdirAll(dir, 0755)
+		err := os.MkdirAll(dir, 0700)
 		assert.NoError(t, err)
 	}
 


### PR DESCRIPTION
This commit fixes where there are areas in which files and directories are
written and created with statically defined permissions. Many of these
permissions are rather open, potentially allowing other system tenants to
view and interact with their contents, which may be sensitive.

Fixed G303: Poor file permissions used for directory by using the most narrow permission

Resoves: https://github.com/rook/rook/issues/4580

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]