### PR TITLE
ceph: Additional clusterInfo cleanup for user creds

### DIFF
--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -50,7 +50,7 @@ type AddrvecEntry struct {
 }
 
 // GetMonQuorumStatus calls quorum_status mon_command
-func GetMonQuorumStatus(context *clusterd.Context, clusterInfo *ClusterInfo, cephUsername string) (MonStatusResponse, error) {
+func GetMonQuorumStatus(context *clusterd.Context, clusterInfo *ClusterInfo) (MonStatusResponse, error) {
 	args := []string{"quorum_status"}
 	cmd := NewCephCommand(context, clusterInfo, args)
 	buf, err := cmd.Run()

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -104,7 +104,7 @@ func (c *Cluster) checkHealth() error {
 
 	// For an external connection we use a special function to get the status
 	if c.spec.External.Enable {
-		quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo, c.ClusterInfo.CephCred.Username)
+		quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to get external mon quorum status")
 		}
@@ -114,7 +114,7 @@ func (c *Cluster) checkHealth() error {
 
 	// connect to the mons
 	// get the status and check for quorum
-	quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo, c.ClusterInfo.CephCred.Username)
+	quorumStatus, err := client.GetMonQuorumStatus(c.context, c.ClusterInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to get mon quorum status")
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -984,7 +984,7 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterInfo *cephclient.Cl
 
 		// get the quorum_status response that contains info about all monitors in the mon map and
 		// their quorum status
-		monQuorumStatusResp, err := client.GetMonQuorumStatus(context, clusterInfo, clusterInfo.CephCred.Username)
+		monQuorumStatusResp, err := client.GetMonQuorumStatus(context, clusterInfo)
 		if err != nil {
 			logger.Debugf("failed to get quorum_status. %v", err)
 			continue


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The user creds should not be passed to the ceph helper methods since the clusterInfo already has the needed context. Removing a final reference that was missed in the refactor.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
