### PR TITLE
Revert "ceph: Fix md5 crypto to more secure sha256"

### DIFF
--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -18,8 +18,7 @@ limitations under the License.
 package k8sutil
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"crypto/md5"
 	"fmt"
 	"regexp"
 	"strings"
@@ -79,10 +78,9 @@ func GetK8SVersion(clientset kubernetes.Interface) (*version.Version, error) {
 	return version.MustParseSemantic(serverVersion.GitVersion), nil
 }
 
-// Hash stableName computes a stable pseudorandom string suitable for inclusion in a Kubernetes object name from the given seed string.
+// Hash MD5 hash a given string
 func Hash(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:16])
+	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }
 
 // TruncateNodeName hashes the nodeName in case it would case the name to be longer than 63 characters

--- a/pkg/operator/k8sutil/k8sutil_test.go
+++ b/pkg/operator/k8sutil/k8sutil_test.go
@@ -26,7 +26,7 @@ import (
 func TestTruncateNodeName(t *testing.T) {
 	// An entry's key is the result. The first value in the []string is the format and the second is the nodeName
 	tests := map[string][]string{
-		"rook-ceph-osd-prepare-801a3ba95fe6ce6a3bd879552ca2a8b0-config": { // 61 chars
+		"rook-ceph-osd-prepare-47d1eb58e063be11c11c995b74cc5fbe-config": { // 61 chars
 			"rook-ceph-osd-prepare-%s-config",                                      // 29 chars (without format)
 			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
 		},
@@ -38,11 +38,11 @@ func TestTruncateNodeName(t *testing.T) {
 			"rook-ceph-osd-prepare-%s",                  // 22 chars (without format)
 			"k8s-worker-500.this.is.a.not.so.long.name", // 41 chars
 		},
-		"801a3ba95fe6ce6a3bd879552ca2a8b0": { // 32 chars
+		"47d1eb58e063be11c11c995b74cc5fbe": { // 32 chars
 			"%s", // 0 chars (without format)
 			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
 		},
-		"rook-ceph-osd-prepare-test-very-long-name-801a3ba95fe6ce6a3bd879552ca2a8b0": { // 74 chars
+		"rook-ceph-osd-prepare-test-very-long-name-47d1eb58e063be11c11c995b74cc5fbe": { // 74 chars
 			"rook-ceph-osd-prepare-test-very-long-name-%s",                         // 42 chars (without format)
 			"k8s-worker-1234567890.this.is.a.very.very.long.node.name.example.com", // 68 chars
 		},

--- a/pkg/operator/k8sutil/volume_test.go
+++ b/pkg/operator/k8sutil/volume_test.go
@@ -40,7 +40,7 @@ func TestPathToVolumeName(t *testing.T) {
 		{"full-width symbols", "q￠￥￦℃℉p", "q-----p"}, // only those written left-to-right
 		{"longer than 63 chars", // if you change the arg string, the hash on the end will change
 			"/this/is/some-path/.that/is_longer/than/$63/chars/1234567890/and/i'm/still/typing",
-			"this-is-some-path--that-i---7890-and-i-m-still-typing-b6b6f18b"},
+			"this-is-some-path--that-i---7890-and-i-m-still-typing-c4132749"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Reverts rook/rook#4587


MD5 is fine for uniqueness: https://stackoverflow.com/questions/201705/how-many-random-elements-before-md5-produces-collisions

The Hash function was also used to create names that were supposed to be consistent: https://github.com/rook/rook/blob/master/pkg/operator/ceph/disruption/nodedrain/reconcile.go#L83

Changing the Hash will remove the promise of consistent names.

This results in orphaned resources across upgrades.