### PR TITLE
Yugabyte tests should use image built by rook

### DIFF
--- a/tests/framework/installer/yugabytedb_manifests.go
+++ b/tests/framework/installer/yugabytedb_manifests.go
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: rook-yugabytedb-operator
       containers:
       - name: rook-yugabytedb-operator
-        image: samkulkarni20/rook-yugabytedb:latest
+        image: rook/yugabytedb:master
         args: ["yugabytedb", "operator"]
         env:
         - name: POD_NAME


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests for yugabyte were pointing to an image outside of the rook repo. Since that image changed unexpectedly it broke the rook integration tests. The tests need to use the image built by rook.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test yugabytedb]