### PR TITLE
ceph: adding ability to specify crushroot in the CRD

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -240,6 +240,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -273,6 +275,8 @@ spec:
               items:
                 properties:
                   failureDomain:
+                    type: string
+                  crushRoot:
                     type: string
                   replicated:
                     properties:
@@ -390,6 +394,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -415,6 +421,8 @@ spec:
             dataPool:
               properties:
                 failureDomain:
+                  type: string
+                crushRoot:
                   type: string
                 replicated:
                   properties:
@@ -540,6 +548,8 @@ spec:
         spec:
           properties:
             failureDomain:
+                type: string
+            crushRoot:
                 type: string
             replicated:
               properties:

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -320,6 +320,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -351,6 +353,8 @@ spec:
               items:
                 properties:
                   failureDomain:
+                    type: string
+                  crushRoot:
                     type: string
                   replicated:
                     properties:
@@ -476,6 +480,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -501,6 +507,8 @@ spec:
             dataPool:
               properties:
                 failureDomain:
+                  type: string
+                crushRoot:
                   type: string
                 replicated:
                   properties:
@@ -633,6 +641,8 @@ spec:
         spec:
           properties:
             failureDomain:
+                type: string
+            crushRoot:
                 type: string
             replicated:
               properties:

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
@@ -294,6 +294,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -325,6 +327,8 @@ spec:
               items:
                 properties:
                   failureDomain:
+                    type: string
+                  crushRoot:
                     type: string
                   replicated:
                     properties:
@@ -446,6 +450,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -471,6 +477,8 @@ spec:
             dataPool:
               properties:
                 failureDomain:
+                  type: string
+                crushRoot:
                   type: string
                 replicated:
                   properties:
@@ -593,6 +601,8 @@ spec:
         spec:
           properties:
             failureDomain:
+                type: string
+            crushRoot:
                 type: string
             replicated:
               properties:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -323,6 +323,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -354,6 +356,8 @@ spec:
               items:
                 properties:
                   failureDomain:
+                    type: string
+                  crushRoot:
                     type: string
                   replicated:
                     properties:
@@ -469,6 +473,8 @@ spec:
               properties:
                 failureDomain:
                   type: string
+                crushRoot:
+                  type: string
                 replicated:
                   properties:
                     size:
@@ -494,6 +500,8 @@ spec:
             dataPool:
               properties:
                 failureDomain:
+                  type: string
+                crushRoot:
                   type: string
                 replicated:
                   properties:
@@ -620,6 +628,8 @@ spec:
         spec:
           properties:
             failureDomain:
+                type: string
+            crushRoot:
                 type: string
             replicated:
               properties:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Previously, we did not had crush root definition in the CRDs for fileSystems , Blocks and others. After this change, we have added the definition, one can define the crushRoot and it will be used.


**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/rook/rook/issues/5809

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
