### PR TITLE
ceph: set pgnum of block pools to the default value

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -231,7 +231,7 @@ func givePoolAppTag(context *clusterd.Context, clusterName string, poolName stri
 }
 
 func CreateECPoolForApp(context *clusterd.Context, clusterName string, newPool CephStoragePoolDetails, appName string, enableECOverwrite bool, erasureCodedConfig model.ErasureCodedPoolConfig) error {
-	args := []string{"osd", "pool", "create", newPool.Name, strconv.Itoa(newPool.Number), "erasure", newPool.ErasureCodeProfile}
+	args := []string{"osd", "pool", "create", newPool.Name, "0", "erasure", newPool.ErasureCodeProfile}
 
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
@@ -261,7 +261,7 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, clusterName string, n
 		return err
 	}
 
-	args := []string{"osd", "pool", "create", newPool.Name, strconv.Itoa(newPool.Number), "replicated", newPool.Name}
+	args := []string{"osd", "pool", "create", newPool.Name, "0", "replicated", newPool.Name}
 
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**

Rook should always set the pgnum of the new block pool
to the default value("0"). The current implementation accidentally
works fine because newPool.Number is always 0 here.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [o] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [o] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]