### PR TITLE
docs: added rbd mirror crd documentation

### DIFF
--- a/Documentation/ceph-rbd-mirror-crd.md
+++ b/Documentation/ceph-rbd-mirror-crd.md
@@ -27,3 +27,21 @@ spec:
 ### Prerequisites
 
 This guide assumes you have created a Rook cluster as explained in the main [Quickstart guide](ceph-quickstart.md)
+
+## Settings
+
+If any setting is unspecified, a suitable default will be used automatically.
+
+### RBDMirror metadata
+
+* `name`: The name that will be used for the Ceph RBD Mirror daemon.
+* `namespace`: The Kubernetes namespace that will be created for the Rook cluster. The services, pods, and other resources created by the operator will be added to this namespace.
+
+### RBDMirror Settings
+
+* `count`: The number of rbd mirror instance to run.
+* `placement`: The rbd mirror pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph/cluster.yaml).
+* `annotations`: Key value pair list of annotations to add.
+* `labels`: Key value pair list of labels to add.
+* `resources`: The resource requirements for the rbd mirror pods.
+* `priorityClassName`: The priority class to set on the rbd mirror pods.

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -773,9 +773,9 @@ type RBDMirroringSpec struct {
 	// The annotations-related configuration to add/set on each Pod related object.
 	Annotations rookv1.Annotations `json:"annotations,omitempty"`
 
-	// The resource requirements for the rgw pods
+	// The resource requirements for the rbd mirror pods
 	Resources v1.ResourceRequirements `json:"resources"`
 
-	// PriorityClassName sets priority classes on the rgw pods
+	// PriorityClassName sets priority class on the rbd mirror pods
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 }


### PR DESCRIPTION
**Description of your changes:**

This adds some basic RBDMirror CRD documentation and fixes the types.go
comments accordingly.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

I will skip the CI as only comments and documentation has been updated, but if we see the need as code has been changed we can run the full Ceph test.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
