### PR TITLE
Allow setting admin roles for dashboard

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -117,6 +117,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
   * `urlPrefix`: Allows to serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
   * `port`: Allows to change the default port where the dashboard is served
   * `ssl`: Whether to serve the dashboard via SSL, ignored on Ceph versions older than `13.2.2`
+  * `readonly`: Assigns Dashboard admin user read-only role
 * `monitoring`: Settings for monitoring Ceph using Prometheus. To enable monitoring on your cluster see the [monitoring guide](Documentation/ceph-monitoring.md#prometheus-alerts).
   * `enabled`: Whether to enable prometheus based monitoring for this cluster
   * `rulesNamespace`: Namespace to deploy prometheusRule. If empty, namespace of the cluster will be used.

--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -60,6 +60,7 @@ The following dashboard configuration settings are supported:
       urlPrefix: /ceph-dashboard
       port: 8443
       ssl: true
+      readonly: false
 ```
 
 * `urlPrefix` If you are accessing the dashboard via a reverse proxy, you may
@@ -71,6 +72,8 @@ The following dashboard configuration settings are supported:
 * `ssl` The dashboard may be served without SSL (useful for when you deploy the
   dashboard behind a proxy already served using SSL) by setting the `ssl` option
   to be false.
+
+* `readonly` assigns admin user read-only role
 
 ## Viewing the Dashboard External to the Cluster
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -5,6 +5,7 @@
 ## Notable Features
 
 ### Ceph
+- Added ceph dashboard read-only mode. This sets `read-only` role to admin user [see](https://docs.ceph.com/docs/master/mgr/dashboard/#user-roles-and-permissions)
 
 ### EdgeFS
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -132,6 +132,8 @@ type DashboardSpec struct {
 	Port int `json:"port,omitempty"`
 	// Whether SSL should be used
 	SSL bool `json:"ssl,omitempty"`
+	// Dashboard Admin user have read-only role
+	ReadOnly bool `json:"readonly,omitempty"`
 }
 
 // MonitoringSpec represents the settings for Prometheus based Ceph monitoring


### PR DESCRIPTION
We have a use case to have ceph dashboard read-only rights for
Admin user.

This commit adds Role field to DashboardSpec

Signed-off-by: Dinar Valeev <k0da@opensuse.org>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.
