### PR TITLE
ceph: remove specific rgw configuration on mon configuration database

### DIFF
--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"encoding/json"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -63,6 +64,18 @@ func (m *MonStore) Set(who, option, value string) error {
 	return nil
 }
 
+// Delete a config in the centralized mon configuration database.
+func (m *MonStore) Delete(who, option string) error {
+	args := []string{"config", "rm", who, normalizeKey(option)}
+	cephCmd := client.NewCephCommand(m.context, m.namespace, args)
+	out, err := cephCmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete ceph config in the centralized mon configuration database. output: %s",
+			string(out))
+	}
+	return nil
+}
+
 // Get retrieves a config in the centralized mon configuration database.
 // https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
 func (m *MonStore) Get(who, option string) (string, error) {
@@ -73,6 +86,47 @@ func (m *MonStore) Get(who, option string) (string, error) {
 		return "", errors.Wrapf(err, "failed to get config setting %q for user %q", option, who)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// GetDaemon retrieves all configs for a specific daemon in the centralized mon configuration database.
+func (m *MonStore) GetDaemon(who string) ([]Option, error) {
+	args := []string{"config", "get", who}
+	cephCmd := client.NewCephCommand(m.context, m.namespace, args)
+	out, err := cephCmd.Run()
+	if err != nil {
+		return []Option{}, errors.Wrapf(err, "failed to get config for daemon %q. output: %s", who, string(out))
+	}
+	var result map[string]interface{}
+	err = json.Unmarshal(out, &result)
+	if err != nil {
+		return []Option{}, errors.Wrapf(err, "failed to parse json config for daemon %q. json: %s", who, string(out))
+	}
+	daemonOptions := []Option{}
+	for k := range result {
+		v := result[k].(map[string]interface{})
+		optionWho := v["section"].(string)
+		// Only get specialized options (don't take global one)
+		if optionWho == who {
+			daemonOptions = append(daemonOptions, Option{optionWho, k, v["value"].(string)})
+		}
+	}
+	return daemonOptions, nil
+}
+
+// DeleteDaemon delete all configs for a specific daemon in the centralized mon configuration database.
+func (m *MonStore) DeleteDaemon(who string) error {
+	configOptions, err := m.GetDaemon(who)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get daemon config for %q", who)
+	}
+
+	for _, option := range configOptions {
+		err := m.Delete(who, option.Option)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete option %q on %q", option.Option, who)
+		}
+	}
+	return nil
 }
 
 // SetAll sets all configs from the overrides in the centralized mon configuration database.

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -18,6 +18,7 @@ package file
 
 import (
 	"fmt"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -89,7 +90,33 @@ func createFilesystem(
 }
 
 // deleteFileSystem deletes the filesystem from Ceph
-func deleteFilesystem(context *clusterd.Context, cephVersion cephver.CephVersion, fs cephv1.CephFilesystem) error {
+func deleteFilesystem(
+	clusterInfo *cephconfig.ClusterInfo,
+	context *clusterd.Context,
+	fs cephv1.CephFilesystem,
+	clusterSpec *cephv1.ClusterSpec,
+	ownerRefs metav1.OwnerReference,
+	dataDirHostPath string,
+	scheme *runtime.Scheme,
+) error {
+	filesystem, err := client.GetFilesystem(context, fs.Namespace, fs.Name)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get filesystem %q", fs.Name)
+	}
+	c := mds.NewCluster(clusterInfo, context, clusterSpec, fs, filesystem, ownerRefs, dataDirHostPath, scheme)
+
+	// Delete mds CephX keys and configuration in centralized mon database
+	replicas := fs.Spec.MetadataServer.ActiveCount * 2
+	for i := 0; i < int(replicas); i++ {
+		daemonLetterID := k8sutil.IndexToName(i)
+		daemonName := fmt.Sprintf("%s-%s", fs.Name, daemonLetterID)
+
+		err = c.DeleteMdsCephObjects(daemonName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete mds ceph objects for filesystem %q", fs.Name)
+		}
+	}
+
 	// The most important part of deletion is that the filesystem gets removed from Ceph
 	// The K8s resources will already be removed with the K8s owner references
 	if err := downFilesystem(context, fs.Namespace, fs.Name); err != nil {

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -111,3 +111,15 @@ func (c *clusterConfig) setDefaultFlagsMonConfigStore(rgwName string) error {
 
 	return nil
 }
+
+func (c *clusterConfig) deleteFlagsMonConfigStore(rgwName string) error {
+	monStore := cephconfig.GetMonStore(c.context, c.store.Namespace)
+	who := generateCephXUser(rgwName)
+	err := monStore.DeleteDaemon(who)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete rgw config for %q in mon configuration database", who)
+	}
+
+	logger.Infof("successfully deleted rgw config for %q in mon configuration database", who)
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: n.fraison <n.fraison@criteo.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Remove specific rgw config added to the mon configuration database when deleting a CephObjectstore or when scaling down number of rgw

**Which issue is resolved by this Pull Request:**
Resolves #5185 

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]