### PR TITLE
ci: fix log output

### DIFF
--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -125,7 +125,7 @@ func (suite *CephMgrSuite) waitForOrchestrationModule() {
 	var err error
 	for timeout := 0; timeout < 30; timeout++ {
 		err, output := suite.execute([]string{"status"})
-		logger.Info("%s", output)
+		logger.Infof("%s", output)
 		if err == nil {
 			logger.Info("Rook Toolbox ready to execute commands")
 			break


### PR DESCRIPTION
During debugging my PR, I noticed the following error does not output properly in [this test](https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/PR-5909/runs/6/nodes/57/steps/123/log/?start=0).

This is because of using `logger.Info`, so I fixed it.

```
2020-07-28 20:46:54.684364 D | exec: Running command: kubectl exec -i rook-ceph-tools -n mgr-ns -- ceph orch status --connect-timeout=15
2020-07-28 20:46:55.772286 W | installer: Error executing command "ceph": <exit status 22>
2020-07-28 20:46:55.772353 I | integrationTest: %s. no valid command found; 10 closest matches:
pg stat
pg getmap
pg dump [all|summary|sum|delta|pools|osds|pgs|pgs_brief...]
pg dump_json [all|summary|sum|pools|osds|pgs...]
pg dump_pools_json
pg ls-by-pool <poolstr> [<states>...]
pg ls-by-primary <id|osd.id> [<pool:int>] [<states>...]
pg ls-by-osd <id|osd.id> [<pool:int>] [<states>...]
pg ls [<pool:int>] [<states>...]
pg dump_stuck [inactive|unclean|stale|undersized|degraded...] [<threshold:int>]
Error EINVAL: invalid command
command terminated with exit code 22
```

Also, this error message is seen in other PR's CI which passes.
For example, [this](https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/PR-5909/runs/6/nodes/57/steps/123/log/?start=0)

It seems to me that `ceph orch status` would work later than  [ceph v15.2.0](https://github.com/ceph/ceph/blob/v15.2.0/doc/mgr/orchestrator.rst#status) and, before the version, maybe `ceph orchestrator status`  would be appropriate.
In [ceph v15.1.0](https://github.com/ceph/ceph/blob/v15.1.0/doc/mgr/orchestrator_cli.rst#status), `ceph orchestrator status` would work.


Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
