### PR TITLE
ceph: separate controller for CephBlockPool CRD

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1423,7 +1423,7 @@
 
 [[projects]]
   branch = "release-0.2"
-  digest = "1:a8b792e14d6900b58c297ad1d754b8c0d677ba692a04d707594b00bf0cf7a936"
+  digest = "1:76731d8c90dc619c96c01cbdabf0e2fe76e3f6cc11f162a1ebba770d998dc64d"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -1431,6 +1431,7 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/controller/controllerutil",
     "pkg/event",
@@ -1585,6 +1586,7 @@
     "k8s.io/kubernetes/pkg/volume/flexvolume",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/event",

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -107,12 +108,26 @@ func newCephToolCommand(tool string, context *clusterd.Context, clusterName stri
 	}
 }
 
+// TODO: make this work even if the operator config comes from the CM?
+// IsDebugLevel detects operator log level
+func IsDebugLevel() bool {
+	logLevel := os.Getenv("ROOK_LOG_LEVEL")
+	switch logLevel {
+	case "INFO":
+		return true
+	case "DEBUG":
+		return false
+	default:
+		return true
+	}
+}
+
 func NewCephCommand(context *clusterd.Context, clusterName string, args []string) *CephToolCommand {
-	return newCephToolCommand(CephTool, context, clusterName, args, false)
+	return newCephToolCommand(CephTool, context, clusterName, args, IsDebugLevel())
 }
 
 func NewRBDCommand(context *clusterd.Context, clusterName string, args []string) *CephToolCommand {
-	cmd := newCephToolCommand(RBDTool, context, clusterName, args, false)
+	cmd := newCephToolCommand(RBDTool, context, clusterName, args, IsDebugLevel())
 	cmd.JsonOutput = false
 	cmd.OutputFile = false
 	return cmd

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -86,7 +86,7 @@ func GetCrushMap(context *clusterd.Context, clusterName string) (CrushMap, error
 	args := []string{"osd", "crush", "dump"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return c, errors.Wrapf(err, "failed to get crush map")
+		return c, errors.Wrapf(err, "failed to get crush map. %s", string(buf))
 	}
 
 	err = json.Unmarshal(buf, &c)

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -173,7 +173,7 @@ func CreatePoolWithProfile(context *clusterd.Context, clusterName string, newPoo
 func checkForImagesInPool(context *clusterd.Context, name, namespace string) error {
 	var err error
 	var stats = new(PoolStatistics)
-	logger.Infof("checking any images/snapshosts present in pool %s", name)
+	logger.Debugf("checking any images/snapshosts present in pool %q", name)
 	stats, err = GetPoolStatistics(context, name, namespace)
 	if err != nil {
 		if strings.Contains(err.Error(), "No such file or directory") {
@@ -182,26 +182,27 @@ func checkForImagesInPool(context *clusterd.Context, name, namespace string) err
 		return errors.Wrapf(err, "failed to list images/snapshosts in pool %s", name)
 	}
 	if stats.Images.Count == 0 && stats.Images.SnapCount == 0 {
-		logger.Infof("no images/snapshosts present in pool %s", name)
+		logger.Infof("no images/snapshosts present in pool %q", name)
 		return nil
 	}
 
-	return errors.Errorf("pool %s contains images/snapshosts", name)
+	return errors.Errorf("pool %q contains images/snapshosts", name)
 }
 
+// DeletePool purges a pool from Ceph
 func DeletePool(context *clusterd.Context, clusterName string, name string) error {
 	// check if the pool exists
 	pool, err := GetPoolDetails(context, clusterName, name)
 	if err != nil {
-		logger.Infof("pool %q not found for deletion. %v", name, err)
-		return nil
+		return errors.Wrapf(err, "failed to get pool %q details", name)
 	}
 
 	err = checkForImagesInPool(context, name, clusterName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete pool %q", name)
+		return errors.Wrapf(err, "failed to check if pool %q has rbd images", name)
 	}
-	logger.Infof("purging pool %s (id=%d)", name, pool.Number)
+
+	logger.Infof("purging pool %q (id=%d)", name, pool.Number)
 	args := []string{"osd", "pool", "delete", name, name, reallyConfirmFlag}
 	_, err = NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
@@ -212,7 +213,7 @@ func DeletePool(context *clusterd.Context, clusterName string, name string) erro
 	args = []string{"osd", "crush", "rule", "rm", name}
 	_, err = NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		logger.Infof("did not delete crush rule %q. %v", name, err)
+		logger.Errorf("failed to delete crush rule %q. %v", name, err)
 	}
 
 	logger.Infof("purge completed for pool %q", name)
@@ -375,63 +376,6 @@ func GetPoolStatistics(context *clusterd.Context, name, clusterName string) (*Po
 	}
 
 	return &poolStats, nil
-}
-
-func GetPools(context *clusterd.Context, clusterName string) ([]model.Pool, error) {
-	// list pool summaries using the ceph client
-	cephPoolSummaries, err := ListPoolSummaries(context, clusterName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list pools")
-	}
-
-	// get the details for each pool from its summary information
-	cephPools := make([]CephStoragePoolDetails, len(cephPoolSummaries))
-	for i := range cephPoolSummaries {
-		poolDetails, err := GetPoolDetails(context, clusterName, cephPoolSummaries[i].Name)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get details for pool %s", cephPoolSummaries[i].Name)
-		}
-
-		cephPools[i] = poolDetails
-	}
-
-	var ecProfileDetails map[string]CephErasureCodeProfile
-	lookupECProfileDetails := false
-	for i := range cephPools {
-		if cephPools[i].ErasureCodeProfile != "" {
-			// at least one pool is erasure coded, we'll need to look up erasure code profile details
-			lookupECProfileDetails = true
-			break
-		}
-	}
-	if lookupECProfileDetails {
-		// list each erasure code profile
-		ecProfileNames, err := ListErasureCodeProfiles(context, clusterName)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list erasure code profiles")
-		}
-
-		// get the details of each erasure code profile and store them in the map
-		ecProfileDetails = make(map[string]CephErasureCodeProfile, len(ecProfileNames))
-		for _, name := range ecProfileNames {
-			ecp, err := GetErasureCodeProfileDetails(context, clusterName, name)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get erasure code profile details for %q", name)
-			}
-			ecProfileDetails[name] = ecp
-		}
-	}
-
-	// convert the ceph pools details to model pools
-	pools := make([]model.Pool, len(cephPools))
-	for i, p := range cephPools {
-		pool, err := cephPoolToModelPool(p, ecProfileDetails)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to convert ceph pool to model")
-		}
-		pools[i] = pool
-	}
-	return pools, nil
 }
 
 func cephPoolToModelPool(cephPool CephStoragePoolDetails, ecpDetails map[string]CephErasureCodeProfile) (model.Pool, error) {

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -110,11 +110,12 @@ func GetPoolNamesByID(context *clusterd.Context, clusterName string) (map[int]st
 	return names, nil
 }
 
+// GetPoolDetails gets all the details of a given pool
 func GetPoolDetails(context *clusterd.Context, clusterName, name string) (CephStoragePoolDetails, error) {
 	args := []string{"osd", "pool", "get", name, "all"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return CephStoragePoolDetails{}, errors.Wrapf(err, "failed to get pool %s details", name)
+		return CephStoragePoolDetails{}, errors.Wrapf(err, "failed to get pool %s details. %s", name, string(buf))
 	}
 
 	// The response for osd pool get when passing var=all is actually malformed JSON similar to:
@@ -263,7 +264,7 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, clusterName string, n
 
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to create replicated pool %s", newPool.Name)
+		return errors.Wrapf(err, "failed to create replicated pool %s. %s", newPool.Name, string(buf))
 	}
 
 	// the pool is type replicated, set the size for the pool now that it's been created
@@ -287,7 +288,7 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, clusterName string, n
 		}
 	}
 
-	logger.Infof("creating replicated pool %s succeeded, buf: %s", newPool.Name, string(buf))
+	logger.Infof("creating replicated pool %s succeeded", newPool.Name)
 	return nil
 }
 

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -148,7 +148,7 @@ func Status(context *clusterd.Context, clusterName string, debug bool) (CephStat
 	cmd.Debug = debug
 	buf, err := cmd.Run()
 	if err != nil {
-		return CephStatus{}, errors.Wrapf(err, "failed to get status")
+		return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
 	}
 
 	var status CephStatus

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -38,8 +38,8 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/rbd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
-	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,7 +163,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	}
 
 	if c.Spec.External.Enable && c.Spec.CephVersion.Image != "" {
-		c.Info.CephVersion, err = cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, *version)
+		c.Info.CephVersion, err = controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, *version)
 		if err != nil {
 			return errors.Wrapf(err, "failed to validate ceph version between external and local")
 		}

--- a/pkg/operator/ceph/cluster/crash/add.go
+++ b/pkg/operator/ceph/cluster/crash/add.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,7 +45,7 @@ const (
 )
 
 // Add adds a new Controller based on nodedrain.ReconcileNode and registers the relevant watches and handlers
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, context *clusterd.Context) error {
 	reconcileNode := &ReconcileNode{
 		client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),

--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -27,9 +27,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/file/mds"
 	"github.com/rook/rook/pkg/operator/ceph/object"
-	"github.com/rook/rook/pkg/operator/ceph/spec"
 	"github.com/rook/rook/pkg/operator/ceph/version"
 
 	"github.com/coreos/pkg/capnslog"
@@ -210,7 +210,7 @@ func getImageVersion(cephCluster cephv1.CephCluster) (*version.CephVersion, erro
 		// controller should wait for the version to be detected.
 		if cephCluster.Status.CephVersion != nil && cephCluster.Spec.CephVersion.Image == cephCluster.Status.CephVersion.Image {
 			logger.Debugf("ceph version found %q", cephCluster.Status.CephVersion.Version)
-			return spec.ExtractCephVersionFromLabel(cephCluster.Status.CephVersion.Version)
+			return controller.ExtractCephVersionFromLabel(cephCluster.Status.CephVersion.Version)
 		}
 		<-time.After(time.Second * getVersionRetryInterval)
 	}

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -34,7 +34,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
@@ -144,7 +144,7 @@ func (c *Cluster) getDaemonIDs() []string {
 // Start begins the process of running a cluster of Ceph mgrs.
 func (c *Cluster) Start() error {
 	// Validate pod's memory if specified
-	err := opspec.CheckPodMemory(c.resources, cephMgrPodMinimumMemory)
+	err := controller.CheckPodMemory(c.resources, cephMgrPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephutil "github.com/rook/rook/pkg/daemon/ceph/util"
-	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -309,7 +309,7 @@ func removeMonitorFromQuorum(context *clusterd.Context, clusterName, name string
 func (c *Cluster) handleExternalMonStatus(status client.MonStatusResponse) error {
 	// We don't need to validate Ceph version if no image is present
 	if c.spec.CephVersion.Image == "" {
-		_, err := cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, c.ClusterInfo.CephVersion)
+		_, err := controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, c.ClusterInfo.CephVersion)
 		if err != nil {
 			return errors.Wrapf(err, "failed to validate external ceph version")
 		}

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -83,7 +83,7 @@ func (c *Cluster) checkHealth() error {
 
 	// connect to the mons
 	// get the status and check for quorum
-	quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo.Name, true)
+	quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo.Name, client.IsDebugLevel())
 	if err != nil {
 		return errors.Wrapf(err, "failed to get mon quorum status")
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -986,7 +986,7 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterName string, mons [
 
 		// get the quorum_status response that contains info about all monitors in the mon map and
 		// their quorum status
-		monQuorumStatusResp, err := client.GetMonQuorumStatus(context, clusterName, false)
+		monQuorumStatusResp, err := client.GetMonQuorumStatus(context, clusterName, client.IsDebugLevel())
 		if err != nil {
 			logger.Debugf("failed to get quorum_status. %v", err)
 			continue

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -24,7 +24,7 @@ import (
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
 	testop "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
@@ -73,10 +73,10 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 
 	if pvc {
 		d.Spec.Template.Spec.Volumes = append(
-			d.Spec.Template.Spec.Volumes, opspec.DaemonVolumesDataPVC("i-am-pvc"))
+			d.Spec.Template.Spec.Volumes, controller.DaemonVolumesDataPVC("i-am-pvc"))
 	} else {
 		d.Spec.Template.Spec.Volumes = append(
-			d.Spec.Template.Spec.Volumes, opspec.DaemonVolumesDataHostPath(monConfig.DataPathMap)...)
+			d.Spec.Template.Spec.Volumes, controller.DaemonVolumesDataHostPath(monConfig.DataPathMap)...)
 	}
 
 	// Deployment should have Ceph labels

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -19,7 +19,7 @@ package osd
 import (
 	"github.com/pkg/errors"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +29,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 
 	// Iterate over storageClassDeviceSet
 	for _, storageClassDeviceSet := range c.DesiredStorage.StorageClassDeviceSets {
-		if err := opspec.CheckPodMemory(storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
+		if err := controller.CheckPodMemory(storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
 			config.addError("cannot use storageClassDeviceSet %q for creating osds %v", storageClassDeviceSet.Name, err)
 			continue
 		}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -36,7 +36,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	osdconfig "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
@@ -182,7 +182,7 @@ func (c *Cluster) Start() error {
 	config := c.newProvisionConfig()
 
 	// Validate pod's memory if specified
-	err := opspec.CheckPodMemory(c.resources, cephOsdPodMinimumMemory)
+	err := controller.CheckPodMemory(c.resources, cephOsdPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "failed to check pod memory")
 	}

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -30,7 +30,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
@@ -104,7 +104,7 @@ var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 // Start begins the process of running rbd mirroring daemons.
 func (m *Mirroring) Start() error {
 	// Validate pod's memory if specified
-	err := opspec.CheckPodMemory(m.resources, cephRbdMirrorPodMinimumMemory)
+	err := controller.CheckPodMemory(m.resources, cephRbdMirrorPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/cluster/register_controllers.go
+++ b/pkg/operator/ceph/cluster/register_controllers.go
@@ -17,22 +17,30 @@ limitations under the License.
 package cluster
 
 import (
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	"github.com/rook/rook/pkg/operator/ceph/pool"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager (entrypoint for controller)
-var AddToManagerFuncs = []func(manager.Manager) error{
+var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context) error{
 	crash.Add,
+	pool.Add,
 }
 
 // AddToManager adds all the registered controllers to the passed manager.
 // each controller package will have an Add method listed in AddToManagerFuncs
 // which will setup all the necessary watch
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, c *clusterd.Context) error {
+	if c == nil {
+		return errors.New("nil context passed")
+	}
+
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, c); err != nil {
 			return err
 		}
 	}

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
+	ImmediateRetryResult = reconcile.Result{Requeue: true}
+	// WaitForRequeueIfCephClusterNotReadyAfter requeue after 10sec if the operator is not ready
+	WaitForRequeueIfCephClusterNotReadyAfter = 10 * time.Second
+	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
+	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: WaitForRequeueIfCephClusterNotReadyAfter}
+)
+
+// IsReadyToReconcile determines if a controller is ready to reconcile or not
+func IsReadyToReconcile(client client.Client, clustercontext *clusterd.Context, namespacedName types.NamespacedName) (cephv1.ClusterSpec, bool, reconcile.Result) {
+	namespacedName.Name = namespacedName.Namespace
+
+	// Running ceph commands won't work and the controller will keep re-queuing so I believe it's fine not to check
+	// Make sure a CephCluster exists before doing anything
+	cephCluster := &cephv1.CephCluster{}
+	err := client.Get(context.TODO(), namespacedName, cephCluster)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			logger.Errorf("CephCluster resource %q not found in namespace %q", namespacedName.Name, namespacedName.Namespace)
+			return cephv1.ClusterSpec{}, false, ImmediateRetryResult
+		} else if err != nil {
+			logger.Errorf("failed to fetch CephCluster %v", err)
+			return cephv1.ClusterSpec{}, false, ImmediateRetryResult
+		}
+	}
+
+	// If the cluster is ready
+	// Not using k8sutil.ReadyStatus to avoid import cycles
+	if cephCluster.Status.Phase == k8sutil.ReadyStatus {
+		// Test a Ceph command to verify the Operator is ready
+		// This is done to silence errors when the operator just started and cannot reconcile yet
+		_, err = cephclient.Status(clustercontext, namespacedName.Namespace, true)
+		if err != nil {
+			if strings.Contains(err.Error(), "error calling conf_read_file") {
+				logger.Info("operator is not ready to run ceph command, cannot reconcile yet.")
+				return cephCluster.Spec, false, WaitForRequeueIfCephClusterNotReady
+			}
+			// We should not arrive there
+			logger.Errorf("ceph command error %v", err)
+			return cephCluster.Spec, false, ImmediateRetryResult
+		}
+		return cephCluster.Spec, true, reconcile.Result{}
+	}
+
+	return cephCluster.Spec, false, ImmediateRetryResult
+}
+
+// Contains checks if an item exists in a given list.
+func Contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Removes any element from a list
+func Remove(list []string, s string) []string {
+	for i, v := range list {
+		if v == s {
+			list = append(list[:i], list[i+1:]...)
+		}
+	}
+
+	return list
+}

--- a/pkg/operator/ceph/controller/label.go
+++ b/pkg/operator/ceph/controller/label.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package spec
+package controller
 
 import (
 	"fmt"

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package spec provides Kubernetes controller/pod/container spec items used for many Ceph daemons
-package spec
+// Package controller provides Kubernetes controller/pod/container spec items used for many Ceph daemons
+package controller
 
 import (
 	"fmt"

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package spec
+package controller
 
 import (
 	"math"

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package spec
+package controller
 
 import (
 	"github.com/pkg/errors"

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -36,19 +36,19 @@ func (o *Operator) startManager(namespaceToWatch string, stopCh <-chan struct{})
 	logger.Info("setting up the controller-runtime manager")
 	kubeConfig, err := config.GetConfig()
 	if err != nil {
-		logger.Errorf("unable to get client config for controller-runtime manager. %v", err)
+		logger.Errorf("failed to get client config for controller-runtime manager. %v", err)
 		return
 	}
 	mgr, err := manager.New(kubeConfig, mgrOpts)
 	if err != nil {
-		logger.Errorf("unable to set up overall controller-runtime manager. %v", err)
+		logger.Errorf("failed to set up overall controller-runtime manager. %v", err)
 		return
 	}
 
 	// Add the registered controllers to the manager (entrypoint for controllers)
-	err = cluster.AddToManager(mgr)
+	err = cluster.AddToManager(mgr, o.context)
 	if err != nil {
-		logger.Errorf("cannot add controllers to controller-runtime manager. %v", err)
+		logger.Errorf("failed to add controllers to controller-runtime manager. %v", err)
 	}
 	// options to pass to the controllers
 	controllerOpts := &controllerconfig.Context{
@@ -60,7 +60,7 @@ func (o *Operator) startManager(namespaceToWatch string, stopCh <-chan struct{})
 	// Add the registered controllers to the manager (entrypoint for controllers)
 	err = controllers.AddToManager(mgr, controllerOpts)
 	if err != nil {
-		logger.Errorf("cannot add controllers to controller-runtime manager. %v", err)
+		logger.Errorf("failed to add controllers to controller-runtime manager. %v", err)
 	}
 
 	logger.Info("starting the controller-runtime manager")

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -27,7 +27,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -107,7 +107,7 @@ func (c *FilesystemController) onAdd(obj interface{}) {
 	defer c.releaseOrchestrationLock()
 
 	if c.clusterSpec.External.Enable {
-		_, err := cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
+		_, err := controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -31,7 +31,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -99,7 +99,7 @@ var UpdateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 // Start starts or updates a Ceph mds cluster in Kubernetes.
 func (c *Cluster) Start() error {
 	// Validate pod's memory if specified
-	err := opspec.CheckPodMemory(c.fs.Spec.MetadataServer.Resources, cephMdsPodMinimumMemory)
+	err := controller.CheckPodMemory(c.fs.Spec.MetadataServer.Resources, cephMdsPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -51,7 +51,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 				c.makeMdsDaemonContainer(mdsConfig),
 			},
 			RestartPolicy:     v1.RestartPolicyAlways,
-			Volumes:           opspec.DaemonVolumes(mdsConfig.DataPathMap, mdsConfig.ResourceName),
+			Volumes:           controller.DaemonVolumes(mdsConfig.DataPathMap, mdsConfig.ResourceName),
 			HostNetwork:       c.clusterSpec.Network.IsHost(),
 			PriorityClassName: c.fs.Spec.MetadataServer.PriorityClassName,
 		},
@@ -85,16 +85,16 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) *apps.Deployment {
 	}
 	k8sutil.AddRookVersionLabelToDeployment(d)
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
-	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
+	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
 	return d
 }
 
 func (c *Cluster) makeChownInitContainer(mdsConfig *mdsConfig) v1.Container {
-	return opspec.ChownCephDataDirsInitContainer(
+	return controller.ChownCephDataDirsInitContainer(
 		*mdsConfig.DataPathMap,
 		c.clusterSpec.CephVersion.Image,
-		opspec.DaemonVolumeMounts(mdsConfig.DataPathMap, mdsConfig.ResourceName),
+		controller.DaemonVolumeMounts(mdsConfig.DataPathMap, mdsConfig.ResourceName),
 		c.fs.Spec.MetadataServer.Resources,
 		mon.PodSecurityContext(),
 	)
@@ -102,7 +102,7 @@ func (c *Cluster) makeChownInitContainer(mdsConfig *mdsConfig) v1.Container {
 
 func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 	args := append(
-		opspec.DaemonFlags(c.clusterInfo, mdsConfig.DaemonID),
+		controller.DaemonFlags(c.clusterInfo, mdsConfig.DaemonID),
 		"--foreground",
 	)
 
@@ -113,9 +113,9 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 		},
 		Args:         args,
 		Image:        c.clusterSpec.CephVersion.Image,
-		VolumeMounts: opspec.DaemonVolumeMounts(mdsConfig.DataPathMap, mdsConfig.ResourceName),
+		VolumeMounts: controller.DaemonVolumeMounts(mdsConfig.DataPathMap, mdsConfig.ResourceName),
 		Env: append(
-			opspec.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
+			controller.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
 		),
 		Resources:       c.fs.Spec.MetadataServer.Resources,
 		SecurityContext: mon.PodSecurityContext(),
@@ -125,7 +125,7 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 }
 
 func (c *Cluster) podLabels(mdsConfig *mdsConfig) map[string]string {
-	labels := opspec.PodLabels(AppName, c.fs.Namespace, "mds", mdsConfig.DaemonID)
+	labels := controller.PodLabels(AppName, c.fs.Namespace, "mds", mdsConfig.DaemonID)
 	labels["rook_file_system"] = c.fs.Name
 	return labels
 }

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -22,7 +22,7 @@ import (
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
-	opspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -86,7 +86,7 @@ func (c *CephNFSController) makeDeployment(nfs cephv1.CephNFS, cfg daemonConfig)
 		},
 	}
 	k8sutil.AddRookVersionLabelToDeployment(deployment)
-	opspec.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
+	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	nfs.Spec.Server.Annotations.ApplyToObjectMeta(&deployment.ObjectMeta)
 
 	cephConfigVol, _ := cephConfigVolumeAndMount()
@@ -146,7 +146,7 @@ func (c *CephNFSController) makeDeployment(nfs cephv1.CephNFS, cfg daemonConfig)
 func (c *CephNFSController) connectionConfigInitContainer(nfs cephv1.CephNFS) v1.Container {
 	_, cephConfigMount := cephConfigVolumeAndMount()
 
-	return opspec.GenerateMinimalCephConfInitContainer(
+	return controller.GenerateMinimalCephConfInitContainer(
 		"client.admin",
 		keyring.VolumeMount().AdminKeyringFilePath(),
 		c.clusterSpec.CephVersion.Image,
@@ -182,7 +182,7 @@ func (c *CephNFSController) daemonContainer(nfs cephv1.CephNFS, cfg daemonConfig
 			dbusMount,
 		},
 		Env: append(
-			opspec.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
+			controller.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
 		),
 		Resources:       nfs.Spec.Server.Resources,
 		SecurityContext: mon.PodSecurityContext(),
@@ -215,15 +215,15 @@ func (c *CephNFSController) dbusContainer(nfs cephv1.CephNFS) v1.Container {
 }
 
 func getLabels(n cephv1.CephNFS, name string) map[string]string {
-	labels := opspec.AppLabels(appName, n.Namespace)
+	labels := controller.AppLabels(appName, n.Namespace)
 	labels["ceph_nfs"] = n.Name
 	labels["instance"] = name
 	return labels
 }
 
 func cephConfigVolumeAndMount() (v1.Volume, v1.VolumeMount) {
-	// nfs ganesha produces its own ceph config file, so cannot use opspec.DaemonVolume or
-	// opspec.DaemonVolumeMounts since that will bring in global ceph config file
+	// nfs ganesha produces its own ceph config file, so cannot use controller.DaemonVolume or
+	// controller.DaemonVolumeMounts since that will bring in global ceph config file
 	cfgDir := cephconfig.DefaultConfigDir
 	volName := k8sutil.PathToVolumeName(cfgDir)
 	v := v1.Volume{Name: volName, VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	daemonconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	cephspec "github.com/rook/rook/pkg/operator/ceph/spec"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -106,7 +106,7 @@ func (c *ObjectStoreController) onAdd(obj interface{}) {
 	updateCephObjectStoreStatus(objectStore.GetName(), objectStore.GetNamespace(), k8sutil.ProcessingStatus, c.context)
 
 	if c.clusterSpec.External.Enable {
-		_, err := cephspec.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
+		_, err := controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical

--- a/pkg/operator/ceph/operator_test.go
+++ b/pkg/operator/ceph/operator_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
-	"github.com/rook/rook/pkg/operator/ceph/pool"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,9 +39,9 @@ func TestOperator(t *testing.T) {
 	assert.NotNil(t, o.clusterController)
 	assert.NotNil(t, o.resources)
 	assert.Equal(t, context, o.context)
-	assert.Equal(t, len(o.resources), 6)
+	assert.Equal(t, len(o.resources), 5)
 	for _, r := range o.resources {
-		if r.Name != cluster.ClusterResource.Name && r.Name != pool.PoolResource.Name && r.Name != object.ObjectStoreResource.Name &&
+		if r.Name != cluster.ClusterResource.Name && r.Name != object.ObjectStoreResource.Name &&
 			r.Name != file.FilesystemResource.Name && r.Name != attachment.VolumeResource.Name && r.Name != objectuser.ObjectStoreUserResource.Name {
 			assert.Fail(t, fmt.Sprintf("Resource %s is not valid", r.Name))
 		}

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/operator/k8sutil/status.go
+++ b/pkg/operator/k8sutil/status.go
@@ -23,4 +23,8 @@ const (
 	ProcessingStatus = "Processing"
 	// FailedStatus reflects that some task failed for ceph related CRs
 	FailedStatus = "Failed"
+	// ReconcilingStatus indicates the CR is reconciling
+	ReconcilingStatus = "Reconciling"
+	// ReconcileFailedStatus indicates a reconciliation failed
+	ReconcileFailedStatus = "ReconcileFailed"
 )

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -193,7 +193,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(debug bool, actionName stri
 	cmd := exec.Command(command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 	// if there was anything that went to stdout/stderr then log it, even before we return an error
-	if string(cmdOut) != "" && debug {
+	if string(cmdOut) != "" {
 		logger.Debug(string(cmdOut))
 	}
 	if err != nil {

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -193,8 +193,8 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(debug bool, actionName stri
 	cmd := exec.Command(command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 	// if there was anything that went to stdout/stderr then log it, even before we return an error
-	if string(cmdOut) != "" {
-		logger.Info(string(cmdOut))
+	if string(cmdOut) != "" && debug {
+		logger.Debug(string(cmdOut))
 	}
 	if err != nil {
 		return string(cmdOut), err


### PR DESCRIPTION
**Description of your changes:**

Now, the CephBlockPool CRD is managed with the controller-runtime.
So the watcher is outside of the main controller reconciliation loop of
CephCluster which brings numerous benefit such as:

* having its own reconciliation loop
* won't block anything from the main CephCluster controller loop
* fast than waiting for CephCluster loop to completion

Partially close: https://github.com/rook/rook/issues/1981
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]