### PR TITLE
ceph: fix the wrong document of tuneDeviceClass

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -69,7 +69,7 @@ spec:
     - name: set1
       count: 3
       portable: false
-      tuneSlowDeviceClass: false
+      tuneDeviceClass: false
       volumeClaimTemplates:
       - metadata:
           name: data
@@ -330,7 +330,7 @@ The following are the settings for Storage Class Device Sets which can be config
   However, if there are more OSDs than nodes, this anti-affinity will not be effective. Another placement scheme to consider is to add labels to the nodes in such a way that the OSDs can be grouped on those nodes, create multiple storageClassDeviceSets, and add node affinity to each of the device sets that will place the OSDs in those sets of nodes.
 
 * `portable`: If `true`, the OSDs will be allowed to move between nodes during failover. This requires a storage class that supports portability (e.g. `aws-ebs`, but not the local storage provisioner). If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
-* `tuneSlowDeviceClass`: If `true`, because the OSD can be on a slow device class, Rook will adapt to that by tuning the OSD process. This will make Ceph perform better under that slow device.
+* `tuneDeviceClass`: If `true`, because the OSD can be on a slow device class, Rook will adapt to that by tuning the OSD process. This will make Ceph perform better under that slow device.
 * `volumeClaimTemplates`: A list of PVC templates to use for provisioning the underlying storage devices.
   * `resources.requests.storage`: The desired capacity for the underlying storage devices.
   * `storageClassName`: The StorageClass to provision PVCs from. Default would be to use the cluster-default StorageClass. This StorageClass should provide a raw block device, multipath device, or logical volume. Other types are not supported.
@@ -737,7 +737,7 @@ spec:
     - name: set1
       count: 3
       portable: false
-      tuneSlowDeviceClass: false
+      tuneDeviceClass: false
       resources:
         limits:
           cpu: "500m"
@@ -791,7 +791,7 @@ So just taking the `storage` section this will give something like:
     - name: set1
       count: 3
       portable: false
-      tuneSlowDeviceClass: false
+      tuneDeviceClass: false
       volumeClaimTemplates:
       - metadata:
           name: data

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -57,7 +57,7 @@ spec:
       # Certain storage class in the Cloud are slow
       # Rook can configure the OSD running on PVC to accommodate that by tuning some of the Ceph internal
       # Currently, "gp2" has been identified as such
-      tuneSlowDeviceClass: true
+      tuneDeviceClass: true
       # Since the OSDs could end up on any node, an effort needs to be made to spread the OSDs
       # across nodes as much as possible. Unfortunately the pod anti-affinity breaks down
       # as soon as you have more than one OSD per node. If you have more OSDs than nodes, K8s may

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1937,7 +1937,7 @@ spec:
     - name: set1
       count: 1
       portable: false
-      tuneSlowDeviceClass: true
+      tuneDeviceClass: true
       volumeClaimTemplates:
       - metadata:
           name: data

--- a/tests/framework/installer/ceph_manifests_v1.2.go
+++ b/tests/framework/installer/ceph_manifests_v1.2.go
@@ -1650,7 +1650,7 @@ spec:
     - name: set1
       count: 1
       portable: false
-      tuneSlowDeviceClass: true
+      tuneDeviceClass: true
       volumeClaimTemplates:
       - metadata:
           name: data


### PR DESCRIPTION
**Description of your changes:**

The tuning parameter of slow devices is defined as "tuneDeviceClass". However, it's written in the document as "tuneSlowDeviceClass".

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]