### PR TITLE
ceph: fail for unsupported version

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -460,7 +460,7 @@ func (c *ClusterController) configureLocalCephCluster(namespace, name string, cl
 				logger.Errorf(failedMessage)
 				if !canRetry {
 					// it may seem strange to exit true but we don't want to retry if the version is not supported
-					return true, nil
+					return true, err
 				}
 				return false, nil
 			}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

We must return `err` instead of nil so that we can fail the
orchestration properly.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5498

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]

**MASTER DOES NOT HAVE THE BUG SO PUSHING TO RELEASE BRANCH DIRECTLY.**