### PR TITLE
ceph: Continue with memory limits below min settings

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -423,19 +423,15 @@ It scrapes for Ceph daemon core dumps and sends them to the Ceph manager crash m
 You can read more about the [Ceph Crash module](https://docs.ceph.com/docs/master/mgr/crash/).
 * `cleanup`: Set resource requests/limits for cleanup job, responsible for wiping cluster's data after uninstall
 
-In order to provide the best possible experience running Ceph in containers, Rook internally enforces minimum memory limits if resource limits are passed.
-If a user configures a limit or request value that is too low, Rook will refuse to run the pod(s).
-Here are the current minimum amounts of memory in MB to apply so that Rook will agree to run Ceph pods:
+In order to provide the best possible experience running Ceph in containers, Rook internally recommends minimum memory limits if resource limits are passed.
+If a user configures a limit or request value that is too low, Rook will still run the pod(s) and print a warning to the operator log.
 
 * `mon`: 1024MB
 * `mgr`: 512MB
 * `osd`: 2048MB
 * `mds`: 4096MB
-
-Rook does not enforce any minimum limit nor request on the following:
-
-* prepare OSD pod: This pod commonly takes up to 50MB, but depending on the OSD scenario may need more memory. 100MB would be more conservative.
-* crashcollector pod: This pod commonly takes around 60MB.
+* `prepareosd`: 50MB
+* `crashcollector`: 60MB
 
 ### Resource Requirements/Limits
 

--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -30,8 +30,12 @@ const (
 	ResourcesKeyOSD = "osd"
 	// ResourcesKeyPrepareOSD represents the name of resource in the CR for the osd prepare job
 	ResourcesKeyPrepareOSD = "prepareosd"
+	// ResourcesKeyMDS represents the name of resource in the CR for the mds
+	ResourcesKeyMDS = "mds"
 	// ResourcesKeyCrashCollector represents the name of resource in the CR for the crash
 	ResourcesKeyCrashCollector = "crashcollector"
+	// ResourcesKeyRBDMirror represents the name of resource in the CR for the rbd mirror
+	ResourcesKeyRBDMirror = "rbdmirror"
 	// ResourcesKeyCleanup represents the name of resource in the CR for the cleanup
 	ResourcesKeyCleanup = "cleanup"
 )

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -103,7 +103,7 @@ func (c *Cluster) getDaemonIDs() []string {
 // Start begins the process of running a cluster of Ceph mgrs.
 func (c *Cluster) Start() error {
 	// Validate pod's memory if specified
-	err := controller.CheckPodMemory(cephv1.GetMgrResources(c.spec.Resources), cephMgrPodMinimumMemory)
+	err := controller.CheckPodMemory(cephv1.ResourcesKeyMgr, cephv1.GetMgrResources(c.spec.Resources), cephMgrPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -200,7 +200,7 @@ func (c *Cluster) Start(clusterInfo *cephclient.ClusterInfo, rookVersion string,
 	}
 
 	// Validate pod's memory if specified
-	err := controller.CheckPodMemory(cephv1.GetMonResources(c.spec.Resources), cephMonPodMinimumMemory)
+	err := controller.CheckPodMemory(cephv1.ResourcesKeyMon, cephv1.GetMonResources(c.spec.Resources), cephMonPodMinimumMemory)
 	if err != nil {
 		return nil, errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -74,7 +74,7 @@ func TestNodeAffinity(t *testing.T) {
 func TestHostNetworkSameNode(t *testing.T) {
 	namespace := "ns"
 	context, err := newTestStartCluster(t, namespace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// cluster host networking
 	c := newCluster(context, namespace, true, v1.ResourceRequirements{})
 	c.spec.Network.HostNetwork = true
@@ -88,7 +88,7 @@ func TestHostNetworkSameNode(t *testing.T) {
 func TestPodMemory(t *testing.T) {
 	namespace := "ns"
 	context, err := newTestStartCluster(t, namespace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	// Test memory limit alone
 	r := v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -100,7 +100,7 @@ func TestPodMemory(t *testing.T) {
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// Test REQUEST == LIMIT
 	r = v1.ResourceRequirements{
@@ -116,7 +116,7 @@ func TestPodMemory(t *testing.T) {
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
 	// Test LIMIT != REQUEST but obviously LIMIT > REQUEST
 	r = v1.ResourceRequirements{
@@ -132,9 +132,9 @@ func TestPodMemory(t *testing.T) {
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 
-	// Test valid case where pod resource is set approprietly
+	// Test valid case where pod resource is set appropriately
 	r = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: *resource.NewQuantity(1073741824, resource.BinarySI), // size in Bytes
@@ -148,7 +148,7 @@ func TestPodMemory(t *testing.T) {
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Test no resources were specified on the pod
 	r = v1.ResourceRequirements{}
@@ -156,7 +156,7 @@ func TestPodMemory(t *testing.T) {
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
 	// start a basic cluster
 	_, err = c.Start(c.ClusterInfo, c.rookVersion, cephver.Nautilus, c.spec)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 }
 
@@ -203,7 +203,7 @@ func extractArgValue(args []string, name string) (string, string) {
 func TestGetNodeInfoFromNode(t *testing.T) {
 	clientset := test.New(t, 1)
 	node, err := clientset.CoreV1().Nodes().Get("node0", metav1.GetOptions{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, node)
 
 	node.Status = v1.NodeStatus{}
@@ -221,6 +221,6 @@ func TestGetNodeInfoFromNode(t *testing.T) {
 	node.Status.Addresses[0].Type = v1.NodeInternalIP
 	node.Status.Addresses[0].Address = "172.17.0.1"
 	info, err = getNodeInfoFromNode(*node)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "172.17.0.1", info.Address)
 }

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	v1 "k8s.io/api/core/v1"
@@ -32,7 +33,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 
 	// Iterate over storageClassDeviceSet
 	for _, storageClassDeviceSet := range c.spec.Storage.StorageClassDeviceSets {
-		if err := controller.CheckPodMemory(storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
+		if err := controller.CheckPodMemory(cephv1.ResourcesKeyPrepareOSD, storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
 			config.addError("cannot use storageClassDeviceSet %q for creating osds %v", storageClassDeviceSet.Name, err)
 			continue
 		}

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -172,7 +172,7 @@ func (c *Cluster) Start() error {
 	config := c.newProvisionConfig()
 
 	// Validate pod's memory if specified
-	err := controller.CheckPodMemory(cephv1.GetOSDResources(c.spec.Resources), cephOsdPodMinimumMemory)
+	err := controller.CheckPodMemory(cephv1.ResourcesKeyOSD, cephv1.GetOSDResources(c.spec.Resources), cephOsdPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "failed to check pod memory")
 	}

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -45,7 +45,7 @@ var updateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 // Start begins the process of running rbd mirroring daemons.
 func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) error {
 	// Validate pod's memory if specified
-	err := controller.CheckPodMemory(cephRBDMirror.Spec.Resources, cephRbdMirrorPodMinimumMemory)
+	err := controller.CheckPodMemory(cephv1.ResourcesKeyRBDMirror, cephRBDMirror.Spec.Resources, cephRbdMirrorPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -66,6 +66,7 @@ func TestMountsMatchVolumes(t *testing.T) {
 func TestCheckPodMemory(t *testing.T) {
 	// This value is in MB
 	const PodMinimumMemory uint64 = 1024
+	name := "test"
 
 	// A value for the memory used in the tests
 	var memory_value = int64(PodMinimumMemory * 8 * uint64(math.Pow10(6)))
@@ -73,7 +74,7 @@ func TestCheckPodMemory(t *testing.T) {
 	// Case 1: No memory limits, no memory requested
 	test_resource := v1.ResourceRequirements{}
 
-	if err := CheckPodMemory(test_resource, PodMinimumMemory); err != nil {
+	if err := CheckPodMemory(name, test_resource, PodMinimumMemory); err != nil {
 		t.Errorf("Error case 1: %s", err.Error())
 	}
 
@@ -87,7 +88,7 @@ func TestCheckPodMemory(t *testing.T) {
 		},
 	}
 
-	if err := CheckPodMemory(test_resource, PodMinimumMemory); err != nil {
+	if err := CheckPodMemory(name, test_resource, PodMinimumMemory); err != nil {
 		t.Errorf("Error case 2: %s", err.Error())
 	}
 
@@ -98,7 +99,7 @@ func TestCheckPodMemory(t *testing.T) {
 		},
 	}
 
-	if err := CheckPodMemory(test_resource, PodMinimumMemory); err != nil {
+	if err := CheckPodMemory(name, test_resource, PodMinimumMemory); err != nil {
 		t.Errorf("Error case 3: %s", err.Error())
 	}
 }

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -102,7 +102,7 @@ var UpdateDeploymentAndWait = mon.UpdateCephDeploymentAndWait
 // Start starts or updates a Ceph mds cluster in Kubernetes.
 func (c *Cluster) Start() error {
 	// Validate pod's memory if specified
-	err := controller.CheckPodMemory(c.fs.Spec.MetadataServer.Resources, cephMdsPodMinimumMemory)
+	err := controller.CheckPodMemory(cephv1.ResourcesKeyMDS, c.fs.Spec.MetadataServer.Resources, cephMdsPodMinimumMemory)
 	if err != nil {
 		return errors.Wrap(err, "error checking pod memory")
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator will now allow the resource limits to be applied below the recommended minimums. In small clusters, even the recommended minimums may not be necessary. A warning is still printed to the operator log, but we allow the configuration to continue.

Resolves: #5079 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
