### PR TITLE
ceph: refactor <StartTestCluster>

### DIFF
--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -81,10 +81,22 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 	s.namespace = "flex-ns"
 	s.pvcNameRWO = "block-persistent-rwo"
 	s.pvcNameRWX = "block-persistent-rwx"
-	useHelm := false
-	mons := 1
-	rbdMirrorWorkers := 1
-	s.op, s.kh = StartTestCluster(s.T, flexDriverMinimalTestVersion, s.namespace, "bluestore", useHelm, false, "", mons, rbdMirrorWorkers, installer.VersionMaster, installer.OctopusVersion, false)
+
+	flexTestCluster := TestCluster{
+		namespace:               s.namespace,
+		storeType:               "bluestore",
+		storageClassName:        "",
+		useHelm:                 false,
+		usePVC:                  false,
+		mons:                    1,
+		rbdMirrorWorkers:        1,
+		rookCephCleanup:         false,
+		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
+		rookVersion:             installer.VersionMaster,
+		cephVersion:             installer.OctopusVersion,
+	}
+
+	s.op, s.kh = StartTestCluster(s.T, &flexTestCluster)
 	s.testClient = clients.CreateTestClient(s.kh, s.op.installer.Manifests)
 	s.bc = s.testClient.BlockClient
 }

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -68,10 +68,21 @@ type HelmSuite struct {
 
 func (hs *HelmSuite) SetupSuite() {
 	hs.namespace = "helm-ns"
-	mons := 1
-	rbdMirrorWorkers := 1
-	rookCephCleanup := true
-	hs.op, hs.kh = StartTestCluster(hs.T, helmMinimalTestVersion, hs.namespace, "bluestore", true, false, "", mons, rbdMirrorWorkers, installer.VersionMaster, installer.NautilusVersion, rookCephCleanup)
+	helmTestCluster := TestCluster{
+		namespace:               hs.namespace,
+		storeType:               "bluestore",
+		storageClassName:        "",
+		useHelm:                 true,
+		usePVC:                  false,
+		mons:                    1,
+		rbdMirrorWorkers:        1,
+		rookCephCleanup:         true,
+		minimalMatrixK8sVersion: helmMinimalTestVersion,
+		rookVersion:             installer.VersionMaster,
+		cephVersion:             installer.NautilusVersion,
+	}
+
+	hs.op, hs.kh = StartTestCluster(hs.T, &helmTestCluster)
 	hs.helper = clients.CreateTestClient(hs.kh, hs.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -78,9 +78,21 @@ type SmokeSuite struct {
 
 func (suite *SmokeSuite) SetupSuite() {
 	suite.namespace = "smoke-ns"
-	mons := 3
-	rbdMirrorWorkers := 1
-	suite.op, suite.k8sh = StartTestCluster(suite.T, smokeSuiteMinimalTestVersion, suite.namespace, "bluestore", false, false, "", mons, rbdMirrorWorkers, installer.VersionMaster, installer.OctopusVersion, false)
+	smokeTestCluster := TestCluster{
+		namespace:               suite.namespace,
+		storeType:               "bluestore",
+		storageClassName:        "",
+		useHelm:                 false,
+		usePVC:                  false,
+		mons:                    3,
+		rbdMirrorWorkers:        1,
+		rookCephCleanup:         false,
+		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
+		rookVersion:             installer.VersionMaster,
+		cephVersion:             installer.OctopusVersion,
+	}
+
+	suite.op, suite.k8sh = StartTestCluster(suite.T, &smokeTestCluster)
 	suite.helper = clients.CreateTestClient(suite.k8sh, suite.op.installer.Manifests)
 }
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -72,21 +72,21 @@ type UpgradeSuite struct {
 
 func (s *UpgradeSuite) SetupSuite() {
 	s.namespace = "upgrade-ns"
-	mons := 1
-	rbdMirrorWorkers := 0
-	s.op, s.k8sh = StartTestCluster(s.T,
-		upgradeMinimalTestVersion,
-		s.namespace,
-		"",
-		false,
-		false,
-		"",
-		mons,
-		rbdMirrorWorkers,
-		installer.Version1_2,
-		installer.NautilusVersion,
-		false,
-	)
+	upgradeTestCluster := TestCluster{
+		namespace:               s.namespace,
+		storeType:               "",
+		storageClassName:        "",
+		useHelm:                 false,
+		usePVC:                  false,
+		mons:                    1,
+		rbdMirrorWorkers:        0,
+		rookCephCleanup:         false,
+		minimalMatrixK8sVersion: upgradeMinimalTestVersion,
+		rookVersion:             installer.Version1_2,
+		cephVersion:             installer.NautilusVersion,
+	}
+
+	s.op, s.k8sh = StartTestCluster(s.T, &upgradeTestCluster)
 	s.helper = clients.CreateTestClient(s.k8sh, s.op.installer.Manifests)
 }
 


### PR DESCRIPTION
Refactor the StartTestCluster method to make it more readable.
I have put most of the parameters used in this function in the <TesCluster> struct.
In this way the call to this function is more easy to understand and to use.
The addition of new parameters to this method started to be annoying.

[test ceph]

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
