### PR TITLE
cassandra: Initialize merged annotations when empty

### DIFF
--- a/pkg/apis/rook.io/v1/annotations.go
+++ b/pkg/apis/rook.io/v1/annotations.go
@@ -41,6 +41,9 @@ func (a Annotations) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 // Placement's attributes will override the original ones if defined.
 func (a Annotations) Merge(with Annotations) Annotations {
 	ret := a
+	if ret == nil {
+		ret = map[string]string{}
+	}
 	for k, v := range with {
 		if _, ok := ret[k]; !ok {
 			ret[k] = v

--- a/pkg/apis/rook.io/v1/annotations.go
+++ b/pkg/apis/rook.io/v1/annotations.go
@@ -51,12 +51,3 @@ func (a Annotations) Merge(with Annotations) Annotations {
 	}
 	return ret
 }
-
-// GetMapStringString return the Annotations as a
-func (a Annotations) GetMapStringString() map[string]string {
-	res := map[string]string{}
-	for k, v := range a {
-		res[k] = v
-	}
-	return res
-}

--- a/pkg/apis/rook.io/v1/annotations_test.go
+++ b/pkg/apis/rook.io/v1/annotations_test.go
@@ -60,11 +60,11 @@ func TestAnnotationsApply(t *testing.T) {
 		"hello": "world",
 	}
 	testAnnotations.ApplyToObjectMeta(objMeta)
-	assert.Equal(t, testAnnotations.GetMapStringString(), objMeta.Annotations)
+	assert.Equal(t, testAnnotations.getMapStringString(), objMeta.Annotations)
 
 	testAnnotations["isthisatest"] = "test"
 	testAnnotations.ApplyToObjectMeta(objMeta)
-	assert.Equal(t, testAnnotations.GetMapStringString(), objMeta.Annotations)
+	assert.Equal(t, testAnnotations.getMapStringString(), objMeta.Annotations)
 }
 
 func TestAnnotationsMerge(t *testing.T) {
@@ -81,12 +81,21 @@ func TestAnnotationsMerge(t *testing.T) {
 		"bar":   "foo",
 		"hello": "world",
 	}
-	assert.Equal(t, expected, testAnnotationsPart1.Merge(testAnnotationsPart2).GetMapStringString())
+	assert.Equal(t, expected, testAnnotationsPart1.Merge(testAnnotationsPart2).getMapStringString())
 
 	// Test that nil annotations can still be appended to
 	testAnnotationsPart3 := Annotations{
 		"hello": "world",
 	}
 	var empty Annotations
-	assert.Equal(t, map[string]string(testAnnotationsPart3), empty.Merge(testAnnotationsPart3).GetMapStringString())
+	assert.Equal(t, map[string]string(testAnnotationsPart3), empty.Merge(testAnnotationsPart3).getMapStringString())
+}
+
+// getMapStringString return the Annotations as a
+func (a Annotations) getMapStringString() map[string]string {
+	res := map[string]string{}
+	for k, v := range a {
+		res[k] = v
+	}
+	return res
 }

--- a/pkg/apis/rook.io/v1/annotations_test.go
+++ b/pkg/apis/rook.io/v1/annotations_test.go
@@ -53,7 +53,7 @@ mon:
 	assert.Equal(t, expected, annotations)
 }
 
-func TestAnnotations_ApplyToPodSpec(t *testing.T) {
+func TestAnnotationsApply(t *testing.T) {
 	objMeta := &metav1.ObjectMeta{}
 	testAnnotations := Annotations{
 		"foo":   "bar",
@@ -67,7 +67,7 @@ func TestAnnotations_ApplyToPodSpec(t *testing.T) {
 	assert.Equal(t, testAnnotations.GetMapStringString(), objMeta.Annotations)
 }
 
-func TestAnnotations_Merge(t *testing.T) {
+func TestAnnotationsMerge(t *testing.T) {
 	testAnnotationsPart1 := Annotations{
 		"foo":   "bar",
 		"hello": "world",
@@ -76,9 +76,17 @@ func TestAnnotations_Merge(t *testing.T) {
 		"bar":   "foo",
 		"hello": "earth",
 	}
-	assert.Equal(t, map[string]string{
+	expected := map[string]string{
 		"foo":   "bar",
 		"bar":   "foo",
 		"hello": "world",
-	}, testAnnotationsPart1.Merge(testAnnotationsPart2).GetMapStringString())
+	}
+	assert.Equal(t, expected, testAnnotationsPart1.Merge(testAnnotationsPart2).GetMapStringString())
+
+	// Test that nil annotations can still be appended to
+	testAnnotationsPart3 := Annotations{
+		"hello": "world",
+	}
+	var empty Annotations
+	assert.Equal(t, map[string]string(testAnnotationsPart3), empty.Merge(testAnnotationsPart3).GetMapStringString())
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Two changes:
1.  Initialize merged annotations when empty. This was causing the cassandra operator to fail when annotations were added to the cluster
1. Move annotations helper into test code since it's not needed in production code.

**Which issue is resolved by this Pull Request:**
Resolves #6054 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
