### PR TITLE
docs: Remove references to xfs for ceph volumes

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -67,8 +67,9 @@ parameters:
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
 
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
-    # will set default as `ext4`.
-    csi.storage.k8s.io/fstype: xfs
+    # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+    # in hyperconverged settings where the volume is mounted on the same node as the osds.
+    csi.storage.k8s.io/fstype: ext4
 
 # Delete the rbd volume when a PVC is deleted
 reclaimPolicy: Delete
@@ -169,7 +170,7 @@ parameters:
   # The value of "clusterNamespace" MUST be the same as the one in which your rook cluster exist
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
-  fstype: xfs
+  fstype: ext4
 # Optional, default reclaimPolicy is "Delete". Other options are: "Retain", "Recycle" as documented in https://kubernetes.io/docs/concepts/storage/storage-classes/
 reclaimPolicy: Retain
 # Optional, if you want to add dynamic resize for PVC. Works for Kubernetes 1.14+

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -47,7 +47,8 @@ parameters:
     csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
-    # will set default as `ext4`.
+    # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+    # in hyperconverged settings where the volume is mounted on the same node as the osds.
     csi.storage.k8s.io/fstype: ext4
 # uncomment the following to use rbd-nbd as mounter on supported nodes
 # **IMPORTANT**: If you are using rbd-nbd as the mounter, during upgrade you will be hit a ceph-csi

--- a/cluster/examples/kubernetes/ceph/flex/storageclass-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass-ec.yaml
@@ -45,4 +45,4 @@ parameters:
   # This is also the namespace where the cluster will be
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
-  fstype: xfs
+  fstype: ext4

--- a/cluster/examples/kubernetes/ceph/flex/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass-test.yaml
@@ -22,4 +22,4 @@ allowVolumeExpansion: true
 parameters:
   blockPool: replicapool
   clusterNamespace: rook-ceph
-  fstype: xfs
+  fstype: ext4

--- a/cluster/examples/kubernetes/ceph/flex/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/flex/storageclass.yaml
@@ -27,7 +27,7 @@ parameters:
   # This is also the namespace where the cluster will be
   clusterNamespace: rook-ceph
   # Specify the filesystem type of the volume. If not specified, it will use `ext4`.
-  fstype: xfs
+  fstype: ext4
   # (Optional) Specify an existing Ceph user that will be used for mounting storage with this StorageClass.
   #mountUser: user1
   # (Optional) Specify an existing Kubernetes secret name containing just one key holding the Ceph user secret.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When mounting a ceph volume, xfs may cause issues with potential deadlocks if the volume is on the same node as the OSDs. To avoid this issue the default recommendation is ext4. This default had already been changed long ago in the csi example yamls, but the docs were not updated yet.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
