### PR TITLE
ceph: use deleteOBCResourceLogError instead of deleteOBCResource

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -104,7 +104,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 	// setting quota limit if it is enabled
 	err = p.setAdditionalSettings(options)
 	if err != nil {
-		p.deleteOBCResource(p.bucketName)
+		p.deleteOBCResourceLogError(p.bucketName)
 		return nil, err
 	}
 
@@ -192,7 +192,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 	// setting quota limit if it is enabled
 	err = p.setAdditionalSettings(options)
 	if err != nil {
-		p.deleteOBCResource("")
+		p.deleteOBCResourceLogError("")
 		return nil, err
 	}
 

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -504,9 +504,9 @@ func (p *Provisioner) populateDomainAndPort(sc *storagev1.StorageClass) error {
 	return nil
 }
 
-func (p *Provisioner) deleteOBCResourceLogError(name string) {
-	if err := p.deleteOBCResource(""); err != nil {
-		logger.Warningf("error deleting OBC resource. %v", err)
+func (p *Provisioner) deleteOBCResourceLogError(bucketname string) {
+	if err := p.deleteOBCResource(bucketname); err != nil {
+		logger.Warningf("failed to delete OBC resource. %v", err)
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
using deleteOBCResourceLogError() instead of deleteOBCResource to resolve issues related to GOSEC. Also fixed a bug in deleteOBCResourceLogError()
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
