### PR TITLE
ceph: re-hydrate clusterInfo for external mode

### DIFF
--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -81,18 +81,11 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.Equal(t, "client.admin", info.CephCred.Username)
 	assert.Equal(t, adminSecret, info.CephCred.Secret)
 
-	// Check that the external cluster can load the admin creds
-	externalClusterInfo, err := loadExternalClusterInfo(context, namespace)
-	assert.NotNil(t, externalClusterInfo)
-	assert.NoError(t, err)
-	assert.Equal(t, info.CephCred.Username, externalClusterInfo.CephCred.Username)
-	assert.Equal(t, info.CephCred.Secret, externalClusterInfo.CephCred.Secret)
-
 	// Fail to load the external cluster if the admin placeholder is specified
 	secret.Data[adminSecretNameKey] = []byte(adminSecretNameKey)
 	_, err = clientset.CoreV1().Secrets(namespace).Update(secret)
 	assert.NoError(t, err)
-	externalClusterInfo, err = loadExternalClusterInfo(context, namespace)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
 	assert.Error(t, err)
 
 	// Load the external cluster with the legacy external creds
@@ -103,8 +96,8 @@ func TestCreateClusterSecrets(t *testing.T) {
 	}
 	_, err = clientset.CoreV1().Secrets(namespace).Create(secret)
 	assert.NoError(t, err)
-	externalClusterInfo, err = loadExternalClusterInfo(context, namespace)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
 	assert.NoError(t, err)
-	assert.Equal(t, "testid", externalClusterInfo.CephCred.Username)
-	assert.Equal(t, "testkey", externalClusterInfo.CephCred.Secret)
+	assert.Equal(t, "testid", info.CephCred.Username)
+	assert.Equal(t, "testkey", info.CephCred.Secret)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Whether we run an external cluster or not we need to load the
appropriate clusterInfo.
**Which issue is resolved by this Pull Request:**

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
