### PR TITLE
tests: enhance README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,7 @@ Using one of the following:
 - Using Kubeadm
 ```
 tests/scripts/kubeadm.sh up
+export KUBECONFIG=~/admin.conf
 tests/scripts/helm.sh up
 ```
 - Using minikube
@@ -96,7 +97,7 @@ tests/scripts/helm.sh up
 #### 3. Run integration tests:
 Integration tests can be run using tests binary `_output/tests/${platform}/integration` that is generated during build time e.g.:
 ```
-~/integration -test.v
+_output/tests/${platform}/integration/integration -test.v
 ```
 
 ### Test parameters


### PR DESCRIPTION
[skip ci]

- setting config path is necessary between kubeadm.sh and helm.sh
- fix the path of integration test binary

Signed-off-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
