### PR TITLE
ceph: Adding status.state variable and assigned it to status.phase

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -142,6 +142,7 @@ type MonitoringSpec struct {
 }
 
 type ClusterStatus struct {
+	State       string          `json:"state,omitempty"`
 	Phase       ConditionType   `json:"phase,omitempty"`
 	Message     string          `json:"message,omitempty"`
 	Conditions  []Condition     `json:"conditions,omitempty"`

--- a/pkg/operator/ceph/config/conditions.go
+++ b/pkg/operator/ceph/config/conditions.go
@@ -72,6 +72,9 @@ func setCondition(context *clusterd.Context, namespace, name string, newConditio
 
 	if newCondition.Status == v1.ConditionTrue {
 		cluster.Status.Phase = newCondition.Type
+		if state := translatePhasetoState(newCondition.Type); state != "" {
+			cluster.Status.State = state
+		}
 		cluster.Status.Message = newCondition.Message
 		logger.Infof("CephCluster %q status: %q. %q", namespace, cluster.Status.Phase, cluster.Status.Message)
 	}
@@ -82,6 +85,30 @@ func setCondition(context *clusterd.Context, namespace, name string, newConditio
 	if newCondition.Type == cephv1.ConditionReady {
 		checkConditionFalse(context, namespace, name)
 	}
+}
+
+// translatePhasetoState convert the Phases to corresponding State
+// 1. We still need to set the State in case someone is still using it
+// instead of Phase. If we stopped setting the State it would be a
+// breaking change.
+// 2. We can't change the enum values of the State since that is also
+// a breaking change. Therefore, we translate new phases to the original
+// State values
+func translatePhasetoState(phase cephv1.ConditionType) string {
+	if phase == cephv1.ConditionProgressing {
+		return "Creating"
+	} else if phase == cephv1.ConditionReady {
+		return "Created"
+	} else if phase == cephv1.ConditionUpgrading || phase == cephv1.ConditionUpdating {
+		return "Updating"
+	} else if phase == cephv1.ConditionFailure || phase == cephv1.ConditionIgnored {
+		return "Error"
+	} else if phase == cephv1.ConditionConnected {
+		return "Connected"
+	} else if phase == cephv1.ConditionConnecting {
+		return "Connecting"
+	}
+	return ""
 }
 
 // Updating the status of Progressing, Updating or Upgrading to False once cluster is Ready


### PR DESCRIPTION
Most of the OLM UI currently uses status.Phase to show the status of the cluster and in some case it uses status.State to show the information. Having both would be a redundant information but for now we can just use it and slowly deprecate the use of status.state is the most appropriate way to do now.

Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]