### PR TITLE
Skip reconcile events where the spec is not updated

### DIFF
--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -60,14 +60,14 @@ func WatchControllerPredicate() predicate.Funcs {
 				objNew := e.ObjectNew.(*cephv1.CephObjectStore)
 				logger.Debug("update event from the parent object CephObjectStore")
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" ||
-					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
-					objOld.GetGeneration() != objNew.GetGeneration() {
+				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					// Checking if diff is not empty so we don't print it when the CR gets deleted
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
 					return true
+				} else if objOld.GetGeneration() != objNew.GetGeneration() {
+					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}
 				// Handling upgrades
 				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())
@@ -79,42 +79,42 @@ func WatchControllerPredicate() predicate.Funcs {
 				objNew := e.ObjectNew.(*cephv1.CephObjectStoreUser)
 				logger.Debug("update event from the parent object CephObjectStoreUser")
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" ||
-					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
-					objOld.GetGeneration() != objNew.GetGeneration() {
+				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					// Checking if diff is not empty so we don't print it when the CR gets deleted
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
 					return true
+				} else if objOld.GetGeneration() != objNew.GetGeneration() {
+					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}
 
 			case *cephv1.CephBlockPool:
 				objNew := e.ObjectNew.(*cephv1.CephBlockPool)
 				logger.Debug("update event from the parent object CephBlockPool")
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" ||
-					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
-					objOld.GetGeneration() != objNew.GetGeneration() {
+				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					// Checking if diff is not empty so we don't print it when the CR gets deleted
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
 					return true
+				} else if objOld.GetGeneration() != objNew.GetGeneration() {
+					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}
 
 			case *cephv1.CephFilesystem:
 				objNew := e.ObjectNew.(*cephv1.CephFilesystem)
 				logger.Debug("update event from the parent object CephFilesystem")
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" ||
-					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
-					objOld.GetGeneration() != objNew.GetGeneration() {
+				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					// Checking if diff is not empty so we don't print it when the CR gets deleted
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
 					return true
+				} else if objOld.GetGeneration() != objNew.GetGeneration() {
+					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}
 				// Handling upgrades
 				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())
@@ -126,14 +126,14 @@ func WatchControllerPredicate() predicate.Funcs {
 				objNew := e.ObjectNew.(*cephv1.CephNFS)
 				logger.Debug("update event from the parent object CephNFS")
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" ||
-					objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() ||
-					objOld.GetGeneration() != objNew.GetGeneration() {
+				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					// Checking if diff is not empty so we don't print it when the CR gets deleted
 					if diff != "" {
 						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					}
 					return true
+				} else if objOld.GetGeneration() != objNew.GetGeneration() {
+					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}
 				// Handling upgrades
 				isUpgrade := isUpgrade(objOld.GetLabels(), objNew.GetLabels())


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The controllers should ignore events for status updates. The reconcile only needs to happen when the spec is updated or the resource is marked for deletion. Otherwise, the controllers may stay in an update loop as the reconcile events are triggered again every time there is a status update during the reconcile.

The second commit is to more reliably update the status. When updating the status on resources sometimes the update fails due to the resource being an outdated version. This frequently occurs when the same reconcile loop updates the status multiple times, or the finalizer is added, or some other update to the resource. Upon the next reconcile the error would generally go away since the status or finalizer didn't need to be updated multiple times. But now the error is not expected since the controller will retrieve the latest version of the resource immediately before attempting to update it.

**Which issue is resolved by this Pull Request:**
Resolves #5173 

**Checklist:**

- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
- [ ] Comments have been added or updated based on the standards set in [CONTRIBUTING.md](https://github.com/rook/rook/blob/master/CONTRIBUTING.md#comments)
- [ ] Add the flag for skipping the CI if this PR does not require a build. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for more details.

[test ceph]