### PR TITLE
CSI: Fix enable resizer for custom ceph-csi image

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -219,7 +219,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	// v1.2.x
 	attacher := strings.Split(CSIParam.AttacherImage, ":")
 	if len(attacher) > 1 {
-		if strings.HasPrefix(attacher[1], "v1.2.") {
+		if strings.HasPrefix(attacher[len(attacher)-1], "v1.2.") {
 			tp.SetAttacherLeaderElectionType = true
 		}
 	}
@@ -227,7 +227,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	csiPluginImage := strings.Split(CSIParam.CSIPluginImage, ":")
 	// as ceph-csi v2.x.x support resizer, enable it
 	if len(csiPluginImage) > 1 {
-		if strings.HasPrefix(csiPluginImage[1], "v2.") {
+		if strings.HasPrefix(csiPluginImage[len(csiPluginImage)-1], "v2.") {
 			tp.EnableResizer = true
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

If the user has specified the custom ceph-csi image name in the operator the starting of the resizer
will fail, this Fix will use the last index of the slice to check the image version is v2.x or not.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #5073

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
[test ceph]