### PR TITLE
ceph: trigger update on child controllers

### DIFF
--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -31,6 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+const (
+	cephVersionLabelKey = "ceph_version"
+)
+
 // WatchControllerPredicate is a special update filter for update events
 // do not reconcile if the the status changes, this avoids a reconcile storm loop
 //
@@ -63,6 +67,11 @@ func WatchControllerPredicate() predicate.Funcs {
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
+					return true
+				}
+				// Handling upgrades
+				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())
+				if isUpgrade {
 					return true
 				}
 
@@ -107,6 +116,11 @@ func WatchControllerPredicate() predicate.Funcs {
 					}
 					return true
 				}
+				// Handling upgrades
+				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())
+				if isUpgrade {
+					return true
+				}
 
 			case *cephv1.CephNFS:
 				objNew := e.ObjectNew.(*cephv1.CephNFS)
@@ -121,7 +135,11 @@ func WatchControllerPredicate() predicate.Funcs {
 					}
 					return true
 				}
-
+				// Handling upgrades
+				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())
+				if isUpgrade {
+					return true
+				}
 			}
 
 			logger.Debug("wont update unknown object")
@@ -235,4 +253,26 @@ func isValidEvent(patch []byte) bool {
 
 	logger.Debugf("will reconcile based on patch %s", patchString)
 	return true
+}
+
+func isUpgrade(oldLabels, newLabels map[string]string) bool {
+	oldLabelVal, oldLabelKeyExist := oldLabels[cephVersionLabelKey]
+	newLabelVal, newLabelKeyExist := newLabels[cephVersionLabelKey]
+
+	// Nothing exists
+	if !oldLabelKeyExist && !newLabelKeyExist {
+		return false
+	}
+
+	// The new object has the label key so we reconcile
+	if !oldLabelKeyExist && newLabelKeyExist {
+		return true
+	}
+
+	// Both objects have the label and values are different so we reconcile
+	if (oldLabelKeyExist && newLabelKeyExist) && oldLabelVal != newLabelVal {
+		return true
+	}
+
+	return false
 }

--- a/pkg/operator/ceph/controller/predicate_test.go
+++ b/pkg/operator/ceph/controller/predicate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -73,4 +74,31 @@ func TestObjectChanged(t *testing.T) {
 	changed, err = objectChanged(oldObject, newObject)
 	assert.NoError(t, err)
 	assert.True(t, changed)
+}
+
+func TestIsUpgrade(t *testing.T) {
+	oldLabel := make(map[string]string)
+	newLabel := map[string]string{
+		"foo": "bar",
+	}
+
+	// no value do nothing
+	b := isUpgrade(oldLabel, newLabel)
+	assert.False(t, b)
+
+	// different value do something
+	newLabel["ceph_version"] = "15.2.0-octopus"
+	b = isUpgrade(oldLabel, newLabel)
+	assert.True(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
+
+	// same value do nothing
+	oldLabel["ceph_version"] = "15.2.0-octopus"
+	newLabel["ceph_version"] = "15.2.0-octopus"
+	b = isUpgrade(oldLabel, newLabel)
+	assert.False(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
+
+	// different value do something
+	newLabel["ceph_version"] = "15.2.1-octopus"
+	b = isUpgrade(oldLabel, newLabel)
+	assert.True(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
 }


### PR DESCRIPTION
**Description of your changes:**

When the CephCluster CR gets updated with a new image version, we need
to notify the child controllers of that upgrade.
For this, we set a 'ceph_version' label on the CR itself which will
effectively trigger a reconcile based on an update event.
This needs to be revisited and see how we can make use of
`EnqueueRequestsFromMapFunc` which might be a better approach using
controller-runtime built-in.

Closes: https://github.com/rook/rook/issues/5153
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves  https://github.com/rook/rook/issues/5153

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]