### PR TITLE
ceph: support device names with special chars

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -16,6 +16,7 @@
   - OSD on PVC now supports multipath device.
   - OSDs can now be provisioned using Ceph's Drive Groups definitions for Ceph Octopus v15.2.5+.
     [See docs for more](Documentation/ceph-cluster-crd.md#storage-selection-via-ceph-drive-groups)
+  - OSDs can be provisioned on support /dev/disk/by-path/pci-HHHH:HH:HH.H devices with colons (`:`)
 - Added [admission controller](Documentation/admission-controller-usage.md) support for CRD validations.
   - Support for Ceph CRDs is provided. Some validations for CephClusters are included and additional validations can be added for other CRDs
   - Can be extended to add support for other providers

--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -47,17 +47,27 @@ const (
 	DeviceClassKey     = "deviceClass"
 )
 
+// StoreConfig represents the configuration of an OSD on a device.
 type StoreConfig struct {
 	StoreType       string `json:"storeType,omitempty"`
 	WalSizeMB       int    `json:"walSizeMB,omitempty"`
 	DatabaseSizeMB  int    `json:"databaseSizeMB,omitempty"`
 	OSDsPerDevice   int    `json:"osdsPerDevice,omitempty"`
 	EncryptedDevice bool   `json:"encryptedDevice,omitempty"`
+	MetadataDevice  string `json:"metadataDevice,omitempty"`
 	DeviceClass     string `json:"deviceClass,omitempty"`
 }
 
+// NewStoreConfig returns a StoreConfig with proper defaults set.
+func NewStoreConfig() StoreConfig {
+	return StoreConfig{
+		OSDsPerDevice: 1,
+	}
+}
+
+// ToStoreConfig converts a config string-string map to a StoreConfig.
 func ToStoreConfig(config map[string]string) StoreConfig {
-	storeConfig := StoreConfig{}
+	storeConfig := NewStoreConfig()
 	for k, v := range config {
 		switch k {
 		case StoreTypeKey:
@@ -67,9 +77,14 @@ func ToStoreConfig(config map[string]string) StoreConfig {
 		case DatabaseSizeMBKey:
 			storeConfig.DatabaseSizeMB = convertToIntIgnoreErr(v)
 		case OSDsPerDeviceKey:
-			storeConfig.OSDsPerDevice = convertToIntIgnoreErr(v)
+			i := convertToIntIgnoreErr(v)
+			if i > 0 { // only allow values 1 or more to be set
+				storeConfig.OSDsPerDevice = i
+			}
 		case EncryptedDeviceKey:
 			storeConfig.EncryptedDevice = (v == "true")
+		case MetadataDeviceKey:
+			storeConfig.MetadataDevice = v
 		case DeviceClassKey:
 			storeConfig.DeviceClass = v
 		}
@@ -104,3 +119,9 @@ type DriveGroupBlob string
 
 // DriveGroupBlobs is a mapping from Ceph Drive Group names to JSON blobs of Drive Group specs.
 type DriveGroupBlobs map[string]string
+
+// ConfiguredDevice is a device with a corresponding configuration.
+type ConfiguredDevice struct {
+	ID          string      `json:"id"`
+	StoreConfig StoreConfig `json:"storeConfig"`
+}


### PR DESCRIPTION
Pass desired devices to the OSD provisioning container by
JSON-marshalling/-unmarshalling a disk ID with StorageConfig settings.
This will allow disks to be specified that contain special characters.
Notably, this will support /dev/disk/by-path/pci-HHHH:HH:HH.H devices
that were unsupported previously due to the format which separated
devices from params with colons (:).

Fixes #5056
Fixes #5535

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]