### PR TITLE
OSD prepare pod was not signaling completion when zero OSDs configured

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -143,9 +143,7 @@ func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
 func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string) error {
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
-	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
-		return err
-	}
+	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 
 	// create the ceph.conf with the default settings
 	cephConfig, err := cephconfig.CreateDefaultCephConfig(context, agent.cluster)
@@ -218,9 +216,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 
 	// orchestration is about to start, update the status
 	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating, PvcBackedOSD: agent.pvcBacked}
-	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
-		return err
-	}
+	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 
 	// start the desired OSDs on devices
 	logger.Infof("configuring osd devices: %+v", devices)
@@ -272,13 +268,9 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 		}
 	}
 
-	osds := deviceOSDs
-
 	// orchestration is completed, update the status
-	status = oposd.OrchestrationStatus{OSDs: osds, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
-	if err := oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status); err != nil {
-		return err
-	}
+	status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
+	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 
 	return nil
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -232,6 +232,8 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	// So we need to make sure the list is filled up, otherwise fail
 	if len(deviceOSDs) == 0 {
 		logger.Warningf("skipping OSD configuration as no devices matched the storage settings for this node %q", agent.nodeName)
+		status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
+		oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 		return nil
 	}
 

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -53,8 +53,7 @@ func TestOrchestrationStatus(t *testing.T) {
 
 	// update the status map with some status
 	status := OrchestrationStatus{Status: OrchestrationStatusOrchestrating, Message: "doing work"}
-	err = UpdateNodeStatus(kv, nodeName, status)
-	assert.Nil(t, err)
+	UpdateNodeStatus(kv, nodeName, status)
 
 	// retrieve the status and verify it
 	statusMap, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Get(cmName, metav1.GetOptions{})


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSD prepare pod must always update status on the status configmap in order to alert the operator that the OSD configuration on the node is completed. This fixes an issue where the status was not being reported if no devices were configured.

Also, a simplification to the helper that updates the status... The communication between the operator and OSD prepare job is done through updates to the configmap. If an update fails
to the configmap, we are anyway going to need to check the logs for failure. So let's just log the error and make a best effort to continue the orchestration. If the failure was temporary,
the next update to the status would succeed and likely continue working as expected.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]