### PR TITLE
ceph: fix import script csi details

### DIFF
--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -124,8 +124,8 @@ function importCsiCephFSNodeSecret() {
     secret \
     generic \
     "$CSI_CEPHFS_NODE_SECRET_NAME" \
-    --from-literal=userID=csi-cephfs-node \
-    --from-literal=userKey="$CSI_CEPHFS_NODE_SECRET"
+    --from-literal=adminID=csi-cephfs-node \
+    --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
 }
 
 function importCsiCephFSProvisionerSecret() {
@@ -134,8 +134,8 @@ function importCsiCephFSProvisionerSecret() {
     secret \
     generic \
     "$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-    --from-literal=userID=csi-cephfs-provisioner \
-    --from-literal=userKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+    --from-literal=adminID=csi-cephfs-provisioner \
+    --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
 }
 
 ########


### PR DESCRIPTION
**Description of your changes:**

The cephfs csi driver expects both adminID and adminKey instead of
userID and userKey which are only specific to rbd.

Closes: https://github.com/rook/rook/issues/5432
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5432

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
