### PR TITLE
ceph: skip csi version detect if allowunsupported is set

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -28,9 +28,13 @@ import (
 )
 
 func ValidateAndConfigureDrivers(clientset kubernetes.Interface, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerRef *metav1.OwnerReference) {
-	if err := validateCSIVersion(clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
-		logger.Errorf("invalid csi version. %+v", err)
-		return
+	if !AllowUnsupported {
+		if err := validateCSIVersion(clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
+			logger.Errorf("invalid csi version. %+v", err)
+			return
+		}
+	} else {
+		logger.Info("Skipping csi version check, since unsupported versions are allowed")
 	}
 
 	if err := startDrivers(clientset, namespace, serverVersion, ownerRef); err != nil {

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -625,10 +625,6 @@ func validateCSIVersion(clientset kubernetes.Interface, namespace, rookImage, se
 
 	version, err := extractCephCSIVersion(stdout)
 	if err != nil {
-		if AllowUnsupported {
-			logger.Infof("failed to extract csi version, but continuing since unsupported versions are allowed. %v", err)
-			return nil
-		}
 		return errors.Wrap(err, "failed to extract ceph CSI version")
 	}
 	logger.Infof("Detected ceph CSI image version: %q", version)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the AllowUnsupported flag is set to true we should not check the csi version as it will be kind of no-op as even in case of failure we continue. if we disable the version check, in this case, the deployment will be a little faster as we don't wait for version check to complete to start CSI pods.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
[test ceph]