### PR TITLE
Ceph: manager integration tests

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -62,6 +62,7 @@ type clusterSettings struct {
 	RBDMirrorWorkers int
 	UsePVCs          bool
 	StorageClassName string
+	skipOSDCreation  bool
 	CephVersion      cephv1.CephVersionSpec
 }
 
@@ -1924,9 +1925,9 @@ spec:
   skipUpgradeChecks: true
   metadataDevice:
   storage:
-    useAllNodes: true
-    useAllDevices: true
-    deviceFilter: ''
+    useAllNodes: ` + strconv.FormatBool(!settings.skipOSDCreation) + `
+    useAllDevices: ` + strconv.FormatBool(!settings.skipOSDCreation) + `
+    deviceFilter:  ''
     config:
       ` + store + `
       databaseSizeMB: "1024"

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -40,6 +40,11 @@ func testStorageProvider() string {
 	return getEnvVarWithDefault("STORAGE_PROVIDER_TESTS", "")
 }
 
+// TestIsOfficialBuild gets the storage provider for which tests should be run
+func TestIsOfficialBuild() bool {
+	return os.Getenv("TEST_IS_OFFICIAL_BUILD") == "true"
+}
+
 // baseTestDir gets the base test directory
 func baseTestDir() string {
 	// If the base test directory is actively set to empty (as in CI), we use the current working directory.

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -40,11 +40,12 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion   = "1.14.0"
-	multiClusterMinimalTestVersion = "1.15.0"
-	helmMinimalTestVersion         = "1.16.0"
-	upgradeMinimalTestVersion      = "1.17.0"
-	smokeSuiteMinimalTestVersion   = "1.18.0"
+	flexDriverMinimalTestVersion      = "1.14.0"
+	cephMasterSuiteMinimalTestVersion = "1.15.0"
+	multiClusterMinimalTestVersion    = "1.15.0"
+	helmMinimalTestVersion            = "1.16.0"
+	upgradeMinimalTestVersion         = "1.17.0"
+	smokeSuiteMinimalTestVersion      = "1.18.0"
 )
 
 var (
@@ -110,6 +111,7 @@ type TestCluster struct {
 	mons                    int
 	rbdMirrorWorkers        int
 	rookCephCleanup         bool
+	skipOSDCreation         bool
 	minimalMatrixK8sVersion string
 	rookVersion             string
 	cephVersion             cephv1.CephVersionSpec
@@ -166,7 +168,7 @@ func (op *TestCluster) Setup() {
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
 
 	isRookInstalled, err := op.installer.InstallRook(op.namespace, op.storeType, op.usePVC, op.storageClassName,
-		cephv1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers)
+		cephv1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers, op.skipOSDCreation)
 
 	if !isRookInstalled || err != nil {
 		logger.Errorf("Rook was not installed successfully: %v", err)

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -91,6 +91,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		mons:                    1,
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         false,
+		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.OctopusVersion,

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -77,6 +77,7 @@ func (hs *HelmSuite) SetupSuite() {
 		mons:                    1,
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         true,
+		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: helmMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.NautilusVersion,

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/tests/framework/installer"
+	"github.com/rook/rook/tests/framework/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// **************************************************
+// *** Mgr operations covered by TestMgrSmokeSuite ***
+//
+// Ceph orchestrator device ls
+// Ceph orchestrator status
+// Ceph orchestrator host ls
+// Ceph orchestrator create OSD
+// Ceph orchestrator ls
+// **************************************************
+func TestCephMgrSuite(t *testing.T) {
+	if installer.SkipTestSuite(installer.CephTestSuite) {
+		t.Skip()
+	}
+	// Skip this test suite in master and release builds. If there is an issue
+	// running against Ceph master we don't want to block the official builds.
+	if installer.TestIsOfficialBuild() {
+		t.Skip()
+	}
+
+	s := new(CephMgrSuite)
+	defer func(s *CephMgrSuite) {
+		HandlePanics(recover(), s.cluster, s.T)
+	}(s)
+	suite.Run(t, s)
+}
+
+type CephMgrSuite struct {
+	suite.Suite
+	cluster   *TestCluster
+	k8sh      *utils.K8sHelper
+	namespace string
+}
+
+type host struct {
+	Addr     string
+	Hostname string
+	Labels   []string
+	Status   string
+}
+
+type serviceStatus struct {
+	ContainerImageName string `json:"Container_image_name"`
+	LastRefresh        string `json:"Last_refresh"`
+	Running            int
+	Size               int
+}
+
+type service struct {
+	placement   map[string]string
+	ServiceName string `json:"Service_name"`
+	ServiceType string `json:"Service_type"`
+	Status      serviceStatus
+}
+
+func (suite *CephMgrSuite) SetupSuite() {
+	suite.namespace = "mgr-ns"
+
+	mgrTestCluster := TestCluster{
+		clusterName:             suite.namespace,
+		namespace:               suite.namespace,
+		storeType:               "bluestore",
+		storageClassName:        "",
+		useHelm:                 false,
+		usePVC:                  false,
+		mons:                    1,
+		rbdMirrorWorkers:        0,
+		rookCephCleanup:         true,
+		skipOSDCreation:         true,
+		minimalMatrixK8sVersion: cephMasterSuiteMinimalTestVersion,
+		rookVersion:             installer.VersionMaster,
+		cephVersion:             installer.MasterVersion,
+	}
+
+	suite.cluster, suite.k8sh = StartTestCluster(suite.T, &mgrTestCluster)
+	suite.waitForOrchestrationModule()
+}
+
+func (suite *CephMgrSuite) AfterTest(suiteName, testName string) {
+	suite.cluster.installer.CollectOperatorLog(suiteName, testName, installer.SystemNamespace(suite.namespace))
+}
+
+func (suite *CephMgrSuite) TearDownSuite() {
+	suite.cluster.Teardown()
+}
+
+func (suite *CephMgrSuite) execute(command []string) (error, string) {
+	orchCommand := append([]string{"orch"}, command...)
+	return suite.cluster.installer.Execute("ceph", orchCommand, suite.namespace)
+}
+
+func (suite *CephMgrSuite) waitForOrchestrationModule() {
+	for timeout := 0; timeout < 30; timeout++ {
+		err, output := suite.execute([]string{"status"})
+		logger.Info("%s", output)
+		if err == nil {
+			logger.Info("Rook Toolbox ready to execute commands")
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+func (suite *CephMgrSuite) TestDeviceLs() {
+	logger.Info("Testing .... <ceph orch device ls>")
+	err, device_list := suite.execute([]string{"device", "ls"})
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", device_list)
+}
+
+func (suite *CephMgrSuite) TestStatus() {
+	logger.Info("Testing .... <ceph orch status>")
+	err, status := suite.execute([]string{"status"})
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", status)
+
+	assert.Equal(suite.T(), status, "Backend: rook\nAvailable: True")
+}
+
+func (suite *CephMgrSuite) TestHostLs() {
+	logger.Info("Testing .... <ceph orch host ls>")
+
+	// Get the orchestrator hosts
+	err, output := suite.execute([]string{"host", "ls", "json"})
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", output)
+
+	hosts := []byte(output)
+	var hostsList []host
+
+	err = json.Unmarshal(hosts, &hostsList)
+	if err != nil {
+		assert.Nil(suite.T(), err)
+	}
+
+	var hostOutput []string
+	for _, hostItem := range hostsList {
+		hostOutput = append(hostOutput, hostItem.Addr)
+	}
+	sort.Strings(hostOutput)
+
+	// get the k8s nodes
+	nodes, err := k8sutil.GetNodeHostNames(suite.k8sh.Clientset)
+	assert.Nil(suite.T(), err)
+
+	k8sNodes := make([]string, 0, len(nodes))
+	for k := range nodes {
+		k8sNodes = append(k8sNodes, k)
+	}
+	sort.Strings(k8sNodes)
+
+	// nodes and hosts must be the same
+	assert.Equal(suite.T(), hostOutput, k8sNodes)
+}
+
+func (suite *CephMgrSuite) TestCreateOSD() {
+	logger.Info("Testing .... <ceph orch create OSD>")
+
+	// Get the first available device
+	err, deviceList := suite.execute([]string{"device", "ls", "--format", "json"})
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", deviceList)
+
+	inventory := make([]map[string]interface{}, 0)
+
+	err = json.Unmarshal([]byte(deviceList), &inventory)
+	assert.Nil(suite.T(), err)
+
+	selectedNode := ""
+	selectedDevice := ""
+	for _, node := range inventory {
+		for _, device := range node["devices"].([]interface{}) {
+			if device.(map[string]interface{})["available"].(bool) {
+				selectedNode = node["name"].(string)
+				selectedDevice = strings.TrimPrefix(device.(map[string]interface{})["path"].(string), "/dev/")
+				break
+			}
+		}
+		if selectedDevice != "" {
+			break
+		}
+	}
+	assert.NotEqual(suite.T(), "", selectedDevice, "No devices available to create test OSD")
+	assert.NotEqual(suite.T(), "", selectedNode, "No nodes available to create test OSD")
+
+	if selectedDevice == "" || selectedNode == "" {
+		return
+	}
+	// Create the OSD
+	err, output := suite.execute([]string{"daemon", "add", "osd", fmt.Sprintf("%s:%s", selectedNode, selectedDevice)})
+
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", output)
+
+	err = suite.k8sh.WaitForPodCount("app=rook-ceph-osd", suite.namespace, 1)
+	assert.Nil(suite.T(), err)
+}
+
+func (suite *CephMgrSuite) TestServiceLs() {
+	logger.Info("Testing .... <ceph orch ls>")
+	err, output := suite.execute([]string{"ls", "--format", "json"})
+	assert.Nil(suite.T(), err)
+	logger.Infof("output = %s", output)
+
+	services := []byte(output)
+	var servicesList []service
+
+	err = json.Unmarshal(services, &servicesList)
+	assert.Nil(suite.T(), err)
+
+	for _, svc := range servicesList {
+		labelFilter := fmt.Sprintf("app=rook-ceph-%s", svc.ServiceName)
+		k8sPods, err := k8sutil.PodsRunningWithLabel(suite.k8sh.Clientset, suite.namespace, labelFilter)
+		logger.Infof("Service: %+v", svc)
+		logger.Infof("k8s pods for svc %q: %d", svc.ServiceName, k8sPods)
+		assert.Nil(suite.T(), err)
+		assert.Equal(suite.T(), svc.Status.Running, k8sPods, fmt.Sprintf("Wrong number of pods for kind of service <%s>", svc.ServiceName))
+	}
+}

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -184,7 +184,7 @@ func (o MCTestOperations) Teardown() {
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
 	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
-		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, installer.NautilusVersion)
+		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -87,6 +87,7 @@ func (suite *SmokeSuite) SetupSuite() {
 		mons:                    3,
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         false,
+		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.OctopusVersion,

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -82,6 +82,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		mons:                    1,
 		rbdMirrorWorkers:        0,
 		rookCephCleanup:         false,
+		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: upgradeMinimalTestVersion,
 		rookVersion:             installer.Version1_2,
 		cephVersion:             installer.NautilusVersion,


### PR DESCRIPTION
First approach to see if the Ceph manager integration tests can be implemented in this way

[test ceph]
[test full]

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

**Details about execution of this test**

```
[jolmomar@juanmipc rook]$ go test -v -timeout 1800s -run TestMgrSmokeSuite ./tests/integration 
=== RUN   TestMgrSmokeSuite
2020-02-25 13:49:38.773506 I | exec: Running command: kubectl config view -o json
2020-02-25 13:49:38.822631 I | testutil: Loaded kubectl context kubernetes at https://192.168.122.136:6443. secure=false
2020-02-25 13:49:38.822912 I | integrationTest: running all tests
2020-02-25 13:49:38.827730 I | exec: Running command: kubectl config view -o json
2020-02-25 13:49:38.878703 I | testutil: Loaded kubectl context kubernetes at https://192.168.122.136:6443. secure=false
2020-02-25 13:49:38.878965 I | installer: Rook Version: master
2020-02-25 13:49:38.878974 I | installer: Ceph Version: ceph/ceph:v14
2020-02-25 13:49:38.879746 I | exec: Running command: docker pull ceph/ceph:v14
2020-02-25 13:49:40.276699 I | v14: Pulling from ceph/ceph
2020-02-25 13:49:40.671509 I | Digest: sha256:ffe37f29900e292203ef00f3ee04e71266fe710d7c540bb908475c0b2ddc0693
2020-02-25 13:49:40.671528 I | Status: Image is up to date for ceph/ceph:v14
2020-02-25 13:49:40.675368 I | installer: Installing rook on k8s v1.17.3
2020-02-25 13:49:40.675383 I | installer: Starting Rook Operator
2020-02-25 13:49:40.675388 I | exec: Running command: kubectl create clusterrolebinding anon-user-access --clusterrole cluster-admin --user system:anonymous
2020-02-25 13:49:40.741677 E | utils: Failed to execute: kubectl [create clusterrolebinding anon-user-access --clusterrole cluster-admin --user system:anonymous] : Failed to complete 'kubectl': exit status 1. . Error from server (AlreadyExists): clusterrolebindings.rbac.authorization.k8s.io "anon-user-access" already exists
2020-02-25 13:49:40.741702 W | testutil: anon-user-access not created
2020-02-25 13:49:40.741710 I | installer: Creating Rook CRDs
2020-02-25 13:49:40.741724 I | testutil: Running kubectl [create -f -]
customresourcedefinition.apiextensions.k8s.io/cephclusters.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/cephfilesystems.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/cephnfses.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/cephobjectstores.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/cephobjectstoreusers.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/cephblockpools.ceph.rook.io created
customresourcedefinition.apiextensions.k8s.io/volumes.rook.io created
customresourcedefinition.apiextensions.k8s.io/objectbuckets.objectbucket.io created
customresourcedefinition.apiextensions.k8s.io/objectbucketclaims.objectbucket.io created
customresourcedefinition.apiextensions.k8s.io/cephclients.ceph.rook.io created
2020-02-25 13:49:41.137609 I | testutil: changed hostname of node ku-master-00.jmolabs.com to test-prefix-this-is-a-very-long-hostname-ku-master-00.jmolabs.com
2020-02-25 13:49:41.160078 I | testutil: Running kubectl [create -f -]
role.rbac.authorization.k8s.io/rook-ceph-system created
clusterrole.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt created
clusterrole.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt-rules created
clusterrole.rbac.authorization.k8s.io/rook-ceph-global created
clusterrole.rbac.authorization.k8s.io/rook-ceph-global-rules created
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-cluster created
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-cluster-rules created
clusterrole.rbac.authorization.k8s.io/rook-ceph-osd created
clusterrole.rbac.authorization.k8s.io/rook-ceph-agent-mount created
clusterrole.rbac.authorization.k8s.io/rook-ceph-agent-mount-rules created
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-system created
clusterrole.rbac.authorization.k8s.io/rook-ceph-mgr-system-rules created
clusterrole.rbac.authorization.k8s.io/rook-ceph-object-bucket created
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-object-bucket created
serviceaccount/rook-ceph-system created
rolebinding.rbac.authorization.k8s.io/rook-ceph-system created
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-global created
serviceaccount/rook-csi-rbd-plugin-sa created
clusterrole.rbac.authorization.k8s.io/rbd-csi-nodeplugin created
clusterrole.rbac.authorization.k8s.io/rbd-csi-nodeplugin-rules created
clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-nodeplugin created
serviceaccount/rook-csi-rbd-provisioner-sa created
clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner created
clusterrole.rbac.authorization.k8s.io/rbd-external-provisioner-runner-rules created
clusterrolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role created
role.rbac.authorization.k8s.io/rbd-external-provisioner-cfg created
rolebinding.rbac.authorization.k8s.io/rbd-csi-provisioner-role-cfg created
serviceaccount/rook-csi-cephfs-plugin-sa created
clusterrole.rbac.authorization.k8s.io/cephfs-csi-nodeplugin created
clusterrole.rbac.authorization.k8s.io/cephfs-csi-nodeplugin-rules created
clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-nodeplugin created
serviceaccount/rook-csi-cephfs-provisioner-sa created
clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner created
clusterrole.rbac.authorization.k8s.io/cephfs-external-provisioner-runner-rules created
clusterrolebinding.rbac.authorization.k8s.io/cephfs-csi-provisioner-role created
role.rbac.authorization.k8s.io/cephfs-external-provisioner-cfg created
rolebinding.rbac.authorization.k8s.io/cephfs-csi-provisioner-role-cfg created
podsecuritypolicy.policy/rook-privileged created
clusterrole.rbac.authorization.k8s.io/psp:rook created
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-system-psp created
clusterrolebinding.rbac.authorization.k8s.io/rook-csi-rbd-provisioner-sa-psp created
clusterrolebinding.rbac.authorization.k8s.io/rook-csi-rbd-plugin-sa-psp created
clusterrolebinding.rbac.authorization.k8s.io/rook-csi-cephfs-provisioner-sa-psp created
clusterrolebinding.rbac.authorization.k8s.io/rook-csi-cephfs-plugin-sa-psp created
deployment.apps/rook-ceph-operator created
2020-02-25 13:49:42.051187 I | installer: Rook Operator started
2020-02-25 13:49:47.065395 I | installer: Creating cluster: namespace=mgr-ns, systemNamespace=mgr-ns-system, storeType=bluestore, dataDirHostPath=/data/rook-test/mgr-ns/test-5577006791947779410, usePVC=false, storageClassName=, startWithAllNodes=false, mons={Count:3 AllowMultiplePerNode:true VolumeClaimTemplate:nil}
2020-02-25 13:49:47.065413 I | installer: Creating namespace mgr-ns
2020-02-25 13:49:47.068633 I | installer: Creating cluster roles
2020-02-25 13:49:47.068664 I | testutil: Running kubectl [create -f -]
serviceaccount/rook-ceph-osd created
serviceaccount/rook-ceph-mgr created
serviceaccount/rook-ceph-cmd-reporter created
role.rbac.authorization.k8s.io/rook-ceph-osd created
role.rbac.authorization.k8s.io/rook-ceph-mgr created
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-osd-mgr-ns created
clusterrolebinding.rbac.authorization.k8s.io/rook-ceph-mgr-cluster-mgr-ns created
role.rbac.authorization.k8s.io/rook-ceph-cmd-reporter created
rolebinding.rbac.authorization.k8s.io/rook-ceph-cluster-mgmt created
rolebinding.rbac.authorization.k8s.io/rook-ceph-osd created
rolebinding.rbac.authorization.k8s.io/rook-ceph-mgr created
rolebinding.rbac.authorization.k8s.io/rook-ceph-mgr-system mgr-ns created
rolebinding.rbac.authorization.k8s.io/rook-ceph-cmd-reporter created
rolebinding.rbac.authorization.k8s.io/rook-ceph-default-psp created
rolebinding.rbac.authorization.k8s.io/rook-ceph-osd-psp created
rolebinding.rbac.authorization.k8s.io/rook-ceph-mgr-psp created
rolebinding.rbac.authorization.k8s.io/rook-ceph-cmd-reporter-psp created
2020-02-25 13:49:47.472477 I | testutil: Running kubectl [create -f -]
job.batch/rook-ceph-disk-wipe-1 created
2020-02-25 13:49:47.676990 I | testutil: Running kubectl [create -f -]
job.batch/rook-ceph-disk-wipe-2 created
2020-02-25 13:49:47.908779 I | testutil: Running kubectl [create -f -]
job.batch/rook-ceph-disk-wipe-3 created
2020-02-25 13:49:48.163461 I | testutil: Running kubectl [create -f -]
job.batch/rook-ceph-disk-wipe-4 created
2020-02-25 13:49:58.419562 I | installer: Starting Rook Cluster with yaml
2020-02-25 13:49:58.419593 I | testutil: Running kubectl [create -f -]
cephcluster.ceph.rook.io/mgr-ns created
2020-02-25 13:49:59.030157 I | testutil: waiting for 3 pods (found 0) with label app=rook-ceph-mon in namespace mgr-ns
2020-02-25 13:50:04.304131 I | testutil: waiting for 3 pods (found 0) with label app=rook-ceph-mon in namespace mgr-ns
2020-02-25 13:50:09.307479 I | testutil: waiting for 3 pods (found 0) with label app=rook-ceph-mon in namespace mgr-ns
2020-02-25 13:50:14.312476 I | testutil: found 3 pods with label app=rook-ceph-mon
2020-02-25 13:50:14.314424 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:19.317709 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:24.324502 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:29.329091 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:34.334610 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:39.339972 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:44.344820 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:49.349864 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:54.355204 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:50:59.360035 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:04.365089 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:09.370968 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:14.376191 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:19.380530 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:24.385110 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:29.387675 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:34.389987 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:39.395238 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:44.399264 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:49.404316 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:54.409791 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:51:59.413901 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-mgr in namespace mgr-ns
2020-02-25 13:52:04.419686 I | testutil: found 1 pods with label app=rook-ceph-mgr
2020-02-25 13:52:04.424019 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:09.426998 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:14.429093 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:19.432098 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:24.435812 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:29.440092 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:34.443619 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:39.445988 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:44.448965 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:49.452498 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:54.455778 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:52:59.462268 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:53:04.465801 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:53:09.472529 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:53:14.479467 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:53:19.481832 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-osd in namespace mgr-ns
2020-02-25 13:53:24.490943 I | testutil: found 1 pods with label app=rook-ceph-osd
2020-02-25 13:53:24.506563 I | testutil: waiting for 1 pods (found 0) with label app=rook-ceph-rbd-mirror in namespace mgr-ns
2020-02-25 13:53:29.511167 I | testutil: found 1 pods with label app=rook-ceph-rbd-mirror
2020-02-25 13:53:29.511186 I | installer: Rook Cluster started
2020-02-25 13:53:29.525361 I | testutil: waiting for pod(s) with label app=rook-ceph-osd in namespace mgr-ns to be running. status=Pending, running=0/4, err=<nil>
2020-02-25 13:53:34.531253 I | testutil: waiting for pod(s) with label app=rook-ceph-osd in namespace mgr-ns to be running. status=Pending, running=1/4, err=<nil>
2020-02-25 13:53:39.535660 I | testutil: All 4 pod(s) with label app=rook-ceph-osd are running
2020-02-25 13:53:39.543076 I | installer: Starting Rook toolbox
2020-02-25 13:53:39.543092 I | testutil: Running kubectl [create -f -]
pod/rook-ceph-tools created
2020-02-25 13:53:44.741414 I | testutil: waiting for pod rook-ceph-tools in namespace mgr-ns to be running
2020-02-25 13:53:44.743246 I | installer: Rook Toolbox started
2020-02-25 13:53:44.743263 I | installer: installed rook operator and cluster : mgr-ns on k8s v1.17.3
=== RUN   TestMgrSmokeSuite/TestDevicels
2020-02-25 13:53:44.743764 I | exec: Running command: kubectl -it exec rook-ceph-tools -n mgr-ns -- ceph orchestrator device ls --connect-timeout=15 --format json
2020-02-25 13:53:45.516747 I | integrationTest: RESULT =[{"name": "ku-worker-01.jmolabs.com", "devices": []}, {"name": "ku-master-00.jmolabs.com", "devices": []}, {"name": "ku-worker-02.jmolabs.com", "devices": []}, {"name": "ku-worker-00.jmolabs.com", "devices": []}]
2020-02-25 13:53:45.516786 I | installer: Uninstalling Rook
2020-02-25 13:53:45.529051 I | testutil: Running kubectl [delete -f -]
serviceaccount "rook-ceph-osd" deleted
serviceaccount "rook-ceph-mgr" deleted
serviceaccount "rook-ceph-cmd-reporter" deleted
role.rbac.authorization.k8s.io "rook-ceph-osd" deleted
role.rbac.authorization.k8s.io "rook-ceph-mgr" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-ceph-osd-mgr-ns" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-ceph-mgr-cluster-mgr-ns" deleted
role.rbac.authorization.k8s.io "rook-ceph-cmd-reporter" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cluster-mgmt" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-osd" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-mgr" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-mgr-system mgr-ns" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cmd-reporter" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-default-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-osd-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-mgr-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cmd-reporter-psp" deleted
2020-02-25 13:53:47.097105 I | exec: Running command: kubectl delete -n mgr-ns cephcluster mgr-ns --wait=false
2020-02-25 13:53:47.194247 I | installer: removed finalizers from cluster mgr-ns
2020-02-25 13:53:47.194266 I | testutil: custom resource mgr-ns still exists
2020-02-25 13:53:49.204421 E | installer: failed to remove finalizer. failed to get cluster. cephclusters.ceph.rook.io "mgr-ns" not found
2020-02-25 13:53:49.204437 I | testutil: custom resource mgr-ns deleted
2020-02-25 13:53:49.204444 I | exec: Running command: kubectl delete namespace mgr-ns --wait=false
2020-02-25 13:53:49.278080 I | exec: Running command: kubectl delete namespace mgr-ns-system --wait=false
2020-02-25 13:53:49.342319 I | installer: removing the operator from namespace mgr-ns-system
2020-02-25 13:53:49.342353 I | exec: Running command: kubectl delete crd cephclusters.ceph.rook.io cephblockpools.ceph.rook.io cephobjectstores.ceph.rook.io cephobjectstoreusers.ceph.rook.io cephfilesystems.ceph.rook.io cephnfses.ceph.rook.io cephclients.ceph.rook.io volumes.rook.io objectbuckets.objectbucket.io objectbucketclaims.objectbucket.io
2020-02-25 13:53:49.758943 I | installer: Deleting all the resources in the operator manifest
2020-02-25 13:53:49.758981 I | testutil: Running kubectl [delete -f -]
role.rbac.authorization.k8s.io "rook-ceph-system" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-cluster-mgmt" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-cluster-mgmt-rules" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-global" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-global-rules" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-mgr-cluster" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-mgr-cluster-rules" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-osd" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-agent-mount" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-agent-mount-rules" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-mgr-system" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-mgr-system-rules" deleted
clusterrole.rbac.authorization.k8s.io "rook-ceph-object-bucket" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-ceph-object-bucket" deleted
serviceaccount "rook-ceph-system" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-system" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-ceph-global" deleted
serviceaccount "rook-csi-rbd-plugin-sa" deleted
clusterrole.rbac.authorization.k8s.io "rbd-csi-nodeplugin" deleted
clusterrole.rbac.authorization.k8s.io "rbd-csi-nodeplugin-rules" deleted
clusterrolebinding.rbac.authorization.k8s.io "rbd-csi-nodeplugin" deleted
serviceaccount "rook-csi-rbd-provisioner-sa" deleted
clusterrole.rbac.authorization.k8s.io "rbd-external-provisioner-runner" deleted
clusterrole.rbac.authorization.k8s.io "rbd-external-provisioner-runner-rules" deleted
clusterrolebinding.rbac.authorization.k8s.io "rbd-csi-provisioner-role" deleted
role.rbac.authorization.k8s.io "rbd-external-provisioner-cfg" deleted
rolebinding.rbac.authorization.k8s.io "rbd-csi-provisioner-role-cfg" deleted
serviceaccount "rook-csi-cephfs-plugin-sa" deleted
clusterrole.rbac.authorization.k8s.io "cephfs-csi-nodeplugin" deleted
clusterrole.rbac.authorization.k8s.io "cephfs-csi-nodeplugin-rules" deleted
clusterrolebinding.rbac.authorization.k8s.io "cephfs-csi-nodeplugin" deleted
serviceaccount "rook-csi-cephfs-provisioner-sa" deleted
clusterrole.rbac.authorization.k8s.io "cephfs-external-provisioner-runner" deleted
clusterrole.rbac.authorization.k8s.io "cephfs-external-provisioner-runner-rules" deleted
clusterrolebinding.rbac.authorization.k8s.io "cephfs-csi-provisioner-role" deleted
role.rbac.authorization.k8s.io "cephfs-external-provisioner-cfg" deleted
rolebinding.rbac.authorization.k8s.io "cephfs-csi-provisioner-role-cfg" deleted
podsecuritypolicy.policy "rook-privileged" deleted
clusterrole.rbac.authorization.k8s.io "psp:rook" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-ceph-system-psp" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-csi-rbd-provisioner-sa-psp" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-csi-rbd-plugin-sa-psp" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-csi-cephfs-provisioner-sa-psp" deleted
clusterrolebinding.rbac.authorization.k8s.io "rook-csi-cephfs-plugin-sa-psp" deleted
deployment.apps "rook-ceph-operator" deleted
2020-02-25 13:53:57.345563 I | installer: DONE deleting all the resources in the operator manifest
2020-02-25 13:54:01.748751 I | installer: done removing the operator from namespace mgr-ns-system
2020-02-25 13:54:01.748781 I | installer: removing host data dir /data/rook-test
2020-02-25 13:54:01.753931 I | testutil: Running kubectl [create -f -]
job.batch/rook-cleanup-6efb0637-164e-46c8-af45-6bed78a3893f created
2020-02-25 13:54:02.012998 I | installer: removing /data/rook-test from node ku-master-00.jmolabs.com. err=<nil>
2020-02-25 13:54:02.013025 I | testutil: Running kubectl [create -f -]
job.batch/rook-cleanup-8c14f488-d355-4e56-9688-64561fdb513a created
2020-02-25 13:54:02.237387 I | installer: removing /data/rook-test from node ku-worker-00.jmolabs.com. err=<nil>
2020-02-25 13:54:02.237422 I | testutil: Running kubectl [create -f -]
job.batch/rook-cleanup-3e4afb8e-53f9-4e38-8076-9569122c3069 created
2020-02-25 13:54:02.467281 I | installer: removing /data/rook-test from node ku-worker-01.jmolabs.com. err=<nil>
2020-02-25 13:54:02.467325 I | testutil: Running kubectl [create -f -]
job.batch/rook-cleanup-f512e8a1-b090-4065-8300-2035f312f535 created
2020-02-25 13:54:02.662997 I | installer: removing /data/rook-test from node ku-worker-02.jmolabs.com. err=<nil>
2020-02-25 13:54:02.682817 I | installer: system namespace "mgr-ns-system" still found...
2020-02-25 13:54:07.684924 I | installer: system namespace "mgr-ns-system" still found...
2020-02-25 13:54:12.686903 I | installer: system namespace "mgr-ns-system" removed
--- PASS: TestMgrSmokeSuite (273.91s)
    --- PASS: TestMgrSmokeSuite/TestDevicels (0.77s)
PASS
ok  	github.com/rook/rook/tests/integration	27
```


**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
