### PR TITLE
ceph: ability to configure livenessprobe for cephobjectstore crd

### DIFF
--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -89,3 +89,6 @@ spec:
     endpoint:
       enabled: true
       interval: 60s
+    # Configure the pod liveness probe for the rgw daemon
+    livenessProbe:
+      disabled: false

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -434,12 +434,13 @@ type ObjectStoreSpec struct {
 	// The multisite info
 	Zone ZoneSpec `json:"zone"`
 
-	// The rgw endpoint healthcheck
+	// The rgw Bucket healthchecks and liveness probe
 	HealthCheck BucketHealthCheckSpec `json:"healthCheck"`
 }
 
 type BucketHealthCheckSpec struct {
-	Bucket HealthCheckSpec `json:"bucket,omitempty"`
+	Bucket        HealthCheckSpec   `json:"rgw,omitempty"`
+	LivenessProbe *rookv1.ProbeSpec `json:"livenessProbe,omitempty"`
 }
 
 type HealthCheckSpec struct {

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -30,6 +30,11 @@ import (
 func (in *BucketHealthCheckSpec) DeepCopyInto(out *BucketHealthCheckSpec) {
 	*out = *in
 	out.Bucket = in.Bucket
+	if in.LivenessProbe != nil {
+		in, out := &in.LivenessProbe, &out.LivenessProbe
+		*out = new(rookiov1.ProbeSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -31,7 +31,7 @@ import (
 const (
 	s3UserHealthCheckName      = "rook-ceph-internal-s3-user-checker"
 	s3HealthCheckBucketName    = "rook-ceph-bucket-checker"
-	defaultStatusCheckInterval = 1 * time.Minute
+	defaultHealthCheckInterval = 1 * time.Minute
 	s3HealthCheckObjectBody    = "Test Rook Object Data"
 	s3HealthCheckObjectBodyMD5 = "5f286306a2227a156ba770800e71b796"
 	s3HealthCheckObjectKey     = "rookHealthCheckTestObject"
@@ -55,7 +55,7 @@ func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP,
 	c := &bucketChecker{
 		context:         context,
 		objContext:      objContext,
-		interval:        defaultStatusCheckInterval,
+		interval:        defaultHealthCheckInterval,
 		serviceIP:       serviceIP,
 		port:            port,
 		namespacedName:  namespacedName,


### PR DESCRIPTION
this commit allows us to disable livenessprobe for
cephobjectstore crd.

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5807

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
