### PR TITLE
ceph: do not use label selector on external svc

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -342,6 +342,9 @@ func (c *Cluster) EnableServiceMonitor(service *v1.Service) error {
 	}
 	serviceMonitor.SetName(name)
 	serviceMonitor.SetNamespace(namespace)
+	if c.spec.External.Enable {
+		serviceMonitor.Spec.Endpoints[0].Port = ServiceExternalMetricName
+	}
 	k8sutil.SetOwnerRef(&serviceMonitor.ObjectMeta, &c.clusterInfo.OwnerRef)
 	serviceMonitor.Spec.NamespaceSelector.MatchNames = []string{namespace}
 	serviceMonitor.Spec.Selector.MatchLabels = service.GetLabels()

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -280,8 +280,7 @@ func (c *Cluster) MakeMetricsService(name, servicePortMetricName string) *v1.Ser
 			Labels:    labels,
 		},
 		Spec: v1.ServiceSpec{
-			Selector: labels,
-			Type:     v1.ServiceTypeClusterIP,
+			Type: v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{
 					Name:     servicePortMetricName,
@@ -290,6 +289,11 @@ func (c *Cluster) MakeMetricsService(name, servicePortMetricName string) *v1.Ser
 				},
 			},
 		},
+	}
+
+	// If the cluster is external we don't need to add the selector
+	if name != ExternalMgrAppName {
+		svc.Spec.Selector = labels
 	}
 
 	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.clusterInfo.OwnerRef)

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -384,7 +384,15 @@ func WatchPredicateForNonCRDObject(owner runtime.Object, scheme *runtime.Scheme)
 				// CONFIGMAP WHITELIST
 				// Only reconcile on rook-config-override CM changes
 				isCMTConfigOverride := isCMTConfigOverride(e.ObjectNew)
-				if !isCMTConfigOverride {
+				if isCMTConfigOverride {
+					logger.Debugf("do reconcile when the cm is %s", k8sutil.ConfigOverrideName)
+					return true
+				}
+
+				// If the resource is a ConfigMap we don't reconcile
+				_, ok := e.ObjectNew.(*corev1.ConfigMap)
+				if ok {
+					logger.Debugf("do not reconcile on configmap that is not %q", k8sutil.ConfigOverrideName)
 					return false
 				}
 
@@ -397,7 +405,7 @@ func WatchPredicateForNonCRDObject(owner runtime.Object, scheme *runtime.Scheme)
 				}
 
 				// If the resource is a deployment we don't reconcile
-				_, ok := e.ObjectNew.(*appsv1.Deployment)
+				_, ok = e.ObjectNew.(*appsv1.Deployment)
 				if ok {
 					return false
 				}

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -303,18 +303,22 @@ func objectChanged(oldObj, newObj runtime.Object, objectName string) (bool, erro
 	currentResourceVersion, err := accessor.ResourceVersion(old)
 	if err == nil {
 		if err := accessor.SetResourceVersion(new, currentResourceVersion); err != nil {
-			return false, err
+			return false, errors.Wrapf(err, "failed to set resource version to %s", currentResourceVersion)
 		}
+	} else {
+		return false, errors.Wrap(err, "failed to query current resource version")
 	}
 
 	// Calculate diff between old and new object
 	diff, err := patch.DefaultPatchMaker.Calculate(old, new)
 	if err != nil {
 		doReconcile = true
-		return doReconcile, errors.Wrap(err, "failed to calculate object diff")
+		return doReconcile, errors.Wrap(err, "failed to calculate object diff but let's reconcile just in case")
 	} else if diff.IsEmpty() {
+		logger.Debug("diff is empty nothing to reconcile")
 		return doReconcile, nil
 	}
+	logger.Debugf("object diff is %s", diff.String())
 
 	return isValidEvent(diff.Patch, objectName), nil
 }
@@ -407,6 +411,7 @@ func WatchPredicateForNonCRDObject(owner runtime.Object, scheme *runtime.Scheme)
 				// If the resource is a deployment we don't reconcile
 				_, ok = e.ObjectNew.(*appsv1.Deployment)
 				if ok {
+					logger.Debug("do not reconcile deployments updates")
 					return false
 				}
 
@@ -415,6 +420,7 @@ func WatchPredicateForNonCRDObject(owner runtime.Object, scheme *runtime.Scheme)
 				if err != nil {
 					logger.Errorf("failed to check if object %q changed. %v", objectName, err)
 				}
+
 				return objectChanged
 			}
 
@@ -431,28 +437,33 @@ func WatchPredicateForNonCRDObject(owner runtime.Object, scheme *runtime.Scheme)
 // if we should reconcile that event or not
 // The goal is to avoid double-reconcile as much as possible
 func isValidEvent(patch []byte, objectName string) bool {
-	patchString := string(patch)
-
 	var p map[string]interface{}
 	err := json.Unmarshal(patch, &p)
 	if err != nil {
-		logger.Infof("failed to unmarshal patch %v", err)
+		logger.Errorf("failed to unmarshal patch. %v", err)
+		return false
 	}
+	logger.Debugf("patch before trimming is %s", string(patch))
+
 	// don't reconcile on status update on an object (e.g. status "creating")
+	logger.Debugf("trimming 'status' field from patch")
 	delete(p, "status")
 
 	// Do not reconcile on metadata change since managedFields are often updated by the server
+	logger.Debugf("trimming 'metadata' field from patch")
 	delete(p, "metadata")
 
-	// If the patch is now empty, we don't reconcile, nothing changed
+	// If the patch is now empty, we don't reconcile
 	if len(p) == 0 {
+		logger.Debug("patch is empty after trimming")
 		return false
 	}
 
 	// Re-marshal to get the last diff
 	patch, err = json.Marshal(p)
 	if err != nil {
-		logger.Infof("controller will reconcile resource %q based on patch: %s", objectName, patchString)
+		logger.Errorf("failed to marshal patch. %v", err)
+		return false
 	}
 
 	// If after all the filtering there is still something in the patch, we reconcile

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -80,7 +80,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		return nil, errors.Wrap(err, "Provision: can't create ceph user")
 	}
 
-	s3svc, err := cephObject.NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint())
+	s3svc, err := cephObject.NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint(), true)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 		return nil, errors.Wrapf(err, "could not get user (user: %s)", stats.Owner)
 	}
 
-	s3svc, err := cephObject.NewS3Agent(*objectUser.AccessKey, *objectUser.SecretKey, p.getObjectStoreEndpoint())
+	s3svc, err := cephObject.NewS3Agent(*objectUser.AccessKey, *objectUser.SecretKey, p.getObjectStoreEndpoint(), true)
 	if err != nil {
 		p.deleteOBCResourceLogError("")
 		return nil, err
@@ -250,7 +250,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 			return nil
 		}
 
-		s3svc, err := cephObject.NewS3Agent(*user.AccessKey, *user.SecretKey, p.getObjectStoreEndpoint())
+		s3svc, err := cephObject.NewS3Agent(*user.AccessKey, *user.SecretKey, p.getObjectStoreEndpoint(), true)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -151,7 +151,7 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 
 	// Initiate s3 agent
 	logger.Debugf("initializing s3 connection for object store %q", c.namespacedName.Name)
-	s3client, err := NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint)
+	s3client, err := NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize s3 connection")
 	}

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -35,9 +35,13 @@ type S3Agent struct {
 	Client *s3.S3
 }
 
-func NewS3Agent(accessKey, secretKey, endpoint string) (*S3Agent, error) {
+func NewS3Agent(accessKey, secretKey, endpoint string, debug bool) (*S3Agent, error) {
 	const cephRegion = "us-east-1"
 
+	logLevel := aws.LogOff
+	if debug {
+		logLevel = aws.LogDebug
+	}
 	sess, err := session.NewSession(
 		aws.NewConfig().
 			WithRegion(cephRegion).
@@ -49,7 +53,7 @@ func NewS3Agent(accessKey, secretKey, endpoint string) (*S3Agent, error) {
 			WithHTTPClient(&http.Client{
 				Timeout: time.Second * 15,
 			}).
-			WithLogLevel(aws.LogDebug),
+			WithLogLevel(logLevel),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -248,9 +248,6 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 			Namespace: cephObjectStore.Namespace,
 			Labels:    labels,
 		},
-		Spec: v1.ServiceSpec{
-			Selector: labels,
-		},
 	}
 
 	if c.clusterSpec.Network.IsHost() {
@@ -262,6 +259,11 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 	// When the cluster is external we must use the same one as the gateways are listening on
 	if c.clusterSpec.External.Enable {
 		destPort.IntVal = cephObjectStore.Spec.Gateway.Port
+	} else {
+		// If the cluster is not external we add the Selector
+		svc.Spec = v1.ServiceSpec{
+			Selector: labels,
+		}
 	}
 	addPort(svc, "http", cephObjectStore.Spec.Gateway.Port, destPort.IntVal)
 	addPort(svc, "https", cephObjectStore.Spec.Gateway.SecurePort, cephObjectStore.Spec.Gateway.SecurePort)

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -161,7 +161,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	s3endpoint, _ := helper.ObjectClient.GetEndPointUrl(namespace, storeName)
 	s3AccessKey, _ := helper.BucketClient.GetAccessKey(obcName)
 	s3SecretKey, _ := helper.BucketClient.GetSecretKey(obcName)
-	s3client, err := rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint)
+	s3client, err := rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, true)
 	require.Nil(s.T(), err)
 	logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 


### PR DESCRIPTION
**Description of your changes:**

We must move the endpoint creation after the service monitor otherwise,
the service monitor will override the endpoint values.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]