### PR TITLE
ceph: Update maxMonId if incorrect

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -281,23 +281,23 @@ func TestMonInQuorum(t *testing.T) {
 
 func TestNameToIndex(t *testing.T) {
 	// invalid
-	id, err := fullNameToIndex("m")
+	id, err := fullNameToIndex("rook-ceph-monitor0")
 	assert.NotNil(t, err)
 	assert.Equal(t, -1, id)
-	id, err = fullNameToIndex("mon")
-	assert.NotNil(t, err)
-	assert.Equal(t, -1, id)
-	id, err = fullNameToIndex("rook-ceph-monitor0")
+	id, err = fullNameToIndex("rook-ceph-mon123")
 	assert.NotNil(t, err)
 	assert.Equal(t, -1, id)
 
 	// valid
+	id, err = fullNameToIndex("b")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, id)
+	id, err = fullNameToIndex("m")
+	assert.Nil(t, err)
+	assert.Equal(t, 12, id)
 	id, err = fullNameToIndex("rook-ceph-mon-a")
 	assert.Nil(t, err)
 	assert.Equal(t, 0, id)
-	id, err = fullNameToIndex("rook-ceph-mon123")
-	assert.Nil(t, err)
-	assert.Equal(t, 123, id)
 }
 
 func TestWaitForQuorum(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the operator loads the mons and checks for a valid maxMonId the check of the id against the currently running mons was outdated from legacy mon ids. The check now has to parse the new id which is just the letter instead of having a number from legacy mon ids. Without this fix, the maxMonId would stay incorrect if it was somehow corrupted.

**Which issue is resolved by this Pull Request:**
Resolves #5644 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
