### PR TITLE
ceph: purge a down osd with a job

### DIFF
--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: rook-ceph
+  labels:
+    app: rook-ceph-purge-osd
+spec:
+  template:
+    spec:
+      serviceAccountName: rook-ceph-system
+      containers:
+        - name: osd-removal
+          image: rook/ceph:master
+          # TODO: Insert the OSD ID in the last parameter that is to be removed
+          # The OSD IDs are a comma-separated list. For example: "0" or "0,2".
+          args: ["ceph", "osd", "remove", "--osd-ids", "<OSD-IDs>"]
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ROOK_MON_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  key: data
+                  name: rook-ceph-mon-endpoints
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: ceph-username
+                  name: rook-ceph-mon
+            - name: ROOK_CEPH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: ceph-secret
+                  name: rook-ceph-mon
+            - name: ROOK_CONFIG_DIR
+              value: /var/lib/rook
+            - name: ROOK_CEPH_CONFIG_OVERRIDE
+              value: /etc/rook/config/override.conf
+            - name: ROOK_FSID
+              valueFrom:
+                secretKeyRef:
+                  key: fsid
+                  name: rook-ceph-mon
+            - name: ROOK_LOG_LEVEL
+              value: DEBUG
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-conf-emptydir
+      volumes:
+        - emptyDir: {}
+          name: ceph-conf-emptydir
+      restartPolicy: Never

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"fmt"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+)
+
+// RemoveOSDs purges a list of OSDs from the cluster
+func RemoveOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdsToRemove []string) error {
+
+	// Generate the ceph config for running ceph commands similar to the operator
+	if err := writeCephConfig(context, clusterInfo); err != nil {
+		return errors.Wrap(err, "failed to write the ceph config")
+	}
+
+	osdDump, err := client.GetOSDDump(context, clusterInfo)
+	if err != nil {
+		return errors.Wrap(err, "failed to get osd dump")
+	}
+
+	for _, osdIDStr := range osdsToRemove {
+		osdID, err := strconv.Atoi(osdIDStr)
+		if err != nil {
+			logger.Errorf("invalid OSD ID: %s. %v", osdIDStr, err)
+			continue
+		}
+		logger.Debugf("validating status of osd.%d", osdID)
+		status, _, err := osdDump.StatusByID(int64(osdID))
+		if err != nil {
+			return errors.Wrapf(err, "failed to get osd status for osd %d", osdID)
+
+		}
+		const upStatus int64 = 1
+		if status == upStatus {
+			logger.Debugf("osd.%d is healthy. It cannot be removed unless it is 'down'", osdID)
+			continue
+		}
+		logger.Debugf("osd.%d is marked 'DOWN'. Removing it", osdID)
+		removeOSD(context, clusterInfo, osdID)
+	}
+
+	return nil
+}
+
+func removeOSD(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdID int) {
+	// Get the host where the OSD is found
+	hostName, err := client.GetCrushHostName(context, clusterInfo, osdID)
+	if err != nil {
+		logger.Errorf("failed to get the host where osd.%d is running. %v", osdID, err)
+	}
+
+	// Mark the OSD as out.
+	args := []string{"osd", "out", fmt.Sprintf("osd.%d", osdID)}
+	_, err = client.NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		logger.Errorf("failed to exclude osd.%d out of the crush map. %v", osdID, err)
+	}
+
+	// Remove the OSD deployment
+	deploymentName := fmt.Sprintf("rook-ceph-osd-%d", osdID)
+	deployment, err := context.Clientset.AppsV1().Deployments(clusterInfo.Namespace).Get(deploymentName, metav1.GetOptions{})
+	if err != nil {
+		logger.Errorf("failed to fetch the deployment %q. %v", deploymentName, err)
+	} else {
+		logger.Infof("removing the OSD deployment %q", deploymentName)
+		if err := k8sutil.DeleteDeployment(context.Clientset, clusterInfo.Namespace, deploymentName); err != nil {
+			if err != nil {
+				// Continue purging the OSD even if the deployment fails to be deleted
+				logger.Errorf("failed to delete deployment for OSD %d. %v", osdID, err)
+			}
+		}
+		const pvcLabelName = "ceph.rook.io/pvc"
+		if pvcName, ok := deployment.GetLabels()[pvcLabelName]; ok {
+			prepareJobList, err := context.Clientset.BatchV1().Jobs(clusterInfo.Namespace).List(metav1.ListOptions{LabelSelector: pvcLabelName + pvcName})
+			if err != nil && !kerrors.IsNotFound(err) {
+				logger.Errorf("failed to list prepareJobs with labels %q. %v ", pvcLabelName+pvcName, err)
+			}
+			// Remove osd prepare job
+			for _, prepareJob := range prepareJobList.Items {
+				logger.Infof("removing the osd prepare job %q", prepareJob.GetName())
+				if err := k8sutil.DeleteBatchJob(context.Clientset, clusterInfo.Namespace, prepareJob.GetName(), false); err != nil {
+					if err != nil {
+						// Continue deleting the OSD prepare job even if the deployment fails to be deleted
+						logger.Errorf("failed to delete prepare job for osd %q. %v", prepareJob.GetName(), err)
+					}
+				}
+
+				logger.Infof("removing the OSD PVC %q", pvcName)
+				if err := context.Clientset.CoreV1().PersistentVolumeClaims(clusterInfo.Namespace).Delete(pvcName, &metav1.DeleteOptions{}); err != nil {
+					if err != nil {
+						// Continue deleting the OSD PVC even if PVC deletion fails
+						logger.Errorf("failed to delete pvc for OSD %q. %v", pvcName, err)
+					}
+				}
+			}
+		}
+	}
+
+	// purge the osd
+	purgeosdargs := []string{"osd", "purge", fmt.Sprintf("osd.%d", osdID), "--force", "--yes-i-really-mean-it"}
+	_, err = client.NewCephCommand(context, clusterInfo, purgeosdargs).Run()
+	if err != nil {
+		logger.Errorf("failed to purge osd.%d. %v", osdID, err)
+	}
+
+	// Attempting to remove the parent host. Errors can be ignored if there are other OSDs on the same host
+	hostargs := []string{"osd", "crush", "rm", hostName}
+	_, err = client.NewCephCommand(context, clusterInfo, hostargs).Run()
+	if err != nil {
+		logger.Errorf("failed to remove CRUSH host %q. %v", hostName, err)
+	}
+
+	logger.Infof("completed removal of OSD %d", osdID)
+}


### PR DESCRIPTION
If an OSD is down and needs to be removed from the cluster,
a job can be run that will remove the OSD deployment
and purge the OSD from ceph. If the OSD is still up,
the purge will be rejected.

To purge multiple OSDs at the same time, the OSD IDs can be
specified as a comma-separated list.

Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
