### PR TITLE
ceph: update helm chart manifests

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      rbac.rook.ceph.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
+      rbac.ceph.rook.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
 rules: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -20,7 +20,7 @@ metadata:
   labels:
     operator: rook
     storage-backend: ceph
-    rbac.rook.ceph.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
+    rbac.ceph.rook.io/aggregate-to-rook-ceph-cluster-mgmt: "true"
 rules:
 - apiGroups:
   - ""
@@ -497,7 +497,7 @@ aggregationRule:
       rbac.ceph.rook.io/aggregate-to-rook-ceph-system-psp-user: "true"
 rules: []
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: 'psp:rook'

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -117,7 +117,10 @@ spec:
                             pattern: ^(true|false)$
                       useAllDevices:
                         type: boolean
-                      deviceFilter: {}
+                      deviceFilter:
+                        type: string
+                      devicePathFilter:
+                        type: string
                       devices:
                         type: array
                         items:
@@ -129,7 +132,10 @@ spec:
                   type: array
                 useAllDevices:
                   type: boolean
-                deviceFilter: {}
+                deviceFilter:
+                  type: string
+                devicePathFilter:
+                  type: string
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
@@ -138,10 +144,6 @@ spec:
                   type: boolean
                 rulesNamespace:
                   type: string
-            rbdMirroring:
-              properties:
-                workers:
-                  type: integer
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:
@@ -167,10 +169,14 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-    - name: State
+    - name: Phase
       type: string
-      description: Current State
-      JSONPath: .status.state
+      description: Phase
+      JSONPath: .status.phase
+    - name: Message
+      type: string
+      description: Message
+      JSONPath: .status.message
     - name: Health
       type: string
       description: Ceph Health

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -4,26 +4,36 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: rook-ceph-system
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
 rules:
 - apiGroups:
   - ""
-  - apps
-  - extensions
   resources:
   - pods
   - configmaps
   - services
-  - daemonsets
-  - statefulsets
-  - deployment
   verbs:
   - get
   - list
   - watch
   - patch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  - statefulsets
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
   - create
   - update
   - delete
@@ -38,6 +48,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-osd
+  namespace:  {{  .Release.Namespace }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -51,6 +62,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-mgr
+  namespace:  {{  .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -85,6 +97,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: rook-ceph-cmd-reporter
+  namespace:  {{  .Release.Namespace }}
 rules:
 - apiGroups:
   - ""
@@ -103,6 +116,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-external-provisioner-cfg
+  namespace:  {{  .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -118,6 +132,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-external-provisioner-cfg
+  namespace:  {{  .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]

--- a/cluster/charts/rook-ceph/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-system
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -14,6 +15,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -25,6 +27,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -35,6 +38,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
+  namespace:  {{  .Release.Namespace }}
   labels:
     operator: rook
     storage-backend: ceph
@@ -46,6 +50,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
+  namespace:  {{  .Release.Namespace }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the cephfs csi provisioner
@@ -53,6 +58,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
+  namespace:  {{  .Release.Namespace }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi driver
@@ -60,6 +66,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
+  namespace:  {{  .Release.Namespace }}
 {{ template "imagePullSecrets" . }}
 ---
 # Service account for the rbd csi provisioner
@@ -67,4 +74,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
+  namespace:  {{  .Release.Namespace }}
 {{ template "imagePullSecrets" . }}

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -122,7 +122,7 @@ spec:
                             type: string
                           storeType:
                             type: string
-                            pattern: ^(filestore|bluestore)$
+                            pattern: ^(bluestore)$
                           databaseSizeMB:
                             type: string
                           walSizeMB:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1926,7 +1926,7 @@ spec:
   storage:
     useAllNodes: true
     useAllDevices: true
-    deviceFilter:
+    deviceFilter: ''
     config:
       ` + store + `
       databaseSizeMB: "1024"


### PR DESCRIPTION
Currently, helm chart is somehow outdated and has differences with
example/common.yaml.
This commit modifies both manifests to use the same resources.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]