### PR TITLE
edgefs: docs: note nfs service name restrictions

### DIFF
--- a/Documentation/edgefs-nfs-crd.md
+++ b/Documentation/edgefs-nfs-crd.md
@@ -115,6 +115,8 @@ Now cluster is setup, services can be now created and attached to CSI provisione
 
 4. Create NFS service objects for tenants:
 
+> **NOTE**: Service names must contain only [lowercase alphanumeric characters or '-'](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names). Otherwise, corresponding EdgeFS NFS object names created in the next step will be invalid.
+
 ```console
 efscli service create nfs nfs-cola
 efscli service serve nfs-cola Hawaii/Cola/bk1


### PR DESCRIPTION
Add a note that NFS service names created by efscli need to comply with
k8 DNS naming restrictions. Failure to do so will result in an invalid NFS
object manifest name.

Signed-off-by: Benjamin Deuson <benjamindeuson@gmail.com>

[skip ci]

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
