### PR TITLE
ceph: check channel is open before closing

### DIFF
--- a/pkg/operator/ceph/cluster/operator_watchers.go
+++ b/pkg/operator/ceph/cluster/operator_watchers.go
@@ -44,7 +44,11 @@ func (c *ClusterController) StartOperatorSettingsWatch(namespace string, stopCh 
 // StopWatch stop watchers
 func (c *ClusterController) StopWatch() {
 	for _, cluster := range c.clusterMap {
-		close(cluster.stopCh)
+		// check channel is open before closing
+		if !cluster.closedStopCh {
+			close(cluster.stopCh)
+			cluster.closedStopCh = true
+		}
 	}
 	c.clusterMap = make(map[string]*cluster)
 }


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
To avoid operator panic we should check the channel is open before closing as a safety measure.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

```text
2020-08-11 06:18:26.485261 I | operator: shutdown signal received, exiting...
panic: close of closed channel

goroutine 1 [running]:
github.com/rook/rook/pkg/operator/ceph/cluster.(*ClusterController).StopWatch(0xc000731600)
	/home/rook/go/src/github.com/rook/rook/pkg/operator/ceph/cluster/operator_watchers.go:47 +0x82
github.com/rook/rook/pkg/operator/ceph.(*Operator).cleanup(...)
	/home/rook/go/src/github.com/rook/rook/pkg/operator/ceph/operator.go:106
github.com/rook/rook/pkg/operator/ceph.(*Operator).Run(0xc00063e8a0, 0x2602900, 0xc00011aac0)
	/home/rook/go/src/github.com/rook/rook/pkg/operator/ceph/operator.go:174 +0x846
github.com/rook/rook/cmd/rook/ceph.startOperator(0x371f8a0, 0x375ac10, 0x0, 0x0, 0x0, 0x0)
	/home/rook/go/src/github.com/rook/rook/cmd/rook/ceph/operator.go:94 +0x345
github.com/spf13/cobra.(*Command).execute(0x371f8a0, 0x375ac10, 0x0, 0x0, 0x371f8a0, 0x375ac10)
	/home/rook/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0x3722540, 0xc000717f00, 0xa, 0xa)
	/home/rook/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/home/rook/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/home/rook/go/src/github.com/rook/rook/cmd/rook/main.go:34
```
the above is the panic I had seen in my local cluster.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

// known CI issue
[skip ci]