### PR TITLE
cassandra: Update Jolokia lib in Cassandra sidecar image

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -36,6 +36,7 @@
 
 ### Cassandra
 
+- Updated Jolokia javaagent from 1.6.0 to 1.6.2 due to CVEs.
 - Updated Base image from Alpine 3.8 to 3.12 due to CVEs.
 
 ## Breaking Changes

--- a/images/cassandra/Dockerfile
+++ b/images/cassandra/Dockerfile
@@ -16,6 +16,7 @@ FROM alpine:3.12
 
 ARG ARCH
 ARG TINI_VERSION
+ARG JOLOKIA_VERSION=1.6.2
 
 ADD rook /usr/local/bin/
 
@@ -25,7 +26,7 @@ RUN mkdir -p /sidecar/plugins
 
 ADD rook /sidecar/
 # Jolokia plugin for JMX<->HTTP
-ADD "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.0/jolokia-jvm-1.6.0-agent.jar" /sidecar/plugins/jolokia.jar
+ADD "https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/${JOLOKIA_VERSION}/jolokia-jvm-${JOLOKIA_VERSION}-agent.jar" /sidecar/plugins/jolokia.jar
 # JMX exporter for prometheus metrics
 ADD "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.11.0/jmx_prometheus_javaagent-0.11.0.jar" /sidecar/plugins/jmx_prometheus.jar
 


### PR DESCRIPTION
**Description of your changes:**
The Cassandra sidecar uses the Jolokia javaagent to expose a REST API of
Cassandra's administrative interface, which is normally only exposed via
JMX, a Java-only RPC protocol. Update the Jolokia javaagent to a newer
version, containing new features and security bug fixes.


**Which issue is resolved by this Pull Request:**
Issue was reported via mailing list. cc @galexrt 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.


[test cassandra]