### PR TITLE
ceph: add support for wal encrypted device on pvc

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -398,9 +398,14 @@ func TestClusterGetPVCEncryptionOpenInitContainerActivate(t *testing.T) {
 	assert.Equal(t, 1, len(containers))
 
 	// With metadata PVC
-	osdProperties.metadataPVC.ClaimName = "pvc2"
+	osdProperties.metadataPVC.ClaimName = "pvcDB"
 	containers = c.getPVCEncryptionOpenInitContainerActivate(osdProperties)
 	assert.Equal(t, 2, len(containers))
+
+	// With wal PVC
+	osdProperties.walPVC.ClaimName = "pvcWal"
+	containers = c.getPVCEncryptionOpenInitContainerActivate(osdProperties)
+	assert.Equal(t, 3, len(containers))
 }
 
 func TestClusterGetPVCEncryptionInitContainerActivate(t *testing.T) {
@@ -418,7 +423,12 @@ func TestClusterGetPVCEncryptionInitContainerActivate(t *testing.T) {
 	assert.Equal(t, 1, len(containers))
 
 	// With metadata PVC
-	osdProperties.metadataPVC.ClaimName = "pvc2"
+	osdProperties.metadataPVC.ClaimName = "pvcDB"
 	containers = c.getPVCEncryptionInitContainerActivate(mountPath, osdProperties)
 	assert.Equal(t, 2, len(containers))
+
+	// With wal PVC
+	osdProperties.walPVC.ClaimName = "pvcWal"
+	containers = c.getPVCEncryptionInitContainerActivate(mountPath, osdProperties)
+	assert.Equal(t, 3, len(containers))
 }


### PR DESCRIPTION
**Description of your changes:**

Similar to https://github.com/rook/rook/pull/5977 but for wal devices.
So if a cluster is deployed on PVC and wal devices, those will be
encrypted as well.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
