### PR TITLE
ceph: adding support for quota in object bucket claims

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -28,7 +28,8 @@ spec:
   generateBucketName: photo-booth [4]
   storageClassName: rook-ceph-bucket [4]
   additionalConfig: [5]
-    ANY_KEY: VALUE ...
+    maxObjects: "1000"
+    maxSize: "2G"
 ```
 1. `name` of the `ObjectBucketClaim`. This name becomes the name of the Secret and ConfigMap.
 1. `namespace`(optional) of the `ObjectBucketClaim`, which is also the namespace of the ConfigMap and Secret.
@@ -39,7 +40,9 @@ an entire object store.
 If both `bucketName` and `generateBucketName` are supplied then `BucketName` has precedence and `GenerateBucketName` is ignored.
 If both `bucketName` and `generateBucketName` are blank or omitted then the storage class is expected to contain the name of an _existing_ bucket. It's an error if all three bucket related names are blank or omitted.
 1. `storageClassName` which defines the StorageClass which contains the names of the bucket provisioner, the object-store and specifies the bucket retention policy.
-1. `additionalConfig` is an optional list of key-value pairs used to define attributes specific to the bucket being provisioned by this OBC. This information is typically tuned to a particular bucket provisioner and may limit application portability. Examples can include config values such as tenant, user and policy settings, etc.
+1. `additionalConfig` is an optional list of key-value pairs used to define attributes specific to the bucket being provisioned by this OBC. This information is typically tuned to a particular bucket provisioner and may limit application portability. Options supported:
+  - `maxObjects`: The maximum number of objects in the bucket
+  - `maxSize`: The maximum size of the bucket, please note minimum recommended value is 4K.
 
 ### OBC Custom Resource after Bucket Provisioning
 ```yaml

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -23,6 +23,7 @@
 - OBC changes:
   - Updated lib bucket provisioner version to support multithread and required change can be found in [operator.yaml](cluster/examples/kubernetes/ceph/operator.yaml#L449)
     - Can be extended to add support for other providers
+  - Added support for [quota](Documentation/ceph-object-bucket-claim.md#obc-custom-resource), have options for object count and total size.
 - CephObjectStore CRD changes:
   - Health displayed in the Status field
   - Supports connecting to external Ceph Rados Gateways, refer to the [external object section](Documentation/ceph-object.html#connect-to-external-object-store)

--- a/cluster/examples/kubernetes/ceph/object-bucket-claim-delete.yaml
+++ b/cluster/examples/kubernetes/ceph/object-bucket-claim-delete.yaml
@@ -11,3 +11,7 @@ spec:
   #bucketName: 
   generateBucketName: ceph-bkt
   storageClassName: rook-ceph-delete-bucket
+  additionalConfig:
+    # To set for quota for OBC
+    #maxObjects: "1000"
+    #maxSize: "2G"

--- a/cluster/examples/kubernetes/ceph/object-bucket-claim-retain.yaml
+++ b/cluster/examples/kubernetes/ceph/object-bucket-claim-retain.yaml
@@ -11,3 +11,7 @@ spec:
   #bucketName: 
   generateBucketName: ceph-bkt
   storageClassName: rook-ceph-retain-bucket
+  additionalConfig:
+    # To set for quota for OBC
+    #maxObjects: "1000"
+    #maxSize: "2G"

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -94,8 +94,8 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		return nil, err
 	}
 
-	_, errCode, err := cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, maxBuckets)
-	if errCode > 0 {
+	_, err = cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, maxBuckets)
+	if err != nil {
 		p.deleteOBCResourceLogError(p.bucketName)
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	}
 
 	// need to quota into -1 for restricting creation of new buckets in rgw
-	_, _, err = cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, -1)
+	_, err = cephObject.SetQuotaUserBucketMax(p.objectContext, p.cephUserName, -1)
 	if err != nil {
 		p.deleteOBCResourceLogError("")
 		return nil, err

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner"
+	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -133,4 +134,12 @@ func randomString(n int) string {
 		b[i] = letterRunes[r.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func MaxObjectQuota(options *apibkt.BucketOptions) string {
+	return options.ObjectBucketClaim.Spec.AdditionalConfig["maxObjects"]
+}
+
+func MaxSizeQuota(options *apibkt.BucketOptions) string {
+	return options.ObjectBucketClaim.Spec.AdditionalConfig["maxSize"]
 }

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -183,6 +183,7 @@ func DeleteUser(c *Context, id string, opts ...string) (string, error) {
 	return result, errors.Wrap(err, "failed to delete s3 user")
 }
 
+// SetQuotaUserBucketMax will set maximum bucket quota for a user
 func SetQuotaUserBucketMax(c *Context, id string, max int) (string, error) {
 	logger.Infof("Setting user %q max buckets to %d", id, max)
 	args := []string{"--quota-scope", "user", "--max-buckets", strconv.Itoa(max)}
@@ -202,6 +203,7 @@ func setUserQuota(c *Context, id string, args []string) (string, error) {
 	return result, err
 }
 
+// LinkUser will link a user to a bucket
 func LinkUser(c *Context, id, bucket string) (string, int, error) {
 	logger.Infof("Linking (user: %s) (bucket: %s)", id, bucket)
 	args := []string{"bucket", "link", "--uid", id, "--bucket", bucket}
@@ -215,6 +217,7 @@ func LinkUser(c *Context, id, bucket string) (string, int, error) {
 	return result, RGWErrorNone, nil
 }
 
+// UnlinkUser will unlink the user from a bucket
 func UnlinkUser(c *Context, id, bucket string) (string, int, error) {
 	logger.Infof("Unlinking (user: %s) (bucket: %s)", id, bucket)
 	args := []string{"bucket", "unlink", "--uid", id, "--bucket", bucket}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -230,3 +230,37 @@ func UnlinkUser(c *Context, id, bucket string) (string, int, error) {
 	}
 	return result, RGWErrorNone, nil
 }
+
+// EnableUserQuota will allows to enable quota defined for a user
+func EnableUserQuota(c *Context, id string) (string, error) {
+	logger.Debug("Enabling user quota for %q", id)
+	args := append([]string{"quota", "enable", "--quota-scope", "user", "--uid", id})
+	result, err := runAdminCommand(c, args...)
+	if err != nil {
+		err = errors.Wrap(err, "failed to enable quota for the user")
+	}
+	return result, err
+
+}
+
+// SetQuotaUserObject allows to set maximum limit on objects for a user
+func SetQuotaUserObjectMax(c *Context, id string, maxobjects string) (string, error) {
+	logger.Debugf("Setting user %q max objects to %s", id, maxobjects)
+	args := []string{"--quota-scope", "user", "--max-objects", maxobjects}
+	result, err := setUserQuota(c, id, args)
+	if err != nil {
+		err = errors.Wrap(err, "failed setting object max")
+	}
+	return result, err
+}
+
+// SetQuotaUserMaxSize allows to set maximum size for a user
+func SetQuotaUserMaxSize(c *Context, id string, maxsize string) (string, error) {
+	logger.Debugf("Setting user %q max size to %s", id, maxsize)
+	args := []string{"--quota-scope", "user", "--max-size", maxsize}
+	result, err := setUserQuota(c, id, args)
+	if err != nil {
+		err = errors.Wrap(err, "failed setting max size")
+	}
+	return result, err
+}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -183,23 +183,23 @@ func DeleteUser(c *Context, id string, opts ...string) (string, error) {
 	return result, errors.Wrap(err, "failed to delete s3 user")
 }
 
-func SetQuotaUserBucketMax(c *Context, id string, max int) (string, int, error) {
+func SetQuotaUserBucketMax(c *Context, id string, max int) (string, error) {
 	logger.Infof("Setting user %q max buckets to %d", id, max)
 	args := []string{"--quota-scope", "user", "--max-buckets", strconv.Itoa(max)}
-	result, errCode, err := setUserQuota(c, id, args)
-	if errCode != RGWErrorNone {
+	result, err := setUserQuota(c, id, args)
+	if err != nil {
 		err = errors.Wrap(err, "failed setting bucket max")
 	}
-	return result, errCode, err
+	return result, err
 }
 
-func setUserQuota(c *Context, id string, args []string) (string, int, error) {
+func setUserQuota(c *Context, id string, args []string) (string, error) {
 	args = append([]string{"quota", "set", "--uid", id}, args...)
 	result, err := runAdminCommand(c, args...)
 	if err != nil {
 		err = errors.Wrap(err, "failed to set max buckets for user")
 	}
-	return result, RGWErrorNone, err
+	return result, err
 }
 
 func LinkUser(c *Context, id, bucket string) (string, int, error) {

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -44,12 +44,12 @@ func (b *BucketOperation) DeleteBucketStorageClass(namespace string, storeName s
 	return err
 }
 
-func (b *BucketOperation) CreateObc(obcName string, storageClassName string, bucketName string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("create", b.manifests.GetObc(obcName, storageClassName, bucketName, createBucket))
+func (b *BucketOperation) CreateObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("create", b.manifests.GetObc(obcName, storageClassName, bucketName, maxObject, createBucket))
 }
 
-func (b *BucketOperation) DeleteObc(obcName string, storageClassName string, bucketName string, createBucket bool) error {
-	return b.k8sh.ResourceOperation("delete", b.manifests.GetObc(obcName, storageClassName, bucketName, createBucket))
+func (b *BucketOperation) DeleteObc(obcName string, storageClassName string, bucketName string, maxObject string, createBucket bool) error {
+	return b.k8sh.ResourceOperation("delete", b.manifests.GetObc(obcName, storageClassName, bucketName, maxObject, createBucket))
 }
 
 // CheckOBC, returns true if the obc, secret and configmap are all in the "check" state,

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -49,7 +49,7 @@ type CephManifests interface {
 	GetObjectStore(namespace, name string, replicaCount, port int) string
 	GetObjectStoreUser(namespace, name, displayName, store string) string
 	GetBucketStorageClass(namespace, storeName, storageClassName, reclaimPolicy, region string) string
-	GetObc(obcName, storageClassName, bucketName string, createBucket bool) string
+	GetObc(obcName, storageClassName, bucketName string, maxObject string, createBucket bool) string
 	GetClient(namespace, name string, caps map[string]string) string
 }
 
@@ -2294,7 +2294,7 @@ parameters:
 }
 
 //GetObc returns the manifest to create object bucket claim
-func (m *CephManifestsMaster) GetObc(claimName string, storageClassName string, objectBucketName string, varBucketName bool) string {
+func (m *CephManifestsMaster) GetObc(claimName string, storageClassName string, objectBucketName string, maxObject string, varBucketName bool) string {
 	bucketParameter := "generateBucketName"
 	if varBucketName {
 		bucketParameter = "bucketName"
@@ -2305,7 +2305,9 @@ metadata:
   name: ` + claimName + `
 spec:
   ` + bucketParameter + `: ` + objectBucketName + `
-  storageClassName: ` + storageClassName
+  storageClassName: ` + storageClassName + `
+  additionalConfig:
+    maxObjects: "` + maxObject + `"`
 }
 
 func (m *CephManifestsMaster) GetClient(namespace string, claimName string, caps map[string]string) string {

--- a/tests/framework/installer/ceph_manifests_v1.2.go
+++ b/tests/framework/installer/ceph_manifests_v1.2.go
@@ -1903,7 +1903,7 @@ parameters:
 }
 
 //GetObc returns the manifest to create object bucket claim
-func (m *CephManifestsV1_2) GetObc(claimName string, storageClassName string, objectBucketName string, varBucketName bool) string {
+func (m *CephManifestsV1_2) GetObc(claimName string, storageClassName string, objectBucketName string, maxObject string, varBucketName bool) string {
 	bucketParameter := "generateBucketName"
 	if varBucketName {
 		bucketParameter = "bucketName"
@@ -1914,7 +1914,9 @@ metadata:
   name: ` + claimName + `
 spec:
   ` + bucketParameter + `: ` + objectBucketName + `
-  storageClassName: ` + storageClassName
+  storageClassName: ` + storageClassName + `
+  additionalConfig:
+    maxObjects: "` + maxObject + `"`
 }
 
 func (m *CephManifestsV1_2) GetClient(namespace string, claimName string, caps map[string]string) string {

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -56,6 +56,7 @@ import (
 // - Create/delete buckets
 // - Create/delete users
 // - PUT/GET objects
+// - Quota limit wrt no of objects
 // ************************************************
 func TestCephSmokeSuite(t *testing.T) {
 	if installer.SkipTestSuite(installer.CephTestSuite) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Adding support for quota in Object bucket claims. Currently users can set quota on bucket/user via toolbox using radosgw-admin command. With this change there is configurable parameter in object bucket claim CRD 

Please not the quota scope used is here is user, so that OBC with same bucket can have different quota.

**Which issue is resolved by this Pull Request:**
Resolves #5274

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
