### PR TITLE
ceph: add uninstall mode

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -1232,6 +1232,7 @@ However, the administrator might want to sanitize the drives in more depth with 
   * `dataSource`: indicate where to get random bytes from to write on the disk. Possible choices are 'zero' (default) or 'random'.
   Using random sources will consume entropy from the system and will take much more time then the zero source
   * `iteration`: overwrite N times instead of the default (1). Takes an integer value
+* `allowUninstallWithVolumes`: If set to true, then the cephCluster deletion doesn't wait for the PVCs to be deleted. Default is false.
 
 To automate activation of the cleanup, you can use the following command. **WARNING: DATA WILL BE PERMANENTLY DELETED**:
 
@@ -1241,3 +1242,5 @@ kubectl -n rook-ceph patch cephcluster rook-ceph --type merge -p '{"spec":{"clea
 
 Nothing will happen until the deletion of the CR is requested, so this can still be reverted.
 However, all new configuration by the operator will be blocked with this cleanup policy enabled.
+
+Rook waits for the deletion of PVs provisioned using the cephCluster before proceeding to delete the cephCluster. To force deletion of the cephCluster without waiting for the PVs to be deleted,  you can set the allowUninstallWithVolumes to true under spec.CleanupPolicy.

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -105,6 +105,9 @@ spec:
       # iteration overwrite N times instead of the default (1)
       # takes an integer value
       iteration: 1
+    # allowUninstallWithVolumes defines how the uninstall should be performed
+    # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
+    allowUninstallWithVolumes: false
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
   # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
   # tolerate taints with a key of 'storage-node'.

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -740,8 +740,9 @@ type ClientSpec struct {
 }
 
 type CleanupPolicySpec struct {
-	Confirmation  CleanupConfirmationProperty `json:"confirmation,omitempty"`
-	SanitizeDisks SanitizeDisksSpec           `json:"sanitizeDisks"`
+	Confirmation              CleanupConfirmationProperty `json:"confirmation,omitempty"`
+	SanitizeDisks             SanitizeDisksSpec           `json:"sanitizeDisks"`
+	AllowUninstallWithVolumes bool                        `json:"allowUninstallWithVolumes,omitempty"`
 }
 
 type CleanupConfirmationProperty string


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This adds an uninstall mode to the ceph cluster. If the UninstallMode CR spec is set to `yes-really-uninstall-even-if-in-use` then the cluster deletion does not wait for the PVs to be deleted.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
