### PR TITLE
Pool resize test hangs during cleanup with latest v15.2.2

### DIFF
--- a/tests/framework/clients/pool.go
+++ b/tests/framework/clients/pool.go
@@ -106,8 +106,10 @@ func (p *PoolOperation) CephPoolExists(namespace, name string) (bool, error) {
 	return false, nil
 }
 
+// DeletePool deletes a pool after deleting all the block images contained by the pool
 func (p *PoolOperation) DeletePool(blockClient *BlockOperation, namespace, poolName string) error {
 	// Delete all the images in a pool
+	logger.Infof("listing images in pool %q", poolName)
 	blockImagesList, _ := blockClient.ListImagesInPool(namespace, poolName)
 	for _, blockImage := range blockImagesList {
 		logger.Infof("force deleting block image %q in pool %q", blockImage, poolName)

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -214,28 +214,33 @@ func (suite *SmokeSuite) TestPoolResize() {
 
 	require.Equal(suite.T(), true, poolFound, "pool not found")
 
-	err = suite.helper.PoolClient.Update(poolName, suite.namespace, 3)
+	err = suite.helper.PoolClient.Update(poolName, suite.namespace, 2)
 	require.Nil(suite.T(), err)
 
-	poolFound = false
+	poolResized := false
 	// Wait for pool resize to happen
 	for i := 0; i < 10; i++ {
-
 		details, err := suite.helper.PoolClient.GetCephPoolDetails(suite.namespace, poolName)
 		require.Nil(suite.T(), err)
 		if details.Size > 1 {
-			logger.Infof("pool %s size got updated", poolName)
-			require.Equal(suite.T(), 3, int(details.Size))
-			poolFound = true
+			logger.Infof("pool %s size was updated", poolName)
+			require.Equal(suite.T(), 2, int(details.Size))
+			poolResized = true
+
+			// resize the pool back to 1 to avoid hangs around not having enough OSDs to satisfy rbd
+			err = suite.helper.PoolClient.Update(poolName, suite.namespace, 1)
+			require.Nil(suite.T(), err)
+		} else if poolResized && details.Size == 1 {
+			logger.Infof("pool resized back to 1")
 			break
 		}
-		logger.Infof("pool %s size not updated yet. details: %+v", poolName, details)
 
+		logger.Debugf("pool %s size not updated yet. details: %+v", poolName, details)
 		logger.Infof("Waiting for pool %s resize to happen", poolName)
 		time.Sleep(2 * time.Second)
 	}
 
-	require.Equal(suite.T(), true, poolFound, fmt.Sprintf("pool %s not found", poolName))
+	require.Equal(suite.T(), true, poolResized, fmt.Sprintf("pool %s not found", poolName))
 
 	// clean up the pool
 	suite.helper.PoolClient.DeletePool(suite.helper.BlockClient, suite.namespace, poolName)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In Octopus 15.2.2 there is an rbd change that causes the rbd ls command to hang if there are not sufficient OSDs. The smoke suite just started hanging today since the 15.2.2 image was released. Therefore, the test that resizes the pool to replica 3 must resize back to 1 before cleaning up.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]