### PR TITLE
ceph: Follow up for adding the state variable

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -142,7 +142,7 @@ type MonitoringSpec struct {
 }
 
 type ClusterStatus struct {
-	State       string          `json:"state,omitempty"`
+	State       ClusterState    `json:"state,omitempty"`
 	Phase       ConditionType   `json:"phase,omitempty"`
 	Message     string          `json:"message,omitempty"`
 	Conditions  []Condition     `json:"conditions,omitempty"`
@@ -191,6 +191,17 @@ const (
 	ConditionDeleting    ConditionType = "Deleting"
 	// DefaultFailureDomain for PoolSpec
 	DefaultFailureDomain = "host"
+)
+
+type ClusterState string
+
+const (
+	ClusterStateCreating   ClusterState = "Creating"
+	ClusterStateCreated    ClusterState = "Created"
+	ClusterStateUpdating   ClusterState = "Updating"
+	ClusterStateConnecting ClusterState = "Connecting"
+	ClusterStateConnected  ClusterState = "Connected"
+	ClusterStateError      ClusterState = "Error"
 )
 
 type MonSpec struct {

--- a/pkg/operator/ceph/config/conditions.go
+++ b/pkg/operator/ceph/config/conditions.go
@@ -94,21 +94,27 @@ func setCondition(context *clusterd.Context, namespace, name string, newConditio
 // 2. We can't change the enum values of the State since that is also
 // a breaking change. Therefore, we translate new phases to the original
 // State values
-func translatePhasetoState(phase cephv1.ConditionType) string {
-	if phase == cephv1.ConditionProgressing {
-		return "Creating"
-	} else if phase == cephv1.ConditionReady {
-		return "Created"
-	} else if phase == cephv1.ConditionUpgrading || phase == cephv1.ConditionUpdating {
-		return "Updating"
-	} else if phase == cephv1.ConditionFailure || phase == cephv1.ConditionIgnored {
-		return "Error"
-	} else if phase == cephv1.ConditionConnected {
-		return "Connected"
-	} else if phase == cephv1.ConditionConnecting {
-		return "Connecting"
+func translatePhasetoState(phase cephv1.ConditionType) cephv1.ClusterState {
+	switch phase {
+	case cephv1.ConditionConnecting:
+		return cephv1.ClusterStateConnecting
+	case cephv1.ConditionConnected:
+		return cephv1.ClusterStateConnected
+	case cephv1.ConditionFailure:
+		return cephv1.ClusterStateError
+	case cephv1.ConditionIgnored:
+		return cephv1.ClusterStateError
+	case cephv1.ConditionProgressing:
+		return cephv1.ClusterStateCreating
+	case cephv1.ConditionReady:
+		return cephv1.ClusterStateCreated
+	case cephv1.ConditionUpgrading:
+		return cephv1.ClusterStateUpdating
+	case cephv1.ConditionUpdating:
+		return cephv1.ClusterStateUpdating
+	default:
+		return ""
 	}
-	return ""
 }
 
 // Updating the status of Progressing, Updating or Upgrading to False once cluster is Ready


### PR DESCRIPTION
Added back the status.State to the exact way it was implemented on the ceph cluster. Added the States as a Constant and used that constant to call the status.State.

Follow up of https://github.com/rook/rook/pull/4931
Signed-off-by: Nizamudeen <nia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]