### PR TITLE
ceph: add support for encrypted metadata pvc

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -722,7 +722,12 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	// lv can be a block device if raw mode is used
 	cvMode := "raw"
 
-	result, err := callCephVolume(context, cvMode, "list", block, "--format", "json")
+	args := []string{cvMode, "list", block, "--format", "json"}
+	if block == "" {
+		args = []string{cvMode, "list", "--format", "json"}
+	}
+
+	result, err := callCephVolume(context, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -632,7 +632,7 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 
 	var lvPath string
 
-	result, err := context.Executor.ExecuteCommandWithOutput(cephVolumeCmd, cvMode, "list", lv, "--format", "json")
+	result, err := callCephVolume(context, cvMode, "list", lv, "--format", "json")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}
@@ -641,7 +641,7 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	var cephVolumeResult map[string][]osdInfo
 	err = json.Unmarshal([]byte(result), &cephVolumeResult)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results", cvMode)
+		return nil, errors.Wrapf(err, "failed to unmarshal ceph-volume %s list results. %s", cvMode, result)
 	}
 
 	for name, osdInfo := range cephVolumeResult {
@@ -722,7 +722,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	// lv can be a block device if raw mode is used
 	cvMode := "raw"
 
-	result, err := context.Executor.ExecuteCommandWithOutput(cephVolumeCmd, cvMode, "list", block, "--format", "json")
+	result, err := callCephVolume(context, cvMode, "list", block, "--format", "json")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -331,7 +331,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 				}
 
 				// Return failure
-				return "", "", "", errors.Wrap(err, "failed ceph-volume") // fail return here as validation provided by ceph-volume
+				return "", "", "", errors.Wrapf(err, "failed to run ceph-volume. debug logs below:\n%s", cvLog)
 			}
 			logger.Infof("%v", op)
 			// if raw mode is used or PV on LV, let's return the path of the device

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -489,13 +489,15 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 
 func TestParseCephVolumeLVMResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
-		if command == "ceph-volume" {
-			return cephVolumeLVMTestResult, nil
+		logger.Infof("%s %v", command, args)
+		if command == "stdbuf" {
+			if args[4] == "lvm" && args[5] == "list" {
+				return cephVolumeLVMTestResult, nil
+			}
 		}
-
 		return "", errors.Errorf("unknown command %s %s", command, args)
 	}
 
@@ -508,14 +510,15 @@ func TestParseCephVolumeLVMResult(t *testing.T) {
 
 func TestParseCephVolumeRawResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
-
-		if command == "ceph-volume" {
-			return cephVolumeRAWTestResult, nil
+		if command == "stdbuf" {
+			if args[4] == "raw" && args[5] == "list" {
+				return cephVolumeRAWTestResult, nil
+			}
 		}
 
-		return "", errors.Errorf("unknown command %s %s", command, args)
+		return "", errors.Errorf("unknown command: %s, args: %#v", command, args)
 	}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "name"}
 
@@ -529,11 +532,13 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
-		if command == "ceph-volume" {
-			return cephVolumeTestResultMultiCluster, nil
+		if command == "stdbuf" {
+			if args[4] == "lvm" && args[5] == "list" {
+				return cephVolumeTestResultMultiCluster, nil
+			}
 		}
 
 		return "", errors.Errorf("unknown command %s %s", command, args)
@@ -541,6 +546,7 @@ func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 
 	context := &clusterd.Context{Executor: executor}
 	osds, err := GetCephVolumeLVMOSDs(context, &cephclient.ClusterInfo{Namespace: "name"}, "451267e6-883f-4936-8dff-080d781c67d5", "", false, false)
+
 	assert.Nil(t, err)
 	require.NotNil(t, osds)
 	assert.Equal(t, 1, len(osds))
@@ -550,11 +556,13 @@ func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 func TestCephVolumeResultMultiClusterMultiOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
-		if command == "ceph-volume" {
-			return cephVolumeTestResultMultiClusterMultiOSD, nil
+		if command == "stdbuf" {
+			if args[4] == "lvm" && args[5] == "list" {
+				return cephVolumeTestResultMultiClusterMultiOSD, nil
+			}
 		}
 
 		return "", errors.Errorf("unknown command %s% s", command, args)

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -157,3 +157,14 @@ func generateOSDEncryptedKeySecret(pvcName, namespace, key string) *v1.Secret {
 func generateOSDEncryptionSecretName(pvcName string) string {
 	return fmt.Sprintf("%s-%s", osdEncryptionSecretNamePrefix, pvcName)
 }
+
+func (c *Cluster) isCephVolumeRAwModeSupported() bool {
+	if c.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawEncryptionModeMinNautilusCephVersion) && !c.clusterInfo.CephVersion.IsOctopus() {
+		return true
+	}
+	if c.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawEncryptionModeMinOctopusCephVersion) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -121,12 +121,12 @@ func encryptionKeyPath() string {
 	return fmt.Sprintf("%s/%s", opconfig.EtcCephDir, encryptionKeyFileName)
 }
 
-func encryptionDMName(pvcName string) string {
-	return fmt.Sprintf("%s-block-dmcrypt", pvcName)
+func encryptionDMName(pvcName, blockType string) string {
+	return fmt.Sprintf("%s-%s", pvcName, blockType)
 }
 
-func encryptionDMPath(pvcName string) string {
-	return fmt.Sprintf("/dev/mapper/%s", encryptionDMName(pvcName))
+func encryptionDMPath(pvcName, blockType string) string {
+	return fmt.Sprintf("/dev/mapper/%s", encryptionDMName(pvcName, blockType))
 }
 
 func generateDmCryptKey() (string, error) {
@@ -158,7 +158,7 @@ func generateOSDEncryptionSecretName(pvcName string) string {
 	return fmt.Sprintf("%s-%s", osdEncryptionSecretNamePrefix, pvcName)
 }
 
-func (c *Cluster) isCephVolumeRAwModeSupported() bool {
+func (c *Cluster) isCephVolumeRawModeSupported() bool {
 	if c.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawEncryptionModeMinNautilusCephVersion) && !c.clusterInfo.CephVersion.IsOctopus() {
 		return true
 	}

--- a/pkg/operator/ceph/cluster/osd/config_test.go
+++ b/pkg/operator/ceph/cluster/osd/config_test.go
@@ -76,7 +76,7 @@ func TestClusterIsCephVolumeRAwModeSupported(t *testing.T) {
 				ValidStorage: tt.fields.ValidStorage,
 				kv:           tt.fields.kv,
 			}
-			if got := c.isCephVolumeRAwModeSupported(); got != tt.want {
+			if got := c.isCephVolumeRawModeSupported(); got != tt.want {
 				t.Errorf("Cluster.isCephVolumeRAwModeSupported() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/operator/ceph/cluster/osd/config_test.go
+++ b/pkg/operator/ceph/cluster/osd/config_test.go
@@ -20,6 +20,11 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,4 +45,40 @@ func TestEncryptionKeyPath(t *testing.T) {
 
 func TestGenerateOSDEncryptionSecretName(t *testing.T) {
 	assert.Equal(t, "rook-ceph-osd-encryption-key-set1-data-0-7dwll", generateOSDEncryptionSecretName("set1-data-0-7dwll"))
+}
+
+func TestClusterIsCephVolumeRAwModeSupported(t *testing.T) {
+	type fields struct {
+		context      *clusterd.Context
+		clusterInfo  *cephclient.ClusterInfo
+		rookVersion  string
+		spec         cephv1.ClusterSpec
+		ValidStorage rookv1.StorageScopeSpec
+		kv           *k8sutil.ConfigMapKVStore
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"nok-14.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, false},
+		{"ok-14.2.11", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, true},
+		{"nok-15.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, false},
+		{"ok-15.2.5", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Cluster{
+				context:      tt.fields.context,
+				clusterInfo:  tt.fields.clusterInfo,
+				rookVersion:  tt.fields.rookVersion,
+				spec:         tt.fields.spec,
+				ValidStorage: tt.fields.ValidStorage,
+				kv:           tt.fields.kv,
+			}
+			if got := c.isCephVolumeRAwModeSupported(); got != tt.want {
+				t.Errorf("Cluster.isCephVolumeRAwModeSupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -254,7 +254,7 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 
 		// If the deviceSet template has "encrypted" but the Ceph version is not compatible
 		if osdProps.encrypted {
-			if !c.isCephVolumeRAwModeSupported() {
+			if !c.isCephVolumeRawModeSupported() {
 				errMsg := fmt.Sprintf("failed to validate storageClassDeviceSet %q. min required ceph version to support encryption is %q or %q", volume.Name, cephVolumeRawEncryptionModeMinNautilusCephVersion.String(), cephVolumeRawEncryptionModeMinOctopusCephVersion.String())
 				config.addError(errMsg)
 				continue

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -49,9 +49,10 @@ import (
 )
 
 var (
-	logger                                    = capnslog.NewPackageLogger("github.com/rook/rook", "op-osd")
-	updateDeploymentAndWait                   = mon.UpdateCephDeploymentAndWait
-	cephVolumeRawEncryptionModeMinCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}
+	logger                                            = capnslog.NewPackageLogger("github.com/rook/rook", "op-osd")
+	updateDeploymentAndWait                           = mon.UpdateCephDeploymentAndWait
+	cephVolumeRawEncryptionModeMinNautilusCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}
+	cephVolumeRawEncryptionModeMinOctopusCephVersion  = cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}
 )
 
 const (
@@ -252,10 +253,12 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 		logger.Debugf("osdProps are %+v", osdProps)
 
 		// If the deviceSet template has "encrypted" but the Ceph version is not compatible
-		if osdProps.encrypted && !c.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawEncryptionModeMinCephVersion) {
-			errMsg := fmt.Sprintf("failed to validate storageClassDeviceSet %q. min required ceph version to support encryption is %q", volume.Name, cephVolumeRawEncryptionModeMinCephVersion.String())
-			config.addError(errMsg)
-			continue
+		if osdProps.encrypted {
+			if !c.isCephVolumeRAwModeSupported() {
+				errMsg := fmt.Sprintf("failed to validate storageClassDeviceSet %q. min required ceph version to support encryption is %q or %q", volume.Name, cephVolumeRawEncryptionModeMinNautilusCephVersion.String(), cephVolumeRawEncryptionModeMinOctopusCephVersion.String())
+				config.addError(errMsg)
+				continue
+			}
 		}
 
 		// create encryption Kubernetes Secret if the PVC is encrypted


### PR DESCRIPTION
**Description of your changes:**

Now the metadata pvc will also be encrypted if the storageClassDeviceSet
has the "encrypted" flag turned on.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

// known CI issue
[skip ci]