### PR TITLE
edgefs: raw disk empty check regression fix

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -144,7 +144,9 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 		}
 	}
 	if val, ok := diskProps["PKNAME"]; ok {
-		disk.Parent = path.Base(val)
+		if val != "" {
+			disk.Parent = path.Base(val)
+		}
 	}
 	if val, ok := diskProps["NAME"]; ok {
 		disk.RealPath = val


### PR DESCRIPTION
Signed-off-by: Dmitry Yusupov <dmitry.yusupov@nexenta.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Regression caused by ab83738aacf844c9727eadee699d41076cf690e7 commit. This PR isn't revert. It addressing the case when empty PKNAME and path.Base()

**Which issue is resolved by this Pull Request:**
Resolves #5244

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
