### PR TITLE
ceph: let the healthcheck set the status phase

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -204,6 +204,8 @@ spec:
       type: string
       description: Ceph Health
       JSONPath: .status.ceph.health
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -137,7 +137,6 @@ function importCsiCephFSProvisionerSecret() {
 checkEnvVars
 importSecret
 importConfigMap
-importCheckerSecret
 importCsiRBDNodeSecret
 importCsiRBDProvisionerSecret
 importCsiCephFSNodeSecret

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -230,7 +230,6 @@ const (
 	ConditionFailure     ConditionType = "Failure"
 	ConditionUpgrading   ConditionType = "Upgrading"
 	ConditionDeleting    ConditionType = "Deleting"
-	ConditionHealthy     ConditionType = "Healthy"
 	// DefaultFailureDomain for PoolSpec
 	DefaultFailureDomain = "host"
 )

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters.go
@@ -47,7 +47,7 @@ func (c *CephCluster) ValidateCreate() error {
 }
 
 func (c *CephCluster) ValidateUpdate(old runtime.Object) error {
-	logger.Info("validate update cephcluster %q", c.ObjectMeta.Name)
+	logger.Infof("validate update cephcluster %q", c.ObjectMeta.Name)
 
 	if err := validateCommon(*c); err != nil {
 		return err

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -139,9 +139,6 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 	}
 
-	// Everything went well so let's update the CR's status to "connected"
-	config.ConditionExport(c.context, c.namespacedName, cephv1.ConditionConnected, v1.ConditionTrue, "ClusterConnected", "Cluster connected successfully")
-
 	// Mark initialization has done
 	cluster.initCompleted = true
 

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -120,7 +120,7 @@ func (c *ClusterController) startMonitoringCheck(cluster *cluster, clusterInfo *
 		}
 
 	case "status":
-		cephChecker := newCephStatusChecker(c.context, clusterInfo, cluster.Spec.HealthCheck)
+		cephChecker := newCephStatusChecker(c.context, clusterInfo, cluster.Spec)
 		logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
 		go cephChecker.checkCephStatus(cluster.monitoringChannels[daemon].stopChan)
 	}

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -117,9 +117,11 @@ func (c *ClusterController) startMonitoringCheck(cluster *cluster, clusterInfo *
 		go healthChecker.Check(cluster.monitoringChannels[daemon].stopChan)
 
 	case "osd":
-		c.osdChecker = osd.NewOSDHealthMonitor(c.context, clusterInfo, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Spec.HealthCheck)
-		logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
-		go c.osdChecker.Start(cluster.monitoringChannels[daemon].stopChan)
+		if !cluster.Spec.External.Enable {
+			c.osdChecker = osd.NewOSDHealthMonitor(c.context, clusterInfo, cluster.Spec.RemoveOSDsIfOutAndSafeToRemove, cluster.Spec.HealthCheck)
+			logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
+			go c.osdChecker.Start(cluster.monitoringChannels[daemon].stopChan)
+		}
 
 	case "status":
 		cephChecker := newCephStatusChecker(c.context, clusterInfo, cluster.Spec.HealthCheck)

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -55,10 +55,6 @@ func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInf
 				}
 			}
 		} else {
-			// If the mon does not exist in the map, this is a first deployment or an operator restart
-			// So we check the desired state from the CR and run it if necessary
-			//
-			// If the mon monitoring is enabled
 			if !isDisabled {
 				cluster.monitoringChannels[daemon] = &clusterHealth{
 					stopChan:          make(chan struct{}),

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -26,11 +26,14 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/object/bucket"
 )
 
+var (
+	monitorDaemonList = []string{"mon", "osd", "status"}
+)
+
 func (c *ClusterController) configureCephMonitoring(cluster *cluster, clusterInfo *cephclient.ClusterInfo) {
 	var isDisabled bool
-	daemons := []string{"mon", "osd", "status"}
 
-	for _, daemon := range daemons {
+	for _, daemon := range monitorDaemonList {
 		// Is the monitoring enabled for that daemon?
 		isDisabled = isMonitoringDisabled(daemon, cluster.Spec)
 		if health, ok := cluster.monitoringChannels[daemon]; ok {

--- a/pkg/operator/ceph/config/conditions.go
+++ b/pkg/operator/ceph/config/conditions.go
@@ -89,7 +89,7 @@ func setCondition(c *clusterd.Context, namespaceName types.NamespacedName, newCo
 		logger.Infof("CephCluster %q status: %q. %q", namespaceName.Namespace, cluster.Status.Phase, cluster.Status.Message)
 	}
 
-	err = c.Client.Update(context.TODO(), cluster)
+	err = c.Client.Status().Update(context.TODO(), cluster)
 	if err != nil {
 		logger.Errorf("failed to update cluster condition to %+v. %v", newCondition, err)
 	}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -279,8 +279,8 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		return r.setFailedStatus(request.NamespacedName, "failed to create object store deployments", err)
 	}
 
-	// Set Ready status, we are done reconciling
-	updateStatus(r.client, request.NamespacedName, cephv1.ConditionReady, buildStatusInfo(cephObjectStore))
+	// Set Progressing status, we are done reconciling, the health check go routine will update the status
+	updateStatus(r.client, request.NamespacedName, cephv1.ConditionProgressing, buildStatusInfo(cephObjectStore))
 
 	// Return and do not requeue
 	logger.Debug("done reconciling")
@@ -479,7 +479,7 @@ func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjec
 		port = strconv.Itoa(int(objectstore.Spec.Gateway.SecurePort))
 	}
 
-	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec.HealthCheck)
+	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec.HealthCheck, r.cephClusterSpec.External.Enable)
 	logger.Info("starting rgw healthcheck")
 	go rgwChecker.checkObjectStore(r.objectStoreChannels[objectstore.Name].stopChan)
 }

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -328,7 +328,7 @@ func TestCephObjectStoreController(t *testing.T) {
 	assert.False(t, res.Requeue)
 	err = r.client.Get(context.TODO(), req.NamespacedName, objectStore)
 	assert.NoError(t, err)
-	assert.Equal(t, cephv1.ConditionReady, objectStore.Status.Phase, objectStore)
+	assert.Equal(t, cephv1.ConditionProgressing, objectStore.Status.Phase, objectStore)
 	assert.NotEmpty(t, objectStore.Status.Info["endpoint"], objectStore)
 	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", objectStore.Status.Info["endpoint"], objectStore)
 	logger.Info("PHASE 3 DONE")

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -48,10 +48,11 @@ type bucketChecker struct {
 	client          client.Client
 	namespacedName  types.NamespacedName
 	healthCheckSpec *cephv1.BucketHealthCheckSpec
+	isExternal      bool
 }
 
 // newbucketChecker creates a new HealthChecker object
-func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP, port string, client client.Client, namespacedName types.NamespacedName, healthCheckSpec *cephv1.BucketHealthCheckSpec) *bucketChecker {
+func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP, port string, client client.Client, namespacedName types.NamespacedName, healthCheckSpec *cephv1.BucketHealthCheckSpec, isExternal bool) *bucketChecker {
 	c := &bucketChecker{
 		context:         context,
 		objContext:      objContext,
@@ -61,6 +62,7 @@ func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP,
 		namespacedName:  namespacedName,
 		client:          client,
 		healthCheckSpec: healthCheckSpec,
+		isExternal:      isExternal,
 	}
 
 	// allow overriding the check interval
@@ -169,7 +171,7 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	logger.Debug("successfully checked object store endpoint for object store %q", c.namespacedName.Name)
 
 	// Update the EndpointStatus in the CR to reflect the healthyness
-	updateStatusBucket(c.client, c.namespacedName, cephv1.ConditionHealthy, "")
+	updateStatusBucket(c.client, c.namespacedName, cephv1.ConditionConnected, "")
 
 	return nil
 }

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -71,6 +71,7 @@ func updateStatusBucket(client client.Client, name types.NamespacedName, phase c
 	}
 
 	objectStore.Status.BucketStatus = toCustomResourceStatus(objectStore.Status.BucketStatus, details, phase)
+	objectStore.Status.Phase = phase
 	if err := opcontroller.UpdateStatus(client, objectStore); err != nil {
 		logger.Errorf("failed to set object store %q status to %v. %v", name, phase, err)
 		return

--- a/tests/framework/clients/block.go
+++ b/tests/framework/clients/block.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,7 +86,12 @@ func (b *BlockOperation) DeletePVC(namespace, claimName string) error {
 
 func (b *BlockOperation) DeleteStorageClass(storageClassName string) error {
 	logger.Infof("deleting storage class %q", storageClassName)
-	return b.k8sClient.Clientset.StorageV1().StorageClasses().Delete(storageClassName, &metav1.DeleteOptions{})
+	err := b.k8sClient.Clientset.StorageV1().StorageClasses().Delete(storageClassName, &metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete storage class %q. %v", storageClassName, err)
+	}
+
+	return nil
 }
 
 // BlockDelete Function to delete a Block using Rook

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -287,6 +287,8 @@ spec:
       type: string
       description: Ceph Health
       JSONPath: .status.ceph.health
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -86,7 +86,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	// Check object store status
 	objectStore, err := k8sh.RookClientset.CephV1().CephObjectStores(namespace).Get(storeName, metav1.GetOptions{})
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), cephv1.ConditionHealthy, objectStore.Status.BucketStatus.Health)
+	assert.Equal(s.T(), cephv1.ConditionConnected, objectStore.Status.BucketStatus.Health)
 	// Info field has the endpoint in it
 	assert.NotEmpty(s.T(), objectStore.Status.Info)
 	assert.NotEmpty(s.T(), objectStore.Status.Info["endpoint"])

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -173,8 +173,10 @@ func (s *CephFlexDriverSuite) statefulSetDataCleanup(poolName, storageClassName,
 	// Delete all PVCs
 	s.kh.DeletePvcWithLabel(defaultNamespace, statefulSetName)
 	// Delete storageclass and pool
-	s.testClient.PoolClient.DeletePool(s.testClient.BlockClient, s.clusterInfo, poolName)
-	s.testClient.BlockClient.DeleteStorageClass(storageClassName)
+	err := s.testClient.PoolClient.DeletePool(s.testClient.BlockClient, s.clusterInfo, poolName)
+	require.Nil(s.T(), err)
+	err = s.testClient.BlockClient.DeleteStorageClass(storageClassName)
+	require.Nil(s.T(), err)
 }
 
 func (s *CephFlexDriverSuite) setupPVCs() {


### PR DESCRIPTION
**Description of your changes:**

Instead of setting the Phase of the CR once the reconcile is done, let's actually set in from the healthcheck so it is more accurate.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5249 and https://github.com/rook/rook/issues/5840

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
