### PR TITLE
ceph: Allowing ceph filesystem argument to be optional

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -482,21 +482,6 @@ class RadosJSON:
                 }
             },
             {
-                "name": "cephfs",
-                "kind": "StorageClass",
-                "data": {
-                    "fsName": self.out_map['CEPHFS_FS_NAME'],
-                    "pool": self.out_map['CEPHFS_POOL_NAME']
-                }
-            },
-            {
-                "name": "ceph-rgw",
-                "kind": "StorageClass",
-                "data": {
-                    "endpoint": self.out_map['RGW_ENDPOINT']
-                }
-            },
-            {
                 "name": "monitoring-endpoint",
                 "kind": "CephCluster",
                 "data": {
@@ -505,6 +490,27 @@ class RadosJSON:
                 }
             }
         ]
+        # if 'CEPHFS_FS_NAME' exists, then only add 'cephfs' StorageClass
+        if self.out_map['CEPHFS_FS_NAME']:
+            json_out.append(
+                    {
+                        "name": "cephfs",
+                        "kind": "StorageClass",
+                        "data": {
+                            "fsName": self.out_map['CEPHFS_FS_NAME'],
+                            "pool": self.out_map['CEPHFS_POOL_NAME']
+                        }
+            })
+        # if 'RGW_ENDPOINT' exists, then only add 'ceph-rgw' StorageClass
+        if self.out_map['RGW_ENDPOINT']:
+            json_out.append(
+                    {
+                        "name": "ceph-rgw",
+                        "kind": "StorageClass",
+                        "data": {
+                            "endpoint": self.out_map['RGW_ENDPOINT']
+                        }
+            })
         return json.dumps(json_out)+LINESEP
 
     def main(self):


### PR DESCRIPTION
If we are unable to get a default ceph data pool name,
script won't be throwing an error.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]