### PR TITLE
remove unnecessary namespace fields

### DIFF
--- a/Documentation/edgefs-cluster-crd.md
+++ b/Documentation/edgefs-cluster-crd.md
@@ -618,7 +618,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-system-psp
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/coreos/rbac.yaml
+++ b/cluster/examples/coreos/rbac.yaml
@@ -7,7 +7,6 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: rook-ceph
   name: rook-node-annotator
 rules:
 - apiGroups: [""]
@@ -18,7 +17,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-node-annotator
-  namespace: rook-ceph
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -903,7 +903,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-global
-  namespace: rook-ceph
   labels:
     operator: rook
     storage-backend: ceph
@@ -972,7 +971,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-osd
-  namespace: rook-ceph
 rules:
 - apiGroups:
   - ""
@@ -987,7 +985,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: rook-ceph
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -998,7 +995,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-system-rules
-  namespace: rook-ceph
   labels:
       rbac.ceph.rook.io/aggregate-to-rook-ceph-mgr-system: "true"
 rules:

--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus.yaml
@@ -8,7 +8,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  namespace: rook-ceph
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -19,7 +18,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus-rules
-  namespace: rook-ceph
   labels:
     rbac.ceph.rook.io/aggregate-to-prometheus: "true"
 rules:
@@ -41,7 +39,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
-  namespace: rook-ceph
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -64,7 +64,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-cockroachdb-operator
-  namespace: rook-cockroachdb-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/edgefs/cluster.yaml
+++ b/cluster/examples/kubernetes/edgefs/cluster.yaml
@@ -98,7 +98,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-system-psp
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -112,7 +111,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-cluster-psp
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/edgefs/cluster_kvssd.yaml
+++ b/cluster/examples/kubernetes/edgefs/cluster_kvssd.yaml
@@ -98,7 +98,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-system-psp
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -112,7 +111,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-cluster-psp
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/edgefs/monitoring/prometheus.yaml
+++ b/cluster/examples/kubernetes/edgefs/monitoring/prometheus.yaml
@@ -8,7 +8,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
-  namespace: rook-edgefs
 rules:
 - apiGroups: [""]
   resources:
@@ -28,7 +27,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus
-  namespace: rook-edgefs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -351,7 +351,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-edgefs-global
-  namespace: rook-edgefs-system
   labels:
     operator: rook
     storage-backend: edgefs

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -73,7 +73,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-nfs-operator
-  namespace: rook-nfs-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/examples/kubernetes/yugabytedb/operator.yaml
+++ b/cluster/examples/kubernetes/yugabytedb/operator.yaml
@@ -70,7 +70,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: rook-yugabytedb-operator
-  namespace: rook-yugabytedb-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/design/ceph/security-model.md
+++ b/design/ceph/security-model.md
@@ -52,7 +52,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-operator
-  namespace: rook-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -93,7 +92,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-agent
-  namespace: rook-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/framework/installer/cassandra_manifests.go
+++ b/tests/framework/installer/cassandra_manifests.go
@@ -18,6 +18,7 @@ package installer
 
 import (
 	"fmt"
+
 	cassandrav1alpha1 "github.com/rook/rook/pkg/apis/cassandra.rook.io/v1alpha1"
 )
 
@@ -127,7 +128,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-cassandra-operator
-  namespace: %[1]s
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -993,7 +993,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-global
-  namespace: ` + namespace + `
   labels:
     operator: rook
     storage-backend: ceph

--- a/tests/framework/installer/ceph_manifests_v1.1.go
+++ b/tests/framework/installer/ceph_manifests_v1.1.go
@@ -748,7 +748,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: ` + namespace + `
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -759,7 +758,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-system-rules
-  namespace: ` + namespace + `
   labels:
     rbac.ceph.rook.io/aggregate-to-rook-ceph-mgr-system: "true"
 rules:
@@ -802,7 +800,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-global
-  namespace: ` + namespace + `
   labels:
     operator: rook
     storage-backend: ceph

--- a/tests/framework/installer/cockroachdb_manifests.go
+++ b/tests/framework/installer/cockroachdb_manifests.go
@@ -96,7 +96,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-cockroachdb-operator
-  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/framework/installer/edgefs_manifest.go
+++ b/tests/framework/installer/edgefs_manifest.go
@@ -141,7 +141,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-edgefs-global
-  namespace: ` + namespace + `
   labels:
     operator: rook
     storage-backend: edgefs
@@ -286,7 +285,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-system-psp
-  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -300,7 +298,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: rook-edgefs-cluster-psp
-  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/framework/installer/nfs_manifests.go
+++ b/tests/framework/installer/nfs_manifests.go
@@ -95,7 +95,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-nfs-operator
-  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/framework/installer/yugabytedb_manifests.go
+++ b/tests/framework/installer/yugabytedb_manifests.go
@@ -80,7 +80,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: rook-yugabytedb-operator
-  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -465,7 +465,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-osd
-  namespace: ` + namespace + `
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
**Description of your changes:**

There are many namespace fields in ClusterRole{,Binding}. However,
ClusterRole{,Binding} are not namespaced. So we can remove these.

**Checklist:**

- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [o] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [o] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
