### PR TITLE
ceph: support topoplogySpreadConstraints

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -325,6 +325,7 @@ A Placement configuration is specified (according to the kubernetes PodSpec) as:
 * `podAffinity`: kubernetes [PodAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
 * `podAntiAffinity`: kubernetes [PodAntiAffinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature)
 * `tolerations`: list of kubernetes [Toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+* `topologySpreadConstraints`: kubernetes [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/)
 
 The `mon` pod does not allow `Pod` affinity or anti-affinity. Instead, `mon`s have built-in anti-affinity with each other through the operator. The operator determines which nodes should run a `mon`. Each `mon` is then tied to a node with a node selector using a hostname.
 See the [mon design doc](https://github.com/rook/rook/blob/master/design/ceph/mon-health.md) for more details on the `mon` failover design.

--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -61,6 +61,7 @@ spec:
     #    operator: Exists
     #  podAffinity:
     #  podAntiAffinity:
+    #  topologySpreadConstraints:
     resources:
     #  limits:
     #    cpu: "500m"

--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -52,6 +52,8 @@ spec:
     #    operator: Exists
     #  podAffinity:
     #  podAntiAffinity:
+    #  topologySpreadConstraints:
+
     # The requests and limits set here allow the ganesha pod(s) to use half of one CPU core and 1 gigabyte of memory
     resources:
     #  limits:

--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -58,6 +58,7 @@ spec:
     #    operator: Exists
     #  podAffinity:
     #  podAntiAffinity:
+    #  topologySpreadConstraints:
     resources:
     #  limits:
     #    cpu: "500m"

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,6 +22,7 @@ ConfigMap can be used in mix with the already existing Env Vars defined in opera
 - Rook monitor, mds and osd now have liveness probe checks on their respective sockets
 - Pools can now be configured to inline compress the data using the `compressionMode` parameter. Support added [here](https://github.com/rook/rook/pull/5124)
 - Ceph OSDs do not use the host PID, but the PID namespace of the pod (more security). The OSD does not see host running processes anymore.
+- placement of all the ceph daemons now supports [topologySpreadConstraints](Documentation/ceph-cluster-crd.md#placement-configuration-settings).
 
 ### EdgeFS
 

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -60,8 +60,7 @@ spec:
       # across nodes as much as possible. Unfortunately the pod anti-affinity breaks down
       # as soon as you have more than one OSD per node. If you have more OSDs than nodes, K8s may
       # choose to schedule many of them on the same node. What we need is the Pod Topology
-      # Spread Constraints, which is alpha in K8s 1.16. This means that a feature gate must be
-      # enabled for this feature, and Rook also still needs to add support for this feature.
+      # Spread Constraints.
       # Another approach for a small number of OSDs is to create a separate device set for each
       # zone (or other set of nodes with a common label) so that the OSDs will end up on different
       # nodes. This would require adding nodeAffinity to the placement here.
@@ -81,6 +80,17 @@ spec:
                   values:
                   - rook-ceph-osd-prepare
               topologyKey: kubernetes.io/hostname
+        topologySpreadConstraints:
+        - maxSkew: 1
+           topologyKey: kubernetes.io/hostname
+           whenUnsatisfiable: DoNotSchedule
+           labelSelector:
+             matchExpressions:
+             - key: app
+               operator: In
+               values:
+               - rook-ceph-osd
+               - rook-ceph-osd-prepare
       resources:
       #   limits:
       #     cpu: "500m"

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -99,6 +99,7 @@ spec:
 #              - storage-node
 #      podAffinity:
 #      podAntiAffinity:
+#      topologySpreadConstraints:
 #      tolerations:
 #      - key: storage-node
 #        operator: Exists

--- a/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
@@ -42,6 +42,7 @@ spec:
     #          operator: In
     #          values:
     #          - mds-node
+    #  topologySpreadConstraints:
     #  tolerations:
     #  - key: mds-node
     #    operator: Exists

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -48,6 +48,7 @@ spec:
     #          operator: In
     #          values:
     #          - mds-node
+    #  topologySpreadConstraints:
     #  tolerations:
     #  - key: mds-node
     #    operator: Exists

--- a/cluster/examples/kubernetes/ceph/nfs.yaml
+++ b/cluster/examples/kubernetes/ceph/nfs.yaml
@@ -25,6 +25,7 @@ spec:
     #          operator: In
     #          values:
     #          - mds-node
+    #  topologySpreadConstraints:
     #  tolerations:
     #  - key: mds-node
     #    operator: Exists

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -46,6 +46,7 @@ spec:
     #          operator: In
     #          values:
     #          - rgw-node
+    #  topologySpreadConstraints:
     #  tolerations:
     #  - key: rgw-node
     #    operator: Exists

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -59,6 +59,7 @@ spec:
     #          operator: In
     #          values:
     #          - rgw-node
+    #  topologySpreadConstraints:
     #  tolerations:
     #  - key: rgw-node
     #    operator: Exists

--- a/design/ceph/filesystem.md
+++ b/design/ceph/filesystem.md
@@ -73,7 +73,7 @@ Multiple data pools can be configured for the file system. Assigning users or fi
 The metadata server settings correspond to the MDS service.
 - `activeCount`: The number of active MDS instances. As load increases, CephFS will automatically partition the file system across the MDS instances. Rook will create double the number of MDS instances as requested by the active count. The extra instances will be in standby mode for failover.
 - `activeStandby`: If true, the extra MDS instances will be in active standby mode and will keep a warm cache of the file system metadata for faster failover. The instances will be assigned by CephFS in failover pairs. If false, the extra MDS instances will all be on passive standby mode and will not maintain a warm cache of the metadata.
-- `placement`: The mds pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
+- `placement`: The mds pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, `podAntiAffinity`, and `topologySpreadConstraints` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
 
 ```yaml
   metadataServer:

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -84,7 +84,7 @@ The gateway settings correspond to the RGW service.
 - `port`: The service port where the RGW service will be listening (http)
 - `securePort`: The service port where the RGW service will be listening (https)
 - `instances`: The number of RGW pods that will be started for this object store
-- `placement`: The rgw pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
+- `placement`: The rgw pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, `podAntiAffinity`, and `topologySpreadConstraints` similar to placement defined for daemons configured by the [cluster CRD](/cluster/examples/kubernetes/ceph/cluster.yaml).
 
 The RGW service can be configured to listen on both http and https by specifying both `port` and `securePort`.
 

--- a/pkg/apis/rook.io/v1/placement.go
+++ b/pkg/apis/rook.io/v1/placement.go
@@ -37,9 +37,11 @@ func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
 	if p.PodAntiAffinity != nil {
 		t.Affinity.PodAntiAffinity = p.PodAntiAffinity.DeepCopy()
 	}
-
 	if p.Tolerations != nil {
 		t.Tolerations = p.Tolerations
+	}
+	if p.TopologySpreadConstraints != nil {
+		t.TopologySpreadConstraints = p.TopologySpreadConstraints
 	}
 }
 
@@ -59,6 +61,9 @@ func (p Placement) Merge(with Placement) Placement {
 	}
 	if with.Tolerations != nil {
 		ret.Tolerations = with.Tolerations
+	}
+	if with.TopologySpreadConstraints != nil {
+		ret.TopologySpreadConstraints = with.TopologySpreadConstraints
 	}
 	return ret
 }

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -72,10 +72,11 @@ type Selection struct {
 type PlacementSpec map[KeyType]Placement
 
 type Placement struct {
-	NodeAffinity    *v1.NodeAffinity    `json:"nodeAffinity,omitempty"`
-	PodAffinity     *v1.PodAffinity     `json:"podAffinity,omitempty"`
-	PodAntiAffinity *v1.PodAntiAffinity `json:"podAntiAffinity,omitempty"`
-	Tolerations     []v1.Toleration     `json:"tolerations,omitempty"`
+	NodeAffinity              *v1.NodeAffinity              `json:"nodeAffinity,omitempty"`
+	PodAffinity               *v1.PodAffinity               `json:"podAffinity,omitempty"`
+	PodAntiAffinity           *v1.PodAntiAffinity           `json:"podAntiAffinity,omitempty"`
+	Tolerations               []v1.Toleration               `json:"tolerations,omitempty"`
+	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 type ResourceSpec map[string]v1.ResourceRequirements

--- a/pkg/apis/rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/rook.io/v1/zz_generated.deepcopy.go
@@ -219,6 +219,13 @@ func (in *Placement) DeepCopyInto(out *Placement) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]corev1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
**Description of your changes:**

Support topologySpreadConstraints to spread OSD pods among failure domains.

https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

Without this feature, the number of OSD pods would be different between the failure domains very much. At worst, there is a possibility that a failure domain has many OSDs and other failure domains have no OSDs. It can partly be mitigated with podAntiAffinity. However, it only works if there are at most one OSD per node. For more detail, please refer to the following document.

https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml#L59

**Which issue is resolved by this Pull Request:**

Resolves #4387 

**Checklist:**

- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [o] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [o] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]