### PR TITLE
ceph: add missing security context to crash collector

### DIFF
--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -172,10 +172,11 @@ func getCrashDaemonContainer(cephCluster cephv1.CephCluster, cephVersion version
 		Command: []string{
 			"ceph-crash",
 		},
-		Image:        cephImage,
-		Env:          envVars,
-		VolumeMounts: volumeMounts,
-		Resources:    cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
+		Image:           cephImage,
+		Env:             envVars,
+		VolumeMounts:    volumeMounts,
+		Resources:       cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
+		SecurityContext: mon.PodSecurityContext(),
 	}
 
 	return container


### PR DESCRIPTION

**Description of your changes:**

The crash collector was missing the security context to properly run on
OCP, thus crashing when trying to post a crash dump.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]