### PR TITLE
ceph: fix osd number detection on upgrade

### DIFF
--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -370,21 +370,18 @@ func buildHostListFromTree(tree OsdTree) (OsdTree, error) {
 // it checks for various cluster info like number of OSD and their placement
 // it returns 'true' if we need to do nothing and false and we should pre-check/post-check
 func osdDoNothing(context *clusterd.Context, clusterName string) bool {
-	versions, err := GetAllCephDaemonVersions(context, clusterName)
+	osds, err := OsdListNum(context, clusterName)
 	if err != nil {
-		logger.Warningf("failed to get ceph daemons versions, this likely means there is no cluster yet. %v", err)
-		return true
+		logger.Warningf("failed to determine the total number of osds. will check if the osd is ok-to-stop anyways. %v", err)
+		// If calling osd list fails, we assume there are more than 3 OSDs and we check if ok-to-stop
+		// If there are less than 3 OSDs, the ok-to-stop call will fail
+		// this can still be controlled by setting continueUpgradeAfterChecksEvenIfNotHealthy
+		// At least this will happen for a single OSD only, which means 2 OSDs will restart in a small interval
+		return false
 	}
-
-	if len(versions.Osd) == 1 {
-		// now trying to parse and find how many osds are presents
-		// if we have less than 3 osds we skip the check and do best-effort
-		for _, osdCount := range versions.Osd {
-			if osdCount < 3 {
-				logger.Warningf("the cluster has less than 3 OSDs, not performing upgrade check, running in best-effort")
-				return true
-			}
-		}
+	if len(osds) < 3 {
+		logger.Warningf("the cluster has less than 3 osds, not performing upgrade check, running in best-effort")
+		return true
 	}
 
 	// aio means all in one

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -390,10 +390,9 @@ func osdDoNothing(context *clusterd.Context, clusterName string) bool {
 	// aio means all in one
 	aio, err := allOSDsSameHost(context, clusterName)
 	if err != nil {
-		// That's tricky, we are about to perform an update so it's difficult to break the update for this
-		// let's consider this is not a problem but log what happened
-		logger.Warningf("not able to determine if all OSDs are running on the same host, not performing upgrade check, running in best-effort")
-		return true
+		// If calling osd list fails, we assume there are more than 3 OSDs and we check if ok-to-stop
+		logger.Warningf("failed to determine if all osds are running on the same host, performing upgrade check anyways. %v", err)
+		return false
 	}
 
 	if aio {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

If the cluster has 3 OSDs, during the upgrade when the OSD restarts it
will temporarily disappear from the "ceph versions" list so we need
a more robust way to list the number of OSDs and always returns the total
number of OSDs.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5521

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
