### PR TITLE
ceph: fix resync failure of OSD pod using LV-backed-PV

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -697,6 +697,13 @@ func (c *Cluster) getOSDInfo(d *apps.Deployment) ([]OSDInfo, error) {
 		if envVar.Name == "ROOK_CV_MODE" {
 			osd.CVMode = envVar.Value
 		}
+		if envVar.Name == "ROOK_LV_BACKED_PV" {
+			lvBackedPV, err := strconv.ParseBool(envVar.Value)
+			if err != nil {
+				return []OSDInfo{}, errors.Wrap(err, "error parsing ROOK_LV_BACKED_PV")
+			}
+			osd.LVBackedPV = lvBackedPV
+		}
 		if envVar.Name == "ROOK_METADATA_DEVICE" {
 			osd.MetadataPath = envVar.Value
 		}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -291,8 +291,9 @@ func TestGetOSDInfo(t *testing.T) {
 
 	node := "n1"
 	location := "root=default host=myhost zone=myzone"
-	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", Location: location}
-	osd2 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: ""}
+	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location}
+	osd2 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true}
+	osd3 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: ""}
 	osdProp := osdProperties{
 		crushHostname: node,
 		pvc:           v1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
@@ -308,10 +309,19 @@ func TestGetOSDInfo(t *testing.T) {
 	assert.Equal(t, 1, len(osds1))
 	assert.Equal(t, osd1.ID, osds1[0].ID)
 	assert.Equal(t, osd1.BlockPath, osds1[0].BlockPath)
+	assert.Equal(t, osd1.CVMode, osds1[0].CVMode)
 	assert.Equal(t, location, osds1[0].Location)
 
 	d2, _ := c.makeDeployment(osdProp, osd2, dataPathMap)
-	osds2, err := c.getOSDInfo(d2)
-	assert.Equal(t, 0, len(osds2))
+	osds2, _ := c.getOSDInfo(d2)
+	assert.Equal(t, 1, len(osds2))
+	assert.Equal(t, osd2.ID, osds2[0].ID)
+	assert.Equal(t, osd2.BlockPath, osds2[0].BlockPath)
+	assert.Equal(t, osd2.CVMode, osds2[0].CVMode)
+	assert.Equal(t, osd2.LVBackedPV, osds2[0].LVBackedPV)
+
+	d3, _ := c.makeDeployment(osdProp, osd3, dataPathMap)
+	osds3, err := c.getOSDInfo(d3)
+	assert.Equal(t, 0, len(osds3))
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
**Description of your changes:**

This fixes the resync of the Deployment of the OSD pod that uses
an LV-backed PV.
`getOSDInfo()` reads the configuration of the OSD pod from the existing
Deployment, but it overlooked this case.

**Which issue is resolved by this Pull Request:**
Resolves #5139

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]
