### PR TITLE
Wait for volume deletion before removing the cluster finalizer

### DIFF
--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -144,7 +144,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	return nil
 }
 
-func purgeExternalCluster(clientset kubernetes.Interface, namespace string) error {
+func purgeExternalCluster(clientset kubernetes.Interface, namespace string) {
 	// Purge the config maps
 	cmsToDelete := []string{
 		mon.EndpointConfigMapName,
@@ -173,8 +173,6 @@ func purgeExternalCluster(clientset kubernetes.Interface, namespace string) erro
 			logger.Errorf("failed to delete secret %q. %v", secret, err)
 		}
 	}
-
-	return nil
 }
 
 func validateExternalClusterSpec(cluster *cluster) error {

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -157,7 +157,7 @@ func (r *ReconcileCephRBDMirror) reconcile(request reconcile.Request) (reconcile
 	// Make sure a CephCluster is present otherwise do nothing
 	cephClusterSpec, isReadyToReconcile, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
-		logger.Debugf("CephCluster resource not ready in namespace %q, retrying in %q.", request.NamespacedName.Namespace, opcontroller.WaitForRequeueIfCephClusterNotReadyAfter.String())
+		logger.Debugf("CephCluster resource not ready in namespace %q, retrying in %q.", request.NamespacedName.Namespace, reconcileResponse.RequeueAfter.String())
 		return reconcileResponse, nil
 	}
 	r.cephClusterSpec = &cephClusterSpec

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -41,6 +41,8 @@ var (
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
 	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
 	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+	// WaitForRequeueIfFinalizerBlocked waits for resources to be cleaned up before the finalizer can be removed
+	WaitForRequeueIfFinalizerBlocked = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 )
 
 // IsReadyToReconcile determines if a controller is ready to reconcile or not

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -39,10 +39,8 @@ const OperatorSettingConfigMapName string = "rook-ceph-operator-config"
 var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
-	// WaitForRequeueIfCephClusterNotReadyAfter requeue after 10sec if the operator is not ready
-	WaitForRequeueIfCephClusterNotReadyAfter = 10 * time.Second
 	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
-	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: WaitForRequeueIfCephClusterNotReadyAfter}
+	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 )
 
 // IsReadyToReconcile determines if a controller is ready to reconcile or not

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -188,7 +188,8 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 			// Return and do not requeue. Successful deletion.
 			return reconcile.Result{}, nil
 		}
-		logger.Debugf("ObjectStore resource not ready in namespace %q, retrying in %q. %v", request.NamespacedName.Namespace, opcontroller.WaitForRequeueIfCephClusterNotReadyAfter.String(), err)
+		logger.Debugf("ObjectStore resource not ready in namespace %q, retrying in %q. %v",
+			request.NamespacedName.Namespace, opcontroller.WaitForRequeueIfCephClusterNotReady.RequeueAfter.String(), err)
 		updateStatus(r.client, request.NamespacedName, k8sutil.ReconcileFailedStatus)
 		return opcontroller.WaitForRequeueIfCephClusterNotReady, nil
 	}

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -22,7 +22,6 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
-	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -64,12 +63,6 @@ var (
 
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
-
-	// WaitForRequeueIfCephClusterNotReadyAfter requeue after 10sec if the operator is not ready
-	WaitForRequeueIfCephClusterNotReadyAfter = 10 * time.Second
-
-	// WaitForRequeueIfCephClusterNotReady waits for the CephCluster to be ready
-	WaitForRequeueIfCephClusterNotReady = reconcile.Result{Requeue: true, RequeueAfter: WaitForRequeueIfCephClusterNotReadyAfter}
 )
 
 // Operator type for managing storage


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
During cluster deletion, we currently only retry for a couple minutes to wait for the pvcs to be deleted. After the timeout, we proceed with the cluster deletion. To properly protect the pvcs for proper cleanup, the finalizer should not be removed until the pvcs are all confirmed to be deleted. In order to not block other cluster events, we re-queue the deletion event to run again every 10s until the pvcs are deleted or the finalizer is manually removed.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]