### PR TITLE
Codegen needs to copy to pkg subfolder

### DIFF
--- a/build/codegen/codegen.sh
+++ b/build/codegen/codegen.sh
@@ -35,7 +35,7 @@ bash ${codegendir}/generate-groups.sh \
     "${GROUP_VERSIONS}" \
     --output-base "${scriptdir}/../../vendor" \
     --go-header-file "${scriptdir}/boilerplate.go.txt"
-cp -r "${scriptdir}/../../vendor/github.com/rook/rook/pkg/" "${scriptdir}/../../"
+cp -r "${scriptdir}/../../vendor/github.com/rook/rook/pkg" "${scriptdir}/../../"
 
 SED="sed -i.bak"
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The codegen output is moving the apis and client folders to the root folder instead of under pkg. @leseb Why was this changed in #5200? Perhaps there is a difference in dev environment setup.

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[skip ci]