### PR TITLE
Document monitoring namespace for OpenShift

### DIFF
--- a/Documentation/openshift-issues.md
+++ b/Documentation/openshift-issues.md
@@ -10,11 +10,22 @@ indent: true
 
 OpenShift Console uses OpenShift Prometheus for monitoring and populating data in Storage Dashboard. Additional configuration is required to monitor the Ceph Cluster from the storage dashboard.
 
-1. Enable Ceph Cluster monitoring
+1. Change the monitoring namespace to `openshift-monitoring`
 
-    Follow [ceph-monitoring/prometheus-alerts](https://github.com/rook/rook/blob/master/Documentation/ceph-monitoring.md#prometheus-alerts).
+    Change the namespace of the RoleBinding `rook-ceph-metrics` from `rook-ceph` to `openshift-monitoring` for the `prometheus-k8s` ServiceAccount in [rbac.yaml](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/monitoring/rbac.yaml#L70).
 
-2. Set the required label on the namespace
+```
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+```
+
+2. Enable Ceph Cluster monitoring
+
+    Follow [ceph-monitoring/prometheus-alerts](ceph-monitoring.md#prometheus-alerts).
+
+3. Set the required label on the namespace
 
     `$ oc label namespace rook-ceph "openshift.io/cluster-monitoring=true"`
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
OpenShift requires the monitoring to be bound to the openshift-monitoring namespace instead of the rook default

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]