### PR TITLE
ceph: obc clean up resources incase of failure

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -292,12 +292,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 		}
 	}
 
-	_, _, err = cephObject.UnlinkUser(p.objectContext, p.cephUserName, p.bucketName)
-	if err != nil {
-		return err
-	}
-
-	// finally, delete unlinked user
+	// finally, delete the user
 	p.deleteOBCResource("")
 	return nil
 }

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -94,11 +94,13 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	if err != nil {
 		err = errors.Wrapf(err, "error creating bucket %q", p.bucketName)
 		logger.Errorf(err.Error())
+		p.deleteOBCResource("")
 		return nil, err
 	}
 
 	_, errCode, err := cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, maxBuckets)
 	if errCode > 0 {
+		p.deleteOBCResource(p.bucketName)
 		return nil, err
 	}
 	logger.Infof("set user %q bucket max to %d", p.cephUserName, maxBuckets)
@@ -131,21 +133,25 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	// need to quota into -1 for restricting creation of new buckets in rgw
 	_, _, err = cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, -1)
 	if err != nil {
+		p.deleteOBCResource("")
 		return nil, err
 	}
 
 	// get the bucket's owner via the bucket metadata
 	stats, _, err := cephObject.GetBucket(p.objectContext, p.bucketName)
 	if err != nil {
+		p.deleteOBCResource("")
 		return nil, errors.Wrapf(err, "could not get bucket stats (bucket: %s)", p.bucketName)
 	}
 	objectUser, _, err := cephObject.GetUser(p.objectContext, stats.Owner)
 	if err != nil {
+		p.deleteOBCResource("")
 		return nil, errors.Wrapf(err, "could not get user (user: %s)", stats.Owner)
 	}
 
 	s3svc, err := NewS3Agent(*objectUser.AccessKey, *objectUser.SecretKey, p.getObjectStoreEndpoint())
 	if err != nil {
+		p.deleteOBCResource("")
 		return nil, err
 	}
 
@@ -154,6 +160,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() != "NoSuchBucketPolicy" {
+				p.deleteOBCResource("")
 				return nil, err
 			}
 		}
@@ -175,6 +182,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 
 	logger.Infof("PutBucketPolicy output: %v", out)
 	if err != nil {
+		p.deleteOBCResource("")
 		return nil, err
 	}
 	// returned ob with connection info

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -197,11 +197,7 @@ func (p Provisioner) Delete(ob *bktv1alpha1.ObjectBucket) error {
 		return err
 	}
 
-	err = p.deleteCephUser(p.cephUserName)
-	if err != nil {
-		return err
-	}
-	err = p.deleteBucket(p.bucketName)
+	err = p.deleteOBCResource(p.bucketName)
 	if err != nil {
 		return err
 	}
@@ -294,10 +290,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 	}
 
 	// finally, delete unlinked user
-	err = p.deleteCephUser(p.cephUserName)
-	if err != nil {
-		return err
-	}
+	p.deleteOBCResource("")
 	return nil
 }
 

--- a/pkg/operator/ceph/object/bucket/rgw-handlers.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers.go
@@ -122,3 +122,38 @@ func (p *Provisioner) genUserName() (genName string, err error) {
 	}
 	return genName, nil
 }
+
+// Delete the user and bucket created by OBC with help of radosgw-admin commands
+// If delete user failed, error is no longer returned since its permission is
+// already revoked and hence user is no longer able to access the bucket
+// Empty string is passed for bucketName only if user needs to be removed, ex Revoke()
+func (p *Provisioner) deleteOBCResource(bucketName string) error {
+
+	logger.Infof("deleting Ceph user %s and bucket %q", p.cephUserName, bucketName)
+	if len(p.cephUserName) > 0 {
+		_, errCode, _ := cephObject.DeleteUser(p.objectContext, p.cephUserName)
+
+		if errCode == cephObject.RGWErrorNone {
+			logger.Infof("user %q successfully deleted", p.cephUserName)
+		} else if errCode == cephObject.RGWErrorNotFound {
+			// opinion: "not found" is not an error
+			logger.Infof("user %q does not exist", p.cephUserName)
+		} else {
+			logger.Warningf("failed to delete user %q: errCode: %d", p.cephUserName, errCode)
+		}
+	}
+	if len(bucketName) > 0 {
+		// delete bucket with purge option to remove all objects
+		errCode, err := cephObject.DeleteBucket(p.objectContext, bucketName, true)
+
+		if errCode == cephObject.RGWErrorNone {
+			logger.Infof("bucket %q successfully deleted", p.bucketName)
+		} else if errCode == cephObject.RGWErrorNotFound {
+			// opinion: "not found" is not an error
+			logger.Infof("bucket %q does not exist", p.bucketName)
+		} else {
+			return errors.Wrapf(err, "failed to delete bucket %q: errCode: %d", bucketName, errCode)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When obc creation fails in Grant() or Provision() the resources such as rgw user or bucket
created while provisioning need to remove.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
