### PR TITLE
ceph: Fix toolbox when mon hosts can contain numbers and hype

### DIFF
--- a/images/ceph/toolbox.sh
+++ b/images/ceph/toolbox.sh
@@ -30,7 +30,8 @@ write_endpoints() {
     endpoints=$(cat ${MON_CONFIG})
 
     # filter out the mon names
-    mon_endpoints=$(echo ${endpoints} | sed 's/[a-z]\+=//g')
+    # external cluster can have numbers or hypens in mon names, handling them in regex
+    mon_endpoints=$(echo ${endpoints} | sed 's/[a-z0-9_-]\+=//g')
 
     DATE=$(date)
     echo "$DATE writing mon endpoints to ${CEPH_CONFIG}: ${endpoints}"


### PR DESCRIPTION
**Description of your changes:**

When hostname has hypen and/or numbers, the mon endpoints are incorrectly split and can point
to invalid monitor names inside toolbox, Add fix to split the hostname/ip that can include
hypen, underscore or numbers.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
