### PR TITLE
ceph: fix CRs not reconciling on updates

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/validate_resources_test.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_resources_test.go
@@ -1,9 +1,26 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestCephClusterValidateCreate(t *testing.T) {

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -75,6 +75,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -99,6 +100,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -118,6 +120,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -137,6 +140,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -156,6 +160,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -173,10 +178,11 @@ func WatchControllerPredicate() predicate.Funcs {
 					return false
 				}
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
-				if diff != "" || objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					if diff != "" {
-						logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
-					}
+				if diff != "" {
+					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
+				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
+					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -194,6 +200,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -218,6 +225,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true
@@ -242,6 +250,7 @@ func WatchControllerPredicate() predicate.Funcs {
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
 					logger.Debugf("CR %q is going be deleted", objNew.Name)
 					return true


### PR DESCRIPTION
**Description of your changes:**

Most of the CRs expect CephCluster and CephBlockPool were not
reconciling on updates. The predicate must return true on CR diff.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
