### PR TITLE
ceph: nfs do not use rook binary

### DIFF
--- a/pkg/operator/ceph/spec/spec.go
+++ b/pkg/operator/ceph/spec/spec.go
@@ -19,6 +19,7 @@ package spec
 
 import (
 	"fmt"
+
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
@@ -374,6 +375,49 @@ func ChownCephDataDirsInitContainer(
 		Args:            args,
 		Image:           containerImage,
 		VolumeMounts:    volumeMounts,
+		Resources:       resources,
+		SecurityContext: securityContext,
+	}
+}
+
+// GenerateMinimalCephConfInitContainer returns an init container that will generate the most basic
+// Ceph config for connecting non-Ceph daemons to a Ceph cluster (e.g., nfs-ganesha). Effectively
+// what this means is that it generates '/etc/ceph/ceph.conf' with 'mon_host' populated and a
+// keyring path associated with the user given. 'mon_host' is determined by the 'ROOK_CEPH_MON_HOST'
+// env var present in other Ceph daemon pods, and the keyring is expected to be mounted into the
+// container with a Kubernetes pod volume+mount.
+func GenerateMinimalCephConfInitContainer(
+	username, keyringPath string,
+	containerImage string,
+	volumeMounts []v1.VolumeMount,
+	resources v1.ResourceRequirements,
+	securityContext *v1.SecurityContext,
+) v1.Container {
+	cfgPath := cephconfig.DefaultConfigFilePath()
+	// Note that parameters like $(PARAM) will be replaced by Kubernetes with env var content before
+	// container creation.
+	confScript := `
+set -xEeuo pipefail
+
+cat << EOF > ` + cfgPath + `
+[global]
+mon_host = $(ROOK_CEPH_MON_HOST)
+
+[` + username + `]
+keyring = ` + keyringPath + `
+EOF
+
+chmod 444 ` + cfgPath + `
+
+cat ` + cfgPath + `
+`
+	return v1.Container{
+		Name:            "generate-minimal-ceph-conf",
+		Command:         []string{"/bin/bash", "-c", confScript},
+		Args:            []string{},
+		Image:           containerImage,
+		VolumeMounts:    volumeMounts,
+		Env:             config.StoredMonHostEnvVars(),
 		Resources:       resources,
 		SecurityContext: securityContext,
 	}


### PR DESCRIPTION
Do not use the Rook binary to generate minimal config for Ceph's
NFS-Ganesha pods. Instead, `cat` the minimal file in an init container
using the Ceph container.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]