### PR TITLE
ceph: fix error message

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -485,7 +485,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		assert.NoError(h.T(), err, "failed to retrieve pool CRs")
 		for _, pool := range pools.Items {
 			logger.Infof("found pools: %v", pools)
-			assert.Failf(h.T(), "pool %q still exists", pool.Name)
+			assert.Fail(h.T(), fmt.Sprintf("pool %q still exists", pool.Name))
 			// Get the operator log
 			h.GatherAllRookLogs(h.T().Name()+"poolcheck", systemNamespace)
 		}


### PR DESCRIPTION
During checking [my pull request test result](https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/PR-5573/runs/12/nodes/60/steps/129/log/?start=0), I noticed that the error message is not appropriate.

```
...
--- FAIL: TestCephFlexSuite (517.73s)
...
    --- PASS: TestCephFlexSuite/TestFileSystem (105.79s)
    ceph_installer.go:490: 
        	Error Trace:	ceph_installer.go:490
        	            				ceph_installer.go:459
        	            				ceph_base_deploy_test.go:192
        	            				ceph_flex_test.go:237
        	            				suite.go:106
        	            				suite.go:139
        	            				ceph_flex_test.go:64
        	Error:      	pool %q still exists
        	Test:       	TestCephFlexSuite
        	Messages:   	block-pool-rwo
```

Therefore, I fixed the error message.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
