### PR TITLE
ceph: double check for a filesystem

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -373,12 +373,12 @@ func CheckIfDeviceAvailable(executor exec.Executor, name string, pvcBacked bool)
 
 //GetPVCDeviceFileSystems returns the file system on a PVC device.
 func GetPVCDeviceFileSystems(executor exec.Executor, device string) (string, error) {
-	cmd := fmt.Sprintf("get pvc filesystem type for %q", device)
+	cmd := fmt.Sprintf("get filesystem type for %q", device)
 	output, err := executor.ExecuteCommandWithOutput(false, cmd, "lsblk", device, "--bytes", "--nodeps", "--noheadings", "--output", "FSTYPE")
 	if err != nil {
 		return "", fmt.Errorf("command %q failed. %+v", cmd, err)
 	}
-	logger.Debugf("filesystem on pvc device %q is %q", device, output)
+	logger.Debugf("filesystem on device %q is %q", device, output)
 
 	return output, nil
 }


### PR DESCRIPTION
**Description of your changes:**

It appears that udev does not report `ID_FS_TYPE` sometimes so let's try
again with lsblk before not skipping the device.

Closes: https://github.com/rook/rook/issues/5022
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5022

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]