### PR TITLE
Suppress gosec errors for closing files

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -210,6 +210,7 @@ func TerminateFatal(reason error) {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("failed to write message to termination log: %+v", err))
 	} else {
+		// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 		defer file.Close()
 		if _, err = file.WriteString(reason.Error()); err != nil {
 			fmt.Fprintln(os.Stderr, fmt.Errorf("failed to write message to termination log: %+v", err))

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -250,6 +250,7 @@ func configureFlexVolume(driverFile, driverDir, driverName string) error {
 	return nil
 }
 
+// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 func copyFile(src, dest string) error {
 	srcFile, err := os.Open(filepath.Clean(src))
 	if err != nil {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -654,6 +654,7 @@ func readCVLogContent(cvLogFilePath string) string {
 		logger.Errorf("failed to open ceph-volume log file %q. %v", cvLogFilePath, err)
 		return ""
 	}
+	// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 	defer cvLogFile.Close()
 
 	// Read c-v log file

--- a/pkg/daemon/util/copybins.go
+++ b/pkg/daemon/util/copybins.go
@@ -36,6 +36,7 @@ func CopyBinaries(target string) error {
 	return copyBinary(defaultTiniDir, target, "tini")
 }
 
+// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 func copyBinary(sourceDir, targetDir, filename string) error {
 	sourcePath := path.Join(sourceDir, filename)
 	targetPath := path.Join(targetDir, filename)

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -134,6 +134,7 @@ func (*CommandExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...
 }
 
 // ExecuteCommandWithOutputFileTimeout Same as ExecuteCommandWithOutputFile but with a timeout limit.
+// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duration,
 	command, outfileArg string, arg ...string) (string, error) {
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
To ensure a file handle is closed, we defer the close command so it is guaranteed to run when the method returns. The closing of the file handle is not going to fail in our usage since we aren't using the SetDeadline on the files that would cancel a request and return an error.

**Which issue is resolved by this Pull Request:**
Resolves (partially) #3765 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
