### PR TITLE
Update prometheus-operator version from v0.26.0 to v0.39.0 written in ceph-monitoring.md.

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -21,7 +21,7 @@ First the Prometheus operator needs to be started in the cluster so it can watch
 A full explanation can be found in the [Prometheus operator repository on GitHub](https://github.com/coreos/prometheus-operator), but the quick instructions can be found here:
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.39.0/bundle.yaml
 ```
 
 This will start the Prometheus operator, but before moving on, wait until the operator is in the `Running` state:


### PR DESCRIPTION
**Description of your changes:**

Duplicated apis is used in prometheus-operator v0.26.0 so we unable to create prometheus-operator in the version of k8s v1.18.0 like below. 

```
pi@node1:~/ $ kubectl version
Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:58:59Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/arm"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:50:46Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/arm"}'

pi@node1:~/ $ kubectl -n rook-ceph exec -it rook-ceph-tools-6d659f5579-b9x6w -- rook version
rook: v1.3.0-beta.0.43.gafd8398
go: go1.13.8

pi@node1:~/ $ kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml
error: unable to recognize "https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml": no matches for kind "Deployment" in version "apps/v1beta2
```

I checked that v0.39.0 is working correctly so I think v0.39.0 is better than v0.26.0.

```
pi@node1:~/ $ kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.39.0/bundle.yaml
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
clusterrolebinding.rbac.authorization.k8s.io/prometheus-operator created
clusterrole.rbac.authorization.k8s.io/prometheus-operator created
deployment.apps/prometheus-operator created
serviceaccount/prometheus-operator created
service/prometheus-operator created

pi@node1:~/rook/cluster/examples/kubernetes/ceph/monitoring $ kubectl create -f service-monitor.yaml
servicemonitor.monitoring.coreos.com/rook-ceph-mgr created

pi@node1:~/rook/cluster/examples/kubernetes/ceph/monitoring $ kubectl create -f prometheus.yaml
serviceaccount/prometheus created
clusterrole.rbac.authorization.k8s.io/prometheus created
clusterrole.rbac.authorization.k8s.io/prometheus-rules created
clusterrolebinding.rbac.authorization.k8s.io/prometheus created
prometheus.monitoring.coreos.com/rook-prometheus created

pi@node1:~/rook/cluster/examples/kubernetes/ceph/monitoring $ kubectl create -f prometheus-service.yaml
service/rook-prometheus created

pi@node1:~/rook/cluster/examples/kubernetes/ceph/monitoring $ kubectl -n rook-ceph get pod prometheus-rook-prometheus-0
NAME                           READY   STATUS    RESTARTS   AGE
prometheus-rook-prometheus-0   3/3     Running   1          56s

pi@node1:~/ $ kubectl get svc -n rook-ceph | grep rook-prometheus
rook-prometheus                        LoadBalancer   10.108.194.7     192.168.100.103   9090:30900/TCP      16h

pi@node1:~/ $ curl http://192.168.100.103:9090/api/v1/query?query=ceph_osd_up
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"ceph_osd_up","ceph_daemon":"osd.3","endpoint":"http-metrics","instance":"10.244.4.9:9283","job":"rook-ceph-mgr","namespace":"rook-ceph","pod":"rook-ceph-mgr-a-68b8664b47-94rcn","service":"rook-ceph-mgr"},"value":[1589626481.18,"1"]},
(snip)
```

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]