### PR TITLE
doc: fix helm command usage

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -46,7 +46,18 @@ The release channel is the most recent release of Rook that is considered stable
 
 ```console
 helm repo add rook-release https://charts.rook.io/release
-helm install --namespace rook-ceph rook-release/rook-ceph
+```
+
+For Helm `v3.x`:
+
+```console
+helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph
+```
+
+For Helm `v2.x` the `--name` flag needs to be specified:
+
+```console
+helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph
 ```
 
 ### Master
@@ -58,15 +69,23 @@ To install the helm chart from master, you will need to pass the specific versio
 
 ```console
 helm repo add rook-master https://charts.rook.io/master
+
+# For Helm v3.x
+helm search repo rook-ceph --versions
+helm install --namespace rook-ceph rook-ceph rook-master/rook-ceph --version <version>
+
+# For Helm v2.x
 helm search rook-ceph
-helm install --namespace rook-ceph rook-master/rook-ceph --version <version>
+helm install --namespace rook-ceph --name rook-ceph rook-master/rook-ceph --version <version>
 ```
 
-For example:
+For example to install version `v1.3.0.860.g80ff2bb`:
 
-```cosnole
-helm install --namespace rook-ceph rook-master/rook-ceph --version v0.7.0-278.gcbd9726
+```console
+helm install --namespace rook-ceph rook-ceph rook-master/rook-ceph --version v1.3.0.860.g80ff2bb
 ```
+
+For Helm `v2.x` the `--name` flag must be specified instead of just `rook-ceph`, e.g., `--name rook-ceph`.
 
 ### Development Build
 
@@ -78,8 +97,9 @@ To deploy from a local build from your development environment:
 
 ```console
 cd cluster/charts/rook-ceph
-helm install --namespace rook-ceph --name rook-ceph .
+helm install --namespace rook-ceph rook-ceph .
 ```
+For Helm `v2.x` the `--name` flag must be specified instead of just `rook-ceph`, e.g., `--name rook-ceph`.
 
 ## Uninstalling the Chart
 
@@ -166,16 +186,20 @@ The following tables lists the configurable parameters of the rook-operator char
 You can pass the settings with helm command line parameters. Specify each parameter using the
 `--set key=value[,key=value]` argument to `helm install`. For example, the following command will install rook where RBAC is not enabled.
 
+For Helm `v2.x` the `--name` flag must be specified instead of just `rook-ceph`, e.g., `--name rook-ceph`.
+
 ```console
-helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph --set rbacEnable=false
+helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph --set rbacEnable=false
 ```
 
 ### Settings File
 
 Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while installing the chart.
 
+For Helm `v2.x` the `--name` flag must be specified instead of just `rook-ceph`, e.g., `--name rook-ceph`.
+
 ```console
-helm install --namespace rook-ceph --name rook-ceph rook-release/rook-ceph -f values.yaml
+helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph -f values.yaml
 ```
 
 Here are the sample settings to get you started.


### PR DESCRIPTION
**Description of your changes:**

This fixes the helm commands to be compatible with Helm v3.x and adds an
example / notes for Helm v2.x users.

Resolves #5491

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #5491

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]