### PR TITLE
chore: Make csv generation work with operator-sdk 0.15.0 and later, remove support for previous versions.

### DIFF
--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -16,16 +16,18 @@ OLM_CATALOG_DIR=cluster/olm/ceph
 DEPLOY_DIR="$OLM_CATALOG_DIR/deploy"
 CRDS_DIR="$DEPLOY_DIR/crds"
 
-TMP_CSV_GEN_FILE="$OLM_CATALOG_DIR/deploy/olm-catalog/rook-ceph.v9999.9999.9999.clusterserviceversion.yaml"
 TEMPLATES_DIR="$OLM_CATALOG_DIR/templates"
 
 function generate_template() {
     local provider=$1
+    local csv_manifest_path="$DEPLOY_DIR/olm-catalog/${provider}/9999.9999.9999/manifests"
+    local tmp_csv_gen_file="$csv_manifest_path/ceph.clusterserviceversion.yaml"
     local csv_template_file="$TEMPLATES_DIR/rook-ceph-${provider}.vVERSION.clusterserviceversion.yaml.in"
+    rm -rf $csv_manifest_path
 
     # v9999.9999.9999 is just a placeholder. operator-sdk requires valid semver here.
     (cluster/olm/ceph/generate-rook-csv.sh "9999.9999.9999" $provider "{{.RookOperatorImage}}")
-    mv $TMP_CSV_GEN_FILE $csv_template_file
+    mv $tmp_csv_gen_file $csv_template_file
 
     # replace the placeholder with the templated value
     sed -i "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
@@ -34,7 +36,6 @@ function generate_template() {
 }
 
 # start clean
-rm -f $TMP_CSV_GEN_FILE
 if [ -d $TEMPLATES_DIR ]; then
     rm -rf $TEMPLATES_DIR
 fi

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -24,7 +24,7 @@ CEPH_VERSION = v14.2.9-20200506
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
-OPERATOR_SDK_VERSION = v0.10.0
+OPERATOR_SDK_VERSION = v0.17.1
 GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go
 
 TEMP := $(shell mktemp -d)
@@ -69,7 +69,7 @@ generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
 $(YQ):
 	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		echo === installing yq $(GOHOST);\
-		curl -JL https://github.com/mikefarah/yq/releases/download/2.4.1/yq_$(HOST_PLATFORM) -o $(YQ);\
+		curl -JL https://github.com/mikefarah/yq/releases/download/3.3.0/yq_$(HOST_PLATFORM) -o $(YQ);\
 		chmod +x $(YQ);\
 	fi
 


### PR DESCRIPTION
**Description of your changes:**
Newer versions of operator-sdk (since 0.15.0, released Jan 2020) have a different command line to generate CSV. Make changes to the script generating the CSV so that it works with these new versions.

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip tests]