### PR TITLE
ceph: add CRD setting for pool size 1

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -71,6 +71,7 @@ When creating an erasure-coded pool, it is highly recommended to create the pool
 * `replicated`: Settings for a replicated pool. If specified, `erasureCoded` settings must not be specified.
   * `size`: The desired number of copies to make of the data in the pool.
   * `targetSizeRatio:` gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool, for more info see the [ceph documentation](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size)
+  * `requireSafeReplicaSize`: set to false if you want to create a pool with size 1, setting pool size 1 could lead to data loss without recovery. Make sure you are *ABSOLUTELY CERTAIN* that is what you want.
 * `erasureCoded`: Settings for an erasure-coded pool. If specified, `replicated` settings must not be specified. See below for more details on [erasure coding](#erasure-coding).
   * `dataChunks`: Number of chunks to divide the original object into
   * `codingChunks`: Number of coding chunks to generate

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,7 +15,7 @@
 - OSD on PVC doesn't use LVM anymore to configure OSD, but solely relies on the entire block device, done [here](https://github.com/rook/rook/pull/4435).
 - Specific devices for OSDs can now be specified using the full udev path (e.g. /dev/disk/by-id/ata-ST4000DM004-XXXX) instead of the device name.
 - OSD on PVC CRUSH device storage class can now be changed by setting an annotation "crushDeviceClass" on the "data" volume template. See "cluster-on-pvc.yaml" for example.
-
+- Rook will now refuse to create pools with replica size 1 unless `requireSafeReplicaSize` is set to false.
 
 ### EdgeFS
 

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -396,6 +396,8 @@ spec:
                   maximum: 9
                 targetSizeRatio:
                   type: number
+                requireSafeReplicaSize:
+                  type: boolean
             erasureCoded:
               properties:
                 dataChunks:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -264,6 +264,8 @@ spec:
                       minimum: 0
                       maximum: 10
                       type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
                 erasureCoded:
                   properties:
                     dataChunks:
@@ -286,6 +288,8 @@ spec:
                         minimum: 0
                         maximum: 10
                         type: integer
+                      requireSafeReplicaSize:
+                        type: boolean
                   erasureCoded:
                     properties:
                       dataChunks:
@@ -458,6 +462,8 @@ spec:
                   maximum: 9
                 targetSizeRatio:
                   type: number
+                requireSafeReplicaSize:
+                  type: boolean
             erasureCoded:
               properties:
                 dataChunks:

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
@@ -7,6 +7,12 @@ spec:
   failureDomain: host
   replicated:
     size: 1
+    # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+    # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+    requireSafeReplicaSize: false
+    # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+    # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+    #targetSizeRatio: .5
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -7,6 +7,12 @@ spec:
   failureDomain: host
   replicated:
     size: 3
+    # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+    # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+    requireSafeReplicaSize: true
+    # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+    # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+    #targetSizeRatio: .5
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/cluster/examples/kubernetes/ceph/filesystem-test.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-test.yaml
@@ -12,10 +12,12 @@ spec:
   metadataPool:
     replicated:
       size: 1
+      requireSafeReplicaSize: false
   dataPools:
     - failureDomain: osd
       replicated:
         size: 1
+        requireSafeReplicaSize: false
   preservePoolsOnDelete: false
   metadataServer:
     activeCount: 1

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -14,11 +14,15 @@ spec:
   metadataPool:
     replicated:
       size: 3
+      requireSafeReplicaSize: true
   # The list of data pool specs. Can use replication or erasure coding.
   dataPools:
     - failureDomain: host
       replicated:
         size: 3
+        # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+        # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+        requireSafeReplicaSize: true
         # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
         # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
         #targetSizeRatio: .5

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -15,11 +15,23 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+      # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+      # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+      requireSafeReplicaSize: true
+      # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+      # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+      #targetSizeRatio: .5
   # The pool spec used to create the data pool. Can use replication or erasure coding.
   dataPool:
     failureDomain: host
     replicated:
       size: 3
+      # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+      # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+      requireSafeReplicaSize: true
+      # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+      # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+      #targetSizeRatio: .5
   # Whether to preserve metadata and data pools on object store deletion
   preservePoolsOnDelete: false
   # The gateway service configuration

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -15,10 +15,12 @@ spec:
   # For a pool based on raw copies, specify the number of copies. A size of 1 indicates no redundancy.
   replicated:
     size: 3
+    # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+    # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+    requireSafeReplicaSize: true
     # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
     # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
     #targetSizeRatio: .5
-
   # A key/value list of annotations
   annotations:
   #  key: value

--- a/pkg/apis/ceph.rook.io/v1/blockpool.go
+++ b/pkg/apis/ceph.rook.io/v1/blockpool.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import "github.com/rook/rook/pkg/daemon/ceph/model"
@@ -25,6 +26,7 @@ func (p *PoolSpec) ToModel(name string) *model.Pool {
 		pool.ReplicatedConfig.Size = r.Size
 		pool.Type = model.Replicated
 		pool.ReplicatedConfig.TargetSizeRatio = r.TargetSizeRatio
+		pool.ReplicatedConfig.RequireSafeReplicaSize = r.RequireSafeReplicaSize
 	} else {
 		ec := p.ErasureCode()
 		if ec != nil {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -270,6 +270,9 @@ type ReplicatedSpec struct {
 
 	// TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity
 	TargetSizeRatio float64 `json:"targetSizeRatio"`
+
+	// RequireSafeReplicaSize if false allows you to set replica 1
+	RequireSafeReplicaSize bool `json:"requireSafeReplicaSize"`
 }
 
 // ErasureCodeSpec represents the spec for erasure code in a pool

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -125,6 +125,7 @@ func ModelPoolToCephPool(modelPool model.Pool) CephStoragePoolDetails {
 	if modelPool.Type == model.Replicated {
 		pool.Size = modelPool.ReplicatedConfig.Size
 		pool.TargetSizeRatio = modelPool.ReplicatedConfig.TargetSizeRatio
+		pool.RequireSafeReplicaSize = modelPool.ReplicatedConfig.RequireSafeReplicaSize
 	} else if modelPool.Type == model.ErasureCoded {
 		pool.ErasureCodeProfile = GetErasureCodeProfileForPool(modelPool.Name)
 	}

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -57,14 +57,15 @@ var (
 
 // GlobalConfig represents the [global] sections of Ceph's config file.
 type GlobalConfig struct {
-	FSID               string `ini:"fsid,omitempty"`
-	MonMembers         string `ini:"mon initial members,omitempty"`
-	MonHost            string `ini:"mon host"`
-	PublicAddr         string `ini:"public addr,omitempty"`
-	PublicNetwork      string `ini:"public network,omitempty"`
-	ClusterAddr        string `ini:"cluster addr,omitempty"`
-	ClusterNetwork     string `ini:"cluster network,omitempty"`
-	MonAllowPoolDelete bool   `ini:"mon_allow_pool_delete"`
+	FSID                string `ini:"fsid,omitempty"`
+	MonMembers          string `ini:"mon initial members,omitempty"`
+	MonHost             string `ini:"mon host"`
+	PublicAddr          string `ini:"public addr,omitempty"`
+	PublicNetwork       string `ini:"public network,omitempty"`
+	ClusterAddr         string `ini:"cluster addr,omitempty"`
+	ClusterNetwork      string `ini:"cluster network,omitempty"`
+	MonAllowPoolDelete  bool   `ini:"mon_allow_pool_delete"`
+	MonAllowPoolSizeOne bool   `ini:"mon_allow_pool_size_one"`
 }
 
 // CephConfig represents an entire Ceph config including all sections.
@@ -162,14 +163,15 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 
 	conf := &CephConfig{
 		GlobalConfig: &GlobalConfig{
-			FSID:               cluster.FSID,
-			MonMembers:         strings.Join(monMembers, " "),
-			MonHost:            strings.Join(monHosts, ","),
-			PublicAddr:         context.NetworkInfo.PublicAddr,
-			PublicNetwork:      context.NetworkInfo.PublicNetwork,
-			ClusterAddr:        context.NetworkInfo.ClusterAddr,
-			ClusterNetwork:     context.NetworkInfo.ClusterNetwork,
-			MonAllowPoolDelete: true,
+			FSID:                cluster.FSID,
+			MonMembers:          strings.Join(monMembers, " "),
+			MonHost:             strings.Join(monHosts, ","),
+			PublicAddr:          context.NetworkInfo.PublicAddr,
+			PublicNetwork:       context.NetworkInfo.PublicNetwork,
+			ClusterAddr:         context.NetworkInfo.ClusterAddr,
+			ClusterNetwork:      context.NetworkInfo.ClusterNetwork,
+			MonAllowPoolDelete:  true,
+			MonAllowPoolSizeOne: true,
 		},
 	}
 

--- a/pkg/daemon/ceph/model/pool.go
+++ b/pkg/daemon/ceph/model/pool.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package model
 
 const (
@@ -24,8 +25,9 @@ const (
 type PoolType int
 
 type ReplicatedPoolConfig struct {
-	Size            uint    `json:"size"`
-	TargetSizeRatio float64 `json:"targetSizeRatio"`
+	Size                   uint    `json:"size"`
+	TargetSizeRatio        float64 `json:"targetSizeRatio"`
+	RequireSafeReplicaSize bool    `json:"requireSafeReplicaSize"`
 }
 
 type ErasureCodedPoolConfig struct {

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -53,7 +53,7 @@ func TestValidateSpec(t *testing.T) {
 
 	// missing data pools
 	assert.NotNil(t, validateFilesystem(context, fs))
-	p := cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}
+	p := cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}}
 	fs.Spec.DataPools = append(fs.Spec.DataPools, p)
 
 	// missing metadata pool
@@ -98,8 +98,8 @@ func TestCreateFilesystem(t *testing.T) {
 	fs := cephv1.CephFilesystem{
 		ObjectMeta: metav1.ObjectMeta{Name: "myfs", Namespace: "ns"},
 		Spec: cephv1.FilesystemSpec{
-			MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}},
-			DataPools:    []cephv1.PoolSpec{{Replicated: cephv1.ReplicatedSpec{Size: 1}}},
+			MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
+			DataPools:    []cephv1.PoolSpec{{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}}},
 			MetadataServer: cephv1.MetadataServerSpec{
 				ActiveCount: 1,
 				Resources: v1.ResourceRequirements{

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -103,7 +103,7 @@ func simpleStore() cephv1.CephObjectStore {
 	return cephv1.CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "mycluster"},
 		Spec: cephv1.ObjectStoreSpec{
-			MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}},
+			MetadataPool: cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}},
 			DataPool:     cephv1.PoolSpec{ErasureCoded: cephv1.ErasureCodedSpec{CodingChunks: 1, DataChunks: 2}},
 			Gateway:      cephv1.GatewaySpec{Port: 123},
 		},

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -278,6 +278,11 @@ func ValidatePoolSpec(context *clusterd.Context, namespace string, p *cephv1.Poo
 		}
 	}
 
+	// validate pool replica size
+	if p.Replicated.Size == 1 && p.Replicated.RequireSafeReplicaSize {
+		return errors.Errorf("error pool size is %d and requireSafeReplicaSize is %t, must be false", p.Replicated.Size, p.Replicated.RequireSafeReplicaSize)
+	}
+
 	return nil
 }
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -414,6 +414,8 @@ spec:
                   properties:
                     size:
                       type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
                 erasureCoded:
                   properties:
                     dataChunks:
@@ -428,6 +430,8 @@ spec:
                   properties:
                     size:
                       type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
                 erasureCoded:
                   properties:
                     dataChunks:
@@ -482,6 +486,8 @@ spec:
                   maximum: 9
                 targetSizeRatio:
                   type: number
+                requireSafeReplicaSize:
+                  type: boolean
             erasureCoded:
               properties:
                 dataChunks:
@@ -1992,7 +1998,8 @@ metadata:
 spec:
   replicated:
     size: ` + replicaSize + `
-    targetSizeRatio: .5`
+    targetSizeRatio: .5
+    requireSafeReplicaSize: false`
 }
 
 func (m *CephManifestsMaster) GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, systemNamespace string) string {
@@ -2073,9 +2080,11 @@ spec:
   metadataPool:
     replicated:
       size: 1
+      requireSafeReplicaSize: false
   dataPools:
   - replicated:
       size: 1
+      requireSafeReplicaSize: false
   metadataServer:
     activeCount: ` + strconv.Itoa(activeCount) + `
     activeStandby: true`
@@ -2106,9 +2115,11 @@ spec:
   metadataPool:
     replicated:
       size: 1
+      requireSafeReplicaSize: false
   dataPool:
     replicated:
       size: 1
+      requireSafeReplicaSize: false
   gateway:
     type: s3
     sslCertificateRef:


### PR DESCRIPTION
**Description of your changes:**

As of Octopus, Ceph will prevent you from creating a pool with a
replica size of 1. Allowing such pool could lead to data loss, so enable
the new option: allowUnsafeSingleReplica: true if you are **ABSOLUTELY**
certain that is what you want.

Closes: https://github.com/rook/rook/issues/4889
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4889

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
