### PR TITLE
ceph: set ROOK_CEPH_CLUSTER_CRD_NAME with cluster name

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -55,6 +55,7 @@ func TestStartMGR(t *testing.T) {
 		ConfigDir: configDir,
 		Clientset: clientset}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Annotations:        map[rookv1.KeyType]rookv1.Annotations{cephv1.KeyMgr: {"my": "annotation"}},
 		Labels:             map[rookv1.KeyType]rookv1.Labels{cephv1.KeyMgr: {"my-label-key": "value"}},

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -357,7 +357,7 @@ func (c *Cluster) cephMgrOrchestratorModuleEnvs() []v1.EnvVar {
 	envVars := []v1.EnvVar{
 		{Name: "ROOK_OPERATOR_NAMESPACE", Value: operatorNamespace},
 		{Name: "ROOK_CEPH_CLUSTER_CRD_VERSION", Value: rookcephv1.Version},
-		{Name: "ROOK_CEPH_CLUSTER_CRD_NAME", Value: c.clusterInfo.Namespace},
+		{Name: "ROOK_CEPH_CLUSTER_CRD_NAME", Value: c.clusterInfo.NamespacedName().Name},
 		k8sutil.PodIPEnvVar(podIPEnvVar),
 	}
 	return envVars

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -35,6 +35,7 @@ import (
 func TestPodSpec(t *testing.T) {
 	clientset := optest.New(t, 1)
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		CephVersion:        cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"},
 		Dashboard:          cephv1.DashboardSpec{Port: 1234},
@@ -93,6 +94,7 @@ func TestServiceSpec(t *testing.T) {
 func TestHostNetwork(t *testing.T) {
 	clientset := optest.New(t, 1)
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Network:         cephv1.NetworkSpec{HostNetwork: true},
 		Dashboard:       cephv1.DashboardSpec{Port: 1234},
@@ -117,6 +119,7 @@ func TestHostNetwork(t *testing.T) {
 func TestHttpBindFix(t *testing.T) {
 	clientset := optest.New(t, 1)
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Dashboard:       cephv1.DashboardSpec{Enabled: true, Port: 1234},
 		DataDirHostPath: "/var/lib/rook/",
@@ -144,6 +147,7 @@ func TestApplyPrometheusAnnotations(t *testing.T) {
 		DataDirHostPath: "/var/lib/rook/",
 	}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	clusterInfo.SetName("test")
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")
 
 	mgrTestConfig := mgrConfig{


### PR DESCRIPTION
ROOK_CEPH_CLUSTER_CRD_NAME is incorrectly set to cluster namespace value

Signed-off-by: Varsha <varao@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
