### PR TITLE
test: Kubeadm-install add support for arm64

### DIFF
--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash +e
 
 KUBE_VERSION=${1:-"v1.13.1"}
-
+ARCH=$(dpkg --print-architecture)
 null_str=
 KUBE_INSTALL_VERSION="${KUBE_VERSION/v/$null_str}"-00
 
@@ -51,7 +51,16 @@ sudo apt-get install -y kubernetes-cni="0.6.0-00"
 sudo apt-get install -y kubelet="${KUBE_INSTALL_VERSION}"  && sudo apt-get install -y kubeadm="${KUBE_INSTALL_VERSION}"
 
 #get matching kubectl
-wget "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl"
+case ${ARCH} in
+    amd64|arm64)
+        wget "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${ARCH}/kubectl"
+        ;;
+    *)
+        echo "[ERROR] Unsupported build ARCH ${ARCH}"
+        exit 1
+        ;;
+esac
+
 chmod +x kubectl
 sudo cp kubectl /usr/local/bin
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Only kubectl for amd64 is currently available.This modification adds
arm64 version of kubectl that can successfully deploy kubernetes on
arm64 machine.

Signed-off-by: Haichao Li <haichao.li@arm.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
