### PR TITLE
build: add a seperate make command for cleaning olm files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,10 @@ codegen: ## Run code generators.
 mod.check: go.mod.check ## Check if any go modules changed.
 mod.update: go.mod.update ## Update all go modules.
 
-clean: ## Remove all files that are created by building.
+clean: csv-clean ## Remove all files that are created by building.
 	@$(MAKE) go.mod.clean
 	@$(MAKE) -C images clean
 	@rm -fr $(OUTPUT_DIR) $(WORK_DIR)
-	@rm -fr cluster/olm/ceph/deploy/*
 
 distclean: clean ## Remove all files that are created by building or configuring.
 	@rm -fr $(CACHE_DIR)
@@ -160,6 +159,9 @@ prune: ## Prune cached artifacts.
 
 csv-ceph: ## Generate a CSV file for OLM.
 	@cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)
+
+csv-clean: ## Remove existing OLM files.
+	@rm -fr cluster/olm/ceph/deploy/* cluster/olm/ceph/templates/*
 
 .PHONY: all build.common cross.build.parallel
 .PHONY: build build.all install test check vet fmt codegen mod.check clean distclean prune


### PR DESCRIPTION
Currently olm will be removed as part of clean command, but it cleans up
all the dependent modules as well
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
