### PR TITLE
Metadatadevice should not be added to osd data device list

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -396,6 +396,11 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 	metadataDevices := make(map[string]map[string]string)
 	for name, device := range devices.Entries {
 		if device.Data == -1 {
+			if device.Metadata != nil {
+				logger.Infof("skipping metadata device %s config since it will be configured with a data device", name)
+				continue
+			}
+
 			logger.Infof("configuring new device %s", name)
 			deviceArg := path.Join("/dev", name)
 			// ceph-volume prefers to use /dev/mapper/<name> if the device has this kind of alias


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the metadataDevice is specified, it was a regression that it was being interpreted also as a data device. ceph-volume was failing when the metadataDevice was added as both a data and metadata device. So we ensure it is not added to the list of data devices.

**Which issue is resolved by this Pull Request:**
Resolves #5300 

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]