### PR TITLE
Gather operator logs when the test pools are not deleted

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -414,16 +414,14 @@ func (h *CephInstaller) InstallRook(namespace, storeType string, usePVC bool, st
 }
 
 // UninstallRook uninstalls rook from k8s
-func (h *CephInstaller) UninstallRook(namespace string, gatherLogs bool) {
-	h.UninstallRookFromMultipleNS(gatherLogs, SystemNamespace(namespace), namespace)
+func (h *CephInstaller) UninstallRook(namespace string) {
+	h.UninstallRookFromMultipleNS(SystemNamespace(namespace), namespace)
 }
 
 // UninstallRookFromMultipleNS uninstalls rook from multiple namespaces in k8s
-func (h *CephInstaller) UninstallRookFromMultipleNS(gatherLogs bool, systemNamespace string, namespaces ...string) {
-	if gatherLogs {
-		// Gather logs after status checks
-		h.GatherAllRookLogs(h.T().Name(), append([]string{systemNamespace}, namespaces...)...)
-	}
+func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, namespaces ...string) {
+	// Gather logs after status checks
+	h.GatherAllRookLogs(h.T().Name(), append([]string{systemNamespace}, namespaces...)...)
 
 	logger.Infof("Uninstalling Rook")
 	var err error
@@ -581,30 +579,6 @@ func (h *CephInstaller) removeClusterFinalizers(namespace, name string) {
 		return
 	}
 	logger.Infof("removed finalizers from cluster %s", objectMeta.Name)
-}
-
-func (h *CephInstaller) purgeClusters() error {
-	// get all namespaces
-	namespaces, err := h.k8shelper.Clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get namespaces. %+v", err)
-	}
-
-	// look for the clusters in all namespaces
-	for _, n := range namespaces.Items {
-		namespace := n.Name
-		logger.Infof("looking in namespace %s for clusters to purge", namespace)
-		clusters, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).List(metav1.ListOptions{})
-		if err != nil {
-			logger.Warningf("failed to get clusters in namespace %s. %+v", namespace, err)
-			continue
-		}
-		if len(clusters.Items) > 0 {
-			logger.Warningf("FOUND UNEXPECTED CLUSTER IN NAMESPACE %s. Removing...", namespace)
-			h.UninstallRook(namespace, false)
-		}
-	}
-	return nil
 }
 
 func (h *CephInstaller) checkCephHealthStatus(namespace string) {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -441,6 +441,8 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		for _, pool := range pools.Items {
 			logger.Infof("found pools: %v", pools)
 			assert.Failf(h.T(), "pool %q still exists", pool.Name)
+			// Get the operator log
+			h.GatherAllRookLogs(h.T().Name()+"poolcheck", systemNamespace)
 		}
 
 		roles := h.Manifests.GetClusterRoles(namespace, systemNamespace)

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -176,5 +176,5 @@ func (op *TestCluster) SetInstallData(version string) {}
 
 // TearDownRook is a wrapper for tearDown after Suite
 func (op *TestCluster) Teardown() {
-	op.installer.UninstallRook(op.namespace, true)
+	op.installer.UninstallRook(op.namespace)
 }

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -177,7 +177,7 @@ func (o MCTestOperations) Setup() {
 
 // TearDownRook is a wrapper for tearDown after suite
 func (o MCTestOperations) Teardown() {
-	o.installer.UninstallRookFromMultipleNS(true, installer.SystemNamespace(o.namespace1), o.namespace1, o.namespace2)
+	o.installer.UninstallRookFromMultipleNS(installer.SystemNamespace(o.namespace1), o.namespace1, o.namespace2)
 }
 
 func (o MCTestOperations) startCluster(namespace, store string) error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- The operator logs are necessary for troubleshooting why the pools may still exist at the end of the integration tests.
- Remove dead test code.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]