### PR TITLE
ceph: If spec diff checking fails during upgrade, assume it changed

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package osd
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -385,6 +386,7 @@ func TestGetOSDInfo(t *testing.T) {
 	}
 	d1, _ := c.makeDeployment(osdProp, osd1, dataPathMap)
 	osds1, _ := c.getOSDInfo(d1)
+	findDuplicateEnvVars(t, d1.Spec.Template.Spec)
 	assert.Equal(t, 1, len(osds1))
 	assert.Equal(t, osd1.ID, osds1[0].ID)
 	assert.Equal(t, osd1.BlockPath, osds1[0].BlockPath)
@@ -403,6 +405,17 @@ func TestGetOSDInfo(t *testing.T) {
 	osds3, err := c.getOSDInfo(d3)
 	assert.Equal(t, 0, len(osds3))
 	assert.NotNil(t, err)
+}
+
+func findDuplicateEnvVars(t *testing.T, pod v1.PodSpec) {
+	for _, container := range pod.Containers {
+		envVars := map[string]string{}
+		for _, v := range container.Env {
+			_, ok := envVars[v.Name]
+			assert.False(t, ok, fmt.Sprintf("env var duplicated: %s", v.Name))
+			envVars[v.Name] = v.Value
+		}
+	}
 }
 
 func TestOSDPlacement(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -146,6 +146,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	} else {
 		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec)
 	}
+	removeDuplicateEnvVars(&podSpec)
 
 	podMeta := metav1.ObjectMeta{
 		Name: AppName,

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -443,6 +443,8 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		}
 	}
 
+	removeDuplicateEnvVars(&podTemplateSpec.Spec)
+
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
@@ -493,6 +495,30 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 
 	return deployment, nil
+}
+
+func removeDuplicateEnvVars(pod *v1.PodSpec) {
+	for i := range pod.Containers {
+		removeDuplicateEnvVarsFromContainer(&pod.Containers[i])
+	}
+	for i := range pod.InitContainers {
+		removeDuplicateEnvVarsFromContainer(&pod.InitContainers[i])
+	}
+}
+
+func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
+	foundVars := map[string]string{}
+	vars := []v1.EnvVar{}
+	for _, v := range container.Env {
+		if _, ok := foundVars[v.Name]; ok {
+			logger.Infof("duplicate env var %q skipped on container %q", v.Name, container.Name)
+			continue
+		}
+
+		vars = append(vars, v)
+		foundVars[v.Name] = v.Value
+	}
+	container.Env = vars
 }
 
 // To get rook inside the container, the config init container needs to copy "tini" and "rook" binaries into a volume.

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -63,6 +63,7 @@ func TestPodContainer(t *testing.T) {
 	assert.Equal(t, "ceph", container.Args[2])
 	assert.Equal(t, "osd", container.Args[3])
 	assert.Equal(t, "provision", container.Args[4])
+	findDuplicateEnvVars(t, c.Spec)
 }
 
 func TestDaemonset(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the pod spec changed, we expect an upgrade to proceed for that daemon. If the check for a changed pod spec fails, we were skipping the update of that daemon. Instead of skipping the update, we now assume the pod spec changed if we fail to detect the change so that we can ensure the upgrade even if we check for upgrades too often.

The case of failure in #6268 appears to be from env vars being duplicated in the osd pod spec. Now we avoid that duplication so we won't hit diff detection failure at least in that case.
 
**Which issue is resolved by this Pull Request:**
Resolves #6268 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
