### PR TITLE
discover: fix info log for discovered devices

### DIFF
--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -395,13 +395,23 @@ func updateDeviceCM(context *clusterd.Context) error {
 	return nil
 }
 
+func logDevices(devices []*sys.LocalDisk) {
+	var devicesList []string
+	for _, device := range devices {
+		logger.Debugf("localdevice %q: %+v", device.Name, device)
+		devicesList = append(devicesList, device.Name)
+	}
+	logger.Infof("localdevices: %q", strings.Join(devicesList, ", "))
+}
+
 func probeDevices(context *clusterd.Context) ([]sys.LocalDisk, error) {
 	devices := make([]sys.LocalDisk, 0)
 	localDevices, err := clusterd.DiscoverDevices(context.Executor)
-	logger.Infof("localdevices: %+v", localDevices)
 	if err != nil {
 		return devices, fmt.Errorf("failed initial hardware discovery. %+v", err)
 	}
+
+	logDevices(localDevices)
 
 	// ceph-volume inventory command takes a little time to complete.
 	// Get this data only if it is needed and once by function execution


### PR DESCRIPTION
Fix the info log statement to log the discovered devices as their string
representation instead of pointers.
This uses a loop to generate the sprintf output for each device and then
strings.Join to join the outputs.

Resolves #5625

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
