### PR TITLE
ceph: mention helm upgrade path for csi driver

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -63,6 +63,8 @@ need these features now, you can skip this step for the patch upgrade.
 
 ## Enabling the CSI v2.0 driver
 
+> If you are deploying the rook-operator with the helm chart you only need to specify the related images in your values.yaml. The RBAC settings will be created for you by the chart.
+
 To enable the CSI v2.0 driver, you will need to apply updated RBAC settings:
 
 ```sh


### PR DESCRIPTION
Signed-off-by: Paul <paulcatinean@gmail.com>

Update documentation to mention helm chart upgrade path for csi driver. 

**Which issue is resolved by this Pull Request:**

Prevents the user from manually applying the RBAC roles when the helm chart does it for him also notifies him where to set the images for CSI in the helm chart.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
Update documentation to mention helm chart upgrade path for csi driver. 

**Which issue is resolved by this Pull Request:**

Prevents the user from manually applying the RBAC roles when the helm chart does it for him also notifies him where to set the images for CSI in the helm chart.

[skip ci]