### PR TITLE
ci: remove unnecessary "rm" command

### DIFF
--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -113,8 +113,6 @@ wait_for_ready(){
 kubeadm_reset() {
     kubectl delete -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
     sudo kubeadm reset $skippreflightcheck
-    sudo rm /usr/local/bin/kube*
-    sudo rm kubectl
     rm $HOME/admin.conf
     rm -rf $HOME/.kube
     sudo apt-get -y remove kubelet


### PR DESCRIPTION
**Description of your changes:**
This commit will remove "sudo rm /usr/local/bin/kube*" and "sudo rm kubectl" in "tests/scripts/kubeadm.sh".
I think that CI-test doesn't make those files.

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]