### PR TITLE
Fixes #5118. /etc/timezone now exposed

### DIFF
--- a/pkg/apis/edgefs.rook.io/v1/resources.go
+++ b/pkg/apis/edgefs.rook.io/v1/resources.go
@@ -29,6 +29,9 @@ const (
 
 	hostLocalTimeVolName = "host-local-time"
 	hostLocalTimePath    = "/etc/localtime"
+
+	hostTimeZoneVolName = "host-time-zone"
+	hostTimeZonePath    = "/etc/timezone"
 )
 
 // GetMgrResources returns the placement for the MGR service
@@ -142,6 +145,25 @@ func GetHostLocalTimeVolume() v1.Volume {
 		VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{
 				Path: hostLocalTimePath,
+			},
+		},
+	}
+}
+
+func GetHostTimeZoneVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      hostTimeZoneVolName,
+		MountPath: hostTimeZonePath,
+		ReadOnly:  true,
+	}
+}
+
+func GetHostTimeZoneVolume() v1.Volume {
+	return v1.Volume{
+		Name: hostTimeZoneVolName,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: hostTimeZonePath,
 			},
 		},
 	}

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -291,6 +291,7 @@ func (c *Cluster) makeDeployment(name, clusterName, rookImage string, replicas i
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	if c.dataVolumeSize.Value() > 0 {
@@ -382,6 +383,7 @@ func (c *Cluster) uiContainer(name string, containerImage string) v1.Container {
 	volumeMounts := []v1.VolumeMount{}
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	return v1.Container{
@@ -452,6 +454,7 @@ func (c *Cluster) restApiContainer(name string, containerImage string) v1.Contai
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	cont := v1.Container{
@@ -548,6 +551,7 @@ func (c *Cluster) grpcProxyContainer(name string, containerImage string) v1.Cont
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	cont := v1.Container{

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -89,6 +89,7 @@ func (c *Cluster) makeCorosyncContainer(containerImage string) v1.Container {
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	return v1.Container{
@@ -141,6 +142,7 @@ func (c *Cluster) makeAuditdContainer(containerImage string) v1.Container {
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	return v1.Container{
@@ -221,6 +223,7 @@ func (c *Cluster) makeDaemonContainer(containerImage string, dro edgefsv1.Device
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	if containerSlaveIndex > 0 {
@@ -427,6 +430,7 @@ func (c *Cluster) createPodSpec(rookImage string, dro edgefsv1.DevicesResurrectO
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -133,6 +133,7 @@ func (c *ISCSIController) makeDeployment(svcname, namespace, rookImage string, i
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	if c.dataVolumeSize.Value() > 0 {
@@ -231,6 +232,7 @@ func (c *ISCSIController) iscsiContainer(svcname, name, containerImage string, i
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	cont := v1.Container{

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -202,6 +202,7 @@ func (c *ISGWController) makeDeployment(svcname, namespace, rookImage string, is
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	if c.dataVolumeSize.Value() > 0 {
@@ -311,6 +312,7 @@ func (c *ISGWController) isgwContainer(svcname, name, containerImage string, isg
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	configJSON := getISGWConfigJSON(isgwSpec)

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -137,6 +137,7 @@ func (c *NFSController) makeDeployment(svcname, namespace, rookImage string, nfs
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	if c.dataVolumeSize.Value() > 0 {
@@ -233,6 +234,7 @@ func (c *NFSController) nfsContainer(svcname, name, containerImage string, nfsSp
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	cont := v1.Container{

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -171,6 +171,7 @@ func (c *S3Controller) makeDeployment(svcname, namespace, rookImage, imageArgs s
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	// add ssl certificate volume if defined
@@ -289,6 +290,7 @@ func (c *S3Controller) s3Container(svcname, name, containerImage, args string, s
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	if len(s3Spec.SSLCertificateRef) > 0 {

--- a/pkg/operator/edgefs/s3x/s3x.go
+++ b/pkg/operator/edgefs/s3x/s3x.go
@@ -155,6 +155,7 @@ func (c *S3XController) makeDeployment(svcname, namespace, rookImage string, s3x
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	// add ssl certificate volume if defined
@@ -274,6 +275,7 @@ func (c *S3XController) s3xContainer(svcname, name, containerImage string, s3xSp
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	if len(s3xSpec.SSLCertificateRef) > 0 {

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -160,6 +160,7 @@ func (c *SWIFTController) makeDeployment(svcname, namespace, rookImage, imageArg
 
 	if c.useHostLocalTime {
 		volumes = append(volumes, edgefsv1.GetHostLocalTimeVolume())
+		volumes = append(volumes, edgefsv1.GetHostTimeZoneVolume())
 	}
 
 	// add ssl certificate volume if defined
@@ -271,6 +272,7 @@ func (c *SWIFTController) swiftContainer(svcname, name, containerImage, args str
 
 	if c.useHostLocalTime {
 		volumeMounts = append(volumeMounts, edgefsv1.GetHostLocalTimeVolumeMount())
+		volumeMounts = append(volumeMounts, edgefsv1.GetHostTimeZoneVolumeMount())
 	}
 
 	if len(swiftSpec.SSLCertificateRef) > 0 {


### PR DESCRIPTION
Signed-off-by: Dmitry Yusupov <dmitry.yusupov@nexenta.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

/etc/timezone now exposed by operator

**Which issue is resolved by this Pull Request:**
Resolves #5118 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test edgefs]