### PR TITLE
ceph: make admin key optional for external cluster

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -824,25 +824,37 @@ The script will look for the following populated environment variables:
 
 * `NAMESPACE`: the namespace where the configmap and secrets should be injected
 * `ROOK_EXTERNAL_FSID`: the fsid of the external Ceph cluster, it can be retrieved via the `ceph fsid` command
-* `ROOK_EXTERNAL_ADMIN_SECRET`: the external Ceph cluster admin secret key, it can be retrieved via the `ceph auth get-key client.admin` command
 * `ROOK_EXTERNAL_CEPH_MON_DATA`: is a common-separated list of running monitors IP address along with their ports, e.g: `a=172.17.0.4:6789,b=172.17.0.5:6789,c=172.17.0.6:6789`. You don't need to specify all the monitors, you can simply pass one and the Operator will discover the rest. The name of the monitor is the name that appears in the `ceph status` output.
+
+Now, we need to give Rook a key to connect to the cluster in order to perform various operations such as health cluster check, CSI keys management etc...
+It is recommended to generate keys with minimal access so the admin key does not need to be used by the external cluster.
+In this case, the admin key is only needed to generate the keys that will be used by the external cluster.
+But if the admin key is to be used by the external cluster, set the following variable:
+
+* `ROOK_EXTERNAL_ADMIN_SECRET`: **OPTIONAL:** the external Ceph cluster admin secret key, it can be retrieved via the `ceph auth get-key client.admin` command.
+
+> **WARNING**: If you plan to create CRs (pool, rgw, mds, nfs) in the external cluster, you **MUST** inject the client.admin keyring as well as injecting `cluster-external-management.yaml`
 
 **Example**:
 
 ```console
 export NAMESPACE=rook-ceph-external
 export ROOK_EXTERNAL_FSID=3240b4aa-ddbc-42ee-98ba-4ea7b2a61514
-export ROOK_EXTERNAL_ADMIN_SECRET=AQC6Ylxdja+NDBAAB7qy9MEAr4VLLq4dCIvxtg==
 export ROOK_EXTERNAL_CEPH_MON_DATA=a=172.17.0.4:6789
+export ROOK_EXTERNAL_ADMIN_SECRET=AQC6Ylxdja+NDBAAB7qy9MEAr4VLLq4dCIvxtg==
 ```
 
-Then you can simply execute the script like this:
+If the Ceph admin key is not provided, the following script needs to be executed on a machine that can connect to the Ceph cluster using the Ceph admin key.
+On that machine, run `cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh`.
+The script will automatically create users and keys with the lowest possible privileges and populate the necessary environment variables for `cluster/examples/kubernetes/ceph/import-external-cluster.sh` to work correctly.
+
+Finally, you can simply execute the script like this from a machine that has access to your Kubernetes cluster:
 
 ```console
 bash cluster/examples/kubernetes/ceph/import-external-cluster.sh
 ```
 
-#### CephCluster example
+#### CephCluster example (consumer)
 
 Assuming the above section has successfully completed, here is a CR example:
 
@@ -855,10 +867,8 @@ metadata:
 spec:
   external:
     enable: true
-  dataDirHostPath: /var/lib/rook
-  # providing an image is optional, do this if you want to create other CRs (rgw, mds, nfs)
-  cephVersion:
-    image: ceph/ceph:v14.2.9 # MUST match external cluster version
+  crashCollector:
+    disable: true
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.
@@ -873,3 +883,25 @@ kubectl create -f cluster/examples/kubernetes/ceph/cluster-external.yaml
 If the previous section has not been completed, the Rook Operator will still acknowledge the CR creation but will wait forever to receive connection information.
 
 > **WARNING**: If no cluster is managed by the current Rook Operator, you need to inject `common.yaml`, then modify `cluster-external.yaml` and specify `rook-ceph` as `namespace`.
+
+#### CephCluster example (management)
+
+The following CephCluster CR represents a cluster that will perform management tasks on the external cluster.
+It will not only act as a consumer but will also allow the deployment of other CRDs such as CephFilesystem or CephObjectStore.
+As mentioned above, you would need to inject the admin keyring for that.
+
+The corresponding YAML example:
+
+```yaml
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph-external
+  namespace: rook-ceph-external
+spec:
+  external:
+    enable: true
+  dataDirHostPath: /var/lib/rook
+  cephVersion:
+    image: ceph/ceph:v14.2.9 # Should match external cluster version
+```

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -8,7 +8,7 @@
 
 # If there is already a cluster managed by Rook in 'rook-ceph' then do:
 #   kubectl create -f common-external.yaml
-#   kubectl create -f cluster-external.yaml
+#   kubectl create -f cluster-external-management.yaml
 #################################################################################################################
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
@@ -18,5 +18,7 @@ metadata:
 spec:
   external:
     enable: true
-  crashCollector:
-    disable: true
+  dataDirHostPath: /var/lib/rook
+  # providing an image is required, if you want to create other CRs (rgw, mds, nfs)
+  cephVersion:
+    image: ceph/ceph:v14.2.8 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/common-external.yaml
+++ b/cluster/examples/kubernetes/ceph/common-external.yaml
@@ -9,7 +9,7 @@
 # Then common-external.yaml
 #
 # If there is no cluster managed by the current Rook Operator
-# you can simply replace all occurence of rook-ceph-external with rook-ceph
+# you can simply replace all occurrence of rook-ceph-external with rook-ceph
 #
 # And remove the following code:
 #

--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# this script creates all the users/keys on the external cluster
+# those keys will be injected via the import-external-cluster.sh once this one is done running
+# so you can run import-external-cluster.sh right after this script
+set -Eeuo pipefail
+
+#############
+# VARIABLES #
+#############
+
+: "${CLIENT_CHECKER_NAME:=client.healthchecker}"
+
+#############
+# FUNCTIONS #
+#############
+
+function is_available {
+  command -v "$@" &>/dev/null
+}
+
+function checkEnv() {
+  if ! is_available ceph; then
+    echo "'ceph' binary is expected'"
+    exit 1
+  fi
+
+  if ! ceph -s 1>/dev/null; then
+    echo "cannot connect to the ceph cluster"
+    exit 1
+fi
+}
+
+function createCheckerKey() {
+  checkerKey=$(ceph auth get-or-create "$CLIENT_CHECKER_NAME" mon 'allow r, allow command quorum_status'|awk '/key =/ { print $3}')
+  echo "export ROOK_EXTERNAL_USER_SECRET=$checkerKey"
+  echo "export ROOK_EXTERNAL_USERNAME=$CLIENT_CHECKER_NAME"
+}
+
+function createCephCSIKeyringRBDNode() {
+  cephCSIKeyringRBDNodeKey=$(ceph auth get-or-create client.csi-rbd-node mon 'profile rbd' osd 'profile rbd'|awk '/key =/ { print $3}')
+  echo "export CSI_RBD_NODE_SECRET_SECRET=$cephCSIKeyringRBDNodeKey"
+}
+
+function createCephCSIKeyringRBDProvisioner() {
+  cephCSIKeyringRBDProvisionerKey=$(ceph auth get-or-create client.csi-rbd-provisioner mon 'profile rbd' mgr 'allow rw' osd 'profile rbd'|awk '/key =/ { print $3}')
+  echo "export CSI_RBD_PROVISIONER_SECRET=$cephCSIKeyringRBDProvisionerKey"
+}
+
+function createCephCSIKeyringCephFSNode() {
+  cephCSIKeyringCephFSNodeKey=$(ceph auth get-or-create client.csi-cephfs-node mon 'allow r' mgr 'allow rw' osd 'allow rw tag cephfs *=*' mds 'allow rw'|awk '/key =/ { print $3}')
+  echo "export CSI_CEPHFS_NODE_SECRET=$cephCSIKeyringCephFSNodeKey"
+}
+
+function createCephCSIKeyringCephFSProvisioner() {
+  cephCSIKeyringCephFSProvisionerKey=$(ceph auth get-or-create client.csi-cephfs-provisioner mon 'allow r' mgr 'allow rw' osd 'allow rw tag cephfs metadata=*'|awk '/key =/ { print $3}')
+  echo "export CSI_CEPHFS_PROVISIONER_SECRET=$cephCSIKeyringCephFSProvisionerKey"
+}
+
+
+########
+# MAIN #
+########
+checkEnv
+createCheckerKey
+createCephCSIKeyringRBDNode
+createCephCSIKeyringRBDProvisioner
+createCephCSIKeyringCephFSNode
+createCephCSIKeyringCephFSProvisioner
+
+echo -e "successfully created users and keys, execute the above commands and run import-external-cluster.sh to inject them in your Kubernetes cluster."

--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -5,6 +5,11 @@ set -e
 # VARIABLES #
 #############
 MON_SECRET_NAME=rook-ceph-mon
+OPERATOR_CREDS=rook-ceph-operator-creds
+CSI_RBD_NODE_SECRET_NAME=rook-csi-rbd-node
+CSI_RBD_PROVISIONER_SECRET_NAME=rook-csi-rbd-provisioner
+CSI_CEPHFS_NODE_SECRET_NAME=rook-csi-cephfs-node
+CSI_CEPHFS_PROVISIONER_SECRET_NAME=rook-csi-cephfs-provisioner
 MON_SECRET_CLUSTER_NAME_KEYNAME=cluster-name
 MON_SECRET_FSID_KEYNAME=fsid
 MON_SECRET_ADMIN_KEYRING_KEYNAME=admin-secret
@@ -14,6 +19,7 @@ ROOK_EXTERNAL_CLUSTER_NAME=$NAMESPACE
 ROOK_EXTERNAL_MAX_MON_ID=2
 ROOK_EXTERNAL_MAPPING={}
 ROOK_EXTERNAL_MONITOR_SECRET=mon-secret
+: "${ROOK_EXTERNAL_ADMIN_SECRET:=admin-secret}"
 
 #############
 # FUNCTIONS #
@@ -28,13 +34,35 @@ function checkEnvVars() {
         echo "Please populate the environment variable ROOK_EXTERNAL_FSID"
         exit 1
     fi
-    if [ -z "$ROOK_EXTERNAL_ADMIN_SECRET" ]; then
-        echo "Please populate the environment variable ROOK_EXTERNAL_ADMIN_SECRET"
-        exit 1
-    fi
     if [ -z "$ROOK_EXTERNAL_CEPH_MON_DATA" ]; then
         echo "Please populate the environment variable ROOK_EXTERNAL_CEPH_MON_DATA"
         exit 1
+    fi
+    if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" == "admin-secret" ]]; then
+        if [ -z "$ROOK_EXTERNAL_USER_SECRET" ]; then
+            echo "Please populate the environment variable ROOK_EXTERNAL_USER_SECRET"
+            exit 1
+        fi
+        if [ -z "$ROOK_EXTERNAL_USERNAME" ]; then
+            echo "Please populate the environment variable ROOK_EXTERNAL_USERNAME"
+            exit 1
+        fi
+        if [ -z "$CSI_RBD_NODE_SECRET_SECRET" ]; then
+            echo "Please populate the environment variable CSI_RBD_NODE_SECRET_SECRET"
+            exit 1
+        fi
+        if [ -z "$CSI_RBD_PROVISIONER_SECRET" ]; then
+            echo "Please populate the environment variable CSI_RBD_PROVISIONER_SECRET"
+            exit 1
+        fi
+        if [ -z "$CSI_CEPHFS_NODE_SECRET" ]; then
+            echo "Please populate the environment variable CSI_CEPHFS_NODE_SECRET"
+            exit 1
+        fi
+        if [ -z "$CSI_CEPHFS_PROVISIONER_SECRET" ]; then
+            echo "Please populate the environment variable CSI_CEPHFS_PROVISIONER_SECRET"
+            exit 1
+        fi
     fi
 }
 
@@ -60,9 +88,64 @@ function importConfigMap() {
     --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
 }
 
+function importCheckerSecret() {
+    kubectl -n "$NAMESPACE" \
+    create \
+    secret \
+    generic \
+    "$OPERATOR_CREDS" \
+    --from-literal=userID="$ROOK_EXTERNAL_USERNAME" \
+    --from-literal=userKey="$ROOK_EXTERNAL_USER_SECRET"
+}
+
+function importCsiRBDNodeSecret() {
+    kubectl -n "$NAMESPACE" \
+    create \
+    secret \
+    generic \
+    "$CSI_RBD_NODE_SECRET_NAME" \
+    --from-literal=userID=csi-rbd-node \
+    --from-literal=userKey="$CSI_RBD_NODE_SECRET_SECRET"
+}
+
+function importCsiRBDProvisionerSecret() {
+    kubectl -n "$NAMESPACE" \
+    create \
+    secret \
+    generic \
+    "$CSI_RBD_PROVISIONER_SECRET_NAME" \
+    --from-literal=userID=csi-rbd-provisioner \
+    --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
+}
+
+function importCsiCephFSNodeSecret() {
+    kubectl -n "$NAMESPACE" \
+    create \
+    secret \
+    generic \
+    "$CSI_CEPHFS_NODE_SECRET_NAME" \
+    --from-literal=userID=csi-cephfs-node \
+    --from-literal=userKey="$CSI_CEPHFS_NODE_SECRET"
+}
+
+function importCsiCephFSProvisionerSecret() {
+    kubectl -n "$NAMESPACE" \
+    create \
+    secret \
+    generic \
+    "$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+    --from-literal=userID=csi-cephfs-provisioner \
+    --from-literal=userKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+}
+
 ########
 # MAIN #
 ########
 checkEnvVars
 importSecret
 importConfigMap
+importCheckerSecret
+importCsiRBDNodeSecret
+importCsiRBDProvisionerSecret
+importCsiCephFSNodeSecret
+importCsiCephFSProvisionerSecret

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -33,10 +33,11 @@ func TestFinalizeCephCommandArgs(t *testing.T) {
 		"--connect-timeout=15",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
+		"--name=client.admin",
 		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
 	}
 
-	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)
+	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName, "client.admin")
 	assert.Exactly(t, expectedCommand, cmd)
 	assert.Exactly(t, expectedArgs, args)
 }
@@ -62,10 +63,11 @@ func TestFinalizeRadosGWAdminCommandArgs(t *testing.T) {
 		"--rgw-zonegroup=default-rook",
 		"--cluster=rook",
 		"--conf=/var/lib/rook/rook-ceph/rook/rook.config",
+		"--name=client.admin",
 		"--keyring=/var/lib/rook/rook-ceph/rook/client.admin.keyring",
 	}
 
-	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)
+	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName, "client.admin")
 	assert.Exactly(t, expectedCommand, cmd)
 	assert.Exactly(t, expectedArgs, args)
 }
@@ -88,7 +90,7 @@ func TestFinalizeCephCommandArgsToolBox(t *testing.T) {
 		"--connect-timeout=15",
 	}
 
-	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)
+	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName, "client.admin")
 	assert.Exactly(t, "kubectl", cmd)
 	assert.Exactly(t, expectedArgs, args)
 }
@@ -104,7 +106,7 @@ func TestFinalizeCephCommandArgsClusterDefaultName(t *testing.T) {
 		"--connect-timeout=15",
 	}
 
-	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName)
+	cmd, args := FinalizeCephCommandArgs(expectedCommand, args, configDir, clusterName, "client.admin")
 	assert.Exactly(t, expectedCommand, cmd)
 	assert.Exactly(t, expectedArgs, args)
 }

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -66,3 +66,22 @@ func GetMonQuorumStatus(context *clusterd.Context, clusterName string) (MonStatu
 
 	return resp, nil
 }
+
+// GetMonQuorumStatusHealth calls quorum_status mon_command with a special client key
+func GetMonQuorumStatusHealth(context *clusterd.Context, clusterName, userName string) (MonStatusResponse, error) {
+	args := []string{"quorum_status", "--format", "json"}
+	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName, userName)
+
+	buf, err := context.Executor.ExecuteCommandWithOutput(command, args...)
+	if err != nil {
+		return MonStatusResponse{}, errors.Wrap(err, "mon quorum status failed")
+	}
+
+	var resp MonStatusResponse
+	err = json.Unmarshal([]byte(buf), &resp)
+	if err != nil {
+		return MonStatusResponse{}, errors.Wrapf(err, "unmarshal failed. raw buffer response: %s", buf)
+	}
+
+	return resp, nil
+}

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -25,18 +25,18 @@ import (
 func TestCephArgs(t *testing.T) {
 	// cluster a under /etc
 	args := []string{}
-	command, args := FinalizeCephCommandArgs(CephTool, args, "/etc", "a")
+	command, args := FinalizeCephCommandArgs(CephTool, args, "/etc", "a", "client.admin")
 	assert.Equal(t, CephTool, command)
-	assert.Equal(t, 4, len(args))
-	assert.Equal(t, 4, len(args))
+	assert.Equal(t, 5, len(args))
 	assert.Equal(t, "--connect-timeout=15", args[0])
 	assert.Equal(t, "--cluster=a", args[1])
 	assert.Equal(t, "--conf=/etc/a/a.config", args[2])
-	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", args[3])
+	assert.Equal(t, "--name=client.admin", args[3])
+	assert.Equal(t, "--keyring=/etc/a/client.admin.keyring", args[4])
 
 	RunAllCephCommandsInToolbox = true
 	args = []string{}
-	command, args = FinalizeCephCommandArgs(CephTool, args, "/etc", "a")
+	command, args = FinalizeCephCommandArgs(CephTool, args, "/etc", "a", "client.admin")
 	assert.Equal(t, Kubectl, command)
 	assert.Equal(t, 8, len(args), fmt.Sprintf("%+v", args))
 	assert.Equal(t, "-it", args[0])
@@ -51,17 +51,18 @@ func TestCephArgs(t *testing.T) {
 
 	// cluster under /var/lib/rook
 	args = []string{"myarg"}
-	command, args = FinalizeCephCommandArgs(RBDTool, args, "/var/lib/rook", "rook")
+	command, args = FinalizeCephCommandArgs(RBDTool, args, "/var/lib/rook", "rook", "client.admin")
 	assert.Equal(t, RBDTool, command)
-	assert.Equal(t, 4, len(args))
+	assert.Equal(t, 5, len(args))
 	assert.Equal(t, "myarg", args[0])
 	assert.Equal(t, "--cluster=rook", args[1])
 	assert.Equal(t, "--conf=/var/lib/rook/rook/rook.config", args[2])
-	assert.Equal(t, "--keyring=/var/lib/rook/rook/client.admin.keyring", args[3])
+	assert.Equal(t, "--name=client.admin", args[3])
+	assert.Equal(t, "--keyring=/var/lib/rook/rook/client.admin.keyring", args[4])
 
 	// the default ceph cluster will not need the config args
 	args = []string{"myarg"}
-	command, args = FinalizeCephCommandArgs(CephTool, args, "/etc", "ceph")
+	command, args = FinalizeCephCommandArgs(CephTool, args, "/etc", "ceph", "client.admin")
 	assert.Equal(t, CephTool, command)
 	assert.Equal(t, 2, len(args))
 	assert.Equal(t, "myarg", args[0])

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -158,6 +158,23 @@ func Status(context *clusterd.Context, clusterName string) (CephStatus, error) {
 	return status, nil
 }
 
+func StatusWithUser(context *clusterd.Context, clusterName, userName string) (CephStatus, error) {
+	args := []string{"status", "--format", "json"}
+	command, args := FinalizeCephCommandArgs("ceph", args, context.ConfigDir, clusterName, userName)
+
+	buf, err := context.Executor.ExecuteCommandWithOutput(command, args...)
+	if err != nil {
+		return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+	}
+
+	var status CephStatus
+	if err := json.Unmarshal([]byte(buf), &status); err != nil {
+		return CephStatus{}, errors.Wrapf(err, "failed to unmarshal status response")
+	}
+
+	return status, nil
+}
+
 // IsClusterClean returns msg (string), clean (bool), err (error)
 // msg describes the state of the PGs
 // clean is true if the cluster is clean

--- a/pkg/daemon/ceph/config/config_test.go
+++ b/pkg/daemon/ceph/config/config_test.go
@@ -99,6 +99,9 @@ func TestGenerateConfigFile(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 
+	isInitialized := clusterInfo.IsInitialized()
+	assert.True(t, isInitialized)
+
 	// generate the config file to disk now
 	configFilePath, err := GenerateConfigFile(context, clusterInfo, configDir, "myuser", filepath.Join(configDir, "mykeyring"), nil, nil)
 	assert.Nil(t, err)

--- a/pkg/daemon/ceph/config/info.go
+++ b/pkg/daemon/ceph/config/info.go
@@ -47,11 +47,21 @@ type MonInfo struct {
 // of the ClusterInfo struct during startup, specifically that it is expected to exist after the
 // Rook operator has started up or connected to the first components of the Ceph cluster.
 func (c *ClusterInfo) IsInitialized() bool {
-	if c == nil || c.FSID == "" || c.MonitorSecret == "" || c.AdminSecret == "" {
-		logger.Errorf("clusterInfo: %+v", c)
-		return false
+	var isInitialized bool
+
+	if c == nil {
+		logger.Error("clusterInfo is nil")
+	} else if c.FSID == "" {
+		logger.Error("cluster fsid is empty")
+	} else if c.MonitorSecret == "" {
+		logger.Error("monitor secret is empty")
+	} else if c.AdminSecret == "" {
+		logger.Error("admin secret is empty")
+	} else {
+		isInitialized = true
 	}
-	return true
+
+	return isInitialized
 }
 
 // NewMonInfo returns a new Ceph mon info struct from the given inputs.

--- a/pkg/daemon/ceph/config/info.go
+++ b/pkg/daemon/ceph/config/info.go
@@ -31,6 +31,7 @@ type ClusterInfo struct {
 	FSID          string
 	MonitorSecret string
 	AdminSecret   string
+	ExternalCred  ExternalCred
 	Name          string
 	Monitors      map[string]*MonInfo
 	CephVersion   cephver.CephVersion
@@ -40,6 +41,12 @@ type ClusterInfo struct {
 type MonInfo struct {
 	Name     string `json:"name"`
 	Endpoint string `json:"endpoint"`
+}
+
+// ExternalCred represents the external cluster username and key
+type ExternalCred struct {
+	Username string `json:"name"`
+	Secret   string `json:"secret"`
 }
 
 // IsInitialized returns true if the critical information in the ClusterInfo struct has been filled
@@ -62,6 +69,26 @@ func (c *ClusterInfo) IsInitialized() bool {
 	}
 
 	return isInitialized
+}
+
+// IsInitializedExternalCred returns true if the critical information in the ExternalCred struct has been filled
+// in for the external cluster connection
+func (c *ClusterInfo) IsInitializedExternalCred(logError bool) bool {
+	var isInitializedExternalCred bool
+
+	if c.ExternalCred.Username == "" {
+		if logError {
+			logger.Error("external credential username is empty")
+		}
+	} else if c.ExternalCred.Secret == "" {
+		if logError {
+			logger.Error("external credential secret is empty")
+		}
+	} else {
+		isInitializedExternalCred = true
+	}
+
+	return isInitializedExternalCred
 }
 
 // NewMonInfo returns a new Ceph mon info struct from the given inputs.

--- a/pkg/operator/ceph/cluster/controller_test.go
+++ b/pkg/operator/ceph/cluster/controller_test.go
@@ -254,13 +254,13 @@ func TestRemoveFinalizer(t *testing.T) {
 func TestValidateExternalClusterSpec(t *testing.T) {
 	c := &cluster{Spec: &cephv1.ClusterSpec{}, mons: &mon.Cluster{}}
 	err := validateExternalClusterSpec(c)
+	assert.NoError(t, err)
+
+	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.9"
+	err = validateExternalClusterSpec(c)
 	assert.Error(t, err)
 
 	c.Spec.DataDirHostPath = "path"
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err, err)
-
-	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.9"
-	err = validateExternalClusterSpec(c)
-	assert.NoError(t, err)
 }

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -37,6 +37,6 @@ func SecretEnvVar() v1.EnvVar {
 
 // AdminSecretEnvVar is the admin secret environment var
 func AdminSecretEnvVar() v1.EnvVar {
-	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: adminSecretName}
+	ref := &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: AppName}, Key: AdminSecretName}
 	return v1.EnvVar{Name: "ROOK_ADMIN_SECRET", ValueFrom: &v1.EnvVarSource{SecretKeyRef: ref}}
 }

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -59,13 +59,15 @@ const (
 	MappingKey = "mapping"
 
 	// AppName is the name of the secret storing cluster mon.admin key, fsid and name
-	AppName           = "rook-ceph-mon"
-	monNodeAttr       = "mon_node"
-	monClusterAttr    = "mon_cluster"
-	tprName           = "mon.rook.io"
-	fsidSecretName    = "fsid"
-	monSecretName     = "mon-secret"
-	adminSecretName   = "admin-secret"
+	AppName        = "rook-ceph-mon"
+	operatorCreds  = "rook-ceph-operator-creds"
+	monNodeAttr    = "mon_node"
+	monClusterAttr = "mon_cluster"
+	tprName        = "mon.rook.io"
+	fsidSecretName = "fsid"
+	monSecretName  = "mon-secret"
+	// AdminSecretName is the name of the admin secret
+	AdminSecretName   = "admin-secret"
 	clusterSecretName = "cluster-name"
 
 	// DefaultMonCount Default mon count for a cluster

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-// */
+*/
 
 package rbd
 

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -29,16 +29,16 @@ import (
 const (
 	csiKeyringRBDProvisionerUsername = "client.csi-rbd-provisioner"
 	csiKeyringRBDNodeUsername        = "client.csi-rbd-node"
-	csiRBDNodeSecret                 = "rook-csi-rbd-node"
-	csiRBDProvisionerSecret          = "rook-csi-rbd-provisioner"
+	CsiRBDNodeSecret                 = "rook-csi-rbd-node"
+	CsiRBDProvisionerSecret          = "rook-csi-rbd-provisioner"
 )
 
 // #nosec because of the word `Secret`
 const (
 	csiKeyringCephFSProvisionerUsername = "client.csi-cephfs-provisioner"
 	csiKeyringCephFSNodeUsername        = "client.csi-cephfs-node"
-	csiCephFSNodeSecret                 = "rook-csi-cephfs-node"
-	csiCephFSProvisionerSecret          = "rook-csi-cephfs-provisioner"
+	CsiCephFSNodeSecret                 = "rook-csi-cephfs-node"
+	CsiCephFSProvisionerSecret          = "rook-csi-cephfs-provisioner"
 )
 
 func createCSIKeyringRBDNode(s *keyring.SecretStore) (string, error) {
@@ -135,10 +135,10 @@ func createOrUpdateCSISecret(namespace, csiRBDProvisionerSecretKey, csiRBDNodeSe
 	}
 
 	keyringSecretMap := make(map[string]map[string][]byte)
-	keyringSecretMap[csiRBDProvisionerSecret] = csiRBDProvisionerSecrets
-	keyringSecretMap[csiRBDNodeSecret] = csiRBDNodeSecrets
-	keyringSecretMap[csiCephFSProvisionerSecret] = csiCephFSProvisionerSecrets
-	keyringSecretMap[csiCephFSNodeSecret] = csiCephFSNodeSecrets
+	keyringSecretMap[CsiRBDProvisionerSecret] = csiRBDProvisionerSecrets
+	keyringSecretMap[CsiRBDNodeSecret] = csiRBDNodeSecrets
+	keyringSecretMap[CsiCephFSProvisionerSecret] = csiCephFSProvisionerSecrets
+	keyringSecretMap[CsiCephFSNodeSecret] = csiCephFSNodeSecrets
 
 	for secretName, secret := range keyringSecretMap {
 		s := &v1.Secret{

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -37,7 +37,7 @@ func NewContext(context *clusterd.Context, name, clusterName string) *Context {
 }
 
 func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
-	command, args := client.FinalizeCephCommandArgs("radosgw-admin", args, c.Context.ConfigDir, c.ClusterName)
+	command, args := client.FinalizeCephCommandArgs("radosgw-admin", args, c.Context.ConfigDir, c.ClusterName, client.AdminUsername)
 
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(command, args...)

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -339,7 +339,7 @@ subjects:
 }
 
 func waitForFilesystemActive(k8sh *utils.K8sHelper, namespace, filesystemName string) error {
-	command, args := cephclient.FinalizeCephCommandArgs("ceph", []string{"fs", "status", filesystemName}, k8sh.MakeContext().ConfigDir, namespace)
+	command, args := cephclient.FinalizeCephCommandArgs("ceph", []string{"fs", "status", filesystemName}, k8sh.MakeContext().ConfigDir, namespace, cephclient.AdminUsername)
 	var stat string
 	var err error
 


### PR DESCRIPTION
**Description of your changes:**

Currently, we need to configure the Ceph external Admin key in the Rook deployment to be able to connect to an external Ceph cluster.
If we wanted to run in a multi-tenant fashion were several K8s/Rook clusters wanted to connect to the same external ceph cluster, each K8s deployment would have the access to the External Ceph Admin key and could potentially access or delete the Data from pools that belong to other k8s/Rook Clusters.

Now the admin key is optional but the helper script create-external-cluster-resources.sh
will help create the necessary keys/users to connect to that cluster.

Closes: https://github.com/rook/rook/issues/4917 and https://github.com/rook/rook/issues/5249
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4917

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]