### PR TITLE
ceph: only enable init container if dash is enabled

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -70,8 +70,14 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 	// Replace default unreachable node toleration
 	k8sutil.AddUnreachableNodeToleration(&podSpec.Spec)
 
+	// Only add the dashboard init container if dashboard is enabled
+	if c.spec.Dashboard.Enabled {
+		podSpec.Spec.InitContainers = append(podSpec.Spec.InitContainers, []v1.Container{
+			c.makeSetServerAddrInitContainer(mgrConfig, "dashboard"),
+		}...)
+	}
+
 	podSpec.Spec.InitContainers = append(podSpec.Spec.InitContainers, []v1.Container{
-		c.makeSetServerAddrInitContainer(mgrConfig, "dashboard"),
 		c.makeSetServerAddrInitContainer(mgrConfig, "prometheus"),
 	}...)
 

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -118,7 +118,7 @@ func TestHttpBindFix(t *testing.T) {
 	clientset := optest.New(t, 1)
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
 	clusterSpec := cephv1.ClusterSpec{
-		Dashboard:       cephv1.DashboardSpec{Port: 1234},
+		Dashboard:       cephv1.DashboardSpec{Enabled: true, Port: 1234},
 		DataDirHostPath: "/var/lib/rook/",
 	}
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")


### PR DESCRIPTION
**Description of your changes:**

If the dashboard module is not enabled we don't need to run the
"dashboard-server-addr" init container.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
