### PR TITLE
ceph: remove unwanted metadatastore and mountcache flag

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -75,7 +75,6 @@ spec:
             - "--v={{ .LogLevel }}"
             - "--controllerserver=true"
             - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
-            - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
             - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-sts.yaml
@@ -56,7 +56,6 @@ spec:
             - "--v={{ .LogLevel }}"
             - "--controllerserver=true"
             - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
-            - "--metadatastorage=k8s_configmap"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
             - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -63,8 +63,6 @@ spec:
             - "--v={{ .LogLevel }}"
             - "--nodeserver=true"
             - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
-            - "--metadatastorage=k8s_configmap"
-            - "--mountcachedir=/mount-cache-dir"
             - "--pidlimit=-1"
             - "--metricsport={{ .CephFSGRPCMetricsPort }}"
             - "--forcecephkernelclient={{ .ForceCephFSKernelClient }}"
@@ -102,8 +100,6 @@ spec:
               readOnly: true
             - name: host-dev
               mountPath: /dev
-            - name: mount-cache-dir
-              mountPath: /mount-cache-dir
             - name: ceph-csi-config
               mountPath: /etc/ceph-csi-config/
             - name: keys-tmp-dir
@@ -158,8 +154,6 @@ spec:
         - name: host-dev
           hostPath:
             path: /dev
-        - name: mount-cache-dir
-          emptyDir: {}
         - name: ceph-csi-config
           configMap:
             name: rook-ceph-csi-config

--- a/tests/framework/installer/ceph_csi_templates.go
+++ b/tests/framework/installer/ceph_csi_templates.go
@@ -91,7 +91,6 @@ const (
                 - "--type=rbd"
                 - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
                 - "--containerized=true"
-                - "--metadatastorage=k8s_configmap"
                 - "--pidlimit=-1"
               env:
                 - name: HOST_ROOTFS
@@ -207,7 +206,6 @@ const (
                 - "--type=rbd"
                 - "--drivername={{ .DriverNamePrefix }}rbd.csi.ceph.com"
                 - "--containerized=true"
-                - "--metadatastorage=k8s_configmap"
               env:
                 - name: HOST_ROOTFS
                   value: "/rootfs"
@@ -346,7 +344,6 @@ const (
                 - "--v=5"
                 - "--type=cephfs"
                 - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
-                - "--metadatastorage=k8s_configmap"
                 - "--pidlimit=-1"
               env:
                 - name: NODE_ID
@@ -453,8 +450,6 @@ const (
                 - "--v=5"
                 - "--type=cephfs"
                 - "--drivername={{ .DriverNamePrefix }}cephfs.csi.ceph.com"
-                - "--metadatastorage=k8s_configmap"
-                - "--mountcachedir=/mount-cache-dir"
               env:
                 - name: NODE_ID
                   valueFrom:
@@ -483,8 +478,6 @@ const (
                   readOnly: true
                 - name: host-dev
                   mountPath: /dev
-                - name: mount-cache-dir
-                  mountPath: /mount-cache-dir
                 - name: ceph-csi-config
                   mountPath: /etc/ceph-csi-config/
                 - name: keys-tmp-dir
@@ -517,8 +510,6 @@ const (
             - name: host-dev
               hostPath:
                 path: /dev
-            - name: mount-cache-dir
-              emptyDir: {}
             - name: ceph-csi-config
               configMap:
                 name: rook-ceph-csi-config


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

metadatastore and mountcache are required for PVC created by cephcsi v1.0.0 as rook doesn't use ceph-csi v1.+ version
we can remove this flag. Removing these flags doesn't affect the functionality of anything.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

more info on https://github.com/ceph/ceph-csi/pull/1226 and https://github.com/ceph/ceph-csi/issues/882
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
[test ceph]