### PR TITLE
ceph: report secret in cephobjectstoreuser status field 

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -503,8 +503,13 @@ type BucketStatus struct {
 type CephObjectStoreUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
-	Spec              ObjectStoreUserSpec `json:"spec"`
-	Status            *Status             `json:"status"`
+	Spec              ObjectStoreUserSpec    `json:"spec"`
+	Status            *ObjectStoreUserStatus `json:"status"`
+}
+
+type ObjectStoreUserStatus struct {
+	Phase string            `json:"phase,omitempty"`
+	Info  map[string]string `json:"info"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -561,7 +561,7 @@ func (in *CephObjectStoreUser) DeepCopyInto(out *CephObjectStoreUser) {
 	out.Spec = in.Spec
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status
-		*out = new(Status)
+		*out = new(ObjectStoreUserStatus)
 		**out = **in
 	}
 	return

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -296,3 +296,18 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	assert.Equal(t, "Ready", objectUser.Status.Phase, objectUser)
 	logger.Info("PHASE 5 DONE")
 }
+
+func TestBuildUpdateStatusInfo(t *testing.T) {
+	cephObjectStoreUser := &cephv1.CephObjectStoreUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cephv1.ObjectStoreUserSpec{
+			Store: store,
+		},
+	}
+
+	statusInfo := generateStatusInfo(cephObjectStoreUser)
+	assert.NotEmpty(t, statusInfo["secretName"])
+	assert.Equal(t, "rook-ceph-object-user-my-store-my-user", statusInfo["secretName"])
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->
adding secret name in cephobjectstoreUser
status field in order to programmatically
retrieve the name of the secret generated
by the cephobjectstoreuser crd.

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5684

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.