### PR TITLE
ceph: resync crds when update from 1.2

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -241,6 +241,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPools:
               type: array
               items:
@@ -273,6 +275,8 @@ spec:
                     - passive
                     - aggressive
                     - force
+                  parameters:
+                    type: object
             preservePoolsOnDelete:
               type: boolean
   subresources:
@@ -379,6 +383,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPool:
               properties:
                 failureDomain:
@@ -403,6 +409,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             preservePoolsOnDelete:
               type: boolean
   subresources:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -294,6 +294,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPools:
               type: array
               items:
@@ -326,6 +328,8 @@ spec:
                     - passive
                     - aggressive
                     - force
+                  parameters:
+                    type: object
             preservePoolsOnDelete:
               type: boolean
   additionalPrinterColumns:
@@ -436,6 +440,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPool:
               properties:
                 failureDomain:
@@ -460,6 +466,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             preservePoolsOnDelete:
               type: boolean
   subresources:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
@@ -273,6 +273,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPools:
               type: array
               items:
@@ -305,6 +307,8 @@ spec:
                     - passive
                     - aggressive
                     - force
+                parameters:
+                  type: object
             preservePoolsOnDelete:
               type: boolean
   additionalPrinterColumns:
@@ -411,6 +415,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             dataPool:
               properties:
                 failureDomain:
@@ -435,6 +441,8 @@ spec:
                   - passive
                   - aggressive
                   - force
+                parameters:
+                  type: object
             preservePoolsOnDelete:
               type: boolean
   subresources:
@@ -507,6 +515,8 @@ spec:
               - passive
               - aggressive
               - force
+            parameters:
+              type: object
   subresources:
     status: {}
 ---


### PR DESCRIPTION
**Description of your changes:**

Some CRDs definitions were missing, rending some CRD unusable. Now if
someone upgrades from 1.2, all CRDs will work as expected.

Closes: https://github.com/rook/rook/issues/5742
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5742

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
