### PR TITLE
ceph: change command to add 3300 port for monmap

### DIFF
--- a/Documentation/ceph-disaster-recovery.md
+++ b/Documentation/ceph-disaster-recovery.md
@@ -294,7 +294,7 @@ Assuming `dataHostPathData` is `/var/lib/rook`, and the `CephCluster` trying to 
         container# monmaptool --rm c monmap  # Repeat this pattern until all the old ceph-mons are removed
         container# monmaptool --rm d monmap
         container# monmaptool --rm e monmap
-        container# monmaptool --add a 10.77.2.216:6789 monmap   # Replace it with the rook-ceph-mon-a address you got from previous command.
+        container# monmaptool --addv a [v2:10.77.2.216:3300,v1:10.77.2.216:6789] monmap   # Replace it with the rook-ceph-mon-a address you got from previous command.
         container# ceph-mon --inject-monmap monmap --mon-data ./mon-a/data  # Replace monmap in ceph-mon db with our modified version.
         container# rm monmap
         container# exit


### PR DESCRIPTION
In the latest version of rook-ceph, disaster recovery does not work properly with the following command. Therefore, the command was updated to the latest command.

**Description of your changes:**
Changed the monmap to add 3300, the port of messenger v2.

**Which issue is resolved by this Pull Request:**
Resolves #5662, #5649 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)

[skip ci]