### PR TITLE
ceph: fail prepare pod if lvm2 pkg is missing

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -59,6 +59,7 @@ Rook v1.3 has several breaking changes that must be considered **before** upgrad
    OSDs in your cluster, run `lsblk` on each host to see what partitions exist.
    - If you see **three partitions** on a device running an OSD, this is a legacy OSD. See below for [converting legacy OSDs](#converting-legacy-osds).
    - If you see a single partition or LV with the `ceph` prefix, the OSD is **not** a legacy OSD and you will not need to convert the OSDs.
+4. Make sure the `lvm2` package is installed on the host where OSDs are running. If not, the prepare job will fail and the upgrade will be blocked.
 
 ### CSI Snapshots
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -29,6 +29,7 @@
   - The CephObjectStore CR runs health checks on the object store endpoint, refer to the [health check section](Documentation/ceph-object-store-crd.html#health-settings)
   - The endpoint is now displayed in the Status field
 - Prometheus monitoring for external clusters is now possible, refer to the [external cluster section](Documentation/ceph-cluster-crd.html#external-cluster)
+- The operator will check for the presence of the `lvm2` package on the host where OSDs will run. If not available, the prepare job will fail. This will prevent issues of OSDs not restarting on node reboot.
 
 ### EdgeFS
 

--- a/pkg/daemon/ceph/osd/nsenter.go
+++ b/pkg/daemon/ceph/osd/nsenter.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+const (
+	// mountNsPath is the default mount namespace of the host
+	mountNsPath = "/rootfs/proc/1/ns/mnt"
+	// nsenterCmd is the nsenter command
+	nsenterCmd = "nsenter"
+)
+
+var (
+	binPathsToCheck = []string{"/usr/sbin", "/sbin/"}
+)
+
+// NSEnter is an nsenter object
+type NSEnter struct {
+	context    *clusterd.Context
+	binary     string
+	binaryArgs []string
+}
+
+// NewNsenter returns an instance of the NSEnter object
+func NewNsenter(context *clusterd.Context, binary string, binaryArgs []string) *NSEnter {
+	return &NSEnter{
+		context:    context,
+		binary:     binary,
+		binaryArgs: binaryArgs,
+	}
+}
+
+func (ne *NSEnter) buildNsEnterCLI(binPath string) []string {
+	baseArgs := []string{fmt.Sprintf("--mount=%s", mountNsPath), "--", binPath}
+	baseArgs = append(baseArgs, ne.binaryArgs...)
+
+	return baseArgs
+}
+
+func (ne *NSEnter) callNsEnter(binPath string) error {
+	args := ne.buildNsEnterCLI(binPath)
+	op, err := ne.context.Executor.ExecuteCommandWithCombinedOutput(nsenterCmd, args...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to execute nsenter. output: %s", op)
+	}
+
+	logger.Info("successfully called nsenter")
+	return nil
+}
+
+func (ne *NSEnter) checkIfBinaryExistsOnHost() error {
+	for _, path := range binPathsToCheck {
+		binPath := filepath.Join(path, ne.binary)
+		err := ne.callNsEnter(binPath)
+		if err != nil {
+			logger.Debugf("failed to call nsenter. %v", err)
+			continue
+		}
+		logger.Infof("binary %q found on the host, proceeding with osd preparation", binPath)
+		return nil
+	}
+
+	return errors.Errorf("binary %q does not exist on the host", ne.binary)
+}

--- a/pkg/daemon/ceph/osd/nsenter_test.go
+++ b/pkg/daemon/ceph/osd/nsenter_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildNsEnterCLI(t *testing.T) {
+	ne := NewNsenter(&clusterd.Context{}, lvmCommandToCheck, []string{"--help"})
+	args := ne.buildNsEnterCLI(filepath.Join("/sbin/", ne.binary))
+	expectedCLI := []string{"--mount=/rootfs/proc/1/ns/mnt", "--", "/sbin/lvm", "--help"}
+
+	assert.Equal(t, expectedCLI, args)
+}
+
+func TestCheckIfBinaryExistsOnHost(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if command == "nsenter" && args[0] == "--mount=/rootfs/proc/1/ns/mnt" && args[1] == "--" && args[3] == "--help" {
+			if args[2] == "/usr/sbin/lvm" || args[2] == "/sbin/lvm" {
+				return "success", nil
+			}
+		}
+
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+
+	context := &clusterd.Context{Executor: executor}
+	ne := NewNsenter(context, lvmCommandToCheck, []string{"--help"})
+	err := ne.checkIfBinaryExistsOnHost()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
**Description of your changes:**

A long-standing issue that was only solved via a documentation note. Now,
during the prepare pod instantiation, we check for the presence of the
lvm binary on the host. Success will indicate that we can bootstrap
OSDs where failure will refuse to prepare the OSD.

Closes: https://github.com/rook/rook/issues/5627
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5627

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]