### PR TITLE
ceph: set crush device class via annotations on PVC

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,6 +14,7 @@
 - Ceph Nautilus 14.2.5 is the minimum supported version
 - OSD on PVC doesn't use LVM anymore to configure OSD, but solely relies on the entire block device, done [here](https://github.com/rook/rook/pull/4435).
 - Specific devices for OSDs can now be specified using the full udev path (e.g. /dev/disk/by-id/ata-ST4000DM004-XXXX) instead of the device name.
+- OSD on PVC CRUSH device storage class can now be changed by setting an annotation "crushDeviceClass" on the "data" volume template. See "cluster-on-pvc.yaml" for example.
 
 
 ### EdgeFS

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -91,6 +91,9 @@ spec:
       volumeClaimTemplates:
       - metadata:
           name: data
+          # if you are looking at giving your OSD a different CRUSH device class than the one detected by Ceph
+          # annotations:
+          #   crushDeviceClass: hybrid
         spec:
           resources:
             requests:

--- a/pkg/apis/rook.io/v1alpha2/types.go
+++ b/pkg/apis/rook.io/v1alpha2/types.go
@@ -147,7 +147,8 @@ type VolumeSource struct {
 	Resources                   v1.ResourceRequirements              `json:"resources,omitempty"`
 	Placement                   Placement                            `json:"placement,omitempty"`
 	Config                      map[string]string                    `json:"config,omitempty"`
-	Portable                    bool                                 `json:"portable,omitempty"`        // Portable OSD portability across the hosts
-	TuneSlowDeviceClass         bool                                 `json:"tuneDeviceClass,omitempty"` // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
-	Type                        string                               `json:"type,omitempty"`            // Type represents the device type for an OSD, possible values are "data": the bluestore 'block' data and "metadata": the bluestore 'block.db' device
+	Portable                    bool                                 `json:"portable,omitempty"`         // Portable OSD portability across the hosts
+	TuneSlowDeviceClass         bool                                 `json:"tuneDeviceClass,omitempty"`  // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
+	Type                        string                               `json:"type,omitempty"`             // Type represents the device type for an OSD, possible values are "data": the bluestore 'block' data and "metadata": the bluestore 'block.db' device
+	CrushDeviceClass            string                               `json:"crushDeviceClass,omitempty"` // CrushDeviceClass represents the crush device class for an OSD
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -258,7 +258,14 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 		// This will make the devices.Entries larger than usual
 		if _, ok := devices.Entries["metadata"]; ok {
 			metadataDev = true
-			metadataArg = append(metadataArg, []string{"--block.db", devices.Entries["metadata"].Config.Name}...)
+			metadataArg = append(metadataArg, []string{"--block.db",
+				devices.Entries["metadata"].Config.Name,
+			}...)
+
+			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
+			if crushDeviceClass != "" {
+				metadataArg = append(metadataArg, []string{crushDeviceClassFlag, crushDeviceClass}...)
+			}
 			metadataBlockPath = devices.Entries["metadata"].Config.Name
 		}
 

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -57,6 +57,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rooka
 					},
 					Portable:            storageClassDeviceSet.Portable,
 					TuneSlowDeviceClass: storageClassDeviceSet.TuneSlowDeviceClass,
+					CrushDeviceClass:    pvcTemplate.Annotations["crushDeviceClass"],
 				})
 				logger.Infof("successfully provisioned pvc %q for VolumeClaimTemplates %q for storageClassDeviceSet %q of set %v", pvc.GetName(), pvcTemplate.GetName(), storageClassDeviceSet.Name, i)
 			}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -174,6 +174,7 @@ type osdProperties struct {
 	location            string
 	portable            bool
 	tuneSlowDeviceClass bool
+	crushDeviceClass    string
 }
 
 // Start the osd management
@@ -270,12 +271,13 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 		}
 
 		osdProps := osdProperties{
-			crushHostname: volume.PersistentVolumeClaimSource.ClaimName,
-			pvc:           volume.PersistentVolumeClaimSource,
-			metadataPVC:   metadataDevicePVCSource,
-			resources:     volume.Resources,
-			placement:     volume.Placement,
-			portable:      volume.Portable,
+			crushHostname:    volume.PersistentVolumeClaimSource.ClaimName,
+			pvc:              volume.PersistentVolumeClaimSource,
+			metadataPVC:      metadataDevicePVCSource,
+			resources:        volume.Resources,
+			placement:        volume.Placement,
+			portable:         volume.Portable,
+			crushDeviceClass: volume.CrushDeviceClass,
 		}
 
 		logger.Debugf("osdProps are %+v", osdProps)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -49,6 +49,7 @@ const (
 	blockPathVarName                            = "ROOK_BLOCK_PATH"
 	cvModeVarName                               = "ROOK_CV_MODE"
 	lvBackedPVVarName                           = "ROOK_LV_BACKED_PV"
+	CrushDeviceClassVarName                     = "ROOK_OSD_CRUSH_DEVICE_CLASS"
 	rookBinariesMountPath                       = "/rook"
 	rookBinariesVolumeName                      = "rook-binaries"
 	activateOSDVolumeName                       = "activate-osd"
@@ -917,6 +918,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		}
 		envVars = append(envVars, dataDevicesEnvVar(strings.Join(dev, ",")))
 		envVars = append(envVars, pvcBackedOSDEnvVar("true"))
+		envVars = append(envVars, crushDeviceClassEnvVar(osdProps.crushDeviceClass))
 	}
 
 	// elevate to be privileged if it is going to mount devices or if running in a restricted environment such as openshift
@@ -1049,6 +1051,10 @@ func cvModeEnvVariable(cvMode string) v1.EnvVar {
 
 func lvBackedPVEnvVar(lvBackedPV string) v1.EnvVar {
 	return v1.EnvVar{Name: lvBackedPVVarName, Value: lvBackedPV}
+}
+
+func crushDeviceClassEnvVar(crushDeviceClass string) v1.EnvVar {
+	return v1.EnvVar{Name: CrushDeviceClassVarName, Value: crushDeviceClass}
 }
 
 func osdOnSDNFlag(network cephv1.NetworkSpec) []string {


### PR DESCRIPTION
**Description of your changes:**

When the OSD on PVC is backed by a metadata block PVC, the Ceph CRUSH
device class should be set to something else rather than the rotational
property of the drive.

Closes: https://github.com/rook/rook/issues/4881
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4881

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
