### PR TITLE
ci: fix helm path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,9 +232,7 @@ def RunIntegrationTest(k, v) {
                         echo "Running full regression"
                         sh '''#!/bin/bash
                               set -o pipefail
-                              export PATH="/tmp/rook-tests-scripts-helm/linux-amd64:$PATH" \
-                                  KUBECONFIG=$HOME/admin.conf \
-                                  TEST_HELM_PATH=/tmp/rook-tests-scripts-helm/linux-amd64/helm \
+                              export KUBECONFIG=$HOME/admin.conf \
                                   TEST_ENV_NAME='''+"${k}"+''' \
                                   TEST_BASE_DIR="WORKING_DIR" \
                                   TEST_LOG_COLLECTION_LEVEL='''+"${env.getLogs}"+''' \

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -22,7 +22,7 @@ import (
 
 // testHelmPath gets the helm path
 func testHelmPath() string {
-	return getEnvVarWithDefault("TEST_HELM_PATH", "helm")
+	return getEnvVarWithDefault("TEST_HELM_PATH", "/tmp/rook-tests-scripts-helm/helm")
 }
 
 // TestLogCollectionLevel gets whether to collect all logs


### PR DESCRIPTION
**Description of your changes:**

Download the pre-defined helm by default to make the integration test simpler. As a result, we can make PATH/TEST_HELM_PATH environment variable optional. In addition, the default helm path can be simplified that doesn't include arch and os.

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]