### PR TITLE
ceph: add schedulerName property to storageClassDeviceSet

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -336,6 +336,7 @@ The following are the settings for Storage Class Device Sets which can be config
   * `storageClassName`: The StorageClass to provision PVCs from. Default would be to use the cluster-default StorageClass. This StorageClass should provide a raw block device, multipath device, or logical volume. Other types are not supported.
   * `volumeMode`: The volume mode to be set for the PVC. Which should be Block
   * `accessModes`: The access mode for the PVC to be bound by OSD.
+* `schedulerName`: Scheduler name for OSD pod placement. (Optional)
 
 ### OSD Configuration Settings
 

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -128,6 +128,8 @@ spec:
       #     volumeMode: Block
       #     accessModes:
       #       - ReadWriteOnce
+      # Scheduler name for OSD pod placement
+      # schedulerName: osd-scheduler
   disruptionManagement:
     managePodBudgets: false
     osdMaintenanceTimeout: 30

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -111,6 +111,7 @@ type StorageClassDeviceSet struct {
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"` // List of PVC templates for the underlying storage devices
 	Portable             bool                       `json:"portable,omitempty"`             // OSD portability across the hosts
 	TuneSlowDeviceClass  bool                       `json:"tuneDeviceClass,omitempty"`      // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
+	SchedulerName        string                     `json:"schedulerName,omitempty"`        // Scheduler name for OSD pod placement
 }
 
 // VolumeSource is a volume source spec for Rook
@@ -122,6 +123,7 @@ type VolumeSource struct {
 	Config              map[string]string                               `json:"config,omitempty"`
 	Portable            bool                                            `json:"portable,omitempty"`         // Portable OSD portability across the hosts
 	TuneSlowDeviceClass bool                                            `json:"tuneDeviceClass,omitempty"`  // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
+	SchedulerName       string                                          `json:"schedulerName,omitempty"`    // Scheduler name for OSD pod placement
 	CrushDeviceClass    string                                          `json:"crushDeviceClass,omitempty"` // CrushDeviceClass represents the crush device class for an OSD
 	Size                string                                          `json:"size,omitempty"`             // Size represents the size requested for the PVC
 }

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -77,6 +77,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 				PVCSources:          pvcSources,
 				Portable:            storageClassDeviceSet.Portable,
 				TuneSlowDeviceClass: storageClassDeviceSet.TuneSlowDeviceClass,
+				SchedulerName:       storageClassDeviceSet.SchedulerName,
 				CrushDeviceClass:    crushDeviceClass,
 			})
 		}

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -41,6 +41,7 @@ func TestPrepareDeviceSets(t *testing.T) {
 		Count:                1,
 		Portable:             true,
 		VolumeClaimTemplates: []v1.PersistentVolumeClaim{claim},
+		SchedulerName:        "custom-scheduler",
 	}
 	desired := rookv1.StorageScopeSpec{StorageClassDeviceSets: []rookv1.StorageClassDeviceSet{deviceSet}}
 	cluster := &Cluster{
@@ -57,6 +58,7 @@ func TestPrepareDeviceSets(t *testing.T) {
 	assert.True(t, volumeSources[0].Portable)
 	_, dataOK := volumeSources[0].PVCSources["data"]
 	assert.True(t, dataOK)
+	assert.Equal(t, "custom-scheduler", volumeSources[0].SchedulerName)
 
 	// Verify that the PVC has the expected generated name with the default of "data" in the name
 	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.Namespace).List(metav1.ListOptions{})

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -175,6 +175,7 @@ type osdProperties struct {
 	location            string
 	portable            bool
 	tuneSlowDeviceClass bool
+	schedulerName       string
 	crushDeviceClass    string
 }
 
@@ -269,6 +270,7 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 			placement:        volume.Placement,
 			portable:         volume.Portable,
 			crushDeviceClass: volume.CrushDeviceClass,
+			schedulerName:    volume.SchedulerName,
 		}
 
 		logger.Debugf("osdProps are %+v", osdProps)
@@ -624,6 +626,7 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				portable:            volumeSource.Portable,
 				tuneSlowDeviceClass: volumeSource.TuneSlowDeviceClass,
 				pvcSize:             volumeSource.Size,
+				schedulerName:       volumeSource.SchedulerName,
 			}
 			// If OSD isn't portable, we're getting the host name either from the osd deployment that was already initialized
 			// or from the osd prepare job from initial creation.

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -437,7 +437,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 					LivenessProbe:   controller.GenerateLivenessProbeExecDaemon(opconfig.OsdType, osdID),
 				},
 			},
-			Volumes: volumes,
+			Volumes:       volumes,
+			SchedulerName: osdProps.schedulerName,
 		},
 	}
 
@@ -582,6 +583,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 		Volumes:           volumes,
 		HostNetwork:       c.Network.IsHost(),
 		PriorityClassName: c.priorityClassName,
+		SchedulerName:     osdProps.schedulerName,
 	}
 	if c.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -43,6 +43,7 @@ func TestPodContainer(t *testing.T) {
 		devices:       []rookv1.Device{},
 		resources:     v1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
+		schedulerName: "custom-scheduler",
 	}
 	dataPathMap := &provisionConfig{
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(cluster.Namespace, "/var/lib/rook"),
@@ -52,6 +53,7 @@ func TestPodContainer(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(c.Spec.InitContainers))
 	assert.Equal(t, 1, len(c.Spec.Containers))
+	assert.Equal(t, "custom-scheduler", c.Spec.SchedulerName)
 	container := c.Spec.InitContainers[0]
 	logger.Infof("container: %+v", container)
 	assert.Equal(t, "copy-binaries", container.Args[0])
@@ -103,6 +105,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		selection:     n.Selection,
 		resources:     v1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
+		schedulerName: "custom-scheduler",
 	}
 
 	dataPathMap := &provisionConfig{
@@ -129,6 +132,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	if !devMountNeeded && len(dataDir) > 0 {
 		assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Volumes))
 	}
+	assert.Equal(t, "custom-scheduler", deployment.Spec.Template.Spec.SchedulerName)
 
 	assert.Equal(t, "rook-data", deployment.Spec.Template.Spec.Volumes[0].Name)
 


### PR DESCRIPTION
**Description of your changes:**
Support schedulerName in storageClassDeviceSets to use another scheduler for OSD pod placement.

This will enable more flexible pod placement.

**Which issue is resolved by this Pull Request:**
Resolves #5536

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
