### PR TITLE
Only log to debug when finding osds

### DIFF
--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -100,6 +100,8 @@ func GetCrushMap(context *clusterd.Context, clusterName string) (CrushMap, error
 // FindOSDInCrushMap finds an OSD in the CRUSH map
 func FindOSDInCrushMap(context *clusterd.Context, clusterName string, osdID int) (*CrushFindResult, error) {
 	args := []string{"osd", "find", strconv.Itoa(osdID)}
+	cmd := NewCephCommand(context, clusterName, args)
+	cmd.Debug = true
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find osd.%d in crush map: %s", osdID, string(buf))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
A small log cleanup issue... Finding OSDs is verbose when the cluster disruption controller is active. This changes the find osd logging to debug level so the operator log can remain relatively clean.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]