### PR TITLE
ceph: Less generic messages for the cluster Progressing Condition

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -397,7 +397,7 @@ func (c *ClusterController) configureLocalCephCluster(namespace, name string, cl
 				}
 				return false, nil
 			}
-			message := config.CheckConditionReady(c.context, namespace, name)
+			message := config.CheckConditionReady(c.context, namespace, name, "mon")
 			config.ConditionExport(c.context, namespace, name,
 				cephv1.ConditionProgressing, v1.ConditionTrue, "ClusterProgressing", message)
 

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -151,6 +151,10 @@ func (c *Cluster) Start() error {
 	}
 
 	logger.Infof("start running mgr")
+	message := config.CheckConditionReady(c.context, c.Namespace, c.clusterInfo.Name, "mgr")
+	config.ConditionExport(c.context, c.Namespace, c.clusterInfo.Name,
+		cephv1.ConditionProgressing, v1.ConditionTrue, "ClusterProgressing", message)
+
 	daemonIDs := c.getDaemonIDs()
 	for _, daemonID := range daemonIDs {
 		resourceName := fmt.Sprintf("%s-%s", AppName, daemonID)


### PR DESCRIPTION
This commit will changes the message for the Progressing condition to a more generic one..

When the initial reconciliation takes place, for `Progressing`
first the message will be `Cluster is checking for mon health`,
once that is done then `Cluster starts running mgr`, 
then it'll be `Cluster is checking for osd health`.
when everything is done `Cluster created succesfully`.

If the operator is restarted the message will be `Cluster is checking for updates if needed` everytime.

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
