### PR TITLE
ceph: pass csi resources as string in helm

### DIFF
--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -69,7 +69,7 @@ csi:
   allowUnsupportedVersion: false
     # (Optional) CEPH CSI RBD provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # csiRBDProvisionerResource:
+  # csiRBDProvisionerResource: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -120,7 +120,7 @@ csi:
   #        cpu: 100m
   # (Optional) CEPH CSI RBD plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # csiRBDPluginResource:
+  # csiRBDPluginResource: |
   #  - name : driver-registrar
   #    resource:
   #      requests:
@@ -147,7 +147,7 @@ csi:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS provisioner resource requirement list, Put here list of resource
   # requests and limits you want to apply for provisioner pod
-  # csiCephFSProvisionerResource:
+  # csiCephFSProvisionerResource: |
   #  - name : csi-provisioner
   #    resource:
   #      requests:
@@ -190,7 +190,7 @@ csi:
   #        cpu: 100m
   # (Optional) CEPH CSI CephFS plugin resource requirement list, Put here list of resource
   # requests and limits you want to apply for plugin pod
-  # csiCephFSPluginResource:
+  # csiCephFSPluginResource: |
   #  - name : driver-registrar
   #    resource:
   #      requests:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Currently, the CSI resources are getting passed as the map instead of a string, due to this the yaml unmarshal is getting failed. This commit adds the missing '|' to pass the resources as the string instead of map

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>


**Which issue is resolved by this Pull Request:**
Resolves #5501

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
[skip ci]

added skip ci as this changes only the commented line.