### PR TITLE
docs: ceph: add no support for changing networking

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -233,6 +233,9 @@ Configure the network that will be enabled for the cluster and services.
 * `provider`: Specifies the network provider that will be used to connect the network interface. You can choose between `host`, and `multus`.
 * `selectors`: List the network selector(s) that will be used associated by a key.
 
+> **NOTE:** Changing networking configuration after a Ceph cluster has been deployed is NOT
+> supported and will result in a non-functioning cluster.
+
 #### Host Networking
 
 To use host networking, set `provider: host`.


### PR DESCRIPTION
Clarify in the docs that changing networking modes after a Cpeh cluster
has been deployed is not supported and can result in a nonfunctional
cluster.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]