### PR TITLE
ci: reset test cluster without prompting

### DIFF
--- a/tests/scripts/kubeadm.sh
+++ b/tests/scripts/kubeadm.sh
@@ -112,7 +112,7 @@ wait_for_ready(){
 
 kubeadm_reset() {
     kubectl delete -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
-    sudo kubeadm reset $skippreflightcheck
+    sudo kubeadm reset --force $skippreflightcheck
     rm $HOME/admin.conf
     rm -rf $HOME/.kube
     sudo apt-get -y remove kubelet


### PR DESCRIPTION
**Description of your changes:**

It's messy to answer `y` everytime in `tests/script/kubeadm.sh clean.` Since the cluster only exists for testing, it's safe to reset without prompting.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]