### PR TITLE
ceph: convert NFS controller to the controller-runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/yanniszark/go-nodetool v0.0.0-20191206125106-cd8f91fa16be
 	gopkg.in/ini.v1 v1.51.1 // indirect
 	k8s.io/api v0.17.2
-	k8s.io/apiextensions-apiserver v0.15.7
+	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/apiserver v0.17.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -112,7 +112,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea h1:n2Ltr3SrfQlf/9nOna1DoGKxLx3qTSI8Ttl6Xrqp6mw=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/prometheus-operator v0.34.0 h1:TF9qaydNeUamLKs0hniaapa4FBz8U8TIlRRtJX987A4=
 github.com/coreos/prometheus-operator v0.34.0/go.mod h1:Li6rMllG/hYIyXfMuvUwhyC+hqwJVHdsDdP21hypT1M=
 github.com/corpix/uarand v0.1.1 h1:RMr1TWc9F4n5jiPDzFHtmaUXLKLNUFK0SgCLo4BhX/U=
@@ -857,6 +856,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -975,6 +975,7 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=
+sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH+UQM=
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -63,7 +63,6 @@ type cluster struct {
 	orchestrationRunning bool
 	orchestrationNeeded  bool
 	orchMux              sync.Mutex
-	childControllers     []childController
 	isUpgrade            bool
 }
 
@@ -308,12 +307,6 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 
 		logger.Infof("Done creating rook instance in namespace %s", c.Namespace)
 		c.initCompleted = true
-	}
-
-	// Notify the child controllers that the cluster spec might have changed
-	logger.Debug("notifying CR child of the potential upgrade")
-	for _, child := range c.childControllers {
-		go child.ParentClusterChanged(*c.Spec, c.Info, c.isUpgrade)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
-	"github.com/rook/rook/pkg/operator/ceph/nfs"
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -464,16 +463,6 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	//   bucket library's `NewProvisioner` function
 	bucketController, _ := bucket.NewBucketController(c.context.KubeConfig, bucketProvisioner)
 	go bucketController.Run(cluster.stopCh)
-
-	// Start nfs ganesha CRD watcher
-	ganeshaController := nfs.NewCephNFSController(cluster.Info, c.context, cluster.Spec.DataDirHostPath, cluster.Namespace, c.rookImage, cluster.Spec, cluster.ownerRef)
-	ganeshaController.StartWatch(cluster.Namespace, cluster.stopCh)
-
-	// Populate childControllers
-	logger.Debug("populating child controllers, so cluster CR spec updates will be propagaged to other CR")
-	cluster.childControllers = []childController{
-		ganeshaController,
-	}
 
 	// Populate ClusterInfo
 	if cluster.Spec.External.Enable {

--- a/pkg/operator/ceph/cluster/register_controllers.go
+++ b/pkg/operator/ceph/cluster/register_controllers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/crash"
 	"github.com/rook/rook/pkg/operator/ceph/file"
+	"github.com/rook/rook/pkg/operator/ceph/nfs"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	objectuser "github.com/rook/rook/pkg/operator/ceph/object/user"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
@@ -35,6 +36,7 @@ var AddToManagerFuncs = []func(manager.Manager, *clusterd.Context) error{
 	objectuser.Add,
 	object.Add,
 	file.Add,
+	nfs.Add,
 }
 
 // AddToManager adds all the registered controllers to the passed manager.

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -108,7 +108,22 @@ func WatchControllerPredicate() predicate.Funcs {
 					return true
 				}
 
+			case *cephv1.CephNFS:
+				objNew := e.ObjectNew.(*cephv1.CephNFS)
+				logger.Debug("update event from the parent object CephNFS")
+				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
+				if diff != "" ||
+					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
+					objOld.GetGeneration() != objNew.GetGeneration() {
+					// Checking if diff is not empty so we don't print it when the CR gets deleted
+					if diff != "" {
+						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					}
+					return true
+				}
+
 			}
+
 			logger.Debug("wont update unknown object")
 			return false
 		},

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -195,7 +195,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 	daemon := string(opconfig.MonType)
 	currentCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo.Name, daemon)
 	if err != nil {
-		logger.Errorf("failed to retrieve current ceph %q version. %v", daemon, err)
+		return reconcile.Result{}, errors.Wrapf(err, "failed to retrieve current ceph %q version", daemon)
 	}
 	r.clusterInfo.CephVersion = currentCephVersion
 

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -133,6 +133,12 @@ const (
 		"id":1
 	 }`
 	mdsCephAuthGetOrCreateKey = `{"key":"AQCvzWBeIV9lFRAAninzm+8XFxbSfTiPwoX50g=="}`
+	dummyVersionsRaw          = `
+	{
+		"mon": {
+			"ceph version 14.2.8 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 3
+		}
+	}`
 )
 
 var (
@@ -180,6 +186,9 @@ func TestCephObjectStoreController(t *testing.T) {
 			}
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return mdsCephAuthGetOrCreateKey, nil
+			}
+			if args[0] == "versions" {
+				return dummyVersionsRaw, nil
 			}
 			return "", nil
 		},

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -27,7 +27,7 @@ const (
 	userID = "admin"
 )
 
-func getNFSNodeID(n cephv1.CephNFS, name string) string {
+func getNFSNodeID(n *cephv1.CephNFS, name string) string {
 	return fmt.Sprintf("%s.%s", n.Name, name)
 }
 
@@ -35,7 +35,7 @@ func getGaneshaConfigObject(nodeID string) string {
 	return fmt.Sprintf("conf-%s", nodeID)
 }
 
-func getRadosURL(n cephv1.CephNFS, nodeID string) string {
+func getRadosURL(n *cephv1.CephNFS, nodeID string) string {
 	url := fmt.Sprintf("rados://%s/", n.Spec.RADOS.Pool)
 
 	if n.Spec.RADOS.Namespace != "" {
@@ -46,7 +46,7 @@ func getRadosURL(n cephv1.CephNFS, nodeID string) string {
 	return url
 }
 
-func getGaneshaConfig(n cephv1.CephNFS, name string) string {
+func getGaneshaConfig(n *cephv1.CephNFS, name string) string {
 	nodeID := getNFSNodeID(n, name)
 	url := getRadosURL(n, nodeID)
 	return `

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package nfs to manage a rook ceph nfs
+package nfs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	name             = "my-nfs"
+	namespace        = "rook-ceph"
+	dummyVersionsRaw = `
+	{
+		"mon": {
+			"ceph version 14.2.8 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 3
+		}
+	}`
+	poolDetails = `{
+		"pool": "foo",
+		"pool_id": 1,
+		"size": 3,
+		"min_size": 2,
+		"pg_num": 8,
+		"pgp_num": 8,
+		"crush_rule": "replicated_rule",
+		"hashpspool": true,
+		"nodelete": false,
+		"nopgchange": false,
+		"nosizechange": false,
+		"write_fadvise_dontneed": false,
+		"noscrub": false,
+		"nodeep-scrub": false,
+		"use_gmt_hitset": true,
+		"fast_read": 0,
+		"pg_autoscale_mode": "on"
+	  }`
+)
+
+func TestCephNFSController(t *testing.T) {
+	// Set DEBUG logging
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	//
+	// TEST 1 SETUP
+	//
+	// FAILURE because no CephCluster
+	//
+	// A Pool resource with metadata and spec.
+	cephNFS := &cephv1.CephNFS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.NFSGaneshaSpec{
+			RADOS: cephv1.GaneshaRADOSSpec{
+				Pool:      "foo",
+				Namespace: namespace,
+			},
+			Server: cephv1.GaneshaServerSpec{
+				Active: 1,
+			},
+		},
+		TypeMeta: controllerTypeMeta,
+	}
+	cephCluster := &cephv1.CephCluster{}
+
+	// Objects to track in the fake client.
+	object := []runtime.Object{
+		cephNFS,
+	}
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			if args[0] == "status" {
+				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
+			}
+			if args[0] == "versions" {
+				return dummyVersionsRaw, nil
+			}
+			if args[0] == "osd" && args[1] == "pool" && args[2] == "get" {
+				return poolDetails, nil
+			}
+			return "", errors.New("unknown command")
+		},
+		MockExecuteCommand: func(command string, args ...string) error {
+			if command == "rados" {
+				logger.Infof("mock execute. %s. %s", command, args)
+				assert.Equal(t, "stat", args[6])
+				return nil
+			}
+			return errors.New("unknown command")
+		},
+		MockExecuteCommandWithEnv: func(env []string, command string, args ...string) error {
+			if command == "ganesha-rados-grace" {
+				logger.Infof("mock execute. %s. %s", command, args)
+				assert.Equal(t, "add", args[4])
+				assert.Len(t, env, 1)
+				return nil
+			}
+			return errors.New("unknown command")
+		},
+	}
+	clientset := test.New(t, 3)
+	c := &clusterd.Context{
+		Executor:      executor,
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     clientset,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephNFS{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileCephNFS object with the scheme and fake client.
+	r := &ReconcileCephNFS{client: cl, scheme: s, context: c}
+
+	// Mock request to simulate Reconcile() being called on an event for a
+	// watched resource .
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	logger.Info("STARTING PHASE 1")
+	res, err := r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 1 DONE")
+
+	//
+	// TEST 2:
+	//
+	// FAILURE we have a cluster but it's not ready
+	//
+	cephCluster = &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namespace,
+			Namespace: namespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: "",
+		},
+	}
+	object = append(object, cephCluster)
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+	// Create a ReconcileCephNFS object with the scheme and fake client.
+	r = &ReconcileCephNFS{client: cl, scheme: s, context: c}
+	logger.Info("STARTING PHASE 2")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.True(t, res.Requeue)
+	logger.Info("PHASE 2 DONE")
+
+	//
+	// TEST 3:
+	//
+	// SUCCESS! The CephCluster is ready
+	//
+
+	// Mock clusterInfo
+	secrets := map[string][]byte{
+		"cluster-name": []byte("foo-cluster"),
+		"fsid":         []byte(name),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: namespace,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+	_, err = c.Clientset.CoreV1().Secrets(namespace).Create(secret)
+	assert.NoError(t, err)
+
+	// Add ready status to the CephCluster
+	cephCluster.Status.Phase = k8sutil.ReadyStatus
+
+	// Create a fake client to mock API calls.
+	cl = fake.NewFakeClientWithScheme(s, object...)
+
+	// Create a ReconcileCephNFS object with the scheme and fake client.
+	r = &ReconcileCephNFS{client: cl, scheme: s, context: c}
+
+	logger.Info("STARTING PHASE 3")
+	res, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue)
+	err = r.client.Get(context.TODO(), req.NamespacedName, cephNFS)
+	assert.NoError(t, err)
+	assert.Equal(t, "Ready", cephNFS.Status.Phase, cephNFS)
+	logger.Info("PHASE 3 DONE")
+}

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -18,10 +18,7 @@ limitations under the License.
 package nfs
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
-	"strings"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
@@ -36,6 +33,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -51,25 +49,18 @@ type daemonConfig struct {
 }
 
 // Create the ganesha server
-func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
-	if err := validateGanesha(c.context, n); err != nil {
-		return err
-	}
-
-	logger.Infof("Starting cephNFS %s(%d-%d)", n.Name, oldActive,
-		n.Spec.Server.Active-1)
-
+func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS, oldActive int) error {
 	for i := oldActive; i < n.Spec.Server.Active; i++ {
 		id := k8sutil.IndexToName(i)
 
-		configName, err := c.generateConfig(n, id)
+		configName, err := r.createConfigMap(n, id)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create config")
+			return errors.Wrap(err, "failed to create config")
 		}
 
-		err = c.addRADOSConfigFile(n, id)
+		err = r.addRADOSConfigFile(n, id)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create RADOS config object")
+			return errors.Wrap(err, "failed to create RADOS config object")
 		}
 
 		cfg := daemonConfig{
@@ -83,7 +74,13 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 		}
 
 		// create the deployment
-		deployment := c.makeDeployment(n, cfg)
+		deployment := r.makeDeployment(n, cfg)
+
+		// Set owner ref to cephNFS object
+		err = controllerutil.SetControllerReference(n, deployment, r.scheme)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set owner reference for ceph nfs %q secret", deployment.Name)
+		}
 
 		// Set the deployment hash as an annotation
 		err = patch.DefaultAnnotator.SetLastAppliedAnnotation(deployment)
@@ -92,130 +89,164 @@ func (c *CephNFSController) upCephNFS(n cephv1.CephNFS, oldActive int) error {
 		}
 
 		// start the deployment
-		_, err = c.context.Clientset.AppsV1().Deployments(n.Namespace).Create(deployment)
+		_, err = r.context.Clientset.AppsV1().Deployments(n.Namespace).Create(deployment)
 		if err != nil {
 			if !kerrors.IsAlreadyExists(err) {
-				return errors.Wrapf(err, "failed to create ganesha deployment")
+				return errors.Wrap(err, "failed to create ceph nfs deployment")
 			}
-			logger.Infof("ganesha deployment %s already exists. updating if needed", deployment.Name)
-			if err := updateDeploymentAndWait(c.context, deployment, n.Namespace, "nfs", id, c.clusterSpec.SkipUpgradeChecks, false); err != nil {
-				return errors.Wrapf(err, "failed to update ganesha deployment %q", deployment.Name)
+			logger.Infof("ceph nfs deployment %q already exists. updating if needed", deployment.Name)
+			if err := updateDeploymentAndWait(r.context, deployment, n.Namespace, "nfs", id, r.cephClusterSpec.SkipUpgradeChecks, false); err != nil {
+				return errors.Wrapf(err, "failed to update ceph nfs deployment %q", deployment.Name)
 			}
 		} else {
-			logger.Infof("ganesha deployment %s started", deployment.Name)
+			logger.Infof("ceph nfs deployment %q started", deployment.Name)
 		}
 
 		// create a service
-		err = c.createCephNFSService(n, cfg)
+		err = r.createCephNFSService(n, cfg)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create ganesha service")
+			return errors.Wrap(err, "failed to create ceph nfs service")
 		}
 
-		c.addServerToDatabase(n, id)
+		// Add server to database
+		err = r.addServerToDatabase(n, id)
+		if err != nil {
+			return errors.Wrapf(err, "failed to add server %q to database", id)
+		}
 	}
 
 	return nil
 }
 
 // Create empty config file for new ganesha server
-func (c *CephNFSController) addRADOSConfigFile(n cephv1.CephNFS, name string) error {
+func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS, name string) error {
 	nodeID := getNFSNodeID(n, name)
 	config := getGaneshaConfigObject(nodeID)
 	cmd := "rados"
 	args := []string{
 		"--pool", n.Spec.RADOS.Pool,
 		"--namespace", n.Spec.RADOS.Namespace,
-		"--conf", cephclient.CephConfFilePath(c.context.ConfigDir, c.namespace),
+		"--conf", cephclient.CephConfFilePath(r.context.ConfigDir, n.Namespace),
 	}
-	err := c.context.Executor.ExecuteCommand(cmd, append(args, "stat", config)...)
+	err := r.context.Executor.ExecuteCommand(cmd, append(args, "stat", config)...)
 	if err == nil {
 		// If stat works then we assume it's present already
 		return nil
 	}
+
 	// try to create it
-	return c.context.Executor.ExecuteCommand(cmd, append(args, "create", config)...)
+	return r.context.Executor.ExecuteCommand(cmd, append(args, "create", config)...)
 }
 
-func (c *CephNFSController) addServerToDatabase(nfs cephv1.CephNFS, name string) {
-	logger.Infof("Adding ganesha %s to grace db", name)
+func (r *ReconcileCephNFS) addServerToDatabase(nfs *cephv1.CephNFS, name string) error {
+	logger.Infof("adding ganesha %q to grace db", name)
 
-	if err := c.runGaneshaRadosGrace(nfs, name, "add"); err != nil {
-		logger.Errorf("failed to add %q to grace db. %v", name, err)
+	if err := r.runGaneshaRadosGrace(nfs, name, "add"); err != nil {
+		return errors.Wrapf(err, "failed to add %q to grace db", name)
 	}
+
+	return nil
 }
 
-func (c *CephNFSController) removeServerFromDatabase(nfs cephv1.CephNFS, name string) {
-	logger.Infof("Removing ganesha %q from grace db", name)
+func (r *ReconcileCephNFS) removeServerFromDatabase(nfs *cephv1.CephNFS, name string) {
+	logger.Infof("removing ganesha %q from grace db", name)
 
-	if err := c.runGaneshaRadosGrace(nfs, name, "remove"); err != nil {
+	if err := r.runGaneshaRadosGrace(nfs, name, "remove"); err != nil {
 		logger.Errorf("failed to remove %q from grace db. %v", name, err)
 	}
 }
 
-func (c *CephNFSController) runGaneshaRadosGrace(nfs cephv1.CephNFS, name, action string) error {
+func (r *ReconcileCephNFS) runGaneshaRadosGrace(nfs *cephv1.CephNFS, name, action string) error {
 	nodeID := getNFSNodeID(nfs, name)
 	cmd := ganeshaRadosGraceCmd
 	args := []string{"--pool", nfs.Spec.RADOS.Pool, "--ns", nfs.Spec.RADOS.Namespace, action, nodeID}
-	moniker := ganeshaRadosGraceCmd + " " + action + " " + nodeID
-	// Need to run a command with CEPH_CONF env var set, so don't use c.context.Executor
-	x := exec.Command(cmd, args...)
-	x.Env = []string{fmt.Sprintf("CEPH_CONF=%s", cephclient.CephConfFilePath(c.context.ConfigDir, c.namespace))}
-	var b bytes.Buffer
-	x.Stdout = &b
-	x.Stderr = &b
-	logger.Infof("Running command: %s %s %s", x.Env[0], cmd, strings.Join(args, " "))
-	if err := x.Run(); err != nil {
-		return errors.Wrapf(err, `failed to execute %q
-stdout: %s
-stderr: %s`, moniker, x.Stdout, x.Stderr)
-	}
-	return nil
-	// The below can be used when/if `ganesha-rados-grace` supports a `--cephconf` or similar option
-	// return c.context.Executor.ExecuteCommand(cmd, args...)
+	env := []string{fmt.Sprintf("CEPH_CONF=%s", cephclient.CephConfFilePath(r.context.ConfigDir, nfs.Namespace))}
+
+	return r.context.Executor.ExecuteCommandWithEnv(env, cmd, args...)
 }
 
-func (c *CephNFSController) generateConfig(n cephv1.CephNFS, name string) (string, error) {
+func (r *ReconcileCephNFS) generateConfigMap(n *cephv1.CephNFS, name string) *v1.ConfigMap {
 
 	data := map[string]string{
 		"config": getGaneshaConfig(n, name),
 	}
 	configMap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s-%s", appName, n.Name, name),
+			Name:      fmt.Sprintf("%s-%s-%s", AppName, n.Name, name),
 			Namespace: n.Namespace,
 			Labels:    getLabels(n, name),
 		},
 		Data: data,
 	}
-	if _, err := c.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Create(configMap); err != nil {
-		if kerrors.IsAlreadyExists(err) {
-			if _, err := c.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Update(configMap); err != nil {
-				return "", errors.Wrapf(err, "failed to update ganesha config")
-			}
-			return configMap.Name, nil
-		}
-		return "", errors.Wrapf(err, "failed to create ganesha config")
+
+	return configMap
+}
+
+func (r *ReconcileCephNFS) createConfigMap(n *cephv1.CephNFS, name string) (string, error) {
+	// Generate configMap
+	configMap := r.generateConfigMap(n, name)
+
+	// Set owner reference
+	err := controllerutil.SetControllerReference(n, configMap, r.scheme)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to set owner reference for ceph nfs %q config map", configMap.Name)
 	}
+
+	if _, err := r.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Create(configMap); err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			return "", errors.Wrapf(err, "failed to create ganesha config map")
+		}
+
+		logger.Debugf("updating config map %q that already exists", configMap.Name)
+		if _, err = r.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Update(configMap); err != nil {
+			return "", errors.Wrapf(err, "failed to update ganesha config map")
+		}
+	}
+
 	return configMap.Name, nil
 }
 
-// Delete the ganesha server
-func (c *CephNFSController) downCephNFS(n cephv1.CephNFS, newActive int) error {
-	for i := n.Spec.Server.Active - 1; i >= newActive; i-- {
-		name := k8sutil.IndexToName(i)
+// Down scale the ganesha server
+func (r *ReconcileCephNFS) downCephNFS(n *cephv1.CephNFS, nfsServerListNum int) error {
+	diffCount := nfsServerListNum - n.Spec.Server.Active
+	for i := 0; i < diffCount; {
+		depIDToRemove := nfsServerListNum - 1
+
+		name := k8sutil.IndexToName(depIDToRemove)
+		depNameToRemove := instanceName(n, name)
+
+		// Remove deployment
+		logger.Infof("removing deployment %q", depNameToRemove)
+		err := r.context.Clientset.AppsV1().Deployments(n.Namespace).Delete(depNameToRemove, &metav1.DeleteOptions{})
+		if err != nil {
+			if !kerrors.IsAlreadyExists(err) {
+				return errors.Wrap(err, "failed to delete ceph nfs deployment")
+			}
+		}
 
 		// Remove from grace db
-		c.removeServerFromDatabase(n, name)
+		r.removeServerFromDatabase(n, name)
+
+		nfsServerListNum = nfsServerListNum - 1
+		i++
 	}
 
 	return nil
 }
 
-func instanceName(n cephv1.CephNFS, name string) string {
-	return fmt.Sprintf("%s-%s-%s", appName, n.Name, name)
+func (r *ReconcileCephNFS) removeServersFromDatabase(n *cephv1.CephNFS, newActive int) error {
+	for i := n.Spec.Server.Active - 1; i >= newActive; i-- {
+		name := k8sutil.IndexToName(i)
+		r.removeServerFromDatabase(n, name)
+	}
+
+	return nil
+}
+func instanceName(n *cephv1.CephNFS, name string) string {
+	return fmt.Sprintf("%s-%s-%s", AppName, n.Name, name)
 }
 
-func validateGanesha(context *clusterd.Context, n cephv1.CephNFS) error {
+func validateGanesha(context *clusterd.Context, n *cephv1.CephNFS) error {
 	// core properties
 	if n.Name == "" {
 		return errors.New("missing name")
@@ -241,7 +272,7 @@ func validateGanesha(context *clusterd.Context, n cephv1.CephNFS) error {
 	// The existence of the pool provided in n.Spec.RADOS.Pool is necessary otherwise addRADOSConfigFile() will fail
 	_, err := client.GetPoolDetails(context, n.Namespace, n.Spec.RADOS.Pool)
 	if err != nil {
-		return errors.Wrapf(err, "pool %s not found, did the filesystem cr successfully complete?", n.Spec.RADOS.Pool)
+		return errors.Wrapf(err, "pool %q not found, did the filesystem cr successfully complete?", n.Spec.RADOS.Pool)
 	}
 
 	return nil

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -195,7 +195,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	daemon := string(opconfig.MonType)
 	currentCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo.Name, daemon)
 	if err != nil {
-		logger.Errorf("failed to retrieve current ceph %q version. %v", daemon, err)
+		return reconcile.Result{}, errors.Wrapf(err, "failed to retrieve current ceph %q version", daemon)
 	}
 	r.clusterInfo.CephVersion = currentCephVersion
 

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -131,6 +131,12 @@ const (
 		"realm_id": ""
 	}`
 	rgwCephAuthGetOrCreateKey = `{"key":"AQCvzWBeIV9lFRAAninzm+8XFxbSfTiPwoX50g=="}`
+	dummyVersionsRaw          = `
+	{
+		"mon": {
+			"ceph version 14.2.8 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 3
+		}
+	}`
 )
 
 var (
@@ -172,6 +178,9 @@ func TestCephObjectStoreController(t *testing.T) {
 			}
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return rgwCephAuthGetOrCreateKey, nil
+			}
+			if args[0] == "versions" {
+				return dummyVersionsRaw, nil
 			}
 			return "", nil
 		},

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package test
 
 import (
@@ -20,9 +21,10 @@ import (
 	"time"
 )
 
-// ******************** MockExecutor ********************
+// MockExecutor mocks all the exec commands
 type MockExecutor struct {
 	MockExecuteCommand                      func(command string, arg ...string) error
+	MockExecuteCommandWithEnv               func(env []string, command string, arg ...string) error
 	MockStartExecuteCommand                 func(command string, arg ...string) (*exec.Cmd, error)
 	MockExecuteCommandWithOutput            func(command string, arg ...string) (string, error)
 	MockExecuteCommandWithCombinedOutput    func(command string, arg ...string) (string, error)
@@ -31,6 +33,7 @@ type MockExecutor struct {
 	MockExecuteCommandWithTimeout           func(timeout time.Duration, command string, arg ...string) (string, error)
 }
 
+// ExecuteCommand mocks ExecuteCommand
 func (e *MockExecutor) ExecuteCommand(command string, arg ...string) error {
 	if e.MockExecuteCommand != nil {
 		return e.MockExecuteCommand(command, arg...)
@@ -39,6 +42,16 @@ func (e *MockExecutor) ExecuteCommand(command string, arg ...string) error {
 	return nil
 }
 
+// ExecuteCommandWithEnv mocks ExecuteCommandWithEnv
+func (e *MockExecutor) ExecuteCommandWithEnv(env []string, command string, arg ...string) error {
+	if e.MockExecuteCommandWithEnv != nil {
+		return e.MockExecuteCommandWithEnv(env, command, arg...)
+	}
+
+	return nil
+}
+
+// ExecuteCommandWithOutput mocks ExecuteCommandWithOutput
 func (e *MockExecutor) ExecuteCommandWithOutput(command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutput != nil {
 		return e.MockExecuteCommandWithOutput(command, arg...)
@@ -47,6 +60,7 @@ func (e *MockExecutor) ExecuteCommandWithOutput(command string, arg ...string) (
 	return "", nil
 }
 
+// ExecuteCommandWithTimeout mocks ExecuteCommandWithTimeout
 func (e *MockExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error) {
 
 	if e.MockExecuteCommandWithTimeout != nil {
@@ -56,6 +70,7 @@ func (e *MockExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command 
 	return "", nil
 }
 
+// ExecuteCommandWithCombinedOutput mocks ExecuteCommandWithCombinedOutput
 func (e *MockExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithCombinedOutput != nil {
 		return e.MockExecuteCommandWithCombinedOutput(command, arg...)
@@ -64,6 +79,7 @@ func (e *MockExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...s
 	return "", nil
 }
 
+// ExecuteCommandWithOutputFile mocks ExecuteCommandWithOutputFile
 func (e *MockExecutor) ExecuteCommandWithOutputFile(command, outfileArg string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutputFile != nil {
 		return e.MockExecuteCommandWithOutputFile(command, outfileArg, arg...)
@@ -72,6 +88,7 @@ func (e *MockExecutor) ExecuteCommandWithOutputFile(command, outfileArg string, 
 	return "", nil
 }
 
+// ExecuteCommandWithOutputFileTimeout mocks ExecuteCommandWithOutputFileTimeout
 func (e *MockExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duration, command, outfileArg string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutputFileTimeout != nil {
 		return e.MockExecuteCommandWithOutputFileTimeout(timeout, command, outfileArg, arg...)

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package exec
 
 import (
@@ -35,6 +36,12 @@ type TranslateCommandExecutor struct {
 func (e *TranslateCommandExecutor) ExecuteCommand(command string, arg ...string) error {
 	transCommand, transArgs := e.Translator(command, arg...)
 	return e.Executor.ExecuteCommand(transCommand, transArgs...)
+}
+
+// ExecuteCommandWithEnv starts a process with an env variable and wait for its completion
+func (e *TranslateCommandExecutor) ExecuteCommandWithEnv(env []string, command string, arg ...string) error {
+	transCommand, transArgs := e.Translator(command, arg...)
+	return e.Executor.ExecuteCommandWithEnv(env, transCommand, transArgs...)
 }
 
 // ExecuteCommandWithOutput starts a process and wait for its completion


### PR DESCRIPTION
**Description of your changes:**

The CRD watcher has been replaced by the new controller-runtime
framework.
This brings robustness in our operator, meaning that any resources that
are modified will be reconciled into the desired state.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4941

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]
