### PR TITLE
ceph: add ceph_daemon_type label to Ceph daemon pods

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -30,6 +30,7 @@
   - The endpoint is now displayed in the Status field
 - Prometheus monitoring for external clusters is now possible, refer to the [external cluster section](Documentation/ceph-cluster-crd.html#external-cluster)
 - The operator will check for the presence of the `lvm2` package on the host where OSDs will run. If not available, the prepare job will fail. This will prevent issues of OSDs not restarting on node reboot.
+- Added a new label "ceph_daemon_type" label to Ceph daemon pods to go alongside the existing "ceph_daemon_id" label.
 
 ### EdgeFS
 

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -323,7 +323,7 @@ func (c *Cluster) makeDashboardService(name string) *v1.Service {
 }
 
 func (c *Cluster) getPodLabels(daemonName string) map[string]string {
-	labels := controller.PodLabels(AppName, c.clusterInfo.Namespace, "mgr", daemonName)
+	labels := controller.CephDaemonAppLabels(AppName, c.clusterInfo.Namespace, "mgr", daemonName)
 	// leave "instance" key for legacy usage
 	labels["instance"] = daemonName
 	return labels

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -46,7 +46,7 @@ const (
 func (c *Cluster) getLabels(daemonName string, canary bool, pvcName string) map[string]string {
 	// Mons have a service for each mon, so the additional pod data is relevant for its services
 	// Use pod labels to keep "mon: id" for legacy
-	labels := controller.PodLabels(AppName, c.Namespace, "mon", daemonName)
+	labels := controller.CephDaemonAppLabels(AppName, c.Namespace, "mon", daemonName)
 	// Add "mon_cluster: <namespace>" for legacy
 	labels[monClusterAttr] = c.Namespace
 	if canary {

--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -44,7 +44,7 @@ func makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClas
 
 func (c *Cluster) getOSDLabels(osdID int, failureDomainValue string, portable bool) map[string]string {
 	stringID := fmt.Sprintf("%d", osdID)
-	labels := controller.PodLabels(AppName, c.clusterInfo.Namespace, "osd", stringID)
+	labels := controller.CephDaemonAppLabels(AppName, c.clusterInfo.Namespace, "osd", stringID)
 	// Add "ceph-osd-id: <id>" for legacy
 	labels[OsdIdLabelKey] = stringID
 	labels[FailureDomainKey] = failureDomainValue

--- a/pkg/operator/ceph/cluster/osd/labels.go
+++ b/pkg/operator/ceph/cluster/osd/labels.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 )
 
 const (
@@ -43,11 +43,11 @@ func makeStorageClassDeviceSetPVCLabel(storageClassDeviceSetName, pvcStorageClas
 }
 
 func (c *Cluster) getOSDLabels(osdID int, failureDomainValue string, portable bool) map[string]string {
-	return map[string]string{
-		k8sutil.AppAttr:     AppName,
-		k8sutil.ClusterAttr: c.clusterInfo.Namespace,
-		OsdIdLabelKey:       fmt.Sprintf("%d", osdID),
-		FailureDomainKey:    failureDomainValue,
-		portableKey:         strconv.FormatBool(portable),
-	}
+	stringID := fmt.Sprintf("%d", osdID)
+	labels := controller.PodLabels(AppName, c.clusterInfo.Namespace, "osd", stringID)
+	// Add "ceph-osd-id: <id>" for legacy
+	labels[OsdIdLabelKey] = stringID
+	labels[FailureDomainKey] = failureDomainValue
+	labels[portableKey] = strconv.FormatBool(portable)
+	return labels
 }

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -31,7 +31,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   daemonConfig.ResourceName,
-			Labels: controller.PodLabels(AppName, rbdMirror.Namespace, config.RbdMirrorType, daemonConfig.DaemonID),
+			Labels: controller.CephDaemonAppLabels(AppName, rbdMirror.Namespace, config.RbdMirrorType, daemonConfig.DaemonID),
 		},
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{
@@ -64,7 +64,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 			Name:        daemonConfig.ResourceName,
 			Namespace:   rbdMirror.Namespace,
 			Annotations: rbdMirror.Spec.Annotations,
-			Labels:      controller.PodLabels(AppName, rbdMirror.Namespace, config.RbdMirrorType, daemonConfig.DaemonID),
+			Labels:      controller.CephDaemonAppLabels(AppName, rbdMirror.Namespace, config.RbdMirrorType, daemonConfig.DaemonID),
 		},
 		Spec: apps.DeploymentSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -306,11 +306,11 @@ func AppLabels(appName, namespace string) map[string]string {
 	}
 }
 
-// PodLabels returns pod labels common to all Rook-Ceph pods which may be useful for admins.
+// CephDaemonAppLabels returns pod labels common to all Rook-Ceph pods which may be useful for admins.
 // App name is the name of the application: e.g., 'rook-ceph-mon', 'rook-ceph-mgr', etc.
 // Daemon type is the Ceph daemon type: "mon", "mgr", "osd", "mds", "rgw"
 // Daemon ID is the ID portion of the Ceph daemon name: "a" for "mon.a"; "c" for "mds.c"
-func PodLabels(appName, namespace, daemonType, daemonID string) map[string]string {
+func CephDaemonAppLabels(appName, namespace, daemonType, daemonID string) map[string]string {
 	labels := AppLabels(appName, namespace)
 	labels["ceph_daemon_type"] = daemonType
 	labels["ceph_daemon_id"] = daemonID

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -312,6 +312,7 @@ func AppLabels(appName, namespace string) map[string]string {
 // Daemon ID is the ID portion of the Ceph daemon name: "a" for "mon.a"; "c" for "mds.c"
 func PodLabels(appName, namespace, daemonType, daemonID string) map[string]string {
 	labels := AppLabels(appName, namespace)
+	labels["ceph_daemon_type"] = daemonType
 	labels["ceph_daemon_id"] = daemonID
 	// Also report the daemon id keyed by its daemon type: "mon: a", "mds: c", etc.
 	labels[daemonType] = daemonID

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -133,7 +133,7 @@ func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 }
 
 func (c *Cluster) podLabels(mdsConfig *mdsConfig) map[string]string {
-	labels := controller.PodLabels(AppName, c.fs.Namespace, "mds", mdsConfig.DaemonID)
+	labels := controller.CephDaemonAppLabels(AppName, c.fs.Namespace, "mds", mdsConfig.DaemonID)
 	labels["rook_file_system"] = c.fs.Name
 	return labels
 }

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -240,7 +240,7 @@ func (r *ReconcileCephNFS) dbusContainer(nfs *cephv1.CephNFS) v1.Container {
 }
 
 func getLabels(n *cephv1.CephNFS, name string) map[string]string {
-	labels := controller.AppLabels(AppName, n.Namespace)
+	labels := controller.PodLabels(AppName, n.Namespace, "nfs", name)
 	labels["ceph_nfs"] = n.Name
 	labels["instance"] = name
 	return labels

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -240,7 +240,7 @@ func (r *ReconcileCephNFS) dbusContainer(nfs *cephv1.CephNFS) v1.Container {
 }
 
 func getLabels(n *cephv1.CephNFS, name string) map[string]string {
-	labels := controller.PodLabels(AppName, n.Namespace, "nfs", name)
+	labels := controller.CephDaemonAppLabels(AppName, n.Namespace, "nfs", name)
 	labels["ceph_nfs"] = n.Name
 	labels["instance"] = name
 	return labels

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -349,7 +349,7 @@ func addPortToEndpoint(endpoints *v1.Endpoints, name string, port int32) {
 }
 
 func getLabels(name, namespace string) map[string]string {
-	labels := controller.PodLabels(AppName, namespace, "rgw", name)
+	labels := controller.CephDaemonAppLabels(AppName, namespace, "rgw", name)
 	labels["rook_object_store"] = name
 	return labels
 }


### PR DESCRIPTION
**Description of your changes:**

add 'ceph_daemon_type' label to pod labels

This can help users identify the daemon type similarly to how
'ceph_daemon_id' helps identify the daemon ID. This also makes it so
scripts users create don't have to parse "app=rook-ceph-<daemonType>"
into "<daemonType>" if they desire that bit of info.

Add this label to OSDs and to NFSes.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
