### PR TITLE
Fix `codegen` to find boilerplate outside of the $GOPATH

### DIFF
--- a/build/codegen/boilerplate.go.txt
+++ b/build/codegen/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -32,7 +32,10 @@ bash ${codegendir}/generate-groups.sh \
     all \
     github.com/rook/rook/pkg/client \
     github.com/rook/rook/pkg/apis \
-    "${GROUP_VERSIONS}"
+    "${GROUP_VERSIONS}" \
+    --output-base "${scriptdir}/../../vendor" \
+    --go-header-file "${scriptdir}/boilerplate.go.txt"
+cp -r "${scriptdir}/../../vendor/github.com/rook/rook/pkg/" "${scriptdir}/../../pkg/"
 
 SED="sed -i.bak"
 

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -109,9 +109,6 @@ go.check:
 ifneq ($(shell $(GO) version | grep -q -E '\bgo($(GO_SUPPORTED_VERSIONS))\b' && echo 0 || echo 1), 0)
 	$(error unsupported go version. Please make install one of the following supported version: '$(GO_SUPPORTED_VERSIONS)')
 endif
-ifneq ($(realpath ../../../..), $(realpath $(GOPATH)))
-	$(warning WARNING: the source directory is not relative to the GOPATH at $(GOPATH) or you are using symlinks. The build might run into issue. Please move the source directory to be at $(GOPATH)/src/$(GO_PROJECT))
-endif
 
 -include go.check
 endif


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This specifies `--go-header-file` option at executing `code-generator` to solve this issue(https://github.com/rook/rook/issues/5083) ~~and modifies the header of the generated codes based on `build/codegen/header.txt`.~~

Since this also specifies `--output-base` option to solve the dependencies of `$GOPATH`, we can work outside `$GOPATH` now. (`code-generator` generates files into `$GOPATH` by default.)

**Which issue is resolved by this Pull Request:**
Resolves #
- https://github.com/rook/rook/issues/5083

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
