### PR TITLE
tests: Kubeadm add the makeTestImages tag of arm64

### DIFF
--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -13,6 +13,19 @@ else
     skippreflightcheck=--skip-preflight-checks
 fi
 
+case "$(arch)" in
+        "x86_64" | "amd64")
+            arch="amd64"
+            ;;
+        "aarch64")
+            arch="arm64"
+            ;;
+        *)
+            echo "Couldn't translate 'arch' output to an available arch."
+            exit 1
+            ;;
+esac
+
 usage(){
     echo "usage:" >&2
     echo "  $0 up " >&2
@@ -114,7 +127,7 @@ case "${1:-}" in
     up)
         sudo sh -c "${scriptdir}/kubeadm-install.sh ${KUBE_VERSION}" root
         install_master
-        ${scriptdir}/makeTestImages.sh tag amd64 || true
+        ${scriptdir}/makeTestImages.sh tag ${arch} || true
         ;;
     clean)
         kubeadm_reset


### PR DESCRIPTION
Signed-off-by: Haichao Li <haichao.li@arm.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add the makeTestImages tag of arm64 in kubeadm installation script.
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
