### PR TITLE
Configurable Service Port Names

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -283,7 +283,7 @@ func (c *Cluster) makeDashboardService(name string) *v1.Service {
 	labels := controller.AppLabels(AppName, c.Namespace)
 	portName := "https-dashboard"
 	if !c.dashboard.SSL {
-		portName = "dashboard"
+		portName = "http-dashboard"
 	}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -36,7 +36,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
-					Name: "msgr1",
+					Name: "tcp-msgr1",
 					Port: mon.Port,
 					// --public-bind-addr=IP with no IP:port has the mon listen on port 6789
 					// regardless of what port the mon advertises (--public-addr) to the outside.
@@ -50,7 +50,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	k8sutil.SetOwnerRef(&svcDef.ObjectMeta, &c.ownerRef)
 
 	// If deploying Nautilus or newer we need a new port for the monitor service
-	addServicePort(svcDef, "msgr2", DefaultMsgr2Port)
+	addServicePort(svcDef, "tcp-msgr2", DefaultMsgr2Port)
 
 	s, err := k8sutil.CreateOrUpdateService(c.context.Clientset, c.Namespace, svcDef)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -265,7 +265,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 		SecurityContext: PodSecurityContext(),
 		Ports: []v1.ContainerPort{
 			{
-				Name:          "client",
+				Name:          "tcp-msgr1",
 				ContainerPort: monConfig.Port,
 				Protocol:      v1.ProtocolTCP,
 			},
@@ -287,7 +287,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 	}
 
 	// Add messenger 2 port
-	addContainerPort(container, "msgr2", 3300)
+	addContainerPort(container, "tcp-msgr2", 3300)
 
 	return container
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Trying to integrate rook-ceph with istio, but getting service port name errors as referenced here: https://kiali.io/documentation/validations/#_kia0601_port_name_must_follow_protocol_suffix_form

Understanding that istio isn't the only game in town, I think that it would be best to make the port name configurable at cluster creation. 

Not sure what all needs to be changed in the source, but here are my starting edits. Assistance would be appreciated. 

**Which issue is resolved by this Pull Request:**
Resolves #5587 

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]