### PR TITLE
ceph: convert Filesystem controller to the controller-runtime

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
-	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/nfs"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -466,17 +465,13 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	bucketController, _ := bucket.NewBucketController(c.context.KubeConfig, bucketProvisioner)
 	go bucketController.Run(cluster.stopCh)
 
-	// Start file system CRD watcher
-	fileController := file.NewFilesystemController(cluster.Info, c.context, cluster.Namespace, c.rookImage, cluster.Spec, cluster.ownerRef, cluster.Spec.DataDirHostPath)
-	fileController.StartWatch(cluster.Namespace, cluster.stopCh)
-
 	// Start nfs ganesha CRD watcher
 	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, cluster.Spec.DataDirHostPath, cluster.Namespace, c.rookImage, cluster.Spec, cluster.ownerRef)
 	ganeshaController.StartWatch(cluster.Namespace, cluster.stopCh)
+
 	// Populate childControllers
 	logger.Debug("populating child controllers, so cluster CR spec updates will be propagaged to other CR")
 	cluster.childControllers = []childController{
-		fileController,
 		ganeshaController,
 	}
 

--- a/pkg/operator/ceph/cluster/register_controllers.go
+++ b/pkg/operator/ceph/cluster/register_controllers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
+	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
@@ -33,6 +34,7 @@ var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context) error{
 	pool.Add,
 	objectuser.Add,
 	object.Add,
+	file.Add,
 }
 
 // AddToManager adds all the registered controllers to the passed manager.

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -18,271 +18,262 @@ limitations under the License.
 package file
 
 import (
+	"context"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
-	"github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-file")
+const (
+	controllerName = "ceph-file-controller"
+)
 
-// FilesystemResource represents the filesystem custom resource
-var FilesystemResource = k8sutil.CustomResource{
-	Name:    "cephfilesystem",
-	Plural:  "cephfilesystems",
-	Group:   cephv1.CustomResourceGroup,
-	Version: cephv1.Version,
-	Kind:    reflect.TypeOf(cephv1.CephFilesystem{}).Name(),
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
+
+// List of object resources to watch by the controller
+var objectsToWatch = []runtime.Object{
+	&corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: corev1.SchemeGroupVersion.String()}},
+	// Stop watching for Deployment object until https://github.com/rook/rook/issues/5047 is fully resolved
+	// &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: appsv1.SchemeGroupVersion.String()}},
 }
 
-// FilesystemController represents a controller for filesystem custom resources
-type FilesystemController struct {
-	clusterInfo        *cephconfig.ClusterInfo
-	context            *clusterd.Context
-	namespace          string
-	rookVersion        string
-	clusterSpec        *cephv1.ClusterSpec
-	ownerRef           metav1.OwnerReference
-	dataDirHostPath    string
-	orchestrationMutex sync.Mutex
+var cephFilesystemKind = reflect.TypeOf(cephv1.CephFilesystem{}).Name()
+
+// Sets the type meta for the controller main object
+var controllerTypeMeta = metav1.TypeMeta{
+	Kind:       cephFilesystemKind,
+	APIVersion: fmt.Sprintf("%s/%s", cephv1.CustomResourceGroup, cephv1.Version),
 }
 
-// NewFilesystemController create controller for watching filesystem custom resources created
-func NewFilesystemController(
-	clusterInfo *cephconfig.ClusterInfo,
-	context *clusterd.Context,
-	namespace string,
-	rookVersion string,
-	clusterSpec *cephv1.ClusterSpec,
-	ownerRef metav1.OwnerReference,
-	dataDirHostPath string,
-) *FilesystemController {
-	return &FilesystemController{
-		clusterInfo:     clusterInfo,
-		context:         context,
-		namespace:       namespace,
-		rookVersion:     rookVersion,
-		clusterSpec:     clusterSpec,
-		ownerRef:        ownerRef,
-		dataDirHostPath: dataDirHostPath,
+// ReconcileCephFilesystem reconciles a CephFilesystem object
+type ReconcileCephFilesystem struct {
+	client          client.Client
+	scheme          *runtime.Scheme
+	context         *clusterd.Context
+	cephClusterSpec *cephv1.ClusterSpec
+	clusterInfo     *cephconfig.ClusterInfo
+}
+
+// Add creates a new CephFilesystem Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, context *clusterd.Context) error {
+	return add(mgr, newReconciler(mgr, context))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
+	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
+	mgrScheme := mgr.GetScheme()
+	cephv1.AddToScheme(mgr.GetScheme())
+
+	return &ReconcileCephFilesystem{
+		client:  mgr.GetClient(),
+		scheme:  mgrScheme,
+		context: context,
 	}
 }
 
-// StartWatch watches for instances of Filesystem custom resources and acts on them
-func (c *FilesystemController) StartWatch(namespace string, stopCh chan struct{}) {
-
-	resourceHandlerFuncs := cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onAdd,
-		UpdateFunc: c.onUpdate,
-		DeleteFunc: c.onDelete,
-	}
-
-	logger.Infof("start watching filesystem resource in namespace %s", c.namespace)
-	go k8sutil.WatchCR(FilesystemResource, namespace, resourceHandlerFuncs, c.context.RookClientset.CephV1().RESTClient(), &cephv1.CephFilesystem{}, stopCh)
-}
-
-func (c *FilesystemController) onAdd(obj interface{}) {
-
-	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
-		logger.Warningf("Creating filesystems for an external ceph cluster is disabled because no Ceph image is specified")
-		return
-	}
-
-	filesystem, err := getFilesystemObject(obj)
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
-		logger.Errorf("failed to get filesystem object. %v", err)
-		return
+		return err
 	}
 
-	c.acquireOrchestrationLock()
-	defer c.releaseOrchestrationLock()
+	// Watch for changes on the CephFilesystem CRD object
+	err = c.Watch(&source.Kind{Type: &cephv1.CephFilesystem{TypeMeta: controllerTypeMeta}}, &handler.EnqueueRequestForObject{}, opcontroller.WatchControllerPredicate())
+	if err != nil {
+		return err
+	}
 
-	if c.clusterSpec.External.Enable {
-		_, err := controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.namespace, c.clusterInfo.CephVersion)
+	// Watch all other resources
+	for _, t := range objectsToWatch {
+		err = c.Watch(&source.Kind{Type: t}, &handler.EnqueueRequestForOwner{
+			IsController: true,
+			OwnerType:    &cephv1.CephFilesystem{},
+		}, opcontroller.WatchPredicateForNonCRDObject(&cephv1.CephFilesystem{TypeMeta: controllerTypeMeta}, mgr.GetScheme()))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Reconcile reads that state of the cluster for a CephFilesystem object and makes changes based on the state read
+// and what is in the cephFilesystem.Spec
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileCephFilesystem) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// workaround because the rook logging mechanism is not compatible with the controller-runtime loggin interface
+	reconcileResponse, err := r.reconcile(request)
+	if err != nil {
+		logger.Errorf("failed to reconcile %v", err)
+	}
+
+	return reconcileResponse, err
+}
+
+func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the cephFilesystem instance
+	cephFilesystem := &cephv1.CephFilesystem{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, cephFilesystem)
+	if err != nil {
+		if kerrors.IsNotFound(err) {
+			logger.Debug("cephFilesystem resource not found. Ignoring since object must be deleted.")
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, errors.Wrap(err, "failed to get cephFilesystem")
+	}
+
+	// The CR was just created, initializing status fields
+	if cephFilesystem.Status == nil {
+		cephFilesystem.Status = &cephv1.Status{}
+		cephFilesystem.Status.Phase = k8sutil.Created
+		err := opcontroller.UpdateStatus(r.client, cephFilesystem)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to set status")
+		}
+	}
+
+	// Make sure a CephCluster is present otherwise do nothing
+	cephClusterSpec, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName)
+	if !isReadyToReconcile {
+		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
+		// We skip the deleteFilesystem() function since everything is gone already
+		//
+		// Also, only remove the finalizer if the CephCluster is gone
+		// If not, we should wait for it to be ready
+		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
+		if !cephFilesystem.GetDeletionTimestamp().IsZero() && !cephClusterExists {
+			// Remove finalizer
+			err := opcontroller.RemoveFinalizer(r.client, cephFilesystem)
+			if err != nil {
+				return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
+			}
+
+			// Return and do not requeue. Successful deletion.
+			return reconcile.Result{}, nil
+		}
+
+		logger.Debugf("CephCluster resource not ready in namespace %q, retrying in %q.", request.NamespacedName.Namespace, opcontroller.WaitForRequeueIfCephClusterNotReadyAfter.String())
+		return reconcileResponse, nil
+	}
+	r.cephClusterSpec = &cephClusterSpec
+
+	// Populate clusterInfo
+	// Always populate it during each reconcile
+	clusterInfo, _, _, err := mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
+	}
+	r.clusterInfo = clusterInfo
+
+	// Populate CephVersion
+	daemon := string(opconfig.MonType)
+	currentCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo.Name, daemon)
+	if err != nil {
+		logger.Errorf("failed to retrieve current ceph %q version. %v", daemon, err)
+	}
+	r.clusterInfo.CephVersion = currentCephVersion
+
+	// Set a finalizer so we can do cleanup before the object goes away
+	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephFilesystem)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
+	}
+
+	// DELETE: the CR was deleted
+	if !cephFilesystem.GetDeletionTimestamp().IsZero() {
+		logger.Debugf("deleting filesystem %q", cephFilesystem.Name)
+		err = deleteFilesystem(r.context, r.clusterInfo.CephVersion, *cephFilesystem)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "failed to delete filesystem %q. ", cephFilesystem.Name)
+
+		}
+
+		// Remove finalizer
+		err = opcontroller.RemoveFinalizer(r.client, cephFilesystem)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
+		}
+
+		// Return and do not requeue. Successful deletion.
+		return reconcile.Result{}, nil
+	}
+
+	// validate the filesystem settings
+	if err := validateFilesystem(r.context, cephFilesystem); err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "invalid object filesystem %q arguments", cephFilesystem.Name)
+	}
+
+	// RECONCILE
+	logger.Debug("reconciling ceph filesystem store deployments")
+	reconcileResponse, err = r.reconcileCreateFilesystem(cephFilesystem)
+	if err != nil {
+		cephFilesystem.Status.Phase = k8sutil.ReconcileFailedStatus
+		errStatus := opcontroller.UpdateStatus(r.client, cephFilesystem)
+		if errStatus != nil {
+			logger.Errorf("failed to set status. %v", errStatus)
+		}
+		return reconcileResponse, err
+	}
+
+	// Set Ready status, we are done reconciling
+	cephFilesystem.Status.Phase = k8sutil.ReadyStatus
+	err = opcontroller.UpdateStatus(r.client, cephFilesystem)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "failed to set status")
+	}
+
+	// Return and do not requeue
+	logger.Debug("done reconciling")
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileCephFilesystem) reconcileCreateFilesystem(cephFilesystem *cephv1.CephFilesystem) (reconcile.Result, error) {
+	if r.cephClusterSpec.External.Enable {
+		_, err := opcontroller.ValidateCephVersionsBetweenLocalAndExternalClusters(r.context, cephFilesystem.Namespace, r.clusterInfo.CephVersion)
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical
-			logger.Errorf("refusing to run new crd. %v", err)
-			return
+			return reconcile.Result{}, errors.Wrapf(err, "refusing to run new crd")
 		}
 	}
-	updateCephFilesystemStatus(filesystem.GetName(), filesystem.GetNamespace(), k8sutil.ProcessingStatus, c.context)
 
-	err = createFilesystem(c.clusterInfo, c.context, *filesystem, c.rookVersion, c.clusterSpec, c.filesystemOwner(filesystem), c.clusterSpec.DataDirHostPath)
+	// Create the controller owner ref
+	// It will be associated to all resources of the CephObjectStore
+	ref, err := opcontroller.GetControllerObjectOwnerReference(cephFilesystem, r.scheme)
+	if err != nil || ref == nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to get controller %q owner reference", cephFilesystem.Name)
+	}
+
+	err = createFilesystem(r.clusterInfo, r.context, *cephFilesystem, r.cephClusterSpec, *ref, r.cephClusterSpec.DataDirHostPath, r.scheme)
 	if err != nil {
-		logger.Errorf("failed to create filesystem %q. %v", filesystem.Name, err)
-		updateCephFilesystemStatus(filesystem.GetName(), filesystem.GetNamespace(), k8sutil.FailedStatus, c.context)
-	}
-	updateCephFilesystemStatus(filesystem.GetName(), filesystem.GetNamespace(), k8sutil.ReadyStatus, c.context)
-}
-
-func (c *FilesystemController) onUpdate(oldObj, newObj interface{}) {
-	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
-		logger.Warningf("Updating filesystems for an external ceph cluster is disabled because no Ceph image is specified")
-		return
+		return reconcile.Result{}, errors.Wrapf(err, "failed to create filesystem %q", cephFilesystem.Name)
 	}
 
-	oldFS, err := getFilesystemObject(oldObj)
-	if err != nil {
-		logger.Errorf("failed to get old filesystem object. %v", err)
-		return
-	}
-	newFS, err := getFilesystemObject(newObj)
-	if err != nil {
-		logger.Errorf("failed to get new filesystem object. %v", err)
-		return
-	}
-
-	if !filesystemChanged(oldFS.Spec, newFS.Spec) {
-		logger.Debugf("filesystem %s not updated", newFS.Name)
-		return
-	}
-
-	c.acquireOrchestrationLock()
-	defer c.releaseOrchestrationLock()
-
-	// if the filesystem is modified, allow the filesystem to be created if it wasn't already
-	logger.Infof("updating filesystem %s", newFS.Name)
-	updateCephFilesystemStatus(newFS.GetName(), newFS.GetNamespace(), k8sutil.ProcessingStatus, c.context)
-	err = createFilesystem(c.clusterInfo, c.context, *newFS, c.rookVersion, c.clusterSpec, c.filesystemOwner(newFS), c.clusterSpec.DataDirHostPath)
-	if err != nil {
-		logger.Errorf("failed to create (modify) filesystem %q. %v", newFS.Name, err)
-		updateCephFilesystemStatus(newFS.GetName(), newFS.GetNamespace(), k8sutil.FailedStatus, c.context)
-	}
-	updateCephFilesystemStatus(newFS.GetName(), newFS.GetNamespace(), k8sutil.ReadyStatus, c.context)
-}
-
-// ParentClusterChanged determines wether or not a CR update has been sent
-func (c *FilesystemController) ParentClusterChanged(cluster cephv1.ClusterSpec, clusterInfo *cephconfig.ClusterInfo, isUpgrade bool) {
-	c.clusterInfo = clusterInfo
-	if !isUpgrade {
-		logger.Debugf("No need to update the file system after the parent cluster changed")
-		return
-	}
-
-	logger.Infof("waiting for the orchestration lock to update the filesystem")
-	c.acquireOrchestrationLock()
-	defer c.releaseOrchestrationLock()
-
-	c.clusterSpec.CephVersion = cluster.CephVersion
-	filesystems, err := c.context.RookClientset.CephV1().CephFilesystems(c.namespace).List(metav1.ListOptions{})
-	if err != nil {
-		logger.Errorf("failed to retrieve filesystems to update the ceph version. %v", err)
-		return
-	}
-	for _, fs := range filesystems.Items {
-		logger.Infof("updating the ceph version for filesystem %s to %s", fs.Name, c.clusterSpec.CephVersion.Image)
-		err = createFilesystem(c.clusterInfo, c.context, fs, c.rookVersion, c.clusterSpec, c.filesystemOwner(&fs), c.clusterSpec.DataDirHostPath)
-		if err != nil {
-			logger.Errorf("failed to update filesystem %q. %v", fs.Name, err)
-		} else {
-			logger.Infof("updated filesystem %q to ceph version %q", fs.Name, c.clusterSpec.CephVersion.Image)
-		}
-	}
-}
-
-func (c *FilesystemController) onDelete(obj interface{}) {
-	if c.clusterSpec.External.Enable && c.clusterSpec.CephVersion.Image == "" {
-		logger.Warningf("Deleting filesystems for an external ceph cluster is disabled because no Ceph image is specified")
-		return
-	}
-
-	filesystem, err := getFilesystemObject(obj)
-	if err != nil {
-		logger.Errorf("failed to get filesystem object. %v", err)
-		return
-	}
-
-	c.acquireOrchestrationLock()
-	defer c.releaseOrchestrationLock()
-
-	err = deleteFilesystem(c.context, c.clusterInfo.CephVersion, *filesystem)
-	if err != nil {
-		logger.Errorf("failed to delete filesystem %q. %v", filesystem.Name, err)
-	}
-}
-
-func (c *FilesystemController) filesystemOwner(fs *cephv1.CephFilesystem) metav1.OwnerReference {
-	// Set the filesystem CR as the owner
-	return metav1.OwnerReference{
-		APIVersion: fmt.Sprintf("%s/%s", FilesystemResource.Group, FilesystemResource.Version),
-		Kind:       FilesystemResource.Kind,
-		Name:       fs.Name,
-		UID:        fs.UID,
-	}
-}
-
-func filesystemChanged(oldFS, newFS cephv1.FilesystemSpec) bool {
-	if len(oldFS.DataPools) != len(newFS.DataPools) {
-		logger.Infof("number of data pools changed from %d to %d", len(oldFS.DataPools), len(newFS.DataPools))
-		return true
-	}
-	if oldFS.MetadataServer.ActiveCount != newFS.MetadataServer.ActiveCount {
-		logger.Infof("number of mds active changed from %d to %d", oldFS.MetadataServer.ActiveCount, newFS.MetadataServer.ActiveCount)
-		return true
-	}
-	if oldFS.MetadataServer.ActiveStandby != newFS.MetadataServer.ActiveStandby {
-		logger.Infof("mds active standby changed from %t to %t", oldFS.MetadataServer.ActiveStandby, newFS.MetadataServer.ActiveStandby)
-		return true
-	}
-	if oldFS.PreservePoolsOnDelete != newFS.PreservePoolsOnDelete {
-		logger.Infof("value of Preserve pools setting changed from %t to %t", oldFS.PreservePoolsOnDelete, newFS.PreservePoolsOnDelete)
-		// This setting only will be used when the filesystem will be deleted
-		return false
-	}
-	if oldFS.MetadataServer.PriorityClassName != newFS.MetadataServer.PriorityClassName {
-		logger.Infof("mds priority class name changed from %s to %s", oldFS.MetadataServer.PriorityClassName, newFS.MetadataServer.PriorityClassName)
-		return true
-	}
-	return false
-}
-
-func getFilesystemObject(obj interface{}) (filesystem *cephv1.CephFilesystem, err error) {
-	var ok bool
-	filesystem, ok = obj.(*cephv1.CephFilesystem)
-	if ok {
-		// the filesystem object is of the latest type, simply return it
-		return filesystem.DeepCopy(), nil
-	}
-
-	return nil, errors.Errorf("not a known filesystem object: %+v", obj)
-}
-
-func (c *FilesystemController) acquireOrchestrationLock() {
-	logger.Debugf("Acquiring lock for filesystem orchestration")
-	c.orchestrationMutex.Lock()
-	logger.Debugf("Acquired lock for filesystem orchestration")
-}
-
-func (c *FilesystemController) releaseOrchestrationLock() {
-	c.orchestrationMutex.Unlock()
-	logger.Debugf("Released lock for filesystem orchestration")
-}
-
-func updateCephFilesystemStatus(name, namespace, status string, context *clusterd.Context) {
-	updatedCephFilesystem, err := context.RookClientset.CephV1().CephFilesystems(namespace).Get(name, metav1.GetOptions{})
-	if err != nil {
-		logger.Errorf("Unable to update the cephObjectStore %s status %v", updatedCephFilesystem.GetName(), err)
-		return
-	}
-	if updatedCephFilesystem.Status == nil {
-		updatedCephFilesystem.Status = &cephv1.Status{}
-	} else if updatedCephFilesystem.Status.Phase == status {
-		return
-	}
-	updatedCephFilesystem.Status.Phase = status
-	_, err = context.RookClientset.CephV1().CephFilesystems(updatedCephFilesystem.Namespace).Update(updatedCephFilesystem)
-	if err != nil {
-		logger.Errorf("Unable to update the cephObjectStore %s status %v", updatedCephFilesystem.GetName(), err)
-		return
-	}
+	return reconcile.Result{}, nil
 }

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -14,40 +14,271 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package mds to manage a rook filesystem.
+// Package file to manage a rook filesystem
 package file
 
 import (
+	"context"
+	"os"
 	"testing"
 
+	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestFilesystemChanged(t *testing.T) {
-	// no change
-	old := cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
-	new := cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: true}}
-	changed := filesystemChanged(old, new)
-	assert.False(t, changed)
+const (
+	fsGet = `{
+		"mdsmap":{
+		   "epoch":49,
+		   "flags":50,
+		   "ever_allowed_features":32,
+		   "explicitly_allowed_features":32,
+		   "created":"2020-03-17 13:17:43.743717",
+		   "modified":"2020-03-17 15:22:51.020576",
+		   "tableserver":0,
+		   "root":0,
+		   "session_timeout":60,
+		   "session_autoclose":300,
+		   "min_compat_client":"-1 (unspecified)",
+		   "max_file_size":1099511627776,
+		   "last_failure":0,
+		   "last_failure_osd_epoch":0,
+		   "compat":{
+			  "compat":{
 
-	// changed properties
-	new = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 2, ActiveStandby: true}}
-	assert.True(t, filesystemChanged(old, new))
+			  },
+			  "ro_compat":{
 
-	new = cephv1.FilesystemSpec{MetadataServer: cephv1.MetadataServerSpec{ActiveCount: 1, ActiveStandby: false}}
-	assert.True(t, filesystemChanged(old, new))
-}
+			  },
+			  "incompat":{
+				 "feature_1":"base v0.20",
+				 "feature_2":"client writeable ranges",
+				 "feature_3":"default file layouts on dirs",
+				 "feature_4":"dir inode in separate object",
+				 "feature_5":"mds uses versioned encoding",
+				 "feature_6":"dirfrag is stored in omap",
+				 "feature_8":"no anchor table",
+				 "feature_9":"file layout v2",
+				 "feature_10":"snaprealm v2"
+			  }
+		   },
+		   "max_mds":1,
+		   "in":[
+			  0
+		   ],
+		   "up":{
+			  "mds_0":4463
+		   },
+		   "failed":[
 
-func TestGetFilesystemObject(t *testing.T) {
-	// get a current version filesystem object, should return with no error and no migration needed
-	filesystem, err := getFilesystemObject(&cephv1.CephFilesystem{})
-	assert.NotNil(t, filesystem)
-	assert.Nil(t, err)
+		   ],
+		   "damaged":[
 
-	// try to get an object that isn't a filesystem, should return with an error
-	filesystem, err = getFilesystemObject(&map[string]string{})
-	assert.Nil(t, filesystem)
-	assert.NotNil(t, err)
+		   ],
+		   "stopped":[
+
+		   ],
+		   "info":{
+			  "gid_4463":{
+				 "gid":4463,
+				 "name":"myfs-a",
+				 "rank":0,
+				 "incarnation":5,
+				 "state":"up:active",
+				 "state_seq":3,
+				 "addr":"172.17.0.12:6801/175789278",
+				 "addrs":{
+					"addrvec":[
+					   {
+						  "type":"v2",
+						  "addr":"172.17.0.12:6800",
+						  "nonce":175789278
+					   },
+					   {
+						  "type":"v1",
+						  "addr":"172.17.0.12:6801",
+						  "nonce":175789278
+					   }
+					]
+				 },
+				 "export_targets":[
+
+				 ],
+				 "features":4611087854031667199,
+				 "flags":0
+			  }
+		   },
+		   "data_pools":[
+			  3
+		   ],
+		   "metadata_pool":2,
+		   "enabled":true,
+		   "fs_name":"myfs",
+		   "balancer":"",
+		   "standby_count_wanted":1
+		},
+		"id":1
+	 }`
+	mdsCephAuthGetOrCreateKey = `{"key":"AQCvzWBeIV9lFRAAninzm+8XFxbSfTiPwoX50g=="}`
+)
+
+var (
+	name      = "my-fs"
+	namespace = "rook-ceph"
+)
+
+func TestCephObjectStoreController(t *testing.T) {
+	// Set DEBUG logging
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	//
+	// TEST 1 SETUP
+	//
+	// FAILURE because no CephCluster
+	//
+	// A Pool resource with metadata and spec.
+	fs := &cephv1.CephFilesystem{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.FilesystemSpec{
+			MetadataServer: cephv1.MetadataServerSpec{
+				ActiveCount: 1,
+			},
+		},
+		TypeMeta: controllerTypeMeta,
+	}
+	cephCluster := &cephv1.CephCluster{}
+
+	// Objects to track in the fake client.
+	object := []runtime.Object{
+		fs,
+	}
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			if args[0] == "status" {
+				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+			}
+			if args[0] == "fs" && args[1] == "get" {
+				return fsGet, nil
+			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return mdsCephAuthGetOrCreateKey, nil
+			}
+			return "", nil
+		},
+	}
+	clientset := test.New(t, 3)
+	c := &clusterd.Context{
+		Executor:      executor,
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     clientset,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStore{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileCephFilesystem object with the scheme and fake client.
+	r := &ReconcileCephFilesystem{client: cl, scheme: s, context: c}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	logger.Info("STARTING PHASE 1")
+	res, err := r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 1 DONE")
+
+	//
+	// TEST 2:
+	//
+	// FAILURE we have a cluster but it's not ready
+	//
+	cephCluster = &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespace,
+			Namespace: namespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: "",
+		},
+	}
+	object = append(object, cephCluster)
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileCephFilesystem object with the scheme and fake client.
+	r = &ReconcileCephFilesystem{client: cl, scheme: s, context: c}
+	logger.Info("STARTING PHASE 2")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 2 DONE")
+
+	//
+	// TEST 3:
+	//
+	// SUCCESS! The CephCluster is ready
+	//
+
+	// Mock clusterInfo
+	secrets := map[string][]byte{
+		"cluster-name": []byte("foo-cluster"),
+		"fsid":         []byte(name),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: namespace,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+	_, err = c.Clientset.CoreV1().Secrets(namespace).Create(secret)
+	assert.NoError(t, err)
+
+	// Add ready status to the CephCluster
+	cephCluster.Status.Phase = k8sutil.ReadyStatus
+
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+
+	// Create a ReconcileCephFilesystem object with the scheme and fake client.
+	r = &ReconcileCephFilesystem{client: cl, scheme: s, context: c}
+
+	logger.Info("STARTING PHASE 3")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue)
+	err = r.client.Get(context.TODO(), req.NamespacedName, fs)
+	assert.NoError(t, err)
+	assert.Equal(t, "Ready", fs.Status.Phase, fs)
+	logger.Info("PHASE 3 DONE")
 }

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephtest "github.com/rook/rook/pkg/daemon/ceph/test"
@@ -41,7 +42,7 @@ import (
 
 func TestValidateSpec(t *testing.T) {
 	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
-	fs := cephv1.CephFilesystem{}
+	fs := &cephv1.CephFilesystem{}
 
 	// missing name
 	assert.NotNil(t, validateFilesystem(context, fs))
@@ -116,14 +117,14 @@ func TestCreateFilesystem(t *testing.T) {
 	clusterInfo := &cephconfig.ClusterInfo{FSID: "myfsid"}
 
 	// start a basic cluster
-	err := createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/")
+	err := createFilesystem(clusterInfo, context, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
 	assert.Nil(t, err)
 	validateStart(t, context, fs)
 	assert.ElementsMatch(t, []string{}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
 	// starting again should be a no-op
-	err = createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/")
+	err = createFilesystem(clusterInfo, context, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
 	assert.Nil(t, err)
 	validateStart(t, context, fs)
 	assert.ElementsMatch(t, []string{"rook-ceph-mds-myfs-a", "rook-ceph-mds-myfs-b"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
@@ -144,8 +145,8 @@ func TestCreateFilesystem(t *testing.T) {
 		Clientset: clientset}
 
 	//Create another filesystem which should fail
-	err = createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/")
-	assert.Equal(t, "failed to create filesystem myfs: cannot create multiple filesystems. enable ROOK_ALLOW_MULTIPLE_FILESYSTEMS env variable to create more than one", err.Error())
+	err = createFilesystem(clusterInfo, context, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	assert.Equal(t, "failed to create filesystem \"myfs\": cannot create multiple filesystems. enable ROOK_ALLOW_MULTIPLE_FILESYSTEMS env variable to create more than one", err.Error())
 }
 
 func TestCreateNopoolFilesystem(t *testing.T) {
@@ -183,12 +184,12 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 	clusterInfo := &cephconfig.ClusterInfo{FSID: "myfsid"}
 
 	// start a basic cluster
-	err := createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/")
+	err := createFilesystem(clusterInfo, context, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
 	assert.Nil(t, err)
 	validateStart(t, context, fs)
 
 	// starting again should be a no-op
-	err = createFilesystem(clusterInfo, context, fs, "v0.1", &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/")
+	err = createFilesystem(clusterInfo, context, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
 	assert.Nil(t, err)
 	validateStart(t, context, fs)
 

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"strconv"
 
-	apps "k8s.io/api/apps/v1"
-
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
@@ -63,11 +61,6 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 
 	keyring := fmt.Sprintf(keyringTemplate, m.DaemonID, key)
 	return keyring, s.CreateOrUpdate(m.ResourceName, keyring)
-}
-
-func (c *Cluster) associateKeyring(existingKeyring string, d *apps.Deployment) error {
-	s := keyring.GetSecretStoreForDeployment(c.context, d)
-	return s.CreateOrUpdate(d.GetName(), existingKeyring)
 }
 
 func (c *Cluster) setDefaultFlagsMonConfigStore(mdsID string) error {

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -19,6 +19,7 @@ package mds
 import (
 	"testing"
 
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -62,10 +63,10 @@ func testDeploymentObject(t *testing.T, network cephv1.NetworkSpec) (*apps.Deplo
 		CephVersion: cephver.Nautilus,
 	}
 	clientset := testop.New(t, 1)
+
 	c := NewCluster(
 		clusterInfo,
 		&clusterd.Context{Clientset: clientset},
-		"rook/rook:myversion",
 		&cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:testversion"},
 			Network:     network,
@@ -74,6 +75,7 @@ func testDeploymentObject(t *testing.T, network cephv1.NetworkSpec) (*apps.Deplo
 		&client.CephFilesystemDetails{ID: 15},
 		metav1.OwnerReference{},
 		"/var/lib/rook/",
+		scheme.Scheme,
 	)
 	mdsTestConfig := &mdsConfig{
 		DaemonID:     "myfs-a",

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -31,7 +31,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/agent"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
-	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/ceph/provisioner"
 	"github.com/rook/rook/pkg/operator/discover"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -83,7 +82,7 @@ type Operator struct {
 
 // New creates an operator instance
 func New(context *clusterd.Context, volumeAttachmentWrapper attachment.Attachment, rookImage, securityAccount string) *Operator {
-	schemes := []k8sutil.CustomResource{cluster.ClusterResource, file.FilesystemResource, attachment.VolumeResource}
+	schemes := []k8sutil.CustomResource{cluster.ClusterResource, attachment.VolumeResource}
 
 	operatorNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
 	o := &Operator{

--- a/pkg/operator/ceph/operator_test.go
+++ b/pkg/operator/ceph/operator_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
-	"github.com/rook/rook/pkg/operator/ceph/file"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,9 +36,9 @@ func TestOperator(t *testing.T) {
 	assert.NotNil(t, o.clusterController)
 	assert.NotNil(t, o.resources)
 	assert.Equal(t, context, o.context)
-	assert.Equal(t, len(o.resources), 3)
+	assert.Equal(t, len(o.resources), 2)
 	for _, r := range o.resources {
-		if r.Name != cluster.ClusterResource.Name && r.Name != file.FilesystemResource.Name && r.Name != attachment.VolumeResource.Name {
+		if r.Name != cluster.ClusterResource.Name && r.Name != attachment.VolumeResource.Name {
 			assert.Fail(t, fmt.Sprintf("Resource %s is not valid", r.Name))
 		}
 	}

--- a/tests/framework/clients/filesystem.go
+++ b/tests/framework/clients/filesystem.go
@@ -82,8 +82,13 @@ func (f *FilesystemOperation) Delete(name, namespace string) error {
 		return err
 	}
 
+	crdCheckerFunc := func() error {
+		_, err := f.k8sh.RookClientset.CephV1().CephFilesystems(namespace).Get(name, metav1.GetOptions{})
+		return err
+	}
+
 	logger.Infof("Deleted filesystem %s in namespace %s", name, namespace)
-	return nil
+	return f.k8sh.WaitForCustomResourceDeletion(namespace, crdCheckerFunc)
 }
 
 // List lists filesystems in Rook

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -350,7 +350,7 @@ func (k8sh *K8sHelper) DeleteResource(args ...string) error {
 func (k8sh *K8sHelper) WaitForCustomResourceDeletion(namespace string, checkerFunc func() error) error {
 
 	// wait for the operator to finalize and delete the CRD
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 30; i++ {
 		err := checkerFunc()
 		if err == nil {
 			logger.Infof("custom resource %s still exists", namespace)


### PR DESCRIPTION
**Description of your changes:**

The CRD watcher has been replaced by the new controller-runtime
framework.
This brings robustness in our operator, meaning that any resources that
are modified will be reconciled into the desired state.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4940

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]