### PR TITLE
ceph: do not validate default.rgw.buckets.index

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -353,8 +353,7 @@ class RadosJSON:
                                     "{0}.rgw.control".format(
                 self._arg_parser.rgw_pool_prefix),
                 "{0}.rgw.log".format(
-                self._arg_parser.rgw_pool_prefix),
-                "{0}.rgw.buckets.index".format(self._arg_parser.rgw_pool_prefix)]
+                self._arg_parser.rgw_pool_prefix)]
             pools_to_validate.extend(rgw_pool_to_validate)
         for pool in pools_to_validate:
             if not self.cluster.pool_exists(pool):


### PR DESCRIPTION
This pool is not present when this is no bucket yet. So we don't need to
validate its presence.

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 0c8d20ffb48fdb8649207468f105d6941d23e015)
(cherry picked from commit 46b0b95d4c6d3e39a3d20762de17d86dd24081cd)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
