### PR TITLE
ceph: Separate placement for osd prepare jobs from osd daemons

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -309,6 +309,8 @@ The following are the settings for Storage Class Device Sets which can be config
 
   However, if there are more OSDs than nodes, this anti-affinity will not be effective. Another placement scheme to consider is to add labels to the nodes in such a way that the OSDs can be grouped on those nodes, create multiple storageClassDeviceSets, and add node affinity to each of the device sets that will place the OSDs in those sets of nodes.
 
+* `preparePlacement`: The placement criteria for the preparation of the OSD devices. Creating OSDs is a two-step process and the prepare job may require different placement than the OSD daemons. If the `preparePlacement` is not specified, the `placement` will instead be applied for consistent placement for the OSD prepare jobs and OSD deployments. The `preparePlacement` is only useful for `portable` OSDs in the device sets. OSDs that are not portable will be tied to the host where the OSD prepare job initially runs.
+   * For example, provisioning may require topology spread constraints across zones, but the OSD daemons may require constraints across hosts within the zones.
 * `portable`: If `true`, the OSDs will be allowed to move between nodes during failover. This requires a storage class that supports portability (e.g. `aws-ebs`, but not the local storage provisioner). If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
 * `tuneDeviceClass`: If `true`, because the OSD can be on a slow device class, Rook will adapt to that by tuning the OSD process. This will make Ceph perform better under that slow device.
 * `volumeClaimTemplates`: A list of PVC templates to use for provisioning the underlying storage devices.
@@ -1146,8 +1148,8 @@ In Ceph Cluster let us list the pools available:
 
 ```console
 rados df
-POOL_NAME     USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS  RD WR_OPS  WR USED COMPR UNDER COMPR 
-replicated_2g  0 B       0      0      0                  0       0        0      0 0 B      0 0 B        0 B         0 B 
+POOL_NAME     USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS  RD WR_OPS  WR USED COMPR UNDER COMPR
+replicated_2g  0 B       0      0      0                  0       0        0      0 0 B      0 0 B        0 B         0 B
 ```
 
 Here is an example StorageClass configuration that uses the `replicated_2g` pool from the external cluster:

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -62,13 +62,20 @@ spec:
       encrypted: false
       # Since the OSDs could end up on any node, an effort needs to be made to spread the OSDs
       # across nodes as much as possible. Unfortunately the pod anti-affinity breaks down
-      # as soon as you have more than one OSD per node. If you have more OSDs than nodes, K8s may
-      # choose to schedule many of them on the same node. What we need is the Pod Topology
-      # Spread Constraints.
-      # Another approach for a small number of OSDs is to create a separate device set for each
-      # zone (or other set of nodes with a common label) so that the OSDs will end up on different
-      # nodes. This would require adding nodeAffinity to the placement here.
+      # as soon as you have more than one OSD per node. The topology spread constraints will
+      # give us an even spread on K8s 1.18 or newer.
       placement:
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - rook-ceph-osd
+      preparePlacement:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
@@ -86,14 +93,13 @@ spec:
               topologyKey: kubernetes.io/hostname
         topologySpreadConstraints:
         - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchExpressions:
             - key: app
               operator: In
               values:
-              - rook-ceph-osd
               - rook-ceph-osd-prepare
       resources:
       #   limits:

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -119,7 +119,8 @@ type StorageClassDeviceSet struct {
 	Name                 string                     `json:"name,omitempty"`                 // A unique identifier for the set
 	Count                int                        `json:"count,omitempty"`                // Number of devices in this set
 	Resources            v1.ResourceRequirements    `json:"resources,omitempty"`            // Requests/limits for the devices
-	Placement            Placement                  `json:"placement,omitempty"`            // Placement constraints for the devices
+	Placement            Placement                  `json:"placement,omitempty"`            // Placement constraints for the device daemons
+	PreparePlacement     *Placement                 `json:"preparePlacement,omitempty"`     // Placement constraints for the device preparation
 	Config               map[string]string          `json:"config,omitempty"`               // Provider-specific device configuration
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"` // List of PVC templates for the underlying storage devices
 	Portable             bool                       `json:"portable,omitempty"`             // OSD portability across the hosts
@@ -134,6 +135,7 @@ type VolumeSource struct {
 	PVCSources          map[string]v1.PersistentVolumeClaimVolumeSource `json:"pvcSources,omitempty"`
 	Resources           v1.ResourceRequirements                         `json:"resources,omitempty"`
 	Placement           Placement                                       `json:"placement,omitempty"`
+	PreparePlacement    *Placement                                      `json:"preparePlacement,omitempty"`
 	Config              map[string]string                               `json:"config,omitempty"`
 	Portable            bool                                            `json:"portable,omitempty"`         // Portable OSD portability across the hosts
 	TuneSlowDeviceClass bool                                            `json:"tuneDeviceClass,omitempty"`  // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -75,6 +75,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 				Name:                storageClassDeviceSet.Name,
 				Resources:           storageClassDeviceSet.Resources,
 				Placement:           storageClassDeviceSet.Placement,
+				PreparePlacement:    storageClassDeviceSet.PreparePlacement,
 				Config:              storageClassDeviceSet.Config,
 				Size:                dataSize,
 				PVCSources:          pvcSources,

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -128,7 +128,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	if !osdProps.onPVC() {
 		cephv1.GetOSDPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec)
 	} else {
-		osdProps.placement.ApplyToPodSpec(&podSpec)
+		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec)
 	}
 
 	podMeta := metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The osd prepare jobs and osd daemons may have different placement requirements. In particular, the topology spread constraints or pod anti-affinity should only work on either the prepare job or osd daemon, but does not work effectively on both types at the same time. Therefore, we split out the osd prepare placement to be separate from the osd daemon placement. 

If the osd prepare placement is not set the operator will fall back to the osd daemon placement for backward compatibility.

This only applies to OSDs created by portable storageClassDeviceSets. Non-portable OSDs will be tied to the host on which the OSD prepare job runs.

**Which issue is resolved by this Pull Request:**
Resolves: #5932 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
