### PR TITLE
ceph: add s3 endpoint to the rgw user cr

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -18,9 +18,11 @@
 - OBC changes:
   - Updated lib bucket provisioner version to support multithread and required change can be found in [operator.yaml](cluster/examples/kubernetes/ceph/operator.yaml#L449)
     - Can be extended to add support for other providers
-- The Rook operator reflects the health of the CephObjectStore in its status field
-- The CephObjectStore CR supports connecting to external Ceph Rados Gateways, refer to the [external object section](Documentation/ceph-object.html#connect-to-external-object-store)
-- The CephObjectStore CR runs health checks on the object store endpoint, refer to the [health check section](Documentation/ceph-object-store-crd.html#health-settings)
+- CephObjectStore CRD changes:
+  - Health displayed in the Status field
+  - Supports connecting to external Ceph Rados Gateways, refer to the [external object section](Documentation/ceph-object.html#connect-to-external-object-store)
+  - The CephObjectStore CR runs health checks on the object store endpoint, refer to the [health check section](Documentation/ceph-object-store-crd.html#health-settings)
+  - The endpoint is now displayed in the Status field
 
 ### EdgeFS
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -445,9 +445,10 @@ type ZoneSpec struct {
 }
 
 type ObjectStoreStatus struct {
-	Phase        ConditionType `json:"phase,omitempty"`
-	Message      string        `json:"message,omitempty"`
-	BucketStatus *BucketStatus `json:"bucketStatus,omitempty"`
+	Phase        ConditionType     `json:"phase,omitempty"`
+	Message      string            `json:"message,omitempty"`
+	BucketStatus *BucketStatus     `json:"bucketStatus,omitempty"`
+	Info         map[string]string `json:"info,omitempty"`
 }
 
 type BucketStatus struct {

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -1364,6 +1364,13 @@ func (in *ObjectStoreStatus) DeepCopyInto(out *ObjectStoreStatus) {
 		*out = new(BucketStatus)
 		**out = **in
 	}
+	if in.Info != nil {
+		in, out := &in.Info, &out.Info
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -30,6 +30,7 @@ type Context struct {
 	ClusterName string
 	RunAsUser   string
 	UID         string
+	Endpoint    string
 }
 
 // NewContext creates a new object store context.

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -168,7 +168,8 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 
 	// The CR was just created, initializing status fields
 	if cephObjectStore.Status == nil {
-		updateStatusPhase(r.client, request.NamespacedName, cephv1.ConditionProgressing)
+		// The store is not available so let's not build the status Info yet
+		updateStatus(r.client, request.NamespacedName, cephv1.ConditionProgressing, map[string]string{})
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
@@ -284,7 +285,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Set Ready status, we are done reconciling
-	updateStatusPhase(r.client, request.NamespacedName, cephv1.ConditionReady)
+	updateStatus(r.client, request.NamespacedName, cephv1.ConditionReady, buildStatusInfo(cephObjectStore))
 
 	// Return and do not requeue
 	logger.Debug("done reconciling")

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -165,6 +165,7 @@ func TestCephObjectStoreController(t *testing.T) {
 		TypeMeta: controllerTypeMeta,
 	}
 	cephCluster := &cephv1.CephCluster{}
+	objectStore.Spec.Gateway.Port = 80
 
 	// Objects to track in the fake client.
 	object := []runtime.Object{
@@ -329,5 +330,7 @@ func TestCephObjectStoreController(t *testing.T) {
 	err = r.client.Get(context.TODO(), req.NamespacedName, objectStore)
 	assert.NoError(t, err)
 	assert.Equal(t, cephv1.ConditionReady, objectStore.Status.Phase, objectStore)
+	assert.NotEmpty(t, objectStore.Status.Info["endpoint"], objectStore)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", objectStore.Status.Info["endpoint"], objectStore)
 	logger.Info("PHASE 3 DONE")
 }

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -365,3 +365,8 @@ func emptyPool(pool cephv1.PoolSpec) bool {
 func BuildDomainName(name, namespace string) string {
 	return fmt.Sprintf("%s-%s.%s", AppName, name, namespace)
 }
+
+// buildDNSEndpoint build the dns name to reach out the service endpoint
+func buildDNSEndpoint(domainName string, port int32) string {
+	return fmt.Sprintf("http://%s:%d", domainName, port)
+}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -367,6 +367,10 @@ func BuildDomainName(name, namespace string) string {
 }
 
 // buildDNSEndpoint build the dns name to reach out the service endpoint
-func buildDNSEndpoint(domainName string, port int32) string {
-	return fmt.Sprintf("http://%s:%d", domainName, port)
+func buildDNSEndpoint(domainName string, port int32, secure bool) string {
+	httpPrefix := "http"
+	if secure {
+		httpPrefix = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", httpPrefix, domainName, port)
 }

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -155,9 +155,12 @@ func TestEmptyPoolSpec(t *testing.T) {
 	assert.False(t, emptyPool(p))
 }
 
-func TestBuildDomainName(t *testing.T) {
+func TestBuildDomainNameAndEndpoint(t *testing.T) {
 	name := "my-store"
 	ns := "rook-ceph"
 	dns := BuildDomainName(name, ns)
 	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph", dns)
+	var port int32 = 80
+	ep := buildDNSEndpoint(dns, port)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", ep)
 }

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -24,6 +24,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
+
 	config "github.com/rook/rook/pkg/daemon/ceph/config"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -160,7 +161,14 @@ func TestBuildDomainNameAndEndpoint(t *testing.T) {
 	ns := "rook-ceph"
 	dns := BuildDomainName(name, ns)
 	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph", dns)
+
+	// non-secure endpoint
 	var port int32 = 80
-	ep := buildDNSEndpoint(dns, port)
+	ep := buildDNSEndpoint(dns, port, false)
 	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", ep)
+
+	// Secure endpoint
+	var securePort int32 = 443
+	ep = buildDNSEndpoint(dns, securePort, true)
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", ep)
 }

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -49,9 +49,8 @@ func updateStatus(client client.Client, namespacedName types.NamespacedName, sta
 	}
 
 	objectStore.Status.Phase = status
-	if len(info) != 0 {
-		objectStore.Status.Info = info
-	}
+	objectStore.Status.Info = info
+
 	if err := opcontroller.UpdateStatus(client, objectStore); err != nil {
 		logger.Errorf("failed to set object store %q status to %q. %v", namespacedName, status, err)
 		return
@@ -82,7 +81,11 @@ func updateStatusBucket(client client.Client, name types.NamespacedName, phase c
 
 func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string {
 	m := make(map[string]string)
-	m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port)
+	m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port, false)
+
+	if cephObjectStore.Spec.Gateway.SecurePort != 0 {
+		m["secureEndpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.SecurePort, true)
+	}
 
 	return m
 }

--- a/pkg/operator/ceph/object/status_test.go
+++ b/pkg/operator/ceph/object/status_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildStatusInfo(t *testing.T) {
+	cephObjectStore := &cephv1.CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-store",
+			Namespace: "rook-ceph",
+		},
+	}
+	cephObjectStore.Spec.Gateway.Port = 80
+
+	statusInfo := buildStatusInfo(cephObjectStore)
+	assert.NotEmpty(t, statusInfo["endpoint"])
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", statusInfo["endpoint"])
+}

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -253,6 +253,9 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{
 			Kind: "CephObjectStore",
 		},
+		Status: &cephv1.ObjectStoreStatus{
+			Info: map[string]string{"endpoint": "http://rook-ceph-rgw-my-store.rook-ceph:80"},
+		},
 	}
 	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStore{})
 	s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephObjectStoreList{})

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -85,6 +85,9 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	objectStore, err := k8sh.RookClientset.CephV1().CephObjectStores(namespace).Get(storeName, metav1.GetOptions{})
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), cephv1.ConditionHealthy, objectStore.Status.BucketStatus.Health)
+	// Info field has the endpoint in it
+	assert.NotEmpty(s.T(), objectStore.Status.Info)
+	assert.NotEmpty(s.T(), objectStore.Status.Info["endpoint"])
 
 	assert.True(s.T(), helper.ObjectUserClient.UserSecretExists(namespace, storeName, userid))
 	userInfo, err := helper.ObjectUserClient.GetUser(namespace, storeName, userid)


### PR DESCRIPTION
**Description of your changes:**

Now, when an S3 user gets created, Rook will add the S3 endpoint to the
Secret along with the credentials.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]