### PR TITLE
Doc: update ceph-upgrade.md for handling a known issue

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -145,6 +145,18 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
   starting state.
 * All pods consuming Rook storage should be created, running, and in a steady state. No Rook
   persistent volumes should be in the act of being created or deleted.
+* Your Helm version should be newer than v3.2.0 for avoiding [this issue](https://github.com/helm/helm/issues/7697).
+* For the already deployed Rook cluster with the Helm older than v3.2.0, you also need to execute the following commands.
+
+```sh
+KIND=ClusterRole
+NAME=psp:rook
+RELEASE=your-apps-release-name
+NAMESPACE=your-apps-namespace
+kubectl annotate $KIND $NAME meta.helm.sh/release-name=$RELEASE
+kubectl annotate $KIND $NAME meta.helm.sh/release-namespace=$NAMESPACE
+kubectl label $KIND $NAME app.kubernetes.io/managed-by=Helm
+```
 
 ## Health Verification
 


### PR DESCRIPTION
Because of the ClusterRole api version change,  #5341  may occur
when upgrading the rook chart to the latest version.
This pull request updates `ceph-upgrade.md` for handling the issue.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5341

**Checklist:**

- [x] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]