### PR TITLE
Ceph: Added rook manager module rights for read pod logs

### DIFF
--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -59,6 +59,7 @@ rules:
   resources:
   - pods
   - services
+  - pods/log
   verbs:
   - get
   - list

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -1022,6 +1022,7 @@ rules:
   resources:
   - pods
   - services
+  - pods/log
   verbs:
   - get
   - list

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-apply.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-apply.yaml
@@ -89,6 +89,7 @@ rules:
   resources:
   - pods
   - services
+  - pods/log
   verbs:
   - get
   - list

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1555,6 +1555,7 @@ rules:
   resources:
   - pods
   - services
+  - pods/log
   verbs:
   - get
   - list


### PR DESCRIPTION
This is needed to allow the ceph manager rook module to read the output
of the <lsmcli> command used to switch disk identification light on/off on
physical disk devices

[test ceph]

 Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
