### PR TITLE
ceph: append device path correctly before checking

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -329,7 +329,12 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 		// If filesystem is empty, let's try again with lsblk
 		// Sometime udev does not report the filesystem...
 		if device.Filesystem == "" {
-			partFS, err := sys.GetPVCDeviceFileSystems(context.Executor, device.Name)
+			devicePath := device.Name
+			if !pvcBacked {
+				devicePath = fmt.Sprintf("/dev/%s", device.Name)
+			}
+
+			partFS, err := sys.GetPVCDeviceFileSystems(context.Executor, devicePath)
 			if err != nil {
 				logger.Warningf("failed to get lsblk filesystem info for device %q, might be missing filesystem information. %v", device.Name, err)
 			} else {


### PR DESCRIPTION
**Description of your changes:**

We need to pass /dev/sfa instead of sfa

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]