### PR TITLE
docs: update rook mailing lists to new lists.cncf.io addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please use the following to reach members of the community:
 - Slack: Join our [slack channel](https://slack.rook.io)
 - Forums: [rook-dev](https://groups.google.com/forum/#!forum/rook-dev)
 - Twitter: [@rook_io](https://twitter.com/rook_io)
-- Email: [info@rook.io](mailto:info@rook.io)
+- Email: [cncf-rook-info@lists.cncf.io](mailto:cncf-rook-info@lists.cncf.io)
 
 ### Community Meeting
 
@@ -61,7 +61,7 @@ Anyone who wants to discuss the direction of the project, design and implementat
 ### Reporting Security Vulnerabilities
 
 If you find a vulnerability or a potential vulnerability in Rook please let us know immediately at
-[security@rook.io](mailto:security@rook.io). We'll send a confirmation email to acknowledge your
+[cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io). We'll send a confirmation email to acknowledge your
 report, and we'll send an additional email when we've identified the issues positively or
 negatively.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,9 +31,9 @@ beta or stable storage provider **MUST** have a representative on the PST.
 
 ### Mailing lists
 
-* [security@rook.io](mailto:security@rook.io): for any security concerns. Received by Product
+* [cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io): for any security concerns. Received by Product
   Security Team members, and used by this Team to discuss security issues and fixes.
-* [rook-distributors-announce@lists.cncf.io](mailto:rook-distributors-announce@lists.cncf.io): for
+* [cncf-rook-distributors-announce@lists.cncf.io](mailto:cncf-rook-distributors-announce@lists.cncf.io): for
   early private information on Security patch releases. See below how Rook distributors can apply
   for this list.
 
@@ -43,7 +43,7 @@ beta or stable storage provider **MUST** have a representative on the PST.
 
 If you find a security vulnerability or any security related issues, please **DO NOT** file a public
 issue. **Do not** create a Github issue. Instead, send your report privately to
-[security@rook.io](mailto:security@rook.io). Security reports are greatly appreciated and we will
+[cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io). Security reports are greatly appreciated and we will
 publicly thank you for it.
 
 Please provide as much information as possible, so we can react quickly. For instance, that could
@@ -58,7 +58,7 @@ include:
 ### Public Disclosure Processes
 
 If you know of a publicly disclosed security vulnerability please **IMMEDIATELY** email
-[security@rook.io](mailto:security@rook.io) to inform the Product Security Team (PST) about the
+[cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io) to inform the Product Security Team (PST) about the
 vulnerability so we start the patch, release, and communication process.
 
 If possible the PST will ask the person making the public report if the issue can be handled via a
@@ -107,7 +107,7 @@ These steps should be completed within the 1-7 days of Disclosure.
 If the CVSS score is under 4.0 ([a low severity
 score](https://www.first.org/cvss/specification-document#i5)) the Fix Team can decide to slow the
 release process down in the face of holidays, developer bandwidth, etc. These decisions must be
-discussed on the [security@rook.io](mailto:security@rook.io) mailing list.
+discussed on the [cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io) mailing list.
 
 ### Fix Disclosure Process
 
@@ -130,7 +130,7 @@ patches, understand exact mitigation steps, etc.
   enough to require early disclosure to distributors. Generally this Private Distributor Disclosure
   process should be reserved for remotely exploitable or privilege escalation issues. Otherwise,
   this process can be skipped.
-* The Fix Lead will email the patches to rook-distributors-announce@lists.cncf.io so distributors
+* The Fix Lead will email the patches to cncf-rook-distributors-announce@lists.cncf.io so distributors
   can prepare their own release to be available to users on the day of the issue's announcement.
   Distributors should read about the [Private Distributor List](#private-distributor-list) to find
   out the requirements for being added to this list.
@@ -158,7 +158,7 @@ projects at once. This list is not intended for individuals to find out about se
 
 ### Embargo Policy
 
-The information members receive on rook-distributors-announce@lists.cncf.io must not be made public,
+The information members receive on cncf-rook-distributors-announce@lists.cncf.io must not be made public,
 shared, nor even hinted at anywhere beyond the need-to-know within your specific team except with
 the list's explicit approval. This holds true until the public disclosure date/time that was agreed
 upon by the list. Members of the list and others may not use the information for anything other than
@@ -168,7 +168,7 @@ Before any information from the list is shared with respective members of your t
 said issue, they must agree to the same terms and only find out information on a need-to-know basis.
 
 In the unfortunate event you share the information beyond what is allowed by this policy, you _must_
-urgently inform the [security@rook.io](mailto:security@rook.io) mailing list of exactly what
+urgently inform the [cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io) mailing list of exactly what
 information leaked and to whom.
 
 If you continue to leak information and break the policy outlined here, you will be removed from the
@@ -192,7 +192,7 @@ of the following:
 
 ### Membership Criteria
 
-To be eligible for the rook-distributors-announce@lists.cncf.io mailing list, your distribution
+To be eligible for the cncf-rook-distributors-announce@lists.cncf.io mailing list, your distribution
 should:
 
 1. Be an active distributor of Rook.
@@ -206,7 +206,7 @@ should:
 
 ### Requesting to Join
 
-New membership requests are sent to [security@rook.io](mailto:security@rook.io).
+New membership requests are sent to [cncf-rook-security@lists.cncf.io](mailto:cncf-rook-security@lists.cncf.io).
 
 In the body of your request please specify how you qualify and fulfill each criterion listed in
 [Membership Criteria](#membership-criteria).

--- a/cluster/olm/ceph/assemble/metadata-k8s.yaml
+++ b/cluster/olm/ceph/assemble/metadata-k8s.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   maintainers:
     - name: The Rook Authors
-      email: info@rook.io
+      email: cncf-rook-info@lists.cncf.io
   provider:
     name: The Rook Authors


### PR DESCRIPTION
**Description of your changes:**

This PR updates the readme and docs with the new Rook mailing lists hosted by the CNCF:

  - cncf-rook-info@lists.cncf.io
  - cncf-rook-security@lists.cncf.io
  - cncf-rook-distributors-announce@lists.cncf.io

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]