### PR TITLE
Integration Tests: moving GetCleanupPod() and GetCleanupVerificationPod() methods out of CephManifests interface

### DIFF
--- a/tests/framework/installer/ceph_manifests_v1.1.go
+++ b/tests/framework/installer/ceph_manifests_v1.1.go
@@ -18,8 +18,6 @@ package installer
 
 import (
 	"strconv"
-
-	"github.com/google/uuid"
 )
 
 // CephManifestsV1_1 wraps rook yaml definitions
@@ -1666,41 +1664,6 @@ spec:
         items:
         - key: data
           path: mon-endpoints`
-}
-
-// GetCleanupPod gets a cleanup Pod manifest
-func (m *CephManifestsV1_1) GetCleanupPod(node, removalDir string) string {
-	return `apiVersion: batch/v1
-kind: Job
-metadata:
-  name: rook-cleanup-` + uuid.Must(uuid.NewRandom()).String() + `
-spec:
-    template:
-      spec:
-          restartPolicy: Never
-          containers:
-              - name: rook-cleaner
-                image: rook/ceph:` + m.imageTag + `
-                securityContext:
-                    privileged: true
-                volumeMounts:
-                    - name: cleaner
-                      mountPath: /scrub
-                command:
-                    - "sh"
-                    - "-c"
-                    - "rm -rf /scrub/*"
-          nodeSelector:
-            kubernetes.io/hostname: ` + node + `
-          volumes:
-              - name: cleaner
-                hostPath:
-                   path:  ` + removalDir
-}
-
-// GetCleanupVerificationPod asserts that the dataDirHostPath is empty
-func (m *CephManifestsV1_1) GetCleanupVerificationPod(node, hostPathDir string) string {
-	return ""
 }
 
 func (m *CephManifestsV1_1) GetBlockPoolDef(poolName string, namespace string, replicaSize string) string {


### PR DESCRIPTION
The CephManifests interface is intended for manifests that install the product (RBAC, CRDs, operator, etc). These cleanup methods are more about test code. The test code needs to behave the same whether it is a normal install or an upgrade. We don't need to version it differently for upgrades between the CephManifestsMaster and CephManifestsV1_1 implementations

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Removed GetCleanupPods() and GetCleanupVerificationPod() out of CephManifests interface. 
- Moved both of these into ceph_installer.go file.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]