### PR TITLE
Ensure pool properties are well applied in case of operator restart during pool creation

### DIFF
--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -56,13 +57,13 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
-				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, poolName, args[3])
 				assert.Equal(t, "erasure", args[5])
-				assert.Equal(t, "mypoolprofile", args[6])
+				assert.Equal(t, fmt.Sprintf("%s_ecprofile", poolName), args[6])
 				return "", nil
 			}
 			if args[2] == "set" {
-				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, poolName, args[3])
 				if args[4] == "allow_ec_overwrites" {
 					assert.Equal(t, true, overwrite)
 					assert.Equal(t, "true", args[5])
@@ -76,15 +77,23 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 			}
 			if args[2] == "application" {
 				assert.Equal(t, "enable", args[3])
-				assert.Equal(t, "mypool", args[4])
+				assert.Equal(t, poolName, args[4])
 				assert.Equal(t, "myapp", args[5])
+				return "", nil
+			}
+		}
+		if args[1] == "erasure-code-profile" {
+			if args[2] == "get" {
+				return `{"plugin":"myplugin","technique":"t"}`, nil
+			}
+			if args[2] == "set" {
 				return "", nil
 			}
 		}
 		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
-	err := CreateECPoolForApp(context, "myns", poolName, "mypoolprofile", p, DefaultPGCount, "myapp", overwrite)
+	err := CreateECPoolForApp(context, "myns", poolName, p, DefaultPGCount, "myapp", overwrite)
 	assert.Nil(t, err)
 	if compressionMode != "" {
 		assert.True(t, compressionModeCreated)

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -18,6 +18,7 @@ package client
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -29,21 +30,24 @@ import (
 )
 
 func TestCreateECPoolWithOverwrites(t *testing.T) {
-	testCreateECPool(t, true, "")
+	testCreateECPool(t, true, "", false)
+	testCreateECPool(t, true, "", true)
 }
 
 func TestCreateECPoolWithoutOverwrites(t *testing.T) {
-	testCreateECPool(t, false, "")
+	testCreateECPool(t, false, "", false)
 }
 
 func TestCreateECPoolWithCompression(t *testing.T) {
-	testCreateECPool(t, false, "aggressive")
-	testCreateECPool(t, true, "none")
+	testCreateECPool(t, false, "aggressive", false)
+	testCreateECPool(t, true, "none", false)
+	testCreateECPool(t, true, "none", true)
 }
 
-func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
+func testCreateECPool(t *testing.T, overwrite bool, compressionMode string, poolExist bool) {
 	poolName := "mypool"
 	compressionModeCreated := false
+	poolCreated := false
 	p := cephv1.PoolSpec{
 		FailureDomain: "host",
 		ErasureCoded:  cephv1.ErasureCodedSpec{},
@@ -57,10 +61,20 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
+				poolCreated = true
 				assert.Equal(t, poolName, args[3])
 				assert.Equal(t, "erasure", args[5])
 				assert.Equal(t, fmt.Sprintf("%s_ecprofile", poolName), args[6])
 				return "", nil
+			}
+			if args[2] == "get" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "all", args[4])
+				if poolExist {
+					return "", nil
+				} else {
+					return "", errors.Errorf("pool not found")
+				}
 			}
 			if args[2] == "set" {
 				assert.Equal(t, poolName, args[3])
@@ -95,6 +109,11 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 
 	err := CreateECPoolForApp(context, "myns", poolName, p, DefaultPGCount, "myapp", overwrite)
 	assert.Nil(t, err)
+	if poolExist {
+		assert.False(t, poolCreated)
+	} else {
+		assert.True(t, poolCreated)
+	}
 	if compressionMode != "" {
 		assert.True(t, compressionModeCreated)
 	} else {
@@ -103,35 +122,66 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 }
 
 func TestCreateReplicaPool(t *testing.T) {
-	testCreateReplicaPool(t, "", "", "", "")
+	testCreateReplicaPool(t, "", "", "", "", DefaultPGCount, "", "", false)
+	testCreateReplicaPool(t, "", "", "", "", DefaultPGCount, "", "", true)
+}
+func TestCreateReplicaPoolWithPgCount(t *testing.T) {
+	testCreateReplicaPool(t, "", "", "", "", "8", "", "", false)
+	// Does not create pool as it exist but apply pgCount
+	testCreateReplicaPool(t, "", "", "", "", "8", "", "", true)
+	// Does not create pool as it exist and don't apply pgCount as pgCount already fine
+	testCreateReplicaPool(t, "", "", "", "", "8", "", "{\"pg_num_min\":8}", true)
+}
+func TestCreateReplicaPoolTargetSizeRatio(t *testing.T) {
+	testCreateReplicaPool(t, "", "", "", "", DefaultPGCount, "0.2", "", false)
+	// Does not create pool as it exist but apply targetSizeRatio
+	testCreateReplicaPool(t, "", "", "", "", DefaultPGCount, "0.2", "", true)
+	// Does not create pool as it exist and don't apply targetSizeRatio as targetSizeRatio already fine
+	testCreateReplicaPool(t, "", "", "", "", DefaultPGCount, "0.2", "{\"target_size_ratio\":0.2}", true)
 }
 func TestCreateReplicaPoolWithFailureDomain(t *testing.T) {
-	testCreateReplicaPool(t, "osd", "mycrushroot", "", "")
+	testCreateReplicaPool(t, "osd", "mycrushroot", "", "", DefaultPGCount, "", "", false)
 }
 
 func TestCreateReplicaPoolWithDeviceClass(t *testing.T) {
-	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "")
+	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "", DefaultPGCount, "", "", false)
 }
 
 func TestCreateReplicaPoolWithCompression(t *testing.T) {
-	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "passive")
-	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "force")
+	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "passive", DefaultPGCount, "", "", false)
+	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "force", DefaultPGCount, "", "", false)
+	testCreateReplicaPool(t, "osd", "mycrushroot", "hdd", "force", DefaultPGCount, "", "", true)
 }
 
-func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, compressionMode string) {
+func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, compressionMode, pgCount, targetSizeRatio, poolConfig string, poolExist bool) {
 	crushRuleCreated := false
+	poolCreated := false
 	compressionModeCreated := false
+	pgNumMinSet := false
+	targetSizeRatioSet := false
+	firstGetPoolCall := true
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
 	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
+				poolCreated = true
 				assert.Equal(t, "mypool", args[3])
 				assert.Equal(t, "replicated", args[5])
 				assert.Equal(t, "--size", args[7])
 				assert.Equal(t, "12345", args[8])
 				return "", nil
+			}
+			if args[2] == "get" {
+				assert.Equal(t, "mypool", args[3])
+				assert.Equal(t, "all", args[4])
+				if poolExist || !firstGetPoolCall {
+					return poolConfig, nil
+				} else {
+					firstGetPoolCall = false
+					return "", errors.Errorf("pool not found")
+				}
 			}
 			if args[2] == "set" {
 				assert.Equal(t, "mypool", args[3])
@@ -141,6 +191,14 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 				if args[4] == "compression_mode" {
 					assert.Equal(t, compressionMode, args[5])
 					compressionModeCreated = true
+				}
+				if args[4] == "pg_num_min" {
+					assert.Equal(t, pgCount, args[5])
+					pgNumMinSet = true
+				}
+				if args[4] == "target_size_ratio" {
+					assert.Equal(t, targetSizeRatio, args[5])
+					targetSizeRatioSet = true
 				}
 				return "", nil
 			}
@@ -183,13 +241,34 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 	if compressionMode != "" {
 		p.CompressionMode = compressionMode
 	}
-	err := CreateReplicatedPoolForApp(context, "myns", "mypool", p, DefaultPGCount, "myapp")
+	if targetSizeRatio != "" {
+		fTargetSizeRatio, _ := strconv.ParseFloat(targetSizeRatio, 64)
+		p.Replicated.TargetSizeRatio = fTargetSizeRatio
+	}
+	err := CreateReplicatedPoolForApp(context, "myns", "mypool", p, pgCount, "myapp")
+	poolDetails, err := GetPoolDetails(context, "myns", "mypool")
 	assert.Nil(t, err)
-	assert.True(t, crushRuleCreated)
+	if poolExist {
+		assert.False(t, crushRuleCreated)
+		assert.False(t, poolCreated)
+	} else {
+		assert.True(t, crushRuleCreated)
+		assert.True(t, poolCreated)
+	}
 	if compressionMode != "" {
 		assert.True(t, compressionModeCreated)
 	} else {
 		assert.False(t, compressionModeCreated)
+	}
+	if (pgCount != DefaultPGCount) && (pgCount != strconv.FormatUint(uint64(poolDetails.PgNumMin), 10)) {
+		assert.True(t, pgNumMinSet)
+	} else {
+		assert.False(t, pgNumMinSet)
+	}
+	if (targetSizeRatio != "") && (targetSizeRatio != strconv.FormatFloat(poolDetails.TargetSizeRatio, 'f', -1, 64)) {
+		assert.True(t, targetSizeRatioSet)
+	} else {
+		assert.False(t, targetSizeRatioSet)
 	}
 }
 

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -171,7 +171,7 @@ func newFS(name, namespace string) *Filesystem {
 func SetPoolSize(f *Filesystem, context *clusterd.Context, spec cephv1.FilesystemSpec) error {
 	// generating the metadata pool's name
 	metadataPoolName := generateMetaDataPoolName(f)
-	err := client.CreatePoolWithProfile(context, f.Namespace, metadataPoolName, spec.MetadataPool, "")
+	err := client.CreatePoolWithProfileDefaultPG(context, f.Namespace, metadataPoolName, spec.MetadataPool, "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to update metadata pool %q", metadataPoolName)
 	}
@@ -179,7 +179,7 @@ func SetPoolSize(f *Filesystem, context *clusterd.Context, spec cephv1.Filesyste
 	dataPoolNames := generateDataPoolNames(f, spec)
 	for i, pool := range spec.DataPools {
 		poolName := dataPoolNames[i]
-		err := client.CreatePoolWithProfile(context, f.Namespace, poolName, pool, "")
+		err := client.CreatePoolWithProfileDefaultPG(context, f.Namespace, poolName, pool, "")
 		if err != nil {
 			return errors.Wrapf(err, "failed to update datapool  %q", poolName)
 		}
@@ -237,7 +237,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 	metadataPoolName := generateMetaDataPoolName(f)
 	if _, poolFound := reversedPoolMap[metadataPoolName]; !poolFound {
 		poolsCreated = true
-		err = client.CreatePoolWithProfile(context, f.Namespace, metadataPoolName, spec.MetadataPool, "")
+		err = client.CreatePoolWithProfileDefaultPG(context, f.Namespace, metadataPoolName, spec.MetadataPool, "")
 		if err != nil {
 			return errors.Wrapf(err, "failed to create metadata pool %q", metadataPoolName)
 		}
@@ -248,7 +248,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, cephVersion c
 		poolName := dataPoolNames[i]
 		if _, poolFound := reversedPoolMap[poolName]; !poolFound {
 			poolsCreated = true
-			err = client.CreatePoolWithProfile(context, f.Namespace, poolName, pool, "")
+			err = client.CreatePoolWithProfileDefaultPG(context, f.Namespace, poolName, pool, "")
 			if err != nil {
 				return errors.Wrapf(err, "failed to create data pool %q", poolName)
 			}

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -161,7 +161,18 @@ func TestCephObjectStoreController(t *testing.T) {
 			Name:      store,
 			Namespace: namespace,
 		},
-		Spec:     cephv1.ObjectStoreSpec{},
+		Spec: cephv1.ObjectStoreSpec{
+			MetadataPool: cephv1.PoolSpec{
+				Replicated: cephv1.ReplicatedSpec{
+					Size: 1,
+				},
+			},
+			DataPool: cephv1.PoolSpec{
+				Replicated: cephv1.ReplicatedSpec{
+					Size: 1,
+				},
+			},
+		},
 		TypeMeta: controllerTypeMeta,
 	}
 	cephCluster := &cephv1.CephCluster{}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -218,7 +218,7 @@ func (r *ReconcileCephBlockPool) reconcileCreatePool(cephBlockPool *cephv1.CephB
 func createPool(context *clusterd.Context, p *cephv1.CephBlockPool) error {
 	// create the pool
 	logger.Infof("creating pool %q in namespace %q", p.Name, p.Namespace)
-	if err := cephclient.CreatePoolWithProfile(context, p.Namespace, p.Name, p.Spec, poolApplicationNameRBD); err != nil {
+	if err := cephclient.CreatePoolWithProfileDefaultPG(context, p.Namespace, p.Name, p.Spec, poolApplicationNameRBD); err != nil {
 		return errors.Wrapf(err, "failed to create pool %q", p.Name)
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Ensure that properties of a pool are well applied during pool creation even if the operator restart during this creation (due to an operator upgrade/crash/...)
To ensure that this behavior is applied for all kind of pool creation there is also a refacto to use same pool creation process (rgw ones were not using exactly same code path than cephfs/rbd ones)

**Which issue is resolved by this Pull Request:**
Resolves #5339

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]