### PR TITLE
ceph: avoid duplication of mon anti-affinity

### DIFF
--- a/pkg/apis/rook.io/v1alpha2/placement.go
+++ b/pkg/apis/rook.io/v1alpha2/placement.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (p PlacementSpec) All() Placement {
@@ -29,13 +29,13 @@ func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
 		t.Affinity = &v1.Affinity{}
 	}
 	if p.NodeAffinity != nil {
-		t.Affinity.NodeAffinity = p.NodeAffinity
+		t.Affinity.NodeAffinity = p.NodeAffinity.DeepCopy()
 	}
 	if p.PodAffinity != nil {
-		t.Affinity.PodAffinity = p.PodAffinity
+		t.Affinity.PodAffinity = p.PodAffinity.DeepCopy()
 	}
 	if p.PodAntiAffinity != nil {
-		t.Affinity.PodAntiAffinity = p.PodAntiAffinity
+		t.Affinity.PodAntiAffinity = p.PodAntiAffinity.DeepCopy()
 	}
 
 	if p.Tolerations != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The default pod anti-affinity for the mons that rook adds automatically intended to be appended to any anti-affinity that is specified in the cluster CR.

There is a bug in the ApplyToPodSpec() method that has long existed. The issue is that when antiaffinity is appended, it will append not only to the pod spec, but will modify the original placement spec. Thus, each mon that is started will have one more antiaffinity clause than the previous mon.

This condition is rarely hit or noticed because it commonly is only hit in the canary pods. Since these pods are immediately deleted, there are no side effects of the duplicate affinity clauses. The place where it becomes an issue is when the mons are backed by a PVC. In this case, the mons do not have node affinity and will hit the code path that appends to the antiaffinity and thus modifies the original antiaffinity.

This PR is opened directly against release-1.2 since the cost moved to a new file in master. #5072 is for the same fix in master.

**Which issue is resolved by this Pull Request:**
Resolves #4998 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]