### PR TITLE
ceph: fix object store healthcheck yaml

### DIFF
--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -54,7 +54,7 @@ spec:
     instances: 1
   healthCheck:
     bucket:
-      enabled: true
+      disabled: false
       interval: 60s
 ```
 

--- a/cluster/examples/kubernetes/ceph/object-external.yaml
+++ b/cluster/examples/kubernetes/ceph/object-external.yaml
@@ -18,5 +18,5 @@ spec:
       - ip: 192.168.39.182
   healthCheck:
     bucket:
-      enabled: true
+      disabled: false
       interval: 60s

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -86,8 +86,8 @@ spec:
     #name: zone-a
   # service endpoint healthcheck
   healthCheck:
-    endpoint:
-      enabled: true
+    bucket:
+      disabled: false
       interval: 60s
     # Configure the pod liveness probe for the rgw daemon
     livenessProbe:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -450,7 +450,7 @@ type ObjectStoreSpec struct {
 }
 
 type BucketHealthCheckSpec struct {
-	Bucket        HealthCheckSpec   `json:"rgw,omitempty"`
+	Bucket        HealthCheckSpec   `json:"bucket,omitempty"`
 	LivenessProbe *rookv1.ProbeSpec `json:"livenessProbe,omitempty"`
 }
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -2166,7 +2166,7 @@ spec:
     allNodes: false
   healthCheck:
     bucket:
-      enabled: true
+      disabled: false
       interval: 10s
 `
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Reverting some of
23f0ac7
to re-use `bucket` for the healthcheck configuration.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]