### PR TITLE
Enable pg_autoscaler module in default examples

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -36,6 +36,10 @@ spec:
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false
+  mgr:
+    modules:
+    - name: pg_autoscaler
+      enabled: true
   dashboard:
     enabled: true
     ssl: true

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -42,12 +42,12 @@ spec:
   mon:
     count: 3
     allowMultiplePerNode: false
-  # mgr:
-    # modules:
+  mgr:
+    modules:
     # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
     # are already enabled by other settings in the cluster CR and the "rook" module is always enabled.
-    # - name: pg_autoscaler
-    #   enabled: true
+    - name: pg_autoscaler
+      enabled: true
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The pg_autoscaler is enabled by default in octopus. In nautilus it was a new feature and was not enabled by default for that reason. Now that the pg_autoscaler is more stable and is essentially the same as the autoscaler in octopus, we can enable it by default.

The pg_autoscaler module is already enabled in the integration tests and already mentioned by docs, this is just to enable it by default in the example cluster.yaml.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]