### PR TITLE
Allow creation of object store with pre-existing pools

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -236,25 +236,26 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		return r.setFailedStatus(cephObjectStore, "failed to reconcile service", err)
 	}
 
-	// RECONCILE POOLS
-	logger.Debug("reconciling object store pools")
 	objContext := NewContext(r.context, cephObjectStore.Name, cephObjectStore.Namespace)
+
+	// RECONCILE POOLS
+	logger.Info("reconciling object store pools")
 	metadataPoolToModel := *cephObjectStore.Spec.MetadataPool.ToModel("")
 	dataPoolToModel := *cephObjectStore.Spec.DataPool.ToModel("")
-	err = createPools(objContext, metadataPoolToModel, dataPoolToModel)
+	err = createPools(objContext, cephObjectStore.Spec, metadataPoolToModel, dataPoolToModel)
 	if err != nil {
 		return r.setFailedStatus(cephObjectStore, "failed to create object pools", err)
 	}
 
 	// RECONCILE REALM
-	logger.Debug("reconciling object store realms")
+	logger.Info("reconciling object store realms")
 	err = reconcileRealm(objContext, serviceIP, cephObjectStore.Spec.Gateway.Port)
 	if err != nil {
 		return r.setFailedStatus(cephObjectStore, "failed to create object store realm", err)
 	}
 
 	// CREATE/UPDATE
-	logger.Debug("reconciling object store deployments")
+	logger.Info("reconciling object store deployments")
 	reconcileResponse, err = r.reconcileCreateObjectStore(cephObjectStore)
 	if err != nil {
 		return r.setFailedStatus(cephObjectStore, "failed to create object store deployments", err)
@@ -270,7 +271,6 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	// Return and do not requeue
 	logger.Debug("done reconciling")
 	return reconcile.Result{}, nil
-
 }
 
 func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *cephv1.CephObjectStore) (reconcile.Result, error) {

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -140,3 +140,16 @@ func TestGenerateSecretName(t *testing.T) {
 	secret := c.generateSecretName("a")
 	assert.Equal(t, "rook-ceph-rgw-default-a-keyring", secret)
 }
+
+func TestEmptyPoolSpec(t *testing.T) {
+	assert.True(t, emptyPool(cephv1.PoolSpec{}))
+
+	p := cephv1.PoolSpec{FailureDomain: "foo"}
+	assert.False(t, emptyPool(p))
+
+	p = cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1}}
+	assert.False(t, emptyPool(p))
+
+	p = cephv1.PoolSpec{ErasureCoded: cephv1.ErasureCodedSpec{CodingChunks: 1}}
+	assert.False(t, emptyPool(p))
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The object store pools may already be created by the mgr module before creating the object CR. If the pool specs are not specified in the object CR, skip pool creation and deletion for the object store. 

If the pools are not specified, the operator will verify that they exist before continuing.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]