### PR TITLE
ceph: do not validate rgw pool if no endpoint

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -340,17 +340,19 @@ class RadosJSON:
     def _gen_output_map(self):
         if self.out_map:
             return
+        pools_to_validate = [self._arg_parser.rbd_data_pool_name]
         # if rgw_endpoint is provided, validate it
         if self._arg_parser.rgw_endpoint:
             self._invalid_endpoint(self._arg_parser.rgw_endpoint)
             self.endpoint_dial(self._arg_parser.rgw_endpoint)
-        pools_to_validate = [self._arg_parser.rbd_data_pool_name, "{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
-                             ".rgw.root",
-                             "{0}.rgw.control".format(
-            self._arg_parser.rgw_pool_prefix),
-            "{0}.rgw.log".format(
-            self._arg_parser.rgw_pool_prefix),
-            "{0}.rgw.buckets.index".format(self._arg_parser.rgw_pool_prefix)]
+            rgw_pool_to_validate = ["{0}.rgw.meta".format(self._arg_parser.rgw_pool_prefix),
+                                    ".rgw.root",
+                                    "{0}.rgw.control".format(
+                self._arg_parser.rgw_pool_prefix),
+                "{0}.rgw.log".format(
+                self._arg_parser.rgw_pool_prefix),
+                "{0}.rgw.buckets.index".format(self._arg_parser.rgw_pool_prefix)]
+            pools_to_validate.extend(rgw_pool_to_validate)
         for pool in pools_to_validate:
             if not self.cluster.pool_exists(pool):
                 raise ExecutionFailureException(


### PR DESCRIPTION
**Description of your changes:**

If no endpoint is specified, we don't need to validate the rgw pools.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]