### PR TITLE
fix-image-version-bug

### DIFF
--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -5,7 +5,7 @@
 image:
   prefix: rook
   repository: rook/ceph
-  tag: VERSION
+  tag: master
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
https://github.com/rook/rook/issues/6051

i cloned rook project, and then run 'helm install /rook/cluster/charts/rook-ceph'.then find a error with image no version.and in readme file,tag default value should master value.

[test ceph]