### PR TITLE
ceph: simplify verbose function names and a wrong var name

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -105,8 +105,8 @@ func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 	return nil
 }
 
-// CreateK8sRookOperatorViaHelm creates rook operator via Helm chart named local/rook present in local repo
-func (h *CephInstaller) CreateK8sRookOperatorViaHelm(namespace, chartSettings string) error {
+// CreateRookOperatorViaHelm creates rook operator via Helm chart named local/rook present in local repo
+func (h *CephInstaller) CreateRookOperatorViaHelm(namespace, chartSettings string) error {
 	// creating clusterrolebinding for kubeadm env.
 	h.k8shelper.CreateAnonSystemClusterBinding()
 
@@ -125,8 +125,8 @@ func (h *CephInstaller) CreateK8sRookOperatorViaHelm(namespace, chartSettings st
 	return nil
 }
 
-// CreateK8sRookToolbox creates rook-ceph-tools via kubectl
-func (h *CephInstaller) CreateK8sRookToolbox(namespace string) (err error) {
+// CreateRookToolbox creates rook-ceph-tools via kubectl
+func (h *CephInstaller) CreateRookToolbox(namespace string) (err error) {
 	logger.Infof("Starting Rook toolbox")
 
 	rookToolbox := h.Manifests.GetRookToolBox(namespace)
@@ -145,8 +145,8 @@ func (h *CephInstaller) CreateK8sRookToolbox(namespace string) (err error) {
 	return nil
 }
 
-// CreateK8sRookClusterWithHostPathAndDevicesOrPVC creates rook cluster via kubectl
-func (h *CephInstaller) CreateK8sRookClusterWithHostPathAndDevicesOrPVC(namespace, systemNamespace, storeType string, usePVC bool, storageClassName string,
+// CreateRookCluster creates rook cluster via kubectl
+func (h *CephInstaller) CreateRookCluster(namespace, systemNamespace, storeType string, usePVC bool, storageClassName string,
 	mon cephv1.MonSpec, startWithAllNodes bool, rbdMirrorWorkers int, cephVersion cephv1.CephVersionSpec) error {
 
 	dataDirHostPath, err := h.initTestDir(namespace)
@@ -209,8 +209,8 @@ func (h *CephInstaller) CreateK8sRookClusterWithHostPathAndDevicesOrPVC(namespac
 	return err
 }
 
-// CreateK8sRookExternalCluster creates rook external cluster via kubectl
-func (h *CephInstaller) CreateK8sRookExternalCluster(namespace, firstClusterNamespace string) error {
+// CreateRookExternalCluster creates rook external cluster via kubectl
+func (h *CephInstaller) CreateRookExternalCluster(namespace, firstClusterNamespace string) error {
 
 	dataDirHostPath, err := h.initTestDir(namespace)
 	if err != nil {
@@ -347,8 +347,8 @@ func (h *CephInstaller) GetNodeHostnames() ([]string, error) {
 	return names, nil
 }
 
-// InstallRookOnK8sWithHostPathAndDevicesOrPVC installs rook on k8s
-func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevicesOrPVC(namespace, storeType string, usePVC bool, storageClassName string,
+// InstallRook installs rook on k8s
+func (h *CephInstaller) InstallRook(namespace, storeType string, usePVC bool, storageClassName string,
 	mon cephv1.MonSpec, startWithAllNodes bool, rbdMirrorWorkers int) (bool, error) {
 
 	var err error
@@ -363,7 +363,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevicesOrPVC(namespace, s
 		// disable the discovery daemonset with the helm chart
 		settings := "enableDiscoveryDaemon=false"
 		startDiscovery = false
-		err = h.CreateK8sRookOperatorViaHelm(namespace, settings)
+		err = h.CreateRookOperatorViaHelm(namespace, settings)
 		if err != nil {
 			logger.Errorf("Rook Operator not installed ,error -> %v", err)
 			return false, err
@@ -386,7 +386,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevicesOrPVC(namespace, s
 	}
 
 	// Create rook cluster
-	err = h.CreateK8sRookClusterWithHostPathAndDevicesOrPVC(namespace, onamespace, storeType, usePVC, storageClassName,
+	err = h.CreateRookCluster(namespace, onamespace, storeType, usePVC, storageClassName,
 		cephv1.MonSpec{Count: mon.Count, AllowMultiplePerNode: mon.AllowMultiplePerNode}, startWithAllNodes,
 		rbdMirrorWorkers, h.CephVersion)
 	if err != nil {
@@ -404,7 +404,7 @@ func (h *CephInstaller) InstallRookOnK8sWithHostPathAndDevicesOrPVC(namespace, s
 	}
 
 	// Create rook client
-	err = h.CreateK8sRookToolbox(namespace)
+	err = h.CreateRookToolbox(namespace)
 	if err != nil {
 		logger.Errorf("Rook toolbox in cluster %s not installed, error -> %v", namespace, err)
 		return false, err

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -59,7 +59,7 @@ type ClusterSettings struct {
 	Mons             int
 	RBDMirrorWorkers int
 	UsePVCs          bool
-	UseStorageClass  string
+	StorageClassName string
 	CephVersion      cephv1.CephVersionSpec
 }
 
@@ -1762,7 +1762,7 @@ spec:
     allowMultiplePerNode: true
     volumeClaimTemplate:
       spec:
-        storageClassName: ` + settings.UseStorageClass + `
+        storageClassName: ` + settings.StorageClassName + `
         resources:
           requests:
             storage: 5Gi
@@ -1792,7 +1792,7 @@ spec:
           resources:
             requests:
               storage: 10Gi
-          storageClassName: ` + settings.UseStorageClass + `
+          storageClassName: ` + settings.StorageClassName + `
           volumeMode: Block
           accessModes:
             - ReadWriteOnce

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -157,7 +157,7 @@ func StartTestCluster(t func() *testing.T, minimalMatrixK8sVersion, namespace, s
 
 // SetUpRook is a wrapper for setting up rook
 func (op *TestCluster) Setup() {
-	isRookInstalled, err := op.installer.InstallRookOnK8sWithHostPathAndDevicesOrPVC(op.namespace, op.storeType, op.usePVC, op.storageClassName,
+	isRookInstalled, err := op.installer.InstallRook(op.namespace, op.storeType, op.usePVC, op.storageClassName,
 		cephv1.MonSpec{Count: op.mons, AllowMultiplePerNode: true}, false /* startWithAllNodes */, op.rbdMirrorWorkers)
 
 	if !isRookInstalled || err != nil {

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -171,7 +171,7 @@ func (o MCTestOperations) Teardown() {
 
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
-	err := o.installer.CreateK8sRookClusterWithHostPathAndDevicesOrPVC(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
+	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
 		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, 1, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
@@ -179,7 +179,7 @@ func (o MCTestOperations) startCluster(namespace, store string) error {
 		return fmt.Errorf("failed to create cluster %s. %+v", namespace, err)
 	}
 
-	if err := o.installer.CreateK8sRookToolbox(namespace); err != nil {
+	if err := o.installer.CreateRookToolbox(namespace); err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
 		return fmt.Errorf("failed to create toolbox for %s. %+v", namespace, err)
@@ -190,7 +190,7 @@ func (o MCTestOperations) startCluster(namespace, store string) error {
 
 func (o MCTestOperations) startExternalCluster(namespace string) error {
 	logger.Infof("starting external cluster %q", namespace)
-	err := o.installer.CreateK8sRookExternalCluster(namespace, o.namespace1)
+	err := o.installer.CreateRookExternalCluster(namespace, o.namespace1)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
@@ -198,7 +198,7 @@ func (o MCTestOperations) startExternalCluster(namespace string) error {
 	}
 
 	logger.Infof("running toolbox on namespace %q", namespace)
-	if err := o.installer.CreateK8sRookToolbox(namespace); err != nil {
+	if err := o.installer.CreateRookToolbox(namespace); err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)
 		return fmt.Errorf("failed to create toolbox for %s. %+v", namespace, err)


### PR DESCRIPTION
**Description of your changes:**

Simplify verbose function names and a wrong var name.

**Which issue is resolved by this Pull Request:**

None

**Checklist:**

- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [o] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [o] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
