### PR TITLE
WIP: ci: check ceph-volume.log

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -305,12 +306,22 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			}
 
 			// execute ceph-volume with the device
-			op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, immediateExecuteArgs...)
+			// op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, immediateExecuteArgs...)
+
+			logger.Infof("Installing rook on k8s")
+
+			op, err := context.Executor.ExecuteCommandWithOutput(baseCommand, immediateExecuteArgs...)
 			if err != nil {
 				cvLogFilePath := path.Join(cvLogDir, "ceph-volume.log")
-
 				// Print c-v log before exiting
 				cvLog := readCVLogContent(cvLogFilePath)
+
+				lsOut, lsErr := exec.Command("ls", "-al", cvLogFilePath).Output()
+				logger.Infof("ls -al %s: %v, err: %v", cvLogFilePath, lsOut, lsErr)
+
+				catOut, catErr := exec.Command("cat", cvLogFilePath).Output()
+				logger.Infof("cat %s: %v, err: %v", cvLogFilePath, catOut, catErr)
+
 				if cvLog != "" {
 					logger.Errorf("%s", cvLog)
 				}


### PR DESCRIPTION
**Description of your changes:**
Currently, stderr is not displayed as expected.
This PR fixed problems above.

For example, the error messeage gives only `exit status 1` by [this code](https://github.com/rook/rook/blob/master/pkg/daemon/ceph/osd/volume.go#L307-L320).

```
E | op-osd: orchestration for node set1-data-0-kpt54 failed: &{OSDs:[] Status:failed PvcBackedOSD:true Message:failed to configure devices: failed to initialize devices on PVC: failed ceph-volume: exit status 1}
```
https://jenkins.rook.io/job/rook/job/rook/job/master/2164/artifact/_output/tests/TestCephMultiClusterDeploySuite_aws_1.16.x_mrc-n1-system_rook-ceph-operator-6d567f7758-kgh6c_1597111128.log

Signed-off-by: tenzen-y <toyonomajyutushi@yahoo.co.jp>

**Which issue is resolved by this Pull Request:**
Nothing

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]