### PR TITLE
Set pg_num_min on new rgw metadata pools

### DIFF
--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -315,11 +315,11 @@ func createSimilarPools(context *Context, pools []string, poolSpec cephv1.PoolSp
 					}
 				}
 			}
-			if pgCount != ceph.DefaultPGCount {
-				err = ceph.SetPoolProperty(context.Context, context.ClusterName, name, "pg_num_min", pgCount)
-				if err != nil {
-					return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
-				}
+		}
+		// Set the pg_num_min if not the default so the autoscaler won't immediately increase the pg count
+		if pgCount != ceph.DefaultPGCount {
+			if err := ceph.SetPoolProperty(context.Context, context.ClusterName, name, "pg_num_min", pgCount); err != nil {
+				return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
pg_num_min needs to be set on all new and existing rgw metadata pools so the autoscaler won't immediately increase the pg count. The pg_num_min was only being set on existing pools and not on new pools.

**Which issue is resolved by this Pull Request:**
Resolves #5091 

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
