### PR TITLE
ceph: use octopus base image

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -32,7 +32,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.3
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v14.2.5-20190917
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.3
     # Whether to allow unsupported versions of Ceph. Currently mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Octopus is the version allowed when this is set to true.
     # Do not set to true in production.

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package ceph
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/clusterd"
@@ -31,7 +33,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const containerName = "rook-ceph-operator"
+const (
+	containerName                = "rook-ceph-operator"
+	operatorCephBaseImageVersion = "ROOK_CEPH_BASE_IMAGE_VERSION"
+)
 
 var operatorCmd = &cobra.Command{
 	Use:   "operator",
@@ -79,6 +84,8 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	}
 
 	rookImage := rook.GetOperatorImage(context.Clientset, containerName)
+	rookBaseImageCephVersion := rook.GetOperatorBaseImageCephVersion(context)
+	os.Setenv(operatorCephBaseImageVersion, rookBaseImageCephVersion)
 	serviceAccountName := rook.GetOperatorServiceAccount(context.Clientset)
 	op := operator.New(context, volumeAttachment, rookImage, serviceAccountName)
 	err = op.Run()

--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -17,8 +17,6 @@ limitations under the License.
 package ceph
 
 import (
-	"os"
-
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/clusterd"
@@ -28,14 +26,14 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
 
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
 
 const (
-	containerName                = "rook-ceph-operator"
-	operatorCephBaseImageVersion = "ROOK_CEPH_BASE_IMAGE_VERSION"
+	containerName = "rook-ceph-operator"
 )
 
 var operatorCmd = &cobra.Command{
@@ -84,8 +82,13 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	}
 
 	rookImage := rook.GetOperatorImage(context.Clientset, containerName)
-	rookBaseImageCephVersion := rook.GetOperatorBaseImageCephVersion(context)
-	os.Setenv(operatorCephBaseImageVersion, rookBaseImageCephVersion)
+	rookBaseImageCephVersion, err := rook.GetOperatorBaseImageCephVersion(context)
+	if err != nil {
+		logger.Errorf("failed to get operator base image ceph version. %v", err)
+	}
+	opcontroller.OperatorCephBaseImageVersion = rookBaseImageCephVersion
+	logger.Infof("base ceph version inside the rook operator image is %q", opcontroller.OperatorCephBaseImageVersion)
+
 	serviceAccountName := rook.GetOperatorServiceAccount(context.Clientset)
 	op := operator.New(context, volumeAttachment, rookImage, serviceAccountName)
 	err = op.Run()

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	netclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	"github.com/pkg/errors"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -219,12 +220,11 @@ func TerminateFatal(reason error) {
 }
 
 // GetOperatorBaseImageCephVersion returns the Ceph version of the operator image
-func GetOperatorBaseImageCephVersion(context *clusterd.Context) string {
+func GetOperatorBaseImageCephVersion(context *clusterd.Context) (string, error) {
 	output, err := context.Executor.ExecuteCommandWithOutput("ceph", "--version")
 	if err != nil {
-		logger.Errorf("failed to discover ceph base image version. %v", err)
-		return ""
+		return "", errors.Wrapf(err, "failed to execute command to detect ceph version")
 	}
 
-	return output
+	return output, nil
 }

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -217,3 +217,14 @@ func TerminateFatal(reason error) {
 
 	os.Exit(1)
 }
+
+// GetOperatorBaseImageCephVersion returns the Ceph version of the operator image
+func GetOperatorBaseImageCephVersion(context *clusterd.Context) string {
+	output, err := context.Executor.ExecuteCommandWithOutput("ceph", "--version")
+	if err != nil {
+		logger.Errorf("failed to discover ceph base image version. %v", err)
+		return ""
+	}
+
+	return output
+}

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v14.2.9-20200506
+CEPH_VERSION = v15.2.3-20200530
 else
-CEPH_VERSION = v14.2.9-20200506
+CEPH_VERSION = v15.2.3-20200530
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -39,10 +39,15 @@ const OperatorSettingConfigMapName string = "rook-ceph-operator-config"
 var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
+
 	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
 	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+
 	// WaitForRequeueIfFinalizerBlocked waits for resources to be cleaned up before the finalizer can be removed
 	WaitForRequeueIfFinalizerBlocked = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+
+	// OperatorCephBaseImageVersion is the ceph version in the operator image
+	OperatorCephBaseImageVersion string
 )
 
 // IsReadyToReconcile determines if a controller is ready to reconcile or not

--- a/pkg/operator/ceph/object/bucket.go
+++ b/pkg/operator/ceph/object/bucket.go
@@ -22,6 +22,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+)
+
+const (
+	beforeOctopusTime            = "2006-01-02 15:04:05.999999999Z"
+	octopusAndAfterTime          = "2006-01-02T15:04:05.999999999Z"
+	operatorCephBaseImageVersion = "ROOK_CEPH_BASE_IMAGE_VERSION"
 )
 
 type ObjectBucketMetadata struct {
@@ -140,7 +148,18 @@ func getBucketMetadata(c *Context, bucket string) (*ObjectBucketMetadata, bool, 
 		return nil, false, errors.Wrapf(err, "failed to read buckets list result=%s", result)
 	}
 
-	createdAt, err := time.Parse("2006-01-02 15:04:05.999999999Z", s.Data.CreationTime)
+	timeParser := octopusAndAfterTime
+	version, err := cephver.ExtractCephVersion(opcontroller.OperatorCephBaseImageVersion)
+	if err != nil {
+		logger.Errorf("failed to extract ceph version. %v", err)
+	} else {
+		vv := *version
+		if !vv.IsAtLeastOctopus() {
+			timeParser = beforeOctopusTime
+		}
+	}
+
+	createdAt, err := time.Parse(timeParser, s.Data.CreationTime)
 	if err != nil {
 		return nil, false, errors.Wrapf(err, "Error parsing date (%s)", s.Data.CreationTime)
 	}

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -120,11 +120,12 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	rgwcontext := rgw.NewContext(context, storeName, namespace)
 	var bkt rgw.ObjectBucket
 	for i = 0; i < 4; i++ {
-		b, _, err := rgw.GetBucket(rgwcontext, bucketname)
+		b, code, err := rgw.GetBucket(rgwcontext, bucketname)
 		if b != nil && err == nil {
 			bkt = *b
 			break
 		}
+		logger.Warningf("cannot get bucket %q, retrying... bucket: %v. code: %d, err: %v", bucketname, b, code, err)
 		logger.Infof("(%d) check bucket exists, sleeping for 5 seconds ...", i)
 		time.Sleep(5 * time.Second)
 	}


### PR DESCRIPTION
**Description of your changes:**

Since 1.3 will support both Nautilus and Octopus, let's use Octopus for
the base image. Newer images have retro-compatibility with older Ceph
versions.

Closes: https://github.com/rook/rook/issues/1765 and https://github.com/rook/rook/issues/5666
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/1765

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]