### PR TITLE
ceph: improve callCephVolume() for list and prepare

### DIFF
--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -233,14 +233,7 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 					return cvInventoryOutputAvailable, nil
 				}
 
-			}
-
-			return "", errors.Errorf("unknown command %s %s", command, args)
-		},
-		MockExecuteCommandWithCombinedOutput: func(command string, args ...string) (string, error) {
-			logger.Infof("%s %v", command, args)
-
-			if command == "stdbuf" {
+			} else if command == "stdbuf" {
 				if args[4] == "raw" && args[5] == "list" {
 					return cephVolumeRAWTestResult, nil
 				} else if command == "ceph-volume" && args[0] == "lvm" {
@@ -250,8 +243,7 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 				}
 				return "{}", nil
 			}
-
-			return "", errors.Errorf("unknown command: %s, args: %#v", command, args)
+			return "", errors.Errorf("unknown command %s %s", command, args)
 		},
 	}
 

--- a/pkg/daemon/ceph/osd/drivegroups.go
+++ b/pkg/daemon/ceph/osd/drivegroups.go
@@ -45,7 +45,7 @@ func (a *OsdAgent) configureDriveGroups(context *clusterd.Context) error {
 
 	for group, spec := range a.driveGroups {
 		logger.Infof("configuring Drive Group %q: %+v", group, spec)
-		_, err := callCephVolume(context, cvDriveGroupsCommand, "--spec", spec)
+		_, err := callCephVolume(context, true, cvDriveGroupsCommand, "--spec", spec)
 		if err != nil {
 			return errors.Wrapf(err, "failed to configure Drive Group %q", group)
 		}
@@ -56,7 +56,7 @@ func (a *OsdAgent) configureDriveGroups(context *clusterd.Context) error {
 func (a *OsdAgent) driveGroupsAreSupported(context *clusterd.Context) bool {
 	// Call `ceph-volume drive-group` command with no args:
 	// if supported, will return 0 (and help message which we ingore), else returns nonzero (error)
-	_, err := callCephVolume(context, cvDriveGroupsCommand)
+	_, err := callCephVolume(context, true, cvDriveGroupsCommand)
 	if err != nil {
 		return false
 	}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -631,8 +631,8 @@ func GetCephVolumeLVMOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	cvMode := "lvm"
 
 	var lvPath string
-
-	result, err := callCephVolume(context, cvMode, "list", lv, "--format", "json")
+	args := []string{cvMode, "list", lv, "--format", "json"}
+	result, err := callCephVolume(context, false, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}
@@ -727,7 +727,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 		args = []string{cvMode, "list", "--format", "json"}
 	}
 
-	result, err := callCephVolume(context, args...)
+	result, err := callCephVolume(context, false, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve ceph-volume %s list results", cvMode)
 	}
@@ -802,7 +802,7 @@ func GetCephVolumeRawOSDs(context *clusterd.Context, clusterInfo *client.Cluster
 	return osds, nil
 }
 
-func callCephVolume(context *clusterd.Context, args ...string) (string, error) {
+func callCephVolume(context *clusterd.Context, requiresCombinedOutput bool, args ...string) (string, error) {
 	// Use stdbuf to capture the python output buffer such that we can write to the pod log as the
 	// logging happens instead of using the default buffering that will log everything after
 	// ceph-volume exits
@@ -817,7 +817,13 @@ func callCephVolume(context *clusterd.Context, args ...string) (string, error) {
 	}
 	baseArgs := []string{"-oL", cephVolumeCmd, "--log-path", logPath}
 
-	co, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, append(baseArgs, args...)...)
+	// Do not use combined output for "list" calls, otherwise we will get stderr is the output and this will break the json unmarshall
+	f := context.Executor.ExecuteCommandWithOutput
+	if requiresCombinedOutput {
+		// If the action is preparing we need the combined output
+		f = context.Executor.ExecuteCommandWithCombinedOutput
+	}
+	co, err := f(baseCommand, append(baseArgs, args...)...)
 	if err != nil {
 		// Print c-v log before exiting with failure
 		cvLog := readCVLogContent("/tmp/ceph-log/ceph-volume.log")

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -489,7 +489,7 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 
 func TestParseCephVolumeLVMResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		logger.Infof("%s %v", command, args)
@@ -510,7 +510,7 @@ func TestParseCephVolumeLVMResult(t *testing.T) {
 
 func TestParseCephVolumeRawResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == "stdbuf" {
 			if args[4] == "raw" && args[5] == "list" {
@@ -532,7 +532,7 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		if command == "stdbuf" {
@@ -556,7 +556,7 @@ func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 func TestCephVolumeResultMultiClusterMultiOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		if command == "stdbuf" {


### PR DESCRIPTION
**Description of your changes:**

callCephVolume() was using our exec interface with CombinedOutput which
means return both stdout and stderr. This is fine when preparing OSDs
since we read back the stdout and also want any errors if any (stderr).
However when listing OSD we only want the output since ceph-volume tends
to mix stdout and stderr in the output and does not always silence the
warning types/harmless errors. If the listing has a problem we report it
by printing the ceph-volume log file.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
