### PR TITLE
cassandra: update base image to alpine:3.12

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,6 +22,8 @@
 
 ### Cassandra
 
+- Updated Base image from Alpine 3.8 to 3.12 due to CVEs.
+
 ## Breaking Changes
 
 ### Ceph

--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -12,7 +12,7 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 ARG ARCH
 ARG TINI_VERSION


### PR DESCRIPTION
**Description of your changes:**

Due to CVEs in the alpine:3.8, we need to update the base image.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

[test cassandra]

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
