### PR TITLE
Ceph: modify helm chart to be able to create resources of a ceph cluster in a different namespace

### DIFF
--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -20,7 +20,7 @@ HELM_CHARTS_DIR ?= $(ROOT_DIR)/cluster/charts
 HELM_OUTPUT_DIR ?= $(OUTPUT_DIR)/charts
 
 HELM_HOME := $(abspath $(CACHE_DIR)/helm)
-HELM_VERSION := v2.5.1
+HELM_VERSION := v2.16.5
 HELM := $(TOOLS_HOST_DIR)/helm-$(HELM_VERSION)
 HELM_INDEX := $(HELM_OUTPUT_DIR)/index.yaml
 export HELM_HOME

--- a/cluster/charts/rook-ceph/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph/templates/_helpers.tpl
@@ -24,3 +24,10 @@ imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define clusterNamespace option to use a different namespace for a ceph custer.
+*/}}
+{{- define "clusterNamespace" }}
+{{- default .Release.Namespace  .Values.clusterNamespace -}}
+{{- end -}}

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      rbac.rook.ceph.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
+      rbac.ceph.rook.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
 rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -20,7 +20,7 @@ metadata:
   labels:
     operator: rook
     storage-backend: ceph
-    rbac.rook.ceph.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
+    rbac.ceph.rook.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
 rules:
 - apiGroups:
   - ""
@@ -497,7 +497,7 @@ aggregationRule:
       rbac.ceph.rook.io/aggregate-to-rook-ceph-system-psp-user: "true"
 rules: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: 'psp:rook'
@@ -512,7 +512,7 @@ rules:
   resources:
   - podsecuritypolicies
   resourceNames:
-  - 00-rook-ceph-operator
+  - rook-privileged
   verbs:
   - use
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 # Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
 kind: ClusterRoleBinding
@@ -29,7 +29,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 # Allow the ceph osd to access cluster-wide resources necessary for determining their topology location
 kind: ClusterRoleBinding
@@ -43,7 +43,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-osd
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -65,7 +65,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: ClusterRole
   name: cephfs-csi-nodeplugin
@@ -78,7 +78,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: ClusterRole
   name: cephfs-external-provisioner-runner
@@ -91,7 +91,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: ClusterRole
   name: rbd-external-provisioner-runner
@@ -120,7 +120,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-default-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -162,7 +162,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -175,7 +175,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -188,7 +188,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -201,7 +201,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -210,7 +210,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: ClusterRole
   name: rbd-csi-nodeplugin
@@ -220,7 +220,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-osd-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -228,13 +228,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-osd
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-mgr-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -242,13 +242,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-mgr
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-cmd-reporter-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -256,6 +256,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 {{- end }}
 {{- end }}

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
+  namespace: {{ .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph

--- a/cluster/charts/rook-ceph/templates/namespace.yaml
+++ b/cluster/charts/rook-ceph/templates/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if (ne .Values.clusterNamespace  "") }}
+{{- if (ne .Values.clusterNamespace "") }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/cluster/charts/rook-ceph/templates/namespace.yaml
+++ b/cluster/charts/rook-ceph/templates/namespace.yaml
@@ -1,0 +1,13 @@
+{{- if (ne .Values.clusterNamespace  "") }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{  .Values.clusterNamespace }}
+{{- end }}
+
+{{- if (ne .Release.Namespace  "default") }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{  .Release.Namespace }}
+{{- end }}

--- a/cluster/charts/rook-ceph/templates/psp.yaml
+++ b/cluster/charts/rook-ceph/templates/psp.yaml
@@ -14,7 +14,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: 00-rook-ceph-operator
+  name: rook-privileged
 spec:
   privileged: true
   allowedCapabilities:

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -117,7 +117,10 @@ spec:
                             pattern: ^(true|false)$
                       useAllDevices:
                         type: boolean
-                      deviceFilter: {}
+                      deviceFilter:
+                        type: string
+                      devicePathFilter:
+                        type: string
                       devices:
                         type: array
                         items:
@@ -129,7 +132,10 @@ spec:
                   type: array
                 useAllDevices:
                   type: boolean
-                deviceFilter: {}
+                deviceFilter:
+                  type: string
+                devicePathFilter:
+                  type: string
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
@@ -167,10 +173,14 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-    - name: State
+    - name: Phase
       type: string
-      description: Current State
-      JSONPath: .status.state
+      description: Phase
+      JSONPath: .status.phase
+    - name: Message
+      type: string
+      description: Message
+      JSONPath: .status.message
     - name: Health
       type: string
       description: Ceph Health
@@ -215,6 +225,8 @@ spec:
                       minimum: 0
                       maximum: 10
                       type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
                 erasureCoded:
                   properties:
                     dataChunks:
@@ -245,6 +257,8 @@ spec:
                         minimum: 0
                         maximum: 10
                         type: integer
+                      requireSafeReplicaSize:
+                        type: boolean
                   erasureCoded:
                     properties:
                       dataChunks:

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -4,26 +4,36 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: rook-ceph-system
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
 rules:
 - apiGroups:
   - ""
-  - apps
-  - extensions
   resources:
   - pods
   - configmaps
   - services
-  - daemonsets
-  - statefulsets
-  - deployment
   verbs:
   - get
   - list
   - watch
   - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - statefulsets
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
   - create
   - update
   - delete
@@ -38,6 +48,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-osd
+  namespace: {{ template "clusterNamespace" . }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -51,6 +62,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr
+  namespace: {{ template "clusterNamespace" . }}
 rules:
 - apiGroups:
   - ""
@@ -85,6 +97,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-cmd-reporter
+  namespace: {{ template "clusterNamespace" . }}
 rules:
 - apiGroups:
   - ""
@@ -103,6 +116,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-external-provisioner-cfg
+  namespace: {{ template "clusterNamespace" . }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -118,6 +132,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-external-provisioner-cfg
+  namespace: {{ template "clusterNamespace" . }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/cluster/charts/rook-ceph/templates/rolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/rolebinding.yaml
@@ -37,7 +37,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-osd
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -45,14 +45,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-osd
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 # Allow the ceph mgr to access the cluster-specific resources necessary for the mgr modules
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,14 +60,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 # Allow the ceph mgr to access the rook system resources necessary for the mgr modules
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -75,13 +75,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -89,17 +89,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-cmd-reporter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-csi-provisioner-role-cfg
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: Role
   name: cephfs-external-provisioner-cfg
@@ -109,11 +109,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-csi-provisioner-role-cfg
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "clusterNamespace" . }}
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "clusterNamespace" . }}
 roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg

--- a/cluster/charts/rook-ceph/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-system
+  namespace: {{ .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -14,6 +15,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
+  namespace: {{ template "clusterNamespace" . }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -25,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
+  namespace: {{ template "clusterNamespace" . }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -35,6 +38,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
+  namespace:  {{ template "clusterNamespace" . }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -46,6 +50,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
+  namespace:  {{ template "clusterNamespace" . }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the cephfs csi provisioner
@@ -53,6 +58,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
+  namespace:  {{ template "clusterNamespace" . }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi driver
@@ -60,6 +66,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
+  namespace: {{ template "clusterNamespace" . }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi provisioner
@@ -67,4 +74,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
+  namespace: {{ template "clusterNamespace" . }}
 {{ template "imagePullSecrets" . }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -165,3 +165,4 @@ discoverDaemonUdev:
 # imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 # imagePullSecrets:
 # - name: my-registry-secret
+clusterNamespace: ""

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -68,7 +68,10 @@ csi:
   # Default value is RollingUpdate.
   #cephFSPluginUpdateStrategy: OnDelete
   # Allow starting unsupported ceph-csi image
+  logLevel: ""
   allowUnsupportedVersion: false
+  rbdPluginUpdateStrategy: ""
+  cephFSPluginUpdateStrategy: ""
 
   # Set provisonerTolerations and provisionerNodeAffinity for provisioner pod.
   # The CSI provisioner would be best to start on the same nodes as other ceph daemons.
@@ -90,6 +93,13 @@ csi:
   # Enable Ceph Kernel clients on kernel < 4.17. If your kernel does not support quotas for CephFS
   # you may want to disable this setting. However, this will cause an issue during upgrades
   # with the FUSE client. See the upgrade guide: https://rook.io/docs/rook/v1.2/ceph-upgrade.html
+  provisionerTolerations: ""
+  provisionerNodeAffinity: ""
+  pluginTolerations: ""
+  pluginNodeAffinity: ""
+  cephfsGrpcMetricsPort: ""
+  cephfsLivenessMetricsPort: ""
+  rbdGrpcMetricsPort: ""
   forceCephFSKernelClient: true
   #rbdLivenessMetricsPort: 9080
   #kubeletDirPath: /var/lib/kubelet
@@ -105,12 +115,21 @@ csi:
     #image: quay.io/k8scsi/csi-attacher:v2.1.0
   #resizer:
     #image: quay.io/k8scsi/csi-resizer:v0.4.0
+  rbdLivenessMetricsPort: ""
+  kubeletDirPath: ""
+  cephcsi: ""
+  registrar: ""
+  provisioner: ""
+  snapshotter: ""
+  attacher: ""
+  resizer: ""
 
 enableFlexDriver: false
 enableDiscoveryDaemon: true
 
 ## if true, run rook operator on the host network
 # useOperatorHostNetwork: true
+useOperatorHostNetwork: ""
 
 ## Rook Agent configuration
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute
@@ -132,6 +151,7 @@ enableDiscoveryDaemon: true
 #   flexVolumeDirPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/
 #   libModulesDirPath: /lib/modules
 #   mounts: mount1=/host/path:/container/path,/host/path2:/container/path2
+agent: ""
 
 ## Rook Discover configuration
 ## toleration: NoSchedule, PreferNoSchedule or NoExecute
@@ -146,6 +166,7 @@ enableDiscoveryDaemon: true
 #     operator: Exists
 #     effect: NoSchedule
 #   nodeAffinity: key1=value1,value2; key2=value3
+discover: ""
 
 # In some situations SELinux relabelling breaks (times out) on large filesystems, and doesn't work with cephfs ReadWriteMany volumes (last relabel wins).
 # Disable it here if you have similar issues.
@@ -165,4 +186,5 @@ discoverDaemonUdev:
 # imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 # imagePullSecrets:
 # - name: my-registry-secret
+imagePullSecrets: ""
 clusterNamespace: ""

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -122,7 +122,7 @@ spec:
                             type: string
                           storeType:
                             type: string
-                            pattern: ^(filestore|bluestore)$
+                            pattern: ^(bluestore)$
                           databaseSizeMB:
                             type: string
                           walSizeMB:


### PR DESCRIPTION
Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR is trying to do the following things:
1. update [helm chart](https://github.com/rook/rook/tree/master/cluster/charts/rook-ceph) and generate [common.yaml](https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/common.yaml) by `helm template ./cluster/charts/rook-ceph/ --namespace rook-ceph`
2.  modify [helm chart](https://github.com/rook/rook/tree/master/cluster/charts/rook-ceph)  to create easily a ceph cluster in a different namespace from the operator's one by editing `value.yaml`

Currently, I compared helm chart with the current `common.yaml` and updated helm chart.
Also, by modifying values.yaml, helm chart can create resources for a cluster namespace and operator namespace.

Which issue is resolved by this Pull Request:
Resolves #5049

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
