### PR TITLE
Remove crashcollector pod automatically when the node is deleted.

### DIFF
--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -86,6 +86,22 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: request.Name}}
 	err := r.client.Get(context.TODO(), request.NamespacedName, node)
 	if err != nil {
+		//if a node is not present, check if there are any crashcollector deployment for that node and delete it.
+		deploymentList := &appsv1.DeploymentList{}
+		namespaceListOpts := client.InNamespace(request.Namespace)
+		err := r.client.List(context.TODO(), deploymentList, client.MatchingLabels{k8sutil.AppAttr: AppName, NodeNameLabel: request.Name}, namespaceListOpts)
+		if err != nil {
+			logger.Errorf("failed to list crash collector deployments, delete it/them manually. %v", err)
+		}
+		for _, d := range deploymentList.Items {
+			logger.Infof("deleting deployment %q for deleted node %q", d.ObjectMeta.Name, request.Name)
+			err := r.deleteCrashCollector(d)
+			if err != nil {
+				logger.Errorf("failed to delete crash collector deployment %q, delete it manually. %v", d.Name, err)
+				continue
+			}
+			logger.Infof("crash collector deployment %q successfully removed", d.Name)
+		}
 		return reconcile.Result{}, errors.Errorf("could not get node %q", request.NamespacedName)
 	}
 


### PR DESCRIPTION
The CrashCollector pod remains in pending state indefinitely after
running on a k8s node that was deleted. The code now deletes the
deployment after the node is deleted.

Signed-off-by: rohan47 <rohgupta@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When a node is deleted, the crash controller reconciles and if a node is not found, the code checks for deployments with label selector for the node and deletes the crashcollector deployment if present

**Which issue is resolved by this Pull Request:**
Resolves #5000 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
