### PR TITLE
Update K8s versions for ceph tests with K8s 1.18

### DIFF
--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -40,11 +40,11 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion   = "1.13.0"
-	multiClusterMinimalTestVersion = "1.14.0"
-	helmMinimalTestVersion         = "1.15.0"
-	upgradeMinimalTestVersion      = "1.16.0"
-	smokeSuiteMinimalTestVersion   = "1.17.0"
+	flexDriverMinimalTestVersion   = "1.14.0"
+	multiClusterMinimalTestVersion = "1.15.0"
+	helmMinimalTestVersion         = "1.16.0"
+	upgradeMinimalTestVersion      = "1.17.0"
+	smokeSuiteMinimalTestVersion   = "1.18.0"
 )
 
 var (


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With 1.18 in the test matrix we need to update which versions will run the different ceph test suites.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]