### PR TITLE
Reenable flex driver in the integration tests

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1498,7 +1498,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROOK_ENABLE_FLEX_DRIVER
-          value: "false"
+          value: "true"
         - name: ROOK_CURRENT_NAMESPACE_ONLY
           value: "false"
 ---


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The flex agent was mistakenly disabled in the CSI config change for #5032. The agent must
be enabled for integration tests. The flex and smoke suites have all been failing in master since the merge earlier today. This was missed before merge because it has similar behavior as an intermittent issue with the flex driver.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]