### PR TITLE
mergify: ping user if PR has conflicts

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,11 @@
 pull_request_rules:
+  # if there is a conflict in a backport PR, ping the author to send a proper backport PR
+  - name: ping author on conflicts
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: This pull request has merge conflicts that must be resolved before it can be merged. @{{author}} please rebase it. https://rook.io/docs/rook/master/development-flow.html#updating-your-fork
   # automerge backports if CI successfully ran
   # release-1.1 branch
   - name: automerge backport release-1.1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

That rule posts a comment as soon as a pull request is in conflict, notifying the pull request author that they need to intervene!

Signed-off-by: Sébastien Han <seb@redhat.com>
[skip ci]