### PR TITLE
ceph: Update master to the latest Octopus release v15.2.4

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -54,7 +54,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -100,7 +100,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 * `external`:
   * `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs if an image is provided and will refuse otherwise. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster). If `cephVersion.image` is left blank, Rook will refuse the creation of extra CRs like object, file and nfs.
 * `cephVersion`: The version information for launching the ceph daemons.
-  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v13.2.6-20190604` or `ceph/ceph:v14.2.5`. For more details read the [container images section](#ceph-container-images).
+  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v14.2.10` or `ceph/ceph:v15.2.4`. For more details read the [container images section](#ceph-container-images).
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
   To ensure a consistent version of the image is running across all nodes in the cluster, it is recommended to use a very specific image version.
   Tags also exist that would give the latest version, but they are only recommended for test environments. For example, the tag `v14` will be updated each time a new nautilus build is released.
@@ -458,7 +458,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -490,7 +490,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -531,7 +531,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -578,7 +578,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -681,7 +681,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -727,7 +727,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v14.2.9
+    image: ceph/ceph:v15.2.4
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -930,5 +930,5 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v14.2.9 # Should match external cluster version
+    image: ceph/ceph:v15.2.4 # Should match external cluster version
 ```

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -451,7 +451,7 @@ The majority of the upgrade will be handled by the Rook operator. Begin the upgr
 Ceph image field in the cluster CRD (`spec:cephVersion:image`).
 
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v15.2.0-20200324'
+NEW_CEPH_IMAGE='ceph/ceph:v15.2.4-20200630'
 CLUSTER_NAME="$ROOK_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -21,4 +21,4 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is required, if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v14.2.8 # Should match external cluster version
+    image: ceph/ceph:v15.2.4 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -32,7 +32,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v15.2.3
+    image: ceph/ceph:v15.2.4
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -20,9 +20,9 @@ spec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v14.2.5-20190917
+    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.4-20200630
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v15.2.3
+    image: ceph/ceph:v15.2.4
     # Whether to allow unsupported versions of Ceph. Currently mimic and nautilus are supported, with the recommendation to upgrade to nautilus.
     # Octopus is the version allowed when this is set to true.
     # Do not set to true in production.

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -201,7 +201,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v14.2.9"
+              "image": "ceph/ceph:v15.2.4"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/design/ceph/ceph-cluster-cleanup.md
+++ b/design/ceph/ceph-cluster-cleanup.md
@@ -29,7 +29,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v14.2.7
+    image: ceph/ceph:v15.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v15.2.3-20200530
+CEPH_VERSION = v15.2.4-20200630
 else
-CEPH_VERSION = v15.2.3-20200530
+CEPH_VERSION = v15.2.4-20200630
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -112,7 +112,7 @@ type ClusterSpec struct {
 
 // VersionSpec represents the settings for the Ceph version that Rook is orchestrating.
 type CephVersionSpec struct {
-	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v13.2.6 or ceph/ceph:v14.2.2
+	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.4
 	Image string `json:"image,omitempty"`
 
 	// Whether to allow unsupported versions (do not set to true in production)

--- a/pkg/operator/ceph/cluster/cluster_external_test.go
+++ b/pkg/operator/ceph/cluster/cluster_external_test.go
@@ -29,7 +29,7 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	err := validateExternalClusterSpec(c)
 	assert.NoError(t, err)
 
-	c.Spec.CephVersion.Image = "ceph/ceph:v14.2.9"
+	c.Spec.CephVersion.Image = "ceph/ceph:v15"
 	err = validateExternalClusterSpec(c)
 	assert.Error(t, err)
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -107,7 +107,7 @@ func TestStartSecureDashboard(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: clientset, Executor: executor}, Namespace: "myns",
-		dashboard: cephv1.DashboardSpec{Port: dashboardPortHTTP, Enabled: true, SSL: true}, cephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v13.2.2"}}
+		dashboard: cephv1.DashboardSpec{Port: dashboardPortHTTP, Enabled: true, SSL: true}, cephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"}}
 	c.exitCode = func(err error) (int, bool) {
 		if exitCodeResponse != 0 {
 			return exitCodeResponse, true

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -83,7 +83,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	}
 
 	clientset := fake.NewSimpleClientset()
-	cephVersion := cephv1.CephVersionSpec{Image: "ceph/ceph:v12.2.8"}
+	cephVersion := cephv1.CephVersionSpec{Image: "ceph/ceph:v15"}
 	clusterInfo := &cephconfig.ClusterInfo{
 		CephVersion: cephver.Nautilus,
 	}
@@ -143,7 +143,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 
 	assert.Equal(t, 2, len(deployment.Spec.Template.Spec.InitContainers))
 	initCont := deployment.Spec.Template.Spec.InitContainers[0]
-	assert.Equal(t, "ceph/ceph:v12.2.8", initCont.Image)
+	assert.Equal(t, "ceph/ceph:v15", initCont.Image)
 	assert.Equal(t, "activate", initCont.Name)
 	assert.Equal(t, 3, len(initCont.VolumeMounts))
 

--- a/pkg/operator/ceph/cluster/rbd/spec_test.go
+++ b/pkg/operator/ceph/cluster/rbd/spec_test.go
@@ -48,7 +48,7 @@ func TestPodSpec(t *testing.T) {
 		},
 		Spec: cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{
-				Image: "ceph/ceph:v14",
+				Image: "ceph/ceph:v15",
 			},
 		},
 	}

--- a/pkg/operator/ceph/nfs/spec_test.go
+++ b/pkg/operator/ceph/nfs/spec_test.go
@@ -102,7 +102,7 @@ func TestDeploymentSpec(t *testing.T) {
 		},
 		cephClusterSpec: &cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{
-				Image: "ceph/ceph:v14",
+				Image: "ceph/ceph:v15",
 			},
 		},
 	}

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -54,7 +54,7 @@ func TestPodSpecs(t *testing.T) {
 		store:       store,
 		rookVersion: "rook/rook:myversion",
 		clusterSpec: &cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v13.2.1"},
+			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
 			Network: cephv1.NetworkSpec{
 				HostNetwork: true,
 			},
@@ -107,7 +107,7 @@ func TestSSLPodSpec(t *testing.T) {
 		store:       store,
 		rookVersion: "rook/rook:myversion",
 		clusterSpec: &cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v13.2.1"},
+			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
 			Network: cephv1.NetworkSpec{
 				HostNetwork: true,
 			},

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -41,8 +41,6 @@ import (
 )
 
 const (
-	// test with the latest mimic build
-	mimicTestImage = "ceph/ceph:v13"
 	// test with the latest nautilus build
 	nautilusTestImage = "ceph/ceph:v14"
 	// test with the latest octopus build
@@ -56,7 +54,6 @@ const (
 )
 
 var (
-	MimicVersion       = cephv1.CephVersionSpec{Image: mimicTestImage}
 	NautilusVersion    = cephv1.CephVersionSpec{Image: nautilusTestImage}
 	OctopusVersion     = cephv1.CephVersionSpec{Image: octopusTestImage}
 	MasterVersion      = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}

--- a/tests/scripts/k8s-vagrant-multi-node.sh
+++ b/tests/scripts/k8s-vagrant-multi-node.sh
@@ -43,7 +43,7 @@ function copy_images() {
     if [[ "$1" == "" || "$1" == "ceph" ]]; then
       echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-      copy_image_to_cluster ceph/ceph:v13 ceph/ceph:v13
+      copy_image_to_cluster ceph/ceph:v15 ceph/ceph:v15
     fi
 
     if [[ "$1" == "" || "$1" == "cockroachdb" ]]; then

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -28,7 +28,7 @@ function copy_images() {
       echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
       # uncomment to push the nautilus image when needed
-      #copy_image_to_cluster ceph/ceph:v14 ceph/ceph:v14
+      #copy_image_to_cluster ceph/ceph:v15 ceph/ceph:v15
     fi
 
     if [[ "$1" == "" || "$1" == "cockroachdb" ]]; then


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Update the base operator image and cluster examples to use the latest Octopus release v15.2.4. Also cleanup some old examples and unit tests that were still based on mimic.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
