### PR TITLE
ceph: separate controller for CephObjectStoreUser CRD

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -44,7 +44,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/nfs"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
-	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
@@ -437,10 +436,6 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	objectStoreController := object.NewObjectStoreController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec, cluster.ownerRef, cluster.Spec.DataDirHostPath)
 	objectStoreController.StartWatch(cluster.Namespace, cluster.stopCh)
 
-	// Start object store user CRD watcher
-	objectStoreUserController := objectuser.NewObjectStoreUserController(c.context, cluster.Spec, cluster.Namespace, cluster.ownerRef)
-	objectStoreUserController.StartWatch(cluster.stopCh)
-
 	// Start the object bucket provisioner
 	bucketProvisioner := bucket.NewProvisioner(c.context, cluster.Namespace)
 	// note: the error return below is ignored and is expected to be removed from the
@@ -458,7 +453,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	// Populate childControllers
 	logger.Debug("populating child controllers, so cluster CR spec updates will be propagaged to other CR")
 	cluster.childControllers = []childController{
-		objectStoreController, objectStoreUserController, fileController, ganeshaController,
+		objectStoreController, fileController, ganeshaController,
 	}
 
 	// Populate ClusterInfo

--- a/pkg/operator/ceph/cluster/register_controllers.go
+++ b/pkg/operator/ceph/cluster/register_controllers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -29,6 +30,7 @@ import (
 var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context) error{
 	crash.Add,
 	pool.Add,
+	objectuser.Add,
 }
 
 // AddToManager adds all the registered controllers to the passed manager.

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -60,8 +60,9 @@ func IsReadyToReconcile(client client.Client, clustercontext *clusterd.Context, 
 		}
 	}
 
+	logger.Debugf("CephCluster resource %q found in namespace %q", namespacedName.Name, namespacedName.Namespace)
+
 	// If the cluster is ready
-	// Not using k8sutil.ReadyStatus to avoid import cycles
 	if cephCluster.Status.Phase == k8sutil.ReadyStatus {
 		// Test a Ceph command to verify the Operator is ready
 		// This is done to silence errors when the operator just started and cannot reconcile yet
@@ -75,8 +76,10 @@ func IsReadyToReconcile(client client.Client, clustercontext *clusterd.Context, 
 			logger.Errorf("ceph command error %v", err)
 			return cephCluster.Spec, false, cephClusterExists, ImmediateRetryResult
 		}
+		logger.Debugf("operator is ready to run ceph command, reconciling")
 		return cephCluster.Spec, true, cephClusterExists, reconcile.Result{}
 	}
 
+	logger.Debugf("CephCluster resource %q found in namespace %q but not ready yet", namespacedName.Name, namespacedName.Namespace)
 	return cephCluster.Spec, false, cephClusterExists, ImmediateRetryResult
 }

--- a/pkg/operator/ceph/controller/object_operations.go
+++ b/pkg/operator/ceph/controller/object_operations.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateOrUpdateObject updates an object with a given status
+func CreateOrUpdateObject(client client.Client, obj runtime.Object) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return errors.Wrap(err, "failed to get meta information of object")
+	}
+
+	err = client.Create(context.TODO(), obj)
+	if err != nil {
+		if kerrors.IsAlreadyExists(err) {
+			err = client.Update(context.TODO(), obj)
+			if err != nil {
+				return errors.Wrapf(err, "failed to update object %q", accessor.GetName())
+			}
+
+			logger.Infof("updated ceph object %q", accessor.GetName())
+			return nil
+		}
+		return errors.Wrapf(err, "failed to save ceph object %q", accessor.GetName())
+	}
+
+	return nil
+}

--- a/pkg/operator/ceph/controller/predictate.go
+++ b/pkg/operator/ceph/controller/predictate.go
@@ -92,3 +92,18 @@ func objectChanged(oldObj, newObj runtime.Object) (bool, error) {
 
 	return true, nil
 }
+
+// WatchPredicateForNonCRDObject is a special filter for create events
+// It only applies to non-CRD objects, meaning, for instance a cephv1.CephBlockPool{}
+// object will not have this filter
+// Only for objects like &v1.Secret{} or &v1.Pod{} etc...
+//
+// We return 'false' on a create event so we don't overstep with the main watcher on cephv1.CephBlockPool{}
+// This avoids a double reconcile when the secret gets deleted.
+func WatchPredicateForNonCRDObject() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+	}
+}

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -40,7 +40,7 @@ func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	command, args := client.FinalizeCephCommandArgs("radosgw-admin", args, c.Context.ConfigDir, c.ClusterName)
 
 	// start the rgw admin command
-	output, err := c.Context.Executor.ExecuteCommandWithOutput(false, "", command, args...)
+	output, err := c.Context.Executor.ExecuteCommandWithOutput(client.IsDebugLevel(), "", command, args...)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to run radosgw-admin")
 	}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -30,6 +30,7 @@ const (
 	RGWErrorNotFound
 	RGWErrorBadData
 	RGWErrorParse
+	ErrorCodeFileExists = 17
 )
 
 // An ObjectUser defines the details of an object store user.
@@ -100,7 +101,7 @@ func GetUser(c *Context, id string) (*ObjectUser, int, error) {
 
 // CreateUser creates a new user with the information given.
 func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
-	logger.Infof("Creating user: %s", user.UserID)
+	logger.Debugf("Creating user: %s", user.UserID)
 
 	if strings.TrimSpace(user.UserID) == "" {
 		return nil, RGWErrorBadData, errors.New("userId cannot be empty")
@@ -127,7 +128,7 @@ func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 	}
 
 	if strings.HasPrefix(result, "could not create user: unable to create user, user: ") && strings.HasSuffix(result, " exists") {
-		return nil, RGWErrorBadData, errors.New("user already exists")
+		return nil, ErrorCodeFileExists, errors.New("user already exists")
 	}
 
 	if strings.HasPrefix(result, "could not create user: unable to create user, email: ") && strings.HasSuffix(result, " is the email address an existing user") {
@@ -164,7 +165,6 @@ func UpdateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 
 // DeleteUser deletes the user with the given ID.
 func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
-	logger.Infof("Deleting user: %s", id)
 	args := []string{"user", "rm", "--uid", id}
 	if opts != nil {
 		args = append(args, opts...)

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -18,20 +18,238 @@ limitations under the License.
 package objectuser
 
 import (
+	"context"
 	"testing"
 
+	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestGetObjectStoreUserObject(t *testing.T) {
-	// get a current version objectstoreuser object, should return with no error
-	objectuser, err := getObjectStoreUserObject(&cephv1.CephObjectStoreUser{})
-	assert.NotNil(t, objectuser)
-	assert.Nil(t, err)
+const (
+	userCreateJSON = `{
+	"user_id": "my-user",
+	"display_name": "my-user",
+	"email": "",
+	"suspended": 0,
+	"max_buckets": 1000,
+	"subusers": [],
+	"keys": [
+		{
+			"user": "my-user",
+			"access_key": "EOE7FYCNOBZJ5VFV909G",
+			"secret_key": "qmIqpWm8HxCzmynCrD6U6vKWi4hnDBndOnmxXNsV"
+		}
+	],
+	"swift_keys": [],
+	"caps": [],
+	"op_mask": "read, write, delete",
+	"default_placement": "",
+	"default_storage_class": "",
+	"placement_tags": [],
+	"bucket_quota": {
+		"enabled": false,
+		"check_on_raw": false,
+		"max_size": -1,
+		"max_size_kb": 0,
+		"max_objects": -1
+	},
+	"user_quota": {
+		"enabled": false,
+		"check_on_raw": false,
+		"max_size": -1,
+		"max_size_kb": 0,
+		"max_objects": -1
+	},
+	"temp_url_keys": [],
+	"type": "rgw",
+	"mfa_ids": []
+}`
+)
 
-	// try to get an object that isn't a objectstoreuser, should return with an error
-	objectuser, err = getObjectStoreUserObject(&map[string]string{})
-	assert.Nil(t, objectuser)
-	assert.NotNil(t, err)
+var (
+	name      = "my-user"
+	namespace = "rook-ceph"
+	store     = "my-store"
+)
+
+func TestCephObjectStoreUserController(t *testing.T) {
+	// Set DEBUG logging
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+
+	//
+	// TEST 1 SETUP
+	//
+	// FAILURE because no CephCluster
+	//
+	// A Pool resource with metadata and spec.
+	objectUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store: store,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephObjectStoreUser",
+		},
+	}
+	cephCluster := &cephv1.CephCluster{}
+
+	// Objects to track in the fake client.
+	object := []runtime.Object{
+		objectUser,
+		cephCluster,
+	}
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(debug bool, actionName, command, outfile string, args ...string) (string, error) {
+			if args[0] == "status" {
+				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+			}
+			return "", nil
+		},
+		MockExecuteCommandWithOutput: func(debug bool, actionName, command string, args ...string) (string, error) {
+			if args[0] == "user" {
+				return userCreateJSON, nil
+			}
+			return "", nil
+		},
+	}
+	c := &clusterd.Context{
+		Executor:      executor,
+		RookClientset: rookclient.NewSimpleClientset()}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreUser{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileObjectStoreUser object with the scheme and fake client.
+	r := &ReconcileObjectStoreUser{client: cl, scheme: s, context: c}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	logger.Info("STARTING PHASE 1")
+	res, err := r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 1 DONE")
+
+	//
+	// TEST 2:
+	//
+	// FAILURE we have a cluster but it's not ready
+	//
+	cephCluster = &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespace,
+			Namespace: namespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: "",
+		},
+	}
+	object = append(object, cephCluster)
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileObjectStoreUser object with the scheme and fake client.
+	r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c}
+	logger.Info("STARTING PHASE 2")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 2 DONE")
+
+	//
+	// TEST 3:
+	//
+	// FAILURE! The CephCluster is ready but NO rgw object
+	//
+	cephCluster.Status.Phase = k8sutil.ReadyStatus
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileObjectStoreUser object with the scheme and fake client.
+	r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c}
+
+	logger.Info("STARTING PHASE 3")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 3 DONE")
+
+	//
+	// TEST 4:
+	//
+	// FAILURE! The CephCluster is ready
+	// Rgw object exists but NO pod are running
+	//
+	cephObjectStore := &cephv1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      store,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephObjectStore",
+		},
+	}
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStore{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreList{})
+	object = append(object, cephObjectStore)
+
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileObjectStoreUser object with the scheme and fake client.
+	r = &ReconcileObjectStoreUser{client: cl, scheme: s, context: c}
+
+	logger.Info("STARTING PHASE 4")
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: store, Namespace: namespace}, cephObjectStore)
+	assert.NoError(t, err, cephObjectStore)
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 4 DONE")
+
+	//
+	// TEST 5:
+	//
+	// SUCCESS! The CephCluster is ready
+	// Rgw object exists and pods are running
+	//
+	rgwPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "rook-ceph-rgw-my-store-a-5fd6fb4489-xv65v",
+		Namespace: namespace,
+		Labels:    map[string]string{k8sutil.AppAttr: appName, "rgw": "my-store"}}}
+
+	// Get the updated object.
+	logger.Info("STARTING PHASE 5")
+	err = r.client.Create(context.TODO(), rgwPod)
+	assert.NoError(t, err)
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue)
+	err = r.client.Get(context.TODO(), req.NamespacedName, objectUser)
+	assert.Equal(t, "Ready", objectUser.Status.Phase, objectUser)
+	logger.Info("PHASE 5 DONE")
 }

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -34,7 +34,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
-	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/provisioner"
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -86,7 +85,7 @@ type Operator struct {
 
 // New creates an operator instance
 func New(context *clusterd.Context, volumeAttachmentWrapper attachment.Attachment, rookImage, securityAccount string) *Operator {
-	schemes := []k8sutil.CustomResource{cluster.ClusterResource, object.ObjectStoreResource, objectuser.ObjectStoreUserResource,
+	schemes := []k8sutil.CustomResource{cluster.ClusterResource, object.ObjectStoreResource,
 		file.FilesystemResource, attachment.VolumeResource}
 
 	operatorNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)

--- a/pkg/operator/ceph/operator_test.go
+++ b/pkg/operator/ceph/operator_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
-	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,10 +38,10 @@ func TestOperator(t *testing.T) {
 	assert.NotNil(t, o.clusterController)
 	assert.NotNil(t, o.resources)
 	assert.Equal(t, context, o.context)
-	assert.Equal(t, len(o.resources), 5)
+	assert.Equal(t, len(o.resources), 4)
 	for _, r := range o.resources {
 		if r.Name != cluster.ClusterResource.Name && r.Name != object.ObjectStoreResource.Name &&
-			r.Name != file.FilesystemResource.Name && r.Name != attachment.VolumeResource.Name && r.Name != objectuser.ObjectStoreUserResource.Name {
+			r.Name != file.FilesystemResource.Name && r.Name != attachment.VolumeResource.Name {
 			assert.Fail(t, fmt.Sprintf("Resource %s is not valid", r.Name))
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Now, the CephObjectStoreUser CRD is managed with the controller-runtime.
So the watcher is outside of the main controller reconciliation loop of
CephCluster which brings numerous benefit such as:

* having its own reconciliation loop
* won't block anything from the main CephCluster controller loop
* fast than waiting for CephCluster loop to completion

Related to: https://github.com/rook/rook/issues/1981
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test full]
[test ceph]