### PR TITLE
ceph: Avoid removing a healthy mon unexpectedly when the operator restarts

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -81,6 +81,11 @@ func (c *Cluster) checkHealth() error {
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
 
+	if c.spec.Mon.Count == 0 || !c.ClusterInfo.IsInitialized() {
+		logger.Warningf("skipping mon health check since cluster details are not initialized")
+		return nil
+	}
+
 	logger.Debugf("Checking health for mons in cluster. %s", c.ClusterInfo.Name)
 
 	// For an external connection we use a special function to get the status


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
At startup there is a race condition between the goroutine checking for mon health and the first reconcile of the mons. There is a lock that ensures only one of them will check the mon health at a time. 

The issue is that if the wrong one gets there first, it will not have the desired mon count initialized from the cluster CR as expected and the healther checker will use a desired mon count of 0. The desired count of 0 leads the health checker to remove a mon since there are extra mons. Only one mon is allowed to be removed at a time, and adjusting to fewer than two mons is disallowed once there are at least two mons.

After the health checker is completed, the main reconcile of the mons will proceed with the correct desired mon count of 3 and attempt to restore to the real desired quorum size.

This is a simplified PR to fix the immediate issue affecting 1.3. A more complete fix will be opened against master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
