### PR TITLE
ceph: improve common issues document

### DIFF
--- a/Documentation/ceph-common-issues.md
+++ b/Documentation/ceph-common-issues.md
@@ -583,7 +583,7 @@ $ kubectl -n rook-ceph delete pod -l app=rook-ceph-operator
 
 ## Node hangs after reboot
 
-This issue is fixed in `cephcsi:v2.0.1` and newer.
+This issue is fixed in Rook v1.3 or later.
 
 ### Symptoms
 


### PR DESCRIPTION
**Description of your changes:**

node-hangs-after-reboot problem can't be fixed with ceph-csi:2.0.1 if Rook is v1.2.x. It's because this version doesn't have a bind mount that is needed to fix this problem.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]