### PR TITLE
Multipath support for OSD on PVC

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -34,9 +34,13 @@ var (
 	isRBD  = regexp.MustCompile("^rbd[0-9]+p?[0-9]{0,}$")
 )
 
+func supportedDeviceType(device string) bool {
+	return device == sys.DiskType || device == sys.SSDType || device == sys.LVMType || device == sys.MultiPath || device == sys.PartType || device == sys.LinearType
+}
+
 // GetDeviceEmpty check whether a device is completely empty
 func GetDeviceEmpty(device *sys.LocalDisk) bool {
-	return device.Parent == "" && (device.Type == sys.DiskType || device.Type == sys.SSDType || device.Type == sys.CryptType || device.Type == sys.LVMType) && len(device.Partitions) == 0 && device.Filesystem == ""
+	return device.Parent == "" && supportedDeviceType(device.Type) && len(device.Partitions) == 0 && device.Filesystem == ""
 }
 
 func ignoreDevice(d string) bool {
@@ -106,12 +110,11 @@ func PopulateDeviceInfo(d string, executor exec.Executor) (*sys.LocalDisk, error
 	}
 
 	diskType, ok := diskProps["TYPE"]
-	if !ok || (diskType != sys.SSDType && diskType != sys.CryptType && diskType != sys.DiskType && diskType != sys.PartType && diskType != sys.LinearType && diskType != sys.LVMType) {
-		if !ok {
-			return nil, errors.New("diskType is empty")
-		} else {
-			return nil, fmt.Errorf("unsupported diskType %+s", diskType)
-		}
+	if !ok {
+		return nil, errors.New("diskType is empty")
+	}
+	if !supportedDeviceType(diskType) {
+		return nil, fmt.Errorf("unsupported diskType %+s", diskType)
 	}
 
 	// get the UUID for disks

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -39,6 +39,8 @@ const (
 	CryptType = "crypt"
 	// LVMType is an LVM type
 	LVMType = "lvm"
+	// MultiPath is for multipath devices
+	MultiPath = "mpath"
 	// LinearType is a linear type
 	LinearType = "linear"
 	sgdiskCmd  = "sgdisk"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When configuring an OSD on a multipath device, ceph-volume inventory is failing to detect that the device is available, complaining about insufficient space. 
```
ceph-volume inventory --format json /dev/mapper/3600605b000ac584025e796091b840018
{"available": false, "lvs": [], "rejected_reasons": ["Insufficient space (<5GB)"], "sys_api": {}, "path": "/dev/mapper/3600605b000ac584025e796091b840018", "device_id": ""}
```
Instead of relying on c-v inventory to determine if the device is available, just call c-v raw list to determine if there is already an osd configured on the pv. Otherwise, just attempt to configure the OSD. Instead we should get a fix from c-v, but this will allow testing to see if the OSD config can get path that error while preparing the OSD.      

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
