### PR TITLE
ceph: add external support for object store user

### DIFF
--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -56,7 +56,6 @@ const (
 	crushmapCreatedKey       = "initialCrushMapCreated"
 	enableFlexDriver         = "ROOK_ENABLE_FLEX_DRIVER"
 	detectCephVersionTimeout = 15 * time.Minute
-	externalConnectionRetry  = 60 * time.Second
 )
 
 const (

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -67,27 +65,15 @@ func IsReadyToReconcile(c client.Client, clustercontext *clusterd.Context, names
 
 	logger.Debugf("%q: CephCluster resource %q found in namespace %q", controllerName, cephCluster.Name, namespacedName.Namespace)
 
-	// If the cluster is healthy
-	// Test a Ceph command to verify the Operator is ready
-	// This is done to silence errors when the operator just started and cannot reconcile yet
-	status, err := cephclient.Status(clustercontext, namespacedName.Namespace)
-	if err != nil {
-		if strings.Contains(err.Error(), "error calling conf_read_file") {
-			logger.Infof("%q: operator is not ready to run ceph command, cannot reconcile yet.", controllerName)
-			return cephCluster, false, cephClusterExists, WaitForRequeueIfCephClusterNotReady
+	// read the CR status of the cluster
+	if cephCluster.Status.CephStatus != nil {
+		if cephCluster.Status.CephStatus.Health == "HEALTH_OK" || cephCluster.Status.CephStatus.Health == "HEALTH_WARN" {
+			logger.Debugf("%q: ceph status is %q, operator is ready to run ceph command, reconciling", controllerName, cephCluster.Status.CephStatus.Health)
+			return cephCluster, true, cephClusterExists, WaitForRequeueIfCephClusterNotReady
 		}
-		// We should not arrive there
-		logger.Errorf("%q: ceph command error %v", controllerName, err)
-		return cephCluster, false, cephClusterExists, ImmediateRetryResult
+		logger.Infof("%s: CephCluster %q found but skipping reconcile since ceph health is %q", controllerName, cephCluster.Name, cephCluster.Status.CephStatus)
 	}
 
-	// If Ceph status is ok we can reconcile
-	if status.Health.Status == "HEALTH_OK" || status.Health.Status == "HEALTH_WARN" {
-		logger.Debugf("%q: ceph status is %q, operator is ready to run ceph command, reconciling", controllerName, status.Health.Status)
-		return cephCluster, true, cephClusterExists, reconcile.Result{}
-	}
-
-	logger.Infof("%s: CephCluster %q found but skipping reconcile since Ceph health is %q", controllerName, cephCluster.Name, status.Health.Status)
 	return cephCluster, false, cephClusterExists, WaitForRequeueIfCephClusterNotReady
 }
 

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -146,7 +146,7 @@ var (
 	namespace = "rook-ceph"
 )
 
-func TestCephObjectStoreController(t *testing.T) {
+func TestCephFilesystemController(t *testing.T) {
 	// Set DEBUG logging
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
 	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
@@ -231,6 +231,9 @@ func TestCephObjectStoreController(t *testing.T) {
 		},
 		Status: cephv1.ClusterStatus{
 			Phase: "",
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
 		},
 	}
 	object = append(object, cephCluster)
@@ -270,6 +273,7 @@ func TestCephObjectStoreController(t *testing.T) {
 
 	// Add ready status to the CephCluster
 	cephCluster.Status.Phase = k8sutil.ReadyStatus
+	cephCluster.Status.CephStatus.Health = "HEALTH_OK"
 
 	// Create a fake client to mock API calls.
 	cl = fake.NewFakeClientWithScheme(s, object...)

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -158,6 +158,9 @@ func TestCephNFSController(t *testing.T) {
 		},
 		Status: cephv1.ClusterStatus{
 			Phase: "",
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
 		},
 	}
 	object = append(object, cephCluster)
@@ -197,6 +200,7 @@ func TestCephNFSController(t *testing.T) {
 
 	// Add ready status to the CephCluster
 	cephCluster.Status.Phase = k8sutil.ReadyStatus
+	cephCluster.Status.CephStatus.Health = "HEALTH_OK"
 
 	// Create a fake client to mock API calls.
 	cl = fake.NewFakeClientWithScheme(s, object...)

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -42,7 +42,7 @@ func RunAdminCommandNoRealm(c *Context, args ...string) (string, error) {
 	// start the rgw admin command
 	output, err := c.Context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return "", err
+		return output, err
 	}
 
 	return output, nil

--- a/pkg/operator/ceph/object/bucket/rgw-handlers.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers.go
@@ -91,15 +91,11 @@ func (p *Provisioner) deleteOBCResource(bucketName string) error {
 
 	logger.Infof("deleting Ceph user %s and bucket %q", p.cephUserName, bucketName)
 	if len(p.cephUserName) > 0 {
-		_, errCode, _ := cephObject.DeleteUser(p.objectContext, p.cephUserName)
-
-		if errCode == cephObject.RGWErrorNone {
-			logger.Infof("user %q successfully deleted", p.cephUserName)
-		} else if errCode == cephObject.RGWErrorNotFound {
-			// opinion: "not found" is not an error
-			logger.Infof("user %q does not exist", p.cephUserName)
+		output, err := cephObject.DeleteUser(p.objectContext, p.cephUserName)
+		if err != nil {
+			logger.Warningf("failed to delete user %q. %s. %v", p.cephUserName, output, err)
 		} else {
-			logger.Warningf("failed to delete user %q: errCode: %d", p.cephUserName, errCode)
+			logger.Infof("user %q successfully deleted", p.cephUserName)
 		}
 	}
 	if len(bucketName) > 0 {

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -225,6 +225,9 @@ func TestCephObjectStoreController(t *testing.T) {
 		},
 		Status: cephv1.ClusterStatus{
 			Phase: "",
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
 		},
 	}
 	object = append(object, cephCluster)
@@ -261,6 +264,10 @@ func TestCephObjectStoreController(t *testing.T) {
 	}
 	_, err = c.Clientset.CoreV1().Secrets(namespace).Create(secret)
 	assert.NoError(t, err)
+
+	// Add ready status to the CephCluster
+	cephCluster.Status.Phase = k8sutil.ReadyStatus
+	cephCluster.Status.CephStatus.Health = "HEALTH_OK"
 
 	// Create a fake client to mock API calls.
 	cl = fake.NewFakeClientWithScheme(s, object...)

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -164,21 +166,20 @@ func UpdateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 }
 
 // DeleteUser deletes the user with the given ID.
-func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
+func DeleteUser(c *Context, id string, opts ...string) (string, error) {
 	args := []string{"user", "rm", "--uid", id}
 	if opts != nil {
 		args = append(args, opts...)
 	}
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
-		if strings.Contains(result, "user does not exist") {
-			return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete. %s", id, result)
+		// If User does not exist return success
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
+			return result, nil
 		}
-
-		return "", RGWErrorUnknown, errors.Wrap(err, "failed to delete user")
 	}
 
-	return result, RGWErrorNone, nil
+	return result, errors.Wrap(err, "failed to delete user")
 }
 
 func SetQuotaUserBucketMax(c *Context, id string, max int) (string, int, error) {

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -172,7 +172,7 @@ func DeleteUser(c *Context, id string, opts ...string) (string, int, error) {
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
 		if strings.Contains(result, "user does not exist") {
-			return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete", id)
+			return "", RGWErrorNotFound, errors.Wrapf(err, "user %q does not exist so cannot delete. %s", id, result)
 		}
 
 		return "", RGWErrorUnknown, errors.Wrap(err, "failed to delete user")

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -452,13 +452,9 @@ func (r *ReconcileObjectStoreUser) getRgwPodList(cephObjectStoreUser *cephv1.Cep
 
 // Delete the user
 func (r *ReconcileObjectStoreUser) deleteUser(u *cephv1.CephObjectStoreUser) error {
-	_, rgwerr, err := object.DeleteUser(r.objContext, u.Name)
+	output, err := object.DeleteUser(r.objContext, u.Name)
 	if err != nil {
-		if rgwerr == 2 {
-			logger.Infof("ceph object user %q does not exist in store %q", u.Name, u.Spec.Store)
-		} else {
-			return errors.Wrapf(err, "failed to delete ceph object user %q", u.Name)
-		}
+		return errors.Wrapf(err, "failed to delete ceph object user %q. %v", u.Name, output)
 	}
 
 	logger.Infof("ceph object user %q deleted successfully", u.Name)

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,6 +37,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	cephconfig "github.com/rook/rook/pkg/daemon/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/object"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	corev1 "k8s.io/api/core/v1"
@@ -63,11 +65,13 @@ var controllerTypeMeta = metav1.TypeMeta{
 
 // ReconcileObjectStoreUser reconciles a ObjectStoreUser object
 type ReconcileObjectStoreUser struct {
-	client     client.Client
-	scheme     *runtime.Scheme
-	context    *clusterd.Context
-	objContext *object.Context
-	userConfig object.ObjectUser
+	client          client.Client
+	scheme          *runtime.Scheme
+	context         *clusterd.Context
+	objContext      *object.Context
+	userConfig      object.ObjectUser
+	cephClusterSpec *cephv1.ClusterSpec
+	clusterInfo     *cephconfig.ClusterInfo
 }
 
 // Add creates a new CephObjectStoreUser Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -148,7 +152,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deleteUser() function since everything is gone already
@@ -168,12 +172,26 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		}
 		return reconcileResponse, nil
 	}
+	r.cephClusterSpec = &cephCluster.Spec
 
 	// Set a finalizer so we can do cleanup before the object goes away
 	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephObjectStoreUser)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
 	}
+
+	// Populate clusterInfo
+	// Always populate it during each reconcile
+	var clusterInfo *cephconfig.ClusterInfo
+	if r.cephClusterSpec.External.Enable {
+		clusterInfo = mon.PopulateExternalClusterInfo(r.context, request.NamespacedName.Namespace)
+	} else {
+		clusterInfo, _, _, err = mon.LoadClusterInfo(r.context, request.NamespacedName.Namespace)
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to populate cluster info")
+		}
+	}
+	r.clusterInfo = clusterInfo
 
 	// validate isObjectStoreInitialized
 	objContext, err := r.isObjectStoreInitialized(cephObjectStoreUser)
@@ -200,10 +218,15 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	userConfig := generateUserConfig(cephObjectStoreUser)
 	r.userConfig = userConfig
 
+	// Set the cephx external username if the CephCluster is external
+	if r.cephClusterSpec.External.Enable {
+		r.objContext.RunAsUser = r.clusterInfo.ExternalCred.Username
+	}
+
 	// DELETE: the CR was deleted
 	if !cephObjectStoreUser.GetDeletionTimestamp().IsZero() {
 		logger.Debugf("deleting pool %q", cephObjectStoreUser.Name)
-		err := deleteUser(r.context, cephObjectStoreUser)
+		err := r.deleteUser(cephObjectStoreUser)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrapf(err, "failed to delete ceph object user %q", cephObjectStoreUser.Name)
 		}
@@ -219,7 +242,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	}
 
 	// validate the user settings
-	err = ValidateUser(cephObjectStoreUser)
+	err = r.validateUser(cephObjectStoreUser)
 	if err != nil {
 		updateStatus(r.client, request.NamespacedName, k8sutil.ReconcileFailedStatus)
 		return reconcile.Result{}, errors.Wrapf(err, "invalid pool CR %q spec", cephObjectStoreUser.Name)
@@ -285,6 +308,13 @@ func (r *ReconcileObjectStoreUser) createCephUser(u *cephv1.CephObjectStoreUser)
 
 func (r *ReconcileObjectStoreUser) isObjectStoreInitialized(u *cephv1.CephObjectStoreUser) (*object.Context, error) {
 	objContext := object.NewContext(r.context, u.Spec.Store, u.Namespace)
+
+	// If the cluster is external just return
+	// we don't need to validate u.Spec.Store
+	if r.cephClusterSpec.External.Enable {
+		return objContext, nil
+	}
+
 	err := r.objectStoreInitialized(u)
 	if err != nil {
 		return objContext, errors.Wrap(err, "failed to detect if object store is initialized")
@@ -356,12 +386,14 @@ func (r *ReconcileObjectStoreUser) reconcileCephUserSecret(cephObjectStoreUser *
 }
 
 func (r *ReconcileObjectStoreUser) objectStoreInitialized(cephObjectStoreUser *cephv1.CephObjectStoreUser) error {
-	err := r.getObjectStore(cephObjectStoreUser)
+	err := r.getObjectStore(cephObjectStoreUser.Spec.Store)
 	if err != nil {
 		return err
 	}
 	logger.Debug("CephObjectStore exists")
 
+	// There are no pods running when the cluster is external
+	// Unless you pass the admin key...
 	pods, err := r.getRgwPodList(cephObjectStoreUser)
 	if err != nil {
 		return err
@@ -376,18 +408,25 @@ func (r *ReconcileObjectStoreUser) objectStoreInitialized(cephObjectStoreUser *c
 	return errors.New("no rgw pod found")
 }
 
-func (r *ReconcileObjectStoreUser) getObjectStore(cephObjectStoreUser *cephv1.CephObjectStoreUser) error {
+func (r *ReconcileObjectStoreUser) getObjectStore(storeName string) error {
 	// check if CephObjectStore CR is created
 	objectStores := &cephv1.CephObjectStoreList{}
 	err := r.client.List(context.TODO(), objectStores)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.Wrapf(err, "CephObjectStore %q could not be found", cephObjectStoreUser.Name)
+			return errors.Wrapf(err, "CephObjectStore %q could not be found", storeName)
 		}
 		return errors.Wrap(err, "failed to get CephObjectStore")
 	}
 
-	return nil
+	for _, store := range objectStores.Items {
+		if store.Name == storeName {
+			logger.Infof("CephObjectStore %q found", storeName)
+			return nil
+		}
+	}
+
+	return errors.Errorf("CephObjectStore %q could not be found", storeName)
 }
 
 func (r *ReconcileObjectStoreUser) getRgwPodList(cephObjectStoreUser *cephv1.CephObjectStoreUser) (*corev1.PodList, error) {
@@ -412,11 +451,10 @@ func (r *ReconcileObjectStoreUser) getRgwPodList(cephObjectStoreUser *cephv1.Cep
 }
 
 // Delete the user
-func deleteUser(context *clusterd.Context, u *cephv1.CephObjectStoreUser) error {
-	objContext := object.NewContext(context, u.Spec.Store, u.Namespace)
-	_, rgwerr, err := object.DeleteUser(objContext, u.Name)
+func (r *ReconcileObjectStoreUser) deleteUser(u *cephv1.CephObjectStoreUser) error {
+	_, rgwerr, err := object.DeleteUser(r.objContext, u.Name)
 	if err != nil {
-		if rgwerr == 3 {
+		if rgwerr == 2 {
 			logger.Infof("ceph object user %q does not exist in store %q", u.Name, u.Spec.Store)
 		} else {
 			return errors.Wrapf(err, "failed to delete ceph object user %q", u.Name)
@@ -427,16 +465,18 @@ func deleteUser(context *clusterd.Context, u *cephv1.CephObjectStoreUser) error 
 	return nil
 }
 
-// ValidateUser validates the user arguments
-func ValidateUser(u *cephv1.CephObjectStoreUser) error {
+// validateUser validates the user arguments
+func (r *ReconcileObjectStoreUser) validateUser(u *cephv1.CephObjectStoreUser) error {
 	if u.Name == "" {
 		return errors.New("missing name")
 	}
 	if u.Namespace == "" {
 		return errors.New("missing namespace")
 	}
-	if u.Spec.Store == "" {
-		return errors.New("missing store")
+	if !r.cephClusterSpec.External.Enable {
+		if u.Spec.Store == "" {
+			return errors.New("missing store")
+		}
 	}
 	return nil
 }

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -323,6 +323,9 @@ func TestCephBlockPoolController(t *testing.T) {
 			CephVersion: &cephv1.ClusterVersion{
 				Version: "14.2.9-0",
 			},
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
 		},
 	}
 
@@ -346,6 +349,8 @@ func TestCephBlockPoolController(t *testing.T) {
 	// SUCCESS! The CephCluster is ready
 	//
 	cephCluster.Status.Phase = k8sutil.ReadyStatus
+	cephCluster.Status.CephStatus.Health = "HEALTH_OK"
+
 	objects := []runtime.Object{
 		pool,
 		cephCluster,

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
-	"github.com/pkg/errors"
 )
 
 // Executor is the main interface for all the exec commands
@@ -259,17 +258,21 @@ func logOutput(stdout, stderr io.ReadCloser) {
 func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 	var output []byte
 	var err error
+	var out string
 
 	if combinedOutput {
 		output, err = cmd.CombinedOutput()
 	} else {
 		output, err = cmd.Output()
+		if err != nil {
+			out = fmt.Sprintf("%s. %s", string(output), string(err.(*exec.ExitError).Stderr))
+		}
 	}
 
-	out := strings.TrimSpace(string(output))
+	out = strings.TrimSpace(string(output))
 
 	if err != nil {
-		return out, errors.Wrapf(err, "%s", string(err.(*exec.ExitError).Stderr))
+		return out, err
 	}
 
 	return out, nil

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 )
 
 // Executor is the main interface for all the exec commands
@@ -268,7 +269,7 @@ func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 	out := strings.TrimSpace(string(output))
 
 	if err != nil {
-		return out, err
+		return out, errors.Wrapf(err, "%s", string(err.(*exec.ExitError).Stderr))
 	}
 
 	return out, nil


### PR DESCRIPTION
**Description of your changes:**

Now, the object store user is capable of creating s3 users on an
external Ceph cluster.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
