### PR TITLE
ci: Only build amd64 for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,13 @@ pipeline {
             }
             steps {
                 // run the build
-                sh 'build/run make -j\$(nproc) build.all'
+                script {
+                    if (env.isOfficialBuild == "false") {
+                        sh (script: "build/run make -j\$(nproc) build", returnStdout: true)
+                    } else {
+                        sh (script: "build/run make -j\$(nproc) build.all", returnStdout: true)
+                    }
+                }
                 sh 'git status'
             }
         }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The PRs only test against amd64 and have no need for the arm64 builds. This will save several minutes of build time. This is split out of #5847 so we can get this improvement before the full solution for storage provider builds.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test nfs]