### PR TITLE
docs: improve ceph finalizer patching (#1488)

### DIFF
--- a/Documentation/ceph-teardown.md
+++ b/Documentation/ceph-teardown.md
@@ -115,7 +115,17 @@ The operator is responsible for removing the finalizer after the mounts have bee
 If for some reason the operator is not able to remove the finalizer (ie. the operator is not running anymore), you can delete the finalizer manually with the following command:
 
 ```console
-kubectl -n rook-ceph patch crd cephclusters.ceph.rook.io --type merge -p '{"metadata":{"finalizers": [null]}}'
+for CRD in $(kubectl get crd -n rook-ceph | awk '/ceph.rook.io/ {print $1}'); do kubectl patch crd -n rook-ceph $CRD --type merge -p '{"metadata":{"finalizers": [null]}}'; done
+```
+
+This command will patch the following CRDs on v1.3:
+```console
+cephblockpools.ceph.rook.io
+cephclients.ceph.rook.io
+cephfilesystems.ceph.rook.io
+cephnfses.ceph.rook.io
+cephobjectstores.ceph.rook.io
+cephobjectstoreusers.ceph.rook.io
 ```
 
 Within a few seconds you should see that the cluster CRD has been deleted and will no longer block other cleanup such as deleting the `rook-ceph` namespace.


### PR DESCRIPTION
**Description of your changes:**
Improved the "Removing the Cluster CRD Finalizer" section of Ceph / Cleaning up a Cluster

**Which issue is resolved by this Pull Request:**
Resolves #1488 

[skip ci]

**Checklist:**

- [X] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
