### PR TITLE
ceph: Removed the storage provisioners usage rules.

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -33,18 +33,6 @@ spec:
     - expr: |
         count(count(ceph_mon_metadata{job="rook-ceph-mgr"} or ceph_osd_metadata{job="rook-ceph-mgr"} or ceph_rgw_metadata{job="rook-ceph-mgr"} or ceph_mds_metadata{job="rook-ceph-mgr"} or ceph_mgr_metadata{job="rook-ceph-mgr"}) by(ceph_version))
       record: job:ceph_versions_running:count
-    - expr: |
-        sum(kube_persistentvolumeclaim_resource_requests_storage_bytes * on (namespace,persistentvolumeclaim) group_right() (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~".*rbd.csi.ceph.com"}))
-      record: job:ceph_block_capacity_requested
-    - expr: |
-        sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_right() (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~".*rbd.csi.ceph.com"}))
-      record: job:ceph_block_capacity_used
-    - expr: |
-        sum(kube_persistentvolumeclaim_resource_requests_storage_bytes * on (namespace,persistentvolumeclaim) group_right() (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~".*cephfs.csi.ceph.com"}))
-      record: job:ceph_filesystem_capacity_requested
-    - expr: |
-        sum(kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_right() (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~".*cephfs.csi.ceph.com"}))
-      record: job:ceph_filesystem_capacity_used
   - name: ceph-mgr-status
     rules:
     - alert: CephMgrIsAbsent


### PR DESCRIPTION
In the interest of having the metrics available generically for all the storage provisioners and just not ceph provisioners, the superseding metrics will be added to Openshift directly. Thus, these metrics won't be required in rook.

PR on OCP for the same functionality: https://github.com/openshift/cluster-monitoring-operator/pull/892

Also, fixes: #6011 

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
