### PR TITLE
ceph: force orchestrator backend to rook if not set

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -2050,8 +2050,6 @@ spec:
     modules:
     - name: pg_autoscaler
       enabled: true
-    - name: rook
-      enabled: true
   healthCheck:
     daemonHealth:
       mon:

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -121,20 +121,60 @@ func (suite *CephMgrSuite) execute(command []string) (error, string) {
 	return suite.cluster.installer.Execute("ceph", orchCommand, suite.namespace)
 }
 
+func (suite *CephMgrSuite) enableRookOrchestrator() error {
+	logger.Info("Enabling Rook orchestrator module: <ceph mgr module enable rook>")
+	err, output := suite.cluster.installer.Execute("ceph", []string{"mgr", "module", "enable", "rook"}, suite.namespace)
+	logger.Infof("output: %s", output)
+	if err != nil {
+		logger.Infof("Not possible to enable rook orchestrator module: %q", err)
+		return err
+	}
+	logger.Info("Setting orchestrator backend to Rook .... <ceph orch set backend rook>")
+	err, output = suite.execute([]string{"set", "backend", "rook"})
+	logger.Infof("output: %s", output)
+	if err != nil {
+		logger.Infof("Not possible to set rook as backend orchestrator module: %q", err)
+	}
+	return err
+}
+
 func (suite *CephMgrSuite) waitForOrchestrationModule() {
 	var err error
+	var orchStatus map[string]string
+
+	err = suite.enableRookOrchestrator()
+	if err != nil {
+		logger.Error("First attemp: Error trying to set Rook orchestrator module")
+	}
+
 	for timeout := 0; timeout < 30; timeout++ {
+		logger.Info("Waiting for rook orchestrator module enabled and ready ...")
 		err, output := suite.execute([]string{"status"})
-		logger.Infof("%s", output)
+		logger.Infof("output: %s", output)
 		if err == nil {
 			logger.Info("Rook Toolbox ready to execute commands")
+			// Convert string returned to map
+			outputLines := strings.Split(output, "\n")
+			orchStatus = make(map[string]string)
+			for _, setting := range outputLines {
+				s := strings.Split(setting, ":")
+				orchStatus[strings.TrimSpace(strings.ToLower(s[0]))] = strings.TrimSpace(strings.ToLower(s[1]))
+			}
+			if orchStatus["backend"] != "rook" {
+				err = suite.enableRookOrchestrator()
+				if err != nil {
+					continue
+				}
+			}
 			break
+		} else {
+			logger.Info("Rook orchestrator not ready. Enabling again ... ")
+			err = suite.enableRookOrchestrator()
 		}
 		time.Sleep(2 * time.Second)
 	}
-	logger.Error("Giving up waiting for Rook Toolbox to be ready")
-	assert.Nil(suite.T(), err)
 }
+
 func (suite *CephMgrSuite) TestDeviceLs() {
 	logger.Info("Testing .... <ceph orch device ls>")
 	err, device_list := suite.execute([]string{"device", "ls"})


### PR DESCRIPTION
Verify what is the current backend orchestrator and sets it to rook if it is not set/or it is different from rook.

[test ceph]

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

Resolves #5877

**Checklist:**

- [ x ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
