### PR TITLE
ceph: remove owner reference set by rook on csidriver

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -139,6 +139,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - update
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -983,6 +983,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - update
 ---
 # Aspects of ceph-mgr that require cluster-wide access
 kind: ClusterRole

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -556,14 +556,24 @@ func createCSIDriverInfo(clientset kubernetes.Interface, name string) error {
 		},
 	}
 	csidrivers := clientset.StorageV1beta1().CSIDrivers()
-	_, err := csidrivers.Create(csiDriver)
+	driver, err := csidrivers.Get(name, metav1.GetOptions{})
 	if err == nil {
-		logger.Infof("CSIDriver object created for driver %q", name)
-		return nil
+		// For csidriver we need to provide the resourceVersion when updating the object.
+		// From the docs (https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+		// > "This value MUST be treated as opaque by clients and passed unmodified back to the server"
+		csiDriver.ObjectMeta.ResourceVersion = driver.ObjectMeta.ResourceVersion
+		_, err = csidrivers.Update(csiDriver)
+		if err == nil {
+			logger.Infof("CSIDriver object updated for driver %q", name)
+		}
+		return err
 	}
-	if apierrors.IsAlreadyExists(err) {
-		logger.Infof("CSIDriver CRD already had been registered for %q", name)
-		return nil
+
+	if apierrors.IsNotFound(err) {
+		_, err = csidrivers.Create(csiDriver)
+		if err == nil {
+			logger.Infof("CSIDriver object created for driver %q", name)
+		}
 	}
 
 	return err

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -973,6 +973,8 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - update
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
currently, we are setting the rook  operator as the owner on the csidriver objects,  as csidriver is cluster
the scoped object we should not set a namespaced object as owner on cluster scoped object.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
**Which issue is resolved by this Pull Request:**
Resolves #6162

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
