### PR TITLE
ceph: fix the document of OSD management

### DIFF
--- a/Documentation/ceph-osd-mgmt.md
+++ b/Documentation/ceph-osd-mgmt.md
@@ -70,14 +70,13 @@ in the toolbox may show which OSD is `down`.
 2. Mark the OSD as `out` if not already marked as such by Ceph. This signals Ceph to start moving (backfilling) the data that was on that OSD to another OSD.
    - `ceph osd out osd.<ID>` (for example if the OSD ID is 23 this would be `ceph osd out osd.23`)
 3. Wait for the data to finish backfilling to other OSDs.
-   - `ceph status` will indicate the backfilling is done when all of the PGs are `active+clean`.
-4. Remove the disk from the node.
-5. Update your CephCluster CR such that the operator won't create an OSD on the device anymore.
+   - `ceph status` will indicate the backfilling is done when all of the PGs are `active+clean`. If desired, it's safe to remove the disk after that.
+4. Update your CephCluster CR such that the operator won't create an OSD on the device anymore.
 Depending on your CR settings, you may need to remove the device from the list or update the device filter.
 If you are using `useAllDevices: true`, no change to the CR is necessary.
-6. Remove the OSD from the Ceph cluster
+5. Remove the OSD from the Ceph cluster
    - `ceph osd purge <ID> --yes-i-really-mean-it`
-7. Verify the OSD is removed from the node in the CRUSH map
+6. Verify the OSD is removed from the node in the CRUSH map
    - `ceph osd tree`
 
 ### Remove the OSD Deployment


### PR DESCRIPTION
**Description of your changes:**

Removing a disk is not mandatory after the data in the corresponding OSD is moved to other OSDs.
It's better to just let users to know it's safe to remove the disk.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]