### PR TITLE
ci: fix os version

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@ quickly spin up a Kubernetes cluster.The Test framework is designed to install R
 
 ## Requirements
 1. Docker version => 1.2 && < 17.0 (for other alternatives, see below)
-1. Ubuntu 16 (the framework has only been tested on this version)
-1. kernel >= 4.8
+1. Ubuntu 18 (the framework has only been tested on this version)
+1. kernel >= 4.15
 1. Kubernetes with kubectl configured
 1. Rook
 


### PR DESCRIPTION
**Description of your changes:**

The OS version for CI environment is ubuntu 18.04 now.

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]