### PR TITLE
ceph: remove unnecessary whitespaces in the example

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -82,15 +82,15 @@ spec:
               topologyKey: kubernetes.io/hostname
         topologySpreadConstraints:
         - maxSkew: 1
-           topologyKey: kubernetes.io/hostname
-           whenUnsatisfiable: DoNotSchedule
-           labelSelector:
-             matchExpressions:
-             - key: app
-               operator: In
-               values:
-               - rook-ceph-osd
-               - rook-ceph-osd-prepare
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - rook-ceph-osd
+              - rook-ceph-osd-prepare
       resources:
       #   limits:
       #     cpu: "500m"


### PR DESCRIPTION
**Description of your changes:**

Fix the following error message due to unnecessary whitespaces.

```console
$ kubectl create -f cluster-on-pvc.yaml
error: error parsing cluster-on-pvc.yaml: error converting YAML to JSON: yaml: line 85: mapping values are not allowed in this context
```

**Which issue is resolved by this Pull Request:**
Resolves #5149

**Checklist:**

- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [o] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [o] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]