### PR TITLE
ceph: integration test on openshift

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -142,3 +142,22 @@ To run specific tests inside a suite:
 ```console
 _output/tests/linux_amd64/integration -test.v -test.timeout 1800s -test.run CephSmokeSuite -testify.m TestARookClusterInstallation_SmokeTest
 ```
+
+### To run tests on OpenShift environment
+
+- Setup OpenShift environment and export KUBECONFIG before executing the tests.
+- Make sure `oc` executable file is in the PATH.
+- Only `CephSmokeSuite` is currently supported on OpenShift.
+- Set few environment variables:
+```
+export TEST_ENV_NAME=openshift
+export TEST_STORAGE_CLASS=gp2
+export TEST_BASE_DIR=/tmp
+export RETRY_MAX=40
+```
+
+
+To run a `CephSmokeSuite` (uses regex):
+```console
+$ go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
+```

--- a/tests/framework/installer/cassandra_installer.go
+++ b/tests/framework/installer/cassandra_installer.go
@@ -166,6 +166,6 @@ func (ci *CassandraInstaller) GatherAllCassandraLogs(systemNamespace, namespace,
 		return
 	}
 	logger.Infof("Gathering all logs from Cassandra Cluster %s", namespace)
-	ci.k8sHelper.GetLogsFromNamespace(systemNamespace, testName, testEnvName())
-	ci.k8sHelper.GetLogsFromNamespace(namespace, testName, testEnvName())
+	ci.k8sHelper.GetLogsFromNamespace(systemNamespace, testName, utils.TestEnvName())
+	ci.k8sHelper.GetLogsFromNamespace(namespace, testName, utils.TestEnvName())
 }

--- a/tests/framework/installer/cockroachdb_installer.go
+++ b/tests/framework/installer/cockroachdb_installer.go
@@ -154,6 +154,6 @@ func (h *CockroachDBInstaller) GatherAllCockroachDBLogs(systemNamespace, namespa
 		return
 	}
 	logger.Infof("Gathering all logs from cockroachdb cluster %s", namespace)
-	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, testEnvName())
-	h.k8shelper.GetLogsFromNamespace(namespace, testName, testEnvName())
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, utils.TestEnvName())
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, utils.TestEnvName())
 }

--- a/tests/framework/installer/edgefs_installer.go
+++ b/tests/framework/installer/edgefs_installer.go
@@ -156,6 +156,6 @@ func (h *EdgefsInstaller) GatherAllEdgefsLogs(systemNamespace, namespace, testNa
 		return
 	}
 	logger.Infof("Gathering all logs from edgefs cluster %s", namespace)
-	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, testEnvName())
-	h.k8shelper.GetLogsFromNamespace(namespace, testName, testEnvName())
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, utils.TestEnvName())
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, utils.TestEnvName())
 }

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -20,11 +20,6 @@ import (
 	"os"
 )
 
-// testEnvName gets the name of the test environment. In the CI it is "aws_1.18.x" or similar.
-func testEnvName() string {
-	return getEnvVarWithDefault("TEST_ENV_NAME", "localhost")
-}
-
 // testHelmPath gets the helm path
 func testHelmPath() string {
 	return getEnvVarWithDefault("TEST_HELM_PATH", "helm")
@@ -44,6 +39,14 @@ func testStorageProvider() string {
 func TestIsOfficialBuild() bool {
 	// PRs will set this to "false", but the official build will not set it, so we compare against "false"
 	return getEnvVarWithDefault("TEST_IS_OFFICIAL_BUILD", "") != "false"
+}
+
+func StorageClassName() string {
+	return getEnvVarWithDefault("TEST_STORAGE_CLASS", "")
+}
+
+func UsePVC() bool {
+	return StorageClassName() != ""
 }
 
 // baseTestDir gets the base test directory

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -69,6 +70,10 @@ func SkipTestSuite(name string) bool {
 }
 
 func SystemNamespace(namespace string) string {
+	if utils.IsPlatformOpenShift() {
+		logger.Infof("For openshift execution used system namespace: %s", namespace)
+		return namespace
+	}
 	return fmt.Sprintf("%s-system", namespace)
 }
 

--- a/tests/framework/installer/nfs_installer.go
+++ b/tests/framework/installer/nfs_installer.go
@@ -194,6 +194,6 @@ func (h *NFSInstaller) GatherAllNFSServerLogs(systemNamespace, namespace, testNa
 		return
 	}
 	logger.Infof("Gathering all logs from NFSServer %s", namespace)
-	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, testEnvName())
-	h.k8shelper.GetLogsFromNamespace(namespace, testName, testEnvName())
+	h.k8shelper.GetLogsFromNamespace(systemNamespace, testName, utils.TestEnvName())
+	h.k8shelper.GetLogsFromNamespace(namespace, testName, utils.TestEnvName())
 }

--- a/tests/framework/installer/provisioners.go
+++ b/tests/framework/installer/provisioners.go
@@ -66,7 +66,7 @@ func InstallHostPathProvisioner(k8shelper *utils.K8sHelper) error {
 	err = k8shelper.WaitForLabeledPodsToRun("k8s-app=hostpath-provisioner", "kube-system")
 	if err != nil {
 		logger.Errorf("hostpath provisioner pod is not running: %+v", err)
-		k8shelper.GetPodDescribeFromNamespace("kube-system", "hostPathProvisioner", testEnvName())
+		k8shelper.GetPodDescribeFromNamespace("kube-system", "hostPathProvisioner", utils.TestEnvName())
 		k8shelper.PrintStorageClasses(true /*detailed*/)
 		return err
 	}

--- a/tests/framework/installer/yugabytedb_installer.go
+++ b/tests/framework/installer/yugabytedb_installer.go
@@ -165,6 +165,6 @@ func (y *YugabyteDBInstaller) GatherAllLogs(systemNS, namespace, testName string
 		return
 	}
 	logger.Infof("Gathering all logs from yugabytedb cluster %s", namespace)
-	y.k8sHelper.GetLogsFromNamespace(systemNS, testName, testEnvName())
-	y.k8sHelper.GetLogsFromNamespace(namespace, testName, testEnvName())
+	y.k8sHelper.GetLogsFromNamespace(systemNS, testName, utils.TestEnvName())
+	y.k8sHelper.GetLogsFromNamespace(namespace, testName, utils.TestEnvName())
 }

--- a/tests/framework/utils/env.go
+++ b/tests/framework/utils/env.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// TestEnvName gets the name of the test environment. In the CI it is "aws_1.18.x" or similar.
+func TestEnvName() string {
+	return GetEnvVarWithDefault("TEST_ENV_NAME", "localhost")
+}
+
+// TestRetryNumber  get the max retry. Example, for OpenShift it's 40.
+func TestRetryNumber() int {
+	count := GetEnvVarWithDefault("RETRY_MAX", "30")
+	number, err := strconv.Atoi(count)
+	if err != nil {
+		panic(fmt.Errorf("Error when converting to numeric value %v", err))
+	}
+	return number
+}
+
+// IsPlatformOpenShift check if the platform is openshift or not
+func IsPlatformOpenShift() bool {
+	return TestEnvName() == "openshift"
+}
+
+// GetEnvVarWithDefault get environment variable by key.
+func GetEnvVarWithDefault(env, defaultValue string) string {
+	val := os.Getenv(env)
+	if val == "" {
+		return defaultValue
+	}
+	return val
+}

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -84,9 +84,9 @@ func (suite *SmokeSuite) SetupSuite() {
 	smokeTestCluster := TestCluster{
 		namespace:               suite.namespace,
 		storeType:               "bluestore",
-		storageClassName:        "",
+		storageClassName:        installer.StorageClassName(),
 		useHelm:                 false,
-		usePVC:                  false,
+		usePVC:                  installer.UsePVC(),
 		mons:                    3,
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         true,
@@ -118,7 +118,9 @@ func (suite *SmokeSuite) TestFileStorage_SmokeTest() {
 }
 
 func (suite *SmokeSuite) TestObjectStorage_SmokeTest() {
-	runObjectE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace)
+	if !utils.IsPlatformOpenShift() {
+		runObjectE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace)
+	}
 }
 
 // Test to make sure all rook components are installed and Running


### PR DESCRIPTION
This commit enables the rook integration
testing capability on OpenShift. currently,
this commit enables CephSmokeSuite testing
only.
Current result 
```
go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration

FAIL: TestCephSmokeSuite (1348.94s)
    --- PASS: TestCephSmokeSuite/TestARookClusterInstallation_SmokeTest (28.94s)
    --- PASS: TestCephSmokeSuite/TestBlockStorage_SmokeTest (254.16s)
    --- PASS: TestCephSmokeSuite/TestCreateClient (25.71s)
    --- PASS: TestCephSmokeSuite/TestCreateRBDMirrorClient (30.92s)
    --- PASS: TestCephSmokeSuite/TestFileStorage_SmokeTest (138.12s)
    --- PASS: TestCephSmokeSuite/TestMonFailover (25.40s)
    --- FAIL: TestCephSmokeSuite/TestObjectStorage_SmokeTest (126.95s)
    --- PASS: TestCephSmokeSuite/TestPoolResize (32.58s)
FAIL
FAIL	github.com/rook/rook/tests/integration	1348.967s
FAIL
```

Signed-off-by: subhamkrai <subhamkumarrai03@gmail.com>
co-authored-by: Petr Balogh pbalogh@redhat.com

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #1841

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test full]