### PR TITLE
ceph: Updated initializeBlockPVC method and added unit tests.

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -262,10 +262,6 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				devices.Entries["metadata"].Config.Name,
 			}...)
 
-			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
-			if crushDeviceClass != "" {
-				metadataArg = append(metadataArg, []string{crushDeviceClassFlag, crushDeviceClass}...)
-			}
 			metadataBlockPath = devices.Entries["metadata"].Config.Name
 		}
 
@@ -273,6 +269,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			logger.Infof("configuring new device %q", device.Config.Name)
 			var err error
 			var deviceArg string
+
 			if lvBackedPV {
 				// pass 'vg/lv' to ceph-volume
 				deviceArg, err = sys.GetLVName(context.Executor, device.Config.Name)
@@ -287,6 +284,11 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				"--data",
 				deviceArg,
 			}...)
+
+			crushDeviceClass := os.Getenv(oposd.CrushDeviceClassVarName)
+			if crushDeviceClass != "" {
+				immediateExecuteArgs = append(immediateExecuteArgs, []string{crushDeviceClassFlag, crushDeviceClass}...)
+			}
 
 			// Add the cli argument for the metadata device
 			if metadataDev {


### PR DESCRIPTION
Updated initializeBlockPVC method to add 
crushDeviceClass along with 
immediateExecuteArgs instead of
metadataArg. Also added unit tests for this method.


Closes: https://github.com/rook/rook/issues/3893
Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
