### PR TITLE
LVM infos for RancherOS added to Ceph docs

### DIFF
--- a/Documentation/ceph-prerequisites.md
+++ b/Documentation/ceph-prerequisites.md
@@ -29,8 +29,18 @@ sudo yum install -y lvm2
 
 Ubuntu:
 
-```
+```console
 sudo apt-get install -y lvm2
+```
+
+RancherOS:
+
+- Since version [1.5.0](https://github.com/rancher/os/issues/2551) LVM is supported
+- Logical volumes [will not be activated](https://github.com/rook/rook/issues/5027) during the boot process. You need to add an [runcmd command](https://rancher.com/docs/os/v1.x/en/installation/configuration/running-commands/) for that.
+
+```yaml
+runcmd:
+- [ vgchange, -ay ]
 ```
 
 ## Ceph Flexvolume Configuration


### PR DESCRIPTION
**Description of your changes:**
The default RancherOS configuration breaks the Ceph OSD recovery, because the logical volumes will not be activated during the boot process. This documenation update for the `Ceph Prerequisites` describes the needed `cloud-init` configuration change to fix the RancherOS behavior.

**Which issue is resolved by this Pull Request:**
Resolves #5027

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)

[skip ci]