### PR TITLE
Properly lookup the topology.kubernetes.io label for OSD topology

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -706,12 +706,14 @@ default. When available, Rook will also consider failure domain information in
 the form of Kubernetes node labels when scheduling Ceph monitors.
 
 Currently Rook supports the node label
-`failure-domain.beta.kubernetes.io/zone=<zone>` which can be applied to a node
+`topology.kubernetes.io/zone=<zone>` which can be applied to a node
 to specify its failure domain using the command:
 
 ```console
-kubectl label node <node> failure-domain.beta.kubernetes.io/zone=<zone>
+kubectl label node <node> topology.kubernetes.io/zone=<zone>
 ```
+
+> For versions previous to K8s 1.17, use the topology key: failure-domain.beta.kubernetes.io/zone
 
 Rook uses failure domain labels by trying to schedule monitor pods on different
 failure domains. And all nodes without failure domain labels are treated as a single

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -545,8 +545,8 @@ the desired level in the [CRUSH map](http://docs.ceph.com/docs/master/rados/oper
 The complete list of labels in hierarchy order from highest to lowest is:
 
 ```text
-failure-domain.beta.kubernetes.io/region
-failure-domain.beta.kubernetes.io/zone
+topology.kubernetes.io/region
+topology.kubernetes.io/zone
 topology.rook.io/datacenter
 topology.rook.io/room
 topology.rook.io/pod
@@ -559,9 +559,11 @@ topology.rook.io/chassis
 For example, if the following labels were added to a node:
 
 ```console
-kubectl label node mynode failure-domain.beta.kubernetes.io/zone=zone1
+kubectl label node mynode topology.kubernetes.io/zone=zone1
 kubectl label node mynode topology.rook.io/rack=rack1
 ```
+
+> For versions previous to K8s 1.17, use the topology key: failure-domain.beta.kubernetes.io/zone or region
 
 These labels would result in the following hierarchy for OSDs on that node (this command can be run in the Rook toolbox):
 
@@ -687,7 +689,7 @@ spec:
                   operator: In
                   values:
                     - cluster1
-                topologyKey: "failure-domain.beta.kubernetes.io/zone"
+                topologyKey: "topology.kubernetes.io/zone"
       volumeClaimTemplates:
       - metadata:
           name: data

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -835,10 +835,7 @@ func getNode(clientset kubernetes.Interface, nodeName string) (*corev1.Node, err
 
 func UpdateLocationWithNodeLabels(location *[]string, nodeLabels map[string]string) {
 
-	topology, invalidLabels := ExtractRookTopologyFromLabels(nodeLabels)
-	if len(invalidLabels) > 0 {
-		logger.Warningf("ignored invalid node topology labels: %v", invalidLabels)
-	}
+	topology := ExtractOSDTopologyFromLabels(nodeLabels)
 
 	keys := make([]string, 0, len(topology))
 	for k := range topology {

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -20,18 +20,13 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (
 
-	// The labels that can be specified with the K8s labels such as failure-domain.beta.kubernetes.io/zone
+	// The labels that can be specified with the K8s labels such as topology.kubernetes.io/zone
 	// These are all at the top layers of the CRUSH map.
 	KubernetesTopologyLabels = []string{"zone", "region"}
 
@@ -42,43 +37,13 @@ var (
 	CRUSHMapLevelsOrdered = append([]string{"host"}, append(CRUSHTopologyLabels, KubernetesTopologyLabels...)...)
 )
 
-// ExtractRookTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value,
-// and an array of any invalid labels with a topology prefix.
-func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string, []string) {
-	topology := make(map[string]string)
+// ExtractTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value
+func ExtractOSDTopologyFromLabels(labels map[string]string) map[string]string {
+	topology := k8sutil.ExtractTopologyFromLabels(labels, CRUSHTopologyLabels)
 
-	// get zone
-	zone, ok := labels[corev1.LabelZoneFailureDomain]
-	if ok {
-		topology["zone"] = client.NormalizeCrushName(zone)
+	// Ensure the topology names are normalized for CRUSH
+	for name, value := range topology {
+		topology[name] = client.NormalizeCrushName(value)
 	}
-	// get region
-	region, ok := labels[corev1.LabelZoneRegion]
-	if ok {
-		topology["region"] = client.NormalizeCrushName(region)
-	}
-
-	// get host
-	host, ok := labels[corev1.LabelHostname]
-	if ok {
-		topology["host"] = client.NormalizeCrushName(host)
-	}
-
-	invalidEncountered := make([]string, 0)
-	for labelKey, labelValue := range labels {
-		for _, validTopologyType := range CRUSHTopologyLabels {
-			if strings.HasPrefix(labelKey, k8sutil.TopologyLabelPrefix) {
-				s := strings.Split(labelKey, "/")
-				if len(s) != 2 {
-					invalidEncountered = append(invalidEncountered, fmt.Sprintf("%s=%s", labelKey, labelValue))
-					continue
-				}
-				topologyType := s[1]
-				if topologyType == validTopologyType {
-					topology[validTopologyType] = client.NormalizeCrushName(labelValue)
-				}
-			}
-		}
-	}
-	return topology, invalidEncountered
+	return topology
 }

--- a/pkg/operator/ceph/cluster/osd/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology_test.go
@@ -37,3 +37,23 @@ func TestOrderedCRUSHLabels(t *testing.T) {
 	assert.Equal(t, "zone", CRUSHMapLevelsOrdered[8])
 	assert.Equal(t, "region", CRUSHMapLevelsOrdered[9])
 }
+
+func TestTopologyLabels(t *testing.T) {
+	// load all the expected labels
+	nodeLabels := map[string]string{
+		"topology.kubernetes.io/region": "r.region",
+		"topology.kubernetes.io/zone":   "z.zone",
+		"kubernetes.io/hostname":        "host.name",
+		"topology.rook.io/rack":         "r.rack",
+		"topology.rook.io/row":          "r.row",
+		"topology.rook.io/datacenter":   "d.datacenter",
+	}
+	topology := ExtractOSDTopologyFromLabels(nodeLabels)
+	assert.Equal(t, 6, len(topology))
+	assert.Equal(t, "r-region", topology["region"])
+	assert.Equal(t, "z-zone", topology["zone"])
+	assert.Equal(t, "host-name", topology["host"])
+	assert.Equal(t, "r-rack", topology["rack"])
+	assert.Equal(t, "r-row", topology["row"])
+	assert.Equal(t, "d-datacenter", topology["datacenter"])
+}

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -169,7 +169,7 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			logger.Warningf("node in nodelist was nil")
 			continue
 		}
-		nodeTopologyMap, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+		nodeTopologyMap := osd.ExtractOSDTopologyFromLabels(node.GetLabels())
 
 		for _, osdData := range osdDataList {
 			// get the crush location of the osd

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -191,7 +191,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		deploy.ObjectMeta.OwnerReferences = ownerReferences
 
 		// update the deployment labels
-		topology, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+		topology := osd.ExtractOSDTopologyFromLabels(node.GetLabels())
 		for key, value := range topology {
 			selectorLabels[key] = value
 		}

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -319,16 +319,6 @@ func ExtractTopologyFromLabels(labels map[string]string, additionalTopologyIDs [
 	return topology
 }
 
-// NodeIsInRookNodeList will return true if the target node is found in a given list of Rook nodes.
-func NodeIsInRookNodeList(targetNodeName string, rookNodes []rookv1.Node) bool {
-	for _, rn := range rookNodes {
-		if targetNodeName == rn.Name {
-			return true
-		}
-	}
-	return false
-}
-
 // GenerateNodeAffinity will return v1.NodeAffinity or error
 func GenerateNodeAffinity(nodeAffinity string) (*v1.NodeAffinity, error) {
 	newNodeAffinity := &v1.NodeAffinity{

--- a/pkg/operator/k8sutil/node_test.go
+++ b/pkg/operator/k8sutil/node_test.go
@@ -302,19 +302,6 @@ func TestRookNodesMatchingKubernetesNodes(t *testing.T) {
 	assert.Len(t, retNodes, 0)
 }
 
-func TestNodeIsInRookList(t *testing.T) {
-	rookNodes := []rookv1.Node{}
-
-	assert.False(t, NodeIsInRookNodeList("node0", rookNodes))
-
-	rookNodes = []rookv1.Node{
-		{Name: "node0-hostname"},
-		{Name: "node2"},
-		{Name: "node5"}}
-	assert.False(t, NodeIsInRookNodeList("node0", rookNodes))
-	assert.True(t, NodeIsInRookNodeList("node0-hostname", rookNodes))
-}
-
 func TestGenerateNodeAffinity(t *testing.T) {
 	type args struct {
 		nodeAffinity string

--- a/pkg/operator/k8sutil/node_test.go
+++ b/pkg/operator/k8sutil/node_test.go
@@ -24,6 +24,7 @@ import (
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -388,4 +389,76 @@ func TestGenerateNodeAffinity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTopologyLabels(t *testing.T) {
+	additionalTopologyLabels := []string{
+		"rack", "row", "datacenter",
+	}
+	nodeLabels := map[string]string{}
+	topology := ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// invalid non-namespaced zone and region labels are simply ignored
+	nodeLabels = map[string]string{
+		"region": "badregion",
+		"zone":   "badzone",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// invalid zone and region labels are simply ignored
+	nodeLabels = map[string]string{
+		"topology.rook.io/region": "r1",
+		"topology.rook.io/zone":   "z1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// load all the expected labels
+	nodeLabels = map[string]string{
+		"topology.kubernetes.io/region": "r1",
+		"topology.kubernetes.io/zone":   "z1",
+		"kubernetes.io/hostname":        "myhost",
+		"topology.rook.io/rack":         "rack1",
+		"topology.rook.io/row":          "row1",
+		"topology.rook.io/datacenter":   "d1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 6, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+	assert.Equal(t, "myhost", topology["host"])
+	assert.Equal(t, "rack1", topology["rack"])
+	assert.Equal(t, "row1", topology["row"])
+	assert.Equal(t, "d1", topology["datacenter"])
+
+	// ensure deprecated k8s labels are loaded
+	nodeLabels = map[string]string{
+		corev1.LabelZoneRegion:        "r1",
+		corev1.LabelZoneFailureDomain: "z1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 2, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+
+	// ensure deprecated k8s labels are overridden
+	nodeLabels = map[string]string{
+		"topology.kubernetes.io/region": "r1",
+		"topology.kubernetes.io/zone":   "z1",
+		corev1.LabelZoneRegion:          "oldregion",
+		corev1.LabelZoneFailureDomain:   "oldzone",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 2, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+
+	// invalid labels under topology.rook.io return an error
+	nodeLabels = map[string]string{
+		"topology.rook.io/row/bad": "r1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSDs pick up on several topology labels for CRUSH hierarchy. The GA label topology.kubernetes.io was partially implemented, but not picked up by the OSDs. Now the OSDs will pick up both the topology labels from pre-1.17 such as failure-`domain.beta.kubernetes.io/zone` and `topology.kubernetes.io/zone`.

Also removes some dead code in k8sutil/nodes.go.

**Which issue is resolved by this Pull Request:**
Resolves #4980 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]