### PR TITLE
doc: fix link in k8s-pre-reqs page

### DIFF
--- a/Documentation/k8s-pre-reqs.md
+++ b/Documentation/k8s-pre-reqs.md
@@ -31,7 +31,7 @@ please review this section. By default, Kubernetes clusters do not have PSPs ena
 be able to skip this section.
 
 If you are configuring Ceph on OpenShift, the Ceph walkthrough will configure the PSPs as well
-when you start the operator with [operator-openshift.yaml]((https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph/operator-openshift.yaml).
+when you start the operator with [operator-openshift.yaml](https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph/operator-openshift.yaml).
 
 ### Cluster Role
 


### PR DESCRIPTION
**Description of your changes:**

This fixes a markdwon link on the k8s-pre-reqs doc page.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]