### PR TITLE
ceph: replace CACHEINODE with MDCACHE

### DIFF
--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -56,7 +56,7 @@ NFS_CORE_PARAM {
 	Protocols = 4;
 }
 
-CACHEINODE {
+MDCACHE {
 	Dir_Chunk = 0;
 	NParts = 1;
 	Cache_Size = 1;


### PR DESCRIPTION
CACHEINODE has been deprecated in favor of MDCACHE

https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/454929
https://github.com/nfs-ganesha/nfs-ganesha/commit/4f4d624ceb361e2ac05e9e304583f35832921790

Signed-off-by: Michael Fritch <mfritch@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]