### PR TITLE
ci: Enable the builds to run back to 1.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,6 +151,8 @@ pipeline {
                 stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cockroachdb-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,yugabytedb-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/'
                 script {
                     def data = [
+                        "aws_1.11.x": "v1.11.10",
+                        "aws_1.13.x": "v1.13.12",
                         "aws_1.14.x": "v1.14.10",
                         "aws_1.15.x": "v1.15.11",
                         "aws_1.16.x": "v1.16.8",

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -140,7 +140,6 @@ spec:
                 storageClassDeviceSets: {}
             driveGroups:
               type: array
-              nullable: true
               items:
                 properties:
                   name:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -159,7 +159,6 @@ spec:
                 storageClassDeviceSets: {}
             driveGroups:
               type: array
-              nullable: true
               items:
                 properties:
                   name:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -223,7 +223,6 @@ spec:
                 storageClassDeviceSets: {}
             driveGroups:
               type: array
-              nullable: true
               items:
                 properties:
                   name:

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -40,12 +40,12 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion      = "1.14.0"
-	cephMasterSuiteMinimalTestVersion = "1.15.0"
-	multiClusterMinimalTestVersion    = "1.15.0"
+	flexDriverMinimalTestVersion      = "1.11.0"
+	cephMasterSuiteMinimalTestVersion = "1.12.0"
+	multiClusterMinimalTestVersion    = "1.14.0,1.15.0"
 	helmMinimalTestVersion            = "1.16.0"
 	upgradeMinimalTestVersion         = "1.17.0"
-	smokeSuiteMinimalTestVersion      = "1.18.0"
+	smokeSuiteMinimalTestVersion      = "1.13.0,1.18.0"
 )
 
 var (

--- a/tests/integration/nfs_test.go
+++ b/tests/integration/nfs_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/util/version"
 )
 
 // *******************************************************
@@ -73,6 +74,12 @@ func (suite *NfsSuite) Setup() {
 	suite.instanceCount = 1
 
 	k8shelper, err := utils.CreateK8sHelper(suite.T)
+	v := version.MustParseSemantic(k8shelper.GetK8sServerVersion())
+	if !v.AtLeast(version.MustParseSemantic("1.14.0")) {
+		logger.Info("Skipping NFS tests when not at least K8s v1.14")
+		suite.T().Skip()
+	}
+
 	require.NoError(suite.T(), err)
 	suite.k8shelper = k8shelper
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The CI in the release branch should run back to k8s v1.11 until we officially remove support for that version.

PRs in the release branch will not run the mgr test either, which is only intended to run in master PRs.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
