### PR TITLE
Ensure pools are purged during integration tests

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -149,6 +149,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		logger.Debugf("deleting pool %q", cephBlockPool.Name)
 		err := deletePool(r.context, cephBlockPool)
 		if err != nil {
+			logger.Errorf("could not delete pool %q. %v", cephBlockPool.Name, err)
 			return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to delete pool %q. ", cephBlockPool.Name)
 		}
 

--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -43,10 +43,6 @@ func (p *PoolOperation) Create(name, namespace string, replicas int) error {
 	return p.createOrUpdatePool(name, namespace, "apply", replicas)
 }
 
-func (p *PoolOperation) Delete(name string, namespace string) error {
-	return p.k8sh.ResourceOperation("delete", p.manifests.GetBlockPoolDef(name, namespace, "1"))
-}
-
 func (p *PoolOperation) Update(name, namespace string, replicas int) error {
 	return p.createOrUpdatePool(name, namespace, "apply", replicas)
 }
@@ -119,5 +115,6 @@ func (p *PoolOperation) DeletePool(blockClient *BlockOperation, namespace, poolN
 		}
 	}
 
+	logger.Infof("deleting pool %q", poolName)
 	return p.k8sh.RookClientset.CephV1().CephBlockPools(namespace).Delete(poolName, &metav1.DeleteOptions{})
 }

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -437,6 +437,13 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(gatherLogs bool, systemNames
 			}
 		}
 
+		// The pool CRs should already be removed by the tests that created them
+		pools, err := h.k8shelper.RookClientset.CephV1().CephBlockPools(namespace).List(metav1.ListOptions{})
+		assert.NoError(h.T(), err, "failed to retrieve pool CRs")
+		for _, pool := range pools.Items {
+			assert.Failf(h.T(), "pool %q still exists", pool.Name)
+		}
+
 		roles := h.Manifests.GetClusterRoles(namespace, systemNamespace)
 		_, err = h.k8shelper.KubectlWithStdin(roles, deleteFromStdinArgs...)
 

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -64,11 +64,12 @@ type MultiClusterDeploySuite struct {
 	namespace1 string
 	namespace2 string
 	op         *MCTestOperations
+	poolName   string
 }
 
 // Deploy Multiple Rook clusters
 func (mrc *MultiClusterDeploySuite) SetupSuite() {
-
+	mrc.poolName = "multi-cluster-pool1"
 	mrc.namespace1 = "mrc-n1"
 	mrc.namespace2 = "mrc-n2"
 
@@ -83,13 +84,23 @@ func (mrc *MultiClusterDeploySuite) AfterTest(suiteName, testName string) {
 
 func (mrc *MultiClusterDeploySuite) createPools() {
 	// create a test pool in each cluster so that we get some PGs
-	poolName := "multi-cluster-pool1"
-	logger.Infof("Creating pool %s", poolName)
-	err := mrc.testClient.PoolClient.Create(poolName, mrc.namespace1, 1)
+	logger.Infof("Creating pool %s", mrc.poolName)
+	err := mrc.testClient.PoolClient.Create(mrc.poolName, mrc.namespace1, 1)
 	require.Nil(mrc.T(), err)
 }
 
+func (mrc *MultiClusterDeploySuite) deletePools() {
+	// create a test pool in each cluster so that we get some PGs
+	logger.Infof("Deleting pool %s", mrc.poolName)
+	if err := mrc.testClient.PoolClient.DeletePool(mrc.testClient.BlockClient, mrc.namespace1, mrc.poolName); err != nil {
+		logger.Errorf("failed to delete pool %q. %v", mrc.poolName, err)
+	} else {
+		logger.Infof("deleted pool %q", mrc.poolName)
+	}
+}
+
 func (mrc *MultiClusterDeploySuite) TearDownSuite() {
+	mrc.deletePools()
 	mrc.op.Teardown()
 }
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -223,6 +223,9 @@ func (suite *SmokeSuite) TestPoolResize() {
 	}
 
 	require.Equal(suite.T(), true, poolFound, fmt.Sprintf("pool %s not found", poolName))
+
+	// clean up the pool
+	suite.helper.PoolClient.DeletePool(suite.helper.BlockClient, suite.namespace, poolName)
 }
 
 // Smoke Test for Client CRD


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With a finalizer on the pools, the pools were not always being purged
during the integration tests. Now the multicluster suite will ensure
its pool is purged.

**Which issue is resolved by this Pull Request:**
Resolves #4954 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]