### PR TITLE
cassandra: use latest 3.11.6 version in examples

### DIFF
--- a/Documentation/cassandra-cluster-crd.md
+++ b/Documentation/cassandra-cluster-crd.md
@@ -19,7 +19,7 @@ metadata:
   name: rook-cassandra
   namespace: rook-cassandra
 spec:
-  version: 3.11.1
+  version: 3.11.6
   repository: my-private-repo.io/cassandra
   mode: cassandra
   # A key/value list of annotations

--- a/cluster/examples/kubernetes/cassandra/cluster.yaml
+++ b/cluster/examples/kubernetes/cassandra/cluster.yaml
@@ -70,7 +70,7 @@ metadata:
   name: rook-cassandra
   namespace: rook-cassandra
 spec:
-  version: 3.11.1
+  version: 3.11.6
   mode: cassandra
   # A key/value list of annotations
   annotations:

--- a/tests/framework/installer/cassandra_manifests.go
+++ b/tests/framework/installer/cassandra_manifests.go
@@ -178,7 +178,7 @@ func (i *CassandraManifests) GetCassandraCluster(namespace string, count int, mo
 	if mode == cassandrav1alpha1.ClusterModeScylla {
 		version = "2.3.0"
 	} else {
-		version = "3.11.1"
+		version = "3.11.6"
 	}
 	return fmt.Sprintf(`
 # Namespace for cassandra cluster


### PR DESCRIPTION
**Description of your changes:**

This also updates the cassandra version in the tests.
This is to provide safe and secure defaults to users running Cassandra.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test cassandra]