### PR TITLE
ceph: default the device set template name to data

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package osd
+
+import (
+	"testing"
+
+	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	testexec "github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPrepareDeviceSets(t *testing.T) {
+	clientset := testexec.New(t, 1)
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+	storageClass := "mysource"
+	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
+		StorageClassName: &storageClass,
+	}}
+	deviceSet := rookv1.StorageClassDeviceSet{
+		Name:                 "mydata",
+		Count:                1,
+		Portable:             true,
+		VolumeClaimTemplates: []v1.PersistentVolumeClaim{claim},
+	}
+	desired := rookv1.StorageScopeSpec{StorageClassDeviceSets: []rookv1.StorageClassDeviceSet{deviceSet}}
+	cluster := &Cluster{
+		context:        context,
+		DesiredStorage: desired,
+		Namespace:      "testns",
+	}
+
+	config := &provisionConfig{}
+	volumeSources := cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 1, len(volumeSources))
+	assert.Equal(t, 0, len(config.errorMessages))
+	assert.Equal(t, "mydata", volumeSources[0].Name)
+	assert.Equal(t, "data", volumeSources[0].Type)
+	assert.True(t, volumeSources[0].Portable)
+
+	// Verify that the PVC has the expected generated name with the default of "data" in the name
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(pvcs.Items))
+	assert.Equal(t, "mydata-data-0-", pvcs.Items[0].GenerateName)
+	assert.Equal(t, cluster.Namespace, pvcs.Items[0].Namespace)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In 1.3 we added support for the metadata pvcs, thus requiring the name to be set on the templates to differentiate between data and metadata. For backward compatibility we need to assume the template is for data if it is not set.

Also added a much needed unit test for generating the device set PVCs.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]