### PR TITLE
Backport: Multiple OSD fixes and default to Ceph v14.2.8

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -706,12 +706,14 @@ default. When available, Rook will also consider failure domain information in
 the form of Kubernetes node labels when scheduling Ceph monitors.
 
 Currently Rook supports the node label
-`failure-domain.beta.kubernetes.io/zone=<zone>` which can be applied to a node
+`topology.kubernetes.io/zone=<zone>` which can be applied to a node
 to specify its failure domain using the command:
 
 ```console
-kubectl label node <node> failure-domain.beta.kubernetes.io/zone=<zone>
+kubectl label node <node> topology.kubernetes.io/zone=<zone>
 ```
+
+> For versions previous to K8s 1.17, use the topology key: failure-domain.beta.kubernetes.io/zone
 
 Rook uses failure domain labels by trying to schedule monitor pods on different
 failure domains. And all nodes without failure domain labels are treated as a single

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -54,7 +54,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -394,7 +394,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -426,7 +426,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -507,7 +507,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -554,7 +554,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -654,7 +654,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -700,7 +700,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -800,7 +800,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is optional, do this if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v14.2.7 # MUST match external cluster version
+    image: ceph/ceph:v14.2.8 # MUST match external cluster version
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -586,8 +586,8 @@ the desired level in the [CRUSH map](http://docs.ceph.com/docs/master/rados/oper
 The complete list of labels in hierarchy order from highest to lowest is:
 
 ```text
-failure-domain.beta.kubernetes.io/region
-failure-domain.beta.kubernetes.io/zone
+topology.kubernetes.io/region
+topology.kubernetes.io/zone
 topology.rook.io/datacenter
 topology.rook.io/room
 topology.rook.io/pod
@@ -600,9 +600,11 @@ topology.rook.io/chassis
 For example, if the following labels were added to a node:
 
 ```console
-kubectl label node mynode failure-domain.beta.kubernetes.io/zone=zone1
+kubectl label node mynode topology.kubernetes.io/zone=zone1
 kubectl label node mynode topology.rook.io/rack=rack1
 ```
+
+> For versions previous to K8s 1.17, use the topology key: failure-domain.beta.kubernetes.io/zone or region
 
 These labels would result in the following hierarchy for OSDs on that node (this command can be run in the Rook toolbox):
 
@@ -728,7 +730,7 @@ spec:
                   operator: In
                   values:
                     - cluster1
-                topologyKey: "failure-domain.beta.kubernetes.io/zone"
+                topologyKey: "topology.kubernetes.io/zone"
       volumeClaimTemplates:
       - metadata:
           name: data

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -21,4 +21,4 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is optional, do this if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v14.2.7 # Should match external cluster version
+    image: ceph/ceph:v14.2.8 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-minimal.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
     allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -32,7 +32,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v14.2.5-20190917
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v14.2.8
     # Whether to allow unsupported versions of Ceph. Currently mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Octopus is the version allowed when this is set to true.
     # Do not set to true in production.

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -186,7 +186,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v14.2.7"
+              "image": "ceph/ceph:v14.2.8"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v14.2.7-20200201
+CEPH_VERSION = v14.2.8-20200303
 else
-CEPH_VERSION = v14.2.7-20200206
+CEPH_VERSION = v14.2.8-20200305
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -263,7 +263,7 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err, err)
 
-	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.7"
+	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.8"
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err)
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -832,10 +832,7 @@ func getNode(clientset kubernetes.Interface, nodeName string) (*corev1.Node, err
 
 func UpdateLocationWithNodeLabels(location *[]string, nodeLabels map[string]string) {
 
-	topology, invalidLabels := ExtractRookTopologyFromLabels(nodeLabels)
-	if len(invalidLabels) > 0 {
-		logger.Warningf("ignored invalid node topology labels: %v", invalidLabels)
-	}
+	topology := ExtractOSDTopologyFromLabels(nodeLabels)
 
 	keys := make([]string, 0, len(topology))
 	for k := range topology {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -340,6 +340,10 @@ func (c *Cluster) startProvisioningOverNodes(config *provisionConfig) {
 	}
 
 	if c.DesiredStorage.UseAllNodes {
+		if len(c.DesiredStorage.Nodes) > 0 {
+			logger.Warningf("useAllNodes is TRUE, but nodes are specified. NODES in the cluster CR will be IGNORED unless useAllNodes is FALSE.")
+		}
+
 		// Get the list of all nodes in the cluster. The placement settings will be applied below.
 		hostnameMap, err := k8sutil.GetNodeHostNames(c.context.Clientset)
 		if err != nil {

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -576,11 +576,6 @@ func (c *Cluster) getActivateOSDInitContainer(osdID, osdUUID string, isFilestore
 		{Name: k8sutil.ConfigOverrideName, ReadOnly: true, MountPath: opconfig.EtcCephDir},
 	}
 
-	privileged := true
-	securityContext := &v1.SecurityContext{
-		Privileged: &privileged,
-	}
-
 	return volume, &v1.Container{
 		Command: []string{
 			"/bin/bash",
@@ -590,7 +585,7 @@ func (c *Cluster) getActivateOSDInitContainer(osdID, osdUUID string, isFilestore
 		Name:            "activate-osd",
 		Image:           c.cephVersion.Image,
 		VolumeMounts:    volMounts,
-		SecurityContext: securityContext,
+		SecurityContext: privilegedContext(),
 		Env:             envVars,
 		Resources:       osdProps.resources,
 	}
@@ -1088,4 +1083,12 @@ func getUdevVolume() (v1.Volume, v1.VolumeMount) {
 	}
 
 	return volume, volumeMounts
+}
+
+func privilegedContext() *v1.SecurityContext {
+	privileged := true
+
+	return &v1.SecurityContext{
+		Privileged: &privileged,
+	}
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -66,6 +66,8 @@ const (
 	CephDeviceSetPVCIDLabelKey = "ceph.rook.io/DeviceSetPVCId"
 	// OSDOverPVCLabelKey is the Rook PVC label key
 	OSDOverPVCLabelKey = "ceph.rook.io/pvc"
+	udevPath           = "/run/udev"
+	udevVolName        = "run-udev"
 )
 
 const (
@@ -344,17 +346,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			fmt.Sprintf("--crush-location=%s", osd.Location),
 		}
 
-		// mount /run/udev in the container so ceph-volume (via `lvs`)
-		// can access the udev database
-		volumes = append(volumes, v1.Volume{
-			Name: "run-udev",
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{Path: "/run/udev"}}})
-
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
-			Name:      "run-udev",
-			MountPath: "/run/udev"})
-
 	} else if osd.IsDirectory {
 		// config for dir-based osds is gotten from the commandline or from the mon database
 		doConfigInit = false
@@ -387,6 +378,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	if osd.IsFileStore {
 		args = append(args, fmt.Sprintf("--osd-journal=%s", osd.Journal))
 	}
+
+	// The osd itself needs to talk to udev to report information about the device (vendor/serial etc)
+	udevVolume, udevVolumeMount := getUdevVolume()
+	volumes = append(volumes, udevVolume)
+	volumeMounts = append(volumeMounts, udevVolumeMount)
 
 	// Add the volume to the spec and the mount to the daemon container
 	copyBinariesVolume, copyBinariesContainer := c.getCopyBinariesContainer()
@@ -1076,4 +1072,20 @@ func (c *Cluster) osdRunFlagTuningOnPVC(osdID int) error {
 	}
 
 	return nil
+}
+
+func getUdevVolume() (v1.Volume, v1.VolumeMount) {
+	volume := v1.Volume{
+		Name: udevVolName,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: udevPath},
+		},
+	}
+
+	volumeMounts := v1.VolumeMount{
+		Name:      udevVolName,
+		MountPath: udevPath,
+	}
+
+	return volume, volumeMounts
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -121,10 +121,10 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, v1.RestartPolicyAlways, deployment.Spec.Template.Spec.RestartPolicy)
 	assert.Equal(t, "my-priority-class", deployment.Spec.Template.Spec.PriorityClassName)
 	if devMountNeeded && len(dataDir) > 0 {
-		assert.Equal(t, 6, len(deployment.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 7, len(deployment.Spec.Template.Spec.Volumes))
 	}
 	if devMountNeeded && len(dataDir) == 0 {
-		assert.Equal(t, 6, len(deployment.Spec.Template.Spec.Volumes))
+		assert.Equal(t, 7, len(deployment.Spec.Template.Spec.Volumes))
 	}
 	if !devMountNeeded && len(dataDir) > 0 {
 		assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Volumes))
@@ -146,7 +146,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont := deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, cephVersion.Image, cont.Image)
-	assert.Equal(t, 6, len(cont.VolumeMounts))
+	assert.Equal(t, 7, len(cont.VolumeMounts))
 	assert.Equal(t, "ceph-osd", cont.Command[0])
 }
 

--- a/pkg/operator/ceph/cluster/osd/topology.go
+++ b/pkg/operator/ceph/cluster/osd/topology.go
@@ -20,18 +20,13 @@ limitations under the License.
 package osd
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (
 
-	// The labels that can be specified with the K8s labels such as failure-domain.beta.kubernetes.io/zone
+	// The labels that can be specified with the K8s labels such as topology.kubernetes.io/zone
 	// These are all at the top layers of the CRUSH map.
 	KubernetesTopologyLabels = []string{"zone", "region"}
 
@@ -42,43 +37,13 @@ var (
 	CRUSHMapLevelsOrdered = append([]string{"host"}, append(CRUSHTopologyLabels, KubernetesTopologyLabels...)...)
 )
 
-// ExtractRookTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value,
-// and an array of any invalid labels with a topology prefix.
-func ExtractRookTopologyFromLabels(labels map[string]string) (map[string]string, []string) {
-	topology := make(map[string]string)
+// ExtractTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value
+func ExtractOSDTopologyFromLabels(labels map[string]string) map[string]string {
+	topology := k8sutil.ExtractTopologyFromLabels(labels, CRUSHTopologyLabels)
 
-	// get zone
-	zone, ok := labels[corev1.LabelZoneFailureDomain]
-	if ok {
-		topology["zone"] = client.NormalizeCrushName(zone)
+	// Ensure the topology names are normalized for CRUSH
+	for name, value := range topology {
+		topology[name] = client.NormalizeCrushName(value)
 	}
-	// get region
-	region, ok := labels[corev1.LabelZoneRegion]
-	if ok {
-		topology["region"] = client.NormalizeCrushName(region)
-	}
-
-	// get host
-	host, ok := labels[corev1.LabelHostname]
-	if ok {
-		topology["host"] = client.NormalizeCrushName(host)
-	}
-
-	invalidEncountered := make([]string, 0)
-	for labelKey, labelValue := range labels {
-		for _, validTopologyType := range CRUSHTopologyLabels {
-			if strings.HasPrefix(labelKey, k8sutil.TopologyLabelPrefix) {
-				s := strings.Split(labelKey, "/")
-				if len(s) != 2 {
-					invalidEncountered = append(invalidEncountered, fmt.Sprintf("%s=%s", labelKey, labelValue))
-					continue
-				}
-				topologyType := s[1]
-				if topologyType == validTopologyType {
-					topology[validTopologyType] = client.NormalizeCrushName(labelValue)
-				}
-			}
-		}
-	}
-	return topology, invalidEncountered
+	return topology
 }

--- a/pkg/operator/ceph/cluster/osd/topology_test.go
+++ b/pkg/operator/ceph/cluster/osd/topology_test.go
@@ -37,3 +37,23 @@ func TestOrderedCRUSHLabels(t *testing.T) {
 	assert.Equal(t, "zone", CRUSHMapLevelsOrdered[8])
 	assert.Equal(t, "region", CRUSHMapLevelsOrdered[9])
 }
+
+func TestTopologyLabels(t *testing.T) {
+	// load all the expected labels
+	nodeLabels := map[string]string{
+		"topology.kubernetes.io/region": "r.region",
+		"topology.kubernetes.io/zone":   "z.zone",
+		"kubernetes.io/hostname":        "host.name",
+		"topology.rook.io/rack":         "r.rack",
+		"topology.rook.io/row":          "r.row",
+		"topology.rook.io/datacenter":   "d.datacenter",
+	}
+	topology := ExtractOSDTopologyFromLabels(nodeLabels)
+	assert.Equal(t, 6, len(topology))
+	assert.Equal(t, "r-region", topology["region"])
+	assert.Equal(t, "z-zone", topology["zone"])
+	assert.Equal(t, "host-name", topology["host"])
+	assert.Equal(t, "r-rack", topology["rack"])
+	assert.Equal(t, "r-row", topology["row"])
+	assert.Equal(t, "d-datacenter", topology["datacenter"])
+}

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -169,7 +169,7 @@ func getOSDsForNodes(osdDataList []OsdData, nodeList []*corev1.Node, failureDoma
 			logger.Warningf("node in nodelist was nil")
 			continue
 		}
-		nodeTopologyMap, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+		nodeTopologyMap := osd.ExtractOSDTopologyFromLabels(node.GetLabels())
 
 		for _, osdData := range osdDataList {
 			// get the crush location of the osd

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -191,7 +191,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		deploy.ObjectMeta.OwnerReferences = ownerReferences
 
 		// update the deployment labels
-		topology, _ := osd.ExtractRookTopologyFromLabels(node.GetLabels())
+		topology := osd.ExtractOSDTopologyFromLabels(node.GetLabels())
 		for key, value := range topology {
 			selectorLabels[key] = value
 		}

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/validation"
-
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
@@ -34,12 +34,6 @@ import (
 const (
 	TopologyLabelPrefix = "topology.rook.io/"
 )
-
-var validTopologyLabelKeys = []string{
-	"failure-domain.beta.kubernetes.io", // deprecated in 1.17
-	"topology.kubernetes.io",
-	TopologyLabelPrefix,
-}
 
 // ValidNodeNoSched returns true if the node (1) meets Rook's placement terms,
 // and (2) is ready. Unlike ValidNode, this method will ignore the
@@ -278,25 +272,51 @@ func RookNodesMatchingKubernetesNodes(rookStorage rookalpha.StorageScopeSpec, ku
 	return nodes
 }
 
-func nodeTopologyLocation(kubeNode v1.Node, location string) string {
-	nodeLabels := kubeNode.ObjectMeta.Labels
-	locations := []string{location}
+// ExtractTopologyFromLabels extracts rook topology from labels and returns a map from topology type to value
+func ExtractTopologyFromLabels(labels map[string]string, additionalTopologyIDs []string) map[string]string {
+	topology := make(map[string]string)
 
-	// We're looking for node labels that match the following format:
-	// <validTopologyLabelKey>/<key>: <value>
-	// Where validTopologyLabelKey is an entry in the
-	// validTopologyLabelKeys list, key is a topology element (e.g. region,
-	// zone), and value is the name of the element (e.g. region1, zone2)
-	for label := range nodeLabels {
-		for _, key := range validTopologyLabelKeys {
-			if strings.Contains(label, key) {
-				keys := strings.Split(label, "/")
-				locations = append(locations, fmt.Sprintf("%s=%s", keys[1], nodeLabels[label]))
-			}
-		}
+	// check for the region k8s topology label that was deprecated in 1.17
+	const regionLabel = "region"
+	region, ok := labels[corev1.LabelZoneRegion]
+	if ok {
+		topology[regionLabel] = region
 	}
 
-	return strings.Join(locations, " ")
+	// check for the region k8s topology label that is GA in 1.17.
+	// TODO: Replace with a const when we update to the K8s 1.17 go-client.
+	region, ok = labels["topology.kubernetes.io/region"]
+	if ok {
+		topology[regionLabel] = region
+	}
+
+	// check for the zone k8s topology label that was deprecated in 1.17
+	const zoneLabel = "zone"
+	zone, ok := labels[corev1.LabelZoneFailureDomain]
+	if ok {
+		topology[zoneLabel] = zone
+	}
+
+	// check for the zone k8s topology label that is GA in 1.17.
+	// TODO: Replace with a const when we update to the K8s 1.17 go-client.
+	zone, ok = labels["topology.kubernetes.io/zone"]
+	if ok {
+		topology[zoneLabel] = zone
+	}
+
+	// get host
+	host, ok := labels[corev1.LabelHostname]
+	if ok {
+		topology["host"] = host
+	}
+
+	// get the labels for the CRUSH map hierarchy
+	for _, topologyID := range additionalTopologyIDs {
+		if value, ok := labels[TopologyLabelPrefix+topologyID]; ok {
+			topology[topologyID] = value
+		}
+	}
+	return topology
 }
 
 // NodeIsInRookNodeList will return true if the target node is found in a given list of Rook nodes.

--- a/pkg/operator/k8sutil/node_test.go
+++ b/pkg/operator/k8sutil/node_test.go
@@ -24,6 +24,7 @@ import (
 	rookalpha "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -388,4 +389,76 @@ func TestGenerateNodeAffinity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTopologyLabels(t *testing.T) {
+	additionalTopologyLabels := []string{
+		"rack", "row", "datacenter",
+	}
+	nodeLabels := map[string]string{}
+	topology := ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// invalid non-namespaced zone and region labels are simply ignored
+	nodeLabels = map[string]string{
+		"region": "badregion",
+		"zone":   "badzone",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// invalid zone and region labels are simply ignored
+	nodeLabels = map[string]string{
+		"topology.rook.io/region": "r1",
+		"topology.rook.io/zone":   "z1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
+
+	// load all the expected labels
+	nodeLabels = map[string]string{
+		"topology.kubernetes.io/region": "r1",
+		"topology.kubernetes.io/zone":   "z1",
+		"kubernetes.io/hostname":        "myhost",
+		"topology.rook.io/rack":         "rack1",
+		"topology.rook.io/row":          "row1",
+		"topology.rook.io/datacenter":   "d1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 6, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+	assert.Equal(t, "myhost", topology["host"])
+	assert.Equal(t, "rack1", topology["rack"])
+	assert.Equal(t, "row1", topology["row"])
+	assert.Equal(t, "d1", topology["datacenter"])
+
+	// ensure deprecated k8s labels are loaded
+	nodeLabels = map[string]string{
+		corev1.LabelZoneRegion:        "r1",
+		corev1.LabelZoneFailureDomain: "z1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 2, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+
+	// ensure deprecated k8s labels are overridden
+	nodeLabels = map[string]string{
+		"topology.kubernetes.io/region": "r1",
+		"topology.kubernetes.io/zone":   "z1",
+		corev1.LabelZoneRegion:          "oldregion",
+		corev1.LabelZoneFailureDomain:   "oldzone",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 2, len(topology))
+	assert.Equal(t, "r1", topology["region"])
+	assert.Equal(t, "z1", topology["zone"])
+
+	// invalid labels under topology.rook.io return an error
+	nodeLabels = map[string]string{
+		"topology.rook.io/row/bad": "r1",
+	}
+	topology = ExtractTopologyFromLabels(nodeLabels, additionalTopologyLabels)
+	assert.Equal(t, 0, len(topology))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport multiple fixes that had merge conflicts preventing the bot from backporting.
- #5001 Mount /udev so the osds can discover device info
- #4960 Update to Ceph v14.2.8 and fix an issue with OSDs running on PVs on that version
- #4989 Properly look up the topology.kubernetes.io labels
- Log a warning when useAllNodes is true, but `nodes` are defined in the cluster CR.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test full]
[test ceph]