### PR TITLE
rook: fix codegen

### DIFF
--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -35,7 +35,7 @@ bash ${codegendir}/generate-groups.sh \
     "${GROUP_VERSIONS}" \
     --output-base "${scriptdir}/../../vendor" \
     --go-header-file "${scriptdir}/boilerplate.go.txt"
-cp -r "${scriptdir}/../../vendor/github.com/rook/rook/pkg/" "${scriptdir}/../../pkg/"
+cp -r "${scriptdir}/../../vendor/github.com/rook/rook/pkg/" "${scriptdir}/../../"
 
 SED="sed -i.bak"
 

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -95,6 +95,8 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Edgefs().V1().S3s().Informer()}, nil
 	case edgefsrookiov1.SchemeGroupVersion.WithResource("s3xs"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Edgefs().V1().S3Xs().Informer()}, nil
+	case edgefsrookiov1.SchemeGroupVersion.WithResource("smbs"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Edgefs().V1().SMBs().Informer()}, nil
 	case edgefsrookiov1.SchemeGroupVersion.WithResource("swifts"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Edgefs().V1().SWIFTs().Informer()}, nil
 


### PR DESCRIPTION
**Description of your changes:**

The path was copied in the wrong location, ending up with a duplicated
directory in pkg/pkg/api. We need pkg/ only.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.


[test ceph]