### PR TITLE
ceph: Adding deviceClasses info to CephCluster CR

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -185,6 +185,7 @@ type ClusterStatus struct {
 	Message     string          `json:"message,omitempty"`
 	Conditions  []Condition     `json:"conditions,omitempty"`
 	CephStatus  *CephStatus     `json:"ceph,omitempty"`
+	CephStorage *CephStorage    `json:"storage,omitempty"`
 	CephVersion *ClusterVersion `json:"version,omitempty"`
 }
 
@@ -194,6 +195,14 @@ type CephStatus struct {
 	LastChecked    string                       `json:"lastChecked,omitempty"`
 	LastChanged    string                       `json:"lastChanged,omitempty"`
 	PreviousHealth string                       `json:"previousHealth,omitempty"`
+}
+
+type CephStorage struct {
+	DeviceClasses []DeviceClasses `json:"deviceClasses,omitempty"`
+}
+
+type DeviceClasses struct {
+	Name string `json:"name,omitempty"`
 }
 
 type ClusterVersion struct {

--- a/pkg/daemon/ceph/client/deviceclass.go
+++ b/pkg/daemon/ceph/client/deviceclass.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+)
+
+// GetDeviceClasses gets the available device classes.
+func GetDeviceClasses(context *clusterd.Context, clusterInfo *ClusterInfo) ([]string, error) {
+	args := []string{"osd", "crush", "class", "ls"}
+	cmd := NewCephCommand(context, clusterInfo, args)
+	buf, err := cmd.Run()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get deviceclasses. %s", string(buf))
+	}
+
+	var deviceclass []string
+	if err := json.Unmarshal(buf, &deviceclass); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal osd crush class list response")
+	}
+
+	return deviceclass, nil
+}


### PR DESCRIPTION
Signed-off-by: kesavan <kvellalo@redhat.com>

**Description of your changes:**
The admin needs to start the toolbox and run a command such as ceph osd tree to see the device classes for each OSD. This PR simplifies it by storing the deviceclass info in the CephCluster CR status

**Which issue is resolved by this Pull Request:**
Resolves #5754

**CephCluster CR status** 
```
Status:
  Ceph:
    Health:        HEALTH_OK
    Last Checked:  2020-07-10T11:42:30Z
  Storage:
    Device Classes:
      Name:  hdd
  Version:
    Image:    ceph/ceph:v15.2.3
    Version:  15.2.3-0
```


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
