### PR TITLE
ceph: run obc requests with debug

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -100,5 +100,5 @@ func TestPopulateDomainAndPort(t *testing.T) {
 	p.objectStoreName = store
 	err = p.populateDomainAndPort(sc)
 	assert.NoError(t, err)
-	assert.Equal(t, "rook-ceph-rgw-test-store.ns", p.storeDomainName)
+	assert.Equal(t, "rook-ceph-rgw-test-store.ns.svc.cluster.local", p.storeDomainName)
 }

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -371,7 +371,7 @@ func TestCephObjectStoreController(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cephv1.ConditionProgressing, objectStore.Status.Phase, objectStore)
 	assert.NotEmpty(t, objectStore.Status.Info["endpoint"], objectStore)
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", objectStore.Status.Info["endpoint"], objectStore)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", objectStore.Status.Info["endpoint"], objectStore)
 	logger.Info("PHASE 3 DONE")
 
 	// Test the functionality of verifyObjectUserCleanup

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -44,6 +44,7 @@ const (
 	bucketProvisionerName = "ceph.rook.io/bucket"
 	AccessKeyName         = "access-key"
 	SecretKeyName         = "secret-key"
+	svcDNSSuffix          = "svc.cluster.local"
 )
 
 var (

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -380,7 +380,7 @@ func emptyPool(pool cephv1.PoolSpec) bool {
 
 // BuildDomainName build the dns name to reach out the service endpoint
 func BuildDomainName(name, namespace string) string {
-	return fmt.Sprintf("%s-%s.%s", AppName, name, namespace)
+	return fmt.Sprintf("%s-%s.%s.%s", AppName, name, namespace, svcDNSSuffix)
 }
 
 // buildDNSEndpoint build the dns name to reach out the service endpoint

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -159,15 +159,15 @@ func TestBuildDomainNameAndEndpoint(t *testing.T) {
 	name := "my-store"
 	ns := "rook-ceph"
 	dns := BuildDomainName(name, ns)
-	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph", dns)
+	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local", dns)
 
 	// non-secure endpoint
 	var port int32 = 80
 	ep := buildDNSEndpoint(dns, port, false)
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", ep)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", ep)
 
 	// Secure endpoint
 	var securePort int32 = 443
 	ep = buildDNSEndpoint(dns, securePort, true)
-	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", ep)
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:443", ep)
 }

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -48,7 +48,8 @@ func NewS3Agent(accessKey, secretKey, endpoint string) (*S3Agent, error) {
 			WithDisableSSL(true).
 			WithHTTPClient(&http.Client{
 				Timeout: time.Second * 15,
-			}),
+			}).
+			WithLogLevel(aws.LogDebug),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/ceph/object/status_test.go
+++ b/pkg/operator/ceph/object/status_test.go
@@ -37,7 +37,7 @@ func TestBuildStatusInfo(t *testing.T) {
 	statusInfo := buildStatusInfo(cephObjectStore)
 	assert.NotEmpty(t, statusInfo["endpoint"])
 	assert.Empty(t, statusInfo["secureEndpoint"])
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", statusInfo["endpoint"])
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", statusInfo["endpoint"])
 
 	// SecurePort enabled and Port disabled
 	cephObjectStore.Spec.Gateway.Port = 0
@@ -46,7 +46,7 @@ func TestBuildStatusInfo(t *testing.T) {
 	statusInfo = buildStatusInfo(cephObjectStore)
 	assert.NotEmpty(t, statusInfo["endpoint"])
 	assert.Empty(t, statusInfo["secureEndpoint"])
-	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", statusInfo["endpoint"])
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:443", statusInfo["endpoint"])
 
 	// Both Port and SecurePort enabled
 	cephObjectStore.Spec.Gateway.Port = 80
@@ -55,6 +55,6 @@ func TestBuildStatusInfo(t *testing.T) {
 	statusInfo = buildStatusInfo(cephObjectStore)
 	assert.NotEmpty(t, statusInfo["endpoint"])
 	assert.NotEmpty(t, statusInfo["secureEndpoint"])
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph:80", statusInfo["endpoint"])
-	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph:443", statusInfo["secureEndpoint"])
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", statusInfo["endpoint"])
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:443", statusInfo["secureEndpoint"])
 }


### PR DESCRIPTION
**Description of your changes:**

Use debug log to all the s3 calls so it's either to debug. Also, it's
not so verbose.

Example output of a bucket creation:

```
2020/08/26 16:10:19 DEBUG: Request s3/CreateBucket Details:
---[ REQUEST POST-SIGN ]-----------------------------
PUT /leseb-testing HTTP/1.1
Host: rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
User-Agent: aws-sdk-go/1.34.10 (go1.13.4; linux; amd64)
Content-Length: 0
Authorization: AWS4-HMAC-SHA256 Credential=KWT9T5AMC6X7DOIPI0KP/20200826/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=494fd28799922239355a30a701ba5aa899f06a2eedc881b7b15715b9baaee80c
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20200826T161019Z
Accept-Encoding: gzip


-----------------------------------------------------
2020/08/26 16:10:19 DEBUG: Response s3/CreateBucket Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 0
Connection: Keep-Alive
Date: Wed, 26 Aug 2020 16:10:19 GMT
X-Amz-Request-Id: tx000000000000000000113-005f46896b-ac9a-ocs-storagecluster-cephobjectstore


-----------------------------------------------------
2020/08/26 16:10:19
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
