### PR TITLE
Fix RBAC and handle error to enable deleting of drain-canaries

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -24,29 +24,21 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - apps
+  - extensions
   resources:
   - secrets
   - pods
   - pods/log
   - services
   - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - apps
-  resources:
   - deployments
   - daemonsets
   verbs:
   - get
   - list
   - watch
+  - patch
   - create
   - update
   - delete
@@ -137,6 +129,7 @@ rules:
 - apiGroups:
   - policy
   - apps
+  - extensions
   resources:
   # This is for the clusterdisruption controller
   - poddisruptionbudgets

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -10,21 +10,12 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - apps
+  - extensions
   resources:
   - pods
   - configmaps
   - services
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - apps
-  resources:
   - daemonsets
   - statefulsets
   - deployment
@@ -32,6 +23,7 @@ rules:
   - get
   - list
   - watch
+  - patch
   - create
   - update
   - delete

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -645,29 +645,21 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - apps
+  - extensions
   resources:
   - secrets
   - pods
   - pods/log
   - services
   - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - apps
-  resources:
   - deployments
   - daemonsets
   verbs:
   - get
   - list
   - watch
+  - patch
   - create
   - update
   - delete
@@ -698,6 +690,7 @@ rules:
   - delete
 - apiGroups:
   - apps
+  - extensions
   resources:
   - daemonsets
   - statefulsets
@@ -796,6 +789,7 @@ rules:
 - apiGroups:
   - policy
   - apps
+  - extensions
   resources:
   # This is for the clusterdisruption controller
   - poddisruptionbudgets

--- a/pkg/operator/ceph/disruption/nodedrain/reconcile.go
+++ b/pkg/operator/ceph/disruption/nodedrain/reconcile.go
@@ -92,7 +92,9 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		// delete any canary deployments if the node doesn't exist
 		logger.Infof("deleting drain-canary deployment for deleted node %q", request.Name)
 		err = r.client.Delete(context.TODO(), deploy)
-		if err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		} else if err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "could not delete drain-canary deployment for deleted node %q", request.Name)
 		}
 		return reconcile.Result{}, nil

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -658,21 +658,12 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - apps
+  - extensions
   resources:
   - pods
   - configmaps
   - services
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - create
-  - update
-  - delete
-- apiGroups:
-  - apps
-  resources:
   - daemonsets
   - statefulsets
   - deployments
@@ -680,6 +671,7 @@ rules:
   - get
   - list
   - watch
+  - patch
   - create
   - update
   - delete
@@ -724,6 +716,7 @@ rules:
   - delete
 - apiGroups:
   - apps
+  - extensions
   resources:
   - deployments
   - daemonsets
@@ -817,6 +810,7 @@ rules:
 - apiGroups:
   - policy
   - apps
+  - extensions
   resources:
   # This is for the clusterdisruption controller
   - poddisruptionbudgets


### PR DESCRIPTION
- Some k8s clusters need RBAC permissions for both extensions and apps api groups. Added both.
- Handled a not-found error in a delete operation.


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**


[test ceph]
