### PR TITLE
ceph: use controller runtime logic to watch CephCluster

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -20,7 +20,6 @@ package cluster
 import (
 	"reflect"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -272,15 +271,6 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 			return errors.Wrapf(err, "failed to execute post actions after all the monitors started")
 		}
 
-		// If this is an upgrade, notify all the child controllers
-		if c.isUpgrade {
-			logger.Info("upgrade in progress, notifying child CRs")
-			err := c.notifyChildControllerOfUpgrade()
-			if err != nil {
-				return errors.Wrap(err, "failed to notify child CRs of upgrade")
-			}
-		}
-
 		mgrs := mgr.New(c.Info, c.context, c.Namespace, rookImage,
 			spec.CephVersion, cephv1.GetMgrPlacement(spec.Placement), cephv1.GetMgrAnnotations(c.Spec.Annotations),
 			spec.Network, spec.Dashboard, spec.Monitoring, spec.Mgr, cephv1.GetMgrResources(spec.Resources),
@@ -437,58 +427,6 @@ func (c *cluster) postMonStartupActions() error {
 	// Enable Ceph messenger 2 protocol on Nautilus
 	if err := client.EnableMessenger2(c.context, c.Namespace); err != nil {
 		return errors.Wrapf(err, "failed to enable Ceph messenger version 2.")
-	}
-
-	return nil
-}
-
-func (c *cluster) notifyChildControllerOfUpgrade() error {
-	version := strings.Replace(c.Info.CephVersion.String(), " ", "-", -1)
-
-	// List all child controllers
-	cephFilesystems, err := c.context.RookClientset.CephV1().CephFilesystems(c.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrap(err, "failed to list ceph filesystem CRs")
-	}
-	for _, cephFilesystem := range cephFilesystems.Items {
-		if cephFilesystem.Labels == nil {
-			cephFilesystem.Labels = map[string]string{}
-		}
-		cephFilesystem.Labels["ceph_version"] = version
-		_, err := c.context.RookClientset.CephV1().CephFilesystems(c.Namespace).Update(&cephFilesystem)
-		if err != nil {
-			return errors.Wrapf(err, "failed to update ceph filesystem CR %q with new label", cephFilesystem.Name)
-		}
-	}
-
-	cephObjectStores, err := c.context.RookClientset.CephV1().CephObjectStores(c.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrap(err, "failed to list ceph object store CRs")
-	}
-	for _, cephObjectStore := range cephObjectStores.Items {
-		if cephObjectStore.Labels == nil {
-			cephObjectStore.Labels = map[string]string{}
-		}
-		cephObjectStore.Labels["ceph_version"] = version
-		_, err := c.context.RookClientset.CephV1().CephObjectStores(c.Namespace).Update(&cephObjectStore)
-		if err != nil {
-			return errors.Wrapf(err, "failed to update ceph object store CR %q with new label", cephObjectStore.Name)
-		}
-	}
-
-	cephNFSes, err := c.context.RookClientset.CephV1().CephNFSes(c.Namespace).List(metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrap(err, "failed to list ceph nfs CRs")
-	}
-	for _, cephNFS := range cephNFSes.Items {
-		if cephNFS.Labels == nil {
-			cephNFS.Labels = map[string]string{}
-		}
-		cephNFS.Labels["ceph_version"] = version
-		_, err := c.context.RookClientset.CephV1().CephNFSes(c.Namespace).Update(&cephNFS)
-		if err != nil {
-			return errors.Wrapf(err, "failed to update ceph nfs CR %q with new label", cephNFS.Name)
-		}
 	}
 
 	return nil

--- a/pkg/operator/ceph/controller/handler.go
+++ b/pkg/operator/ceph/controller/handler.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// ObjectToCRMapper returns the list of a given object type metadata
+// It is used to trigger a reconcile object Kind A when watching object Kind B
+// So we reconcile Kind A instead of Kind B
+// For instance, we watch for CephCluster CR changes but want to reconcile CephFilesystem based on a Spec change
+func ObjectToCRMapper(c client.Client, ro runtime.Object, scheme *runtime.Scheme) (handler.Mapper, error) {
+	if _, ok := ro.(metav1.ListInterface); !ok {
+		return nil, errors.Errorf("expected a metav1.ListInterface, got %T instead", ro)
+	}
+
+	gvk, err := apiutil.GVKForObject(ro, scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return handler.ToRequestsFunc(func(o handler.MapObject) []ctrl.Request {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk)
+		err := c.List(context.TODO(), list)
+		if err != nil {
+			return nil
+		}
+
+		results := []ctrl.Request{}
+		for _, obj := range list.Items {
+			results = append(results, ctrl.Request{
+				NamespacedName: client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()},
+			})
+		}
+		return results
+
+	}), nil
+}

--- a/pkg/operator/ceph/controller/handler_test.go
+++ b/pkg/operator/ceph/controller/handler_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func TestObjectToCRMapper(t *testing.T) {
+	fs := &cephv1.CephFilesystem{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: reflect.TypeOf(cephv1.CephFilesystem{}).Name(),
+		},
+	}
+
+	// Objects to track in the fake client.
+	objects := []runtime.Object{
+		&cephv1.CephFilesystemList{},
+		fs,
+	}
+
+	// Register operator types with the runtime scheme.
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephFilesystemList{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephFilesystem{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{})
+
+	// Create a fake client to mock API calls.
+	cl := fake.NewFakeClientWithScheme(s, objects...)
+
+	// Fake reconcile request
+	fakeRequest := []ctrl.Request{
+		{NamespacedName: client.ObjectKey{Name: "my-pool", Namespace: "rook-ceph"}},
+	}
+
+	handlerFunc, err := ObjectToCRMapper(cl, objects[0], s)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, fakeRequest, handlerFunc.Map(handler.MapObject{Object: fs}))
+}

--- a/pkg/operator/ceph/controller/predicate_test.go
+++ b/pkg/operator/ceph/controller/predicate_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -74,31 +73,4 @@ func TestObjectChanged(t *testing.T) {
 	changed, err = objectChanged(oldObject, newObject)
 	assert.NoError(t, err)
 	assert.True(t, changed)
-}
-
-func TestIsUpgrade(t *testing.T) {
-	oldLabel := make(map[string]string)
-	newLabel := map[string]string{
-		"foo": "bar",
-	}
-
-	// no value do nothing
-	b := isUpgrade(oldLabel, newLabel)
-	assert.False(t, b)
-
-	// different value do something
-	newLabel["ceph_version"] = "15.2.0-octopus"
-	b = isUpgrade(oldLabel, newLabel)
-	assert.True(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
-
-	// same value do nothing
-	oldLabel["ceph_version"] = "15.2.0-octopus"
-	newLabel["ceph_version"] = "15.2.0-octopus"
-	b = isUpgrade(oldLabel, newLabel)
-	assert.False(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
-
-	// different value do something
-	newLabel["ceph_version"] = "15.2.1-octopus"
-	b = isUpgrade(oldLabel, newLabel)
-	assert.True(t, b, fmt.Sprintf("%v,%v", oldLabel, newLabel))
 }

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -101,6 +101,18 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Build Handler function to return the list of filesystems
+	handerFunc, err := opcontroller.ObjectToCRMapper(mgr.GetClient(), &cephv1.CephFilesystemList{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes on the CephCluster CR object
+	err = c.Watch(&source.Kind{Type: &cephv1.CephCluster{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: handerFunc}, opcontroller.WatchControllerPredicate())
+	if err != nil {
+		return err
+	}
+
 	// Watch for changes on the CephFilesystem CRD object
 	err = c.Watch(&source.Kind{Type: &cephv1.CephFilesystem{TypeMeta: controllerTypeMeta}}, &handler.EnqueueRequestForObject{}, opcontroller.WatchControllerPredicate())
 	if err != nil {

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -100,6 +100,18 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Build Handler function to return the list of nfs gateways
+	handerFunc, err := opcontroller.ObjectToCRMapper(mgr.GetClient(), &cephv1.CephNFSList{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes on the CephCluster CR object
+	err = c.Watch(&source.Kind{Type: &cephv1.CephCluster{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: handerFunc}, opcontroller.WatchControllerPredicate())
+	if err != nil {
+		return err
+	}
+
 	// Watch for changes on the cephNFS CRD object
 	err = c.Watch(&source.Kind{Type: &cephv1.CephNFS{TypeMeta: controllerTypeMeta}}, &handler.EnqueueRequestForObject{}, opcontroller.WatchControllerPredicate())
 	if err != nil {

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -101,6 +101,18 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Build Handler function to return the list of object stores
+	handerFunc, err := opcontroller.ObjectToCRMapper(mgr.GetClient(), &cephv1.CephObjectStoreList{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes on the CephCluster CR object
+	err = c.Watch(&source.Kind{Type: &cephv1.CephCluster{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: handerFunc}, opcontroller.WatchControllerPredicate())
+	if err != nil {
+		return err
+	}
+
 	// Watch for changes on the cephObjectStore CRD object
 	err = c.Watch(&source.Kind{Type: &cephv1.CephObjectStore{TypeMeta: controllerTypeMeta}}, &handler.EnqueueRequestForObject{}, opcontroller.WatchControllerPredicate())
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**

This is a follow-up on https://github.com/rook/rook/pull/5160 which uses
the controller runtime paradigm approach of watchers. So we now watch
for a CephCluster CR, if the spec image changed we trigger an upgrade.

The downside of that approach is that there is no control over the
workflow and this could allow version rollback.
We could use DiffImageSpecAndClusterRunningVersion but that requires
having a client and passing more to the predicate function. It's not a
hard blocker though, this can be revisited later.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]