### PR TITLE
Set pg_num for rgw metadata pools to lower default

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -42,6 +42,8 @@ const (
 	CrushTool             = "crushtool"
 	CmdExecuteTimeout     = 1 * time.Minute
 	cephConnectionTimeout = "15" // in seconds
+	// DefaultPGCount will cause Ceph to use the internal default PG count
+	DefaultPGCount = "0"
 )
 
 // CephConfFilePath returns the location to the cluster's config file in the operator container.

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -61,7 +61,7 @@ func TestCreateECPoolWithOverwrites(t *testing.T) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, "myns", poolName, "mypoolprofile", p, "myapp", true)
+	err := CreateECPoolForApp(context, "myns", poolName, "mypoolprofile", p, DefaultPGCount, "myapp", true)
 	assert.Nil(t, err)
 }
 
@@ -97,7 +97,7 @@ func TestCreateECPoolWithoutOverwrites(t *testing.T) {
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, "myns", poolName, "mypoolprofile", p, "myapp", false)
+	err := CreateECPoolForApp(context, "myns", poolName, "mypoolprofile", p, DefaultPGCount, "myapp", false)
 	assert.Nil(t, err)
 }
 
@@ -166,7 +166,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass s
 		FailureDomain: failureDomain, CrushRoot: crushRoot, DeviceClass: deviceClass,
 		Replicated: cephv1.ReplicatedSpec{Size: 12345},
 	}
-	err := CreateReplicatedPoolForApp(context, "myns", "mypool", p, "myapp")
+	err := CreateReplicatedPoolForApp(context, "myns", "mypool", p, DefaultPGCount, "myapp")
 	assert.Nil(t, err)
 	assert.True(t, crushRuleCreated)
 }

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -62,6 +62,18 @@ func (m *MonStore) Set(who, option, value string) error {
 	return nil
 }
 
+// Get retrieves a config in the centralized mon configuration database.
+// https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
+func (m *MonStore) Get(who, option string) (string, error) {
+	args := []string{"config", "get", who, normalizeKey(option)}
+	cephCmd := client.NewCephCommand(m.context, m.namespace, args)
+	out, err := cephCmd.Run()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option, who)
+	}
+	return string(out), nil
+}
+
 // SetAll sets all configs from the overrides in the centralized mon configuration database.
 // See MonStore.Set for more.
 func (m *MonStore) SetAll(options ...Option) error {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The PG count on metadata pools should default to rgw_rados_pool_pg_num_min instead of the more general default pg count. This means rgw pools will default to 8 PGs instead of 32 PGs, which means a lot more pools can be created before hitting the default PG limit.
 
**Which issue is resolved by this Pull Request:**
Resolves #5091

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]