### PR TITLE
Allow mons from external cluster in toolbox config

### DIFF
--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -32,9 +32,6 @@ write_endpoints() {
     # filter out the mon names
     mon_endpoints=$(echo ${endpoints} | sed 's/[a-z]\+=//g')
 
-    # filter out the legacy mon names
-    mon_endpoints=$(echo ${mon_endpoints} | sed 's/rook-ceph-mon[0-9]\+=//g')
-
     DATE=$(date)
     echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"
     cat <<EOF > ${CEPH_CONFIG}


### PR DESCRIPTION
**Description of your changes:**
The toolbox was generating a ceph.conf with mons based on the assumption that they all had the prefix rook-ceph. This is no longer true for external clusters. The external clusters may have mons with any variety of names. So we can remove the filter that was added for legacy mons.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]