### PR TITLE
ceph: added alert for RGW health

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules-external.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules-external.yaml
@@ -36,3 +36,18 @@ spec:
       for: 5s
       labels:
         severity: critical
+  - name: cluster-services-alert.rules
+    rules:
+    - alert: ClusterObjectStoreState
+      annotations:
+        description: Cluster Object Store is in unhealthy state for more than 15s.
+          Please check Ceph cluster health or RGW connection.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
+          health or RGW connection.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        ocs_rgw_health_status{job="ocs-metrics-exporter"} > 1
+      for: 15s
+      labels:
+        severity: critical

--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -212,6 +212,21 @@ spec:
       for: 5s
       labels:
         severity: critical
+  - name: cluster-services-alert.rules
+    rules:
+    - alert: ClusterObjectStoreState
+      annotations:
+        description: Cluster Object Store is in unhealthy state for more than 15s.
+          Please check Ceph cluster health or RGW connection.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
+          health or RGW connection.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        ocs_rgw_health_status{job="ocs-metrics-exporter"} > 1
+      for: 15s
+      labels:
+        severity: critical
   - name: cluster-state-alert.rules
     rules:
     - alert: CephClusterErrorState


### PR DESCRIPTION
This commit adds alert for RGW health. It create the alert if cephObjectStore.Status.Phase goes in Failure State.

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
