### PR TITLE
ceph: allow running rgw in rook with external mode

### DIFF
--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -361,7 +361,7 @@ func (r *ReconcileCephObjectStore) validateStore(s *cephv1.CephObjectStore) erro
 	}
 
 	// Fail if we detected an external CephCluster CR and the list of endpoints is empty
-	if r.cephClusterSpec.External.Enable {
+	if r.cephClusterSpec.External.Enable && r.clusterInfo.CephCred.Username != cephclient.AdminUsername {
 		if len(s.Spec.Gateway.ExternalRgwEndpoints) == 0 {
 			return errors.New("ceph cluster is external but externalRgwEndpoints list is empty")
 		}

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -22,6 +22,7 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
@@ -142,6 +143,11 @@ func TestValidateSpec(t *testing.T) {
 				Enable: false,
 			},
 		},
+		clusterInfo: &client.ClusterInfo{
+			CephCred: client.CephCred{
+				Username: "client.admin",
+			},
+		},
 	}
 
 	// valid store
@@ -173,8 +179,13 @@ func TestValidateSpec(t *testing.T) {
 	err = r.validateStore(s)
 	assert.Nil(t, err)
 
-	// external with no endpoints, failure
+	// external with no endpoints but ok since client.admin is used
 	r.cephClusterSpec.External.Enable = true
+	err = r.validateStore(s)
+	assert.NoError(t, err)
+
+	// external with no endpoints, failure
+	r.clusterInfo.CephCred.Username = "client.external"
 	err = r.validateStore(s)
 	assert.NotNil(t, err)
 


### PR DESCRIPTION
**Description of your changes:**

We don't fail anymore if the cluster is external and user wants to
bootstrap rgw gateways in Kubernertes.

Closes: https://github.com/rook/rook/issues/6217
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6217

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
