### PR TITLE
ceph: fix obc additionalConfig field

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -57,6 +57,7 @@ type Provisioner struct {
 	endpoint             string
 	secretName           string
 	secretNamespace      string
+	additionalConfigData map[string]string
 }
 
 var _ apibkt.Provisioner = &Provisioner{}
@@ -305,6 +306,7 @@ func (p *Provisioner) initializeCreateOrGrant(options *apibkt.BucketOptions) err
 	p.setObjectStoreName(sc)
 	p.setObjectStoreNamespace(sc)
 	p.setRegion(sc)
+	p.setAdditionalConfigData(obc.Spec.AdditionalConfig)
 	p.setEndpoint(sc)
 	err = p.setObjectContext()
 	if err != nil {
@@ -351,10 +353,11 @@ func (p *Provisioner) composeObjectBucket() *bktv1alpha1.ObjectBucket {
 
 	conn := &bktv1alpha1.Connection{
 		Endpoint: &bktv1alpha1.Endpoint{
-			BucketHost: p.storeDomainName,
-			BucketPort: int(p.storePort),
-			BucketName: p.bucketName,
-			Region:     p.region,
+			BucketHost:           p.storeDomainName,
+			BucketPort:           int(p.storePort),
+			BucketName:           p.bucketName,
+			Region:               p.region,
+			AdditionalConfigData: p.additionalConfigData,
 		},
 		Authentication: &bktv1alpha1.Authentication{
 			AccessKeys: &bktv1alpha1.AccessKeys{
@@ -426,6 +429,13 @@ func (p *Provisioner) setObjectStoreNamespace(sc *storagev1.StorageClass) {
 
 func (p *Provisioner) setBucketName(name string) {
 	p.bucketName = name
+}
+
+func (p *Provisioner) setAdditionalConfigData(additionalConfigData map[string]string) {
+	if len(additionalConfigData) == 0 {
+		additionalConfigData = make(map[string]string)
+	}
+	p.additionalConfigData = additionalConfigData
 }
 
 func (p *Provisioner) setEndpoint(sc *storagev1.StorageClass) {


### PR DESCRIPTION
**Description of your changes:**

Some external consumers of Rook-Ceph are using the
lib-bucket-provisioner operator which creates different CRDs for both
objectbuckets.objectbucket.io and objectbucketclaims.objectbucket.io.
They have the `additionalConfig` declared in their spec. Rook-Ceph does
not and thus ignores it.
For the OB creation to work, the `additionalConfig` must be acknowledged
by the operator and populate or initialize it if empty.

This is preventing the following error:

controller.go:190] error syncing 'default/ceph-retain-bucket-converged': error creating OB "": ObjectBucket.objectbucket.io "obc-default-ceph-retain-bucket-converged" is invalid: spec.endpoint.additionalConfig: Invalid value: "null": spec.endpoint.additionalConfig in body must be of type object: "null", requeuing

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]