### PR TITLE
ceph: Fixing path on ceph-quickstart to include rook

### DIFF
--- a/Documentation/cassandra.md
+++ b/Documentation/cassandra.md
@@ -22,7 +22,7 @@ First deploy the Rook Cassandra Operator using the following commands:
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/cassandra
+cd rook/cluster/examples/kubernetes/cassandra
 kubectl apply -f operator.yaml
 ```
 

--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -39,7 +39,7 @@ From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/ceph/monitoring
+cd rook/cluster/examples/kubernetes/ceph/monitoring
 ```
 
 Create the service monitor as well as the Prometheus server pod and service:

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -31,7 +31,7 @@ If you're feeling lucky, a simple Rook cluster can be created with the following
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/ceph
+cd rook/cluster/examples/kubernetes/ceph
 kubectl create -f common.yaml
 kubectl create -f operator.yaml
 kubectl create -f cluster.yaml

--- a/Documentation/cockroachdb.md
+++ b/Documentation/cockroachdb.md
@@ -21,7 +21,7 @@ First deploy the Rook CockroachDB operator using the following commands:
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/cockroachdb
+cd rook/cluster/examples/kubernetes/cockroachdb
 kubectl create -f operator.yaml
 ```
 

--- a/Documentation/edgefs-csi.md
+++ b/Documentation/edgefs-csi.md
@@ -107,7 +107,7 @@ Check configuration options and create kubernetes secret for Edgefs CSI NFS plug
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/edgefs/csi/nfs
+cd rook/cluster/examples/kubernetes/edgefs/csi/nfs
 kubectl create secret generic edgefs-nfs-csi-driver-config --from-file=./edgefs-nfs-csi-driver-config.yaml
 ```
 

--- a/Documentation/edgefs-monitoring.md
+++ b/Documentation/edgefs-monitoring.md
@@ -37,7 +37,7 @@ From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/edgefs/monitoring
+cd rook/cluster/examples/kubernetes/edgefs/monitoring
 ```
 
 Create the service monitor as well as the Prometheus server pod and service:

--- a/Documentation/edgefs-quickstart.md
+++ b/Documentation/edgefs-quickstart.md
@@ -49,7 +49,7 @@ If you're feeling lucky, a simple EdgeFS Rook cluster can be created with the fo
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/edgefs
+cd rook/cluster/examples/kubernetes/edgefs
 kubectl create -f operator.yaml
 kubectl create -f cluster.yaml
 ```

--- a/Documentation/nfs.md
+++ b/Documentation/nfs.md
@@ -24,7 +24,7 @@ First deploy the Rook NFS operator using the following commands:
 
 ```console
 git clone --single-branch --branch {{ branchName }} https://github.com/rook/rook.git
-cd cluster/examples/kubernetes/nfs
+cd rook/cluster/examples/kubernetes/nfs
 kubectl create -f operator.yaml
 ```
 


### PR DESCRIPTION
**Description of your changes:**

Merely appending rook to the cd path on this quickstart doc page.

**Checklist:**

- [x ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x ] Documentation has been updated, if necessary.
- [ x] Unit tests have been added, if necessary.
- [x ] Integration tests have been added, if necessary.
- [ x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ x] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ x] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]