### PR TITLE
Governance: Added reviewers for Ceph

### DIFF
--- a/CODE-OWNERS
+++ b/CODE-OWNERS
@@ -31,6 +31,6 @@ areas:
     reviewers:
     - rohan47
   yugabytedb:
-    approvers:
+    reviewers:
     - Arnav15
     - samkulkarni20

--- a/CODE-OWNERS
+++ b/CODE-OWNERS
@@ -16,6 +16,9 @@ areas:
     - travisn
     - BlaineEXE
     - leseb
+    reviewers:
+    - satoru-takeuchi
+    - Madhu-1
   edgefs:
     approvers:
     - dyusupov


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
There are two additions to the reviewers list that I would like to recommend. Both are actively contributing to the project, frequently responding to Slack questions, and helping investigate github issues:
- @satoru-takeuchi Contributed to several areas including Ceph OSD improvements.
- @Madhu-1 Owner for the CSI driver integration with the Ceph provider.

Also there was a typo in the yugabytedb owners list. They should be listed as `reviewers` instead of `approvers`.

Per the Rook governance, approval requires 2/3 majority vote of the steering committee. @jbw976 @dyusupov Your input is needed, thanks!

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]