### PR TITLE
ceph: Don't set ownerref on the csi driver and set .svc suffix on rgw endpoint (bp #6232 #6234)

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -497,13 +497,13 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 
 	if ver.Major > KubeMinMajor || (ver.Major == KubeMinMajor && ver.Minor >= provDeploymentSuppVersion) {
 		if EnableRBD {
-			err = createCSIDriverInfo(clientset, RBDDriverName, ownerRef)
+			err = createCSIDriverInfo(clientset, RBDDriverName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create CSI driver object for %q", RBDDriverName)
 			}
 		}
 		if EnableCephFS {
-			err = createCSIDriverInfo(clientset, CephFSDriverName, ownerRef)
+			err = createCSIDriverInfo(clientset, CephFSDriverName)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create CSI driver object for %q", CephFSDriverName)
 			}
@@ -591,7 +591,7 @@ func applyCephClusterNetworkConfig(objectMeta *metav1.ObjectMeta, rookclientset 
 }
 
 // createCSIDriverInfo Registers CSI driver by creating a CSIDriver object
-func createCSIDriverInfo(clientset kubernetes.Interface, name string, ownerRef *metav1.OwnerReference) error {
+func createCSIDriverInfo(clientset kubernetes.Interface, name string) error {
 	attach := true
 	mountInfo := false
 	// Create CSIDriver object
@@ -605,7 +605,6 @@ func createCSIDriverInfo(clientset kubernetes.Interface, name string, ownerRef *
 		},
 	}
 	csidrivers := clientset.StorageV1beta1().CSIDrivers()
-	k8sutil.SetOwnerRef(&csiDriver.ObjectMeta, ownerRef)
 	_, err := csidrivers.Create(csiDriver)
 	if err == nil {
 		logger.Infof("CSIDriver object created for driver %q", name)

--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -100,5 +100,5 @@ func TestPopulateDomainAndPort(t *testing.T) {
 	p.objectStoreName = store
 	err = p.populateDomainAndPort(sc)
 	assert.NoError(t, err)
-	assert.Equal(t, "rook-ceph-rgw-test-store.ns.svc.cluster.local", p.storeDomainName)
+	assert.Equal(t, "rook-ceph-rgw-test-store.ns.svc", p.storeDomainName)
 }

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -371,7 +371,7 @@ func TestCephObjectStoreController(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cephv1.ConditionProgressing, objectStore.Status.Phase, objectStore)
 	assert.NotEmpty(t, objectStore.Status.Info["endpoint"], objectStore)
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", objectStore.Status.Info["endpoint"], objectStore)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc:80", objectStore.Status.Info["endpoint"], objectStore)
 	logger.Info("PHASE 3 DONE")
 
 	// Test the functionality of verifyObjectUserCleanup

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -44,7 +44,7 @@ const (
 	bucketProvisionerName = "ceph.rook.io/bucket"
 	AccessKeyName         = "access-key"
 	SecretKeyName         = "secret-key"
-	svcDNSSuffix          = "svc.cluster.local"
+	svcDNSSuffix          = "svc"
 )
 
 var (

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -159,15 +159,15 @@ func TestBuildDomainNameAndEndpoint(t *testing.T) {
 	name := "my-store"
 	ns := "rook-ceph"
 	dns := BuildDomainName(name, ns)
-	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local", dns)
+	assert.Equal(t, "rook-ceph-rgw-my-store.rook-ceph.svc", dns)
 
 	// non-secure endpoint
 	var port int32 = 80
 	ep := buildDNSEndpoint(dns, port, false)
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", ep)
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc:80", ep)
 
 	// Secure endpoint
 	var securePort int32 = 443
 	ep = buildDNSEndpoint(dns, securePort, true)
-	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:443", ep)
+	assert.Equal(t, "https://rook-ceph-rgw-my-store.rook-ceph.svc:443", ep)
 }

--- a/pkg/operator/ceph/object/status_test.go
+++ b/pkg/operator/ceph/object/status_test.go
@@ -35,5 +35,6 @@ func TestBuildStatusInfo(t *testing.T) {
 
 	statusInfo := buildStatusInfo(cephObjectStore)
 	assert.NotEmpty(t, statusInfo["endpoint"])
-	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc.cluster.local:80", statusInfo["endpoint"])
+	assert.Empty(t, statusInfo["secureEndpoint"])
+	assert.Equal(t, "http://rook-ceph-rgw-my-store.rook-ceph.svc:80", statusInfo["endpoint"])
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport two fixes to the release-1.4 branch:
- Don't set the ownerRef when creating csidriver object
- Fixed DNS suffix breaks in custom DNS suffix clusters

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
