### PR TITLE
ceph: allow setting pool size 1 on octopus

### DIFF
--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -57,15 +57,13 @@ var (
 
 // GlobalConfig represents the [global] sections of Ceph's config file.
 type GlobalConfig struct {
-	FSID                string `ini:"fsid,omitempty"`
-	MonMembers          string `ini:"mon initial members,omitempty"`
-	MonHost             string `ini:"mon host"`
-	PublicAddr          string `ini:"public addr,omitempty"`
-	PublicNetwork       string `ini:"public network,omitempty"`
-	ClusterAddr         string `ini:"cluster addr,omitempty"`
-	ClusterNetwork      string `ini:"cluster network,omitempty"`
-	MonAllowPoolDelete  bool   `ini:"mon_allow_pool_delete"`
-	MonAllowPoolSizeOne bool   `ini:"mon_allow_pool_size_one"`
+	FSID           string `ini:"fsid,omitempty"`
+	MonMembers     string `ini:"mon initial members,omitempty"`
+	MonHost        string `ini:"mon host"`
+	PublicAddr     string `ini:"public addr,omitempty"`
+	PublicNetwork  string `ini:"public network,omitempty"`
+	ClusterAddr    string `ini:"cluster addr,omitempty"`
+	ClusterNetwork string `ini:"cluster network,omitempty"`
 }
 
 // CephConfig represents an entire Ceph config including all sections.
@@ -163,15 +161,13 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 
 	conf := &CephConfig{
 		GlobalConfig: &GlobalConfig{
-			FSID:                cluster.FSID,
-			MonMembers:          strings.Join(monMembers, " "),
-			MonHost:             strings.Join(monHosts, ","),
-			PublicAddr:          context.NetworkInfo.PublicAddr,
-			PublicNetwork:       context.NetworkInfo.PublicNetwork,
-			ClusterAddr:         context.NetworkInfo.ClusterAddr,
-			ClusterNetwork:      context.NetworkInfo.ClusterNetwork,
-			MonAllowPoolDelete:  true,
-			MonAllowPoolSizeOne: true,
+			FSID:           cluster.FSID,
+			MonMembers:     strings.Join(monMembers, " "),
+			MonHost:        strings.Join(monHosts, ","),
+			PublicAddr:     context.NetworkInfo.PublicAddr,
+			PublicNetwork:  context.NetworkInfo.PublicNetwork,
+			ClusterAddr:    context.NetworkInfo.ClusterAddr,
+			ClusterNetwork: context.NetworkInfo.ClusterNetwork,
 		},
 	}
 

--- a/pkg/operator/ceph/config/defaults.go
+++ b/pkg/operator/ceph/config/defaults.go
@@ -67,6 +67,13 @@ func DefaultCentralizedConfigs(cephVersion version.CephVersion) []Option {
 		}...)
 	}
 
+	// For Octopus
+	if cephVersion.IsAtLeastOctopus() {
+		overrides = append(overrides, []Option{
+			configOverride("global", "mon allow pool size one", "true"),
+		}...)
+	}
+
 	return overrides
 }
 


### PR DESCRIPTION
**Description of your changes:**

Left from https://github.com/rook/rook/pull/4895
Also more cleanup on the ceph.conf since we config is in the mon store.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]