### PR TITLE
ceph: do not enforce osd-memory-target

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -37,27 +37,26 @@ import (
 )
 
 const (
-	osdStoreEnvVarName                          = "ROOK_OSD_STORE"
-	osdDatabaseSizeEnvVarName                   = "ROOK_OSD_DATABASE_SIZE"
-	osdWalSizeEnvVarName                        = "ROOK_OSD_WAL_SIZE"
-	osdJournalSizeEnvVarName                    = "ROOK_OSD_JOURNAL_SIZE"
-	osdsPerDeviceEnvVarName                     = "ROOK_OSDS_PER_DEVICE"
-	encryptedDeviceEnvVarName                   = "ROOK_ENCRYPTED_DEVICE"
-	osdMetadataDeviceEnvVarName                 = "ROOK_METADATA_DEVICE"
-	pvcBackedOSDVarName                         = "ROOK_PVC_BACKED_OSD"
-	blockPathVarName                            = "ROOK_BLOCK_PATH"
-	cvModeVarName                               = "ROOK_CV_MODE"
-	lvBackedPVVarName                           = "ROOK_LV_BACKED_PV"
-	CrushDeviceClassVarName                     = "ROOK_OSD_CRUSH_DEVICE_CLASS"
-	rookBinariesMountPath                       = "/rook"
-	rookBinariesVolumeName                      = "rook-binaries"
-	activateOSDVolumeName                       = "activate-osd"
-	activateOSDMountPath                        = "/var/lib/ceph/osd/ceph-"
-	blockPVCMapperInitContainer                 = "blkdevmapper"
-	blockPVCMetadataMapperInitContainer         = "blkdevmapper-metadata"
-	activatePVCOSDInitContainer                 = "activate"
-	expandPVCOSDInitContainer                   = "expand-bluefs"
-	osdMemoryTargetSafetyFactor         float32 = 0.8
+	osdStoreEnvVarName                  = "ROOK_OSD_STORE"
+	osdDatabaseSizeEnvVarName           = "ROOK_OSD_DATABASE_SIZE"
+	osdWalSizeEnvVarName                = "ROOK_OSD_WAL_SIZE"
+	osdJournalSizeEnvVarName            = "ROOK_OSD_JOURNAL_SIZE"
+	osdsPerDeviceEnvVarName             = "ROOK_OSDS_PER_DEVICE"
+	encryptedDeviceEnvVarName           = "ROOK_ENCRYPTED_DEVICE"
+	osdMetadataDeviceEnvVarName         = "ROOK_METADATA_DEVICE"
+	pvcBackedOSDVarName                 = "ROOK_PVC_BACKED_OSD"
+	blockPathVarName                    = "ROOK_BLOCK_PATH"
+	cvModeVarName                       = "ROOK_CV_MODE"
+	lvBackedPVVarName                   = "ROOK_LV_BACKED_PV"
+	CrushDeviceClassVarName             = "ROOK_OSD_CRUSH_DEVICE_CLASS"
+	rookBinariesMountPath               = "/rook"
+	rookBinariesVolumeName              = "rook-binaries"
+	activateOSDVolumeName               = "activate-osd"
+	activateOSDMountPath                = "/var/lib/ceph/osd/ceph-"
+	blockPVCMapperInitContainer         = "blkdevmapper"
+	blockPVCMetadataMapperInitContainer = "blkdevmapper-metadata"
+	activatePVCOSDInitContainer         = "activate"
+	expandPVCOSDInitContainer           = "expand-bluefs"
 	// CephDeviceSetLabelKey is the Rook device set label key
 	CephDeviceSetLabelKey = "ceph.rook.io/DeviceSet"
 	// CephSetIndexLabelKey is the Rook label key index
@@ -243,12 +242,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to apply tuning on osd %q", strconv.Itoa(osd.ID))
 		}
-	}
-
-	// As of Nautilus Ceph auto-tunes its osd_memory_target on the fly so we don't need to force it
-	if !c.resources.Limits.Memory().IsZero() {
-		osdMemoryTargetValue := float32(c.resources.Limits.Memory().Value()) * osdMemoryTargetSafetyFactor
-		commonArgs = append(commonArgs, fmt.Sprintf("--osd-memory-target=%d", int(osdMemoryTargetValue)))
 	}
 
 	commonArgs = append(commonArgs, "--default-log-to-file", "false")


### PR DESCRIPTION
**Description of your changes:**

As of Nautilus Ceph auto-tunes its osd_memory_target on the fly so we don't need to force it.
ROok does not support Mimic anymore so this can be removed.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]