### PR TITLE
Limit namespace watches when ROOK_CURRENT_NAMESPACE_ONLY is true

### DIFF
--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -25,11 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-func (o *Operator) startManager(stopCh <-chan struct{}) {
+func (o *Operator) startManager(namespaceToWatch string, stopCh <-chan struct{}) {
 
 	// Set up a manager
 	mgrOpts := manager.Options{
 		LeaderElection: false,
+		Namespace:      namespaceToWatch,
 	}
 
 	logger.Info("setting up the controller-runtime manager")

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -145,7 +145,7 @@ func (o *Operator) Run() error {
 	}
 
 	// Start the controller-runtime Manager.
-	go o.startManager(stopChan)
+	go o.startManager(namespaceToWatch, stopChan)
 
 	// watch for changes to the rook clusters
 	o.clusterController.StartWatch(namespaceToWatch, stopChan)


### PR DESCRIPTION
**Description of your changes:**
Limit namespace watches when ROOK_CURRENT_NAMESPACE_ONLY is true

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]