### PR TITLE
ceph: fix to support TLS enabled rgw-endpoint

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -115,17 +115,18 @@ class RadosJSON:
                 "Out of range port number: {}".format(port))
         return False
 
-    def endpoint_dial(self, endpoint_str):
-        try:
-            ep = "http://" + endpoint_str
-            r = requests.head(ep)
-            rc = r.status_code
-            if rc != 200:
-                raise ExecutionFailureException(
-                    "wrong return code {} on rgw endpoint http header request".format(rc))
-        except requests.ConnectionError:
-            raise ExecutionFailureException(
-                "failed to connect to rgw endpoint {}".format(ep))
+    def endpoint_dial(self, endpoint_str, timeout=3):
+        protocols = ["http", "https"]
+        for prefix in protocols:
+            try:
+                ep = "{}://{}".format(prefix, endpoint_str)
+                r = requests.head(ep, timeout=timeout)
+                if r.status_code == 200:
+                    return
+            except:
+                continue
+        raise ExecutionFailureException(
+            "unable to connect to endpoint: {}".format(endpoint_str))
 
     def __init__(self, arg_list=None):
         self.out_map = {}


### PR DESCRIPTION
Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Enables the 'create-external-cluster-resources.py' script to check a given TLS (https) enabled rgw-endpoint.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]