### PR TITLE
docs: fix markdown code block formatting issue

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -902,142 +902,146 @@ Otherwise, having a separate metadata device will not improve the performance.
 The bluestore partition has the following reference combinations supported by the ceph-volume utility:
 
 * A single "data" device.
-```yaml
-  storage:
-    storageClassDeviceSets:
-    - name: set1
-      count: 3
-      portable: false
-      tuneDeviceClass: false
-      volumeClaimTemplates:
-      - metadata:
-          name: data
-        spec:
-          resources:
-            requests:
-              storage: 10Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
-          storageClassName: gp2
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-```
+
+  ```yaml
+    storage:
+      storageClassDeviceSets:
+      - name: set1
+        count: 3
+        portable: false
+        tuneDeviceClass: false
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
+            storageClassName: gp2
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+  ```
 
 * A "data" device and a "metadata" device.
-```yaml
-  storage:
-    storageClassDeviceSets:
-    - name: set1
-      count: 3
-      portable: false
-      tuneDeviceClass: false
-      volumeClaimTemplates:
-      - metadata:
-          name: data
-        spec:
-          resources:
-            requests:
-              storage: 10Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
-          storageClassName: gp2
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-      - metadata:
-          name: metadata
-        spec:
-          resources:
-            requests:
-              # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
-              storage: 5Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
-          storageClassName: io1
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-```
+
+  ```yaml
+    storage:
+      storageClassDeviceSets:
+      - name: set1
+        count: 3
+        portable: false
+        tuneDeviceClass: false
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
+            storageClassName: gp2
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+        - metadata:
+            name: metadata
+          spec:
+            resources:
+              requests:
+                # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
+                storage: 5Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+            storageClassName: io1
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+  ```
 
 * A "data" device and a "wal" device.
 A WAL device can be used for BlueStore’s internal journal or write-ahead log (block.wal), it is only useful to use a WAL device if the device is faster than the primary device (data device).
 There is no separate "metadata" device in this case, the data of main OSD block and block.db located in "data" device.
-```yaml
-  storage:
-    storageClassDeviceSets:
-    - name: set1
-      count: 3
-      portable: false
-      tuneDeviceClass: false
-      volumeClaimTemplates:
-      - metadata:
-          name: data
-        spec:
-          resources:
-            requests:
-              storage: 10Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
-          storageClassName: gp2
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-      - metadata:
-          name: wal
-        spec:
-          resources:
-            requests:
-              # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
-              storage: 5Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
-          storageClassName: io1
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-```
+
+  ```yaml
+    storage:
+      storageClassDeviceSets:
+      - name: set1
+        count: 3
+        portable: false
+        tuneDeviceClass: false
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
+            storageClassName: gp2
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+        - metadata:
+            name: wal
+          spec:
+            resources:
+              requests:
+                # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
+                storage: 5Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+            storageClassName: io1
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+  ```
 
 * A "data" device, a "metadata" device and a "wal" device.
-```yaml
-  storage:
-    storageClassDeviceSets:
-    - name: set1
-      count: 3
-      portable: false
-      tuneDeviceClass: false
-      volumeClaimTemplates:
-      - metadata:
-          name: data
-        spec:
-          resources:
-            requests:
-              storage: 10Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
-          storageClassName: gp2
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-      - metadata:
-          name: metadata
-        spec:
-          resources:
-            requests:
-              # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
-              storage: 5Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
-          storageClassName: io1
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-      - metadata:
-          name: wal
-        spec:
-          resources:
-            requests:
-              # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
-              storage: 5Gi
-          # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
-          storageClassName: io1
-          volumeMode: Block
-          accessModes:
-            - ReadWriteOnce
-```
+
+  ```yaml
+    storage:
+      storageClassDeviceSets:
+      - name: set1
+        count: 3
+        portable: false
+        tuneDeviceClass: false
+        volumeClaimTemplates:
+        - metadata:
+            name: data
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, gp2)
+            storageClassName: gp2
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+        - metadata:
+            name: metadata
+          spec:
+            resources:
+              requests:
+                # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
+                storage: 5Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+            storageClassName: io1
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+        - metadata:
+            name: wal
+          spec:
+            resources:
+              requests:
+                # Find the right size https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing
+                storage: 5Gi
+            # IMPORTANT: Change the storage class depending on your environment (e.g. local-storage, io1)
+            storageClassName: io1
+            volumeMode: Block
+            accessModes:
+              - ReadWriteOnce
+  ```
 
 To determine the size of the metadata block follow the [official Ceph sizing guide](https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#sizing).
 


### PR DESCRIPTION
**Description of your changes:**
Fixes formatting issue in markdown. On the website the code blocks are not being rendered into HTML because of source markdown spacing issue.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.


[skip ci]