### PR TITLE
ceph: fix an argument name

### DIFF
--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -37,8 +37,8 @@ const (
 )
 
 // CreateCrashCollectorSecret creates the Kubernetes Crash Collector Secret
-func CreateCrashCollectorSecret(context *clusterd.Context, clusterName string, ownerRef *metav1.OwnerReference) error {
-	k := keyring.GetSecretStore(context, clusterName, ownerRef)
+func CreateCrashCollectorSecret(context *clusterd.Context, namespace string, ownerRef *metav1.OwnerReference) error {
+	k := keyring.GetSecretStore(context, namespace, ownerRef)
 
 	// Create CrashCollector Ceph key
 	crashCollectorSecretKey, err := createCrashCollectorKeyring(k)
@@ -47,7 +47,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterName string, o
 	}
 
 	// Create or update Kubernetes CSI secret
-	if err := createOrUpdateCrashCollectorSecret(clusterName, crashCollectorSecretKey, k, ownerRef); err != nil {
+	if err := createOrUpdateCrashCollectorSecret(namespace, crashCollectorSecretKey, k, ownerRef); err != nil {
 		return errors.Wrap(err, "failed to create kubernetes csi secret")
 	}
 


### PR DESCRIPTION
When I was debugging, I noticed that [`CreateCrashCollectorSecret` function](https://github.com/rook/rook/blob/master/pkg/operator/ceph/cluster/crash/keyring.go#L40) have `clusterName` as its second argument, but the passed value is the namespace ([this](https://github.com/rook/rook/blob/master/pkg/operator/ceph/cluster/cluster_external.go#L129) and [this](https://github.com/rook/rook/blob/master/pkg/operator/ceph/cluster/cluster.go#L411)) and the `clusterName`  is also used as the namespace in the functions which gets the value ([this](https://github.com/rook/rook/blob/master/pkg/operator/ceph/config/keyring/store.go#L49) and [this](https://github.com/rook/rook/blob/master/pkg/operator/ceph/cluster/crash/keyring.go#L73)).

Therefore, this commit fixes the argument name as `namespace`.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
