### PR TITLE
Pausing OSDs functionality by introducing a small script as command a…

### DIFF
--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -169,6 +169,7 @@ func osdActivateEnvVar() []v1.EnvVar {
 					Name: "rook-ceph-config"},
 					Key: "mon_host"}}},
 		{Name: "CEPH_ARGS", Value: "-m $(ROOK_CEPH_MON_HOST)"},
+		{Name: "PAUSE_OSD", Value: "false"},
 	}
 
 	return append(cephVolumeEnvVar(), monEnvVars...)

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -88,7 +88,9 @@ else
 	# ceph-volume raw mode only supports bluestore so we don't need to pass a store flag
 	ceph-volume "$CV_MODE" activate "${ARGS[@]}"
 fi
-
+if [ "$PAUSE_OSD" == "true" ]; then
+ 	sleep infinity;
+fi
 `
 )
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In this Pull Request, added an ENV variable with the help of which one can pause the OSD containers for better debugging the env.

Signed-off-by: Mridul Verma <mridul@logichub.com>

**Which issue is resolved by this Pull Request:**
https://github.com/rook/rook/issues/5709

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
