### PR TITLE
Cluster CleanupPolicy: Delete correct mon directories under the dataDirHostPath

### DIFF
--- a/pkg/operator/ceph/cluster/cleanup_test.go
+++ b/pkg/operator/ceph/cluster/cleanup_test.go
@@ -61,7 +61,7 @@ func TestCleanUpJobSpec(t *testing.T) {
 		},
 	}
 	controller := NewClusterController(context, "", &attachment.MockAttachment{}, operatorConfigCallbacks, addCallbacks)
-	podTemplateSpec := controller.cleanUpJobTemplateSpec(cluster)
+	podTemplateSpec := controller.cleanUpJobTemplateSpec(cluster, "monSecret")
 	assert.Equal(t, expectedHostPath, podTemplateSpec.Spec.Containers[0].Env[0].Value)
 	assert.Equal(t, expectedNamespace, podTemplateSpec.Spec.Containers[0].Env[1].Value)
 }

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -258,10 +258,11 @@ func genSecret(executor exec.Executor, configDir, name string, args []string) (s
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to read secret file")
 	}
-	return extractKey(string(contents))
+	return ExtractKey(string(contents))
 }
 
-func extractKey(contents string) (string, error) {
+// ExtractKey retrives mon secret key from the keyring file
+func ExtractKey(contents string) (string, error) {
 	secret := ""
 	slice := strings.Fields(sys.Grep(string(contents), "key"))
 	if len(slice) >= 3 {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -572,8 +572,14 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		nodes, err := h.GetNodeHostnames()
 		checkError(h.T(), err, "cannot get node names")
 		for _, node := range nodes {
-			err = h.cleanupDir(node, h.hostPathToDelete)
-			logger.Infof("removing %s from node %s. err=%v", h.hostPathToDelete, node, err)
+			if h.cleanupHost {
+				err = h.verifyDirCleanup(node, h.hostPathToDelete)
+				logger.Infof("verifying clean up of %s from node %s. err=%v", h.hostPathToDelete, node, err)
+				assert.NoError(h.T(), err)
+			} else {
+				err = h.cleanupDir(node, h.hostPathToDelete)
+				logger.Infof("removing %s from node %s. err=%v", h.hostPathToDelete, node, err)
+			}
 		}
 	}
 	if h.changeHostnames {
@@ -646,6 +652,12 @@ func (h *CephInstaller) checkCephHealthStatus(namespace string) {
 
 func (h *CephInstaller) cleanupDir(node, dir string) error {
 	resources := h.Manifests.GetCleanupPod(node, dir)
+	_, err := h.k8shelper.KubectlWithStdin(resources, createFromStdinArgs...)
+	return err
+}
+
+func (h *CephInstaller) verifyDirCleanup(node, dir string) error {
+	resources := h.Manifests.GetCleanupVerificationPod(node, dir)
 	_, err := h.k8shelper.KubectlWithStdin(resources, createFromStdinArgs...)
 	return err
 }

--- a/tests/framework/installer/ceph_manifests_v1.1.go
+++ b/tests/framework/installer/ceph_manifests_v1.1.go
@@ -1698,6 +1698,11 @@ spec:
                    path:  ` + removalDir
 }
 
+// GetCleanupVerificationPod asserts that the dataDirHostPath is empty
+func (m *CephManifestsV1_1) GetCleanupVerificationPod(node, hostPathDir string) string {
+	return ""
+}
+
 func (m *CephManifestsV1_1) GetBlockPoolDef(poolName string, namespace string, replicaSize string) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephBlockPool


### PR DESCRIPTION
This is a follow up PR of #4959
In case of multiple clusters, we don't want to delete all the mon directories under the dataDirHostPath during cluster cleanup.
This PR deletes the mon directory only if the monitor secret key matches.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Fetch the monitor secret before all the ceph daemons are deleted. 
- Pass on this monitor secret as plain text (its ok to send as a plain text since the cluster is being deleted) to the clean up job. 
- (Another reason for passing the secret like this is the original `rook-ceph-mon-keyring` secret will get deleted before the clean up job will start. So it can't be mounted on to the clean up job as a volume)
- Clean up job deletes a mon directory only if this monitor secret matches with the key in '/dataDirHostPath/mon-*/data/keyring'

**Which issue is resolved by this Pull Request:**
Resolves #5131

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]