### PR TITLE
Handle node failure more gracefully (bp #5556)

### DIFF
--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	healthCheckInterval = 300 * time.Second
+	healthCheckInterval = 60 * time.Second
 )
 
 // OSDHealthMonitor defines OSD process monitoring

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -126,7 +126,7 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		Clientset: clientset,
 	}
 
-	pod := &v1.Pod{
+	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "osd0",
 			Namespace: namespace,
@@ -137,13 +137,12 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		},
 	}
 	pod.Spec.NodeName = "node0"
-	_, err := context.Clientset.CoreV1().Pods(namespace).Create(pod)
+	_, err := context.Clientset.CoreV1().Pods(namespace).Create(&pod)
 	assert.NoError(t, err)
 
 	m := NewOSDHealthMonitor(context, namespace, false, cephver.CephVersion{})
 
-	podList := &v1.PodList{Items: []v1.Pod{*pod}}
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should still exist since it wasn't in a deleted state
 	p, err := context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
@@ -152,11 +151,10 @@ func TestOSDRestartIfStuck(t *testing.T) {
 
 	// Add a deletion timestamp to the pod
 	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-	_, err = context.Clientset.CoreV1().Pods(namespace).Update(pod)
+	_, err = context.Clientset.CoreV1().Pods(namespace).Update(&pod)
 	assert.NoError(t, err)
 
-	podList = &v1.PodList{Items: []v1.Pod{*pod}}
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should still exist since the node is ready
 	p, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
@@ -172,7 +170,7 @@ func TestOSDRestartIfStuck(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.NoError(t, m.restartOSDPodsIfStuck(0, podList))
+	assert.NoError(t, k8sutil.ForceDeletePodIfStuck(m.context, pod))
 
 	// The pod should be deleted since the pod is marked as deleted and the node is not ready
 	_, err = context.Clientset.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -25,7 +25,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -330,4 +332,30 @@ func SetNodeAntiAffinityForPod(pod *v1.PodSpec, p rookv1.Placement, requiredDuri
 				PodAffinityTerm: podAntiAffinity,
 			})
 	}
+}
+
+func ForceDeletePodIfStuck(context *clusterd.Context, pod v1.Pod) error {
+	logger.Debugf("checking if pod %q is stuck and should be force deleted", pod.Name)
+	if pod.DeletionTimestamp.IsZero() {
+		logger.Debugf("skipping pod %q restart since the pod is not deleted", pod.Name)
+		return nil
+	}
+	node, err := context.Clientset.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "node status is not available")
+	}
+	if NodeIsReady(*node) {
+		logger.Debugf("skipping restart of pod %q since the node status is ready", pod.Name)
+		return nil
+	}
+
+	logger.Infof("force deleting pod %q that appears to be stuck terminating", pod.Name)
+	var gracePeriod int64
+	deleteOpts := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	if err := context.Clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, deleteOpts); err != nil {
+		logger.Warningf("pod %q deletion failed. %v", pod.Name, err)
+		return nil
+	}
+	logger.Infof("pod %q deletion succeeded", pod.Name)
+	return nil
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport changes to improve the node failure handling.
- The monitoring goroutines that check for mon and osd health, the ceph cluster status, and the bucket provisioner should be started immediately with the first reconcile after an operator restart instead of waiting until the first reconcile is completed. This way the cluster health will be monitored even during the first reconcile.
- During the mon health check, if the mon is stuck terminating on a bad node, force delete the mon pod to allow it to start on another node if possible
- Reduce the OSD health check interval from 300s to 60s for faster response time in the event of node failure

This is a manual backport due to conflicts with the controller runtime updates in master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]