### PR TITLE
ceph: osd re-add udev bindmount

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -66,6 +66,8 @@ const (
 	CephDeviceSetPVCIDLabelKey = "ceph.rook.io/DeviceSetPVCId"
 	// OSDOverPVCLabelKey is the Rook PVC label key
 	OSDOverPVCLabelKey = "ceph.rook.io/pvc"
+	udevPath           = "/run/udev"
+	udevVolName        = "run-udev"
 )
 
 const (
@@ -273,18 +275,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			"--setgroup", "ceph",
 			fmt.Sprintf("--crush-location=%s", osd.Location),
 		}
-
-		// mount /run/udev in the container so ceph-volume (via `lvs`)
-		// can access the udev database
-		volumes = append(volumes, v1.Volume{
-			Name: "run-udev",
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}})
-
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      "run-udev",
-			MountPath: "/run/udev"})
-
 	} else if osdOnPVC && osd.CVMode == "raw" {
 		doBinaryCopyInit = false
 		doConfigInit = false
@@ -311,6 +301,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			fmt.Sprintf("--crush-location=%s", osd.Location),
 		}
 	}
+
+	// The osd itself needs to talk to udev to report information about the device (vendor/serial etc)
+	udevVolume, udevVolumeMount := getUdevVolume()
+	volumes = append(volumes, udevVolume)
+	volumeMounts = append(volumeMounts, udevVolumeMount)
 
 	// Add the volume to the spec and the mount to the daemon container
 	copyBinariesVolume, copyBinariesContainer := c.getCopyBinariesContainer()
@@ -1121,4 +1116,20 @@ func (c *Cluster) osdRunFlagTuningOnPVC(osdID int) error {
 	}
 
 	return nil
+}
+
+func getUdevVolume() (v1.Volume, v1.VolumeMount) {
+	volume := v1.Volume{
+		Name: udevVolName,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: udevPath},
+		},
+	}
+
+	volumeMounts := v1.VolumeMount{
+		Name:      udevVolName,
+		MountPath: udevPath,
+	}
+
+	return volume, volumeMounts
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -121,10 +121,10 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, v1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, "my-priority-class", deployment.Spec.Template.Spec.PriorityClassName)
 	if devMountNeeded && len(dataDir) > 0 {
-		assert.Equal(t, 6, len(deployment.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 7, len(deployment.Spec.Template.Spec.Volumes))
 	}
 	if devMountNeeded && len(dataDir) == 0 {
-		assert.Equal(t, 6, len(deployment.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 7, len(deployment.Spec.Template.Spec.Volumes))
 	}
 	if !devMountNeeded && len(dataDir) > 0 {
 		assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Volumes))
@@ -146,7 +146,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, cephVersion.Image, cont.Image)
-	assert.Equal(t, 6, len(cont.VolumeMounts))
+	assert.Equal(t, 7, len(cont.VolumeMounts))
 	assert.Equal(t, "ceph-osd", cont.Command[0])
 
 	// Test OSD on PVC with LVM
@@ -194,7 +194,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[3].Name)
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont = deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, 5, len(cont.VolumeMounts), cont.VolumeMounts)
+	assert.Equal(t, 6, len(cont.VolumeMounts), cont.VolumeMounts)
 
 	// Test OSD on PVC with RAW and metadata device
 	osd = OSDInfo{
@@ -213,7 +213,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[4].Name)
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont = deployment.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, 5, len(cont.VolumeMounts), cont.VolumeMounts)
+	assert.Equal(t, 6, len(cont.VolumeMounts), cont.VolumeMounts)
 	blkInitCont = deployment.Spec.Template.Spec.InitContainers[1]
 	assert.Equal(t, 1, len(blkInitCont.VolumeDevices))
 	blkMetaInitCont := deployment.Spec.Template.Spec.InitContainers[2]


### PR DESCRIPTION
The OSD needs to talk to the udev socket to get information about a device.
like serial, vendor etc. So that it can populate the output of:
`ceph osd metadata $n` correctly.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]