### PR TITLE
Stop monitoring a cluster immediately when deleted

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -56,6 +56,7 @@ type cluster struct {
 	mons                 *mon.Cluster
 	initCompleted        bool
 	stopCh               chan struct{}
+	closedStopCh         bool
 	ownerRef             metav1.OwnerReference
 	orchestrationRunning bool
 	orchestrationNeeded  bool

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -265,6 +265,7 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 		logger.Infof("deleting ceph cluster %q", cephCluster.Name)
 
 		// Start cluster clean up only if cleanupPolicy is applied to the ceph cluster
+		stopCleanupCh := make(chan struct{})
 		if hasCleanupPolicy(cephCluster) {
 			monSecret, err := r.clusterController.getMonSecret(cephCluster.Namespace)
 			if err != nil {
@@ -274,7 +275,7 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 			if err != nil {
 				return reconcile.Result{}, errors.Wrapf(err, "failed to find valid ceph hosts in the cluster %q", cephCluster.Namespace)
 			}
-			go r.clusterController.startClusterCleanUp(cephCluster, cephHosts, monSecret)
+			go r.clusterController.startClusterCleanUp(stopCleanupCh, cephCluster, cephHosts, monSecret)
 		}
 
 		// Run delete sequence
@@ -282,6 +283,7 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 		if !ok {
 			// If the cluster cannot be deleted, requeue the request for deletion to see if the conditions
 			// will eventually be satisfied such as the volumes being removed
+			close(stopCleanupCh)
 			return response, nil
 		}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two changes to improve the cluster cleanup:
1. During cluster deletion, the finalizer will not be removed until all the PVCs are removed. Since this could wait for a long time, as long as the deletion event is re-queued, we need to cancel the goroutine that is watching for cluster deletion so it can avoid running multiple goroutines as the event runs again and again.
1. When a cluster is requested for deletion there is no longer a reason to monitor the cluster health such as whether mons are in quorum, osds are up and in, or monitor the ceph status.
The cluster will wait potentially for a long time if the PVCs are not deleted by the admin, therefore we stop monitoring the cluster even before the finalizer is removed.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]