### PR TITLE
ceph: Removed 2nd env variable ROOK_HOSTPATH_REQUIRES_PRIVILEGED

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -305,9 +305,6 @@ spec:
         - name: ROOK_ENABLE_MACHINE_DISRUPTION_BUDGET
           value: "false"
 
-        - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
-          value: "true"
-
         # Time to wait until the node controller will move Rook pods to other
         # nodes after detecting an unreachable node.
         # Pods affected by this setting are:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

It is not necessary to have 2 same environment variables and not desired as
changing only one may lead to the second variable being applied with unexpected
value. It is better to have only 1 ROOK_HOSTPATH_REQUIRES_PRIVILEGED environment
variable.

**Which issue is resolved by this Pull Request:**
Resolves #5107 

**Checklist:**

- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [X] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details. 
[skip ci] skip-ci