### PR TITLE
Remove invalid verbose params from lv activate

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -68,12 +68,12 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 		go handleTerminate(context, lvPath, volumeGroupName)
 
 		// It's fine to continue if deactivate fails since we will return error if activate fails
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-anvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-an", volumeGroupName); err != nil {
 			logger.Errorf("failed to deactivate volume group for lv %q. output: %s. %v", lvPath, op, err)
 			return nil
 		}
 
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-ayvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput("vgchange", "-ay", volumeGroupName); err != nil {
 			return errors.Wrapf(err, "failed to activate volume group for lv %q. output: %s", lvPath, op)
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The activation of the LVs for OSDs had an invalid argument to vgchange. The invalid argument is now reverted to enable the OSDs in this scenario again.

This was a regression from #5398.

The invalid argument is seen in the osd log from the deactivate command.
```
2020-05-06T10:20:11.82040536Z 2020-05-06 10:20:11.820313 I | rookcmd: starting Rook 4.4-12.1d7fdd95.release_4.4 with arguments '/rook/rook ceph osd start -- --foreground --id 1 --fsid 76f7ef91-7fce-47cf-bea3-debd3be7c4bb --cluster ceph --setuser ceph --setgroup ceph --setuser-match-path /var/lib/rook/osd1 --crush-location=root=default host=ocs-deviceset-0-0-2w27c rack=rack0 region=us-west-1 zone=us-west-1a --default-log-to-file false --ms-learn-addr-from-peer=false'
2020-05-06T10:20:11.82040536Z 2020-05-06 10:20:11.820377 I | rookcmd: flag values: --help=false, --log-flush-frequency=5s, --log-level=INFO, --lv-backed-pv=false, --lv-path=/dev/ceph-0f2f1538-b4c6-4f3c-9b61-3c4780ac74df/osd-block-835d8a44-3e0d-4105-9e1e-de6d91e27a91, --operator-image=, --osd-id=1, --osd-store-type=bluestore, --osd-uuid=835d8a44-3e0d-4105-9e1e-de6d91e27a91, --pvc-backed-osd=true, --service-account=
2020-05-06T10:20:11.82040536Z 2020-05-06 10:20:11.820381 I | op-mon: parsing mon endpoints: a=172.30.141.225:6789,b=172.30.63.48:6789,c=172.30.123.210:6789
2020-05-06T10:20:11.822758496Z 2020-05-06 10:20:11.822730 I | cephosd: Successfully updated lvm config file "/etc/lvm/lvm.conf"
2020-05-06T10:20:11.822758496Z 2020-05-06 10:20:11.822754 I | exec: Running command: vgchange -anvv ceph-0f2f1538-b4c6-4f3c-9b61-3c4780ac74df
2020-05-06T10:20:11.829171502Z 2020-05-06 10:20:11.829143 E | cephosd: failed to deactivate volume group for lv "/dev/ceph-0f2f1538-b4c6-4f3c-9b61-3c4780ac74df/osd-block-835d8a44-3e0d-4105-9e1e-de6d91e27a91". output: Udev is running and DM_DISABLE_UDEV environment variable is set. Bypassing udev, LVM will manage logical volume symlinks in device directory.
2020-05-06T10:20:11.829171502Z   Udev is running and DM_DISABLE_UDEV environment variable is set. Bypassing udev, LVM will obtain device list by scanning device directory.
2020-05-06T10:20:11.829171502Z   Invalid argument for --activate: nvv
2020-05-06T10:20:11.829171502Z   Error during parsing of command line.. Failed to complete '': exit status 3. 
```

Then the osd fails to start when the activate command is run with the same invalid arguments.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]