### PR TITLE
Ceph: Delete Filesystem only when it exists

### DIFF
--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -97,7 +97,7 @@ func GetFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, fsName s
 	args := []string{"fs", "get", fsName}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get file system %s", fsName)
+		return nil, err
 	}
 
 	var fs CephFilesystemDetails


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Ceph The operator starts an infinite loop for deleting Filesystem, this happens when it tries to delete the filesystem when it doesn't exist. The filesystem should only be deleted when it exists.

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #5783 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from the previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
