### PR TITLE
Ceph: upgrade docs: update upgrade docs for v1.3

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -26,6 +26,7 @@ supported.
 For a guide to upgrade previous versions of Rook, please refer to the version of documentation for
 those releases.
 
+* [Upgrade 1.1 to 1.2](https://rook.io/docs/rook/v1.2/ceph-upgrade.html)
 * [Upgrade 1.0 to 1.1](https://rook.io/docs/rook/v1.1/ceph-upgrade.html)
 * [Upgrade 0.9 to 1.0](https://rook.io/docs/rook/v1.0/ceph-upgrade.html)
 * [Upgrade 0.8 to 0.9](https://rook.io/docs/rook/v0.9/ceph-upgrade.html)
@@ -56,37 +57,7 @@ released, the process of updating from v1.3.0 is as simple as running the follow
 kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.3.1
 ```
 
-## Enabling the CSI v2.0 driver
-
-> If you are deploying the rook-operator with the helm chart you only need to specify the related images in your values.yaml. The RBAC settings will be created for you by the chart.
-
-To enable the CSI v2.0 driver, you will need to apply updated RBAC settings:
-
-```sh
-kubectl apply -f upgrade-from-v1.2-apply.yaml
-```
-
-The following `env` variables will need to be configured in the Rook-Ceph
-operator deployment. The suggested upstream images are included below, which
-you should change to match where your images are located.
-
-```yaml
-  env:
-    - name: ROOK_CSI_CEPH_IMAGE
-        value: "quay.io/cephcsi/cephcsi:v2.0.0"
-    - name: ROOK_CSI_REGISTRAR_IMAGE
-        value: "quay.io/k8scsi/csi-node-driver-registrar:v1.3.0"
-    - name: ROOK_CSI_PROVISIONER_IMAGE
-        value: "quay.io/k8scsi/csi-provisioner:v1.4.0"
-    - name: ROOK_CSI_SNAPSHOTTER_IMAGE
-        value: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
-    - name: ROOK_CSI_ATTACHER_IMAGE
-        value: "quay.io/k8scsi/csi-attacher:v2.1.0"
-    - name: ROOK_CSI_RESIZER_IMAGE
-        value: "quay.io/k8scsi/csi-resizer:v0.4.0"
-```
-
-## Upgrading from v1.1 to v1.2
+## Upgrading from v1.2 to v1.3
 
 **Rook releases from master are expressly unsupported.** It is strongly recommended that you use
 [official releases](https://github.com/rook/rook/releases) of Rook. Unreleased versions from the
@@ -109,9 +80,9 @@ created before v0.8 are likely to be:
 * Clusters created in v0.8 or v0.9: `rook-ceph-system` and `rook-ceph`
 * Clusters created in v1.0 or newer: only `rook-ceph`
 
-With this guide, we do our best not to assume the namespaces in your cluster.
-To make things as easy as possible, modify and use the below snippet to configure your environment.
-We will use these environment variables throughout this document.
+With this guide, we do our best not to assume the namespaces in your cluster. To make things as easy
+as possible, modify and use the below snippet to configure your environment. We will use these
+environment variables throughout this document.
 
 ```sh
 # Parameterize the environment
@@ -119,11 +90,17 @@ export ROOK_SYSTEM_NAMESPACE="rook-ceph"
 export ROOK_NAMESPACE="rook-ceph"
 ```
 
+You must also perform a sed-replace on one of the upgrade manifests to set the namespace for your
+unique cluster if you aren't using the `rook-ceph` namespace above.
+```sh
+sed -i.bak "s/namespace: rook-ceph/namespace: $ROOK_NAMESPACE/g" upgrade-from-v1.2-apply.yaml
+```
+
 In order to successfully upgrade a Rook cluster, the following prerequisites must be met:
 
-* The cluster should be in a healthy state with full functionality.
-  Review the [health verification section](#health-verification) in order to verify your cluster is
-  in a good starting state.
+* The cluster should be in a healthy state with full functionality. Review the
+  [health verification section](#health-verification) in order to verify your cluster is in a good
+  starting state.
 * All pods consuming Rook storage should be created, running, and in a steady state. No Rook
   persistent volumes should be in the act of being created or deleted.
 
@@ -242,8 +219,8 @@ Any pod that is using a Rook volume should also remain healthy:
 ## Rook Operator Upgrade Process
 
 In the examples given in this guide, we will be upgrading a live Rook cluster running `v1.2.7` to
-the version `v1.3.0`. This upgrade should work from any official patch release of Rook v1.1 to any
-official patch release of v1.2. We will further assume that your previous cluster was created using
+the version `v1.3.0`. This upgrade should work from any official patch release of Rook v1.2 to any
+official patch release of v1.3. We will further assume that your previous cluster was created using
 an earlier version of this guide and manifests. If you have created custom manifests, these steps
 may not work as written.
 
@@ -255,70 +232,44 @@ time without compatibility support and without prior notice.
 
 Let's get started!
 
-## 1. Update the RBAC and CRDs
+## 1. Update Ceph to Nautilus version 14.2.5 or higher
 
-First update the Ceph Custom Resource Definitions and the privileges (RBAC) needed by the operator.
-A new `CephClient` CRD is included in v1.2 and the CSI driver privileges changed slightly.
+Rook v1.3 supports Ceph Nautilus v14.2.5 or newer and Ceph Octopus v15.2.0 or newer. These are the
+only supported major versions of Ceph. Rook v1.2 does not support Ceph Octopus. Therefore, if your
+Rook v1.2 cluster must be updated to Ceph Nautilus v14.2.5 or higher before upgrading the Rook
+Operator to v1.3. If an upgrade is necessary, follow the Ceph upgrade steps from Rook's v1.2 release
+[here](https://rook.io/docs/rook/v1.2/ceph-upgrade.html#ceph-version-upgrades).
+
+
+## 2. Update the RBAC and CRDs
+
+First apply new resources. This includes slightly modified privileges (RBAC) needed by the Operator.
+Also update Ceph Custom Resource Definitions (CRDs) at this time. Many CRDs have had a `status` item
+added to them which must be present for Rook v1.3 to update CRD statuses.
 
 ```sh
-kubectl apply -f upgrade-from-v1.1-apply.yaml
+kubectl apply -f upgrade-from-v1.2-apply.yaml -f upgrade-from-v1.2-crds.yaml
 ```
 
-## 2. CSI upgrade pre-requisites
+## 3. Update Ceph CSI version to v2.0
 
-In some scenarios there is an issue in the CSI driver that will cause application pods to be
-disconnected from their mounts when the CSI driver is restarted. Since the upgrade would cause the CSI
-driver to restart if it is updated, you need to be aware of whether this affects your applications.
-This issue will happen when using the Ceph `fuse` client or `rbd-nbd`:
-- CephFS: If you are provision volumes for CephFS and have a kernel less than version 4.17,
-The CSI driver will fall back to use the FUSE client.
-- RBD: If you have set the `mounter: rbd-nbd` option in the
-[RBD storage class](https://github.com/rook/rook/blob/release-1.2/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml#L40),
-the NBD mounter will have this issue. This setting is **not** enabled by default.
+If you have specified custom CSI images in the Rook-Ceph Operator deployment, you should update your
+the deployment to use the latest Ceph-CSI v2.0 and related drivers. If you have not specified custom
+CSI images in the Operator deployment this step is unnecessary; Rook v1.3 will use the latest
+drivers by default.
 
-If you are affected by this issue, you will need to proceed carefully during the upgrade to restart
-your application pods. The first recommended step is to modify the update strategy of the
-CSI driver so that you can control when the CSI driver pods are restarted on each node.
-As seen in the example below, set `CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY` and `CSI_RBD_PLUGIN_UPDATE_STRATEGY`
-values to `OnDelete`.
+See the section [CSI Updates](#csi-updates) for details about how to do this.
 
-To avoid this issue in future upgrades, we recommend that you **do not** use the `fuse` client or `rbd-nbd`.
-The `fuse` client can be avoided by setting the following environment variables in the operator now before this upgrade.
-The side effect of this setting is that the PVC size will not be enforced if the CephFS quotas are not supported in your kernel version.
-To enable this option and avoid this upgrade issue in the future, set `CSI_FORCE_CEPHFS_KERNEL_CLIENT` to `true`.
-
-```console
-kubectl -n $ROOK_SYSTEM_NAMESPACE edit deploy rook-ceph-operator
-```
-```yaml
-  # If you set this image at the same time as the env variables, you can skip step 3 of this guide and avoid a second operator restart
-  image: rook/ceph:v1.3.0
-  env:
-    # Change the update strategy for the CephFS driver if your cluster is affected
-    - name: CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY
-      value: "OnDelete"
-    # Change the update strategy for the RBD driver if your cluster is affected
-    - name: CSI_RBD_PLUGIN_UPDATE_STRATEGY
-      value: "OnDelete"
-    # To avoid this upgrade issue in the future for CephFS, force enable the kernel client
-    - name: CSI_FORCE_CEPHFS_KERNEL_CLIENT
-      value: "true"
-```
-
-After the operator and cluster are updated, we will continue with the CSI and application
-pod restarts in Step 5.
-
-## 3. Update the Rook Operator
+## 4. Update the Rook Operator
 
 The largest portion of the upgrade is triggered when the operator's image is updated to `v1.3.x`.
 When the operator is updated, it will proceed to update all of the Ceph daemons.
-(If step 1 was completed, this change has already been applied.)
 
 ```sh
 kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.3.0
 ```
 
-## 4. Wait for the upgrade to complete
+## 5. Wait for the upgrade to complete
 
 Watch now in amazement as the Ceph mons, mgrs, OSDs, rbd-mirrors, MDSes and RGWs are terminated and
 replaced with updated versions in sequence. The cluster may be offline very briefly as mons update,
@@ -348,7 +299,7 @@ rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.2.7
 rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.2.7
 ```
 
-The MDSes and RGWs are the last daemons to update. An easy check to see if the upgrade is totally
+The MDS, NFS, and RGW daemons are the last to update. An easy check to see if the upgrade is totally
 finished is to check that there is only one `rook-version` reported across the cluster. It is safe
 to proceed with the next step before the MDSes and RGWs are finished updating.
 
@@ -361,46 +312,17 @@ This cluster is finished:
   rook-version=v1.3.0
 ```
 
-## 5. Verify the updated cluster
+## 6. Verify the updated cluster
 
 At this point, your Rook operator should be running version `rook/ceph:v1.3.0`.
 
 Verify the Ceph cluster's health using the [health verification section](#health-verification).
 
-## 6. CSI Manual Update (optional)
-
-If you determined in step 1 that you were affected by the CSI driver restart issue that disconnects
-the application pods from their mounts, continue with this section. Otherwise, you can skip to step 7.
-
-Your cluster should now be in a state where Rook has upgraded everything except the CSI driver.
-The CSI driver pods will not be updated until you delete them manually. This allows you to control
-when your application pods will be affected by the CSI driver restart.
-
-For each node:
-- Drain your application pods from the node
-- Delete the CSI driver pods on the node
-  - The pods to delete will be named with a `csi-cephfsplugin` or `csi-rbdplugin` prefix and have a random suffix on each node.
-    However, no need to delete the provisioner pods: `csi-cephfsplugin-provisioner-*` or `csi-rbdplugin-provisioner-*`
-  - The pod deletion causes the pods to be restarted and updated automatically on the node
-
-
-## 7. Update Rook-Ceph custom resource definitions
-
-> **IMPORTANT**: Do not perform this step until ALL existing Rook-Ceph clusters are updated!
-
-After all Rook-Ceph clusters have been updated following the steps above, update the Rook-Ceph
-Custom Resource Definitions. This will help with creating or modifying Rook-Ceph
-deployments in the future with the updated schema validation.
-
-```sh
-kubectl apply -f upgrade-from-v1.2-crds.yaml
-```
-
 
 ## Ceph Version Upgrades
 
-Rook v1.2 supports Ceph Mimic v13.2.4 or newer and Ceph Nautilus v14.2.0 or newer. These are the only
-supported major versions of Ceph.
+Rook v1.3 supports Ceph Nautilus 14.2.5 or newer and Ceph Octopus v15.2.0 or newer. These are the
+only supported major versions of Ceph.
 
 > **IMPORTANT: When an update is requested, the operator will check Ceph's status, if it is in `HEALTH_ERR` it will refuse to do the upgrade.**
 
@@ -417,15 +339,15 @@ until all the daemons have been updated.
 Official Ceph container images can be found on [Docker Hub](https://hub.docker.com/r/ceph/ceph/tags/).
 These images are tagged in a few ways:
 
-* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v14.2.5-20191210`).
+* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v15.2.0-20200324`).
   These tags are recommended for production clusters, as there is no possibility for the cluster to
   be heterogeneous with respect to the version of Ceph running in containers.
-* Ceph major version tags (e.g., `v14`) are useful for development and test clusters so that the
+* Ceph major version tags (e.g., `v15`) are useful for development and test clusters so that the
   latest version of Ceph is always available.
 
 **Ceph containers other than the official images from the registry above will not be supported.**
 
-### Example upgrade to Ceph Nautilus
+### Example upgrade to Ceph Octopus
 
 #### 1. Update the main Ceph daemons
 
@@ -433,7 +355,7 @@ The majority of the upgrade will be handled by the Rook operator. Begin the upgr
 Ceph image field in the cluster CRD (`spec:cephVersion:image`).
 
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v14.2.5-20191210'
+NEW_CEPH_IMAGE='ceph/ceph:v15.2.0-20200324'
 CLUSTER_NAME="$ROOK_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```
@@ -452,13 +374,11 @@ Determining when the Ceph has fully updated is rather simple.
 ```console
 # kubectl -n $ROOK_NAMESPACE get deployment -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
-    ceph-version=13.2.6
-    ceph-version=14.2.5-0
+    ceph-version=14.2.7-0
+    ceph-version=15.2.0-0
 This cluster is finished:
-    ceph-version=14.2.5-0
+    ceph-version=15.2.0-0
 ```
-
-Note that Ceph version now includes an additional build tag, the `-0` suffix in the example above.
 
 #### 3. Verify the updated cluster
 
@@ -487,15 +407,15 @@ kubectl -n $ROOK_NAMESPACE exec -it $TOOLS_POD -- ceph config set global mon_war
 
 
 ## CSI Updates
-If you have a v1.1 cluster running with CSI drivers enabled and you have configured the Rook-Ceph
-operator to use custom CSI images, the environment (`env`) variables need to be updated
-periodically. If this is the case, it is easiest to `kubectl edit` the operator deployment and
+If you have a cluster running with CSI drivers enabled and you have configured the Rook-Ceph
+Operator to use custom CSI images, the environment (`env`) variables need to be updated
+periodically. If this is the case, it is easiest to `kubectl edit` the Operator Deployment and
 modify everything needed at once. You can switch between using Rook-Ceph's default CSI images and
 custom CSI images as you wish.
 
 ### Use default images
 If you would like Rook to use the inbuilt default upstream images, then you may simply remove all
-`env` variables with the `ROOK_CSI_` prefix from the Rook-Ceph operator deployment.
+`env` variables matching `ROOK_CSI_*_IMAGE` from the Rook-Ceph operator deployment.
 
 ### Use custom images
 OR, if you would like to use images hosted in a different location like a local image registry, then
@@ -505,16 +425,18 @@ located.
 
 ```yaml
   env:
-    - name: ROOK_CSI_CEPH_IMAGE
-        value: "quay.io/cephcsi/cephcsi:v1.2.2"
-    - name: ROOK_CSI_REGISTRAR_IMAGE
-        value: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
-    - name: ROOK_CSI_PROVISIONER_IMAGE
-        value: "quay.io/k8scsi/csi-provisioner:v1.4.0"
-    - name: ROOK_CSI_SNAPSHOTTER_IMAGE
-        value: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
-    - name: ROOK_CSI_ATTACHER_IMAGE
-        value: "quay.io/k8scsi/csi-attacher:v1.2.0"
+  - name: ROOK_CSI_CEPH_IMAGE
+    value: "quay.io/cephcsi/cephcsi:v2.0.0"
+  - name: ROOK_CSI_REGISTRAR_IMAGE
+    value: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0"
+  - name: ROOK_CSI_PROVISIONER_IMAGE
+    value: "quay.io/k8scsi/csi-provisioner:v1.4.0"
+  - name: ROOK_CSI_SNAPSHOTTER_IMAGE
+    value: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
+  - name: ROOK_CSI_ATTACHER_IMAGE
+    value: "quay.io/k8scsi/csi-attacher:v2.1.0"
+  - name: ROOK_CSI_RESIZER_IMAGE
+    value: "quay.io/k8scsi/csi-resizer:v0.4.0"
 ```
 
 ### Verifying updates
@@ -524,9 +446,10 @@ are updated.
 
 ```console
 # kubectl --namespace rook-ceph get pod -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.image}{"\n"}' -l 'app in (csi-rbdplugin,csi-rbdplugin-provisioner,csi-cephfsplugin,csi-cephfsplugin-provisioner)' | sort | uniq
-quay.io/cephcsi/cephcsi:v1.2.2
-quay.io/k8scsi/csi-attacher:v1.2.0
+quay.io/cephcsi/cephcsi:v2.0.0
+quay.io/k8scsi/csi-attacher:v2.1.0
 quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
 quay.io/k8scsi/csi-provisioner:v1.4.0
+quay.io/k8scsi/csi-resizer:v0.4.0
 quay.io/k8scsi/csi-snapshotter:v1.2.2
 ```

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -8,12 +8,14 @@
 #
 # Also see other operator sample files for variations of operator.yaml:
 # - operator-openshift.yaml: Common settings for running in OpenShift
-#################################################################################################################
-# Rook Ceph Operator Config
-# Use this ConfigMap to override operator configurations
-# Precedence will be given to this config in case
-# Env Var also exists for the same
-#
+###############################################################################################################
+
+# Rook Ceph Operator Config ConfigMap
+# Use this ConfigMap to override Rook-Ceph Operator configurations.
+# NOTE! Precedence will be given to this config if the same Env Var config also exists in the
+#       Operator Deployment.
+# To move a configuration(s) from the Operator Deployment to this ConfigMap, add the config
+# here. It is recommended to then remove it from the Deployment to eliminate any future confusion.
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -33,12 +35,12 @@ data:
   # Set logging level for csi containers.
   # Supported values from 0 to 5. 0 for general useful logs, 5 for trace level verbosity.
   # CSI_LOG_LEVEL: "0"
-  
+
   # Enable Ceph Kernel clients on kernel < 4.17 which support quotas for Cephfs
   # If you disable the kernel client, your application may be disrupted during upgrade.
   # See the upgrade guide: https://rook.io/docs/rook/master/ceph-upgrade.html
   CSI_FORCE_CEPHFS_KERNEL_CLIENT: "true"
-  
+
   # (Optional) Allow starting unsupported ceph-csi image
   ROOK_CSI_ALLOW_UNSUPPORTED_VERSION: "false"
   # The default version of CSI supported by Rook will be started. To change the version
@@ -50,17 +52,17 @@ data:
   # ROOK_CSI_PROVISIONER_IMAGE: "quay.io/k8scsi/csi-provisioner:v1.4.0"
   # ROOK_CSI_SNAPSHOTTER_IMAGE: "quay.io/k8scsi/csi-snapshotter:v1.2.2"
   # ROOK_CSI_ATTACHER_IMAGE: "quay.io/k8scsi/csi-attacher:v2.1.0"
-  
+
   # CSI CephFS plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.
   # CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY: "OnDelete"
   # CSI RBD plugin daemonset update strategy, supported values are OnDelete and RollingUpdate.
   # Default value is RollingUpdate.
   # CSI_RBD_PLUGIN_UPDATE_STRATEGY: "OnDelete"
-  
+
   # kubelet directory path, if kubelet configured to use other than /var/lib/kubelet path.
   # ROOK_CSI_KUBELET_DIR_PATH: "/var/lib/kubelet"
-  
+
   # (Optional) Ceph Provisioner NodeAffinity.
   # CSI_PROVISIONER_NODE_AFFINITY: "role=storage-node; storage=rook, ceph"
   # (Optional) CEPH CSI provisioner tolerations list. Put here list of taints you want to tolerate in YAML format.
@@ -83,7 +85,7 @@ data:
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd
   #     operator: Exists
-  
+
   # Configure CSI CSI Ceph FS grpc and liveness metrics port
   # CSI_CEPHFS_GRPC_METRICS_PORT: "9091"
   # CSI_CEPHFS_LIVENESS_METRICS_PORT: "9081"

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-apply.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-apply.yaml
@@ -221,3 +221,17 @@ rules:
   - csidrivers
   verbs:
   - create
+---
+# Rook Ceph Operator Config ConfigMap
+# Use this ConfigMap to override Rook-Ceph Operator configurations.
+# NOTE! Precedence will be given to this config if the same Env Var config also exists in the
+#       Operator Deployment.
+# To move a configuration(s) from the Operator Deployment to this ConfigMap, add the config
+# here. It is recommended to then remove it from the Deployment to eliminate any future confusion.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rook-ceph-operator-config
+  # should be in the namespace of the operator
+  namespace: rook-ceph
+data:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
@@ -212,7 +212,7 @@ spec:
             caps:
               type: object
   subresources:
-  status: {}
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Update both documents and `upgrade-from-v1.2*.yaml` files for Rook v1.3
release.

Fixes #5130 

Of note:
- note when the upgrade to CSI driver v2.0 can be done
- note that CSI image envs can be removed to have Rook use defaults
- update Ceph version upgrade section
- update supported Ceph version info
- add information about new Operator ConfigMap
- update CRDs before upgrade b/c new 'status' fields

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]