### PR TITLE
ceph: obc relax error handling and user deletion

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -43,7 +43,7 @@ func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to run radosgw-admin")
+		return output, errors.Wrap(err, "failed to run radosgw-admin")
 	}
 
 	return output, nil

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -171,10 +171,11 @@ func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
 	}
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
+		if strings.Contains(result, "user does not exist") {
+			return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
+		}
+
 		return "", RGWErrorUnknown, errors.Wrap(err, "failed to delete user")
-	}
-	if result == "unable to remove user, user does not exist" {
-		return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
 	}
 
 	return result, RGWErrorNone, nil


### PR DESCRIPTION
**Description of your changes:**

When a user or a bucket does not exist anymore, let's stop the reconcile
loop instead of waiting forever.
Also, unlink the user before deleting it otherwise the deletion fails.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
