### PR TITLE
ceph: a couple of ceph-mgr fixes

### DIFF
--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -125,8 +125,8 @@ func setBalancerMode(context *clusterd.Context, clusterName, mode string) error 
 	return nil
 }
 
-// SetMinCompatClientLuminous set the minimum compatibility for clients to Luminous
-func SetMinCompatClientLuminous(context *clusterd.Context, clusterName string) error {
+// setMinCompatClientLuminous set the minimum compatibility for clients to Luminous
+func setMinCompatClientLuminous(context *clusterd.Context, clusterName string) error {
 	args := []string{"osd", "set-require-min-compat-client", "luminous", "--yes-i-really-mean-it"}
 	_, err := NewCephCommand(context, clusterName, args).Run()
 	if err != nil {
@@ -136,8 +136,8 @@ func SetMinCompatClientLuminous(context *clusterd.Context, clusterName string) e
 	return nil
 }
 
-// MgrSetBalancerMode sets the given mode to the balancer module
-func MgrSetBalancerMode(context *clusterd.Context, clusterName, balancerModuleMode string) error {
+// mgrSetBalancerMode sets the given mode to the balancer module
+func mgrSetBalancerMode(context *clusterd.Context, clusterName, balancerModuleMode string) error {
 	retryCount := 5
 	for i := 0; i < retryCount; i++ {
 		err := setBalancerMode(context, clusterName, balancerModuleMode)
@@ -151,6 +151,23 @@ func MgrSetBalancerMode(context *clusterd.Context, clusterName, balancerModuleMo
 			}
 		}
 		break
+	}
+
+	return nil
+}
+
+// ConfigureBalancerModule configures the balancer module
+func ConfigureBalancerModule(context *clusterd.Context, clusterName, balancerModuleMode string) error {
+	// Set min compat client to luminous before enabling the balancer mode "upmap"
+	err := setMinCompatClientLuminous(context, clusterName)
+	if err != nil {
+		return errors.Wrap(err, "failed to set minimum compatibility client")
+	}
+
+	// Set balancer module mode
+	err = mgrSetBalancerMode(context, clusterName, balancerModuleMode)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set balancer module mode to %q", balancerModuleMode)
 	}
 
 	return nil

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -236,9 +236,12 @@ func (c *Cluster) configureModules(daemonIDs []string) {
 	startModuleConfiguration("http bind settings", c.clearHTTPBindFix)
 	startModuleConfiguration("orchestrator modules", c.configureOrchestratorModules)
 	startModuleConfiguration("prometheus", c.enablePrometheusModule)
-	startModuleConfiguration("crash", c.enableCrashModule)
-	startModuleConfiguration("mgr module(s) from the spec", c.configureMgrModules)
 	startModuleConfiguration("dashboard", c.configureDashboardModules)
+	// "crash" is part of the "always_on_modules" list as of Octopus
+	if !c.clusterInfo.CephVersion.IsAtLeastOctopus() {
+		startModuleConfiguration("crash", c.enableCrashModule)
+	}
+	startModuleConfiguration("mgr module(s) from the spec", c.configureMgrModules)
 }
 
 func startModuleConfiguration(description string, configureModules func() error) {

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -240,6 +240,11 @@ func (c *Cluster) configureModules(daemonIDs []string) {
 	// "crash" is part of the "always_on_modules" list as of Octopus
 	if !c.clusterInfo.CephVersion.IsAtLeastOctopus() {
 		startModuleConfiguration("crash", c.enableCrashModule)
+	} else {
+		// The balancer module must be configured on Octopus
+		// It is a bit confusing but as of Octopus modules that are in the "always_on_modules" list
+		// are "just" enabled, but still they must be configured to work properly
+		startModuleConfiguration("balancer", c.enableBalancerModule)
 	}
 	startModuleConfiguration("mgr module(s) from the spec", c.configureMgrModules)
 }
@@ -271,6 +276,24 @@ func (c *Cluster) enableCrashModule() error {
 	return nil
 }
 
+func (c *Cluster) enableBalancerModule() error {
+	// The order MATTERS, always configure this module first, then turn it on
+
+	// This sets min compat client to luminous and the balancer module mode
+	err := client.ConfigureBalancerModule(c.context, c.Namespace, balancerModuleMode)
+	if err != nil {
+		return errors.Wrapf(err, "failed to configure module %q", balancerModuleName)
+	}
+
+	// This turns "on" the balancer
+	err = client.MgrEnableModule(c.context, c.Namespace, balancerModuleName, false)
+	if err != nil {
+		return errors.Wrapf(err, "failed to turn on mgr %q module", balancerModuleName)
+	}
+
+	return nil
+}
+
 func (c *Cluster) configureMgrModules() error {
 	// Enable mgr modules from the spec
 	for _, module := range c.mgrSpec.Modules {
@@ -287,15 +310,10 @@ func (c *Cluster) configureMgrModules() error {
 
 		if module.Enabled {
 			if module.Name == balancerModuleName {
-				// Set min compat client to luminous before enabling the balancer mode "upmap"
-				err := client.SetMinCompatClientLuminous(c.context, c.Namespace)
+				// Configure balancer module mode
+				err := client.ConfigureBalancerModule(c.context, c.Namespace, balancerModuleMode)
 				if err != nil {
-					return errors.Wrap(err, "failed to set minimum compatibility client")
-				}
-				// Set balancer module mode
-				err = client.MgrSetBalancerMode(c.context, c.Namespace, balancerModuleMode)
-				if err != nil {
-					return errors.Wrapf(err, "failed to set module %q mode to %q", module.Name, balancerModuleMode)
+					return errors.Wrapf(err, "failed to configure module %q", module.Name)
 				}
 			}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

ceph: do not activate crash module

The mgr crash module is always enabled so we don't need to run the
command again. It saves some orchestration time.

ceph: always turn on balancer on octopus

When running Octopus, we still need to turn on the balancer module. The
distinction is tricky, the module is "enabled" but it has to be "turned
on" and configured.

This was only working when the `pg_autoscaler` module was explicitly
listed in the CephCluster spec mgr section module section but not
automatically configured when running Octopus (the `pg_autoscaler`
module is already enabled).

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
