### PR TITLE
Integration test for upgrade from nautilus to octopus

### DIFF
--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -84,6 +84,6 @@ func IsReadyToReconcile(client client.Client, clustercontext *clusterd.Context, 
 		return cephCluster.Spec, true, cephClusterExists, reconcile.Result{}
 	}
 
-	logger.Debugf("%q: CephCluster resource %q found in namespace %q but cluster state is not appropriate %q", controllerName, namespacedName.Name, namespacedName.Namespace, status.Health.Status)
+	logger.Infof("%s: CephCluster %q found but skipping reconcile since Ceph health is %q", controllerName, namespacedName.Name, status.Health.Status)
 	return cephCluster.Spec, false, cephClusterExists, WaitForRequeueIfCephClusterNotReady
 }

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -251,7 +251,7 @@ func isValidEvent(patch []byte) bool {
 		return false
 	}
 
-	logger.Debugf("will reconcile based on patch %s", patchString)
+	logger.Infof("will reconcile based on patch %s", patchString)
 	return true
 }
 

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -338,22 +338,25 @@ subjects:
 }
 
 func waitForFilesystemActive(k8sh *utils.K8sHelper, namespace, filesystemName string) error {
-	cmd := cephclient.NewCephCommand(k8sh.MakeContext(), namespace, []string{"fs", "status", filesystemName})
-	var stat []byte
+	command, args := cephclient.FinalizeCephCommandArgs("ceph", []string{"fs", "status", filesystemName}, k8sh.MakeContext().ConfigDir, namespace)
+	var stat string
 	var err error
+
 	logger.Infof("waiting for filesystem %q to be active", filesystemName)
 	for i := 0; i < utils.RetryLoop; i++ {
-		stat, err := cmd.Run()
+		// start the rgw admin command
+		stat, err := k8sh.MakeContext().Executor.ExecuteCommandWithCombinedOutput(command, args...)
 		if err != nil {
 			logger.Warningf("failed to get filesystem %q status. %+v", filesystemName, err)
 		}
+
 		// as long as at least one mds is active, it's okay
-		if strings.Contains(string(stat), "active") {
+		if strings.Contains(stat, "active") {
 			logger.Infof("done waiting for filesystem %q to be active", filesystemName)
 			return nil
 		}
 		logger.Infof("waiting for filesystem %q to be active", filesystemName)
 		time.Sleep(utils.RetryInterval * time.Second)
 	}
-	return fmt.Errorf("gave up waiting to get filesystem %q status [err: %+v] Status returned:\n%s", filesystemName, err, string(stat))
+	return fmt.Errorf("gave up waiting to get filesystem %q status [err: %+v] Status returned:\n%s", filesystemName, err, stat)
 }

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -161,7 +161,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	// Upgrade from mimic to nautilus
 	//
 	logger.Infof("*** UPGRADING CEPH FROM Mimic TO Nautilus ***")
-	s.gatherLogs(systemNamespace, "_before_ceph_upgrade")
+	s.gatherLogs(systemNamespace, "_before_nautilus_upgrade")
 	s.upgradeCephVersion(installer.NautilusVersion.Image, numOSDs)
 
 	// Start the file test client now that the CSI driver is supported on nautilus
@@ -175,7 +175,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	}()
 
 	// Verify reading and writing to the test clients
-	newFile = "post-ceph-upgrade-file"
+	newFile = "post-nautilus-upgrade-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
@@ -196,6 +196,19 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
 	logger.Infof("Verified upgrade from v1.2 to master")
+
+	//
+	// Upgrade from nautilus to octopus
+	//
+	logger.Infof("*** UPGRADING CEPH FROM Nautilus TO Octopus ***")
+	s.gatherLogs(systemNamespace, "_before_octopus_upgrade")
+	s.upgradeCephVersion(installer.OctopusVersion.Image, numOSDs)
+	// Verify reading and writing to the test clients
+	newFile = "post-octopus-upgrade-file"
+	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
+	rbdFilesToRead = append(rbdFilesToRead, newFile)
+	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
+	logger.Infof("Verified upgrade from nautilus to octopus")
 }
 
 func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The upgrade test will now support upgrading from nautilus to octopus and that files and be read and written after the upgrade.

Resolves #5153

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
[test full]
