### PR TITLE
ceph: Update the cluster status with a non-cached object

### DIFF
--- a/pkg/operator/ceph/config/conditions.go
+++ b/pkg/operator/ceph/config/conditions.go
@@ -47,8 +47,7 @@ func ConditionExport(context *clusterd.Context, namespaceName types.NamespacedNa
 
 // setCondition updates the conditions of the cluster custom resource
 func setCondition(c *clusterd.Context, namespaceName types.NamespacedName, newCondition cephv1.Condition) {
-	cluster := &cephv1.CephCluster{}
-	err := c.Client.Get(context.TODO(), namespaceName, cluster)
+	cluster, err := c.RookClientset.CephV1().CephClusters(namespaceName.Namespace).Get(namespaceName.Name, metav1.GetOptions{})
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			logger.Errorf("no CephCluster could not be found. %+v", err)
@@ -86,7 +85,7 @@ func setCondition(c *clusterd.Context, namespaceName types.NamespacedName, newCo
 			cluster.Status.State = state
 		}
 		cluster.Status.Message = newCondition.Message
-		logger.Infof("CephCluster %q status: %q. %q", namespaceName.Namespace, cluster.Status.Phase, cluster.Status.Message)
+		logger.Debugf("CephCluster %q status: %q. %q", namespaceName.Namespace, cluster.Status.Phase, cluster.Status.Message)
 	}
 
 	err = c.Client.Status().Update(context.TODO(), cluster)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The cluster CR status needs to be updated with the latest object instead of a cached copy or else it could fail if there is some other update. Using the Rook clientset ensures it is the latest instead of using the cached controller runtime object.

**Which issue is resolved by this Pull Request:**
Resolves #5955 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
