### PR TITLE
ceph: prune crd unknown fields

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,6 +9,7 @@
 - Added a [toolbox job](Documentation/ceph-toolbox.md#toolbox-job) for running a script with Ceph commands, similar to running commands in the Rook toolbox.
 - Ceph RBD Mirror daemon has been extracted to its own CRD, it has been removed from the `CephCluster` CRD, see the [rbd-mirror crd](Documentation/ceph-rbd-mirror-crd.html).
 - CephCluster CRD has been converted to use the controller-runtime framework.
+- Unknown CRD fields will be pruned by Kubernetes.
 
 ### EdgeFS
 

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -12,19 +12,24 @@ spec:
     singular: cephcluster
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             annotations: {}
             cephVersion:
+              type: object
               properties:
                 allowUnsupported:
                   type: boolean
                 image:
                   type: string
             dashboard:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -40,6 +45,7 @@ spec:
               pattern: ^/(\S+)
               type: string
             disruptionManagement:
+              type: object
               properties:
                 machineDisruptionBudgetNamespace:
                   type: string
@@ -54,6 +60,7 @@ spec:
             continueUpgradeAfterChecksEvenIfNotHealthy:
               type: boolean
             mon:
+              type: object
               properties:
                 allowMultiplePerNode:
                   type: boolean
@@ -63,15 +70,18 @@ spec:
                   type: integer
                 volumeClaimTemplate: {}
             mgr:
+              type: object
               properties:
                 modules:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       enabled:
                         type: boolean
             network:
+              type: object
               properties:
                 hostNetwork:
                   type: boolean
@@ -79,8 +89,10 @@ spec:
                   type: string
                 selectors: {}
             storage:
+              type: object
               properties:
                 disruptionManagement:
+                  type: object
                   properties:
                     machineDisruptionBudgetNamespace:
                       type: string
@@ -94,10 +106,12 @@ spec:
                   type: boolean
                 nodes:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       config:
+                        type: object
                         properties:
                           metadataDevice:
                             type: string
@@ -124,6 +138,7 @@ spec:
                       devices:
                         type: array
                         items:
+                          type: object
                           properties:
                             name:
                               type: string
@@ -139,6 +154,7 @@ spec:
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -147,12 +163,14 @@ spec:
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:
+              type: object
               properties:
                 enable:
                   type: boolean
             placement: {}
             resources: {}
             cleanupPolicy:
+              type: object
               properties:
                 deleteDataDirOnHosts:
                   type: string
@@ -195,12 +213,16 @@ spec:
     singular: cephfilesystem
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             metadataServer:
+              type: object
               properties:
                 activeCount:
                   minimum: 1
@@ -212,10 +234,12 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       minimum: 0
@@ -224,6 +248,7 @@ spec:
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       minimum: 0
@@ -244,10 +269,12 @@ spec:
             dataPools:
               type: array
               items:
+                type: object
                 properties:
                   failureDomain:
                     type: string
                   replicated:
+                    type: object
                     properties:
                       size:
                         minimum: 0
@@ -256,6 +283,7 @@ spec:
                       requireSafeReplicaSize:
                         type: boolean
                   erasureCoded:
+                    type: object
                     properties:
                       dataChunks:
                         minimum: 0
@@ -303,18 +331,23 @@ spec:
     - nfs
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             rados:
+              type: object
               properties:
                 pool:
                   type: string
                 namespace:
                   type: string
             server:
+              type: object
               properties:
                 active:
                   type: integer
@@ -337,12 +370,16 @@ spec:
     singular: cephobjectstore
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             gateway:
+              type: object
               properties:
                 type:
                   type: string
@@ -358,16 +395,19 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -382,16 +422,19 @@ spec:
                   - aggressive
                   - force
             dataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -426,6 +469,7 @@ spec:
     - objectuser
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   subresources:
     status: {}
 ---
@@ -442,14 +486,18 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             failureDomain:
                 type: string
             replicated:
+              type: object
               properties:
                 size:
                   type: integer
@@ -460,6 +508,7 @@ spec:
                 requireSafeReplicaSize:
                   type: boolean
             erasureCoded:
+              type: object
               properties:
                 dataChunks:
                   type: integer
@@ -495,6 +544,7 @@ spec:
     - rv
   scope: Namespaced
   version: v1alpha2
+  preserveUnknownFields: false
   subresources:
     status: {}
 ---
@@ -508,6 +558,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   names:
     kind: ObjectBucket
     listKind: ObjectBucketList
@@ -529,6 +580,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   group: objectbucket.io
   names:
     kind: ObjectBucketClaim
@@ -555,10 +607,13 @@ spec:
     singular: cephclient
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             caps:
               type: object
@@ -578,10 +633,13 @@ spec:
     singular: cephrbdmirror
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             count:
               type: integer

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -31,19 +31,24 @@ spec:
     singular: cephcluster
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             annotations: {}
             cephVersion:
+              type: object
               properties:
                 allowUnsupported:
                   type: boolean
                 image:
                   type: string
             dashboard:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -59,6 +64,7 @@ spec:
               pattern: ^/(\S+)
               type: string
             disruptionManagement:
+              type: object
               properties:
                 machineDisruptionBudgetNamespace:
                   type: string
@@ -73,6 +79,7 @@ spec:
             continueUpgradeAfterChecksEvenIfNotHealthy:
               type: boolean
             mon:
+              type: object
               properties:
                 allowMultiplePerNode:
                   type: boolean
@@ -82,15 +89,18 @@ spec:
                   type: integer
                 volumeClaimTemplate: {}
             mgr:
+              type: object
               properties:
                 modules:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       enabled:
                         type: boolean
             network:
+              type: object
               properties:
                 hostNetwork:
                   type: boolean
@@ -98,8 +108,10 @@ spec:
                   type: string
                 selectors: {}
             storage:
+              type: object
               properties:
                 disruptionManagement:
+                  type: object
                   properties:
                     machineDisruptionBudgetNamespace:
                       type: string
@@ -113,10 +125,12 @@ spec:
                   type: boolean
                 nodes:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       config:
+                        type: object
                         properties:
                           metadataDevice:
                             type: string
@@ -143,6 +157,7 @@ spec:
                       devices:
                         type: array
                         items:
+                          type: object
                           properties:
                             name:
                               type: string
@@ -158,6 +173,7 @@ spec:
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -166,10 +182,12 @@ spec:
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:
+              type: object
               properties:
                 enable:
                   type: boolean
             cleanupPolicy:
+              type: object
               properties:
                 deleteDataDirOnHosts:
                   type: string
@@ -218,10 +236,13 @@ spec:
     singular: cephclient
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             caps:
               type: object
@@ -243,10 +264,13 @@ spec:
     singular: cephrbdmirror
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             count:
               type: integer
@@ -270,12 +294,16 @@ spec:
     singular: cephfilesystem
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             metadataServer:
+              type: object
               properties:
                 activeCount:
                   minimum: 1
@@ -287,10 +315,12 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       minimum: 0
@@ -299,6 +329,7 @@ spec:
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       minimum: 0
@@ -319,10 +350,12 @@ spec:
             dataPools:
               type: array
               items:
+                type: object
                 properties:
                   failureDomain:
                     type: string
                   replicated:
+                    type: object
                     properties:
                       size:
                         minimum: 0
@@ -331,6 +364,7 @@ spec:
                       requireSafeReplicaSize:
                         type: boolean
                   erasureCoded:
+                    type: object
                     properties:
                       dataChunks:
                         minimum: 0
@@ -378,18 +412,23 @@ spec:
     - nfs
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             rados:
+              type: object
               properties:
                 pool:
                   type: string
                 namespace:
                   type: string
             server:
+              type: object
               properties:
                 active:
                   type: integer
@@ -414,12 +453,16 @@ spec:
     singular: cephobjectstore
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             gateway:
+              type: object
               properties:
                 type:
                   type: string
@@ -435,16 +478,19 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -459,16 +505,19 @@ spec:
                   - aggressive
                   - force
             dataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -505,6 +554,7 @@ spec:
     - objectuser
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   subresources:
     status: {}
 # OLM: END CEPH OBJECT STORE USERS CRD
@@ -523,14 +573,18 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             failureDomain:
                 type: string
             replicated:
+              type: object
               properties:
                 size:
                   type: integer
@@ -541,6 +595,7 @@ spec:
                 requireSafeReplicaSize:
                   type: boolean
             erasureCoded:
+              type: object
               properties:
                 dataChunks:
                   type: integer
@@ -578,6 +633,7 @@ spec:
     - rv
   scope: Namespaced
   version: v1alpha2
+  preserveUnknownFields: false
   subresources:
     status: {}
 # OLM: END CEPH VOLUME POOL CRD
@@ -593,6 +649,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   names:
     kind: ObjectBucket
     listKind: ObjectBucketList
@@ -616,6 +673,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   group: objectbucket.io
   names:
     kind: ObjectBucketClaim

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
@@ -4,29 +4,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: cephrbdmirrors.ceph.rook.io
-spec:
-  group: ceph.rook.io
-  names:
-    kind: CephRBDMirror
-    listKind: CephRBDMirrorList
-    plural: cephrbdmirrrors
-    singular: cephrbdmirror
-  scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            count:
-              type: integer
-  subresources:
-    status: {}
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: cephclusters.ceph.rook.io
 spec:
   group: ceph.rook.io
@@ -37,19 +14,24 @@ spec:
     singular: cephcluster
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             annotations: {}
             cephVersion:
+              type: object
               properties:
                 allowUnsupported:
                   type: boolean
                 image:
                   type: string
             dashboard:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -65,6 +47,7 @@ spec:
               pattern: ^/(\S+)
               type: string
             disruptionManagement:
+              type: object
               properties:
                 machineDisruptionBudgetNamespace:
                   type: string
@@ -79,6 +62,7 @@ spec:
             continueUpgradeAfterChecksEvenIfNotHealthy:
               type: boolean
             mon:
+              type: object
               properties:
                 allowMultiplePerNode:
                   type: boolean
@@ -88,15 +72,18 @@ spec:
                   type: integer
                 volumeClaimTemplate: {}
             mgr:
+              type: object
               properties:
                 modules:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       enabled:
                         type: boolean
             network:
+              type: object
               properties:
                 hostNetwork:
                   type: boolean
@@ -104,8 +91,10 @@ spec:
                   type: string
                 selectors: {}
             storage:
+              type: object
               properties:
                 disruptionManagement:
+                  type: object
                   properties:
                     machineDisruptionBudgetNamespace:
                       type: string
@@ -119,16 +108,18 @@ spec:
                   type: boolean
                 nodes:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       config:
+                        type: object
                         properties:
                           metadataDevice:
                             type: string
                           storeType:
                             type: string
-                            pattern: ^(filestore|bluestore)$
+                            pattern: ^(bluestore)$
                           databaseSizeMB:
                             type: string
                           walSizeMB:
@@ -149,6 +140,7 @@ spec:
                       devices:
                         type: array
                         items:
+                          type: object
                           properties:
                             name:
                               type: string
@@ -164,6 +156,7 @@ spec:
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -172,10 +165,12 @@ spec:
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:
+              type: object
               properties:
                 enable:
                   type: boolean
             cleanupPolicy:
+              type: object
               properties:
                 deleteDataDirOnHosts:
                   type: string
@@ -208,3 +203,449 @@ spec:
       type: string
       description: Ceph Health
       JSONPath: .status.ceph.health
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephclients.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephClient
+    listKind: CephClientList
+    plural: cephclients
+    singular: cephclient
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            caps:
+              type: object
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephrbdmirrors.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephRBDMirror
+    listKind: CephRBDMirrorList
+    plural: cephrbdmirrors
+    singular: cephrbdmirror
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            count:
+              type: integer
+              minimum: 1
+              maximum: 100
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephfilesystems.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephFilesystem
+    listKind: CephFilesystemList
+    plural: cephfilesystems
+    singular: cephfilesystem
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            metadataServer:
+              type: object
+              properties:
+                activeCount:
+                  minimum: 1
+                  maximum: 10
+                  type: integer
+                activeStandby:
+                  type: boolean
+                annotations: {}
+                placement: {}
+                resources: {}
+            metadataPool:
+              type: object
+              properties:
+                failureDomain:
+                  type: string
+                replicated:
+                  type: object
+                  properties:
+                    size:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  type: object
+                  properties:
+                    dataChunks:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                    codingChunks:
+                      minimum: 0
+                      maximum: 10
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+            dataPools:
+              type: array
+              items:
+                type: object
+                properties:
+                  failureDomain:
+                    type: string
+                  replicated:
+                    type: object
+                    properties:
+                      size:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                      requireSafeReplicaSize:
+                        type: boolean
+                  erasureCoded:
+                    type: object
+                    properties:
+                      dataChunks:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                      codingChunks:
+                        minimum: 0
+                        maximum: 10
+                        type: integer
+                  compressionMode:
+                    type: string
+                    enum:
+                    - ""
+                    - none
+                    - passive
+                    - aggressive
+                    - force
+            preservePoolsOnDelete:
+              type: boolean
+  additionalPrinterColumns:
+    - name: ActiveMDS
+      type: string
+      description: Number of desired active MDS daemons
+      JSONPath: .spec.metadataServer.activeCount
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephnfses.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephNFS
+    listKind: CephNFSList
+    plural: cephnfses
+    singular: cephnfs
+    shortNames:
+    - nfs
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            rados:
+              type: object
+              properties:
+                pool:
+                  type: string
+                namespace:
+                  type: string
+            server:
+              type: object
+              properties:
+                active:
+                  type: integer
+                annotations: {}
+                placement: {}
+                resources: {}
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstores.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStore
+    listKind: CephObjectStoreList
+    plural: cephobjectstores
+    singular: cephobjectstore
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            gateway:
+              type: object
+              properties:
+                type:
+                  type: string
+                sslCertificateRef: {}
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                securePort: {}
+                instances:
+                  type: integer
+                annotations: {}
+                placement: {}
+                resources: {}
+            metadataPool:
+              type: object
+              properties:
+                failureDomain:
+                  type: string
+                replicated:
+                  type: object
+                  properties:
+                    size:
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  type: object
+                  properties:
+                    dataChunks:
+                      type: integer
+                    codingChunks:
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+            dataPool:
+              type: object
+              properties:
+                failureDomain:
+                  type: string
+                replicated:
+                  type: object
+                  properties:
+                    size:
+                      type: integer
+                    requireSafeReplicaSize:
+                      type: boolean
+                erasureCoded:
+                  type: object
+                  properties:
+                    dataChunks:
+                      type: integer
+                    codingChunks:
+                      type: integer
+                compressionMode:
+                  type: string
+                  enum:
+                  - ""
+                  - none
+                  - passive
+                  - aggressive
+                  - force
+            preservePoolsOnDelete:
+              type: boolean
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstoreusers.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStoreUser
+    listKind: CephObjectStoreUserList
+    plural: cephobjectstoreusers
+    singular: cephobjectstoreuser
+    shortNames:
+    - rcou
+    - objectuser
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephblockpools.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephBlockPool
+    listKind: CephBlockPoolList
+    plural: cephblockpools
+    singular: cephblockpool
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            failureDomain:
+                type: string
+            replicated:
+              type: object
+              properties:
+                size:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                targetSizeRatio:
+                  type: number
+                requireSafeReplicaSize:
+                  type: boolean
+            erasureCoded:
+              type: object
+              properties:
+                dataChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+                codingChunks:
+                  type: integer
+                  minimum: 0
+                  maximum: 9
+            compressionMode:
+              type: string
+              enum:
+              - ""
+              - none
+              - passive
+              - aggressive
+              - force
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    singular: volume
+    shortNames:
+    - rv
+  scope: Namespaced
+  version: v1alpha2
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  group: objectbucket.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  preserveUnknownFields: false
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    singular: objectbucket
+    shortNames:
+      - ob
+      - obs
+  scope: Cluster
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  preserveUnknownFields: false
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    singular: objectbucketclaim
+    shortNames:
+      - obc
+      - obcs
+  scope: Namespaced
+  subresources:
+    status: {}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -103,19 +103,24 @@ spec:
     singular: cephcluster
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             annotations: {}
             cephVersion:
+              type: object
               properties:
                 allowUnsupported:
                   type: boolean
                 image:
                   type: string
             dashboard:
+              type: object
               properties:
                 enabled:
                   type: boolean
@@ -131,6 +136,7 @@ spec:
               pattern: ^/(\S+)
               type: string
             disruptionManagement:
+              type: object
               properties:
                 machineDisruptionBudgetNamespace:
                   type: string
@@ -143,6 +149,7 @@ spec:
             skipUpgradeChecks:
               type: boolean
             mon:
+              type: object
               properties:
                 allowMultiplePerNode:
                   type: boolean
@@ -152,15 +159,18 @@ spec:
                   type: integer
                 volumeClaimTemplate: {}
             mgr:
+              type: object
               properties:
                 modules:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       enabled:
                         type: boolean
             network:
+              type: object
               properties:
                 hostNetwork:
                   type: boolean
@@ -168,8 +178,10 @@ spec:
                   type: string
                 selectors: {}
             storage:
+              type: object
               properties:
                 disruptionManagement:
+                  type: object
                   properties:
                     machineDisruptionBudgetNamespace:
                       type: string
@@ -183,10 +195,12 @@ spec:
                   type: boolean
                 nodes:
                   items:
+                    type: object
                     properties:
                       name:
                         type: string
                       config:
+                        type: object
                         properties:
                           metadataDevice:
                             type: string
@@ -210,6 +224,7 @@ spec:
                       devices:
                         type: array
                         items:
+                          type: object
                           properties:
                             name:
                               type: string
@@ -222,22 +237,26 @@ spec:
                 config: {}
                 storageClassDeviceSets: {}
             monitoring:
+              type: object
               properties:
                 enabled:
                   type: boolean
                 rulesNamespace:
                   type: string
             rbdMirroring:
+              type: object
               properties:
                 workers:
                   type: integer
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:
+              type: object
               properties:
                 enable:
                   type: boolean
             cleanupPolicy:
+              type: object
               properties:
                 deleteDataDirOnHosts:
                   type: string
@@ -278,12 +297,16 @@ spec:
     singular: cephfilesystem
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             metadataServer:
+              type: object
               properties:
                 activeCount:
                   minimum: 1
@@ -295,10 +318,12 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       minimum: 0
@@ -307,6 +332,7 @@ spec:
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       minimum: 0
@@ -327,10 +353,12 @@ spec:
             dataPools:
               type: array
               items:
+                type: object
                 properties:
                   failureDomain:
                     type: string
                   replicated:
+                    type: object
                     properties:
                       size:
                         minimum: 0
@@ -339,6 +367,7 @@ spec:
                       requireSafeReplicaSize:
                         type: boolean
                   erasureCoded:
+                    type: object
                     properties:
                       dataChunks:
                         minimum: 0
@@ -384,18 +413,23 @@ spec:
     - nfs
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             rados:
+              type: object
               properties:
                 pool:
                   type: string
                 namespace:
                   type: string
             server:
+              type: object
               properties:
                 active:
                   type: integer
@@ -418,12 +452,16 @@ spec:
     singular: cephobjectstore
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             gateway:
+              type: object
               properties:
                 type:
                   type: string
@@ -439,16 +477,19 @@ spec:
                 placement: {}
                 resources: {}
             metadataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -463,16 +504,19 @@ spec:
                   - aggressive
                   - force
             dataPool:
+              type: object
               properties:
                 failureDomain:
                   type: string
                 replicated:
+                  type: object
                   properties:
                     size:
                       type: integer
                     requireSafeReplicaSize:
                       type: boolean
                 erasureCoded:
+                  type: object
                   properties:
                     dataChunks:
                       type: integer
@@ -507,6 +551,7 @@ spec:
     - objectuser
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   subresources:
     status: {}
 ---
@@ -523,14 +568,18 @@ spec:
     singular: cephblockpool
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             failureDomain:
                 type: string
             replicated:
+              type: object
               properties:
                 size:
                   type: integer
@@ -541,6 +590,7 @@ spec:
                 requireSafeReplicaSize:
                   type: boolean
             erasureCoded:
+              type: object
               properties:
                 dataChunks:
                   type: integer
@@ -576,6 +626,7 @@ spec:
     - rv
   scope: Namespaced
   version: v1alpha2
+  preserveUnknownFields: false
   subresources:
     status: {}
 ---
@@ -589,6 +640,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   names:
     kind: ObjectBucket
     listKind: ObjectBucketList
@@ -610,6 +662,7 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+  preserveUnknownFields: false
   group: objectbucket.io
   names:
     kind: ObjectBucketClaim
@@ -636,12 +689,16 @@ spec:
     singular: cephclient
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             caps:
+              type: object
               properties:
                 mon:
                   type: string
@@ -665,10 +722,13 @@ spec:
     singular: cephrbdmirror
   scope: Namespaced
   version: v1
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           properties:
             count:
               type: integer


### PR DESCRIPTION
**Description of your changes:**

For now, since the pruning is disabled for crds of rook, it only validates known fields
It does not check any validation for unknown fields and just stores them in etcd.

Adding `preserveUnknownFields: false`, in the CRD will prune unknown
fields automatically.

closing: https://github.com/rook/rook/issues/5542
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5542

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]
