### PR TITLE
ceph: remove appropriate rgw ceph user when CephObjectStore is deleted

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -20,7 +20,6 @@ package object
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
@@ -273,8 +272,8 @@ func (c *clusterConfig) deleteStore() error {
 	// Delete rgw CephX keys
 	for i := 0; i < int(c.store.Spec.Gateway.Instances); i++ {
 		daemonLetterID := k8sutil.IndexToName(i)
-		keyName := fmt.Sprintf("client.%s.%s", strings.Replace(c.store.Name, "-", ".", -1), daemonLetterID)
-		err := cephclient.AuthDelete(c.context, c.store.Namespace, keyName)
+		depNameToRemove := fmt.Sprintf("%s-%s-%s", AppName, c.store.Name, daemonLetterID)
+		err := cephclient.AuthDelete(c.context, c.store.Namespace, generateCephXUser(depNameToRemove))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Delete client.rgw.storeName.daemonletter user instead of client.storeName.daemonletter which doesn't exist when we delete all components related to the deletion of a CephObjectStore

**Which issue is resolved by this Pull Request:**
Resolves #5178 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
