### PR TITLE
ceph: Run integration tests on k8s 1.19 for PRs

### DIFF
--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -40,12 +40,12 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion      = "1.14.0"
-	cephMasterSuiteMinimalTestVersion = "1.15.0"
-	multiClusterMinimalTestVersion    = "1.15.0"
-	helmMinimalTestVersion            = "1.16.0"
-	upgradeMinimalTestVersion         = "1.17.0"
-	smokeSuiteMinimalTestVersion      = "1.18.0"
+	flexDriverMinimalTestVersion      = "1.15.0"
+	cephMasterSuiteMinimalTestVersion = "1.16.0"
+	multiClusterMinimalTestVersion    = "1.16.0"
+	helmMinimalTestVersion            = "1.17.0"
+	upgradeMinimalTestVersion         = "1.18.0"
+	smokeSuiteMinimalTestVersion      = "1.19.0"
 )
 
 var (


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In K8s 1.19 the integration tests are not running in PRs since no test suites were assigned to 1.19. Similarly, the flex suite was not being run since 1.14 was removed from the test matrix in master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
