### PR TITLE
ceph: operator should only "watch" OSD placement nodes

### DIFF
--- a/pkg/operator/ceph/cluster/watcher.go
+++ b/pkg/operator/ceph/cluster/watcher.go
@@ -78,7 +78,7 @@ func (c *clientCluster) onK8sNode(object runtime.Object) bool {
 		return false
 	}
 
-	valid, _ := k8sutil.ValidNode(*node, cluster.Spec.Placement.All())
+	valid, _ := k8sutil.ValidNode(*node, cephv1.GetOSDPlacement(cluster.Spec.Placement))
 	if valid {
 		nodeName := node.Name
 		hostname, ok := node.Labels[v1.LabelHostname]


### PR DESCRIPTION
**Description of your changes:**

This change is the first part to improve the watch OSD nodes logic in
the Rook Ceph operator.
This commit changes the "is node valid check" to use the OSD placement
instead of the all placement. The OSD placement is "merged" with the
all placement already.

Second step will be to skip the first "iteration" of the "nodes added"
events and then start the actual watch logic.

Partially resolves #6111.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**

Partially resolves #6111.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.