### PR TITLE
ci: fix inconsistent error log

### DIFF
--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -128,7 +128,7 @@ func (suite *CephMgrSuite) waitForOrchestrationModule() {
 		logger.Infof("%s", output)
 		if err == nil {
 			logger.Info("Rook Toolbox ready to execute commands")
-			break
+			return
 		}
 		time.Sleep(2 * time.Second)
 	}


### PR DESCRIPTION
**Description of your changes:**
`Giving up waiting for Rook Toolbox to be ready` error always
logs.

Because [this code](https://github.com/rook/rook/blob/master/tests/integration/ceph_mgr_test.go#L126-L136) goes `logger.Error("Giving up waiting for Rook Toolbox to be ready")` even if `ceph orch status` command successes.

Example:
https://jenkins.rook.io/blue/rest/organizations/jenkins/pipelines/rook/pipelines/rook/branches/PR-5573/runs/78/nodes/60/steps/118/log/?start=0
```
2020-08-17 22:47:10.759998 I | integrationTest: Rook Toolbox ready to execute commands
2020-08-17 22:47:10.760005 E | integrationTest: Giving up waiting for Rook Toolbox to be ready
```

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
