### PR TITLE
ceph: add raw mode for non-pvc osd

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -61,8 +61,6 @@ jobs:
       run: |
         kubectl create -f cluster/examples/kubernetes/ceph/operator.yaml
         sed -i "s|#deviceFilter:|deviceFilter: $(lsblk|awk '/14G/ {print $1}'| head -1)|g" cluster/examples/kubernetes/ceph/cluster-test.yaml
-        # recent c-v changes don't allow OSDs on a partition, so we stick with v15.2.7 until that is resolved
-        sed -i "s|:v15|:v15.2.7|g" cluster/examples/kubernetes/ceph/cluster-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/cluster-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/object-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/pool-test.yaml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,6 @@ def RunIntegrationTest(k, v) {
                                   STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
                                   TEST_ARGUMENTS='''+"${env.testArgs}"+''' \
                                   TEST_IS_OFFICIAL_BUILD='''+"${env.isOfficialBuild}"+''' \
-                                  TEST_OSDS_ON_PARTITIONS="false" \
                                   TEST_SCRATCH_DEVICE=/dev/nvme0n1
                               kubectl config view
                               _output/tests/linux_amd64/integration -test.v -test.timeout 7200s 2>&1 | tee _output/tests/integrationTests.log'''

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -26,3 +26,4 @@ v1.6...
 * Extending the support of vault KMS configuration for Ceph RGW
 * Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons
 * Add CephFilesystemMirror CRD to deploy cephfs-mirror daemon
+* Ceph OSD: as of Nautilus 14.2.14 and Octopus 15.2.9 if the OSD scenario is simple (one OSD per disk) we won't use LVM to prepare the disk anymore

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -196,17 +196,8 @@ func writeCephConfig(context *clusterd.Context, clusterInfo *cephclient.ClusterI
 
 // Provision provisions an OSD
 func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topologyAffinity string) error {
-
-	// Check for the presence of LVM on the host when NOT running on PVC
-	// since this scenario is still using LVM
-	if !agent.pvcBacked {
-		ne := NewNsenter(context, lvmCommandToCheck, []string{"--help"})
-		err := ne.checkIfBinaryExistsOnHost()
-		if err != nil {
-			return errors.Wrapf(err, "binary %q does not exist on the host, make sure lvm2 package is installed", lvmCommandToCheck)
-		}
+	if agent.pvcBacked {
 		// Init KMS store, retrieve the KEK and store it as an env var for ceph-volume
-	} else {
 		err := setKEKinEnv(context, agent.clusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to set kek as an environment variable")

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -296,8 +296,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 
 	dataDir := k8sutil.DataDir
 	// Create volume config for /dev so the pod can access devices on the host
-	// Only valid when running OSD with LVM mode
-	if osd.CVMode == "lvm" {
+	// Only valid when running OSD with LVM and Raw mode
+	if !osdProps.onPVC() {
 		devVolume := v1.Volume{Name: "devices", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/dev"}}}
 		volumes = append(volumes, devVolume)
 		devMount := v1.VolumeMount{Name: "devices", MountPath: "/dev"}

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -198,7 +198,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	blkInitCont := deployment.Spec.Template.Spec.InitContainers[2]
 	assert.Equal(t, 1, len(blkInitCont.VolumeDevices))
 	cont = deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, 8, len(cont.VolumeMounts), cont.VolumeMounts)
+	assert.Equal(t, 7, len(cont.VolumeMounts), cont.VolumeMounts)
 
 	// Test OSD on PVC with RAW
 	osd = OSDInfo{

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -47,8 +47,8 @@ const (
 	nautilusTestImageOnPartitions = "ceph/ceph:v14.2.12"
 	// test with the latest octopus build
 	octopusTestImage = "ceph/ceph:v15"
-	// test with the latest octopus build. ceph-volume is not allowing OSDs on partitions on v15.2.8 and newer.
-	octopusTestImageOnPartitions = "ceph/ceph:v15.2.7"
+	// test with the latest octopus build.
+	octopusTestImageOnPartitions = "ceph/ceph:v15.2.9"
 	// test with the latest master image
 	masterTestImage    = "ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -42,24 +42,19 @@ import (
 
 const (
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14"
-	// test with the latest nautilus build. ceph-volume is not allowing OSDs on partitions on v14.2.13 and newer.
-	nautilusTestImageOnPartitions = "ceph/ceph:v14.2.12"
+	nautilusTestImage = "ceph/ceph:v14.2.12"
 	// test with the latest octopus build
 	octopusTestImage = "ceph/ceph:v15"
-	// test with the latest octopus build.
-	octopusTestImageOnPartitions = "ceph/ceph:v15.2.9"
 	// test with the latest master image
 	masterTestImage    = "ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"
 	defaultclusterName = "test-cluster"
-	// if false, expect to create OSDs on raw devices,
-	// otherwise use a version of ceph that is compatible with OSDs on partitions
-	usePartitionEnvVar = "TEST_OSDS_ON_PARTITIONS"
 )
 
 var (
-	MasterVersion = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
+	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage}
+	OctopusVersion  = cephv1.CephVersionSpec{Image: octopusTestImage}
+	MasterVersion   = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
 )
 
 // CephInstaller wraps installing and uninstalling rook on a platform
@@ -75,20 +70,6 @@ type CephInstaller struct {
 	CephVersion      cephv1.CephVersionSpec
 	T                func() *testing.T
 	cleanupHost      bool
-}
-
-func NautilusVersion() cephv1.CephVersionSpec {
-	if os.Getenv(usePartitionEnvVar) == "false" {
-		return cephv1.CephVersionSpec{Image: nautilusTestImage}
-	}
-	return cephv1.CephVersionSpec{Image: nautilusTestImageOnPartitions}
-}
-
-func OctopusVersion() cephv1.CephVersionSpec {
-	if os.Getenv(usePartitionEnvVar) == "false" {
-		return cephv1.CephVersionSpec{Image: octopusTestImage}
-	}
-	return cephv1.CephVersionSpec{Image: octopusTestImageOnPartitions}
 }
 
 // CreateCephOperator creates rook-operator via kubectl

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -96,7 +96,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.OctopusVersion(),
+		cephVersion:             installer.OctopusVersion,
 	}
 
 	s.clusterInfo = client.AdminClusterInfo(s.namespace)

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -74,7 +74,7 @@ func (hs *HelmSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: helmMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.NautilusVersion(),
+		cephVersion:             installer.NautilusVersion,
 	}
 
 	hs.op, hs.kh = StartTestCluster(hs.T, &helmTestCluster)

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -142,7 +142,7 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
 
 	cleanupHost := false
-	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion(), cleanupHost)
+	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion, cleanupHost)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1), "", false}
 	if kh.VersionAtLeast("v1.13.0") {
@@ -199,7 +199,7 @@ func (o MCTestOperations) Teardown() {
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
 	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
-		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, false, installer.NautilusVersion())
+		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, false, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -99,7 +99,7 @@ func (suite *SmokeSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.OctopusVersion(),
+		cephVersion:             installer.OctopusVersion,
 	}
 
 	suite.op, suite.k8sh = StartTestCluster(suite.T, &smokeTestCluster)

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -86,7 +86,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: upgradeMinimalTestVersion,
 		rookVersion:             installer.Version1_4,
-		cephVersion:             installer.NautilusVersion(),
+		cephVersion:             installer.NautilusVersion,
 	}
 
 	s.op, s.k8sh = StartTestCluster(s.T, &upgradeTestCluster)
@@ -200,7 +200,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	//
 	logger.Infof("*** UPGRADING CEPH FROM Nautilus TO Octopus ***")
 	s.gatherLogs(systemNamespace, "_before_octopus_upgrade")
-	s.upgradeCephVersion(installer.OctopusVersion().Image, numOSDs)
+	s.upgradeCephVersion(installer.OctopusVersion.Image, numOSDs)
 	// Verify reading and writing to the test clients
 	newFile = "post-octopus-upgrade-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)


### PR DESCRIPTION
**Description of your changes:**

If the user doesn't want:

* an encrypted osd
* an osd with a backing device
* multiple osd on the same block device

Then the OSD will be prepared using the ceph-volume raw mode which does
not use LVM.

Closes: https://github.com/rook/rook/issues/4768
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4768

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

Blocked by https://github.com/ceph/ceph/pull/33371

