### PR TITLE
ceph: Upgrade to v1.4.3 for cluster-on-pvc example hangs due to changing label selectors on the mons

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -52,7 +52,7 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 	if canary {
 		labels["mon_canary"] = "true"
 	}
-	if c.spec.Mon.VolumeClaimTemplate != nil {
+	if c.spec.Mon.VolumeClaimTemplate != nil && includeNewLabels {
 		labels["pvc_name"] = monConfig.ResourceName
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The selector labels used for mons cannot change during upgrade or else the upgrade will hang when the cluster is checking for mon status immediately after the upgrade begins.

This is a regression in the cluster-on-pvc upgrade scenario caused by #6224 where the pvc_name label was added. 

Until the v1.4.4 release is out, the workaround for upgrading to v1.4.3 is to add the following label to each respective mon deployment either before the upgrade or after the upgrade had hit the blocking issue. If the upgrade doesn't immediately start, you may need to restart the operator:
```
   # change the label value depending on each mon name
   pvc_name=rook-ceph-mon-a
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
