### PR TITLE
Ceph: Add replica_size flag in replicated pool creation time

### DIFF
--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -264,7 +264,7 @@ func CreateReplicatedPoolForApp(context *clusterd.Context, namespace, poolName s
 		return err
 	}
 
-	args := []string{"osd", "pool", "create", poolName, pgCount, "replicated", poolName}
+	args := []string{"osd", "pool", "create", poolName, pgCount, "replicated", poolName, "--size", strconv.FormatUint(uint64(pool.Replicated.Size), 10)}
 	output, err := NewCephCommand(context, namespace, args).Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to create replicated pool %s. %s", poolName, string(output))

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -122,6 +122,8 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass s
 			if args[2] == "create" {
 				assert.Equal(t, "mypool", args[3])
 				assert.Equal(t, "replicated", args[5])
+				assert.Equal(t, "--size", args[7])
+				assert.Equal(t, "12345", args[8])
 				return "", nil
 			}
 			if args[2] == "set" {


### PR DESCRIPTION
Co-authored-by: donggyu_park donggyu_park@tmax.co.kr
Signed-off-by: taeuk_kim <taeuk_kim@tmax.co.kr>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

In replicated pool,
- Add replica_size to pool create command
- Delete pool set command

By doing this, pool min_size is computed correctly.

**Which issue is resolved by this Pull Request:**
Resolves #5127 

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
