### PR TITLE
ceph: add support for OBC on external cluster

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
 {{- if .Values.csi.allowUnsupportedVersion }}
         - name: ROOK_CSI_ALLOW_UNSUPPORTED_VERSION
           value: {{ .Values.csi.allowUnsupportedVersion | quote }}
-{{- end }}     
+{{- end }}
 {{- if .Values.csi.pluginTolerations }}
         - name: CSI_PLUGIN_TOLERATIONS
           value: {{ toYaml .Values.csi.pluginTolerations | quote }}
@@ -223,6 +223,8 @@ spec:
           value: "{{ .Values.enableFlexDriver }}"
         - name: ROOK_ENABLE_DISCOVERY_DAEMON
           value: "{{ .Values.enableDiscoveryDaemon }}"
+        - name: ROOK_OBC_WATCH_OPERATOR_NAMESPACE
+          value: "{{ .Values.enableOBCWatchOperatorNamespace }}"
 
         - name: NODE_NAME
           valueFrom:

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -312,3 +312,6 @@ discoverDaemonUdev:
 # imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
 # imagePullSecrets:
 # - name: my-registry-secret
+
+# Whether the OBC provisioner should watch on the operator namespace or not, if not the namespace of the cluster will be used
+enableOBCWatchOperatorNamespace: true

--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
@@ -9,6 +9,7 @@ set -Eeuo pipefail
 #############
 
 : "${CLIENT_CHECKER_NAME:=client.healthchecker}"
+: "${RGW_POOL_PREFIX:=default}"
 
 #############
 # FUNCTIONS #
@@ -31,7 +32,7 @@ fi
 }
 
 function createCheckerKey() {
-  checkerKey=$(ceph auth get-or-create "$CLIENT_CHECKER_NAME" mon 'allow r, allow command quorum_status'|awk '/key =/ { print $3}')
+  checkerKey=$(ceph auth get-or-create "$CLIENT_CHECKER_NAME" mon 'allow r, allow command quorum_status' osd 'allow rwx pool='"$RGW_POOL_PREFIX"'.rgw.meta, allow r pool=.rgw.root, allow rw pool='"$RGW_POOL_PREFIX"'.rgw.control, allow x pool='"$RGW_POOL_PREFIX"'.rgw.buckets.index'|awk '/key =/ { print $3}')
   echo "export ROOK_EXTERNAL_USER_SECRET=$checkerKey"
   echo "export ROOK_EXTERNAL_USERNAME=$CLIENT_CHECKER_NAME"
 }

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -85,7 +85,7 @@ data:
   #   - effect: NoExecute
   #     key: node-role.kubernetes.io/etcd
   #     operator: Exists
- 
+
   # (Optional) CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
   # CSI_RBD_PROVISIONER_RESOURCE: |
@@ -234,13 +234,16 @@ data:
   #      limits:
   #        memory: 256Mi
   #        cpu: 100m
-  
+
   # Configure CSI CSI Ceph FS grpc and liveness metrics port
   # CSI_CEPHFS_GRPC_METRICS_PORT: "9091"
   # CSI_CEPHFS_LIVENESS_METRICS_PORT: "9081"
   # Configure CSI RBD grpc and liveness metrics port
   # CSI_RBD_GRPC_METRICS_PORT: "9090"
   # CSI_RBD_LIVENESS_METRICS_PORT: "9080"
+
+  # Whether the OBC provisioner should watch on the operator namespace or not, if not the namespace of the cluster will be used
+  ROOK_OBC_WATCH_OPERATOR_NAMESPACE: "true"
 ---
 # OLM: BEGIN OPERATOR DEPLOYMENT
 apiVersion: apps/v1

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-delete-bucket
-provisioner: ceph.rook.io/bucket
+provisioner: rook-ceph.ceph.rook.io/bucket
 # set the reclaim policy to delete the bucket and all objects
 # when its OBC is deleted.
 reclaimPolicy: Delete
@@ -10,7 +10,7 @@ parameters:
   objectStoreName: my-store
   objectStoreNamespace: rook-ceph
   region: us-east-1
-  # To accomodate brownfield cases reference the existing bucket name here instead
+  # To accommodate brownfield cases reference the existing bucket name here instead
   # of in the ObjectBucketClaim (OBC). In this case the provisioner will grant
   # access to the bucket by creating a new user, attaching it to the bucket, and
   # providing the credentials via a Secret in the namespace of the requesting OBC.

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-retain-external.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-retain-external.yaml
@@ -1,12 +1,14 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-   name: rook-ceph-retain-bucket
-provisioner: rook-ceph.ceph.rook.io/bucket
+   name: rook-ceph-retain-bucket-external
+provisioner: rook-ceph-external.ceph.rook.io/bucket
 # set the reclaim policy to retain the bucket when its OBC is deleted
 reclaimPolicy: Retain
 parameters:
-  objectStoreName: my-store # port 80 assumed
+  # represents the endpoint IP and Port
+  endpoint: # ip:port
+  # this is the namespace of the external cluster, identical to the namespace it is running on
   objectStoreNamespace: rook-ceph
   region: us-east-1
   # To accommodate brownfield cases reference the existing bucket name here instead

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -208,8 +208,14 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	clientController := cephclient.NewClientController(c.context, cluster.Namespace)
 	clientController.StartWatch(cluster.stopCh)
 
+	clientToUse := client.AdminUsername
+	if cluster.Spec.External.Enable {
+		clientToUse = cluster.Info.ExternalCred.Username
+	}
 	// Start the object bucket provisioner
-	bucketProvisioner := bucket.NewProvisioner(c.context, cluster.Namespace)
+	bucketProvisioner := bucket.NewProvisioner(c.context, cluster.Namespace, clientToUse)
+	// If cluster is external, pass down the user to the bucket controller
+
 	// note: the error return below is ignored and is expected to be removed from the
 	//   bucket library's `NewProvisioner` function
 	bucketController, _ := bucket.NewBucketController(c.context.KubeConfig, bucketProvisioner)

--- a/pkg/operator/ceph/object/bucket/provisionner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisionner_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"fmt"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	name      = "my-user"
+	namespace = "rook-ceph"
+	store     = "my-store"
+)
+
+func TestPopulateDomainAndPort(t *testing.T) {
+	p := NewProvisioner(&clusterd.Context{RookClientset: rookclient.NewSimpleClientset(), Clientset: test.New(t, 1)}, namespace, client.AdminUsername)
+	sc := &storagev1.StorageClass{
+		Parameters: map[string]string{
+			"foo": "bar",
+		},
+	}
+
+	// No endpoint and no CephObjectStore
+	err := p.populateDomainAndPort(sc)
+	assert.Error(t, err)
+
+	// Endpoint is set but port is missing
+	sc.Parameters["endpoint"] = "192.168.0.1"
+	err = p.populateDomainAndPort(sc)
+	assert.Error(t, err)
+
+	// Endpoint is set but IP is missing
+	sc.Parameters["endpoint"] = ":80"
+	err = p.populateDomainAndPort(sc)
+	assert.Error(t, err)
+
+	// Endpoint is correct
+	sc.Parameters["endpoint"] = "192.168.0.1:80"
+	err = p.populateDomainAndPort(sc)
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.0.1", p.storeDomainName)
+	assert.Equal(t, int32(80), p.storePort)
+
+	// No endpoint but a CephObjectStore
+	sc.Parameters["endpoint"] = ""
+	sc.Parameters["objectStoreNamespace"] = namespace
+	sc.Parameters["objectStoreName"] = store
+	cephObjectStore := &cephv1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      store,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephObjectStore"},
+		Spec: cephv1.ObjectStoreSpec{
+			Gateway: cephv1.GatewaySpec{
+				Port: int32(80),
+			},
+		},
+	}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", prefixObjectStoreSvc, store),
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "192.168.0.1",
+			Ports:     []v1.ServicePort{{Name: "port", Port: int32(80)}},
+		},
+	}
+
+	_, err = p.context.RookClientset.CephV1().CephObjectStores(namespace).Create(cephObjectStore)
+	assert.NoError(t, err)
+	_, err = p.context.Clientset.CoreV1().Services(namespace).Create(svc)
+	assert.NoError(t, err)
+	p.objectStoreNamespace = namespace
+	p.objectStoreName = store
+	err = p.populateDomainAndPort(sc)
+	assert.NoError(t, err)
+	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph", p.storeDomainName)
+}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -213,7 +213,7 @@ func LinkUser(c *Context, id, bucket string) (string, int, error) {
 }
 
 func UnlinkUser(c *Context, id, bucket string) (string, int, error) {
-	logger.Info("Unlinking (user: %s) (bucket: %s)", id, bucket)
+	logger.Infof("Unlinking (user: %s) (bucket: %s)", id, bucket)
 	args := []string{"bucket", "unlink", "--uid", id, "--bucket", bucket}
 	result, err := runAdminCommand(c, args...)
 	if err != nil {

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1593,6 +1593,7 @@ data:
   ROOK_CSI_ENABLE_CEPHFS: "true"
   ROOK_CSI_ENABLE_RBD: "true"
   ROOK_CSI_ENABLE_GRPC_METRICS: "true"
+  ROOK_OBC_WATCH_OPERATOR_NAMESPACE: "true"
 `
 }
 
@@ -2151,7 +2152,7 @@ func (m *CephManifestsMaster) GetBucketStorageClass(storeNameSpace string, store
 kind: StorageClass
 metadata:
    name: ` + storageClassName + `
-provisioner: ceph.rook.io/bucket
+provisioner: ` + storeNameSpace + `.ceph.rook.io/bucket
 reclaimPolicy: ` + reclaimPolicy + `
 parameters:
     objectStoreName: ` + storeName + `


### PR DESCRIPTION
**Description of your changes:**

We can now consume an external s3 endpoint which is not managed by Rook.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

**many things need to be fleshed out but I'm opening this early for review and discussion**

[test ceph]