### PR TITLE
ceph: obc relax error handling and user deletion (bp #5465)

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -43,7 +43,7 @@ func runAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to run radosgw-admin")
+		return output, errors.Wrap(err, "failed to run radosgw-admin")
 	}
 
 	return output, nil

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -171,10 +171,11 @@ func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
 	}
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
-		return "", RGWErrorUnknown, errors.Wrapf(err, "failed to delete user")
-	}
-	if result == "unable to remove user, user does not exist" {
-		return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
+		if strings.Contains(result, "user does not exist") {
+			return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
+		}
+
+		return "", RGWErrorUnknown, errors.Wrap(err, "failed to delete user")
 	}
 
 	return result, RGWErrorNone, nil


### PR DESCRIPTION
**Description of your changes:**

When a user or a bucket does not exist anymore, let's stop the reconcile
loop instead of waiting forever.
Also, unlink the user before deleting it otherwise the deletion fails.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 58577a353743fe28c5df243675d585bb68dd12ae)

Backport of #5465
[test ceph]
