### PR TITLE
ceph: Cleanup mon canary pvc if the failover failed

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -574,19 +574,9 @@ func (c *Cluster) removeCanaryDeployments() {
 	}
 
 	for _, canary := range canaryDeployments.Items {
-		logger.Infof("cleaning up canary monitor deployment %q and canary pvc %q.", canary.Name, canary.Labels["pvc_name"])
+		logger.Infof("cleaning up canary monitor deployment %q", canary.Name)
 		if err := k8sutil.DeleteDeployment(c.context.Clientset, c.Namespace, canary.Name); err != nil {
 			logger.Warningf("failed to delete canary monitor deployment %q. %v", canary.Name, err)
-		}
-
-		if canary.Labels["pvc_name"] != "" {
-			var gracePeriod int64 // delete immediately
-			propagation := metav1.DeletePropagationForeground
-			options := &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
-			err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.Namespace).Delete(canary.Labels["pvc_name"], options)
-			if err != nil {
-				logger.Warningf("failed to delete canary monitor %q pvc %q. %v", canary.Name, canary.Labels["pvc_name"], err)
-			}
 		}
 	}
 }

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -168,7 +168,7 @@ func TestHostNetwork(t *testing.T) {
 	c.spec.Network.HostNetwork = true
 
 	monConfig := testGenMonConfig("c")
-	pod, err := c.makeMonPod(monConfig, false, "")
+	pod, err := c.makeMonPod(monConfig, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, pod)
 	assert.Equal(t, true, pod.Spec.HostNetwork)
@@ -180,7 +180,7 @@ func TestHostNetwork(t *testing.T) {
 	assert.Equal(t, "arg not found: --public-bind-addr", message)
 
 	monConfig.Port = 6790
-	pod, err = c.makeMonPod(monConfig, false, "")
+	pod, err = c.makeMonPod(monConfig, false)
 	assert.NoError(t, err)
 	val, message = extractArgValue(pod.Spec.Containers[0].Args, "--public-addr")
 	assert.Equal(t, "2.4.6.3:6790", val, message)

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -30,7 +30,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	svcDef := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   mon.ResourceName,
-			Labels: c.getLabels(mon.DaemonName, false, "", true),
+			Labels: c.getLabels(mon, false, true),
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -43,7 +43,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 					Protocol:   v1.ProtocolTCP,
 				},
 			},
-			Selector: c.getLabels(mon.DaemonName, false, "", false),
+			Selector: c.getLabels(mon, false, false),
 		},
 	}
 	k8sutil.SetOwnerRef(&svcDef.ObjectMeta, &c.ownerRef)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the mon failover fails and the mon is backed by a pvc, the pvc could remain orphaned. This is likely to happen if there is not a node available for scheduling the mon. Therefore, the operator will ensure after a failover that any orphaned mon pvc is cleaned up.

On a related change, the pvc_name label was not being set as expected on canary deployments. Now the label will always be set on both the canary and the daemon pods.  

This replaces #6199.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
