### PR TITLE
Remove invalid verbose params from lv activate (bp #5438)

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -72,12 +72,12 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 		go handleTerminate(context, lvPath, volumeGroupName)
 
 		// It's fine to continue if deactivate fails since we will return error if activate fails
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-anvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-an", volumeGroupName); err != nil {
 			logger.Errorf("failed to deactivate volume group for lv %q. output: %s. %v", lvPath, op, err)
 			return nil
 		}
 
-		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-ayvv", volumeGroupName); err != nil {
+		if op, err := context.Executor.ExecuteCommandWithCombinedOutput(false, "", "vgchange", "-ay", volumeGroupName); err != nil {
 			return errors.Wrapf(err, "failed to activate volume group for lv %q. output: %s", lvPath, op)
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The activation of the lvs for OSDs had an invalid argument to vgchange. The invalid argument is now reverted to enable the OSDs in this scenario again.

Signed-off-by: Travis Nielsen <tnielsen@redhat.com>
(cherry picked from commit af54349a5ef245bdf54bb85dd818be12a4faf426)

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]