### PR TITLE
ceph: Require the cluster spec for initialization of the mons to avoid removing a healthy mon

### DIFF
--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -83,7 +83,7 @@ func newCluster(c *cephv1.CephCluster, context *clusterd.Context, csiMutex *sync
 		monitoringChannels: make(map[string]*clusterHealth),
 		stopCh:             make(chan struct{}),
 		ownerRef:           *ownerRef,
-		mons:               mon.New(context, c.Namespace, c.Spec.DataDirHostPath, c.Spec.Network, *ownerRef, csiMutex),
+		mons:               mon.New(context, c.Namespace, c.Spec, *ownerRef, csiMutex),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -92,6 +92,11 @@ func (c *Cluster) checkHealth() error {
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
 
+	if c.spec.Mon.Count == 0 || !c.ClusterInfo.IsInitialized(true) {
+		logger.Warningf("skipping mon health check since cluster details are not initialized")
+		return nil
+	}
+
 	logger.Debugf("Checking health for mons in cluster. %s", c.ClusterInfo.Namespace)
 
 	// For an external connection we use a special function to get the status

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -101,10 +101,9 @@ func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monRe
 	}, nil
 }
 
-func newCluster(context *clusterd.Context, namespace string, network cephv1.NetworkSpec, allowMultiplePerNode bool, resources v1.ResourceRequirements) *Cluster {
+func newCluster(context *clusterd.Context, namespace string, allowMultiplePerNode bool, resources v1.ResourceRequirements) *Cluster {
 	return &Cluster{
 		ClusterInfo: nil,
-		Network:     network,
 		context:     context,
 		Namespace:   namespace,
 		rookVersion: "myversion",
@@ -146,7 +145,7 @@ func TestStartMonPods(t *testing.T) {
 	namespace := "ns"
 	context, err := newTestStartCluster(t, namespace)
 	assert.Nil(t, err)
-	c := newCluster(context, namespace, cephv1.NetworkSpec{}, true, v1.ResourceRequirements{})
+	c := newCluster(context, namespace, true, v1.ResourceRequirements{})
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// start a basic cluster
@@ -167,7 +166,7 @@ func TestOperatorRestart(t *testing.T) {
 	namespace := "ns"
 	context, err := newTestStartCluster(t, namespace)
 	assert.Nil(t, err)
-	c := newCluster(context, namespace, cephv1.NetworkSpec{}, true, v1.ResourceRequirements{})
+	c := newCluster(context, namespace, true, v1.ResourceRequirements{})
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// start a basic cluster
@@ -177,7 +176,7 @@ func TestOperatorRestart(t *testing.T) {
 
 	validateStart(t, c)
 
-	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, v1.ResourceRequirements{})
+	c = newCluster(context, namespace, true, v1.ResourceRequirements{})
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// starting again should be a no-op, but will not result in an error
@@ -196,7 +195,7 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	assert.Nil(t, err)
 
 	// cluster without host networking
-	c := newCluster(context, namespace, cephv1.NetworkSpec{}, false, v1.ResourceRequirements{})
+	c := newCluster(context, namespace, false, v1.ResourceRequirements{})
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// start a basic cluster
@@ -207,7 +206,8 @@ func TestOperatorRestartHostNetwork(t *testing.T) {
 	validateStart(t, c)
 
 	// cluster with host networking
-	c = newCluster(context, namespace, cephv1.NetworkSpec{HostNetwork: true}, false, v1.ResourceRequirements{})
+	c = newCluster(context, namespace, false, v1.ResourceRequirements{})
+	c.spec.Network.HostNetwork = true
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// starting again should be a no-op, but still results in an error
@@ -232,7 +232,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", "", cephv1.NetworkSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// create the initial config map

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestNodeAffinity(t *testing.T) {
 	clientset := test.New(t, 4)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", cephv1.NetworkSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Placement = map[rookv1.KeyType]rookv1.Placement{}
@@ -76,7 +76,8 @@ func TestHostNetworkSameNode(t *testing.T) {
 	context, err := newTestStartCluster(t, namespace)
 	assert.Nil(t, err)
 	// cluster host networking
-	c := newCluster(context, namespace, cephv1.NetworkSpec{HostNetwork: true}, true, v1.ResourceRequirements{})
+	c := newCluster(context, namespace, true, v1.ResourceRequirements{})
+	c.spec.Network.HostNetwork = true
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 
 	// start a basic cluster
@@ -95,7 +96,7 @@ func TestPodMemory(t *testing.T) {
 		},
 	}
 
-	c := newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
+	c := newCluster(context, namespace, true, r)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
@@ -111,7 +112,7 @@ func TestPodMemory(t *testing.T) {
 		},
 	}
 
-	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
+	c = newCluster(context, namespace, true, r)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
@@ -127,7 +128,7 @@ func TestPodMemory(t *testing.T) {
 		},
 	}
 
-	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
+	c = newCluster(context, namespace, true, r)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
@@ -143,7 +144,7 @@ func TestPodMemory(t *testing.T) {
 		},
 	}
 
-	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
+	c = newCluster(context, namespace, true, r)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
@@ -151,7 +152,7 @@ func TestPodMemory(t *testing.T) {
 
 	// Test no resources were specified on the pod
 	r = v1.ResourceRequirements{}
-	c = newCluster(context, namespace, cephv1.NetworkSpec{}, true, r)
+	c = newCluster(context, namespace, true, r)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
@@ -161,10 +162,10 @@ func TestPodMemory(t *testing.T) {
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(t, 3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", "", cephv1.NetworkSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
-	c.Network.HostNetwork = true
+	c.spec.Network.HostNetwork = true
 
 	monConfig := testGenMonConfig("c")
 	pod := c.makeMonPod(monConfig, false, "")

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -45,8 +45,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 	c := New(
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
-		"/var/lib/rook",
-		cephv1.NetworkSpec{},
+		cephv1.ClusterSpec{},
 		metav1.OwnerReference{},
 		&sync.Mutex{},
 	)
@@ -94,8 +93,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 	c := New(
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
-		"/var/lib/rook",
-		cephv1.NetworkSpec{},
+		cephv1.ClusterSpec{},
 		metav1.OwnerReference{},
 		&sync.Mutex{},
 	)
@@ -155,8 +153,7 @@ func testRequiredDuringScheduling(t *testing.T, hostNetwork, allowMultiplePerNod
 	c := New(
 		&clusterd.Context{},
 		"ns",
-		"/var/lib/rook",
-		cephv1.NetworkSpec{},
+		cephv1.ClusterSpec{},
 		metav1.OwnerReference{},
 		&sync.Mutex{},
 	)

--- a/pkg/operator/ceph/cluster/monitoring.go
+++ b/pkg/operator/ceph/cluster/monitoring.go
@@ -112,7 +112,7 @@ func isMonitoringDisabled(daemon string, clusterSpec *cephv1.ClusterSpec) bool {
 func (c *ClusterController) startMonitoringCheck(cluster *cluster, clusterInfo *cephclient.ClusterInfo, daemon string) {
 	switch daemon {
 	case "mon":
-		healthChecker := mon.NewHealthChecker(cluster.mons, cluster.Spec)
+		healthChecker := mon.NewHealthChecker(cluster.mons)
 		logger.Infof("enabling ceph %s monitoring goroutine for cluster %q", daemon, cluster.Namespace)
 		go healthChecker.Check(cluster.monitoringChannels[daemon].stopChan)
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon was starting with a partial spec. There was a race condition that was causing incorrect initialization in the health check goroutine that could remove a mon upon operator restart. Now the mon will be properly initialized with the full spec.

The side effect of this issue was that when the operator was restarted, it could mistakenly think the desired number of mons was 0 and remove a healthy mon. This was also seen to cause instability in the upgrade integration tests. Evidence of can be seen with the message in the operator log:
```
op-mon: removing an extra mon. currently 3 are in quorum and only 0 are desired
```

This is a more complete fix than what was done in the 1.3 branch with #5868.

This fix also removes some duplication in fields that are all covered by the ClusterSpec type instead of passing the NetworkSpec or dataDirHostPath separately.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
