### PR TITLE
ceph: use different command for lvm2 presence

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -173,7 +173,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	// Check for the presence of LVM on the host when NOT running on PVC
 	// since this scenario is still using LVM
 	if !agent.pvcBacked {
-		ne := NewNsenter(context, lvmCommandToCheck, []string{"--help"})
+		ne := NewNsenter(context, lvmCommandToCheck, []string{"help"})
 		err := ne.checkIfBinaryExistsOnHost()
 		if err != nil {
 			return errors.Wrapf(err, "binary %q does not exist on the host, make sure lvm2 package is installed", lvmCommandToCheck)

--- a/pkg/daemon/ceph/osd/nsenter_test.go
+++ b/pkg/daemon/ceph/osd/nsenter_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestBuildNsEnterCLI(t *testing.T) {
-	ne := NewNsenter(&clusterd.Context{}, lvmCommandToCheck, []string{"--help"})
+	ne := NewNsenter(&clusterd.Context{}, lvmCommandToCheck, []string{"help"})
 	args := ne.buildNsEnterCLI(filepath.Join("/sbin/", ne.binary))
-	expectedCLI := []string{"--mount=/rootfs/proc/1/ns/mnt", "--", "/sbin/lvm", "--help"}
+	expectedCLI := []string{"--mount=/rootfs/proc/1/ns/mnt", "--", "/sbin/lvm", "help"}
 
 	assert.Equal(t, expectedCLI, args)
 }
@@ -38,7 +38,7 @@ func TestCheckIfBinaryExistsOnHost(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
-		if command == "nsenter" && args[0] == "--mount=/rootfs/proc/1/ns/mnt" && args[1] == "--" && args[3] == "--help" {
+		if command == "nsenter" && args[0] == "--mount=/rootfs/proc/1/ns/mnt" && args[1] == "--" && args[3] == "help" {
 			if args[2] == "/usr/sbin/lvm" || args[2] == "/sbin/lvm" {
 				return "success", nil
 			}
@@ -48,7 +48,7 @@ func TestCheckIfBinaryExistsOnHost(t *testing.T) {
 	}
 
 	context := &clusterd.Context{Executor: executor}
-	ne := NewNsenter(context, lvmCommandToCheck, []string{"--help"})
+	ne := NewNsenter(context, lvmCommandToCheck, []string{"help"})
 	err := ne.checkIfBinaryExistsOnHost()
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
**Description of your changes:**

Older versions of lvm do not implement "--help" but "help" only where
new versions support both so let's use "help" so the check works for all
the versions.

Closes: https://github.com/rook/rook/issues/6057
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6057

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.


// Known issue!
[skip ci]