### PR TITLE
ceph: enable/disable dashboard for rgw

### DIFF
--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -40,6 +40,8 @@ If you are on a node in the cluster, you will be able to connect to the dashboar
 DNS name of the service at `https://rook-ceph-mgr-dashboard-https:8443` or by connecting to the cluster IP,
 in this example at `https://10.110.113.240:8443`.
 
+> **IMPORTANT:** Please note the dashboard will only be enabled for the first Ceph object store created by Rook.
+
 ### Login Credentials
 
 After you connect to the dashboard you will need to login for secure access. Rook creates a default user named
@@ -222,23 +224,3 @@ rook-ceph.example.com      kubernetes.io/tls   2         4m
 ```
 
 You can now browse to `https://rook-ceph.example.com/` to log into the dashboard.
-
-## Enabling Dashboard Object Gateway management
-
-Provided you have deployed the [Ceph Toolbox](ceph-toolbox.md), created an [Object Store](ceph-object.md) and a user, you can enable
-[Object Gateway management](http://docs.ceph.com/docs/master/mgr/dashboard/#enabling-the-object-gateway-management-frontend) by providing the user credentials to the dashboard:
-
-```console
-# Access toolbox CLI:
-kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') bash
-
-# Enable system flag on the user:
-radosgw-admin user modify --uid=my-user --system
-
-# Provide the user credentials:
-ceph dashboard set-rgw-api-user-id my-user
-ceph dashboard set-rgw-api-access-key <access-key>
-ceph dashboard set-rgw-api-secret-key <secret-key>
-```
-
-Now you can access the *Object Gateway* menu items.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -33,6 +33,7 @@
 - Prometheus monitoring for external clusters is now possible, refer to the [external cluster section](Documentation/ceph-cluster-crd.html#external-cluster)
 - The operator will check for the presence of the `lvm2` package on the host where OSDs will run. If not available, the prepare job will fail. This will prevent issues of OSDs not restarting on node reboot.
 - Added a new label "ceph_daemon_type" label to Ceph daemon pods to go alongside the existing "ceph_daemon_id" label.
+- The dashboard for the ceph object store will be enabled if the dashboard module is loaded
 
 ### EdgeFS
 
@@ -54,7 +55,9 @@ Backward compatibility is maintained for existing deployments. These settings ar
 
 ## Known Issues
 
-### <Storage Provider>
+### Ceph
+
+- The Ceph dashboard currently only supports a single object store (RGW) and can only be enabled for the first object store created by Rook. Object stores created after the first will not be able to have the same dashboard view as the first.
 
 ## Deprecations
 

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -71,6 +71,12 @@ func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName s
 		return errors.Wrap(err, "failed to start rgw pods")
 	}
 
+	objContext := NewContext(c.context, c.clusterInfo, c.store.Namespace)
+	err := enableRGWDashboard(objContext)
+	if err != nil {
+		logger.Warningf("failed to enable dashboard for rgw. %v", err)
+	}
+
 	logger.Infof("created object store %q in namespace %q", c.store.Name, c.store.Namespace)
 	return nil
 }
@@ -286,6 +292,11 @@ func (c *clusterConfig) deleteStore() error {
 		}
 
 		objContext.Endpoint = c.store.Status.Info["endpoint"]
+
+		err = disableRGWDashboard(objContext)
+		if err != nil {
+			logger.Warningf("failed to disable dashboard for rgw. %v", err)
+		}
 
 		err = deleteRealmAndPools(objContext, c.store.Spec)
 		if err != nil {

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -42,6 +42,7 @@ type ObjectUser struct {
 	Email       *string `json:"email"`
 	AccessKey   *string `json:"accessKey"`
 	SecretKey   *string `json:"secretKey"`
+	SystemUser  bool    `json:"systemuser"`
 }
 
 // ListUsers lists the object pool users.
@@ -124,6 +125,10 @@ func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 
 	if user.Email != nil {
 		args = append(args, "--email", *user.Email)
+	}
+
+	if user.SystemUser {
+		args = append(args, "--system")
 	}
 
 	result, err := runAdminCommand(c, args...)

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -81,6 +81,8 @@ func decodeUser(data string) (*ObjectUser, int, error) {
 	if len(user.Keys) > 0 {
 		rookUser.AccessKey = &user.Keys[0].AccessKey
 		rookUser.SecretKey = &user.Keys[0].SecretKey
+	} else {
+		return nil, RGWErrorBadData, errors.New("AccessKey and SecretKey are missing")
 	}
 
 	return &rookUser, RGWErrorNone, nil


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Ceph Dashboard will be available when mgr pods start, but object-store metrics cannot be viewed. This PR fixes that by providing necessary permissions for the dashboard via admin user

Backport of #4676
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
