### PR TITLE
ceph: add encryption support for osd pvc

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -70,6 +70,7 @@ spec:
       count: 3
       portable: false
       tuneDeviceClass: false
+      encrypted: false
       volumeClaimTemplates:
       - metadata:
           name: data
@@ -315,6 +316,7 @@ The following are the settings for Storage Class Device Sets which can be config
   * `volumeMode`: The volume mode to be set for the PVC. Which should be Block
   * `accessModes`: The access mode for the PVC to be bound by OSD.
 * `schedulerName`: Scheduler name for OSD pod placement. (Optional)
+* `encrypted`: whether to encrypt all the OSDs in a given storageClassDeviceSet
 
 ### OSD Configuration Settings
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -17,6 +17,7 @@
   - OSDs can now be provisioned using Ceph's Drive Groups definitions for Ceph Octopus v15.2.5+.
     [See docs for more](Documentation/ceph-cluster-crd.md#storage-selection-via-ceph-drive-groups)
   - OSDs can be provisioned on support /dev/disk/by-path/pci-HHHH:HH:HH.H devices with colons (`:`)
+  - OSDs on PVC can now be encrypted
 - Added [admission controller](Documentation/admission-controller-usage.md) support for CRD validations.
   - Support for Ceph CRDs is provided. Some validations for CephClusters are included and additional validations can be added for other CRDs
   - Can be extended to add support for other providers

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -58,6 +58,8 @@ spec:
       # Rook can configure the OSD running on PVC to accommodate that by tuning some of the Ceph internal
       # Currently, "gp2" has been identified as such
       tuneDeviceClass: true
+      # whether to encrypt the deviceSet or not
+      encrypted: false
       # Since the OSDs could end up on any node, an effort needs to be made to spread the OSDs
       # across nodes as much as possible. Unfortunately the pod anti-affinity breaks down
       # as soon as you have more than one OSD per node. If you have more OSDs than nodes, K8s may

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -219,6 +219,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 
 	forceFormat := false
 	ownerRef := opcontroller.ClusterOwnerRef(clusterInfo.Namespace, ownerRefID)
+	clusterInfo.OwnerRef = ownerRef
 	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerRef)
 	agent := osddaemon.NewAgent(context, dgs, dataDevices, cfg.metadataDevice, forceFormat,
 		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, cfg.pvcBacked)

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters.go
@@ -74,6 +74,12 @@ func validateUpdatedCephCluster(updatedCephCluster *CephCluster, found *CephClus
 		return errors.Errorf("invalid update: Provider change from %q to %q is not allowed", found.Spec.Network.Provider, updatedCephCluster.Spec.Network.Provider)
 	}
 
+	for i, storageClassDeviceSet := range updatedCephCluster.Spec.Storage.StorageClassDeviceSets {
+		if storageClassDeviceSet.Encrypted != found.Spec.Storage.StorageClassDeviceSets[i].Encrypted {
+			return errors.Errorf("invalid update: StorageClassDeviceSet %q encryption change from %t to %t is not allowed", storageClassDeviceSet.Name, found.Spec.Storage.StorageClassDeviceSets[i].Encrypted, storageClassDeviceSet.Encrypted)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters_test.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	v1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+)
+
+func Test_validateUpdatedCephCluster(t *testing.T) {
+	type args struct {
+		updatedCephCluster *CephCluster
+		found              *CephCluster
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"everything is ok", args{&CephCluster{}, &CephCluster{}}, false},
+		{"changed DataDirHostPath", args{&CephCluster{Spec: ClusterSpec{DataDirHostPath: "foo"}}, &CephCluster{Spec: ClusterSpec{DataDirHostPath: "bar"}}}, true},
+		{"changed HostNetwork", args{&CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: false}}}, &CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: true}}}}, true},
+		{"changed storageClassDeviceSet encryption", args{&CephCluster{Spec: ClusterSpec{Storage: v1.StorageScopeSpec{StorageClassDeviceSets: []v1.StorageClassDeviceSet{{Name: "foo", Encrypted: false}}}}}, &CephCluster{Spec: ClusterSpec{Storage: v1.StorageScopeSpec{StorageClassDeviceSets: []v1.StorageClassDeviceSet{{Name: "foo", Encrypted: true}}}}}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateUpdatedCephCluster(tt.args.updatedCephCluster, tt.args.found); (err != nil) != tt.wantErr {
+				t.Errorf("validateUpdatedCephCluster() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -117,6 +117,7 @@ type StorageClassDeviceSet struct {
 	Portable             bool                       `json:"portable,omitempty"`             // OSD portability across the hosts
 	TuneSlowDeviceClass  bool                       `json:"tuneDeviceClass,omitempty"`      // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
 	SchedulerName        string                     `json:"schedulerName,omitempty"`        // Scheduler name for OSD pod placement
+	Encrypted            bool                       `json:"encrypted,omitempty"`            // Whether to encrypt the deviceSet
 }
 
 // VolumeSource is a volume source spec for Rook
@@ -131,4 +132,5 @@ type VolumeSource struct {
 	SchedulerName       string                                          `json:"schedulerName,omitempty"`    // Scheduler name for OSD pod placement
 	CrushDeviceClass    string                                          `json:"crushDeviceClass,omitempty"` // CrushDeviceClass represents the crush device class for an OSD
 	Size                string                                          `json:"size,omitempty"`             // Size represents the size requested for the PVC
+	Encrypted           bool                                            `json:"encrypted,omitempty"`        // Whether to encrypt the deviceSet
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -430,6 +430,13 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 					}
 				}
 				matchedDevice = desiredDevice
+
+				// On PVC, we must use the real name not the /mnt name since c-v calls udev
+				// udevadm will fail with
+				// stderr Unknown device, --name=, --path=, or absolute path in /dev/ or /sys expected.
+				if agent.pvcBacked {
+					matchedDevice.Name = device.RealPath
+				}
 				if matched {
 					break
 				}

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloseEncryptedDevice(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if command == "cryptsetup" && args[0] == "--verbose" && args[1] == "luksClose" {
+			return "success", nil
+		}
+
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+
+	context := &clusterd.Context{Executor: executor}
+	err := closeEncryptedDevice(context, "/dev/mapper/ceph-43e9efed-0676-4731-b75a-a4c42ece1bb1-xvdbr-block-dmcrypt")
+	assert.NoError(t, err)
+}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -54,6 +54,8 @@ var (
 	cvLogDir      = ""
 	// The "ceph-volume raw" command is available since Ceph 14.2.8 as well as partition support in ceph-volume
 	cephVolumeRawModeMinCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 8}
+
+	isEncrypted = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
 )
 
 type osdInfoBlock struct {
@@ -159,14 +161,6 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if a.pvcBacked {
 		for _, device := range devices.Entries {
 			dev := device.Config.Name
-			// When not using PV backend an LV
-			// Otherwise lsblk will fail since the block will be '/dev/mnt/set1-0-data-l6p5q'
-			// And thus won't be a block device
-			//
-			// The same goes the metadata block device which is stored in /srv
-			if !strings.HasPrefix(dev, "/mnt") && !strings.HasPrefix(dev, "/srv") {
-				dev = path.Join("/dev", dev)
-			}
 			lvBackedPV, err = sys.IsLV(dev, context.Executor)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to check device type")
@@ -205,7 +199,10 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 
 	// List THE configured OSD with ceph-volume raw mode
 	if a.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawModeMinCephVersion) && !lvBackedPV {
-		block = fmt.Sprintf("/mnt/%s", a.nodeName)
+		// When the block is encrypted we need to list against the encrypted device mapper
+		if !isEncrypted {
+			block = fmt.Sprintf("/mnt/%s", a.nodeName)
+		}
 		rawOsds, err = GetCephVolumeRawOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, metadataBlock, lvBackedPV)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
@@ -217,7 +214,6 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 }
 
 func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *DeviceOsdMapping, lvBackedPV bool) (string, string, error) {
-
 	// we need to return the block if raw mode is used and the lv if lvm mode
 	baseCommand := "stdbuf"
 	var baseArgs []string
@@ -299,6 +295,10 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				immediateExecuteArgs = append(immediateExecuteArgs, []string{crushDeviceClassFlag, crushDeviceClass}...)
 			}
 
+			if isEncrypted {
+				immediateExecuteArgs = append(immediateExecuteArgs, encryptedFlag)
+			}
+
 			// Add the cli argument for the metadata device
 			if metadataDev {
 				immediateExecuteArgs = append(immediateExecuteArgs, metadataArg...)
@@ -320,8 +320,13 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			}
 			logger.Infof("%v", op)
 			// if raw mode is used or PV on LV, let's return the path of the device
-			if lvBackedPV || cephVolumeMode == "raw" {
+			if lvBackedPV || cephVolumeMode == "raw" && !isEncrypted {
 				blockPath = deviceArg
+			} else if cephVolumeMode == "raw" && isEncrypted {
+				blockPath = getEncryptedBlockPath(op)
+				if blockPath == "" {
+					return "", "", errors.New("failed to get encrypted block path from ceph-volume lvm prepare output")
+				}
 			} else {
 				blockPath = getLVPath(op)
 				if blockPath == "" {
@@ -348,6 +353,20 @@ func getLVPath(op string) string {
 			return fmt.Sprintf("/dev/%s/%s", vgtmp[1], lvtmp[1])
 		}
 	}
+	return ""
+}
+
+func getEncryptedBlockPath(op string) string {
+	tmp := sys.Grep(op, "luksOpen")
+	tmpList := strings.Split(tmp, " ")
+
+	// The command looks like: "Running command: /usr/sbin/cryptsetup --key-file - --allow-discards luksOpen /dev/xvdbr ceph-43e9efed-0676-4731-b75a-a4c42ece1bb1-xvdbr-block-dmcrypt"
+	for _, item := range tmpList {
+		if strings.Contains(item, "block-dmcrypt") {
+			return fmt.Sprintf("/dev/mapper/%s", item)
+		}
+	}
+
 	return ""
 }
 
@@ -728,8 +747,17 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 			CVMode:        cvMode,
 			Store:         "bluestore",
 		}
-		osds = append(osds, osd)
 
+		// If this is an encrypted OSD
+		if os.Getenv(oposd.CephVolumeEncryptedKeyEnvVarName) != "" {
+			// Close encrypted device
+			err = closeEncryptedDevice(context, block)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to close encrypted device %q for osd %d", block, osdID)
+			}
+		}
+
+		osds = append(osds, osd)
 	}
 	logger.Infof("%d ceph-volume raw osd devices configured on this node", len(osds))
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -268,7 +268,7 @@ func (c *Cluster) getOrGenerateDashboardPassword() (string, error) {
 func GeneratePassword(length int) (string, error) {
 	// #nosec because of the word password
 	const passwordChars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
-	passwd, err := generateRandomBytes(length)
+	passwd, err := GenerateRandomBytes(length)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate password")
 	}
@@ -278,14 +278,15 @@ func GeneratePassword(length int) (string, error) {
 	return string(passwd), nil
 }
 
-// generateRandomBytes returns securely generated random bytes.
-func generateRandomBytes(length int) ([]byte, error) {
+// GenerateRandomBytes returns securely generated random bytes.
+func GenerateRandomBytes(length int) ([]byte, error) {
 	bytes := make([]byte, length)
 	if _, err := rand.Read(bytes); err != nil {
 		return nil, errors.Wrap(err, "failed to generate random bytes")
 	}
 	return bytes, nil
 }
+
 func decodeSecret(secret *v1.Secret) (string, error) {
 	password, ok := secret.Data[passwordKeyName]
 	if !ok {

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -17,15 +17,18 @@ limitations under the License.
 package osd
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -38,6 +41,13 @@ key = %s
 	osdRecoverySleep = "0.1"
 	osdSnapTrimSleep = "2"
 	osdDeleteSleep   = "2"
+
+	// OsdEncryptionSecretNameKeyName is the key name of the Secret that contains the OSD encryption key
+	// #nosec G101 since this is not leaking any hardcoded credentials, it's just the secret key name
+	OsdEncryptionSecretNameKeyName = "dmcrypt-key"
+	dmCryptKeySize                 = 128
+	// #nosec G101 since this is not leaking any hardcoded credentials, it's just the prefix of the secret name
+	osdEncryptionSecretNamePrefix = "rook-ceph-osd-encryption-key"
 )
 
 func (c *Cluster) generateKeyring(osdID int) (string, error) {
@@ -105,4 +115,45 @@ func (c *Cluster) skipVolumeForDirectory(path string) bool {
 	// If attempting to add a directory at /var/lib/rook, we need to skip the volume and volume mount
 	// since the dataDirHostPath is always mounting at /var/lib/rook
 	return path == k8sutil.DataDir
+}
+
+func encryptionKeyPath() string {
+	return fmt.Sprintf("%s/%s", opconfig.EtcCephDir, encryptionKeyFileName)
+}
+
+func encryptionDMName(pvcName string) string {
+	return fmt.Sprintf("%s-block-dmcrypt", pvcName)
+}
+
+func encryptionDMPath(pvcName string) string {
+	return fmt.Sprintf("/dev/mapper/%s", encryptionDMName(pvcName))
+}
+
+func generateDmCryptKey() (string, error) {
+	key, err := mgr.GenerateRandomBytes(dmCryptKeySize)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate random bytes")
+	}
+
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+func generateOSDEncryptedKeySecret(pvcName, namespace, key string) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateOSDEncryptionSecretName(pvcName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				"pvc_name": pvcName,
+			},
+		},
+		StringData: map[string]string{
+			OsdEncryptionSecretNameKeyName: key,
+		},
+		Type: k8sutil.RookType,
+	}
+}
+
+func generateOSDEncryptionSecretName(pvcName string) string {
+	return fmt.Sprintf("%s-%s", osdEncryptionSecretNamePrefix, pvcName)
 }

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -82,6 +82,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 				TuneSlowDeviceClass: storageClassDeviceSet.TuneSlowDeviceClass,
 				SchedulerName:       storageClassDeviceSet.SchedulerName,
 				CrushDeviceClass:    crushDeviceClass,
+				Encrypted:           storageClassDeviceSet.Encrypted,
 			})
 		}
 	}

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -58,11 +58,11 @@ func IsReadyToReconcile(c client.Client, clustercontext *clusterd.Context, names
 	clusterList := &cephv1.CephClusterList{}
 	err := c.List(context.TODO(), clusterList, client.InNamespace(namespacedName.Namespace))
 	if err != nil {
-		logger.Errorf("%q:failed to fetch CephCluster %v", controllerName, err)
+		logger.Errorf("%q: failed to fetch CephCluster %v", controllerName, err)
 		return cephCluster, false, cephClusterExists, ImmediateRetryResult
 	}
 	if len(clusterList.Items) == 0 {
-		logger.Errorf("%q: no CephCluster resource found in namespace %q", controllerName, namespacedName.Namespace)
+		logger.Debugf("%q: no CephCluster resource found in namespace %q", controllerName, namespacedName.Namespace)
 		return cephCluster, false, cephClusterExists, WaitForRequeueIfCephClusterNotReady
 	}
 	cephClusterExists = true

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -113,6 +113,8 @@ type LocalDisk struct {
 	RealPath string `json:"real-path,omitempty"`
 	// KernelName is the kernel name of the device
 	KernelName string `json:"kernel-name,omitempty"`
+	// Whether this device should be encrypted
+	Encrypted bool `json:"encrypted,omitempty"`
 }
 
 // ListDevices list all devices available on a machine

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1886,6 +1886,7 @@ spec:
       count: 1
       portable: false
       tuneDeviceClass: true
+      encrypted: false
       volumeClaimTemplates:
       - metadata:
           name: data


### PR DESCRIPTION
We can now encrypted OSD device that were provisioned via a storage
class using the PV interface.
The encryption works at the storageClassDeviceSets level, which means we
can have encrypted and non-encrypted sets.
Using the new key `encrypted` we can turn it on.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/5590 and https://github.com/rook/rook/issues/5589

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

**Remaining work:**
- [ ] implement metadata device encryption too.