### PR TITLE
Skip upgrade test when CSI is not supported on older K8s

### DIFF
--- a/tests/integration/ceph_base_block_test.go
+++ b/tests/integration/ceph_base_block_test.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"fmt"
 	"strconv"
+	"testing"
 	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -36,17 +37,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func checkSkipCSITest(s suite.Suite, k8sh *utils.K8sHelper) {
+func checkSkipCSITest(t *testing.T, k8sh *utils.K8sHelper) {
 	if !k8sh.VersionAtLeast("v1.13.0") {
 		logger.Info("Skipping tests as kube version is less than 1.13.0 for the CSI driver")
-		s.T().Skip()
+		t.Skip()
 	}
 }
 
 // Smoke Test for Block Storage - Test check the following operations on Block Storage in order
 // Create,Mount,Write,Read,Expand,Unmount and Delete.
 func runBlockCSITest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
-	checkSkipCSITest(s, k8sh)
+	checkSkipCSITest(s.T(), k8sh)
 
 	podName := "block-test"
 	poolName := "replicapool"
@@ -196,7 +197,7 @@ func restartOSDPods(k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
 }
 
 func runBlockCSITestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, clusterNamespace, systemNamespace string, version cephv1.CephVersionSpec) {
-	checkSkipCSITest(s, k8sh)
+	checkSkipCSITest(s.T(), k8sh)
 
 	logger.Infof("Block Storage End to End Integration Test - create storageclass,pool and pvc")
 	logger.Infof("Running on Rook Cluster %s", clusterNamespace)

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -44,7 +44,7 @@ const (
 // Create,Mount,Write,Read,Unmount and Delete.
 func runFileE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace, filesystemName string, useCSI bool) {
 	if useCSI {
-		checkSkipCSITest(s, k8sh)
+		checkSkipCSITest(s.T(), k8sh)
 	}
 
 	defer fileTestDataCleanUp(helper, k8sh, s, filePodName, namespace, filesystemName)

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -50,6 +50,11 @@ func TestCephUpgradeSuite(t *testing.T) {
 		t.Skip()
 	}
 
+	// Skip the suite if CSI is not supported
+	kh, err := utils.CreateK8sHelper(func() *testing.T { return t })
+	require.NoError(t, err)
+	checkSkipCSITest(t, kh)
+
 	s := new(UpgradeSuite)
 	defer func(s *UpgradeSuite) {
 		HandlePanics(recover(), s.op, s.T)
@@ -90,8 +95,6 @@ func (s *UpgradeSuite) TearDownSuite() {
 }
 
 func (s *UpgradeSuite) TestUpgradeToMaster() {
-	checkSkipCSITest(s.Suite, s.k8sh)
-
 	systemNamespace := installer.SystemNamespace(s.namespace)
 
 	//


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The upgrade test requires the CSI driver to be running so we cannot run the test on older versions than k8s 1.13. This means K8s 1.11 in the release branch will be skipping the upgrade test. The only Ceph tests running on K8s 1.11 will be the CephFlexSuite, which should be sufficient for maintenance mode.

This fixes a failure in the release branch CI for the k8s 1.11 tests where we weren't skipping the upgrade test soon enough.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]