### PR TITLE
ceph: check LV availability by "ceph-volume lvm list"

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -19,6 +19,7 @@ package clusterd
 import (
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strconv"
 
@@ -144,10 +145,10 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 		}
 	}
 	if val, ok := diskProps["PKNAME"]; ok {
-		disk.Parent = val
+		disk.Parent = path.Base(val)
 	}
 	if val, ok := diskProps["NAME"]; ok {
-		disk.RealName = val
+		disk.RealPath = val
 	}
 
 	return disk, nil

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -177,16 +177,15 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 
 	context := &clusterd.Context{Executor: executor}
 	context.Devices = []*sys.LocalDisk{
-		{Name: "sda", DevLinks: "/dev/disk/by-id/scsi-0123 /dev/disk/by-path/pci-0:1:2:3-scsi-1", RealName: "sda"},
-		{Name: "sdb", DevLinks: "/dev/disk/by-id/scsi-4567 /dev/disk/by-path/pci-4:5:6:7-scsi-1", RealName: "sdb"},
-		{Name: "sdc", DevLinks: "/dev/disk/by-id/scsi-89ab /dev/disk/by-path/pci-8:9:a:b-scsi-1", RealName: "sdc"},
-		{Name: "sdd", DevLinks: "/dev/disk/by-id/scsi-cdef /dev/disk/by-path/pci-c:d:e:f-scsi-1", RealName: "sdd"},
-		{Name: "sde", DevLinks: "/dev/disk/by-id/sde-0x0000 /dev/disk/by-path/pci-0000:00:18.0-ata-1", RealName: "sde"},
-		{Name: "nvme01", DevLinks: "/dev/disk/by-id/nvme-0246 /dev/disk/by-path/pci-0:2:4:6-nvme-1", RealName: "nvme01"},
-		{Name: "rda", RealName: "rda"},
-		{Name: "rdb", RealName: "rdb"},
-		{Name: "/mnt/set1-0-data-qfhfk", RealName: "xvdcy", Type: "data"},
-		{Name: "sdt1", RealName: "sdt1", Type: sys.PartType},
+		{Name: "sda", DevLinks: "/dev/disk/by-id/scsi-0123 /dev/disk/by-path/pci-0:1:2:3-scsi-1", RealPath: "/dev/sda"},
+		{Name: "sdb", DevLinks: "/dev/disk/by-id/scsi-4567 /dev/disk/by-path/pci-4:5:6:7-scsi-1", RealPath: "/dev/sdb"},
+		{Name: "sdc", DevLinks: "/dev/disk/by-id/scsi-89ab /dev/disk/by-path/pci-8:9:a:b-scsi-1", RealPath: "/dev/sdc"},
+		{Name: "sdd", DevLinks: "/dev/disk/by-id/scsi-cdef /dev/disk/by-path/pci-c:d:e:f-scsi-1", RealPath: "/dev/sdd"},
+		{Name: "sde", DevLinks: "/dev/disk/by-id/sde-0x0000 /dev/disk/by-path/pci-0000:00:18.0-ata-1", RealPath: "/dev/sde"},
+		{Name: "nvme01", DevLinks: "/dev/disk/by-id/nvme-0246 /dev/disk/by-path/pci-0:2:4:6-nvme-1", RealPath: "/dev/nvme01"},
+		{Name: "rda", RealPath: "/dev/rda"},
+		{Name: "rdb", RealPath: "/dev/rdb"},
+		{Name: "sdt1", RealPath: "/dev/sdt1", Type: sys.PartType},
 	}
 
 	version := cephver.Octopus
@@ -265,6 +264,9 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 
 	// test on PVC
 	pvcBackedOSD = true
+	context.Devices = []*sys.LocalDisk{
+		{Name: "/mnt/set1-0-data-qfhfk", RealPath: "/dev/xvdcy", Type: "data"},
+	}
 	mapping, err = getAvailableDevices(context, []DesiredDevice{{Name: "all"}}, "", pvcBackedOSD, version)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(mapping.Entries), mapping)

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -104,8 +104,8 @@ type LocalDisk struct {
 	Empty bool `json:"empty"`
 	// Information provided by Ceph Volume Inventory
 	CephVolumeData string `json:"cephVolumeData,omitempty"`
-	// RealName is the device behind the PVC, behind /mnt/<pvc>/name
-	RealName string `json:"real-name,omitempty"`
+	// RealPath is the device pathname behind the PVC, behind /mnt/<pvc>/name
+	RealPath string `json:"real-path,omitempty"`
 }
 
 // ListDevices list all devices available on a machine
@@ -199,7 +199,7 @@ func GetDeviceProperties(device string, executor exec.Executor) (map[string]stri
 // GetDevicePropertiesFromPath gets a device property from a path
 func GetDevicePropertiesFromPath(devicePath string, executor exec.Executor) (map[string]string, error) {
 	output, err := executor.ExecuteCommandWithOutput("lsblk", devicePath,
-		"--bytes", "--nodeps", "--pairs", "--output", "SIZE,ROTA,RO,TYPE,PKNAME,NAME")
+		"--bytes", "--nodeps", "--pairs", "--paths", "--output", "SIZE,ROTA,RO,TYPE,PKNAME,NAME")
 	if err != nil {
 		// The "not a block device" error also returns code 32 so the ExitStatus() check hides this error
 		if strings.Contains(output, "not a block device") {
@@ -278,8 +278,8 @@ func GetDiskUUID(device string, executor exec.Executor) (string, error) {
 
 // CheckIfDeviceAvailable checks if a device is available for consumption. The caller
 // needs to decide based on the return values whether it is available.
-func CheckIfDeviceAvailable(executor exec.Executor, name string, pvcBacked bool) (bool, string, error) {
-	isAvailable, rejectedReason, err := isDeviceAvailable(executor, name)
+func CheckIfDeviceAvailable(executor exec.Executor, devicePath string, pvcBacked bool) (bool, string, error) {
+	isAvailable, rejectedReason, err := isDeviceAvailable(executor, devicePath)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to determine if the device was available. %v", err)
 	}
@@ -351,10 +351,10 @@ func parseUdevInfo(output string) map[string]string {
 	return result
 }
 
-func isDeviceAvailable(executor exec.Executor, device string) (bool, string, error) {
-	CVInventory, err := inventoryDevice(executor, device)
+func isDeviceAvailable(executor exec.Executor, devicePath string) (bool, string, error) {
+	CVInventory, err := inventoryDevice(executor, devicePath)
 	if err != nil {
-		return false, "", fmt.Errorf("failed to determine if the device %q is available. %v", device, err)
+		return false, "", fmt.Errorf("failed to determine if the device %q is available. %v", devicePath, err)
 	}
 
 	if CVInventory.Available {
@@ -364,20 +364,19 @@ func isDeviceAvailable(executor exec.Executor, device string) (bool, string, err
 	return false, string(CVInventory.RejectedReasons), nil
 }
 
-func inventoryDevice(executor exec.Executor, dev string) (CephVolumeInventory, error) {
+func inventoryDevice(executor exec.Executor, devicePath string) (CephVolumeInventory, error) {
 	var CVInventory CephVolumeInventory
-	device := path.Join("/dev", dev)
 
-	args := []string{"inventory", "--format", "json", device}
+	args := []string{"inventory", "--format", "json", devicePath}
 	inventory, err := executor.ExecuteCommandWithOutput("ceph-volume", args...)
 	if err != nil {
-		return CVInventory, fmt.Errorf("failed to execute ceph-volume inventory on disk %q. %v", err, device)
+		return CVInventory, fmt.Errorf("failed to execute ceph-volume inventory on disk %q. %v", devicePath, err)
 	}
 
 	bInventory := []byte(inventory)
 	err = json.Unmarshal(bInventory, &CVInventory)
 	if err != nil {
-		return CVInventory, fmt.Errorf("error unmarshalling json data coming from ceph-volume inventory %q. %v", err, device)
+		return CVInventory, fmt.Errorf("error unmarshalling json data coming from ceph-volume inventory %q. %v", devicePath, err)
 	}
 
 	return CVInventory, nil

--- a/tests/framework/installer/device.go
+++ b/tests/framework/installer/device.go
@@ -40,9 +40,14 @@ func IsAdditionalDeviceAvailableOnCluster() bool {
 		if props["TYPE"] != "disk" {
 			continue
 		}
+		devicePath, ok := props["NAME"]
+		if !ok {
+			logger.Warningf("failed to find device path for %q", device)
+			continue
+		}
 
 		pvcBackedOSD := false
-		isAvailable, rejectedReason, err := sys.CheckIfDeviceAvailable(executor, device, pvcBackedOSD)
+		isAvailable, rejectedReason, err := sys.CheckIfDeviceAvailable(executor, devicePath, pvcBackedOSD)
 		if err != nil {
 			logger.Warningf("failed to detect device %q availability. %v", device, err)
 			continue


### PR DESCRIPTION
**Description of your changes:**

This adds support for LVs to the device availability check in the OSD prepare pod.
The availability of an LV is checked by "ceph-volume lvm list".
If it returns non-empty result, the LV is in use and not available.

This also fixes the argument for "ceph-volume inventory".
When a device "/dev/mapper/foo" is being checked for its availability, the argument should not be "/dev/foo" nor "/dev/dm-1".

**Which issue is resolved by this Pull Request:**
Resolves #5075

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]