### PR TITLE
CI: Stop downgrading the kubeadm components for the integration tests

### DIFF
--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -43,26 +43,8 @@ sudo cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
-#install kubeadm and kubelet
 sudo apt-get update
 wait_for_dpkg_unlock
 sleep 5
 wait_for_dpkg_unlock
-sudo apt-get install -y --allow-downgrades kubernetes-cni="0.6.0-00"
-sudo apt-get install -y --allow-downgrades kubelet="${KUBE_INSTALL_VERSION}"  && sudo apt-get install -y --allow-downgrades kubeadm="${KUBE_INSTALL_VERSION}"
-
-#get matching kubectl
-case ${ARCH} in
-    amd64|arm64)
-        wget "https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/${ARCH}/kubectl"
-        ;;
-    *)
-        echo "[ERROR] Unsupported build ARCH ${ARCH}"
-        exit 1
-        ;;
-esac
-
-chmod +x kubectl
-sudo cp kubectl /usr/local/bin
-
-sudo apt-get install -y nfs-common
+sudo apt-get install -y kubelet="${KUBE_INSTALL_VERSION}" kubeadm="${KUBE_INSTALL_VERSION}" nfs-common


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Experimenting with the CI script to resolve the issue with kubeadm on older versions than k8s 1.18 where the cluster is failing to start.

**Which issue is resolved by this Pull Request:**
Resolves #5711 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

// run minimal tests just so the integration tests are triggered
[test nfs]