### PR TITLE
CephCluster CRD: make spec.network nullable

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -78,6 +78,7 @@ spec:
                 provider:
                   type: string
                 selectors: {}
+              nullable: true
             storage:
               properties:
                 disruptionManagement:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -97,6 +97,7 @@ spec:
                 provider:
                   type: string
                 selectors: {}
+              nullable: true
             storage:
               properties:
                 disruptionManagement:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.2-crds.yaml
@@ -80,6 +80,7 @@ spec:
                 provider:
                   type: string
                 selectors: {}
+              nullable: true
             storage:
               properties:
                 disruptionManagement:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
@@ -103,6 +103,7 @@ spec:
                 provider:
                   type: string
                 selectors: {}
+              nullable: true
             storage:
               properties:
                 disruptionManagement:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -167,6 +167,7 @@ spec:
                 provider:
                   type: string
                 selectors: {}
+              nullable: true
             storage:
               properties:
                 disruptionManagement:


### PR DESCRIPTION
Reason is the cluster.yaml example uses `network: null`

Fixes: https://github.com/rook/rook-client-python/runs/893687452

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
