### PR TITLE
ceph: use fixed mon directory in ci

### DIFF
--- a/tests/scripts/localPathPV.sh
+++ b/tests/scripts/localPathPV.sh
@@ -12,9 +12,8 @@ fi
 
 lsblk
 
-random_string=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 8)
-
-sudo mkdir -p /var/lib/rook/${random_string}/mon1 /var/lib/rook/${random_string}/mon2 /var/lib/rook/${random_string}/mon3
+sudo rm -rf /var/lib/rook/rook-integration-test
+sudo mkdir -p /var/lib/rook/rook-integration-test/mon1 /var/lib/rook/rook-integration-test/mon2 /var/lib/rook/rook-integration-test/mon3
 
 node_name=$(kubectl get nodes -o jsonpath={.items[*].metadata.name})
 
@@ -38,7 +37,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
   local:
-    path: "/var/lib/rook/${random_string}/mon1" 
+    path: "/var/lib/rook/rook-integration-test/mon1"
   nodeAffinity:
       required:
         nodeSelectorTerms:
@@ -63,7 +62,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
   local:
-    path: "/var/lib/rook/${random_string}/mon2" 
+    path: "/var/lib/rook/rook-integration-test/mon2"
   nodeAffinity:
       required:
         nodeSelectorTerms:
@@ -88,7 +87,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
   local:
-    path: "/var/lib/rook/${random_string}/mon3" 
+    path: "/var/lib/rook/rook-integration-test/mon3"
   nodeAffinity:
       required:
         nodeSelectorTerms:


### PR DESCRIPTION
**Description of your changes:**
It's not necessary to use random string for mon directory.
In addition, current implementation leaves garbage under /var/lib/rook.

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]