### PR TITLE
cassandra: Adds json struct tags to fix cassandra annotations

### DIFF
--- a/pkg/apis/cassandra.rook.io/v1alpha1/types.go
+++ b/pkg/apis/cassandra.rook.io/v1alpha1/types.go
@@ -59,7 +59,7 @@ type ClusterList struct {
 // ClusterSpec is the desired state for a Cassandra Cluster.
 type ClusterSpec struct {
 	// The annotations-related configuration to add/set on each Pod related object.
-	Annotations rookv1.Annotations
+	Annotations rookv1.Annotations `json:"annotations"`
 	// Version of Cassandra to use.
 	Version string `json:"version"`
 	// Repository to pull the image from.
@@ -100,7 +100,7 @@ type RackSpec struct {
 	// Storage describes the underlying storage that Cassandra will consume.
 	Storage rookv1.StorageScopeSpec `json:"storage"`
 	// The annotations-related configuration to add/set on each Pod related object.
-	Annotations rookv1.Annotations
+	Annotations rookv1.Annotations `json:"annotations"`
 	// Placement describes restrictions for the nodes Cassandra is scheduled on.
 	Placement *rookv1.Placement `json:"placement,omitempty"`
 	// Resources the Cassandra Pods will use.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

The lack of the json tag required manifests to use 'Annotations' rather than 'annotations' to propogate annotations to the stateful set pods. This change will allow the software to function as documented.

Structs changed:

x ClusterSpec
x RackSpec



**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5097

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
