### PR TITLE
doc: fix secret env keys on ObjectBucketClaim

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -91,7 +91,7 @@ spec:
 ```
 1. use `env:` if mapping of the defined key names to the env var names used by the app is needed.
 1. makes available to the pod as env variables: `BUCKET_HOST`, `BUCKET_PORT`, `BUCKET_NAME`
-1. makes available to the pod as env variables: `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`
+1. makes available to the pod as env variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 
 ### StorageClass
 ```yaml


### PR DESCRIPTION
**Description of your changes:**

This commit adds the missing `AWS_` prefix to the data keys
of a Secret generated by an OBC.

The documentation on the Ceph ObjectBucketClaim CRD
erroneously states that the generated Secret resource
contains keys `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`.

According to ceph-object.md, and when mounting the secret
into a container via secretRef, or inspecting it with kubectl,
the variables have an `AWS_` prefix.
Like so: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]