### PR TITLE
Only run the cluster monitoring goroutines once

### DIFF
--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 )
 
 type OSDUsage struct {
@@ -253,7 +252,7 @@ func OSDOut(context *clusterd.Context, clusterName string, osdID int) (string, e
 	return string(buf), err
 }
 
-func OsdSafeToDestroy(context *clusterd.Context, clusterName string, osdID int, cephVersion cephver.CephVersion) (bool, error) {
+func OsdSafeToDestroy(context *clusterd.Context, clusterName string, osdID int) (bool, error) {
 	args := []string{"osd", "safe-to-destroy", strconv.Itoa(osdID)}
 	cmd := NewCephCommand(context, clusterName, args)
 	buf, err := cmd.Run()

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -256,7 +256,7 @@ func (c *ClusterController) startClusterMonitoring(cluster *cluster, cephUser st
 
 	if !cluster.Spec.External.Enable {
 		// Start the osd health checker only if running OSDs in the local ceph cluster
-		c.osdChecker = osd.NewOSDHealthMonitor(c.context, cluster.Namespace, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Info.CephVersion)
+		c.osdChecker = osd.NewOSDHealthMonitor(c.context, cluster.Namespace, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove)
 		go c.osdChecker.Start(cluster.stopCh)
 	}
 

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -195,26 +195,25 @@ func populateExternalClusterInfo(context *clusterd.Context, namespace string) *c
 			logger.Warningf("waiting for the connection info of the external cluster. retrying in %s.", externalConnectionRetry.String())
 			time.Sleep(externalConnectionRetry)
 			continue
-		} else {
-			// If an admin key was provided we don't need to load the other resources
-			// Some people might want to give the admin key
-			// The necessary users/keys/secrets will be created by Rook
-			// This is also done to allow backward compatibility
-			if isExternalHealthCheckUserAdmin(clusterInfo.AdminSecret) {
-				break
-			}
-			externalCred, err := mon.ValidateAndLoadExternalClusterSecrets(context, namespace)
-			if err != nil {
-				logger.Warningf("waiting for the connection info of the external cluster. retrying in %s.", externalConnectionRetry.String())
-				logger.Debugf("%v", err)
-				time.Sleep(externalConnectionRetry)
-				continue
-			} else {
-				clusterInfo.ExternalCred = externalCred
-				logger.Infof("found the cluster info to connect to the external cluster. will use %q to check health and monitor status. mons=%+v", clusterInfo.ExternalCred.Username, clusterInfo.Monitors)
-				break
-			}
 		}
+		// If an admin key was provided we don't need to load the other resources
+		// Some people might want to give the admin key
+		// The necessary users/keys/secrets will be created by Rook
+		// This is also done to allow backward compatibility
+		if isExternalHealthCheckUserAdmin(clusterInfo.AdminSecret) {
+			clusterInfo.ExternalCred = cephconfig.ExternalCred{Username: client.AdminUsername, Secret: clusterInfo.AdminSecret}
+			break
+		}
+		externalCred, err := mon.ValidateAndLoadExternalClusterSecrets(context, namespace)
+		if err != nil {
+			logger.Warningf("waiting for the connection info of the external cluster. retrying in %s.", externalConnectionRetry.String())
+			logger.Debugf("%v", err)
+			time.Sleep(externalConnectionRetry)
+			continue
+		}
+		clusterInfo.ExternalCred = externalCred
+		logger.Infof("found the cluster info to connect to the external cluster. will use %q to check health and monitor status. mons=%+v", clusterInfo.ExternalCred.Username, clusterInfo.Monitors)
+		break
 	}
 
 	return clusterInfo

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -303,7 +303,7 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 
 	// Do reconcile here!
 	if err := r.clusterController.onAdd(cephCluster, ref); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile cluster %q", cephCluster.Name))
+		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile cluster %q", cephCluster.Name)
 	}
 
 	// Return and do not requeue

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -302,7 +302,9 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Do reconcile here!
-	r.clusterController.onAdd(cephCluster, ref)
+	if err := r.clusterController.onAdd(cephCluster, ref); err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile cluster %q", cephCluster.Name))
+	}
 
 	// Return and do not requeue
 	return reconcile.Result{}, nil
@@ -321,10 +323,10 @@ func NewClusterController(context *clusterd.Context, rookImage string, volumeAtt
 	}
 }
 
-func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ref *metav1.OwnerReference) {
+func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ref *metav1.OwnerReference) error {
 	if hasCleanupPolicy(clusterObj) {
 		logger.Infof("skipping orchestration for cluster object %q in namespace %q because its cleanup policy is set", clusterObj.Name, clusterObj.Namespace)
-		return
+		return nil
 	}
 
 	cluster, ok := c.clusterMap[clusterObj.Namespace]
@@ -348,7 +350,7 @@ func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ref *metav1.Ow
 	c.csiConfigMutex.Unlock()
 
 	// Start the main ceph cluster orchestration
-	c.initializeCluster(cluster, clusterObj)
+	return c.initializeCluster(cluster, clusterObj)
 }
 
 func (c *ClusterController) requestClusterDelete(cluster *cephv1.CephCluster) (reconcile.Result, bool) {

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,12 +44,11 @@ type OSDHealthMonitor struct {
 	context                        *clusterd.Context
 	namespace                      string
 	removeOSDsIfOUTAndSafeToRemove bool
-	cephVersion                    cephver.CephVersion
 }
 
 // NewOSDHealthMonitor instantiates OSD monitoring
-func NewOSDHealthMonitor(context *clusterd.Context, namespace string, removeOSDsIfOUTAndSafeToRemove bool, cephVersion cephver.CephVersion) *OSDHealthMonitor {
-	return &OSDHealthMonitor{context, namespace, removeOSDsIfOUTAndSafeToRemove, cephVersion}
+func NewOSDHealthMonitor(context *clusterd.Context, namespace string, removeOSDsIfOUTAndSafeToRemove bool) *OSDHealthMonitor {
+	return &OSDHealthMonitor{context, namespace, removeOSDsIfOUTAndSafeToRemove}
 }
 
 // Start runs monitoring logic for osds status at set intervals
@@ -133,7 +131,7 @@ func (m *OSDHealthMonitor) removeOSDDeploymentIfSafeToDestroy(outOSDid int) erro
 		return errors.Wrapf(err, "failed to get osd deployment of osd id %d", outOSDid)
 	}
 	if len(dp.Items) != 0 {
-		safeToDestroyOSD, err := client.OsdSafeToDestroy(m.context, m.namespace, outOSDid, m.cephVersion)
+		safeToDestroyOSD, err := client.OsdSafeToDestroy(m.context, m.namespace, outOSDid)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get osd deployment of osd id %d", outOSDid)
 		}

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -62,7 +62,7 @@ func (m *OSDHealthMonitor) Start(stopCh chan struct{}) {
 			logger.Debug("Checking osd processes status.")
 			err := m.checkOSDHealth()
 			if err != nil {
-				logger.Warningf("failed OSD status check. %v", err)
+				logger.Debugf("failed OSD status check. %v", err)
 			}
 
 		case <-stopCh:

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testexec "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -88,12 +87,8 @@ func TestOSDHealthCheck(t *testing.T) {
 	dp, _ := context.Clientset.AppsV1().Deployments(cluster).List(metav1.ListOptions{LabelSelector: fmt.Sprintf("%v=%d", OsdIdLabelKey, 0)})
 	assert.Equal(t, 1, len(dp.Items))
 
-	cephVersion := cephver.CephVersion{
-		Major: 14,
-	}
-
 	// Initializing an OSD monitoring
-	osdMon := NewOSDHealthMonitor(context, cluster, true, cephVersion)
+	osdMon := NewOSDHealthMonitor(context, cluster, true)
 
 	// Run OSD monitoring routine
 	err := osdMon.checkOSDHealth()
@@ -107,12 +102,8 @@ func TestOSDHealthCheck(t *testing.T) {
 }
 
 func TestMonitorStart(t *testing.T) {
-	cephVersion := cephver.CephVersion{
-		Major: 14,
-	}
-
 	stopCh := make(chan struct{})
-	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, "cluster", true, cephVersion)
+	osdMon := NewOSDHealthMonitor(&clusterd.Context{}, "cluster", true)
 	logger.Infof("starting osd monitor")
 	go osdMon.Start(stopCh)
 	close(stopCh)
@@ -140,7 +131,7 @@ func TestOSDRestartIfStuck(t *testing.T) {
 	_, err := context.Clientset.CoreV1().Pods(namespace).Create(pod)
 	assert.NoError(t, err)
 
-	m := NewOSDHealthMonitor(context, namespace, false, cephver.CephVersion{})
+	m := NewOSDHealthMonitor(context, namespace, false)
 
 	podList := &v1.PodList{Items: []v1.Pod{*pod}}
 	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The monitoring goroutines that check for mon and osd health, the ceph cluster status, and the bucket provisioner should only be started once for each cluster. Previous to this change
and since the controller runtime conversion the goroutines were being started again every time a reconcile was run. This means you could potentially have many goroutines monitoring the same thing.

A separate commit removes versioning info that is no longer needed since dropping mimic. 

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]