### PR TITLE
ceph: add external prometheus endpoint

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -987,6 +987,12 @@ spec:
     enable: true
   crashCollector:
     disable: true
+  # optionally, the ceph-mgr IP address can be pass to gather metric from the prometheus exporter
+  #monitoring:
+    #enabled: true
+    #rulesNamespace: rook-ceph
+    #externalMgrEndpoints:
+      #- ip: 192.168.39.182
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.

--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -21,7 +21,7 @@ First the Prometheus operator needs to be started in the cluster so it can watch
 A full explanation can be found in the [Prometheus operator repository on GitHub](https://github.com/coreos/prometheus-operator), but the quick instructions can be found here:
 
 ```console
-kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml
+kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.40.0/bundle.yaml
 ```
 
 This will start the Prometheus operator, but before moving on, wait until the operator is in the `Running` state:
@@ -146,13 +146,13 @@ The following Grafana dashboards are available:
 
 ## Teardown
 
-To clean up all the artifacts created by the monitoring walkthrough, copy/paste the entire block below (note that errors about resources "not found" can be ignored):
+To clean up all the artifacts created by the monitoring walk-through, copy/paste the entire block below (note that errors about resources "not found" can be ignored):
 
 ```console
 kubectl delete -f service-monitor.yaml
 kubectl delete -f prometheus.yaml
 kubectl delete -f prometheus-service.yaml
-kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.26.0/bundle.yaml
+kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/v0.40.0/bundle.yaml
 ```
 
 Then the rest of the instructions in the [Prometheus Operator docs](https://github.com/coreos/prometheus-operator#removal) can be followed to finish cleaning up.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -27,6 +27,7 @@
   - Supports connecting to external Ceph Rados Gateways, refer to the [external object section](Documentation/ceph-object.html#connect-to-external-object-store)
   - The CephObjectStore CR runs health checks on the object store endpoint, refer to the [health check section](Documentation/ceph-object-store-crd.html#health-settings)
   - The endpoint is now displayed in the Status field
+- Prometheus monitoring for external clusters is now possible, refer to the [external cluster section](Documentation/ceph-cluster-crd.html#external-cluster)
 
 ### EdgeFS
 

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -25,3 +25,9 @@ spec:
       mon:
         disabled: false
         interval: 45s
+  # optionally, the ceph-mgr IP address can be passed to gather metric from the prometheus exporter
+  # monitoring:
+  #   enabled: true
+  #   rulesNamespace: rook-ceph
+  #   externalMgrEndpoints:
+      #- ip: ip

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -175,6 +175,12 @@ spec:
                   type: boolean
                 rulesNamespace:
                   type: string
+                externalMgrEndpoints:
+                  type: array
+                  items:
+                    properties:
+                      ip:
+                        type: string
             removeOSDsIfOutAndSafeToRemove:
               type: boolean
             external:

--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules-external.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules-external.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: rook-prometheus
+    role: alert-rules
+  name: prometheus-ceph-rules
+  namespace: rook-ceph
+spec:
+  groups:
+  - name: persistent-volume-alert.rules
+    rules:
+    - alert: PersistentVolumeUsageNearFull
+      annotations:
+        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed
+          75%. Free up some space.
+        message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion
+          is required.
+        severity_level: warning
+        storage_type: ceph
+      expr: |
+        (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.75
+      for: 5s
+      labels:
+        severity: warning
+    - alert: PersistentVolumeUsageCritical
+      annotations:
+        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed
+          85%. Free up some space immediately.
+        message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data
+          deletion is required.
+        severity_level: error
+        storage_type: ceph
+      expr: |
+        (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) > 0.85
+      for: 5s
+      labels:
+        severity: critical

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -177,6 +177,9 @@ type MonitoringSpec struct {
 	// The namespace where the prometheus rules and alerts should be created.
 	// If empty, the same namespace as the cluster will be used.
 	RulesNamespace string `json:"rulesNamespace,omitempty"`
+
+	// ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
+	ExternalMgrEndpoints []v1.EndpointAddress `json:"externalMgrEndpoints,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -38,7 +39,7 @@ func (c *CephCluster) ValidateCreate() error {
 
 	//If external mode enabled, then check if other fields are empty
 	if c.Spec.External.Enable {
-		if c.Spec.Mon != (MonSpec{}) || c.Spec.Dashboard != (DashboardSpec{}) || c.Spec.Monitoring != (MonitoringSpec{}) || c.Spec.DisruptionManagement != (DisruptionManagementSpec{}) || len(c.Spec.Mgr.Modules) > 0 || len(c.Spec.Network.Provider) > 0 || len(c.Spec.Network.Selectors) > 0 {
+		if c.Spec.Mon != (MonSpec{}) || c.Spec.Dashboard != (DashboardSpec{}) || !reflect.DeepEqual(c.Spec.Monitoring, (MonitoringSpec{})) || c.Spec.DisruptionManagement != (DisruptionManagementSpec{}) || len(c.Spec.Mgr.Modules) > 0 || len(c.Spec.Network.Provider) > 0 || len(c.Spec.Network.Selectors) > 0 {
 			return errors.New("invalid create : external mode enabled cannot have mon,dashboard,monitoring,network,disruptionManagement,storage fields in CR")
 		}
 	}

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -44,6 +44,9 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mgr")
 
 var prometheusRuleName = "prometheus-ceph-vVERSION-rules"
 
+// PrometheusExternalRuleName is the name of the prometheus external rule
+var PrometheusExternalRuleName = "prometheus-ceph-vVERSION-rules-external"
+
 const (
 	// AppName is the ceph mgr application name
 	AppName                = "rook-ceph-mgr"
@@ -152,7 +155,7 @@ func (c *Cluster) Start() error {
 	c.configureModules(daemonIDs)
 
 	// create the metrics service
-	service := c.makeMetricsService(AppName)
+	service := c.MakeMetricsService(AppName, serviceMetricName)
 	if _, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Create(service); err != nil {
 		if !kerrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "failed to create mgr service")
@@ -166,7 +169,7 @@ func (c *Cluster) Start() error {
 	if c.spec.Monitoring.Enabled {
 		logger.Infof("starting monitoring deployment")
 		// servicemonitor takes some metadata from the service for easy mapping
-		if err := c.enableServiceMonitor(service); err != nil {
+		if err := c.EnableServiceMonitor(service); err != nil {
 			logger.Errorf("failed to enable service monitor. %v", err)
 		} else {
 			logger.Infof("servicemonitor enabled")
@@ -177,7 +180,7 @@ func (c *Cluster) Start() error {
 		if namespace == "" {
 			namespace = c.clusterInfo.Namespace
 		}
-		if err := c.deployPrometheusRule(prometheusRuleName, namespace); err != nil {
+		if err := c.DeployPrometheusRule(prometheusRuleName, namespace); err != nil {
 			logger.Errorf("failed to deploy prometheus rule. %v", err)
 		} else {
 			logger.Infof("prometheusRule deployed")
@@ -324,8 +327,8 @@ func wellKnownModule(name string) bool {
 	return false
 }
 
-// add a servicemonitor that allows prometheus to scrape from the monitoring endpoint of the cluster
-func (c *Cluster) enableServiceMonitor(service *v1.Service) error {
+// EnableServiceMonitor add a servicemonitor that allows prometheus to scrape from the monitoring endpoint of the cluster
+func (c *Cluster) EnableServiceMonitor(service *v1.Service) error {
 	name := service.GetName()
 	namespace := service.GetNamespace()
 	serviceMonitor, err := k8sutil.GetServiceMonitor(path.Join(monitoringPath, serviceMonitorFile))
@@ -343,8 +346,8 @@ func (c *Cluster) enableServiceMonitor(service *v1.Service) error {
 	return nil
 }
 
-// deploy prometheusRule that adds alerting and/or recording rules to the cluster
-func (c *Cluster) deployPrometheusRule(name, namespace string) error {
+// DeployPrometheusRule deploy prometheusRule that adds alerting and/or recording rules to the cluster
+func (c *Cluster) DeployPrometheusRule(name, namespace string) error {
 	version := strconv.Itoa(c.clusterInfo.CephVersion.Major)
 	name = strings.Replace(name, "VERSION", version, 1)
 	prometheusRuleFile := name + ".yaml"

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -83,7 +83,7 @@ func TestServiceSpec(t *testing.T) {
 	clusterSpec := cephv1.ClusterSpec{}
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")
 
-	s := c.makeMetricsService("rook-mgr")
+	s := c.MakeMetricsService("rook-mgr", serviceMetricName)
 	assert.NotNil(t, s)
 	assert.Equal(t, "rook-mgr", s.Name)
 	assert.Equal(t, 1, len(s.Spec.Ports))

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -278,7 +278,7 @@ func (c *clusterConfig) reconcileExternalEndpoint(cephObjectStore *cephv1.CephOb
 
 	_, err = k8sutil.CreateOrUpdateEndpoint(c.context.Clientset, cephObjectStore.Namespace, endpoint)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create or update object store %q service", cephObjectStore.Name)
+		return errors.Wrapf(err, "failed to create or update object store %q endpoint", cephObjectStore.Name)
 	}
 
 	return nil


### PR DESCRIPTION
**Description of your changes:**

We can now connect an external Prometheus exporter to Rook to collect
metrics and generate alerts from Prometheus.

Just enable this in the `CephCluster` CR:

```
spec:
  external:
    enable: true
   monitoring:
    enabled: true
    externalMgrEndpoints:
    - ip: 192.168.39.182
```

Closes: https://github.com/rook/rook/issues/5516
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5516

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
