### PR TITLE
makefile: auto generate target help menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ do.build.platform.%:
 
 do.build.parallel: $(foreach p,$(PLATFORMS), do.build.platform.$(p))
 
-build: build.common
+build: build.common ## Build source code for host platform.
 	@$(MAKE) go.build
 # if building on non-linux platforms, also build the linux container
 ifneq ($(GOOS),linux)
@@ -112,7 +112,7 @@ ifneq ($(GOOS),linux)
 endif
 	@$(MAKE) -C images PLATFORM=linux_$(GOHOSTARCH)
 
-build.all: build.common
+build.all: build.common ## Build source code for all platforms. Best done in the cross build container due to cross compiler dependencies.
 ifneq ($(GOHOSTARCH),amd64)
 	$(error cross platform image build only supported on amd64 host currently)
 endif
@@ -122,42 +122,42 @@ endif
 install: build.common
 	@$(MAKE) go.install
 
-check test:
+check test: ## Runs unit tests.
 	@$(MAKE) go.test.unit
 
-test-integration:
+test-integration: ## Runs integration tests.
 	@$(MAKE) go.test.integration
 
-lint:
+lint: ## Check syntax and styling of go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.lint
 
-vet:
+vet: ## Runs lint checks on go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.vet
 
-fmt:
+fmt: ## Check formatting of go sources.
 	@$(MAKE) go.init
 	@$(MAKE) go.fmt
 
-codegen:
+codegen: ## Run code generators.
 	@build/codegen/codegen.sh
 
-mod.check: go.mod.check
-mod.update: go.mod.update
+mod.check: go.mod.check ## Check if any go modules changed.
+mod.update: go.mod.update ## Update all go modules.
 
-clean:
+clean: ## Remove all files that are created by building.
 	@$(MAKE) go.mod.clean
 	@$(MAKE) -C images clean
 	@rm -fr $(OUTPUT_DIR) $(WORK_DIR)
 
-distclean: clean
+distclean: clean ## Remove all files that are created by building or configuring.
 	@rm -fr $(CACHE_DIR)
 
-prune:
+prune: ## Prune cached artifacts.
 	@$(MAKE) -C images prune
 
-csv-ceph:
+csv-ceph: ## Generate a CSV file for OLM.
 	@cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)
 
 .PHONY: all build.common cross.build.parallel
@@ -165,31 +165,7 @@ csv-ceph:
 
 # ====================================================================================
 # Help
-
 define HELPTEXT
-Usage: make <OPTIONS> ... <TARGETS>
-
-Targets:
-    build              Build source code for host platform.
-    build.all          Build source code for all platforms.
-                       Best done in the cross build container
-                       due to cross compiler dependencies.
-    check              Runs unit tests.
-    clean              Remove all files that are created by building.
-    codegen            Run code generators.
-    csv-ceph           Generate a CSV file for OLM.
-    distclean          Remove all files that are created
-                       by building or configuring.
-    fmt                Check formatting of go sources.
-    lint               Check syntax and styling of go sources.
-    help               Show this help info.
-    prune              Prune cached artifacts.
-    test               Runs unit tests.
-    test-integration   Runs integration tests.
-    mod.check          Check / Tidy current modules.
-    mod.update         Update all modules.
-    vet                Runs lint checks on go sources.
-
 Options:
     DEBUG        Whether to generate debug symbols. Default is 0.
     IMAGES       Backend images to make. All by default. See: /rook/images/ dir
@@ -199,9 +175,12 @@ Options:
     VERSION      The version information compiled into binaries.
                  The default is obtained from git.
     V            Set to 1 enable verbose build. Default is 0.
-
 endef
 export HELPTEXT
 .PHONY: help
-help:
+help: ## Show this help menu.
+	@echo "Usage: make [TARGET ...]"
+	@echo ""
+	@grep --no-filename -E '^[a-zA-Z_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo ""
 	@echo "$$HELPTEXT"

--- a/images/Makefile
+++ b/images/Makefile
@@ -22,7 +22,7 @@ export TINI_VERSION = v0.16.1
 # ====================================================================================
 # Image Targets
 
-cross: cross.linux_amd64
+cross: cross.linux_amd64 ## Build images used for cross building.
 cross.%:
 	@$(MAKE) -C cross PLATFORM=$*
 
@@ -48,37 +48,28 @@ yugabytedb.%:
 do.build.images.%: $(foreach i,$(IMAGES), $(i).%);
 
 do.build: do.build.images.$(PLATFORM) ;
-build.all: $(foreach p,$(PLATFORMS), do.build.images.$(p)) ;
+build.all: $(foreach p,$(PLATFORMS), do.build.images.$(p)) ; ## Build images for all platforms.
 
 # ====================================================================================
 # Help
+define HELPTEXT
+Options:
+    PLATFORM     The platform to build.
+    PULL         Whether to pull base images. Default is 1.
+    V            Set to 1 enable verbose build. Default is 0.
 
+Advanced Options:
+    PRUNE_HOURS  The number of hours from when an image is
+                 last used for it to be considered a target for
+                 pruning. Default is 48 hrs.
+    PRUNE_KEEP   The minimum number of cached images to keep.
+                 Default is 24 images.
+endef
+export HELPTEXT
 .PHONY: help
-help:
-	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
-	@echo ''
-	@echo 'Targets:'
-	@echo '    build        Build images for the host platform.'
-	@echo '    build.all    Build images for all platforms.'
-	@echo '    clean        Remove all images created from the'
-	@echo '                 current build.'
-	@echo '    prune        Prunes orphaned and cached images at the.'
-	@echo '                 host level.'
-	@echo ''
-	@echo 'Advanced Targets:'
-	@echo '    cross        Build images used for cross building.'
-	@echo '    clean.all    Remove all images including cached.'
-	@echo '                 images at the host level.'
-	@echo '    prune.all    Prune everything ignoring policy.'
-	@echo ''
-	@echo 'Options:'
-	@echo '    PLATFORM     The platform to build.'
-	@echo '    PULL         Whether to pull base images. Default is 1.'
-	@echo '    V            Set to 1 enable verbose build. Default is 0.'
-	@echo ''
-	@echo 'Advanced Options:'
-	@echo '    PRUNE_HOURS  The number of hours from when an image is'
-	@echo '                 last used for it to be considered a target for'
-	@echo '                 pruning. Default is 48 hrs.'
-	@echo '    PRUNE_KEEP   The minimum number of cached images to keep.'
-	@echo '                 Default is 24 images.'
+help: ## Show this help menu.
+	@echo "Usage: make [TARGET ...]"
+	@echo ""
+	@grep --no-filename -E '^[a-zA-Z_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "$$HELPTEXT"

--- a/images/image.mk
+++ b/images/image.mk
@@ -75,12 +75,12 @@ BUILD_BASE_ARGS += $(BUILD_ARGS)
 .PHONY: all build publish clean
 all: build
 
-build: do.build
+build: do.build ## Build images for the host platform.
 	@$(MAKE) cache.images
 
-clean: clean.build
+clean: clean.build ## Remove all images created from the current build.
 
-prune: cache.prune
+prune: cache.prune ## Prunes orphaned and cached images at the host level.
 
 clean.images:
 	@for i in $(CLEAN_IMAGES); do \


### PR DESCRIPTION
**Description of your changes:**
This uses grep, sort and awk to auto generate the `make help` menu based
on comments after each target.
Removed `clean.all` and `prune.all` targets as they are not available
anymore.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

CI is not skipped as the Makefile might cause issues where I haven't been able to test them locally.

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.