### PR TITLE
Re-enable the Ceph Mgr integration test that runs against Ceph master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,12 +147,6 @@ pipeline {
                 }
             }
             steps {
-                // If it's not a PR assume it is an "official" master or release build
-                script {
-                    if (env.isOfficialBuild == "") {
-                        env.isOfficialBuild = "true"
-                    }
-                }
                 sh 'cat _output/version | xargs tests/scripts/makeTestImages.sh  save amd64'
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,yugabytedb-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script {

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -42,7 +42,8 @@ func testStorageProvider() string {
 
 // TestIsOfficialBuild gets the storage provider for which tests should be run
 func TestIsOfficialBuild() bool {
-	return getEnvVarWithDefault("TEST_IS_OFFICIAL_BUILD", "") == "true"
+	// PRs will set this to "false", but the official build will not set it, so we compare against "false"
+	return getEnvVarWithDefault("TEST_IS_OFFICIAL_BUILD", "") != "false"
 }
 
 // baseTestDir gets the base test directory

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -49,8 +49,6 @@ func TestCephMgrSuite(t *testing.T) {
 	if installer.TestIsOfficialBuild() {
 		t.Skip()
 	}
-	logger.Info("TEMPORARILY disable the test while there is an issue in ceph master")
-	t.Skip()
 
 	s := new(CephMgrSuite)
 	defer func(s *CephMgrSuite) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- The OSD creation has been fixed in Ceph master, therefore we can reenable the Ceph mgr test that runs against master.
- The mgr integration test was running unexpectedly in master due to a change in the env vars in Jenkins. Now the test will only be enabled in PRs again as expected.
    
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]