### PR TITLE
ceph: During mon failover remove the backing pvc

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -312,6 +312,15 @@ func (c *Cluster) removeMon(daemonName string) error {
 		}
 	}
 
+	// Remove the PVC backing the mon if it existed
+	if err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.Namespace).Delete(resourceName, &metav1.DeleteOptions{}); err != nil {
+		if kerrors.IsNotFound(err) {
+			logger.Infof("mon pvc did not exist %q", resourceName)
+		} else {
+			logger.Errorf("failed to remove dead mon pvc %q. %v", resourceName, err)
+		}
+	}
+
 	if err := c.saveMonConfig(); err != nil {
 		return errors.Wrapf(err, "failed to save mon config after failing over mon %s", daemonName)
 	}

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -275,6 +275,7 @@ func (c *Cluster) failoverMon(name string) error {
 	return c.removeMon(name)
 }
 
+// make a best effort to remove the mon and all its resources
 func (c *Cluster) removeMon(daemonName string) error {
 	logger.Infof("ensuring removal of unhealthy monitor %s", daemonName)
 
@@ -288,13 +289,13 @@ func (c *Cluster) removeMon(daemonName string) error {
 		if kerrors.IsNotFound(err) {
 			logger.Infof("dead mon %s was already gone", resourceName)
 		} else {
-			return errors.Wrapf(err, "failed to remove dead mon deployment %s", resourceName)
+			logger.Errorf("failed to remove dead mon deployment %q. %v", resourceName, err)
 		}
 	}
 
 	// Remove the bad monitor from quorum
 	if err := removeMonitorFromQuorum(c.context, c.ClusterInfo.Name, daemonName); err != nil {
-		return errors.Wrapf(err, "failed to remove mon %s from quorum", daemonName)
+		logger.Errorf("failed to remove mon %q from quorum. %v", daemonName, err)
 	}
 	delete(c.ClusterInfo.Monitors, daemonName)
 	// check if a mapping exists for the mon
@@ -307,7 +308,7 @@ func (c *Cluster) removeMon(daemonName string) error {
 		if kerrors.IsNotFound(err) {
 			logger.Infof("dead mon service %s was already gone", resourceName)
 		} else {
-			return errors.Wrapf(err, "failed to remove dead mon service %s", resourceName)
+			logger.Errorf("failed to remove dead mon service %q. %v", resourceName, err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two improvements to mon failover:
- If the mon is backed by a pvc, ensure the pvc is deleted when the mon is failed over. The pvc was being left in a bound state even though it will no longer be used in the cluster.
- During mon failover if the mon fails to be removed, the new mon config was not being saved. The mon removal anyway is not retried if it fails, so it should make a best effort to remove all the resources related to the mon, and then always update the mon config after the failover.

**Which issue is resolved by this Pull Request:**
Resolves #5644 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
