### PR TITLE
Ceph: adds watch to rook-ceph-operator-config ConfigMap

### DIFF
--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -80,14 +80,20 @@ func TestClusterDeleteFlexEnabled(t *testing.T) {
 
 		},
 	}
-	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
-		func(clusterSpec *cephv1.ClusterSpec) error {
+	operatorConfigCallbacks := []func() error{
+		func() error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
+	addCallbacks := []func() error{
+		func() error {
 			logger.Infof("test success callback")
 			return nil
 		},
 	}
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, "", volumeAttachmentController, addCallbacks)
+	controller := NewClusterController(context, "", volumeAttachmentController, operatorConfigCallbacks, addCallbacks)
 	clusterToDelete := &cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 
@@ -117,8 +123,14 @@ func TestClusterDeleteFlexDisabled(t *testing.T) {
 
 		},
 	}
-	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
-		func(clusterSpec *cephv1.ClusterSpec) error {
+	operatorConfigCallbacks := []func() error{
+		func() error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
+	addCallbacks := []func() error{
+		func() error {
 			logger.Infof("test success callback")
 			os.Setenv("ROOK_ENABLE_FLEX_DRIVER", "true")
 			os.Setenv(k8sutil.PodNamespaceEnvVar, rookSystemNamespace)
@@ -127,7 +139,7 @@ func TestClusterDeleteFlexDisabled(t *testing.T) {
 		},
 	}
 	// create the cluster controller and tell it that the cluster has been deleted
-	controller := NewClusterController(context, "", volumeAttachmentController, addCallbacks)
+	controller := NewClusterController(context, "", volumeAttachmentController, operatorConfigCallbacks, addCallbacks)
 	clusterToDelete := &cephv1.CephCluster{ObjectMeta: metav1.ObjectMeta{Namespace: clusterName}}
 	controller.handleDelete(clusterToDelete, time.Microsecond)
 
@@ -198,13 +210,20 @@ func TestRemoveFinalizer(t *testing.T) {
 		Clientset:     clientset,
 		RookClientset: rookfake.NewSimpleClientset(),
 	}
-	addCallbacks := []func(clusterSpec *cephv1.ClusterSpec) error{
-		func(clusterSpec *cephv1.ClusterSpec) error {
+	operatorConfigCallbacks := []func() error{
+		func() error {
+			logger.Infof("test success callback")
+			return nil
+		},
+	}
+	addCallbacks := []func() error{
+		func() error {
 			logger.Infof("test success callback")
 			return errors.New("test failed callback")
 		},
 	}
-	controller := NewClusterController(context, "", &attachment.MockAttachment{}, addCallbacks)
+
+	controller := NewClusterController(context, "", &attachment.MockAttachment{}, operatorConfigCallbacks, addCallbacks)
 
 	// *****************************************
 	// start with a current version ceph cluster

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -31,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// OperatorSettingConfigMapName refers to ConfigMap that configures rook ceph operator
+const OperatorSettingConfigMapName string = "rook-ceph-operator-config"
+
 var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	k8sutil "github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -111,9 +112,9 @@ func getToleration(clientset kubernetes.Interface, provisioner bool) []corev1.To
 	var err error
 	tolerationsRaw := ""
 	if provisioner {
-		tolerationsRaw, err = k8sutil.GetOperatorSetting(clientset, provisionerTolerationsEnv, "")
+		tolerationsRaw, err = k8sutil.GetOperatorSetting(clientset, controller.OperatorSettingConfigMapName, provisionerTolerationsEnv, "")
 	} else {
-		tolerationsRaw, err = k8sutil.GetOperatorSetting(clientset, pluginTolerationsEnv, "")
+		tolerationsRaw, err = k8sutil.GetOperatorSetting(clientset, controller.OperatorSettingConfigMapName, pluginTolerationsEnv, "")
 	}
 	if err != nil {
 		// tolerationsRaw is empty
@@ -143,9 +144,9 @@ func getNodeAffinity(clientset kubernetes.Interface, provisioner bool) *corev1.N
 	v1NodeAffinity := &corev1.NodeAffinity{}
 	var err error
 	if provisioner {
-		nodeAffinity, err = k8sutil.GetOperatorSetting(clientset, provisionerNodeAffinityEnv, "")
+		nodeAffinity, err = k8sutil.GetOperatorSetting(clientset, controller.OperatorSettingConfigMapName, provisionerNodeAffinityEnv, "")
 	} else {
-		nodeAffinity, err = k8sutil.GetOperatorSetting(clientset, pluginNodeAffinityEnv, "")
+		nodeAffinity, err = k8sutil.GetOperatorSetting(clientset, controller.OperatorSettingConfigMapName, pluginNodeAffinityEnv, "")
 	}
 	if err != nil {
 		logger.Warningf("node affinity will not be applied. %v", err)

--- a/pkg/operator/k8sutil/configmap.go
+++ b/pkg/operator/k8sutil/configmap.go
@@ -41,11 +41,10 @@ func DeleteConfigMap(clientset kubernetes.Interface, cmName, namespace string, o
 
 // GetOperatorSetting gets the operator setting from ConfigMap or Env Var
 // returns defaultValue if setting is not found
-func GetOperatorSetting(clientset kubernetes.Interface, settingName, defaultValue string) (string, error) {
+func GetOperatorSetting(clientset kubernetes.Interface, configMapName, settingName, defaultValue string) (string, error) {
 	// config must be in operator pod namespace
-	const rookCephOperatorSetting string = "rook-ceph-operator-config"
 	namespace := os.Getenv("POD_NAMESPACE")
-	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(rookCephOperatorSetting, metav1.GetOptions{})
+	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if settingValue, ok := os.LookupEnv(settingName); ok {
@@ -53,7 +52,7 @@ func GetOperatorSetting(clientset kubernetes.Interface, settingName, defaultValu
 			}
 			return defaultValue, nil
 		}
-		return defaultValue, fmt.Errorf("error reading ConfigMap %q. %v", rookCephOperatorSetting, err)
+		return defaultValue, fmt.Errorf("error reading ConfigMap %q. %v", configMapName, err)
 	}
 	if settingValue, ok := cm.Data[settingName]; ok {
 		return settingValue, nil

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -60,9 +60,10 @@ func TestDeleteConfigMap(t *testing.T) {
 func TestGetOperatorSetting(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
 
+	operatorSettingConfigMapName := "rook-ceph-operator-config"
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rook-ceph-operator-config",
+			Name:      operatorSettingConfigMapName,
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
@@ -77,7 +78,7 @@ func TestGetOperatorSetting(t *testing.T) {
 	defaultValue := ""
 
 	// ConfigMap is not found
-	setting, err := GetOperatorSetting(k8s, nodeAffinity, defaultValue)
+	setting, err := GetOperatorSetting(k8s, operatorSettingConfigMapName, nodeAffinity, defaultValue)
 	assert.NoError(t, err)
 
 	// Env Var doesn't exist
@@ -85,7 +86,7 @@ func TestGetOperatorSetting(t *testing.T) {
 	// Env Var exists
 	err = os.Setenv(nodeAffinity, envSettingValue)
 	assert.NoError(t, err)
-	setting, err = GetOperatorSetting(k8s, nodeAffinity, defaultValue)
+	setting, err = GetOperatorSetting(k8s, operatorSettingConfigMapName, nodeAffinity, defaultValue)
 	assert.NoError(t, err)
 	assert.Equal(t, envSettingValue, setting)
 
@@ -94,7 +95,7 @@ func TestGetOperatorSetting(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Setting exists in ConfigMap
-	setting, err = GetOperatorSetting(k8s, nodeAffinity, defaultValue)
+	setting, err = GetOperatorSetting(k8s, operatorSettingConfigMapName, nodeAffinity, defaultValue)
 	assert.NoError(t, err)
 	// Env Var exists
 	assert.Equal(t, cmSettingValue, setting)
@@ -104,14 +105,14 @@ func TestGetOperatorSetting(t *testing.T) {
 	assert.Equal(t, cmSettingValue, setting)
 
 	// Setting doesn't exist in ConfigMap
-	setting, err = GetOperatorSetting(k8s, podAffinity, defaultValue)
+	setting, err = GetOperatorSetting(k8s, operatorSettingConfigMapName, podAffinity, defaultValue)
 	assert.NoError(t, err)
 	// Env Var doesn't exist
 	assert.Equal(t, defaultValue, setting)
 	// Env Var exists
 	err = os.Setenv(podAffinity, envSettingValue)
 	assert.NoError(t, err)
-	setting, err = GetOperatorSetting(k8s, podAffinity, defaultValue)
+	setting, err = GetOperatorSetting(k8s, operatorSettingConfigMapName, podAffinity, defaultValue)
 	assert.NoError(t, err)
 	assert.Equal(t, envSettingValue, setting)
 }

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -60,21 +60,22 @@ func TestDeleteConfigMap(t *testing.T) {
 func TestGetOperatorSetting(t *testing.T) {
 	k8s := fake.NewSimpleClientset()
 
-	operatorSettingConfigMapName := "rook-ceph-operator-config"
+	operatorSettingConfigMapName := "rook-operator-config"
+	testNamespace := "test-namespace"
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      operatorSettingConfigMapName,
-			Namespace: "test-namespace",
+			Namespace: testNamespace,
 		},
 		Data: map[string]string{
-			"NODE_AFFINITY": "storage=rook, ceph",
+			"NODE_AFFINITY": "storage=rook, worker",
 		},
 	}
 
 	nodeAffinity := "NODE_AFFINITY"
 	podAffinity := "POD_AFFINITY"
 	envSettingValue := "role=storage-node"
-	cmSettingValue := "storage=rook, ceph"
+	cmSettingValue := "storage=rook, worker"
 	defaultValue := ""
 
 	// ConfigMap is not found
@@ -91,7 +92,7 @@ func TestGetOperatorSetting(t *testing.T) {
 	assert.Equal(t, envSettingValue, setting)
 
 	// ConfigMap is found
-	_, err = k8s.CoreV1().ConfigMaps("test-namespace").Create(cm)
+	_, err = k8s.CoreV1().ConfigMaps(testNamespace).Create(cm)
 	assert.NoError(t, err)
 
 	// Setting exists in ConfigMap

--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -26,12 +26,15 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/clusterd"
 	rookversion "github.com/rook/rook/pkg/version"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-k8sutil")
@@ -167,4 +170,20 @@ func validateLabelValue(value string) string {
 		sanitized = sanitized[:maxlen]
 	}
 	return sanitized
+}
+
+// StartOperatorSettingsWatch starts the watch for Operator Settings ConfigMap
+func StartOperatorSettingsWatch(context *clusterd.Context, operatorNamespace, operatorSettingConfigMapName string,
+	addFunc func(obj interface{}), updateFunc func(oldObj, newObj interface{}), deleteFunc func(obj interface{}), stopCh chan struct{}) {
+	_, cacheController := cache.NewInformer(cache.NewFilteredListWatchFromClient(context.Clientset.CoreV1().RESTClient(),
+		"configmaps", operatorNamespace, func(options *metav1.ListOptions) {
+			options.FieldSelector = fmt.Sprintf("%s=%s", "metadata.name", operatorSettingConfigMapName)
+		}), &v1.ConfigMap{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    addFunc,
+			UpdateFunc: updateFunc,
+			DeleteFunc: deleteFunc,
+		})
+	go cacheController.Run(stopCh)
 }


### PR DESCRIPTION
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
watches the rook-ceph-operator-config ConfigMap and updates Ceph csi driver based on watch events

**Which issue is resolved by this Pull Request:**
Resolves #rook-ceph-operator deployment based on watch events

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]