### PR TITLE
Handle node failure more gracefully

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -24,7 +24,6 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -160,35 +159,10 @@ func (m *OSDHealthMonitor) restartOSDIfStuck(osdID int) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to get OSD with ID %d", osdID)
 	}
-	return m.restartOSDPodsIfStuck(osdID, pods)
-}
-
-func (m *OSDHealthMonitor) restartOSDPodsIfStuck(osdID int, pods *v1.PodList) error {
 	for _, pod := range pods.Items {
-		logger.Debugf("checking if osd %d pod is stuck and should be force deleted", osdID)
-		if pod.DeletionTimestamp.IsZero() {
-			logger.Debugf("skipping restart of OSD %d since the pod is not deleted", osdID)
-			continue
+		if err := k8sutil.ForceDeletePodIfStuck(m.context, pod); err != nil {
+			logger.Warningf("skipping restart of OSD %d. %v", osdID, err)
 		}
-		node, err := m.context.Clientset.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
-		if err != nil {
-			logger.Warningf("skipping restart of OSD %d since the node status is not available. %v", osdID, err)
-			continue
-		}
-		if k8sutil.NodeIsReady(*node) {
-			logger.Debugf("skipping restart of OSD %d since the node status is ready", osdID)
-			continue
-		}
-
-		logger.Infof("force deleting pod %q that appears to be stuck terminating", pod.Name)
-		var gracePeriod int64
-		deleteOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
-		if err := m.context.Clientset.CoreV1().Pods(m.namespace).Delete(pod.Name, deleteOpts); err != nil {
-			logger.Warningf("pod %q deletion failed. %v", pod.Name, err)
-			continue
-		}
-		logger.Infof("pod %q deletion succeeded", pod.Name)
 	}
-
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	healthCheckInterval = 300 * time.Second
+	healthCheckInterval = 60 * time.Second
 )
 
 // OSDHealthMonitor defines OSD process monitoring

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -556,7 +556,7 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 		_, createErr := c.context.Clientset.AppsV1().Deployments(c.Namespace).Create(dp)
 		if createErr != nil {
 			if kerrors.IsAlreadyExists(createErr) {
-				logger.Infof("deployment for osd %d already exists. updating if needed", osd.ID)
+				logger.Debugf("deployment for osd %d already exists. updating if needed", osd.ID)
 				if err = updateDeploymentAndWait(c.context, dp, c.Namespace, opconfig.OsdType, strconv.Itoa(osd.ID), c.skipUpgradeChecks, c.continueUpgradeAfterChecksEvenIfNotHealthy); err != nil {
 					logger.Errorf("failed to update osd deployment %d. %v", osd.ID, err)
 				}
@@ -565,8 +565,9 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 				logger.Warningf("failed to create osd deployment for node %q, osd %+v. %v", n.Name, osd, createErr)
 				continue
 			}
+		} else {
+			logger.Infof("created deployment for osd %d", osd.ID)
 		}
-		logger.Infof("started deployment for osd %d", osd.ID)
 	}
 }
 

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -74,6 +74,8 @@ func UpdateDeploymentAndWait(context *clusterd.Context, modifiedDeployment *apps
 
 	// If deployments are different, let's update!
 	if !patchResult.IsEmpty() {
+		logger.Infof("updating deployment %q after verifying it is safe to stop", modifiedDeployment.Name)
+
 		// Let's verify the deployment can be stopped
 		// retry for 5 times, every minute
 		err = util.Retry(5, 60*time.Second, func() error {
@@ -89,7 +91,6 @@ func UpdateDeploymentAndWait(context *clusterd.Context, modifiedDeployment *apps
 			return nil, fmt.Errorf("failed to set hash annotation on deployment %q. %v", modifiedDeployment.Name, err)
 		}
 
-		logger.Infof("updating deployment %q", modifiedDeployment.Name)
 		if _, err := context.Clientset.AppsV1().Deployments(namespace).Update(modifiedDeployment); err != nil {
 			return nil, fmt.Errorf("failed to update deployment %q. %v", modifiedDeployment.Name, err)
 		}

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -25,7 +25,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -330,4 +332,30 @@ func SetNodeAntiAffinityForPod(pod *v1.PodSpec, p rookv1.Placement, requiredDuri
 				PodAffinityTerm: podAntiAffinity,
 			})
 	}
+}
+
+func ForceDeletePodIfStuck(context *clusterd.Context, pod v1.Pod) error {
+	logger.Debugf("checking if pod %q is stuck and should be force deleted", pod.Name)
+	if pod.DeletionTimestamp.IsZero() {
+		logger.Debugf("skipping pod %q restart since the pod is not deleted", pod.Name)
+		return nil
+	}
+	node, err := context.Clientset.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "node status is not available")
+	}
+	if NodeIsReady(*node) {
+		logger.Debugf("skipping restart of pod %q since the node status is ready", pod.Name)
+		return nil
+	}
+
+	logger.Infof("force deleting pod %q that appears to be stuck terminating", pod.Name)
+	var gracePeriod int64
+	deleteOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	if err := context.Clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, deleteOpts); err != nil {
+		logger.Warningf("pod %q deletion failed. %v", pod.Name, err)
+		return nil
+	}
+	logger.Infof("pod %q deletion succeeded", pod.Name)
+	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Several improvements to handle node failure more gracefully:
- During the mon health check, if the mon is stuck terminating on a bad node, force delete the mon pod to allow it to start on another node if possible
- Reduce the OSD health check interval from 300s to 60s for faster response time in the event of node failure
- Misc osd logging improvements and refactor of the force deletion helper from osds

**Checklist:**

- [ ] **CommitLint Bot**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]