### PR TITLE
ceph: do not fail on deactivate

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -68,12 +68,14 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 		go handleTerminate(context, lvPath, volumeGroupName)
 
-		if err := context.Executor.ExecuteCommand("vgchange", "-an", volumeGroupName); err != nil {
-			return errors.Wrapf(err, "failed to deactivate volume group for lv %q", lvPath)
+		// It's fine to continue if deactivate fails since we will return error if activate fails
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-anvv", volumeGroupName); err != nil {
+			logger.Errorf("failed to deactivate volume group for lv %q. output: %s. %v", lvPath, op, err)
+			return nil
 		}
 
-		if err := context.Executor.ExecuteCommand("vgchange", "-ay", volumeGroupName); err != nil {
-			return errors.Wrapf(err, "failed to activate volume group for lv %q", lvPath)
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-ayvv", volumeGroupName); err != nil {
+			return errors.Wrapf(err, "failed to activate volume group for lv %q. output: %s", lvPath, op)
 		}
 	}
 
@@ -91,7 +93,10 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 
 	if pvcBackedOSD && !lvBackedPV {
 		if err := releaseLVMDevice(context, volumeGroupName); err != nil {
-			return errors.Wrap(err, "failed to release device from lvm")
+			// Let's just report the error and not fail as a best-effort since some drivers will force detach anyway
+			// Failing to release the device does not means the detach will fail so let's proceed
+			logger.Errorf("failed to release device from lvm. %v", err)
+			return nil
 		}
 	}
 
@@ -425,10 +430,10 @@ func getAvailableDevices(context *clusterd.Context, desiredDevices []DesiredDevi
 
 // releaseLVMDevice deactivates the LV to release the device.
 func releaseLVMDevice(context *clusterd.Context, volumeGroupName string) error {
-	if err := context.Executor.ExecuteCommand("lvchange", "-an", volumeGroupName); err != nil {
-		return errors.Wrapf(err, "failed to deactivate LVM %s", volumeGroupName)
+	if op, err := context.Executor.ExecuteCommandWithCombinedOutput("lvchange", "-anvv", volumeGroupName); err != nil {
+		return errors.Wrapf(err, "failed to deactivate LVM %s. output: %s", volumeGroupName, op)
 	}
-	logger.Info("Successfully released device from lvm")
+	logger.Info("successfully released device from lvm")
 	return nil
 }
 


### PR DESCRIPTION
**Description of your changes:**

If we fail to release an LVM device, we should not fail the deployment.
We just print the error and let the backend handle the rest. Some
CSI backend will force detach the device anyway.
This prevents the deployment to get stuck in terminating.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


[test ceph]