### PR TITLE
Backport: Allow toolbox script to skip watching mons

### DIFF
--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -70,4 +70,6 @@ EOF
 write_endpoints
 
 # continuously update the mon endpoints if they fail over
-watch_endpoints
+if [ "$1" != "--skip-watch" ]; then
+  watch_endpoints
+fi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The toolbox script is used for configuring the toolbox. If the mons are to fail over while the toolbox is running, the new list of mons needs to be updated. However, if run temporarily
as a one-time job, the script only needs to initialize the ceph.conf and then exit.

This is a minimal backport. The main feature will remain in master for v1.4 as seen in #5284.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]