### PR TITLE
ceph: fix health check invalid pointer on upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -216,6 +216,9 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 		opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, mgr.AppName)}
 		mgrDeployments, err := c.context.Clientset.AppsV1().Deployments(cluster.Namespace).List(opts)
 		if err == nil && len(mgrDeployments.Items) > 0 && cluster.ClusterInfo != nil {
+			// Populate mon cluster's ClusterInfo with the last value
+			cluster.mons.ClusterInfo = clusterInfo
+
 			c.configureCephMonitoring(cluster, clusterInfo)
 		}
 
@@ -225,7 +228,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 		}
 	}
 
-	// Populate ClusterInfo with the last value
+	// Populate mon cluster's ClusterInfo with the last value
 	cluster.mons.ClusterInfo = cluster.ClusterInfo
 
 	// Start the monitoring if not already started


### PR DESCRIPTION
 ceph: make cluster mon info a private struct field

Make the cluster.mons.ClusterInfo a private field.
(i.e., rename it to cluster.mons.clusterInfo)

This forces the internal mon struct representation to be initialized a
little bit differently and does not rely on the developer to remember to
set the mon information separately if loading cluster information before
mons are initialized.

Notably, this helps with loading cluster info to start cluster
monitoring and fixes an invalid pointer dereference issue. This fix
should make it so this specific mistake can't happen again.

fixes #5826

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

[test full]

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5826 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
