### PR TITLE
tests: fix aws_1.11.x test failure

### DIFF
--- a/tests/scripts/kubeadm-install.sh
+++ b/tests/scripts/kubeadm-install.sh
@@ -47,7 +47,7 @@ sudo apt-get update
 wait_for_dpkg_unlock
 sleep 5
 wait_for_dpkg_unlock
-sudo apt-get install -y kubernetes-cni="0.6.0-00"
+sudo apt-get install -y kubernetes-cni="0.7.5-00"
 sudo apt-get install -y kubelet="${KUBE_INSTALL_VERSION}"  && sudo apt-get install -y kubeadm="${KUBE_INSTALL_VERSION}"
 
 #get matching kubectl


### PR DESCRIPTION
**Description of your changes:**

kubelet in aws_1.11.x test requires kubernetes-cni 0.7.5.

**Which issue is resolved by this Pull Request:**

Nothing.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]