### PR TITLE
Revert "ceph: fix exec output"

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -265,7 +265,7 @@ func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 	} else {
 		output, err = cmd.Output()
 		if err != nil {
-			output = []byte(fmt.Sprintf("%s. %s", string(output), string(err.(*exec.ExitError).Stderr)))
+			out = fmt.Sprintf("%s. %s", string(output), string(err.(*exec.ExitError).Stderr))
 		}
 	}
 


### PR DESCRIPTION
Reverts rook/rook#5696

The modified output is causing an error in the OBC integration tests. Reverting the change until it can be more closely analyzed...
```
    --- FAIL: TestCephSmokeSuite/TestObjectStorage_SmokeTest (112.71s)
        ceph_base_object_test.go:116: 
            	Error Trace:	ceph_base_object_test.go:116
            	            				ceph_smoke_test.go:118
            	Error:      	Should not be: 4
            	Test:       	TestCephSmokeSuite/TestObjectStorage_SmokeTest
```

This issue was masked in the CI because of another intermittent issue that is getting more common (see #5711).