### PR TITLE
build: update manifest-tools version to v1.0.2

### DIFF
--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -74,7 +74,7 @@ S3_SYNC_DEL := aws s3 sync --only-show-errors --delete
 # ====================================================================================
 # tools
 
-MANIFEST_TOOL_VERSION=v1.0.0
+MANIFEST_TOOL_VERSION=v1.0.2
 MANIFEST_TOOL := $(TOOLS_HOST_DIR)/manifest-tool-$(MANIFEST_TOOL_VERSION)
 
 $(MANIFEST_TOOL):


### PR DESCRIPTION
**Description of your changes:**

This updates the manifest-tools from v1.0.0 to v1.0.2 to
pickup the following fix
https://github.com/estesp/manifest-tool/pull/90.

This currently prevents the build to push images to Docker
hub.

Resolves #5194

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

This should be enough as the default of the `--tags` flags is `false`, see https://github.com/estesp/manifest-tool/blob/fa20a3b9b43f7c1acedb8d97c249803cc923e009/inspect.go#L21-L24.

**Which issue is resolved by this Pull Request:**
Resolves #5194

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
