### PR TITLE
Ceph: make it possible to pass the integration test in the local environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ def RunIntegrationTest(k, v) {
                     sh '''#!/bin/bash
                           export KUBECONFIG=$HOME/admin.conf
                           tests/scripts/helm.sh up
-                          tests/scripts/localPathPV.sh'''
+                          tests/scripts/localPathPV.sh /dev/xvdc'''
                     try{
                         echo "Running full regression"
                         sh '''#!/bin/bash
@@ -202,7 +202,8 @@ def RunIntegrationTest(k, v) {
                                   TEST_BASE_DIR="WORKING_DIR" \
                                   TEST_LOG_COLLECTION_LEVEL='''+"${env.getLogs}"+''' \
                                   STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
-                                  TEST_ARGUMENTS='''+"${env.testArgs}"+'''
+                                  TEST_ARGUMENTS='''+"${env.testArgs}"+''' \
+                                  TEST_SCRATCH_DEVICE=/dev/xvdc
                               kubectl config view
                               _output/tests/linux_amd64/integration -test.v -test.timeout 7200s 2>&1 | tee _output/tests/integrationTests.log'''
                     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,9 +6,10 @@ quickly spin up a Kubernetes cluster.The Test framework is designed to install R
 
 ## Requirements
 1. Docker version => 1.2 && < 17.0 (for other alternatives, see below)
-2. Ubuntu 16 (the framework has only been tested on this version)
-3. Kubernetes with kubectl configured
-4. Rook
+1. Ubuntu 16 (the framework has only been tested on this version)
+1. kernel >= 4.8
+1. Kubernetes with kubectl configured
+1. Rook
 
 ## Instructions
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -758,6 +758,10 @@ func (h *CephInstaller) WipeClusterDisks(namespace string) error {
 // (non-boot) disks on a node, allowing Ceph to use the disk(s) during its testing.
 func (h *CephInstaller) GetDiskWipeJob(nodeName, jobName, namespace string) string {
 	// put the wipe job in the cluster namespace so that logs get picked up in failure conditions
+	scratchDevice := os.Getenv("TEST_SCRATCH_DEVICE")
+	if scratchDevice == "" {
+		scratchDevice = "/dev/xvdc"
+	}
 	return `apiVersion: batch/v1
 kind: Job
 metadata:
@@ -821,7 +825,7 @@ spec:
                       done
                       # Wipe the specific disk in the CI that was running in raw mode
                       set +Ee
-                      block=/dev/xvdc
+                      block=` + scratchDevice + `
                       wipefs --all "$block"
                       dd if=/dev/zero of="$block" bs=1M count=100 oflag=direct,dsync
                       set -Ee

--- a/tests/scripts/localPathPV.sh
+++ b/tests/scripts/localPathPV.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+test_scratch_device=/dev/xvdc
+if [ $# -ge 1 ] ; then
+  test_scratch_device=$1
+fi
+
+if [ ! -b "${test_scratch_device}" ] ; then
+  echo "invalid scratch device name: ${test_scratch_device}" >&2
+  exit 1
+fi
+
 lsblk
 
 random_string=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 8)
@@ -103,7 +113,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Block
   local:
-    path: "/dev/xvdc" 
+    path: "${test_scratch_device}" 
   nodeAffinity:
       required:
         nodeSelectorTerms:


### PR DESCRIPTION
**Description of your changes:**

Make it possible to pass the Ceph integration test in the local environment. Currently, it's difficult due to the lack of documentation and some CI-environment-specific configurations.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
