### PR TITLE
ceph: closing file which are open for writing

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -215,6 +215,9 @@ func TerminateFatal(reason error) {
 		if _, err = file.WriteString(reason.Error()); err != nil {
 			fmt.Fprintln(os.Stderr, fmt.Errorf("failed to write message to termination log: %+v", err))
 		}
+		if err := file.Close(); err != nil {
+			logger.Errorf("failed to close file. %v", err)
+		}
 	}
 
 	os.Exit(1)

--- a/pkg/daemon/ceph/agent/flexvolume/server.go
+++ b/pkg/daemon/ceph/agent/flexvolume/server.go
@@ -271,7 +271,11 @@ func copyFile(src, dest string) error {
 	if err != nil {
 		return errors.Wrapf(err, "error copying file from %s to %s", src, dest)
 	}
-	return destFile.Sync()
+	err = destFile.Sync()
+	if err := destFile.Close(); err != nil {
+		return err
+	}
+	return err
 }
 
 // Gets the flex driver info (vendor, driver name) from a given path where the flex driver exists.

--- a/pkg/daemon/util/copybins.go
+++ b/pkg/daemon/util/copybins.go
@@ -68,6 +68,9 @@ func copyBinary(sourceDir, targetDir, filename string) error {
 	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
 		return err
 	}
+	if err := destinationFile.Close(); err != nil {
+		return err
+	}
 	// #nosec targetPath requires the permission to execute
 	return os.Chmod(targetPath, 0700)
 }

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -173,6 +173,9 @@ func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duratio
 	}
 
 	fileOut, err := ioutil.ReadAll(outFile)
+	if err := outFile.Close(); err != nil {
+		return "", err
+	}
 	return string(fileOut), err
 }
 
@@ -206,6 +209,9 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 
 	// read the entire output file and return that to the caller
 	fileOut, err := ioutil.ReadAll(outFile)
+	if err := outFile.Close(); err != nil {
+		return "", err
+	}
 	return string(fileOut), err
 }
 


### PR DESCRIPTION
using defer for the closing files which are open
for writing is not safe. so closing file again
following  below steps:

1. open files
2. defer file.close()
3. write 
4.file.close()

these will make sure files are closed.

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
