### PR TITLE
ceph: add support for wal device for OSD on PVC

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -125,8 +125,21 @@ spec:
       #       requests:
       #         # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
       #         storage: 5Gi
-      #     # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
-      #     storageClassName: gp2
+      #     # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+      #     storageClassName: io1
+      #     volumeMode: Block
+      #     accessModes:
+      #       - ReadWriteOnce
+      # dedicated block device to store bluestore wal (block.wal)
+      # - metadata:
+      #     name: wal
+      #   spec:
+      #     resources:
+      #       requests:
+      #         # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
+      #         storage: 5Gi
+      #     # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+      #     storageClassName: io1
       #     volumeMode: Block
       #     accessModes:
       #       - ReadWriteOnce

--- a/pkg/daemon/ceph/cleanup/disk.go
+++ b/pkg/daemon/ceph/cleanup/disk.go
@@ -67,7 +67,7 @@ func (s *DiskSanitizer) StartSanitizeDisks() {
 	}
 
 	// Raw based OSDs
-	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", false)
+	osdRawList, err := osd.GetCephVolumeRawOSDs(s.context, s.clusterInfo, s.clusterInfo.FSID, "", "", "", false)
 	if err != nil {
 		logger.Errorf("failed to list raw osd(s). %v", err)
 	} else {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -94,7 +94,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	var lvmOsds []oposd.OSDInfo
 	var rawOsds []oposd.OSDInfo
 	var lvBackedPV bool
-	var block, lvPath, metadataBlock string
+	var block, lvPath, metadataBlock, walBlock string
 	var err error
 
 	// Idempotency check, if the device list is empty devices have been prepared already
@@ -129,9 +129,9 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 				//    * restarted the operator, again the prepare job was not re-run
 				//
 				// I'm leaving this code with an empty metadata device for now
-				metadataBlock = ""
+				metadataBlock, walBlock = "", ""
 
-				rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, lvBackedPV)
+				rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV)
 				if err != nil {
 					logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
 				}
@@ -181,7 +181,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 
 	// If running on OSD on PVC
 	if a.pvcBacked {
-		if block, metadataBlock, err = a.initializeBlockPVC(context, devices, lvBackedPV); err != nil {
+		if block, metadataBlock, walBlock, err = a.initializeBlockPVC(context, devices, lvBackedPV); err != nil {
 			return nil, errors.Wrap(err, "failed to initialize devices on PVC")
 		}
 	} else {
@@ -203,7 +203,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 		if !isEncrypted {
 			block = fmt.Sprintf("/mnt/%s", a.nodeName)
 		}
-		rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, lvBackedPV)
+		rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, walBlock, lvBackedPV)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 		}
@@ -213,7 +213,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	return osds, err
 }
 
-func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *DeviceOsdMapping, lvBackedPV bool) (string, string, error) {
+func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *DeviceOsdMapping, lvBackedPV bool) (string, string, string, error) {
 	// we need to return the block if raw mode is used and the lv if lvm mode
 	baseCommand := "stdbuf"
 	var baseArgs []string
@@ -235,9 +235,9 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 		baseArgs = []string{"-oL", cephVolumeCmd, "--log-path", cvLogDir, cephVolumeMode, "prepare", "--bluestore"}
 	}
 
-	var metadataArg []string
-	var metadataDev bool
-	var blockPath, metadataBlockPath string
+	var metadataArg, walArg []string
+	var metadataDev, walDev bool
+	var blockPath, metadataBlockPath, walBlockPath string
 
 	// Problem: map is an unordered collection
 	// therefore the iteration order of a map is not guaranteed to be the same every time you iterate over it.
@@ -245,8 +245,8 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 	for name, device := range devices.Entries {
 		// If this is the metadata device there is nothing to do
 		// it'll be used in one of the iterations
-		if name == "metadata" {
-			logger.Debugf("device %q is a metadata device, skipping this iteration it will be used in the next one", device.Config.Name)
+		if name == "metadata" || name == "wal" {
+			logger.Debugf("device %q is a metadata or wal device, skipping this iteration it will be used in the next one", device.Config.Name)
 			// Don't do this device
 			continue
 		}
@@ -263,6 +263,15 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			metadataBlockPath = devices.Entries["metadata"].Config.Name
 		}
 
+		if _, ok := devices.Entries["wal"]; ok {
+			walDev = true
+			walArg = append(walArg, []string{"--block.wal",
+				devices.Entries["wal"].Config.Name,
+			}...)
+
+			walBlockPath = devices.Entries["wal"].Config.Name
+		}
+
 		if device.Data == -1 {
 			logger.Infof("configuring new device %q", device.Config.Name)
 			var err error
@@ -272,7 +281,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				// pass 'vg/lv' to ceph-volume
 				deviceArg, err = sys.GetLVName(context.Executor, device.Config.Name)
 				if err != nil {
-					return "", "", errors.Wrapf(err, "failed to get lv name from device path %q", device.Config.Name)
+					return "", "", "", errors.Wrapf(err, "failed to get lv name from device path %q", device.Config.Name)
 				}
 			} else {
 				deviceArg = device.Config.Name
@@ -304,6 +313,11 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				immediateExecuteArgs = append(immediateExecuteArgs, metadataArg...)
 			}
 
+			// Add the cli argument for the wal device
+			if walDev {
+				immediateExecuteArgs = append(immediateExecuteArgs, walArg...)
+			}
+
 			// execute ceph-volume with the device
 			op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, immediateExecuteArgs...)
 			if err != nil {
@@ -316,7 +330,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				}
 
 				// Return failure
-				return "", "", errors.Wrap(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
+				return "", "", "", errors.Wrap(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
 			}
 			logger.Infof("%v", op)
 			// if raw mode is used or PV on LV, let's return the path of the device
@@ -325,12 +339,12 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			} else if cephVolumeMode == "raw" && isEncrypted {
 				blockPath = getEncryptedBlockPath(op)
 				if blockPath == "" {
-					return "", "", errors.New("failed to get encrypted block path from ceph-volume lvm prepare output")
+					return "", "", "", errors.New("failed to get encrypted block path from ceph-volume lvm prepare output")
 				}
 			} else {
 				blockPath = getLVPath(op)
 				if blockPath == "" {
-					return "", "", errors.New("failed to get lv path from ceph-volume lvm prepare output")
+					return "", "", "", errors.New("failed to get lv path from ceph-volume lvm prepare output")
 				}
 			}
 		} else {
@@ -338,7 +352,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 		}
 	}
 
-	return blockPath, metadataBlockPath, nil
+	return blockPath, metadataBlockPath, walBlockPath, nil
 }
 
 func getLVPath(op string) string {
@@ -695,7 +709,7 @@ func readCVLogContent(cvLogFilePath string) string {
 }
 
 // GetCephVolumeRawOSDs list OSD prepared with raw mode
-func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock string, lvBackedPV bool) ([]oposd.OSDInfo, error) {
+func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, cephfsid, block, metadataBlock, walBlock string, lvBackedPV bool) ([]oposd.OSDInfo, error) {
 	// lv can be a block device if raw mode is used
 	cvMode := "raw"
 
@@ -742,6 +756,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 			// Hence, let's use the PVC name instead which will always remain consistent
 			BlockPath:     block,
 			MetadataPath:  metadataBlock,
+			WalPath:       walBlock,
 			SkipLVRelease: true,
 			LVBackedPV:    lvBackedPV,
 			CVMode:        cvMode,

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -292,10 +292,11 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err := a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err := a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
 	assert.Equal(t, "", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 
 	// Test for failure scenario by giving CephVersion{Major: 14, Minor: 2, Extra: 7}
 	// instead of CephVersion{Major: 14, Minor: 2, Extra: 8}.
@@ -309,7 +310,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.NotNil(t, err)
 
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
@@ -332,10 +333,11 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/dev/ceph-bceae560-85b1-4a87-9375-6335fb760c8c/osd-block-2ac8edb0-0d2e-4d8f-a6cc-4c972d56079c", blockPath)
 	assert.Equal(t, "", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 
 	// Test for failure scenario by giving CephVersion{Major: 14, Minor: 2, Extra: 8}
 	// instead of cephver.CephVersion{Major: 14, Minor: 2, Extra: 7}.
@@ -349,7 +351,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.NotNil(t, err)
 
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
@@ -373,10 +375,11 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
 	assert.Equal(t, "", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 
 	// Test for condition when Data !=-1 with CephVersion{Major: 14, Minor: 2, Extra: 8} for raw  with flag --crush-device-class.
 	devices = &DeviceOsdMapping{
@@ -385,10 +388,11 @@ func TestInitializeBlockPVC(t *testing.T) {
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "", blockPath)
 	assert.Equal(t, "", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 }
 
 func TestInitializeBlockPVCWithMetadata(t *testing.T) {
@@ -412,13 +416,15 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data":     {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}},
 			"metadata": {Data: 0, Metadata: []int{1}, Config: DesiredDevice{Name: "/srv/set1-metadata-0-8c7kr"}},
+			"wal":      {Data: 1, Metadata: []int{2}, Config: DesiredDevice{Name: ""}},
 		},
 	}
 
-	blockPath, metadataBlockPath, err := a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err := a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
 	assert.Equal(t, "/srv/set1-metadata-0-8c7kr", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
@@ -438,13 +444,15 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data":     {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}},
 			"metadata": {Data: 0, Metadata: []int{1}, Config: DesiredDevice{Name: "/srv/set1-metadata-0-8c7kr"}},
+			"wal":      {Data: 1, Metadata: []int{2}, Config: DesiredDevice{Name: ""}},
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/dev/ceph-bceae560-85b1-4a87-9375-6335fb760c8c/osd-block-2ac8edb0-0d2e-4d8f-a6cc-4c972d56079c", blockPath)
 	assert.Equal(t, "/srv/set1-metadata-0-8c7kr", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
@@ -468,13 +476,15 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 		Entries: map[string]*DeviceOsdIDEntry{
 			"data":     {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/mnt/set1-data-0-rpf2k"}},
 			"metadata": {Data: 0, Metadata: []int{1}, Config: DesiredDevice{Name: "/srv/set1-metadata-0-8c7kr"}},
+			"wal":      {Data: 1, Metadata: []int{2}, Config: DesiredDevice{Name: ""}},
 		},
 	}
 
-	blockPath, metadataBlockPath, err = a.initializeBlockPVC(context, devices, false)
+	blockPath, metadataBlockPath, walBlockPath, err = a.initializeBlockPVC(context, devices, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "/mnt/set1-data-0-rpf2k", blockPath)
 	assert.Equal(t, "/srv/set1-metadata-0-8c7kr", metadataBlockPath)
+	assert.Equal(t, "", walBlockPath)
 }
 
 func TestParseCephVolumeLVMResult(t *testing.T) {
@@ -510,7 +520,7 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "name"}
 
 	context := &clusterd.Context{Executor: executor, Clientset: test.New(t, 3)}
-	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", false)
+	osds, err := GetCephVolumeRawOSDs(context, clusterInfo, "4bfe8b72-5e69-4330-b6c0-4d914db8ab89", "", "", "", false)
 	assert.Nil(t, err)
 	require.NotNil(t, osds)
 	assert.Equal(t, 2, len(osds))

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -37,6 +37,7 @@ const (
 	// Hardcoded in ceph-volume do NOT touch
 	CephVolumeEncryptedKeyEnvVarName = "CEPH_VOLUME_DMCRYPT_SECRET"
 	osdMetadataDeviceEnvVarName      = "ROOK_METADATA_DEVICE"
+	osdWalDeviceEnvVarName           = "ROOK_WAL_DEVICE"
 	pvcBackedOSDVarName              = "ROOK_PVC_BACKED_OSD"
 	blockPathVarName                 = "ROOK_BLOCK_PATH"
 	cvModeVarName                    = "ROOK_CV_MODE"
@@ -130,6 +131,10 @@ func devicePathFilterEnvVar(filter string) v1.EnvVar {
 
 func metadataDeviceEnvVar(metadataDevice string) v1.EnvVar {
 	return v1.EnvVar{Name: osdMetadataDeviceEnvVarName, Value: metadataDevice}
+}
+
+func walDeviceEnvVar(walDevice string) v1.EnvVar {
+	return v1.EnvVar{Name: osdWalDeviceEnvVarName, Value: walDevice}
 }
 
 func pvcBackedOSDEnvVar(pvcBacked string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -212,15 +212,17 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		CVMode: "raw",
 	}
 	osdProp.metadataPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-metadata"}
+	osdProp.walPVC = v1.PersistentVolumeClaimVolumeSource{ClaimName: "mypvc-wal"}
 	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 	assert.Nil(t, err)
 	assert.NotNil(t, deployment)
-	assert.Equal(t, 5, len(deployment.Spec.Template.Spec.InitContainers))
+	assert.Equal(t, 6, len(deployment.Spec.Template.Spec.InitContainers))
 	assert.Equal(t, "blkdevmapper", deployment.Spec.Template.Spec.InitContainers[0].Name)
 	assert.Equal(t, "blkdevmapper-metadata", deployment.Spec.Template.Spec.InitContainers[1].Name)
-	assert.Equal(t, "activate", deployment.Spec.Template.Spec.InitContainers[2].Name)
-	assert.Equal(t, "expand-bluefs", deployment.Spec.Template.Spec.InitContainers[3].Name)
-	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[4].Name)
+	assert.Equal(t, "blkdevmapper-wal", deployment.Spec.Template.Spec.InitContainers[2].Name)
+	assert.Equal(t, "activate", deployment.Spec.Template.Spec.InitContainers[3].Name)
+	assert.Equal(t, "expand-bluefs", deployment.Spec.Template.Spec.InitContainers[4].Name)
+	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[5].Name)
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont = deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, 6, len(cont.VolumeMounts), cont.VolumeMounts)


### PR DESCRIPTION
Based on the feature of metadata PVC for OSD: https://github.com/rook/rook/pull/4818/, add the wal device.

For this, you need to create a new volumeClaimTemplates, its name must be "wal", if "wal" is set, "metadata" device will refer specially for block.db device, and "wal" refers for block.wal device in BlueStore.

A template will look like this:

```
volumeClaimTemplates:
- metadata:
    name: data
  spec:
    resources:
      requests:
        storage: 10Gi
    # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
    storageClassName: gp2
    volumeMode: Block
    accessModes:
      - ReadWriteOnce
- metadata:
    name: metadata
  spec:
    resources:
      requests:
        storage: 5Gi
    # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
    storageClassName: io1
    volumeMode: Block
    accessModes:
      - ReadWriteOnce
- metadata:
    name: wal
  spec:
    resources:
      requests:
        storage: 5Gi
    # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
    storageClassName: io1
    volumeMode: Block
    accessModes:
      - ReadWriteOnce
```

We now map block, block.db and block.wal directly inside the container instead of
running ceph-volume activate.

The bluestore partition has the following reference conbinations, this supported by ceph-volume utility
1. A single "data" device.
2. A "data" device and a "metadata"(block.db) device.
3. A "data" device and a "wal"(block.wal) device.
4. A "data" device, a "metadata"(block.db) device and a "wal"(block.wal) device.

Signed-off-by: Chen, Tingjie <tingjie.chen@intel.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
