### PR TITLE
doc: Update port information for object store

### DIFF
--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -91,7 +91,7 @@ The gateway settings correspond to the RGW daemon settings.
 
 * `type`: `S3` is supported
 * `sslCertificateRef`: If the certificate is not specified, SSL will not be configured. If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form."
-* `port`: The port on which the RGW pods and the RGW service will be listening (not encrypted).
+* `port`: The port on which the Object service will be reachable. If host networking is enabled, the RGW daemons will also listen on that port. If running on SDN, the RGW daemon listening port will be 8080 internally.
 * `securePort`: The secure port on which RGW pods will be listening. An SSL certificate must be specified.
 * `instances`: The number of pods that will be started to load balance this object store.
 * `annotations`: Key value pair list of annotations to add.

--- a/cluster/examples/kubernetes/ceph/rgw-external.yaml
+++ b/cluster/examples/kubernetes/ceph/rgw-external.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
   - name: rgw
-    port: 80
+    port: 80 # service port mentioned in object store crd
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: rook-ceph-rgw
     rook_cluster: rook-ceph


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Explaining about port and target port in rgw-external.yaml. Also distinguishing internal port used by rgw daemon with service port given in object store crd
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]