### PR TITLE
ceph: report error on timeout

### DIFF
--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -62,10 +62,12 @@ type HealthStatus struct {
 }
 
 type CheckMessage struct {
-	Severity string `json:"severity"`
-	Summary  struct {
-		Message string `json:"message"`
-	} `json:"summary"`
+	Severity string  `json:"severity"`
+	Summary  Summary `json:"summary"`
+}
+
+type Summary struct {
+	Message string `json:"message"`
 }
 
 type MonMap struct {

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -166,7 +166,10 @@ func StatusWithUser(context *clusterd.Context, clusterInfo *ClusterInfo) (CephSt
 
 	buf, err := context.Executor.ExecuteCommandWithOutput(command, args...)
 	if err != nil {
-		return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+		if buf != "" {
+			return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+		}
+		return CephStatus{}, errors.Wrap(err, "failed to get ceph status")
 	}
 
 	var status CephStatus


### PR DESCRIPTION
**Description of your changes:**

If the healthcheck goroutine cannot check for the ceph status/times out
(if the mons are not in quorum) this should still be reflected in the
CRD status field.

Example:

```
status:
  ceph:
    details:
      error:
        message: 'failed to get status. . timed out: exit status 1'
        severity: Urgent
    health: HEALTH_ERR
    lastChanged: "2020-07-20T14:11:05Z"
    lastChecked: "2020-07-20T14:11:05Z"
    previousHealth: HEALTH_WARN
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
