### PR TITLE
ceph: handling all the gosec errors

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -206,7 +206,7 @@ func TerminateOnError(err error, msg string) {
 func TerminateFatal(reason error) {
 	fmt.Fprintln(os.Stderr, reason)
 
-	file, err := os.OpenFile(terminationLog, os.O_APPEND|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(terminationLog, os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("failed to write message to termination log: %+v", err))
 	} else {

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -260,7 +260,7 @@ func copyFile(src, dest string) error {
 	}
 	defer srcFile.Close()
 
-	// #nosec G304 since destFile needs the permission to execute
+	// #nosec G302,G304 since destFile needs the permission to execute
 	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0750) // creates if file doesn't exist
 	if err != nil {
 		return errors.Wrapf(err, "error creating destination file %s", dest)

--- a/pkg/daemon/ceph/util/util.go
+++ b/pkg/daemon/ceph/util/util.go
@@ -80,6 +80,7 @@ func GetPortFromEndpoint(endpoint string) int32 {
 	if err != nil {
 		logger.Errorf("failed to split host and port for endpoint %q, assuming default Ceph port %q. %v", endpoint, portString, err)
 	} else {
+		// #nosec G109 using Atoi to convert type into int is not a real risk
 		port, err = strconv.Atoi(portString)
 		if err != nil {
 			logger.Errorf("failed to convert %q to integer. %v", portString, err)

--- a/pkg/operator/cassandra/controller/util/util.go
+++ b/pkg/operator/cassandra/controller/util/util.go
@@ -121,6 +121,7 @@ func IndexFromName(n string) (int32, error) {
 		return -1, fmt.Errorf("couldn't get index from name %s", n)
 	}
 
+	// #nosec G109 using Atoi to convert type into int is not a real risk
 	index, err := strconv.Atoi(n[delimIndex+1:])
 	if err != nil {
 		return -1, fmt.Errorf("couldn't get index from name %s", n)

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -17,8 +17,7 @@ limitations under the License.
 package bucket
 
 import (
-	"math/rand"
-	"time"
+	"crypto/rand"
 
 	"github.com/coreos/pkg/capnslog"
 	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
@@ -125,12 +124,13 @@ func getService(c kubernetes.Interface, namespace, name string) (*v1.Service, er
 
 func randomString(n int) string {
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	var letterRunes = []rune("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[r.Intn(len(letterRunes))]
+	var letterRunes = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	for k, v := range b {
+		b[k] = letterRunes[v%byte(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -169,6 +169,7 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 			logger.Errorf("wrong localAddr format")
 			return svc
 		}
+		// #nosec G109 using Atoi to convert type into int is not a real risk
 		lport, _ := strconv.Atoi(port)
 		lportServicePort := v1.ServicePort{Name: "lport", Port: int32(lport), Protocol: v1.ProtocolTCP}
 		if isgwSpec.ExternalPort != 0 {
@@ -187,6 +188,7 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 			logger.Errorf("wrong dynamicFetchAddr format")
 			return svc
 		}
+		// #nosec G109 using Atoi to convert type into int is not a real risk
 		lport, _ := strconv.Atoi(port)
 
 		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{Name: "dfport", Port: int32(lport), Protocol: v1.ProtocolTCP})
@@ -394,6 +396,7 @@ func (c *ISGWController) isgwContainer(svcname, name, containerImage string, isg
 			logger.Errorf("wrong localAddr format")
 			return cont
 		}
+		// #nosec G109 using Atoi to convert type into int is not a real risk
 		lport, _ := strconv.Atoi(port)
 		cont.Ports = append(cont.Ports, v1.ContainerPort{Name: "lport", ContainerPort: int32(lport), Protocol: v1.ProtocolTCP})
 	}
@@ -403,6 +406,7 @@ func (c *ISGWController) isgwContainer(svcname, name, containerImage string, isg
 			logger.Errorf("wrong dynamicFetchAddr format")
 			return cont
 		}
+		// #nosec G109 using Atoi to convert type into int is not a real risk
 		lport, _ := strconv.Atoi(port)
 		cont.Ports = append(cont.Ports, v1.ContainerPort{Name: "dfport", ContainerPort: int32(lport), Protocol: v1.ProtocolTCP})
 	}

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -177,6 +177,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duratio
 }
 
 // ExecuteCommandWithOutputFile executes a command with output on a file
+// #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close
 func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string, arg ...string) (string, error) {
 
 	// create a temporary file to serve as the output file for the command to be run and ensure

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -32,7 +32,7 @@ func WriteFile(filePath string, contentBuffer bytes.Buffer) error {
 	if err := os.MkdirAll(dir, 0744); err != nil {
 		return fmt.Errorf("failed to create config file directory at %s: %+v", dir, err)
 	}
-	if err := ioutil.WriteFile(filePath, contentBuffer.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, contentBuffer.Bytes(), 0600); err != nil {
 		return fmt.Errorf("failed to write config file to %s: %+v", filePath, err)
 	}
 


### PR DESCRIPTION
a few of the gosec errors were left. like
G109: Potential Integer overflow made by strconv.Atoi result conversion to int16/32
(suppressing G109 )
G302: Poor file permissions used with chmod
G306: Poor file permissions used when writing to a new file
G307: Deferring a method which returns an error (suppress G307)
G404:  Insecure random number source (rand) 

so this commit will resolve all the above gosec errors.

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
