### PR TITLE
ceph: do not use external node IP for mon endpoint

### DIFF
--- a/pkg/operator/ceph/cluster/mon/node.go
+++ b/pkg/operator/ceph/cluster/mon/node.go
@@ -52,14 +52,14 @@ func getNodeInfoFromNode(n v1.Node) (*NodeInfo, error) {
 	}
 
 	for _, ip := range n.Status.Addresses {
-		if ip.Type == v1.NodeExternalIP || ip.Type == v1.NodeInternalIP {
-			logger.Debugf("using IP %s for node %s", ip.Address, n.Name)
+		if ip.Type == v1.NodeInternalIP {
+			logger.Debugf("using internal IP %s for node %s", ip.Address, n.Name)
 			nr.Address = ip.Address
 			break
 		}
 	}
 	if nr.Address == "" {
-		return nil, errors.Errorf("couldn't get IP of node %s", nr.Name)
+		return nil, errors.Errorf("failed to find any internal IP on node %s", nr.Name)
 	}
 	return nr, nil
 }

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -212,7 +212,11 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 
 	var info *NodeInfo
 	info, err = getNodeInfoFromNode(*node)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 
-	assert.Equal(t, "1.1.1.1", info.Address)
+	node.Status.Addresses[0].Type = v1.NodeInternalIP
+	node.Status.Addresses[0].Address = "172.17.0.1"
+	info, err = getNodeInfoFromNode(*node)
+	assert.Nil(t, err)
+	assert.Equal(t, "172.17.0.1", info.Address)
 }

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -42,7 +42,7 @@ func New(t *testing.T, nodes int) *fake.Clientset {
 				},
 				Addresses: []v1.NodeAddress{
 					{
-						Type:    v1.NodeExternalIP,
+						Type:    v1.NodeInternalIP,
 						Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i),
 					},
 				},


### PR DESCRIPTION
**Description of your changes:**

When the cluster is using HostNetworking, Rook was either picking up the
external or internal IP of the node. This resulted in mon endpoints have
public IP addresses. Those IP are not reachable from within the cluster
so OSD/CSI couldn't access the monitors from the configmap endpoint.

Also, exposing the cluster on a public network does not seem realistic,
so sticky with private/internal IP addresses is better.

Closes: https://github.com/rook/rook/issues/5495
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5495

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]