### PR TITLE
ceph: suppress gosec errors for g204,g304,g101

### DIFF
--- a/cmd/rookflex/cmd/expander.go
+++ b/cmd/rookflex/cmd/expander.go
@@ -62,8 +62,10 @@ func handleExpandFs(cmd *cobra.Command, args []string) error {
 	var command *exec.Cmd
 	switch opts.FsType {
 	case "ext3", "ext4":
+		// #nosec G204 Rook controls the input to the exec arguments
 		command = exec.Command("resize2fs", args[2])
 	case "xfs":
+		// #nosec G204 Rook controls the input to the exec arguments
 		command = exec.Command("xfs_growfs", "-d", args[2])
 	default:
 		log(client, fmt.Sprintf("resize is not supported for fs: %s", opts.FsType), false)

--- a/cmd/rookflex/cmd/unmount.go
+++ b/cmd/rookflex/cmd/unmount.go
@@ -52,6 +52,7 @@ func handleUnmount(cmd *cobra.Command, args []string) error {
 	mounter := getMounter()
 
 	// Check if it's a cephfs mount
+	// #nosec G204 Rook controls the input to the exec arguments
 	fstype, err := exec.Command("findmnt", "--nofsroot", "--noheadings", "--output", "FSTYPE", "--submounts", "--target", mountDir).Output()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve filesystem type for path %q. %+v", mountDir, err)

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -258,6 +258,7 @@ func copyFile(src, dest string) error {
 	}
 	defer srcFile.Close()
 
+	// #nosec G304 Rook controls the File path provided as input
 	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755) // creates if file doesn't exist
 	if err != nil {
 		return errors.Wrapf(err, "error creating destination file %s", dest)

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -649,6 +649,7 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 func readCVLogContent(cvLogFilePath string) string {
 	// Open c-v log file
+	// #nosec G304 Rook controls File path provided as input
 	cvLogFile, err := os.Open(cvLogFilePath)
 	if err != nil {
 		logger.Errorf("failed to open ceph-volume log file %q. %v", cvLogFilePath, err)

--- a/pkg/operator/ceph/webhook.go
+++ b/pkg/operator/ceph/webhook.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	appName                  = "rook-ceph-admission-controller"
-	secretVolumeName         = "webhook-certificates"
+	secretVolumeName         = "webhook-certificates" // #nosec G101 This is just a var name, not a real secret
 	serviceAccountName       = "rook-ceph-admission-controller"
 	portName                 = "webhook-api"
 	servicePort        int32 = 443

--- a/pkg/operator/nfs/server.go
+++ b/pkg/operator/nfs/server.go
@@ -66,6 +66,7 @@ func Setup(ganeshaConfig string) error {
 func Run(ganeshaConfig string) error {
 	// Start ganesha.nfsd
 	logger.Infof("Running NFS server!")
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command("ganesha.nfsd", "-F", "-L", ganeshaLog, "-f", ganeshaConfig, "-N", ganeshaOptions)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("ganesha.nfsd failed with error: %v, output: %s", err, out)

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -70,6 +70,7 @@ func (*CommandExecutor) ExecuteCommandWithEnv(env []string, command string, arg 
 // ExecuteCommandWithTimeout starts a process and wait for its completion with timeout.
 func (*CommandExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error) {
 	logCommand(command, arg...)
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 
 	var b bytes.Buffer
@@ -122,6 +123,7 @@ func (*CommandExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command
 // ExecuteCommandWithOutput executes a command with output
 func (*CommandExecutor) ExecuteCommandWithOutput(command string, arg ...string) (string, error) {
 	logCommand(command, arg...)
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 	return runCommandWithOutput(cmd, false)
 }
@@ -129,6 +131,7 @@ func (*CommandExecutor) ExecuteCommandWithOutput(command string, arg ...string) 
 // ExecuteCommandWithCombinedOutput executes a command with combined output
 func (*CommandExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error) {
 	logCommand(command, arg...)
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 	return runCommandWithOutput(cmd, true)
 }
@@ -151,6 +154,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duratio
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.CommandContext(ctx, command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 
@@ -188,6 +192,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 	arg = append(arg, outfileArg, outFile.Name())
 
 	logCommand(command, arg...)
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 	// if there was anything that went to stdout/stderr then log it, even before we return an error
@@ -206,6 +211,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 func startCommand(env []string, command string, arg ...string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	logCommand(command, arg...)
 
+	// #nosec G204 Rook controls the input to the exec arguments
 	cmd := exec.Command(command, arg...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
this commit suppress the gosec errors for

g204: Audit use of command execution
g304: File path provided as taint input
g101: Look for hard coded credentials

after this commit:-
`$GOPATH/bin/gosec -include=G204,G304,G101 cmd/... -severity=medium`

```
Summary:
   Files: 35
   Lines: 2955
   Nosec: 3
  Issues: 0
```
`$GOPATH/bin/gosec -include=G204,G304,G101 pkg/... -severity=medium`

```
Summary:
   Files: 519
   Lines: 82514
   Nosec: 17
  Issues: 0
```

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3765

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
