### PR TITLE
ceph: enhancement disk sanitize options

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -169,6 +169,17 @@ spec:
                 confirmation:
                   type: string
                   pattern: ^$|^yes-really-destroy-data$
+                sanitizeDisks:
+                  properties:
+                    method:
+                      type: string
+                      pattern: ^(complete|quick)$
+                    dataSource:
+                      type: string
+                      pattern: ^(zero|random)$
+                    iteration:
+                      type: integer
+                      format: int32
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -92,7 +92,19 @@ spec:
     # To signify that automatic deletion is desired, use the value "yes-really-destroy-data". Only this and an empty
     # string are valid values for this field.
     confirmation: ""
-
+    # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
+    sanitizeDisks:
+      # method indicates if the entire disk should be sanitized or simply ceph's metadata
+      # in both case, re-install is possible
+      # possible choices are 'complete' or 'quick' (default)
+      method: quick
+      # dataSource indicate where to get random bytes from to write on the disk
+      # possible choices are 'zero' (default) or 'random'
+      # using random sources will consume entropy from the system and will take much more time then the zero source
+      dataSource: zero
+      # iteration overwrite N times instead of the default (1)
+      # takes an integer value
+      iteration: 1
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
   # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
   # tolerate taints with a key of 'storage-node'.

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -192,6 +192,17 @@ spec:
                 confirmation:
                   type: string
                   pattern: ^$|^yes-really-destroy-data$
+                sanitizeDisks:
+                  properties:
+                    method:
+                      type: string
+                      pattern: ^(complete|quick)$
+                    dataSource:
+                      type: string
+                      pattern: ^(zero|random)$
+                    iteration:
+                      type: integer
+                      format: int32
             placement: {}
             resources: {}
             healthCheck: {}

--- a/pkg/apis/ceph.rook.io/v1/cleanup.go
+++ b/pkg/apis/ceph.rook.io/v1/cleanup.go
@@ -17,6 +17,18 @@ limitations under the License.
 package v1
 
 const (
+	// SanitizeDataSourceZero uses /dev/zero as sanitize source
+	SanitizeDataSourceZero SanitizeDataSourceProperty = "zero"
+
+	// SanitizeDataSourceRandom uses `shred's default entropy source
+	SanitizeDataSourceRandom SanitizeDataSourceProperty = "random"
+
+	// SanitizeMethodComplete will sanitize everything on the disk
+	SanitizeMethodComplete SanitizeMethodProperty = "complete"
+
+	// SanitizeMethodQuick will sanitize metdata only on the disk
+	SanitizeMethodQuick SanitizeMethodProperty = "quick"
+
 	// DeleteDataDirOnHostsConfirmation represents the validation to destry dataDirHostPath
 	DeleteDataDirOnHostsConfirmation CleanupConfirmationProperty = "yes-really-destroy-data"
 )
@@ -26,6 +38,10 @@ func (c *CleanupPolicySpec) HasDataDirCleanPolicy() bool {
 	return c.Confirmation == DeleteDataDirOnHostsConfirmation
 }
 
-func (c *CleanupConfirmationProperty) String() string {
+func (c *SanitizeMethodProperty) String() string {
+	return string(*c)
+}
+
+func (c *SanitizeDataSourceProperty) String() string {
 	return string(*c)
 }

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -705,10 +705,21 @@ type ClientSpec struct {
 }
 
 type CleanupPolicySpec struct {
-	Confirmation CleanupConfirmationProperty `json:"confirmation,omitempty"`
+	Confirmation  CleanupConfirmationProperty `json:"confirmation,omitempty"`
+	SanitizeDisks SanitizeDisksSpec           `json:"sanitizeDisks"`
 }
 
 type CleanupConfirmationProperty string
+
+type SanitizeDataSourceProperty string
+
+type SanitizeMethodProperty string
+
+type SanitizeDisksSpec struct {
+	Method     SanitizeMethodProperty     `json:"method,omitempty"`
+	DataSource SanitizeDataSourceProperty `json:"dataSource,omitempty"`
+	Iteration  int32                      `json:"iteration,omitempty"`
+}
 
 // +genclient
 // +genclient:noStatus

--- a/pkg/daemon/ceph/cleanup/disk_test.go
+++ b/pkg/daemon/ceph/cleanup/disk_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleanup
+
+import (
+	"reflect"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDataSource(t *testing.T) {
+	s := NewDiskSanitizer(&clusterd.Context{}, &client.ClusterInfo{}, &cephv1.SanitizeDisksSpec{})
+	s.sanitizeDisksSpec.DataSource = cephv1.SanitizeDataSourceZero
+
+	assert.Equal(t, "/dev/zero", s.buildDataSource())
+}
+
+func TestBuildShredArgs(t *testing.T) {
+	var i int32 = 1
+	c := &clusterd.Context{}
+	disk := "/dev/sda"
+	type fields struct {
+		context           *clusterd.Context
+		clusterInfo       *client.ClusterInfo
+		sanitizeDisksSpec *cephv1.SanitizeDisksSpec
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		disk   string
+		want   []string
+	}{
+		{"quick-zero", fields{c, &client.ClusterInfo{}, &cephv1.SanitizeDisksSpec{Method: cephv1.SanitizeMethodQuick, Iteration: i, DataSource: cephv1.SanitizeDataSourceZero}}, disk, []string{"--size=10M", "--random-source=/dev/zero", "--force", "--verbose", "--iterations=1", "/dev/sda"}},
+		{"quick-random", fields{c, &client.ClusterInfo{}, &cephv1.SanitizeDisksSpec{Method: cephv1.SanitizeMethodQuick, Iteration: i, DataSource: cephv1.SanitizeDataSourceRandom}}, disk, []string{"--zero", "--size=10M", "--force", "--verbose", "--iterations=1", "/dev/sda"}},
+		{"complete-zero", fields{c, &client.ClusterInfo{}, &cephv1.SanitizeDisksSpec{Method: cephv1.SanitizeMethodComplete, Iteration: i, DataSource: cephv1.SanitizeDataSourceZero}}, disk, []string{"--random-source=/dev/zero", "--force", "--verbose", "--iterations=1", "/dev/sda"}},
+		{"complete-random", fields{c, &client.ClusterInfo{}, &cephv1.SanitizeDisksSpec{Method: cephv1.SanitizeMethodComplete, Iteration: i, DataSource: cephv1.SanitizeDataSourceRandom}}, disk, []string{"--zero", "--force", "--verbose", "--iterations=1", "/dev/sda"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DiskSanitizer{
+				context:           tt.fields.context,
+				clusterInfo:       tt.fields.clusterInfo,
+				sanitizeDisksSpec: tt.fields.sanitizeDisksSpec,
+			}
+			if got := s.buildShredArgs(tt.disk); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DiskSanitizer.buildShredArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -55,7 +55,7 @@ func StartOSD(context *clusterd.Context, osdType, osdID, osdUUID, lvPath string,
 	}
 
 	// Update LVM config at runtime
-	if err := updateLVMConfig(context, pvcBackedOSD, lvBackedPV); err != nil {
+	if err := UpdateLVMConfig(context, pvcBackedOSD, lvBackedPV); err != nil {
 		return errors.Wrap(err, "failed to update lvm configuration file") // fail return here as validation provided by ceph-volume
 	}
 

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -179,7 +179,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	//
 	// Or keep doing this if the PV is backend by an LV already
 	if !a.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawModeMinCephVersion) || lvBackedPV {
-		if err := updateLVMConfig(context, a.pvcBacked, lvBackedPV); err != nil {
+		if err := UpdateLVMConfig(context, a.pvcBacked, lvBackedPV); err != nil {
 			return nil, errors.Wrap(err, "failed to update lvm configuration file")
 		}
 	}
@@ -343,7 +343,8 @@ func getLVPath(op string) string {
 	return ""
 }
 
-func updateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
+// UpdateLVMConfig updates the lvm.conf file
+func UpdateLVMConfig(context *clusterd.Context, onPVC, lvBackedPV bool) error {
 
 	input, err := ioutil.ReadFile(lvmConfPath)
 	if err != nil {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -520,8 +520,11 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 	for clusterNum, namespace := range namespaces {
 		if h.cleanupHost {
 			//Add cleanup policy to the ceph cluster
-			err = h.addCleanupPolicy(namespace)
-			assert.NoError(h.T(), err)
+			// Add cleanup policy to the ceph cluster but NOT the external one
+			if clusterNum == 0 {
+				err = h.addCleanupPolicy(namespace)
+				assert.NoError(h.T(), err)
+			}
 		}
 
 		if !h.T().Failed() {
@@ -547,8 +550,11 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		checkError(h.T(), err, fmt.Sprintf("cannot remove cluster %s", namespace))
 
 		if h.cleanupHost {
-			err = h.waitForCleanupJobs(namespace)
-			assert.NoError(h.T(), err)
+			// The second cluster is external so the cleanup pod will never exist!
+			if clusterNum == 0 {
+				err = h.waitForCleanupJobs(namespace)
+				assert.NoError(h.T(), err)
+			}
 		}
 
 		roles := h.Manifests.GetClusterRoles(namespace, systemNamespace)

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -97,10 +97,6 @@ func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 	if err != nil {
 		return fmt.Errorf("Failed to start admission controllers: %v", err)
 	}
-
-	if err = h.WipeDisks(namespace, 2); err != nil {
-		return err
-	}
 	rookOperator := h.Manifests.GetRookOperator(namespace)
 	_, err = h.k8shelper.KubectlWithStdin(rookOperator, createFromStdinArgs...)
 	if err != nil {
@@ -190,9 +186,6 @@ func (h *CephInstaller) CreateRookOperatorViaHelm(namespace, chartSettings strin
 
 	}
 
-	if err = h.WipeDisks(namespace, 2); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -805,158 +798,6 @@ func NewCephInstaller(t func() *testing.T, clientset *kubernetes.Clientset, useH
 	return h
 }
 
-// Wipe cluster disks
-func (h *CephInstaller) WipeDisks(namespace string, retries int) (err error) {
-	for i := 1; i <= retries; i++ {
-		if err = h.wipeClusterDisks(namespace); err == nil {
-			logger.Info("disks wiped successfully")
-			return nil
-		} else {
-			logger.Warningf("failed to wipe cluster disks. %+v. Attemp %d/%d ...", err, i, retries)
-		}
-	}
-	return fmt.Errorf("failed to wipe cluster disks. %+v", err)
-}
-
-// wipeClusterDisks runs a disk wipe job on all nodes in the k8s cluster.
-func (h *CephInstaller) wipeClusterDisks(namespace string) error {
-	// Wipe clean disks on all nodes
-	nodes, err := h.GetNodeHostnames()
-	if err != nil {
-		return fmt.Errorf("failed to get node hostnames. %+v", err)
-	}
-	var jobNames []string
-	for _, node := range nodes {
-		// Start the new job
-		globalTestJobIndex++
-		jobName := fmt.Sprintf("rook-ceph-disk-wipe-%d", globalTestJobIndex)
-		jobNames = append(jobNames, jobName)
-		job := h.GetDiskWipeJob(node, jobName, namespace)
-		_, err := h.k8shelper.KubectlWithStdin(job, createFromStdinArgs...)
-		if err != nil {
-			return fmt.Errorf("failed to create disk wipe job for host %s. %+v", node, err)
-		}
-	}
-
-	allJobsAreComplete := func() (done bool, err error) {
-		for _, jobName := range jobNames {
-			j, err := h.k8shelper.Clientset.BatchV1().Jobs(namespace).Get(jobName, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
-			if j.Status.Failed > 0 {
-				return false, fmt.Errorf("job %s failed", jobName)
-			}
-			if j.Status.Succeeded == 0 {
-				return false, nil
-			}
-		}
-		return true, nil
-	}
-
-	// return the error below after cleaning up the jobs
-	err = wait.Poll(5*time.Second, 90*time.Second, allJobsAreComplete)
-	if err != nil {
-		return fmt.Errorf("failed to wait for wipe jobs to complete. %+v", err)
-	}
-	return nil
-}
-
-// GetDiskWipeJob returns a YAML manifest string for a job which will wipe clean the extra
-// (non-boot) disks on a node, allowing Ceph to use the disk(s) during its testing.
-func (h *CephInstaller) GetDiskWipeJob(nodeName, jobName, namespace string) string {
-	// put the wipe job in the cluster namespace so that logs get picked up in failure conditions
-	return `apiVersion: batch/v1
-kind: Job
-metadata:
-  name: ` + jobName + `
-  namespace: ` + namespace + `
-spec:
-    template:
-      spec:
-          restartPolicy: OnFailure
-          containers:
-              - name: disk-wipe
-                image: ` + h.CephVersion.Image + `
-                securityContext:
-                    privileged: true
-                volumeMounts:
-                    - name: dev
-                      mountPath: /dev
-                    - name: run-udev
-                      mountPath: /run/udev
-                command:
-                    - "sh"
-                    - "-c"
-                    - |
-                      set -xEeuo pipefail
-                      # Wipe LVM data from disks
-                      #
-                      udevadm trigger || true
-                      vgimport -a || true
-                      # We should prepopulate the PVs corresponding to Ceph VGs here.
-                      # It's because getting the relationship of the PVs and the VGs
-                      # is impossible after removing the VGs.
-                      TMP=$(pvs --noheadings --separator=',' -o pv_name,vg_name)
-                      PVS=
-                      for line in $TMP ; do
-                        if [[ $line =~ ,ceph- ]]; then
-                          PVS="$PVS ${line%,*}"
-                        fi
-                      done
-                      # Wipe VGs
-                      for vg in $(vgs --noheadings --readonly --separator=' ' -o vg_name); do
-                        if [[ $vg =~ ^ceph- ]]; then
-                          vgremove --yes --force "$vg"
-                        fi
-                      done
-                      # Wipe PVs
-                      for pv in $PVS; do
-                        pvremove --yes --force "$pv"
-                        wipefs --all "$pv"
-                        dd if=/dev/zero of="$pv" bs=1M count=100 oflag=direct,dsync
-                        # do not fail the timeout command
-                        # the command seems to hang sometimes for no reason so let's retry
-                        set +Ee
-                        for i in $(seq 1 3); do
-                            timeout --preserve-status 5s sgdisk --zap-all "$pv"
-                            if [ "$?" -eq 0 ]; then
-                                break
-                            fi
-                            sleep 5
-                        done
-                        set -Ee
-                      done
-                      # Wipe the specific disk in the CI that was running in raw mode
-                      set +Ee
-                      block=` + TestScratchDevice() + `
-                      wipefs --all "$block"
-                      dd if=/dev/zero of="$block" bs=1M count=100 oflag=direct,dsync
-                      set -Ee
-                      # Useful debug commands
-                      lsblk
-                      blkid
-                      df /
-                      #
-                      # some devices might still be mapped that lock the disks
-                      # this can fail with long-gone vestigial devices, so just assume this is successful
-                      ls /dev/mapper/ceph-* | xargs -I% -- dmsetup remove --force % || true
-                      rm -rf /dev/mapper/ceph-*  # clutter
-                      #
-                      # ceph-volume setup also leaves ceph-UUID directories in /dev (just clutter)
-                      rm -rf /dev/ceph-*
-          nodeSelector:
-            kubernetes.io/hostname: ` + nodeName + `
-          volumes:
-              - name: dev
-                hostPath:
-                  path: /dev
-              - name: run-udev
-                hostPath:
-                  path: /run/udev
-`
-}
-
 // GetCleanupPod gets a cleanup Pod that cleans up the dataDirHostPath
 func (h *CephInstaller) GetCleanupPod(node, removalDir string) string {
 	return `apiVersion: batch/v1
@@ -1028,6 +869,7 @@ func (h *CephInstaller) addCleanupPolicy(namespace string) error {
 		return fmt.Errorf("failed to get ceph cluster. %+v", err)
 	}
 	cluster.Spec.CleanupPolicy.Confirmation = cephv1.DeleteDataDirOnHostsConfirmation
+	cluster.Spec.CleanupPolicy.SanitizeDisks.Method = cephv1.SanitizeMethodComplete
 	_, err = h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Update(cluster)
 	if err != nil {
 		return fmt.Errorf("failed to add clean up policy to the cluster. %+v", err)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -254,6 +254,17 @@ spec:
                 confirmation:
                   type: string
                   pattern: ^$|^yes-really-destroy-data$
+                sanitizeDisks:
+                  properties:
+                    method:
+                      type: string
+                      pattern: ^(complete|quick)$
+                    dataSource:
+                      type: string
+                      pattern: ^(zero|random)$
+                    iteration:
+                      type: integer
+                      format: int32
             placement: {}
             resources: {}
   additionalPrinterColumns:

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -92,7 +92,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		usePVC:                  false,
 		mons:                    1,
 		rbdMirrorWorkers:        1,
-		rookCephCleanup:         false,
+		rookCephCleanup:         true,
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,


### PR DESCRIPTION
**Description of your changes:**

Now, we can not only cleanup monitor data, logs and crashes but the
disks too. As part of the cleanupPolicy CR spec, we have a new setting
called sanitizeDisk which holds more details:

* sanitizeDiskConfirmation: the confirmation message to sanitize disks,
use "yes-really-sanitize-disks" to confirm
* sanitizeMethod: indicates if the entire disk should be sanitized or simply ceph's metadata.
Possible choices are 'data' or 'metadata' (default)
* sanitizeDataSource: indicate where to get random bytes from to write on the disk.
Possible choices are 'zero' (default), 'random' or 'urandom'.
Using random sources will consume entropy from the system and will take much more time then the zero source
* sanitizeIteration: overwrite N times instead of the default (1). Takes an integer value
See the documentation for more details.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]