### PR TITLE
Ceph: prepare pvc just before osd on pvc test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,8 +198,7 @@ def RunIntegrationTest(k, v) {
                     sh "tests/scripts/kubeadm.sh up"
                     sh '''#!/bin/bash
                           export KUBECONFIG=$HOME/admin.conf
-                          tests/scripts/helm.sh up
-                          tests/scripts/localPathPV.sh /dev/xvdc'''
+                          tests/scripts/helm.sh up'''
                     try{
                         echo "Running full regression"
                         sh '''#!/bin/bash

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -802,10 +802,6 @@ func (h *CephInstaller) wipeClusterDisks(namespace string) error {
 // (non-boot) disks on a node, allowing Ceph to use the disk(s) during its testing.
 func (h *CephInstaller) GetDiskWipeJob(nodeName, jobName, namespace string) string {
 	// put the wipe job in the cluster namespace so that logs get picked up in failure conditions
-	scratchDevice := os.Getenv("TEST_SCRATCH_DEVICE")
-	if scratchDevice == "" {
-		scratchDevice = "/dev/xvdc"
-	}
 	return `apiVersion: batch/v1
 kind: Job
 metadata:
@@ -869,7 +865,7 @@ spec:
                       done
                       # Wipe the specific disk in the CI that was running in raw mode
                       set +Ee
-                      block=` + scratchDevice + `
+                      block=` + TestScratchDevice() + `
                       wipefs --all "$block"
                       dd if=/dev/zero of="$block" bs=1M count=100 oflag=direct,dsync
                       set -Ee

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -55,6 +55,11 @@ func baseTestDir() string {
 	return val
 }
 
+// TestScratchDevice get the scratch device to be used for OSD
+func TestScratchDevice() string {
+	return getEnvVarWithDefault("TEST_SCRATCH_DEVICE", "/dev/xvdc")
+}
+
 func getEnvVarWithDefault(env, defaultValue string) string {
 	val := os.Getenv(env)
 	if val == "" {

--- a/tests/framework/utils/exec_utils.go
+++ b/tests/framework/utils/exec_utils.go
@@ -32,9 +32,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "testutil")
 // CommandArgs is a warpper for cmd args
 type CommandArgs struct {
 	Command             string
-	SubCommand          string
 	CmdArgs             []string
-	OptionalArgs        []string
 	PipeToStdIn         string
 	EnvironmentVariable []string
 }

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	localPathPVCmd = "tests/scripts/localPathPV.sh"
+)
+
 // *************************************************************
 // *** Major scenarios tested by the MultiClusterDeploySuite ***
 // Setup
@@ -150,6 +154,12 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 // SetUpRook is wrapper for setting up multiple rook clusters.
 func (o MCTestOperations) Setup() {
 	var err error
+	if o.testOverPVC {
+		cmdArgs := utils.CommandArgs{Command: localPathPVCmd, CmdArgs: []string{installer.TestScratchDevice()}}
+		cmdOut := utils.ExecuteCommand(cmdArgs)
+		require.NoError(o.T(), cmdOut.Err)
+	}
+
 	err = o.installer.CreateCephOperator(installer.SystemNamespace(o.namespace1))
 	require.NoError(o.T(), err)
 


### PR DESCRIPTION
**Description of your changes:**

The PVCs for OSD on PVC test is perepared before running the integration test. In addition, users are forced to run this script for this by themselves. To avoid this problem, running this script inside the integration test.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

> This PR has already passed CI and the last reflection of review results is only about the commit message. So CI can be skipped here.

[skip ci]
