### PR TITLE
Mention extra steps to do while installing cluster on a ns other than rook-ceph

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -2,6 +2,9 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
+# rook-ceph here is the namespace where your clusters is installed.
+# If you have your cluster setup in another namespace, please change
+# below to <ns-name>.rbd.csi.ceph.com
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   # clusterID is the namespace where operator is deployed.

--- a/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
@@ -3,6 +3,9 @@ apiVersion: snapshot.storage.k8s.io/v1alpha1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass
+# rook-ceph here is the namespace where your clusters is installed.
+# If you have your cluster setup in another namespace, please change
+# below to <ns-name>.rbd.csi.ceph.com
 snapshotter: rook-ceph.rbd.csi.ceph.com
 parameters:
   # Specify a string that identifies your cluster. Ceph CSI supports any

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -18,6 +18,9 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-block
+# rook-ceph here is the namespace where your clusters is installed.
+# If you have your cluster setup in another namespace, please change
+# below to <ns-name>.rbd.csi.ceph.com
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
     # clusterID is the namespace where the rook cluster is running

--- a/pkg/daemon/ceph/agent/agent.go
+++ b/pkg/daemon/ceph/agent/agent.go
@@ -51,12 +51,12 @@ func New(context *clusterd.Context) *Agent {
 func (a *Agent) Run() error {
 	volumeAttachmentController, err := attachment.New(a.context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create volume attachment controller")
+		return errors.Wrap(err, "failed to create volume attachment controller")
 	}
 
 	volumeManager, err := ceph.NewVolumeManager(a.context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create volume manager")
+		return errors.Wrap(err, "failed to create volume manager")
 	}
 
 	mountSecurityMode := os.Getenv(agent.AgentMountSecurityModeEnv)
@@ -75,12 +75,12 @@ func (a *Agent) Run() error {
 
 	err = rpc.Register(flexvolumeController)
 	if err != nil {
-		return errors.Wrapf(err, "unable to register rpc")
+		return errors.Wrap(err, "unable to register rpc")
 	}
 
 	driverName, err := flexvolume.RookDriverName(a.context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get driver name")
+		return errors.Wrap(err, "failed to get driver name")
 	}
 
 	flexDriverVendors := []string{flexvolume.FlexvolumeVendor, flexvolume.FlexvolumeVendorLegacy}

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager.go
@@ -154,7 +154,7 @@ func (vm *VolumeManager) Attach(image, pool, id, key, clusterNamespace string) (
 
 		retryCount++
 		if retryCount >= findDevicePathMaxRetries {
-			return "", errors.Wrapf(err, "exceeded retry count while finding device path")
+			return "", errors.Wrap(err, "exceeded retry count while finding device path")
 		}
 
 		logger.Infof("failed to find device path, sleeping 1 second. %v", err)
@@ -254,7 +254,7 @@ func getClusterInfo(context *clusterd.Context, clusterNamespace string) (string,
 func (f *devicePathFinder) FindDevicePath(image, pool, clusterNamespace string) (string, error) {
 	mappedFile, err := cephutil.FindRBDMappedFile(image, pool, cephutil.RBDSysBusPathDefault)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to find mapped image")
+		return "", errors.Wrap(err, "failed to find mapped image")
 	}
 
 	if mappedFile != "" {

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -165,7 +165,7 @@ func generateFlexSettings(enableSELinuxRelabeling, enableFSGroup bool) ([]byte, 
 	}
 	result, err := json.Marshal(status)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Invalid flex settings")
+		return nil, errors.Wrap(err, "Invalid flex settings")
 	}
 	return result, nil
 }

--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -85,7 +85,7 @@ func AuthGetCaps(context *clusterd.Context, clusterName, name string) (caps map[
 	var data []map[string]interface{}
 	err = json.Unmarshal(output, &data)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal auth get response")
+		return nil, errors.Wrap(err, "failed to unmarshal auth get response")
 	}
 	caps = make(map[string]string)
 
@@ -119,7 +119,7 @@ func AuthDelete(context *clusterd.Context, clusterName, name string) error {
 func parseAuthKey(buf []byte) (string, error) {
 	var resp map[string]interface{}
 	if err := json.Unmarshal(buf, &resp); err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal get/create key response")
+		return "", errors.Wrap(err, "failed to unmarshal get/create key response")
 	}
 	return resp["key"].(string), nil
 }

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -91,7 +91,7 @@ func GetCrushMap(context *clusterd.Context, clusterName string) (CrushMap, error
 
 	err = json.Unmarshal(buf, &c)
 	if err != nil {
-		return c, errors.Wrapf(err, "failed to unmarshal crush map")
+		return c, errors.Wrap(err, "failed to unmarshal crush map")
 	}
 
 	return c, nil

--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -37,7 +37,7 @@ func ListErasureCodeProfiles(context *clusterd.Context, namespace string) ([]str
 	args := []string{"osd", "erasure-code-profile", "ls"}
 	buf, err := NewCephCommand(context, namespace, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list erasure-code-profiles")
+		return nil, errors.Wrap(err, "failed to list erasure-code-profiles")
 	}
 
 	var ecProfiles []string
@@ -69,7 +69,7 @@ func CreateErasureCodeProfile(context *clusterd.Context, namespace, profileName 
 	// look up the default profile so we can use the default plugin/technique
 	defaultProfile, err := GetErasureCodeProfileDetails(context, namespace, "default")
 	if err != nil {
-		return errors.Wrapf(err, "failed to look up default erasure code profile")
+		return errors.Wrap(err, "failed to look up default erasure code profile")
 	}
 
 	// define the profile with a set of key/value pairs
@@ -93,7 +93,7 @@ func CreateErasureCodeProfile(context *clusterd.Context, namespace, profileName 
 	args = append(args, profilePairs...)
 	_, err = NewCephCommand(context, namespace, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to set ec-profile")
+		return errors.Wrap(err, "failed to set ec-profile")
 	}
 
 	return nil

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -81,7 +81,7 @@ func ListFilesystems(context *clusterd.Context, clusterName string) ([]CephFiles
 	args := []string{"fs", "ls"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list filesystems")
+		return nil, errors.Wrap(err, "failed to list filesystems")
 	}
 
 	var filesystems []CephFilesystem
@@ -353,7 +353,7 @@ func RemoveFilesystem(context *clusterd.Context, clusterName, fsName string, pre
 func deleteFSPools(context *clusterd.Context, clusterName string, fs *CephFilesystemDetails) error {
 	poolNames, err := GetPoolNamesByID(context, clusterName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get pool names")
+		return errors.Wrap(err, "failed to get pool names")
 	}
 
 	var lastErr error = nil

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -55,7 +55,7 @@ func GetMonQuorumStatus(context *clusterd.Context, clusterName string) (MonStatu
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()
 	if err != nil {
-		return MonStatusResponse{}, errors.Wrapf(err, "mon quorum status failed")
+		return MonStatusResponse{}, errors.Wrap(err, "mon quorum status failed")
 	}
 
 	var resp MonStatusResponse

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -205,12 +205,12 @@ func GetOSDUsage(context *clusterd.Context, clusterName string) (*OSDUsage, erro
 	args := []string{"osd", "df"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get osd df")
+		return nil, errors.Wrap(err, "failed to get osd df")
 	}
 
 	var osdUsage OSDUsage
 	if err := json.Unmarshal(buf, &osdUsage); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal osd df response")
+		return nil, errors.Wrap(err, "failed to unmarshal osd df response")
 	}
 
 	return &osdUsage, nil
@@ -220,12 +220,12 @@ func GetOSDPerfStats(context *clusterd.Context, clusterName string) (*OSDPerfSta
 	args := []string{"osd", "perf"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get osd perf")
+		return nil, errors.Wrap(err, "failed to get osd perf")
 	}
 
 	var osdPerfStats OSDPerfStats
 	if err := json.Unmarshal(buf, &osdPerfStats); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal osd perf response")
+		return nil, errors.Wrap(err, "failed to unmarshal osd perf response")
 	}
 
 	return &osdPerfStats, nil
@@ -236,12 +236,12 @@ func GetOSDDump(context *clusterd.Context, clusterName string) (*OSDDump, error)
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get osd dump")
+		return nil, errors.Wrap(err, "failed to get osd dump")
 	}
 
 	var osdDump OSDDump
 	if err := json.Unmarshal(buf, &osdDump); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal osd dump response")
+		return nil, errors.Wrap(err, "failed to unmarshal osd dump response")
 	}
 
 	return &osdDump, nil
@@ -258,12 +258,12 @@ func OsdSafeToDestroy(context *clusterd.Context, clusterName string, osdID int, 
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get safe-to-destroy status")
+		return false, errors.Wrap(err, "failed to get safe-to-destroy status")
 	}
 
 	var output SafeToDestroyStatus
 	if err := json.Unmarshal(buf, &output); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal safe-to-destroy response")
+		return false, errors.Wrap(err, "failed to unmarshal safe-to-destroy response")
 	}
 	if len(output.SafeToDestroy) != 0 && output.SafeToDestroy[0] == osdID {
 		return true, nil
@@ -278,12 +278,12 @@ func HostTree(context *clusterd.Context, clusterName string) (OsdTree, error) {
 	args := []string{"osd", "tree"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return output, errors.Wrapf(err, "failed to get osd tree")
+		return output, errors.Wrap(err, "failed to get osd tree")
 	}
 
 	err = json.Unmarshal(buf, &output)
 	if err != nil {
-		return output, errors.Wrapf(err, "failed to unmarshal 'osd tree' response")
+		return output, errors.Wrap(err, "failed to unmarshal 'osd tree' response")
 	}
 
 	return output, nil
@@ -296,12 +296,12 @@ func OsdListNum(context *clusterd.Context, clusterName string) (OsdList, error) 
 	args := []string{"osd", "ls"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return output, errors.Wrapf(err, "failed to get osd list")
+		return output, errors.Wrap(err, "failed to get osd list")
 	}
 
 	err = json.Unmarshal(buf, &output)
 	if err != nil {
-		return output, errors.Wrapf(err, "failed to unmarshal 'osd ls' response")
+		return output, errors.Wrap(err, "failed to unmarshal 'osd ls' response")
 	}
 
 	return output, nil

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -85,7 +85,7 @@ func ListPoolSummaries(context *clusterd.Context, namespace string) ([]CephStora
 	args := []string{"osd", "lspools"}
 	output, err := NewCephCommand(context, namespace, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list pools")
+		return nil, errors.Wrap(err, "failed to list pools")
 	}
 
 	var pools []CephStoragePoolSummary
@@ -100,7 +100,7 @@ func ListPoolSummaries(context *clusterd.Context, namespace string) ([]CephStora
 func GetPoolNamesByID(context *clusterd.Context, namespace string) (map[int]string, error) {
 	pools, err := ListPoolSummaries(context, namespace)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list pools")
+		return nil, errors.Wrap(err, "failed to list pools")
 	}
 	names := map[int]string{}
 	for _, p := range pools {
@@ -366,12 +366,12 @@ func GetPoolStats(context *clusterd.Context, namespace string) (*CephStoragePool
 	args := []string{"df", "detail"}
 	output, err := NewCephCommand(context, namespace, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get pool stats")
+		return nil, errors.Wrap(err, "failed to get pool stats")
 	}
 
 	var poolStats CephStoragePoolStats
 	if err := json.Unmarshal(output, &poolStats); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal pool stats response")
+		return nil, errors.Wrap(err, "failed to unmarshal pool stats response")
 	}
 
 	return &poolStats, nil
@@ -383,12 +383,12 @@ func GetPoolStatistics(context *clusterd.Context, name, namespace string) (*Pool
 	cmd.JsonOutput = true
 	output, err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get pool stats")
+		return nil, errors.Wrap(err, "failed to get pool stats")
 	}
 
 	var poolStats PoolStatistics
 	if err := json.Unmarshal(output, &poolStats); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal pool stats response")
+		return nil, errors.Wrap(err, "failed to unmarshal pool stats response")
 	}
 
 	return &poolStats, nil

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -152,7 +152,7 @@ func Status(context *clusterd.Context, clusterName string) (CephStatus, error) {
 
 	var status CephStatus
 	if err := json.Unmarshal(buf, &status); err != nil {
-		return CephStatus{}, errors.Wrapf(err, "failed to unmarshal status response")
+		return CephStatus{}, errors.Wrap(err, "failed to unmarshal status response")
 	}
 
 	return status, nil
@@ -169,7 +169,7 @@ func StatusWithUser(context *clusterd.Context, clusterName, userName string) (Ce
 
 	var status CephStatus
 	if err := json.Unmarshal([]byte(buf), &status); err != nil {
-		return CephStatus{}, errors.Wrapf(err, "failed to unmarshal status response")
+		return CephStatus{}, errors.Wrap(err, "failed to unmarshal status response")
 	}
 
 	return status, nil
@@ -252,7 +252,7 @@ func getMDSRank(status CephStatus, clusterName, fsName string) (int, error) {
 func MdsActiveOrStandbyReplay(context *clusterd.Context, clusterName, fsName string) error {
 	status, err := Status(context, clusterName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get ceph status")
+		return errors.Wrap(err, "failed to get ceph status")
 	}
 
 	mdsRank, err := getMDSRank(status, clusterName, fsName)

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -48,7 +48,7 @@ func getCephMonVersionString(context *clusterd.Context, clusterName string) (str
 	args := []string{"version"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to run 'ceph version")
+		return "", errors.Wrap(err, "failed to run 'ceph version")
 	}
 	output := string(buf)
 	logger.Debug(output)
@@ -106,7 +106,7 @@ func EnableMessenger2(context *clusterd.Context, clusterName string) error {
 	args := []string{"mon", "enable-msgr2"}
 	buf, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return errors.Wrapf(err, "failed to enable msgr2 protocol")
+		return errors.Wrap(err, "failed to enable msgr2 protocol")
 	}
 	output := string(buf)
 	logger.Debug(output)
@@ -133,7 +133,7 @@ func EnableReleaseOSDFunctionality(context *clusterd.Context, clusterName, relea
 func OkToStop(context *clusterd.Context, namespace, deployment, daemonType, daemonName string) error {
 	versions, err := GetAllCephDaemonVersions(context, namespace)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get ceph daemons versions")
+		return errors.Wrap(err, "failed to get ceph daemons versions")
 	}
 
 	switch daemonType {
@@ -273,12 +273,12 @@ func LeastUptodateDaemonVersion(context *clusterd.Context, clusterName, daemonTy
 	} else {
 		r, err = daemonMapEntry(versions, daemonType)
 		if err != nil {
-			return vv, errors.Wrapf(err, "failed to find daemon map entry")
+			return vv, errors.Wrap(err, "failed to find daemon map entry")
 		}
 		for v := range r {
 			version, err := cephver.ExtractCephVersion(v)
 			if err != nil {
-				return vv, errors.Wrapf(err, "failed to extract ceph version")
+				return vv, errors.Wrap(err, "failed to extract ceph version")
 			}
 			vv = *version
 			// break right after the first iteration
@@ -316,17 +316,17 @@ func daemonMapEntry(versions *CephDaemonsVersions, daemonType string) (map[strin
 func allOSDsSameHost(context *clusterd.Context, clusterName string) (bool, error) {
 	tree, err := HostTree(context, clusterName)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get the osd tree")
+		return false, errors.Wrap(err, "failed to get the osd tree")
 	}
 
 	osds, err := OsdListNum(context, clusterName)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to get the osd list")
+		return false, errors.Wrap(err, "failed to get the osd list")
 	}
 
 	hostOsdTree, err := buildHostListFromTree(tree)
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to build osd tree")
+		return false, errors.Wrap(err, "failed to build osd tree")
 	}
 
 	hostOsdNodes := len(hostOsdTree.Nodes)

--- a/pkg/daemon/ceph/config/config.go
+++ b/pkg/daemon/ceph/config/config.go
@@ -125,12 +125,12 @@ func GenerateConfigFile(context *clusterd.Context, cluster *ClusterInfo, pathRoo
 
 	configFile, err := createGlobalConfigFileSection(context, cluster, globalConfig)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create global config section")
+		return "", errors.Wrap(err, "failed to create global config section")
 	}
 
 	qualifiedUser := getQualifiedUser(user)
 	if err := addClientConfigFileSection(configFile, qualifiedUser, keyringPath, clientSettings); err != nil {
-		return "", errors.Wrapf(err, "failed to add admin client config section")
+		return "", errors.Wrap(err, "failed to add admin client config section")
 	}
 
 	if cluster.IsInitializedExternalCred(false) {
@@ -167,7 +167,7 @@ func CreateDefaultCephConfig(context *clusterd.Context, cluster *ClusterInfo) (*
 	if cephVersionEnv != "" {
 		v, err := cephver.ExtractCephVersion(cephVersionEnv)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to extract ceph version")
+			return nil, errors.Wrap(err, "failed to extract ceph version")
 		}
 		cluster.CephVersion = *v
 	}
@@ -203,7 +203,7 @@ func createGlobalConfigFileSection(context *clusterd.Context, cluster *ClusterIn
 		var err error
 		ceph, err = CreateDefaultCephConfig(context, cluster)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create default ceph config")
+			return nil, errors.Wrap(err, "failed to create default ceph config")
 		}
 	}
 

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -114,7 +114,7 @@ func getMonMap(context *clusterd.Context, clusterName string) ([]byte, error) {
 	args := []string{"mon", "getmap"}
 	buf, err := client.NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get mon map")
+		return nil, errors.Wrap(err, "failed to get mon map")
 	}
 	return buf, nil
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -150,7 +150,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	// Create OSD bootstrap keyring
 	err = createOSDBootstrapKeyring(context, a.cluster.Name, cephConfigDir)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to generate osd keyring")
+		return nil, errors.Wrap(err, "failed to generate osd keyring")
 	}
 
 	// Check if the PVC is an LVM block device (certain StorageClass do this)
@@ -167,7 +167,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 			}
 			lvBackedPV, err = sys.IsLV(dev, context.Executor)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to check device type")
+				return nil, errors.Wrap(err, "failed to check device type")
 			}
 			break
 		}
@@ -186,11 +186,11 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	// If running on OSD on PVC
 	if a.pvcBacked {
 		if block, metadataBlock, err = a.initializeBlockPVC(context, devices, lvBackedPV); err != nil {
-			return nil, errors.Wrapf(err, "failed to initialize devices on PVC")
+			return nil, errors.Wrap(err, "failed to initialize devices on PVC")
 		}
 	} else {
 		if err = a.initializeDevices(context, devices); err != nil {
-			return nil, errors.Wrapf(err, "failed to initialize devices")
+			return nil, errors.Wrap(err, "failed to initialize devices")
 		}
 	}
 
@@ -305,7 +305,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				}
 
 				// Return failure
-				return "", "", errors.Wrapf(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
+				return "", "", errors.Wrap(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
 			}
 			logger.Infof("%v", op)
 			// if raw mode is used or PV on LV, let's return the path of the device
@@ -476,12 +476,12 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 				logger.Infof("immediateReportArgs - %+v", baseCommand)
 				logger.Infof("immediateExecuteArgs - %+v", immediateExecuteArgs)
 				if err := context.Executor.ExecuteCommand(baseCommand, immediateReportArgs...); err != nil {
-					return errors.Wrapf(err, "failed ceph-volume report") // fail return here as validation provided by ceph-volume
+					return errors.Wrap(err, "failed ceph-volume report") // fail return here as validation provided by ceph-volume
 				}
 
 				// execute ceph-volume immediately with the device-specific setting instead of batching up multiple devices together
 				if err := context.Executor.ExecuteCommand(baseCommand, immediateExecuteArgs...); err != nil {
-					return errors.Wrapf(err, "failed ceph-volume")
+					return errors.Wrap(err, "failed ceph-volume")
 				}
 
 			}
@@ -524,7 +524,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 		}...)
 
 		if err := context.Executor.ExecuteCommand(baseCommand, reportArgs...); err != nil {
-			return errors.Wrapf(err, "failed ceph-volume report") // fail return here as validation provided by ceph-volume
+			return errors.Wrap(err, "failed ceph-volume report") // fail return here as validation provided by ceph-volume
 		}
 
 		reportArgs = append(reportArgs, []string{
@@ -541,7 +541,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 
 		var cvReport cephVolReport
 		if err = json.Unmarshal([]byte(cvOut), &cvReport); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal ceph-volume report json")
+			return errors.Wrap(err, "failed to unmarshal ceph-volume report json")
 		}
 
 		if path.Join("/dev", md) != cvReport.Vg.Devices {
@@ -550,7 +550,7 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 
 		// execute ceph-volume batching up multiple devices
 		if err := context.Executor.ExecuteCommand(baseCommand, mdArgs...); err != nil {
-			return errors.Wrapf(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
+			return errors.Wrap(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
 		}
 	}
 

--- a/pkg/daemon/ceph/test/info.go
+++ b/pkg/daemon/ceph/test/info.go
@@ -10,13 +10,13 @@ import (
 
 func CreateConfigDir(configDir string) error {
 	if err := os.MkdirAll(configDir, 0744); err != nil {
-		return errors.Wrapf(err, "error while creating directory")
+		return errors.Wrap(err, "error while creating directory")
 	}
 	if err := ioutil.WriteFile(path.Join(configDir, "client.admin.keyring"), []byte("key = adminsecret"), 0644); err != nil {
-		return errors.Wrapf(err, "admin writefile error")
+		return errors.Wrap(err, "admin writefile error")
 	}
 	if err := ioutil.WriteFile(path.Join(configDir, "mon.keyring"), []byte("key = monsecret"), 0644); err != nil {
-		return errors.Wrapf(err, "mon writefile error")
+		return errors.Wrap(err, "mon writefile error")
 	}
 	return nil
 }

--- a/pkg/daemon/ceph/util/util.go
+++ b/pkg/daemon/ceph/util/util.go
@@ -47,7 +47,7 @@ func FindRBDMappedFile(imageName, poolName, sysBusDir string) (string, error) {
 
 	files, err := ioutil.ReadDir(sysBusDeviceDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read rbd device dir")
+		return "", errors.Wrap(err, "failed to read rbd device dir")
 	}
 
 	for _, idFile := range files {

--- a/pkg/operator/ceph/agent/agent.go
+++ b/pkg/operator/ceph/agent/agent.go
@@ -69,7 +69,7 @@ func New(clientset kubernetes.Interface) *Agent {
 func (a *Agent) Start(namespace, agentImage, serviceAccount string) error {
 	err := a.createAgentDaemonSet(namespace, agentImage, serviceAccount)
 	if err != nil {
-		return errors.Wrapf(err, "error starting agent daemonset")
+		return errors.Wrap(err, "error starting agent daemonset")
 	}
 	return nil
 }
@@ -267,12 +267,12 @@ func (a *Agent) createAgentDaemonSet(namespace, agentImage, serviceAccount strin
 	_, err = a.clientset.AppsV1().DaemonSets(namespace).Create(ds)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			return errors.Wrapf(err, "failed to create rook-ceph-agent daemon set")
+			return errors.Wrap(err, "failed to create rook-ceph-agent daemon set")
 		}
 		logger.Infof("rook-ceph-agent daemonset already exists, updating ...")
 		_, err = a.clientset.AppsV1().DaemonSets(namespace).Update(ds)
 		if err != nil {
-			return errors.Wrapf(err, "failed to update rook-ceph-agent daemon set")
+			return errors.Wrap(err, "failed to update rook-ceph-agent daemon set")
 		}
 	} else {
 		logger.Infof("rook-ceph-agent daemonset started")

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -371,18 +371,18 @@ func (c *cluster) postMonStartupActions() error {
 	// Create CSI Kubernetes Secrets
 	err := csi.CreateCSISecrets(c.context, c.Namespace, &c.ownerRef)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create csi kubernetes secrets")
+		return errors.Wrap(err, "failed to create csi kubernetes secrets")
 	}
 
 	// Create crash collector Kubernetes Secret
 	err = crash.CreateCrashCollectorSecret(c.context, c.Namespace, &c.ownerRef)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create crash collector kubernetes secret")
+		return errors.Wrap(err, "failed to create crash collector kubernetes secret")
 	}
 
 	// Enable Ceph messenger 2 protocol on Nautilus
 	if err := client.EnableMessenger2(c.context, c.Namespace); err != nil {
-		return errors.Wrapf(err, "failed to enable Ceph messenger version 2.")
+		return errors.Wrap(err, "failed to enable Ceph messenger version 2")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -89,7 +89,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		logger.Info("creating 'rook-ceph-config' configmap.")
 		err = populateConfigOverrideConfigMap(cluster.context, c.namespacedName.Namespace, cluster.ownerRef)
 		if err != nil {
-			return errors.Wrapf(err, "failed to populate config override config map")
+			return errors.Wrap(err, "failed to populate config override config map")
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/crash/add.go
+++ b/pkg/operator/ceph/cluster/crash/add.go
@@ -154,7 +154,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrapf(err, "failed to watch for changes on the ceph pod nodename and enqueue their nodes")
+		return errors.Wrap(err, "failed to watch for changes on the ceph pod nodename and enqueue their nodes")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -48,7 +48,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterName string, o
 
 	// Create or update Kubernetes CSI secret
 	if err := createOrUpdateCrashCollectorSecret(clusterName, crashCollectorSecretKey, k, ownerRef); err != nil {
-		return errors.Wrapf(err, "failed to create kubernetes csi secret")
+		return errors.Wrap(err, "failed to create kubernetes csi secret")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -104,7 +104,7 @@ func (r *ReconcileNode) reconcile(request reconcile.Request) (reconcile.Result, 
 		if len(cephPods) == 0 {
 			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, errors.Wrapf(err, "failed to list all ceph pods")
+		return reconcile.Result{}, errors.Wrap(err, "failed to list all ceph pods")
 	}
 
 	namespaceToPodList := make(map[string][]corev1.Pod)

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -55,18 +55,18 @@ func (c *Cluster) configureDashboardService() error {
 		// expose the dashboard service
 		if _, err := c.context.Clientset.CoreV1().Services(c.Namespace).Create(dashboardService); err != nil {
 			if !kerrors.IsAlreadyExists(err) {
-				return errors.Wrapf(err, "failed to create dashboard mgr service")
+				return errors.Wrap(err, "failed to create dashboard mgr service")
 			}
 			logger.Infof("dashboard service already exists")
 			original, err := c.context.Clientset.CoreV1().Services(c.Namespace).Get(dashboardService.Name, metav1.GetOptions{})
 			if err != nil {
-				return errors.Wrapf(err, "failed to get dashboard service")
+				return errors.Wrap(err, "failed to get dashboard service")
 			}
 			if original.Spec.Ports[0].Port != int32(c.dashboardPort()) {
 				logger.Infof("dashboard port changed. updating service")
 				original.Spec.Ports[0].Port = int32(c.dashboardPort())
 				if _, err := c.context.Clientset.CoreV1().Services(c.Namespace).Update(original); err != nil {
-					return errors.Wrapf(err, "failed to update dashboard mgr service")
+					return errors.Wrap(err, "failed to update dashboard mgr service")
 				}
 			}
 		} else {
@@ -76,7 +76,7 @@ func (c *Cluster) configureDashboardService() error {
 		// delete the dashboard service if it exists
 		err := c.context.Clientset.CoreV1().Services(c.Namespace).Delete(dashboardService.Name, &metav1.DeleteOptions{})
 		if err != nil && !kerrors.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to delete dashboard service")
+			return errors.Wrap(err, "failed to delete dashboard service")
 		}
 	}
 
@@ -98,7 +98,7 @@ func (c *Cluster) configureDashboardModules() error {
 
 	hasChanged, err := c.initializeSecureDashboard()
 	if err != nil {
-		return errors.Wrapf(err, "failed to initialize dashboard")
+		return errors.Wrap(err, "failed to initialize dashboard")
 	}
 
 	for _, daemonID := range c.getDaemonIDs() {
@@ -158,13 +158,13 @@ func (c *Cluster) initializeSecureDashboard() (bool, error) {
 
 	password, err := c.getOrGenerateDashboardPassword()
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to generate a password for the ceph dashboard")
+		return false, errors.Wrap(err, "failed to generate a password for the ceph dashboard")
 	}
 
 	if c.dashboard.SSL {
 		alreadyCreated, err := c.createSelfSignedCert()
 		if err != nil {
-			return false, errors.Wrapf(err, "failed to create a self signed cert for the ceph dashboard")
+			return false, errors.Wrap(err, "failed to create a self signed cert for the ceph dashboard")
 		}
 		if alreadyCreated {
 			return false, nil
@@ -172,7 +172,7 @@ func (c *Cluster) initializeSecureDashboard() (bool, error) {
 	}
 
 	if err := c.setLoginCredentials(password); err != nil {
-		return false, errors.Wrapf(err, "failed to set login credentials for the ceph dashboard")
+		return false, errors.Wrap(err, "failed to set login credentials for the ceph dashboard")
 	}
 
 	return true, nil
@@ -202,7 +202,7 @@ func (c *Cluster) createSelfSignedCert() (bool, error) {
 					continue
 				}
 			}
-			return false, errors.Wrapf(err, "failed to create self signed cert on mgr")
+			return false, errors.Wrap(err, "failed to create self signed cert on mgr")
 		}
 		break
 	}
@@ -235,13 +235,13 @@ func (c *Cluster) getOrGenerateDashboardPassword() (string, error) {
 		return decodeSecret(secret)
 	}
 	if !kerrors.IsNotFound(err) {
-		return "", errors.Wrapf(err, "failed to get dashboard secret")
+		return "", errors.Wrap(err, "failed to get dashboard secret")
 	}
 
 	// Generate a password
 	password, err := generatePassword(passwordLength)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to generate password")
+		return "", errors.Wrap(err, "failed to generate password")
 	}
 
 	// Store the keyring in a secret
@@ -260,7 +260,7 @@ func (c *Cluster) getOrGenerateDashboardPassword() (string, error) {
 
 	_, err = c.context.Clientset.CoreV1().Secrets(c.Namespace).Create(secret)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to save dashboard secret")
+		return "", errors.Wrap(err, "failed to save dashboard secret")
 	}
 	return password, nil
 }
@@ -270,7 +270,7 @@ func generatePassword(length int) (string, error) {
 	const passwordChars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 	passwd, err := generateRandomBytes(length)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to generate password")
+		return "", errors.Wrap(err, "failed to generate password")
 	}
 	for i, pass := range passwd {
 		passwd[i] = passwordChars[pass%byte(len(passwordChars))]
@@ -282,7 +282,7 @@ func generatePassword(length int) (string, error) {
 func generateRandomBytes(length int) ([]byte, error) {
 	bytes := make([]byte, length)
 	if _, err := rand.Read(bytes); err != nil {
-		return nil, errors.Wrapf(err, "failed to generate random bytes")
+		return nil, errors.Wrap(err, "failed to generate random bytes")
 	}
 	return bytes, nil
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -199,7 +199,7 @@ func (c *Cluster) Start() error {
 	service := c.makeMetricsService(AppName)
 	if _, err := c.context.Clientset.CoreV1().Services(c.Namespace).Create(service); err != nil {
 		if !kerrors.IsAlreadyExists(err) {
-			return errors.Wrapf(err, "failed to create mgr service")
+			return errors.Wrap(err, "failed to create mgr service")
 		}
 		logger.Infof("mgr metrics service already exists")
 	} else {
@@ -255,7 +255,7 @@ func startModuleConfiguration(description string, configureModules func() error)
 // Ceph docs about the prometheus module: http://docs.ceph.com/docs/master/mgr/prometheus/
 func (c *Cluster) enablePrometheusModule() error {
 	if err := client.MgrEnableModule(c.context, c.Namespace, prometheusModuleName, true); err != nil {
-		return errors.Wrapf(err, "failed to enable mgr prometheus module")
+		return errors.Wrap(err, "failed to enable mgr prometheus module")
 	}
 	return nil
 }
@@ -263,7 +263,7 @@ func (c *Cluster) enablePrometheusModule() error {
 // Ceph docs about the crash module: https://docs.ceph.com/docs/master/mgr/crash/
 func (c *Cluster) enableCrashModule() error {
 	if err := client.MgrEnableModule(c.context, c.Namespace, crashModuleName, true); err != nil {
-		return errors.Wrapf(err, "failed to enable mgr crash module")
+		return errors.Wrap(err, "failed to enable mgr crash module")
 	}
 	return nil
 }
@@ -306,11 +306,11 @@ func (c *Cluster) configureMgrModules() error {
 				// Ceph Octopus will have that option enabled
 				err := monStore.Set("global", "osd_pool_default_pg_autoscale_mode", "on")
 				if err != nil {
-					return errors.Wrapf(err, "failed to enable pg autoscale mode for newly created pools")
+					return errors.Wrap(err, "failed to enable pg autoscale mode for newly created pools")
 				}
 				err = monStore.Set("global", "mon_pg_warn_min_per_osd", "0")
 				if err != nil {
-					return errors.Wrapf(err, "failed to set minimal number PGs per (in) osd before we warn the admin to")
+					return errors.Wrap(err, "failed to set minimal number PGs per (in) osd before we warn the admin to")
 				}
 			}
 
@@ -353,7 +353,7 @@ func (c *Cluster) enableServiceMonitor(service *v1.Service) error {
 	namespace := service.GetNamespace()
 	serviceMonitor, err := k8sutil.GetServiceMonitor(path.Join(monitoringPath, serviceMonitorFile))
 	if err != nil {
-		return errors.Wrapf(err, "service monitor could not be enabled")
+		return errors.Wrap(err, "service monitor could not be enabled")
 	}
 	serviceMonitor.SetName(name)
 	serviceMonitor.SetNamespace(namespace)
@@ -361,7 +361,7 @@ func (c *Cluster) enableServiceMonitor(service *v1.Service) error {
 	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespace}
 	serviceMonitor.Spec.Selector.MatchLabels = service.GetLabels()
 	if _, err := k8sutil.CreateOrUpdateServiceMonitor(serviceMonitor); err != nil {
-		return errors.Wrapf(err, "service monitor could not be enabled")
+		return errors.Wrap(err, "service monitor could not be enabled")
 	}
 	return nil
 }
@@ -374,14 +374,14 @@ func (c *Cluster) deployPrometheusRule(name, namespace string) error {
 	prometheusRuleFile = path.Join(monitoringPath, prometheusRuleFile)
 	prometheusRule, err := k8sutil.GetPrometheusRule(prometheusRuleFile)
 	if err != nil {
-		return errors.Wrapf(err, "prometheus rule could not be deployed")
+		return errors.Wrap(err, "prometheus rule could not be deployed")
 	}
 	prometheusRule.SetName(name)
 	prometheusRule.SetNamespace(namespace)
 	owners := append(prometheusRule.GetOwnerReferences(), c.ownerRef)
 	k8sutil.SetOwnerRefs(&prometheusRule.ObjectMeta, owners)
 	if _, err := k8sutil.CreateOrUpdatePrometheusRule(prometheusRule); err != nil {
-		return errors.Wrapf(err, "prometheus rule could not be deployed")
+		return errors.Wrap(err, "prometheus rule could not be deployed")
 	}
 	return nil
 }

--- a/pkg/operator/ceph/cluster/mgr/orchestrator.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator.go
@@ -39,13 +39,13 @@ var (
 // Ceph docs about the orchestrator modules: http://docs.ceph.com/docs/master/mgr/orchestrator_cli/
 func (c *Cluster) configureOrchestratorModules() error {
 	if err := client.MgrEnableModule(c.context, c.Namespace, rookModuleName, true); err != nil {
-		return errors.Wrapf(err, "failed to enable mgr rook module")
+		return errors.Wrap(err, "failed to enable mgr rook module")
 	}
 	if err := client.MgrEnableModule(c.context, c.Namespace, orchestratorModuleName, true); err != nil {
-		return errors.Wrapf(err, "failed to enable mgr orchestrator module")
+		return errors.Wrap(err, "failed to enable mgr orchestrator module")
 	}
 	if err := c.setRookOrchestratorBackend(); err != nil {
-		return errors.Wrapf(err, "failed to set rook orchestrator backend")
+		return errors.Wrap(err, "failed to set rook orchestrator backend")
 	}
 	return nil
 }
@@ -61,7 +61,7 @@ func (c *Cluster) setRookOrchestratorBackend() error {
 		return "set rook backend", output, err
 	}, c.exitCode, 5, invalidArgErrorCode, orchestratorInitWaitTime)
 	if err != nil {
-		return errors.Wrapf(err, "failed to set rook as the orchestrator backend")
+		return errors.Wrap(err, "failed to set rook as the orchestrator backend")
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -130,14 +130,14 @@ func (c *Cluster) clearHTTPBindFix() error {
 			// the version being upgraded from.
 			if _, err := client.MgrSetConfig(c.context, c.Namespace, daemonID,
 				fmt.Sprintf("mgr/%s/server_addr", module), "", false); err != nil {
-				return errors.Wrapf(err, "failed to set config for an mgr daemon using v2 format.")
+				return errors.Wrap(err, "failed to set config for an mgr daemon using v2 format")
 			}
 
 			// this is for the format used in v1.0
 			// https://github.com/rook/rook/commit/11d318fb2f77a6ac9a8f2b9be42c826d3b4a93c3
 			if _, err := client.MgrSetConfig(c.context, c.Namespace, daemonID,
 				fmt.Sprintf("mgr/%s/%s/server_addr", module, daemonID), "", false); err != nil {
-				return errors.Wrapf(err, "failed to set config for an mgr daemon using v1 format.")
+				return errors.Wrap(err, "failed to set config for an mgr daemon using v1 format")
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -89,7 +89,7 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 	secrets, err := context.Clientset.CoreV1().Secrets(namespace).Get(AppName, metav1.GetOptions{})
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
-			return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to get mon secrets")
+			return nil, maxMonID, monMapping, errors.Wrap(err, "failed to get mon secrets")
 		}
 		if ownerRef == nil {
 			return nil, maxMonID, monMapping, errors.New("not expected to create new cluster info and did not find existing secret")
@@ -97,7 +97,7 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 
 		clusterInfo, err = createNamedClusterInfo(context, namespace)
 		if err != nil {
-			return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to create mon secrets")
+			return nil, maxMonID, monMapping, errors.Wrap(err, "failed to create mon secrets")
 		}
 
 		err = createClusterAccessSecret(context.Clientset, namespace, clusterInfo, ownerRef)
@@ -117,7 +117,7 @@ func CreateOrLoadClusterInfo(context *clusterd.Context, namespace string, ownerR
 	// get the existing monitor config
 	clusterInfo.Monitors, maxMonID, monMapping, err = loadMonConfig(context.Clientset, namespace)
 	if err != nil {
-		return nil, maxMonID, monMapping, errors.Wrapf(err, "failed to get mon config")
+		return nil, maxMonID, monMapping, errors.Wrap(err, "failed to get mon config")
 	}
 
 	return clusterInfo, maxMonID, monMapping, nil
@@ -172,7 +172,7 @@ func ValidateAndLoadExternalClusterSecrets(context *clusterd.Context, namespace 
 func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo) error {
 	// write the latest config to the config dir
 	if _, err := cephconfig.GenerateAdminConnectionConfig(context, clusterInfo); err != nil {
-		return errors.Wrapf(err, "failed to write connection config")
+		return errors.Wrap(err, "failed to write connection config")
 	}
 
 	return nil
@@ -246,7 +246,7 @@ func createClusterAccessSecret(clientset kubernetes.Interface, namespace string,
 	}
 	k8sutil.SetOwnerRef(&secret.ObjectMeta, ownerRef)
 	if _, err = clientset.CoreV1().Secrets(namespace).Create(secret); err != nil {
-		return errors.Wrapf(err, "failed to save mon secrets")
+		return errors.Wrap(err, "failed to save mon secrets")
 	}
 
 	return nil
@@ -297,12 +297,12 @@ func genSecret(executor exec.Executor, configDir, name string, args []string) (s
 	args = append(base, args...)
 	_, err := executor.ExecuteCommandWithOutput("ceph-authtool", args...)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to gen secret")
+		return "", errors.Wrap(err, "failed to gen secret")
 	}
 
 	contents, err := ioutil.ReadFile(filepath.Clean(path))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read secret file")
+		return "", errors.Wrap(err, "failed to read secret file")
 	}
 	return ExtractKey(string(contents))
 }

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -89,12 +89,12 @@ func (c *Cluster) checkHealth() error {
 		if c.ClusterInfo.AdminSecret != AdminSecretName {
 			quorumStatus, err = client.GetMonQuorumStatus(c.context, c.ClusterInfo.Name)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get external mon quorum status")
+				return errors.Wrap(err, "failed to get external mon quorum status")
 			}
 		} else {
 			quorumStatus, err = client.GetMonQuorumStatusHealth(c.context, c.ClusterInfo.Name, c.ClusterInfo.ExternalCred.Username)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get external mon quorum status")
+				return errors.Wrap(err, "failed to get external mon quorum status")
 			}
 		}
 
@@ -105,7 +105,7 @@ func (c *Cluster) checkHealth() error {
 	// get the status and check for quorum
 	quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo.Name)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get mon quorum status")
+		return errors.Wrap(err, "failed to get mon quorum status")
 	}
 	logger.Debugf("Mon quorum status: %+v", quorumStatus)
 
@@ -239,7 +239,7 @@ func (c *Cluster) failoverMon(name string) error {
 
 	// Assign the pod to a node
 	if err := c.assignMons(mConf); err != nil {
-		return errors.Wrapf(err, "failed to place new mon on a node")
+		return errors.Wrap(err, "failed to place new mon on a node")
 	}
 
 	if c.Network.IsHost() {
@@ -252,7 +252,7 @@ func (c *Cluster) failoverMon(name string) error {
 		// Create the service endpoint
 		serviceIP, err := c.createService(m)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create mon service")
+			return errors.Wrap(err, "failed to create mon service")
 		}
 		m.PublicIP = serviceIP
 	}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -87,7 +87,7 @@ func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monRe
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
 				err := cephtest.CreateConfigDir(path.Join(configDir, namespace))
-				return "", errors.Wrapf(err, "failed testing of start cluster without quorum response")
+				return "", errors.Wrap(err, "failed testing of start cluster without quorum response")
 			}
 			return "", nil
 		},

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -201,13 +201,13 @@ func (r *ReconcileCephRBDMirror) reconcileCreateCephRBDMirror(cephRBDMirror *cep
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical
-			return reconcile.Result{}, errors.Wrapf(err, "refusing to run new crd")
+			return reconcile.Result{}, errors.Wrap(err, "refusing to run new crd")
 		}
 	}
 
 	err := r.start(cephRBDMirror)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to start rbd mirror")
+		return reconcile.Result{}, errors.Wrap(err, "failed to start rbd mirror")
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -125,7 +125,7 @@ func (r *ReconcileCephRBDMirror) removeExtraMirrors(cephRBDMirror *cephv1.CephRB
 	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", AppName)}
 	d, err := r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).List(opts)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get mirrors")
+		return errors.Wrap(err, "failed to get mirrors")
 	}
 
 	if len(d.Items) <= cephRBDMirror.Spec.Count {

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -124,7 +124,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 		[]string{"ceph"}, []string{"--version"},
 		rookImage, cephImage)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to set up ceph version job")
+		return nil, errors.Wrap(err, "failed to set up ceph version job")
 	}
 
 	job := versionReporter.Job()
@@ -135,7 +135,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 
 	stdout, stderr, retcode, err := versionReporter.Run(timeout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to complete ceph version job")
+		return nil, errors.Wrap(err, "failed to complete ceph version job")
 	}
 	if retcode != 0 {
 		return nil, errors.Errorf(`ceph version job returned failure with retcode %d.
@@ -145,7 +145,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 
 	version, err := cephver.ExtractCephVersion(stdout)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to extract ceph version")
+		return nil, errors.Wrap(err, "failed to extract ceph version")
 	}
 	logger.Infof("detected ceph image version: %q", version)
 	return version, nil
@@ -189,7 +189,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	if c.Spec.External.Enable && c.Spec.CephVersion.Image != "" {
 		c.Info.CephVersion, err = controller.ValidateCephVersionsBetweenLocalAndExternalClusters(c.context, c.Namespace, *version)
 		if err != nil {
-			return errors.Wrapf(err, "failed to validate ceph version between external and local")
+			return errors.Wrap(err, "failed to validate ceph version between external and local")
 		}
 	}
 

--- a/pkg/operator/ceph/config/store.go
+++ b/pkg/operator/ceph/config/store.go
@@ -66,7 +66,7 @@ func GetStore(context *clusterd.Context, namespace string, ownerRef *metav1.Owne
 func (s *Store) CreateOrUpdate(clusterInfo *cephconfig.ClusterInfo) error {
 	// these are used for all ceph daemons on the commandline and must *always* be stored
 	if err := s.createOrUpdateMonHostSecrets(clusterInfo); err != nil {
-		return errors.Wrapf(err, "failed to store mon host configs")
+		return errors.Wrap(err, "failed to store mon host configs")
 	}
 
 	return nil

--- a/pkg/operator/ceph/controller/version.go
+++ b/pkg/operator/ceph/controller/version.go
@@ -29,7 +29,7 @@ func ValidateCephVersionsBetweenLocalAndExternalClusters(context *clusterd.Conte
 	// health check should tell us if the external cluster has been upgraded and display a message
 	externalVersion, err := client.GetCephMonVersion(context, namespace)
 	if err != nil {
-		return cephver.CephVersion{}, errors.Wrapf(err, "failed to get ceph mon version")
+		return cephver.CephVersion{}, errors.Wrap(err, "failed to get ceph mon version")
 	}
 
 	return *externalVersion, cephver.ValidateCephVersionsBetweenLocalAndExternalClusters(localVersion, *externalVersion)

--- a/pkg/operator/ceph/csi/cluster_config.go
+++ b/pkg/operator/ceph/csi/cluster_config.go
@@ -56,7 +56,7 @@ func FormatCsiClusterConfig(
 
 	ccJson, err := json.Marshal(cc)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal csi cluster config")
+		return "", errors.Wrap(err, "failed to marshal csi cluster config")
 	}
 	return string(ccJson), nil
 }
@@ -65,7 +65,7 @@ func parseCsiClusterConfig(c string) (csiClusterConfig, error) {
 	var cc csiClusterConfig
 	err := json.Unmarshal([]byte(c), &cc)
 	if err != nil {
-		return cc, errors.Wrapf(err, "failed to parse csi cluster config")
+		return cc, errors.Wrap(err, "failed to parse csi cluster config")
 	}
 	return cc, nil
 }
@@ -73,7 +73,7 @@ func parseCsiClusterConfig(c string) (csiClusterConfig, error) {
 func formatCsiClusterConfig(cc csiClusterConfig) (string, error) {
 	ccJson, err := json.Marshal(cc)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal csi cluster config")
+		return "", errors.Wrap(err, "failed to marshal csi cluster config")
 	}
 	return string(ccJson), nil
 }
@@ -98,7 +98,7 @@ func UpdateCsiClusterConfig(
 	)
 	cc, err := parseCsiClusterConfig(curr)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse current csi cluster config")
+		return "", errors.Wrap(err, "failed to parse current csi cluster config")
 	}
 
 	for i, centry := range cc {
@@ -145,7 +145,7 @@ func CreateCsiConfigMap(namespace string, clientset kubernetes.Interface, ownerR
 
 func DeleteCsiConfigMap(namespace string, clientset kubernetes.Interface) error {
 	if err := clientset.CoreV1().ConfigMaps(namespace).Delete(ConfigName, &metav1.DeleteOptions{}); err != nil {
-		return errors.Wrapf(err, "failed to delete CSI driver configuration and deployments")
+		return errors.Wrap(err, "failed to delete CSI driver configuration and deployments")
 	}
 	return nil
 }
@@ -177,7 +177,7 @@ func SaveClusterConfig(
 	configMap, err := clientset.CoreV1().ConfigMaps(csiNamespace).Get(
 		ConfigName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "failed to fetch current csi config map")
+		return errors.Wrap(err, "failed to fetch current csi config map")
 	}
 
 	// update ConfigMap contents for current cluster
@@ -188,7 +188,7 @@ func SaveClusterConfig(
 	newData, err := UpdateCsiClusterConfig(
 		currData, clusterNamespace, clusterInfo.Monitors)
 	if err != nil {
-		return errors.Wrapf(err, "failed to update csi config map data")
+		return errors.Wrap(err, "failed to update csi config map data")
 	}
 	configMap.Data[ConfigKey] = newData
 

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -170,30 +170,30 @@ func CreateCSISecrets(context *clusterd.Context, clusterName string, ownerRef *m
 	// Create CSI RBD Provisioner Ceph key
 	csiRBDProvisionerSecretKey, err := createCSIKeyringRBDProvisioner(k)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create csi rbd provisioner ceph keyring")
+		return errors.Wrap(err, "failed to create csi rbd provisioner ceph keyring")
 	}
 
 	// Create CSI RBD Node Ceph key
 	csiRBDNodeSecretKey, err := createCSIKeyringRBDNode(k)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create csi rbd node ceph keyring")
+		return errors.Wrap(err, "failed to create csi rbd node ceph keyring")
 	}
 
 	// Create CSI Cephfs provisioner Ceph key
 	csiCephFSProvisionerSecretKey, err := createCSIKeyringCephFSProvisioner(k)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create csi cephfs provisioner ceph keyring")
+		return errors.Wrap(err, "failed to create csi cephfs provisioner ceph keyring")
 	}
 
 	// Create CSI Cephfs node Ceph key
 	csiCephFSNodeSecretKey, err := createCSIKeyringCephFSNode(k)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create csi cephfs node ceph keyring")
+		return errors.Wrap(err, "failed to create csi cephfs node ceph keyring")
 	}
 
 	// Create or update Kubernetes CSI secret
 	if err := createOrUpdateCSISecret(clusterName, csiRBDProvisionerSecretKey, csiRBDNodeSecretKey, csiCephFSProvisionerSecretKey, csiCephFSNodeSecretKey, k, ownerRef); err != nil {
-		return errors.Wrapf(err, "failed to create kubernetes csi secret")
+		return errors.Wrap(err, "failed to create kubernetes csi secret")
 	}
 
 	return nil

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -218,7 +218,7 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	// later when clusters have mons
 	err = CreateCsiConfigMap(namespace, clientset, ownerRef)
 	if err != nil {
-		return errors.Wrapf(err, "failed creating csi config map")
+		return errors.Wrap(err, "failed creating csi config map")
 	}
 
 	tp := templateParam{
@@ -330,43 +330,43 @@ func StartCSIDrivers(namespace string, clientset kubernetes.Interface, ver *vers
 	if EnableRBD {
 		rbdPlugin, err = templateToDaemonSet("rbdplugin", RBDPluginTemplatePath, tp)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load rbdplugin template")
+			return errors.Wrap(err, "failed to load rbdplugin template")
 		}
 		if deployProvSTS {
 			rbdProvisionerSTS, err = templateToStatefulSet("rbd-provisioner", RBDProvisionerSTSTemplatePath, tp)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load rbd provisioner statefulset template")
+				return errors.Wrap(err, "failed to load rbd provisioner statefulset template")
 			}
 		} else {
 			rbdProvisionerDeployment, err = templateToDeployment("rbd-provisioner", RBDProvisionerDepTemplatePath, tp)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load rbd provisioner deployment template")
+				return errors.Wrap(err, "failed to load rbd provisioner deployment template")
 			}
 		}
 		rbdService, err = templateToService("rbd-service", DefaultRBDPluginServiceTemplatePath, tp)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load rbd plugin service template")
+			return errors.Wrap(err, "failed to load rbd plugin service template")
 		}
 	}
 	if EnableCephFS {
 		cephfsPlugin, err = templateToDaemonSet("cephfsplugin", CephFSPluginTemplatePath, tp)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load CephFS plugin template")
+			return errors.Wrap(err, "failed to load CephFS plugin template")
 		}
 		if deployProvSTS {
 			cephfsProvisionerSTS, err = templateToStatefulSet("cephfs-provisioner", CephFSProvisionerSTSTemplatePath, tp)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load CephFS provisioner statefulset template")
+				return errors.Wrap(err, "failed to load CephFS provisioner statefulset template")
 			}
 		} else {
 			cephfsProvisionerDeployment, err = templateToDeployment("cephfs-provisioner", CephFSProvisionerDepTemplatePath, tp)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load rbd provisioner deployment template")
+				return errors.Wrap(err, "failed to load rbd provisioner deployment template")
 			}
 		}
 		cephfsService, err = templateToService("cephfs-service", DefaultCephFSPluginServiceTemplatePath, tp)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load cephfs plugin service template")
+			return errors.Wrap(err, "failed to load cephfs plugin service template")
 		}
 	}
 	// get provisioner toleration and node affinity

--- a/pkg/operator/ceph/csi/util.go
+++ b/pkg/operator/ceph/csi/util.go
@@ -53,12 +53,12 @@ func templateToService(name, templatePath string, p templateParam) (*corev1.Serv
 	var svc corev1.Service
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load service template")
+		return nil, errors.Wrap(err, "failed to load service template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &svc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal service template")
+		return nil, errors.Wrap(err, "failed to unmarshal service template")
 	}
 	return &svc, nil
 }
@@ -67,12 +67,12 @@ func templateToStatefulSet(name, templatePath string, p templateParam) (*apps.St
 	var ss apps.StatefulSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load statefulset template")
+		return nil, errors.Wrap(err, "failed to load statefulset template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ss)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal statefulset template")
+		return nil, errors.Wrap(err, "failed to unmarshal statefulset template")
 	}
 	return &ss, nil
 }
@@ -81,12 +81,12 @@ func templateToDaemonSet(name, templatePath string, p templateParam) (*apps.Daem
 	var ds apps.DaemonSet
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load daemonset template")
+		return nil, errors.Wrap(err, "failed to load daemonset template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal daemonset template")
+		return nil, errors.Wrap(err, "failed to unmarshal daemonset template")
 	}
 	return &ds, nil
 }
@@ -95,7 +95,7 @@ func templateToDeployment(name, templatePath string, p templateParam) (*apps.Dep
 	var ds apps.Deployment
 	t, err := loadTemplate(name, templatePath, p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load deployment template")
+		return nil, errors.Wrap(err, "failed to load deployment template")
 	}
 
 	err = yaml.Unmarshal([]byte(t), &ds)

--- a/pkg/operator/ceph/disruption/clusterdisruption/add.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/add.go
@@ -42,7 +42,7 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 	// Add the cephv1 scheme to the manager scheme
 	mgrScheme := mgr.GetScheme()
 	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		return errors.Wrapf(err, "failed to add ceph scheme to manager scheme.")
+		return errors.Wrap(err, "failed to add ceph scheme to manager scheme")
 	}
 
 	// this will be used to associate namespaces and cephclusters.

--- a/pkg/operator/ceph/disruption/clusterdisruption/location.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/location.go
@@ -40,7 +40,7 @@ func (r *ReconcileClusterDisruption) getOsdDataList(request reconcile.Request, p
 	namespaceListOpts := client.InNamespace(request.Namespace)
 	err := r.client.List(context.TODO(), osdDeploymentList, client.MatchingLabels{k8sutil.AppAttr: osd.AppName}, namespaceListOpts)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not list osd deployments")
+		return nil, errors.Wrap(err, "could not list osd deployments")
 	}
 
 	osds := make([]OsdData, 0)

--- a/pkg/operator/ceph/disruption/clusterdisruption/mon.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/mon.go
@@ -65,7 +65,7 @@ func (r *ReconcileClusterDisruption) reconcileMonPDB(cephCluster *cephv1.CephClu
 	}
 	err := r.reconcileStaticPDB(pdbRequest, pdb)
 	if err != nil {
-		return errors.Wrapf(err, "could not reconcile mon pdb")
+		return errors.Wrap(err, "could not reconcile mon pdb")
 	}
 	return nil
 }

--- a/pkg/operator/ceph/disruption/machinedisruption/add.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/add.go
@@ -34,10 +34,10 @@ import (
 func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 	mgrScheme := mgr.GetScheme()
 	if err := healthchecking.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrapf(err, "failed to add to healthchecking scheme.")
+		return errors.Wrap(err, "failed to add to healthchecking scheme")
 	}
 	if err := cephv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrapf(err, "failed to add to ceph scheme.")
+		return errors.Wrap(err, "failed to add to ceph scheme")
 	}
 
 	reconcileMachineDisruption := &MachineDisruptionReconciler{

--- a/pkg/operator/ceph/disruption/machinelabel/add.go
+++ b/pkg/operator/ceph/disruption/machinelabel/add.go
@@ -42,10 +42,10 @@ const (
 func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 	mgrScheme := mgr.GetScheme()
 	if err := cephv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrapf(err, "failed to add scheme to ceph.")
+		return errors.Wrap(err, "failed to add scheme to ceph")
 	}
 	if err := mapiv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrapf(err, "failed to add scheme to mapi.")
+		return errors.Wrap(err, "failed to add scheme to map")
 	}
 
 	reconcileMachineLabel := &ReconcileMachineLabel{

--- a/pkg/operator/ceph/disruption/machinelabel/reconcile.go
+++ b/pkg/operator/ceph/disruption/machinelabel/reconcile.go
@@ -96,7 +96,7 @@ func (r *ReconcileMachineLabel) reconcile(request reconcile.Request) (reconcile.
 	machines := &mapiv1.MachineList{}
 	err = r.client.List(context.TODO(), machines, client.InNamespace(cephClusterInstance.Spec.DisruptionManagement.MachineDisruptionBudgetNamespace))
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed tp fetch machine list")
+		return reconcile.Result{}, errors.Wrap(err, "failed tp fetch machine list")
 	}
 
 	nodeMachineMap := map[string]machine{}

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -18,6 +18,7 @@ package file
 
 import (
 	"fmt"
+
 	"github.com/rook/rook/pkg/operator/k8sutil"
 
 	"github.com/pkg/errors"
@@ -147,11 +148,11 @@ func validateFilesystem(context *clusterd.Context, f *cephv1.CephFilesystem) err
 		return nil
 	}
 	if err := pool.ValidatePoolSpec(context, f.Namespace, &f.Spec.MetadataPool); err != nil {
-		return errors.Wrapf(err, "invalid metadata pool")
+		return errors.Wrap(err, "invalid metadata pool")
 	}
 	for _, p := range f.Spec.DataPools {
 		if err := pool.ValidatePoolSpec(context, f.Namespace, &p); err != nil {
-			return errors.Wrapf(err, "Invalid data pool")
+			return errors.Wrap(err, "Invalid data pool")
 		}
 	}
 
@@ -213,7 +214,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 
 	fslist, err := client.ListFilesystems(context, f.Namespace)
 	if err != nil {
-		return errors.Wrapf(err, "Unable to list existing filesystem")
+		return errors.Wrap(err, "Unable to list existing filesystem")
 	}
 	if len(fslist) > 0 && !client.IsMultiFSEnabled() {
 		return errors.Errorf("cannot create multiple filesystems. enable %s env variable to create more than one", client.MultiFsEnv)
@@ -221,7 +222,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 
 	poolNames, err := client.GetPoolNamesByID(context, f.Namespace)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get pool names")
+		return errors.Wrap(err, "failed to get pool names")
 	}
 
 	logger.Infof("Creating filesystem %s", f.Name)

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -154,7 +154,7 @@ func (c *Cluster) Start() error {
 				logger.Info("setting mds config flags")
 				err = c.setDefaultFlagsMonConfigStore(mdsConfig.DaemonID)
 				if err != nil {
-					return errors.Wrapf(err, "failed to set default mds config options")
+					return errors.Wrap(err, "failed to set default mds config options")
 				}
 			}
 		}

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -226,7 +226,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 	reconcileResponse, err = r.reconcileCreateCephNFS(cephNFS)
 	if err != nil {
 		updateStatus(r.client, request.NamespacedName, k8sutil.FailedStatus)
-		return reconcile.Result{}, errors.Wrapf(err, "failed to create ceph nfs deployments")
+		return reconcile.Result{}, errors.Wrap(err, "failed to create ceph nfs deployments")
 	}
 
 	// Set Ready status, we are done reconciling
@@ -244,7 +244,7 @@ func (r *ReconcileCephNFS) reconcileCreateCephNFS(cephNFS *cephv1.CephNFS) (reco
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical
-			return reconcile.Result{}, errors.Wrapf(err, "refusing to run new crd")
+			return reconcile.Result{}, errors.Wrap(err, "refusing to run new crd")
 		}
 	}
 
@@ -257,7 +257,7 @@ func (r *ReconcileCephNFS) reconcileCreateCephNFS(cephNFS *cephv1.CephNFS) (reco
 				return reconcile.Result{}, errors.Wrapf(err, "failed to create ceph nfs %q", cephNFS.Name)
 			}
 		} else {
-			return reconcile.Result{}, errors.Wrapf(err, "failed to list ceph nfs deployments")
+			return reconcile.Result{}, errors.Wrap(err, "failed to list ceph nfs deployments")
 		}
 	} else {
 		// Scale up case (CR value cephNFS.Spec.Server.Active changed)

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -194,12 +194,12 @@ func (r *ReconcileCephNFS) createConfigMap(n *cephv1.CephNFS, name string) (stri
 
 	if _, err := r.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Create(configMap); err != nil {
 		if !kerrors.IsAlreadyExists(err) {
-			return "", errors.Wrapf(err, "failed to create ganesha config map")
+			return "", errors.Wrap(err, "failed to create ganesha config map")
 		}
 
 		logger.Debugf("updating config map %q that already exists", configMap.Name)
 		if _, err = r.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Update(configMap); err != nil {
-			return "", errors.Wrapf(err, "failed to update ganesha config map")
+			return "", errors.Wrap(err, "failed to update ganesha config map")
 		}
 	}
 

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -42,7 +42,7 @@ func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to run radosgw-admin")
+		return "", errors.Wrap(err, "failed to run radosgw-admin")
 	}
 
 	return output, nil

--- a/pkg/operator/ceph/object/bucket.go
+++ b/pkg/operator/ceph/object/bucket.go
@@ -81,7 +81,7 @@ func GetBucketStats(c *Context, bucketName string) (*ObjectBucketStats, bool, er
 		if strings.Contains(err.Error(), "exit status 2") {
 			return nil, true, errors.New("not found")
 		} else {
-			return nil, false, errors.Wrapf(err, "failed to get bucket stats")
+			return nil, false, errors.Wrap(err, "failed to get bucket stats")
 		}
 	}
 
@@ -100,7 +100,7 @@ func GetBucketsStats(c *Context) (map[string]ObjectBucketStats, error) {
 		"bucket",
 		"stats")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list buckets")
+		return nil, errors.Wrap(err, "failed to list buckets")
 	}
 
 	var rgwStats []rgwBucketStats
@@ -123,7 +123,7 @@ func getBucketMetadata(c *Context, bucket string) (*ObjectBucketMetadata, bool, 
 		"get",
 		"bucket:"+bucket)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "failed to list buckets")
+		return nil, false, errors.Wrap(err, "failed to list buckets")
 	}
 
 	if strings.Contains(result, "can't get key") {
@@ -153,7 +153,7 @@ func ListBuckets(c *Context) ([]ObjectBucket, error) {
 
 	stats, err := GetBucketsStats(c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to get bucket stats")
+		return nil, errors.Wrap(err, "Failed to get bucket stats")
 	}
 
 	buckets := []ObjectBucket{}
@@ -177,7 +177,7 @@ func GetBucket(c *Context, bucket string) (*ObjectBucket, int, error) {
 	}
 
 	if err != nil {
-		return nil, RGWErrorUnknown, errors.Wrapf(err, "Failed to get bucket stats")
+		return nil, RGWErrorUnknown, errors.Wrap(err, "Failed to get bucket stats")
 	}
 
 	metadata, notFound, err := getBucketMetadata(c, bucket)
@@ -200,7 +200,7 @@ func DeleteBucket(c *Context, bucketName string, purge bool) (int, error) {
 
 	result, err := runAdminCommand(c, options...)
 	if err != nil {
-		return RGWErrorUnknown, errors.Wrapf(err, "failed to delete bucket")
+		return RGWErrorUnknown, errors.Wrap(err, "failed to delete bucket")
 	}
 
 	if result == "" {
@@ -211,5 +211,5 @@ func DeleteBucket(c *Context, bucketName string, purge bool) (int, error) {
 		return RGWErrorNotFound, errors.New("Bucket not found")
 	}
 
-	return RGWErrorUnknown, errors.Wrapf(err, "failed to delete bucket")
+	return RGWErrorUnknown, errors.Wrap(err, "failed to delete bucket")
 }

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -75,7 +75,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	// dynamically create a new ceph user
 	p.accessKeyID, p.secretAccessKey, err = p.createCephUser("")
 	if err != nil {
-		return nil, errors.Wrapf(err, "Provision: can't create ceph user")
+		return nil, errors.Wrap(err, "Provision: can't create ceph user")
 	}
 
 	s3svc, err := NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint())

--- a/pkg/operator/ceph/object/bucket/rgw-handlers.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers.go
@@ -63,7 +63,7 @@ func (p *Provisioner) createCephUser(username string) (accKey string, secKey str
 	if len(username) == 0 {
 		username, err = p.genUserName()
 		if len(username) == 0 || err != nil {
-			return "", "", errors.Wrapf(err, "no user name provided and unable to generate a unique name")
+			return "", "", errors.Wrap(err, "no user name provided and unable to generate a unique name")
 		}
 	}
 	p.cephUserName = username

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -99,9 +99,9 @@ func getObjectStore(c cephclientset.CephV1Interface, namespace, name string) (*c
 	store, err := c.CephObjectStores(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, errors.Wrapf(err, "cephObjectStore not found")
+			return nil, errors.Wrap(err, "cephObjectStore not found")
 		}
-		return nil, errors.Wrapf(err, "error getting cephObjectStore")
+		return nil, errors.Wrap(err, "error getting cephObjectStore")
 	}
 	return store, err
 }
@@ -111,9 +111,9 @@ func getService(c kubernetes.Interface, namespace, name string) (*v1.Service, er
 	svc, err := c.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, errors.Wrapf(err, "cephObjectStore service not found")
+			return nil, errors.Wrap(err, "cephObjectStore service not found")
 		}
-		return nil, errors.Wrapf(err, "error getting cephObjectStore service")
+		return nil, errors.Wrap(err, "error getting cephObjectStore service")
 	}
 	return svc, nil
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -245,7 +245,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 		if err != nil {
 			// This handles the case where the operator is running, the external cluster has been upgraded and a CR creation is called
 			// If that's a major version upgrade we fail, if it's a minor version, we continue, it's not ideal but not critical
-			return reconcile.Result{}, errors.Wrapf(err, "refusing to run new crd")
+			return reconcile.Result{}, errors.Wrap(err, "refusing to run new crd")
 		}
 	}
 

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -59,13 +59,13 @@ type realmType struct {
 func deleteRealmAndPools(context *Context, spec cephv1.ObjectStoreSpec) error {
 	stores, err := getObjectStores(context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to detect object stores during deletion")
+		return errors.Wrap(err, "failed to detect object stores during deletion")
 	}
 	logger.Infof("Found stores %v when deleting store %s", stores, context.Name)
 
 	err = deleteRealm(context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete realm")
+		return errors.Wrap(err, "failed to delete realm")
 	}
 
 	lastStore := false
@@ -76,7 +76,7 @@ func deleteRealmAndPools(context *Context, spec cephv1.ObjectStoreSpec) error {
 	if !spec.PreservePoolsOnDelete {
 		err = deletePools(context, spec, lastStore)
 		if err != nil {
-			return errors.Wrapf(err, "failed to delete object store pools")
+			return errors.Wrap(err, "failed to delete object store pools")
 		}
 	} else {
 		logger.Infof("PreservePoolsOnDelete is set in object store %s. Pools not deleted", context.Name)
@@ -93,7 +93,7 @@ func reconcileRealm(context *Context, serviceIP string, port int32) error {
 	defaultArg := ""
 	stores, err := getObjectStores(context)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get object stores")
+		return errors.Wrap(err, "failed to get object stores")
 	}
 	if len(stores) == 0 {
 		defaultArg = "--default"
@@ -111,7 +111,7 @@ func reconcileRealm(context *Context, serviceIP string, port int32) error {
 
 	realmID, err := decodeID(output)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse realm id")
+		return errors.Wrap(err, "failed to parse realm id")
 	}
 
 	// create the zonegroup if it doesn't exist yet
@@ -126,7 +126,7 @@ func reconcileRealm(context *Context, serviceIP string, port int32) error {
 
 	zoneGroupID, err := decodeID(output)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse zone group id")
+		return errors.Wrap(err, "failed to parse zone group id")
 	}
 
 	// create the zone if it doesn't exist yet
@@ -140,14 +140,14 @@ func reconcileRealm(context *Context, serviceIP string, port int32) error {
 	}
 	zoneID, err := decodeID(output)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse zone id")
+		return errors.Wrap(err, "failed to parse zone id")
 	}
 
 	if updatePeriod {
 		// the period will help notify other zones of changes if there are multi-zones
 		_, err := runAdminCommandNoRealm(context, "period", "update", "--commit")
 		if err != nil {
-			return errors.Wrapf(err, "failed to update period")
+			return errors.Wrap(err, "failed to update period")
 		}
 	}
 
@@ -179,7 +179,7 @@ func decodeID(data string) (string, error) {
 	var id idType
 	err := json.Unmarshal([]byte(data), &id)
 	if err != nil {
-		return "", errors.Wrapf(err, "Failed to unmarshal json")
+		return "", errors.Wrap(err, "Failed to unmarshal json")
 	}
 
 	return id.ID, err
@@ -197,7 +197,7 @@ func getObjectStores(context *Context) ([]string, error) {
 	var r realmType
 	err = json.Unmarshal([]byte(output), &r)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to unmarshal realms")
+		return nil, errors.Wrap(err, "Failed to unmarshal realms")
 	}
 
 	return r.Realms, nil
@@ -267,7 +267,7 @@ func createPools(context *Context, spec cephv1.ObjectStoreSpec) error {
 	}
 
 	if err := createSimilarPools(context, append(metadataPools, rootPool), spec.MetadataPool, metadataPoolPGs, ""); err != nil {
-		return errors.Wrapf(err, "failed to create metadata pools")
+		return errors.Wrap(err, "failed to create metadata pools")
 	}
 
 	ecProfileName := ""
@@ -280,7 +280,7 @@ func createPools(context *Context, spec cephv1.ObjectStoreSpec) error {
 	}
 
 	if err := createSimilarPools(context, []string{dataPoolName}, spec.DataPool, ceph.DefaultPGCount, ecProfileName); err != nil {
-		return errors.Wrapf(err, "failed to create data pool")
+		return errors.Wrap(err, "failed to create data pool")
 	}
 
 	return nil

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -68,7 +68,7 @@ func (c *clusterConfig) createOrUpdateStore() error {
 	logger.Infof("creating object store %q in namespace %q", c.store.Name, c.store.Namespace)
 
 	if err := c.startRGWPods(); err != nil {
-		return errors.Wrapf(err, "failed to start rgw pods")
+		return errors.Wrap(err, "failed to start rgw pods")
 	}
 
 	logger.Infof("created object store %q in namespace %q", c.store.Name, c.store.Namespace)
@@ -153,7 +153,7 @@ func (c *clusterConfig) startRGWPods() error {
 		_, createErr := c.context.Clientset.AppsV1().Deployments(c.store.Namespace).Create(deployment)
 		if createErr != nil {
 			if !kerrors.IsAlreadyExists(createErr) {
-				return errors.Wrapf(createErr, "failed to create rgw deployment")
+				return errors.Wrap(createErr, "failed to create rgw deployment")
 			}
 			logger.Infof("object store %q deployment %q already exists. updating if needed", c.store.Name, deployment.Name)
 			if err := updateDeploymentAndWait(c.context, deployment, c.store.Namespace, config.RgwType, daemonLetterID, c.skipUpgradeChecks, c.clusterSpec.ContinueUpgradeAfterChecksEvenIfNotHealthy); err != nil {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -236,7 +236,7 @@ func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore
 	// Set owner ref to the parent object
 	err := controllerutil.SetControllerReference(cephObjectStore, service, c.scheme)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to set owner reference to ceph object store")
+		return "", errors.Wrap(err, "failed to set owner reference to ceph object store")
 	}
 
 	svc, err := k8sutil.CreateOrUpdateService(c.context.Clientset, cephObjectStore.Namespace, service)

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -46,7 +46,7 @@ type ObjectUser struct {
 func ListUsers(c *Context) ([]string, int, error) {
 	result, err := runAdminCommand(c, "user", "list")
 	if err != nil {
-		return nil, RGWErrorUnknown, errors.Wrapf(err, "failed to list users")
+		return nil, RGWErrorUnknown, errors.Wrap(err, "failed to list users")
 	}
 
 	var s []string
@@ -71,7 +71,7 @@ func decodeUser(data string) (*ObjectUser, int, error) {
 	var user rgwUserInfo
 	err := json.Unmarshal([]byte(data), &user)
 	if err != nil {
-		return nil, RGWErrorParse, errors.Wrapf(err, "Failed to unmarshal json")
+		return nil, RGWErrorParse, errors.Wrap(err, "Failed to unmarshal json")
 	}
 
 	rookUser := ObjectUser{UserID: user.UserID, DisplayName: &user.DisplayName, Email: &user.Email}
@@ -94,7 +94,7 @@ func GetUser(c *Context, id string) (*ObjectUser, int, error) {
 		return nil, RGWErrorNotFound, errors.New("warn: user not found")
 	}
 	if err != nil {
-		return nil, RGWErrorUnknown, errors.Wrapf(err, "radosgw-admin command err")
+		return nil, RGWErrorUnknown, errors.Wrap(err, "radosgw-admin command err")
 	}
 	return decodeUser(result)
 }
@@ -124,7 +124,7 @@ func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
-		return nil, RGWErrorUnknown, errors.Wrapf(err, "failed to create user")
+		return nil, RGWErrorUnknown, errors.Wrap(err, "failed to create user")
 	}
 
 	if strings.HasPrefix(result, "could not create user: unable to create user, user: ") && strings.HasSuffix(result, " exists") {
@@ -153,7 +153,7 @@ func UpdateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 
 	body, err := runAdminCommand(c, args...)
 	if err != nil {
-		return nil, RGWErrorUnknown, errors.Wrapf(err, "failed to update user")
+		return nil, RGWErrorUnknown, errors.Wrap(err, "failed to update user")
 	}
 
 	if body == "could not modify user: unable to modify user, user not found" {
@@ -171,7 +171,7 @@ func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
 	}
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
-		return "", RGWErrorUnknown, errors.Wrapf(err, "failed to delete user")
+		return "", RGWErrorUnknown, errors.Wrap(err, "failed to delete user")
 	}
 	if result == "unable to remove user, user does not exist" {
 		return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
@@ -185,7 +185,7 @@ func SetQuotaUserBucketMax(c *Context, id string, max int) (string, int, error) 
 	args := []string{"--quota-scope", "user", "--max-buckets", strconv.Itoa(max)}
 	result, errCode, err := setUserQuota(c, id, args)
 	if errCode != RGWErrorNone {
-		err = errors.Wrapf(err, "failed setting bucket max")
+		err = errors.Wrap(err, "failed setting bucket max")
 	}
 	return result, errCode, err
 }
@@ -194,7 +194,7 @@ func setUserQuota(c *Context, id string, args []string) (string, int, error) {
 	args = append([]string{"quota", "set", "--uid", id}, args...)
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
-		err = errors.Wrapf(err, "failed to set max buckets for user")
+		err = errors.Wrap(err, "failed to set max buckets for user")
 	}
 	return result, RGWErrorNone, err
 }

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -202,13 +202,13 @@ func (o *Operator) updateDrivers() error {
 	if EnableFlexDriver {
 		rookAgent := agent.New(o.context.Clientset)
 		if err := rookAgent.Start(o.operatorNamespace, o.rookImage, o.securityAccount); err != nil {
-			return errors.Wrapf(err, "error starting agent daemonset")
+			return errors.Wrap(err, "error starting agent daemonset")
 		}
 	}
 
 	serverVersion, err := o.context.Clientset.Discovery().ServerVersion()
 	if err != nil {
-		return errors.Wrapf(err, "error getting server version")
+		return errors.Wrap(err, "error getting server version")
 	}
 
 	if err = o.setCSIParams(); err != nil {
@@ -229,7 +229,7 @@ func (o *Operator) updateDrivers() error {
 	}
 
 	if err = csi.ValidateCSIParam(); err != nil {
-		return errors.Wrapf(err, "invalid csi params")
+		return errors.Wrap(err, "invalid csi params")
 	}
 
 	if err = csi.ValidateCSIVersion(o.context.Clientset, o.operatorNamespace, o.rookImage, o.securityAccount); err != nil {
@@ -237,7 +237,7 @@ func (o *Operator) updateDrivers() error {
 	}
 
 	if err = csi.StartCSIDrivers(o.operatorNamespace, o.context.Clientset, serverVersion); err != nil {
-		return errors.Wrapf(err, "failed to start Ceph csi drivers")
+		return errors.Wrap(err, "failed to start Ceph csi drivers")
 	}
 	logger.Infof("successfully started Ceph CSI driver(s)")
 	return nil

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -128,7 +128,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get CephBlockPool")
+		return reconcile.Result{}, errors.Wrap(err, "failed to get CephBlockPool")
 	}
 
 	// The CR was just created, initializing status fields
@@ -229,7 +229,7 @@ func createPool(context *clusterd.Context, p *cephv1.CephBlockPool) error {
 func deletePool(context *clusterd.Context, p *cephv1.CephBlockPool) error {
 	pools, err := cephclient.ListPoolSummaries(context, p.Namespace)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list pools")
+		return errors.Wrap(err, "failed to list pools")
 	}
 
 	// Only delete the pool if it exists...

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -50,7 +50,7 @@ func ValidatePoolSpec(context *clusterd.Context, namespace string, p *cephv1.Poo
 	if p.FailureDomain != "" || p.CrushRoot != "" {
 		crush, err = cephclient.GetCrushMap(context, namespace)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get crush map")
+			return errors.Wrap(err, "failed to get crush map")
 		}
 	}
 

--- a/pkg/operator/ceph/provisioner/provisioner.go
+++ b/pkg/operator/ceph/provisioner/provisioner.go
@@ -123,7 +123,7 @@ func (p *RookVolumeProvisioner) Provision(options controller.ProvisionOptions) (
 
 	driverName, err := flexvolume.RookDriverName(p.context)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get driver name")
+		return nil, errors.Wrap(err, "failed to get driver name")
 	}
 
 	flexdriver := fmt.Sprintf("%s/%s", p.flexDriverVendor, driverName)


### PR DESCRIPTION

**Description of your changes:**
If we are deploying the cluster on any namespace other than rook-ceph
we will have to change the provisioner and snapshotter in the files
`storageclass.yaml` and `snapshotclass.yaml` as well.
This change adds a comment that clearly mentions that.


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
