### PR TITLE
docs: update the obc provisioner name

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -101,7 +101,7 @@ metadata:
   name: rook-ceph-bucket
   labels:
     aws-s3/object [1]
-provisioner: ceph.rook.io/bucket [2]
+provisioner: rook-ceph.ceph.rook.io/bucket [2]
 parameters: [3]
   objectStoreName: my-store
   objectStoreNamespace: rook-ceph

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -67,7 +67,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-bucket
-provisioner: ceph.rook.io/bucket
+provisioner: rook-ceph.ceph.rook.io/bucket
 reclaimPolicy: Delete
 parameters:
   objectStoreName: my-store

--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -265,18 +265,18 @@ Signed-off-by: First Name Last Name <email address>
 ```
 
 The `component` **MUST** be one of the following:
-    - bot
-    - build
-    - cassandra
-    - ceph
-    - ci
-    - cockroachdb
-    - core
-    - docs
-    - edgefs
-    - nfs
-    - test
-    - yugabytedb
+- bot
+- build
+- cassandra
+- ceph
+- ci
+- cockroachdb
+- core
+- docs
+- edgefs
+- nfs
+- test
+- yugabytedb
 
 Note: sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text.
 In that case, it is acceptable to shorten the commit message.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OBC provisioner name changed recently to include the namespace as a prefix, but the docs were not updated.

Another minor fix is the whitespace on the list of commit prefixes that are allowed.
    
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]