### PR TITLE
ceph: use a different port for rgw on sdn

### DIFF
--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -35,10 +35,11 @@ caps mon = "allow rw"
 caps osd = "allow rwx"
 `
 
-	certVolumeName = "rook-ceph-rgw-cert"
-	certDir        = "/etc/ceph/private"
-	certKeyName    = "cert"
-	certFilename   = "rgw-cert.pem"
+	certVolumeName            = "rook-ceph-rgw-cert"
+	certDir                   = "/etc/ceph/private"
+	certKeyName               = "cert"
+	certFilename              = "rgw-cert.pem"
+	rgwPortInternalPort int32 = 8080
 )
 
 var (
@@ -50,6 +51,9 @@ func (c *clusterConfig) portString() string {
 
 	port := c.store.Spec.Gateway.Port
 	if port != 0 {
+		if !c.clusterSpec.Network.IsHost() {
+			port = rgwPortInternalPort
+		}
 		portString = fmt.Sprintf("port=%s", strconv.Itoa(int(port)))
 	}
 	if c.store.Spec.Gateway.SecurePort != 0 && c.store.Spec.Gateway.SSLCertificateRef != "" {


### PR DESCRIPTION
**Description of your changes:**

When running on SDN, the container is not privileged and the network
stack is not exposed so running the gw on port 80 will not work (not
enough privileged).

Closes: https://github.com/rook/rook/issues/5106
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5106

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]