### PR TITLE
ci: clean up after SmokeTest

### DIFF
--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -88,7 +88,7 @@ func (suite *SmokeSuite) SetupSuite() {
 		usePVC:                  false,
 		mons:                    3,
 		rbdMirrorWorkers:        1,
-		rookCephCleanup:         false,
+		rookCephCleanup:         true,
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
@@ -301,6 +301,9 @@ func (suite *SmokeSuite) TestCreateRBDMirrorClient() {
 	rbdMirrorName := "my-rbd-mirror"
 
 	err := suite.helper.RBDMirrorClient.Create(suite.namespace, rbdMirrorName, 1)
+	require.Nil(suite.T(), err)
+
+	err = suite.helper.RBDMirrorClient.Delete(suite.namespace, rbdMirrorName)
 	require.Nil(suite.T(), err)
 }
 


### PR DESCRIPTION
**Description of your changes:**
Currently, SmokeTest is not cleaned up after the test.
As this can affect other following tests, this commit sets rookCephCleanup as true.

To use cleanup job, it needs to be cleaned `rook-ceph-rbd-mirror` pod beforehand [here](https://github.com/rook/rook/blob/master/pkg/operator/ceph/cluster/cleanup.go#L163-L220).
Therefore, this commit also deletes CephRBDMirror resource after its test is over

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]