### PR TITLE
ceph: Set the OSD prepare resources

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -96,6 +96,7 @@ spec:
               - rook-ceph-osd
               - rook-ceph-osd-prepare
       resources:
+      # These are the OSD daemon limits. For OSD prepare limits, see the separate section below for "prepareosd" resources
       #   limits:
       #     cpu: "500m"
       #     memory: "4Gi"
@@ -145,6 +146,14 @@ spec:
       #       - ReadWriteOnce
       # Scheduler name for OSD pod placement
       # schedulerName: osd-scheduler
+  resources:
+  #  prepareosd:
+  #    limits:
+  #      cpu: "200m"
+  #      memory: "200Mi"
+  #   requests:
+  #      cpu: "200m"
+  #      memory: "200Mi"
   disruptionManagement:
     managePodBudgets: false
     osdMaintenanceTimeout: 30

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -252,18 +252,15 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 
 		logger.Debugf("osdProps are %+v", osdProps)
 
-		// If the deviceSet template has "encrypted" but the Ceph version is not compatible
 		if osdProps.encrypted {
+			// If the deviceSet template has "encrypted" but the Ceph version is not compatible
 			if !c.isCephVolumeRawModeSupported() {
 				errMsg := fmt.Sprintf("failed to validate storageClassDeviceSet %q. min required ceph version to support encryption is %q or %q", volume.Name, cephVolumeRawEncryptionModeMinNautilusCephVersion.String(), cephVolumeRawEncryptionModeMinOctopusCephVersion.String())
 				config.addError(errMsg)
 				continue
 			}
-		}
 
-		// create encryption Kubernetes Secret if the PVC is encrypted
-		if osdProps.encrypted {
-			// Generate dmcrypt key
+			// create encryption Kubernetes Secret if the PVC is encrypted
 			key, err := generateDmCryptKey()
 			if err != nil {
 				errMsg := fmt.Sprintf("failed to generate dmcrypt key for osd claim %q. %v", osdProps.pvc.ClaimName, err)

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -72,7 +72,20 @@ func (c *Cluster) makeJob(osdProps osdProperties, provisionConfig *provisionConf
 	k8sutil.AddRookVersionLabelToJob(job)
 	controller.AddCephVersionLabelToJob(c.clusterInfo.CephVersion, job)
 	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.clusterInfo.OwnerRef)
+
+	// override the resources of all the init containers and main container with the expected osd prepare resources
+	c.applyResourcesToAllContainers(&podSpec.Spec, cephv1.GetPrepareOSDResources(c.spec.Resources))
 	return job, nil
+}
+
+// applyResourcesToAllContainers applies consistent resource requests for all containers and all init containers in the pod
+func (c *Cluster) applyResourcesToAllContainers(spec *v1.PodSpec, resources v1.ResourceRequirements) {
+	for i := range spec.InitContainers {
+		spec.InitContainers[i].Resources = resources
+	}
+	for i := range spec.Containers {
+		spec.Containers[i].Resources = resources
+	}
 }
 
 func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.RestartPolicy, provisionConfig *provisionConfig) (*v1.PodTemplateSpec, error) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The osd prepare resources were only being set on the main container while the init containers either did not have resources set, or were inheriting the resource settings from the device set resources for osds. Now the osd prepare resources will be consistently set based on the prepareosd resources in the main section of the cluster CR.

Also a small code simplification to remove an extra check for whether the OSDs are encrypted. There is no change in functionality for this commit.

**Which issue is resolved by this Pull Request:**
Resolves: #5586 #6117

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
