### PR TITLE
Images: allow building images using Podman.

### DIFF
--- a/images/cassandra/Makefile
+++ b/images/cassandra/Makefile
@@ -26,7 +26,7 @@ TEMP := $(shell mktemp -d)
 # Build Rook Cassandra
 
 do.build:
-	@echo === docker build $(CASSANDRA_OPERATOR_IMAGE)
+	@echo === container build $(CASSANDRA_OPERATOR_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@$(DOCKERCMD) build $(BUILD_ARGS) \

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -41,7 +41,7 @@ YQ := $(TOOLS_HOST_DIR)/yq
 # Build Rook
 
 do.build: generate-csv-ceph-templates
-	@echo === docker build $(CEPH_IMAGE)
+	@echo === container build $(CEPH_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp toolbox.sh $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)

--- a/images/cockroachdb/Makefile
+++ b/images/cockroachdb/Makefile
@@ -25,7 +25,7 @@ TEMP := $(shell mktemp -d)
 # Build Rook CockroachDB
 
 do.build:
-	@echo === docker build $(COCKROACHDB_IMAGE)
+	@echo === container build $(COCKROACHDB_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@$(DOCKERCMD) build $(BUILD_ARGS) \

--- a/images/cross/Makefile
+++ b/images/cross/Makefile
@@ -20,7 +20,7 @@ CACHE_IMAGES = $(IMAGE)
 TEMP := $(shell mktemp -d)
 
 do.build:
-	@echo === docker build $(IMAGE)
+	@echo === container build $(IMAGE)
 	@cp -a . $(TEMP)
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \

--- a/images/edgefs/Makefile
+++ b/images/edgefs/Makefile
@@ -32,7 +32,7 @@ CURRENT_IMAGE_ID := $$($(DOCKERCMD) images -q $(EDGEFS_IMAGE))
 IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/edgefs.tar.gz
 
 do.build:
-	@echo === docker build $(EDGEFS_IMAGE)
+	@echo === container build $(EDGEFS_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@$(DOCKERCMD) build $(BUILD_ARGS) \

--- a/images/image.mk
+++ b/images/image.mk
@@ -18,7 +18,10 @@
 override GOOS=linux
 
 ifeq ($(origin DOCKERCMD),undefined)
-DOCKERCMD := docker
+DOCKERCMD?=$(shell docker version >/dev/null 2>&1 && echo docker)
+ifeq ($(DOCKERCMD),)
+DOCKERCMD=$(shell podman version >/dev/null 2>&1 && echo podman)
+endif
 endif
 
 # include the common make file

--- a/images/nfs/Makefile
+++ b/images/nfs/Makefile
@@ -39,7 +39,7 @@ CURRENT_IMAGE_ID := $$($(DOCKERCMD) images -q $(NFS_IMAGE))
 IMAGE_FILENAME := $(IMAGE_OUTPUT_DIR)/nfs.tar.gz
 
 do.build:
-	@echo === docker build $(NFS_IMAGE)
+	@echo === container build $(NFS_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@cd $(TEMP) && $(SED_CMD) 's|NFS_BASEIMAGE|$(NFS_BASEIMAGE)|g' Dockerfile

--- a/images/yugabytedb/Makefile
+++ b/images/yugabytedb/Makefile
@@ -25,7 +25,7 @@ TEMP := $(shell mktemp -d)
 # Build Rook YugabyteDB
 
 do.build:
-	@echo === docker build $(YUGABYTEDB_IMAGE)
+	@echo === container build $(YUGABYTEDB_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
 	@$(DOCKERCMD) build $(BUILD_ARGS) \


### PR DESCRIPTION
Automatically detect Podman if Docker is not available.
This allows me to run make and complete it succesfully without Docker
and without the need to set the DOCKERCMD env. variable.

Fixes: #5335 
Signed-off-by: Yaniv Kaul <ykaul@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5335

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
