### PR TITLE
Lookup of the cluster cannot rely on namespace name

### DIFF
--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -129,8 +129,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 
 	// Register operator types with the runtime scheme.
 	s := scheme.Scheme
-	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreUser{})
-	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{})
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreUser{}, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
 
 	// Create a fake client to mock API calls.
 	cl := fake.NewFakeClientWithScheme(s, object...)

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -322,7 +322,8 @@ func TestCephBlockPoolController(t *testing.T) {
 			Phase: "",
 		},
 	}
-	s.AddKnownTypes(cephv1.SchemeGroupVersion, cephCluster)
+
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
 
 	// Create CephCluster for updateCephBlockPoolStatus()
 	_, err = c.RookClientset.CephV1().CephClusters(namespace).Create(cephCluster)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -36,8 +36,8 @@ type CephManifests interface {
 	GetRookOperator(namespace string) string
 	GetClusterRoles(namespace, systemNamespace string) string
 	GetClusterExternalRoles(namespace, systemNamespace string) string
-	GetRookCluster(settings *ClusterSettings) string
-	GetRookExternalCluster(settings *ClusterExternalSettings) string
+	GetRookCluster(settings *clusterSettings) string
+	GetRookExternalCluster(settings *clusterExternalSettings) string
 	GetRookToolBox(namespace string) string
 	GetBlockPoolDef(poolName, namespace, replicaSize string) string
 	GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, systemNamespace string) string
@@ -53,7 +53,8 @@ type CephManifests interface {
 	GetClient(namespace, name string, caps map[string]string) string
 }
 
-type ClusterSettings struct {
+type clusterSettings struct {
+	ClusterName      string
 	Namespace        string
 	StoreType        string
 	DataDirHostPath  string
@@ -64,8 +65,8 @@ type ClusterSettings struct {
 	CephVersion      cephv1.CephVersionSpec
 }
 
-// ClusterExternalSettings represents the settings of an external cluster
-type ClusterExternalSettings struct {
+// clusterExternalSettings represents the settings of an external cluster
+type clusterExternalSettings struct {
 	Namespace       string
 	DataDirHostPath string
 }
@@ -1844,7 +1845,7 @@ subjects:
 }
 
 // GetRookCluster returns rook-cluster manifest
-func (m *CephManifestsMaster) GetRookCluster(settings *ClusterSettings) string {
+func (m *CephManifestsMaster) GetRookCluster(settings *clusterSettings) string {
 	store := "# storeType not specified; Rook will use default store types"
 	if settings.StoreType != "" {
 		store = `storeType: "` + settings.StoreType + `"`
@@ -1854,7 +1855,8 @@ func (m *CephManifestsMaster) GetRookCluster(settings *ClusterSettings) string {
 		return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: ` + settings.Namespace + `
+  # set the name to something different from the namespace
+  name: ` + settings.ClusterName + `
   namespace: ` + settings.Namespace + `
 spec:
   dataDirHostPath: ` + settings.DataDirHostPath + `
@@ -1905,7 +1907,7 @@ spec:
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: ` + settings.Namespace + `
+  name: ` + settings.ClusterName + `
   namespace: ` + settings.Namespace + `
 spec:
   cephVersion:
@@ -2244,7 +2246,7 @@ rules:
   - delete`
 }
 
-func (m *CephManifestsMaster) GetRookExternalCluster(settings *ClusterExternalSettings) string {
+func (m *CephManifestsMaster) GetRookExternalCluster(settings *clusterExternalSettings) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:

--- a/tests/framework/installer/ceph_manifests_v1.2.go
+++ b/tests/framework/installer/ceph_manifests_v1.2.go
@@ -1609,7 +1609,7 @@ subjects:
 }
 
 // GetRookCluster returns rook-cluster manifest
-func (m *CephManifestsV1_2) GetRookCluster(settings *ClusterSettings) string {
+func (m *CephManifestsV1_2) GetRookCluster(settings *clusterSettings) string {
 	store := "# storeType not specified; Rook will use default store types"
 	if settings.StoreType != "" {
 		store = `storeType: "` + settings.StoreType + `"`
@@ -1619,7 +1619,7 @@ func (m *CephManifestsV1_2) GetRookCluster(settings *ClusterSettings) string {
 		return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: ` + settings.Namespace + `
+  name: ` + settings.ClusterName + `
   namespace: ` + settings.Namespace + `
 spec:
   dataDirHostPath: ` + settings.DataDirHostPath + `
@@ -1672,7 +1672,7 @@ spec:
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: ` + settings.Namespace + `
+  name: ` + settings.ClusterName + `
   namespace: ` + settings.Namespace + `
 spec:
   cephVersion:
@@ -1987,7 +1987,7 @@ rules:
   - delete`
 }
 
-func (m *CephManifestsV1_2) GetRookExternalCluster(settings *ClusterExternalSettings) string {
+func (m *CephManifestsV1_2) GetRookExternalCluster(settings *clusterExternalSettings) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -101,6 +101,7 @@ type TestCluster struct {
 	kh                      *utils.K8sHelper
 	helper                  *clients.TestClient
 	T                       func() *testing.T
+	clusterName             string
 	namespace               string
 	storeType               string
 	storageClassName        string
@@ -143,7 +144,7 @@ func StartTestCluster(t func() *testing.T, cluster *TestCluster) (*TestCluster, 
 	require.NoError(t(), err)
 	checkIfShouldRunForMinimalTestMatrix(t, kh, cluster.minimalMatrixK8sVersion)
 
-	cluster.installer = installer.NewCephInstaller(t, kh.Clientset, cluster.useHelm, cluster.rookVersion, cluster.cephVersion, cluster.rookCephCleanup)
+	cluster.installer = installer.NewCephInstaller(t, kh.Clientset, cluster.useHelm, cluster.clusterName, cluster.rookVersion, cluster.cephVersion, cluster.rookCephCleanup)
 	cluster.kh = kh
 	cluster.helper = nil
 	cluster.T = t

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -135,7 +135,7 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
 
 	cleanupHost := false
-	i := installer.NewCephInstaller(t, kh.Clientset, false, installer.VersionMaster, installer.NautilusVersion, cleanupHost)
+	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion, cleanupHost)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1), "", false}
 	p := kh.IsStorageClassPresent("manual")

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -73,6 +73,7 @@ type UpgradeSuite struct {
 func (s *UpgradeSuite) SetupSuite() {
 	s.namespace = "upgrade-ns"
 	upgradeTestCluster := TestCluster{
+		clusterName:             s.namespace,
 		namespace:               s.namespace,
 		storeType:               "",
 		storageClassName:        "",


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The name of a CephCluster is commonly the same as the namespace, but not always. When looking up the ceph cluster we can look for the first one in the namespace rather than requiring the name to be the same as the namespace.

**Which issue is resolved by this Pull Request:**
Resolves #5302 

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]