### PR TITLE
ceph: check rootfs for lvm too

### DIFF
--- a/pkg/daemon/ceph/osd/nsenter_test.go
+++ b/pkg/daemon/ceph/osd/nsenter_test.go
@@ -51,4 +51,23 @@ func TestCheckIfBinaryExistsOnHost(t *testing.T) {
 	ne := NewNsenter(context, lvmCommandToCheck, []string{"help"})
 	err := ne.checkIfBinaryExistsOnHost()
 	assert.NoError(t, err)
+
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		switch command {
+
+		case "/rootfs/usr/sbin/lvm":
+			return "success", nil
+
+		case "/rootfs/sbin/lvm":
+			return "success", nil
+
+		}
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+
+	context = &clusterd.Context{Executor: executor}
+	ne = NewNsenter(context, lvmCommandToCheck, []string{"help"})
+	err = ne.checkIfBinaryExistsOnHost()
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
**Description of your changes:**

On rancher OS, the lvm binary is in a different location and cannot be
accessed via the root namespace. So we now also check directly from
/rootfs. When using nsenter, itbreaks out of container's mount
namespace and executes an lvm command.

Closes: https://github.com/rook/rook/issues/6078
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6078

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
