### PR TITLE
ceph: enable multi fs by default on octopus

### DIFF
--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -18,12 +18,14 @@ package client
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 
 	"github.com/rook/rook/pkg/clusterd"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -165,4 +167,19 @@ func TestFilesystemRemove(t *testing.T) {
 	assert.True(t, metadataDeleted)
 	assert.True(t, dataDeleted)
 	assert.True(t, crushDeleted)
+}
+
+func TestIsMultiFSEnabled(t *testing.T) {
+	v := cephver.Nautilus
+	b := IsMultiFSEnabled(v)
+	assert.False(t, b)
+
+	os.Setenv("ROOK_ALLOW_MULTIPLE_FILESYSTEMS", "true")
+	b = IsMultiFSEnabled(v)
+	assert.True(t, b)
+
+	os.Setenv("ROOK_ALLOW_MULTIPLE_FILESYSTEMS", "false")
+	v = cephver.Octopus
+	b = IsMultiFSEnabled(v)
+	assert.True(t, b)
 }

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -186,7 +186,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 	if err != nil {
 		return errors.Wrapf(err, "Unable to list existing filesystem")
 	}
-	if len(fslist) > 0 && !client.IsMultiFSEnabled() {
+	if len(fslist) > 0 && !client.IsMultiFSEnabled(cephVersion) {
 		return errors.Errorf("cannot create multiple filesystems. enable %s env variable to create more than one", client.MultiFsEnv)
 	}
 
@@ -232,7 +232,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 
 	// create the filesystem ('fs new' needs to be forced in order to reuse pre-existing pools)
 	// if only one pool is created new it wont work (to avoid inconsistencies).
-	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames, !poolsCreated); err != nil {
+	if err := client.CreateFilesystem(context, clusterName, f.Name, f.metadataPool.Name, dataPoolNames, !poolsCreated, cephVersion); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**Description of your changes:**

As of Octopus, multiple FS are supported by default, so we don't need
to set the flag.

Closes: https://github.com/rook/rook/issues/5012
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5012

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]