### PR TITLE
ceph: Symlink prometheus manifests in same dir

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v15-rules-external.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v15-rules-external.yaml
@@ -1,1 +1,1 @@
-cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules-external.yaml
+prometheus-ceph-v14-rules-external.yaml

--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v15-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v15-rules.yaml
@@ -1,1 +1,1 @@
-cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+prometheus-ceph-v14-rules.yaml


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The prometheus manifests should be symlinked in the same directory instead of from the root of the repo for building across all platforms. This was causing the build to fail on mac.

Resolves: #5958 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
