### PR TITLE
ceph: reject small devices

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -34,8 +34,13 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/display"
 	"github.com/rook/rook/pkg/util/sys"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	fiveGiBInBytes uint64 = 5 * 1024 * 1024 * 1024 // this is 5GiB in Bytes
 )
 
 var (
@@ -338,6 +343,12 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 		// If the disk/partition has a filesystem
 		if device.Filesystem != "" {
 			logger.Infof("skipping device %q because it contains a filesystem %q", device.Name, device.Filesystem)
+			continue
+		}
+
+		// If the disk/partition is smaller than 5GiB
+		if device.Size < fiveGiBInBytes {
+			logger.Infof("skipping device %q because it is smaller than 5GiB, actual size is %q", device.Name, display.BytesToString(device.Size))
 			continue
 		}
 

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -170,7 +170,7 @@ func TestAvailableDevices(t *testing.T) {
 		if command == "lsblk" {
 			if strings.Index(name, "sdb") != -1 {
 				// /dev/sdb has a partition
-				return `NAME="sdb" SIZE="65" TYPE="disk" PKNAME=""
+				return `NAME="sdb" SIZE="510825332736" TYPE="disk" PKNAME=""
 NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 			}
 			return "", nil
@@ -192,14 +192,15 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 
 	context := &clusterd.Context{Executor: executor}
 	context.Devices = []*sys.LocalDisk{
-		{Name: "sda", DevLinks: "/dev/disk/by-id/scsi-0123 /dev/disk/by-path/pci-0:1:2:3-scsi-1"},
-		{Name: "sdb", DevLinks: "/dev/disk/by-id/scsi-4567 /dev/disk/by-path/pci-4:5:6:7-scsi-1"},
-		{Name: "sdc", DevLinks: "/dev/disk/by-id/scsi-89ab /dev/disk/by-path/pci-8:9:a:b-scsi-1"},
-		{Name: "sdd", DevLinks: "/dev/disk/by-id/scsi-cdef /dev/disk/by-path/pci-c:d:e:f-scsi-1"},
-		{Name: "nvme01", DevLinks: "/dev/disk/by-id/nvme-0246 /dev/disk/by-path/pci-0:2:4:6-nvme-1"},
-		{Name: "rda"},
-		{Name: "rdb"},
-		{Name: "sdt1", Type: sys.PartType},
+		{Name: "sda", DevLinks: "/dev/disk/by-id/scsi-0123 /dev/disk/by-path/pci-0:1:2:3-scsi-1", Size: 510825332736},
+		{Name: "sdb", DevLinks: "/dev/disk/by-id/scsi-4567 /dev/disk/by-path/pci-4:5:6:7-scsi-1", Size: 510825332736},
+		{Name: "sdc", DevLinks: "/dev/disk/by-id/scsi-89ab /dev/disk/by-path/pci-8:9:a:b-scsi-1", Size: 510825332736},
+		{Name: "sdd", DevLinks: "/dev/disk/by-id/scsi-cdef /dev/disk/by-path/pci-c:d:e:f-scsi-1", Size: 510825332736},
+		{Name: "nvme01", DevLinks: "/dev/disk/by-id/nvme-0246 /dev/disk/by-path/pci-0:2:4:6-nvme-1", Size: 510825332736},
+		{Name: "rda", Size: 510825332736},
+		{Name: "rdb", Size: 510825332736},
+		{Name: "sdt1", Type: sys.PartType, Size: 510825332736},
+		{Name: "sdz1", Type: sys.PartType, Size: 209715200},
 	}
 
 	version := cephver.Octopus


### PR DESCRIPTION
**Description of your changes:**

disk/partition smaller than 5GiB will be skipped and not used for OSD.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]