### PR TITLE
ceph: disable object store port when secureport specified

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -382,9 +382,12 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 65535
-                securePort: {}
+                securePort:
+                  type: integer
+                  minimum: 0
+                  maximum: 65535
                 instances:
                   type: integer
                 annotations: {}

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -462,9 +462,12 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 65535
-                securePort: {}
+                securePort:
+                  type: integer
+                  minimum: 0
+                  maximum: 65535
                 instances:
                   type: integer
                 externalRgwEndpoints:

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -51,7 +51,7 @@ spec:
     # The port that RGW pods will listen on (http)
     port: 80
     # The port that RGW pods will listen on (https). An ssl certificate is required.
-    securePort:
+    # securePort: 443
     # The number of pods in the rgw deployment
     instances: 1
     # The affinity rules to apply to the rgw deployment or daemonset.

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -474,10 +474,13 @@ func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjec
 
 	var port string
 
-	if objectstore.Spec.Gateway.Port != 0 {
-		port = strconv.Itoa(int(objectstore.Spec.Gateway.Port))
-	} else if objectstore.Spec.Gateway.SecurePort != 0 {
+	if objectstore.Spec.Gateway.SecurePort != 0 && objectstore.Spec.Gateway.SSLCertificateRef != "" {
 		port = strconv.Itoa(int(objectstore.Spec.Gateway.SecurePort))
+	} else if objectstore.Spec.Gateway.Port != 0 {
+		port = strconv.Itoa(int(objectstore.Spec.Gateway.Port))
+	} else {
+		logger.Error("At least one of Port or SecurePort should be non-zero")
+		return
 	}
 
 	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec.HealthCheck, r.cephClusterSpec.External.Enable)

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -320,7 +320,8 @@ func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore
 		return "", errors.Wrapf(err, "failed to create or update object store %q service", cephObjectStore.Name)
 	}
 
-	logger.Infof("ceph object store gateway service running at %s:%d", svc.Spec.ClusterIP, cephObjectStore.Spec.Gateway.Port)
+	logger.Infof("ceph object store gateway service running at %s", svc.Spec.ClusterIP)
+
 	return svc.Spec.ClusterIP, nil
 }
 

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -84,10 +84,14 @@ func updateStatusBucket(client client.Client, name types.NamespacedName, phase c
 
 func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string {
 	m := make(map[string]string)
-	m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port, false)
 
-	if cephObjectStore.Spec.Gateway.SecurePort != 0 {
+	if cephObjectStore.Spec.Gateway.SecurePort != 0 && cephObjectStore.Spec.Gateway.Port != 0 {
 		m["secureEndpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.SecurePort, true)
+		m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port, false)
+	} else if cephObjectStore.Spec.Gateway.SecurePort != 0 {
+		m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.SecurePort, true)
+	} else {
+		m["endpoint"] = buildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port, false)
 	}
 
 	return m

--- a/pkg/operator/ceph/object/status_test.go
+++ b/pkg/operator/ceph/object/status_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestBuildStatusInfo(t *testing.T) {
+	// Port enabled and SecurePort disabled
 	cephObjectStore := &cephv1.CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-store",
@@ -35,5 +36,25 @@ func TestBuildStatusInfo(t *testing.T) {
 
 	statusInfo := buildStatusInfo(cephObjectStore)
 	assert.NotEmpty(t, statusInfo["endpoint"])
+	assert.Empty(t, statusInfo["secureEndpoint"])
 	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", statusInfo["endpoint"])
+
+	// SecurePort enabled and Port disabled
+	cephObjectStore.Spec.Gateway.Port = 0
+	cephObjectStore.Spec.Gateway.SecurePort = 443
+
+	statusInfo = buildStatusInfo(cephObjectStore)
+	assert.NotEmpty(t, statusInfo["endpoint"])
+	assert.Empty(t, statusInfo["secureEndpoint"])
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", statusInfo["endpoint"])
+
+	// Both Port and SecurePort enabled
+	cephObjectStore.Spec.Gateway.Port = 80
+	cephObjectStore.Spec.Gateway.SecurePort = 443
+
+	statusInfo = buildStatusInfo(cephObjectStore)
+	assert.NotEmpty(t, statusInfo["endpoint"])
+	assert.NotEmpty(t, statusInfo["secureEndpoint"])
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", statusInfo["endpoint"])
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", statusInfo["secureEndpoint"])
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -461,9 +461,12 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 65535
-                securePort: {}
+                securePort:
+                  type: integer
+                  minimum: 0
+                  maximum: 65535
                 instances:
                   type: integer
                 annotations: {}
@@ -2159,7 +2162,6 @@ spec:
     type: s3
     sslCertificateRef:
     port: ` + strconv.Itoa(port) + `
-    securePort:
     instances: ` + strconv.Itoa(replicaCount) + `
     allNodes: false
   healthCheck:

--- a/tests/framework/installer/ceph_manifests_v1.2.go
+++ b/tests/framework/installer/ceph_manifests_v1.2.go
@@ -322,7 +322,8 @@ spec:
                 sslCertificateRef: {}
                 port:
                   type: integer
-                securePort: {}
+                securePort:
+                  type: integer
                 instances:
                   type: integer
                 annotations: {}
@@ -1872,7 +1873,6 @@ spec:
     type: s3
     sslCertificateRef:
     port: ` + strconv.Itoa(port) + `
-    securePort:
     instances: ` + strconv.Itoa(replicaCount) + `
     allNodes: false
 `


### PR DESCRIPTION
currently, the object store schema requires the
port to be non-zero. This does not allow http
access to the object store to be disabled.
so setting the port minimum to 0 to from 1 in the cr.

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5806

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
