### PR TITLE
ceph: support IPv6 single-stack

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -245,6 +245,10 @@ The Network attachment definitions should be using whereabouts cni.
 If Rook cannot find the provided Network attachment definition it will fail running the Ceph OSD pods.
 You can add the Multus network attachment selection annotation selecting the created network attachment definition on `selectors`.
 
+#### IPFamily
+
+Provide single-stack IPv4 or IPv6 protocol to assign corresponding addresses to pods and services. This field is optional. Possible inputs are IPv6 and IPv4. Empty value will be treated as IPv4. Kubernetes version should be at least v1.13 to run IPv6. Dual-stack is not supported by ceph.
+
 ### Node Settings
 
 In addition to the cluster level settings specified above, each individual node can also specify configuration to override the cluster level settings and defaults.

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -82,6 +82,8 @@ spec:
       #
       #public: public-conf --> NetworkAttachmentDefinition object name in Multus
       #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+    # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
+    #ipFamily: "IPv6"
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -741,6 +741,9 @@ type NetworkSpec struct {
 
 	// HostNetwork to enable host network
 	HostNetwork bool `json:"hostNetwork"`
+
+	// IPFamily is the single stack IPv6 or IPv4 protocol
+	IPFamily IPFamilyType `json:"ipFamily,omitempty"`
 }
 
 // DisruptionManagementSpec configures management of daemon disruptions
@@ -848,3 +851,13 @@ type RBDMirroringPeerSpec struct {
 	// SecretNames represents the Kubernetes Secret names to add rbd-mirror peers
 	SecretNames []string `json:"secretNames,omitempty"`
 }
+
+// IPFamilyType represents the single stack Ipv4 or Ipv6 protocol.
+type IPFamilyType string
+
+const (
+	// IPv6 internet protocol version
+	IPv6 IPFamilyType = "IPv6"
+	// IPv4 internet protocol version
+	IPv4 IPFamilyType = "IPv4"
+)

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -215,7 +215,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 			"ceph-mgr",
 		},
 		Args: append(
-			controller.DaemonFlags(c.clusterInfo, mgrConfig.DaemonID),
+			controller.DaemonFlags(c.clusterInfo, &c.spec, mgrConfig.DaemonID),
 			// for ceph-mgr cephfs
 			// see https://github.com/ceph/ceph-csi/issues/486 for more details
 			config.NewFlag("client-mount-uid", "0"),

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -216,7 +216,7 @@ func (c *Cluster) makeMonFSInitContainer(monConfig *monConfig) v1.Container {
 			cephMonCommand,
 		},
 		Args: append(
-			controller.DaemonFlags(c.ClusterInfo, monConfig.DaemonName),
+			controller.DaemonFlags(c.ClusterInfo, &c.spec, monConfig.DaemonName),
 			// needed so we can generate an initial monmap
 			// otherwise the mkfs will say: "0  no local addrs match monmap"
 			config.NewFlag("public-addr", monConfig.PublicIP),
@@ -249,7 +249,7 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) v1.Container {
 			cephMonCommand,
 		},
 		Args: append(
-			controller.DaemonFlags(c.ClusterInfo, monConfig.DaemonName),
+			controller.DaemonFlags(c.ClusterInfo, &c.spec, monConfig.DaemonName),
 			"--foreground",
 			// If the mon is already in the monmap, when the port is left off of --public-addr,
 			// it will still advertise on the previous port b/c monmap is saved to mon database.

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -296,6 +296,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	args = append(args, opconfig.LoggingFlags()...)
 	args = append(args, osdOnSDNFlag(c.spec.Network)...)
 
+	if c.spec.Network.IPFamily == cephv1.IPv6 {
+		args = append(args, opconfig.NewFlag("ms-bind-ipv6", "true"))
+	}
+
 	osdDataDirPath := activateOSDMountPath + osdID
 	if osdProps.onPVC() && osd.CVMode == "lvm" {
 		// Let's use the old bridge for these lvm based pvc osds

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -113,7 +113,7 @@ func (r *ReconcileCephRBDMirror) makeMirroringDaemonContainer(daemonConfig *daem
 			"rbd-mirror",
 		},
 		Args: append(
-			controller.DaemonFlags(r.clusterInfo, daemonConfig.DaemonID),
+			controller.DaemonFlags(r.clusterInfo, r.cephClusterSpec, daemonConfig.DaemonID),
 			"--foreground",
 			"--name="+fullDaemonName(daemonConfig.DaemonID),
 		),

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -110,7 +110,7 @@ func (c *Cluster) makeChownInitContainer(mdsConfig *mdsConfig) v1.Container {
 
 func (c *Cluster) makeMdsDaemonContainer(mdsConfig *mdsConfig) v1.Container {
 	args := append(
-		controller.DaemonFlags(c.clusterInfo, mdsConfig.DaemonID),
+		controller.DaemonFlags(c.clusterInfo, c.clusterSpec, mdsConfig.DaemonID),
 		"--foreground",
 	)
 

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -150,7 +150,8 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 			"radosgw",
 		},
 		Args: append(
-			controller.DaemonFlags(c.clusterInfo, strings.TrimPrefix(generateCephXUser(rgwConfig.ResourceName), "client.")),
+			controller.DaemonFlags(c.clusterInfo, c.clusterSpec,
+				strings.TrimPrefix(generateCephXUser(rgwConfig.ResourceName), "client.")),
 			"--foreground",
 			cephconfig.NewFlag("rgw frontends", fmt.Sprintf("%s %s", rgwFrontendName, c.portString())),
 			cephconfig.NewFlag("host", controller.ContainerEnvVarReference(k8sutil.PodNameEnvVar)),


### PR DESCRIPTION
- Add `--ms-bind-ipv6 true` args to following daemons
  - mon, osd, mgr, object, mds, rbd

Pending: 

- [x] Testing on an IPv6 cluster other than Kind IPv6
- [x] Unit tests

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #3850

Initial testing on local multi-node IPv6 cluster:

1. OSD on devices:
```
 NAME                                                    READY   STATUS      RESTARTS   AGE     IP                      NODE         
csi-cephfsplugin-j8p2h                                  3/3     Running     0          35m     fd00:f00d::102          k86-worker2   
csi-cephfsplugin-provisioner-559f57dff6-4sknq           6/6     Running     0          35m     fd00:f00d::103:0:0:7    k86-worker3 
csi-cephfsplugin-provisioner-559f57dff6-pkz2w           6/6     Running     0          35m     fd00:f00d::101:0:0:6    k86-worker1   
csi-cephfsplugin-ptcpj                                  3/3     Running     0          35m     fd00:f00d::101          k86-worker1   
csi-cephfsplugin-q2d7x                                  3/3     Running     0          35m     fd00:f00d::103          k86-worker3   
csi-rbdplugin-5xqql                                     3/3     Running     0          35m     fd00:f00d::102          k86-worker2   
csi-rbdplugin-gmm9p                                     3/3     Running     0          35m     fd00:f00d::103          k86-worker3   
csi-rbdplugin-provisioner-65f85f795c-7n7q7              6/6     Running     0          35m     fd00:f00d::102:0:0:5    k86-worker2   
csi-rbdplugin-provisioner-65f85f795c-pldfc              6/6     Running     0          35m     fd00:f00d::101:0:0:5    k86-worker1   
csi-rbdplugin-tr4bd                                     3/3     Running     0          35m     fd00:f00d::101          k86-worker1   
rook-ceph-crashcollector-k86-worker1-849c775dbd-mxtfl   1/1     Running     0          33m     fd00:f00d::101:0:0:c    k86-worker1   
rook-ceph-crashcollector-k86-worker2-67d5fc7c79-tvf75   1/1     Running     0          13m     fd00:f00d::102:0:0:13   k86-worker2   
rook-ceph-crashcollector-k86-worker3-5b64db6d9d-w9lwg   1/1     Running     0          2m37s   fd00:f00d::103:0:0:19   k86-worker3   
rook-ceph-mgr-a-6564c4644c-wf5bt                        1/1     Running     0          23m     fd00:f00d::102:0:0:8    k86-worker2   
rook-ceph-mon-a-65b946bdd6-p7jfn                        1/1     Running     0          21m     fd00:f00d::103:0:0:11   k86-worker3   
rook-ceph-mon-b-7ddbb96f7b-j65x8                        1/1     Running     0          33m     fd00:f00d::101:0:0:7    k86-worker1  
rook-ceph-mon-c-bc5fbb87-phzhj                          1/1     Running     0          33m     fd00:f00d::102:0:0:6    k86-worker2   
rook-ceph-operator-57d594bb7f-hwcsf                     1/1     Running     0          43m     fd00:f00d::102:0:0:2    k86-worker2   
rook-ceph-osd-0-784c858df6-bqtn9                        1/1     Running     0          23m     fd00:f00d::102:0:0:b    k86-worker2   
rook-ceph-osd-1-6cccd68dcc-k5ttx                        1/1     Running     0          23m     fd00:f00d::101:0:0:9    k86-worker1   
rook-ceph-osd-2-5c5dccc87d-n6lvc                        1/1     Running     0          23m     fd00:f00d::103:0:0:c    k86-worker3   
rook-ceph-osd-3-6c6d9cd967-7f6fw                        1/1     Running     0          23m     fd00:f00d::102:0:0:c    k86-worker2   
rook-ceph-osd-4-757d849cdd-7rhfp                        1/1     Running     0          23m     fd00:f00d::101:0:0:a    k86-worker1   
rook-ceph-osd-5-7fc9669894-krrcv                        1/1     Running     0          23m     fd00:f00d::103:0:0:d    k86-worker3   
rook-ceph-osd-6-6d6bc7d665-2qmxt                        1/1     Running     0          23m     fd00:f00d::102:0:0:d    k86-worker2   
rook-ceph-osd-7-79d7b588cd-jr6g4                        1/1     Running     0          23m     fd00:f00d::101:0:0:b    k86-worker1   
rook-ceph-osd-8-674688d8c-fxqh6                         1/1     Running     0          23m     fd00:f00d::103:0:0:e    k86-worker3   
rook-ceph-osd-prepare-k86-worker1-p6gbt                 0/1     Completed   0          21m     fd00:f00d::101:0:0:d    k86-worker1   
rook-ceph-osd-prepare-k86-worker2-5d5q6                 0/1     Completed   0          21m     fd00:f00d::102:0:0:e    k86-worker2  
rook-ceph-osd-prepare-k86-worker3-8dh52                 0/1     Completed   0          21m     fd00:f00d::103:0:0:12   k86-worker3   
rook-ceph-rgw-my-store-a-764cbfc7f6-m4m8z               1/1     Running     0          13m     fd00:f00d::102:0:0:12   k86-worker2   
rook-ceph-tools-6b4889fdfd-twhwl                        1/1     Running     0          29m     fd00:f00d::103:0:0:9    k86-worker3  
rook-discover-62g4n                                     1/1     Running     0          41m     fd00:f00d::102:0:0:3    k86-worker2   
rook-discover-phqsv                                     1/1     Running     0          41m     fd00:f00d::103:0:0:2    k86-worker3   
rook-discover-wctph                                     1/1     Running     0          41m     fd00:f00d::101:0:0:2    k86-worker1   
```
- cephfs pv:
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                STORAGECLASS      REASON   AGE
pvc-f9764039-0945-4d23-8d21-db29f11536b4   1Gi        RWO            Delete           Bound    default/cephfs-pvc   rook-cephfs                2m7s
```

- pod using cephfs pv:

```
NAME                 READY   STATUS    RESTARTS   AGE   IP                      NODE          NOMINATED NODE   READINESS GATES
csicephfs-demo-pod   1/1     Running   0          29s   fd00:f00d::103:0:0:1c   k86-worker3   <none>           <none>
```

```
Events:
  Type    Reason                  Age        From                     Message
  ----    ------                  ----       ----                     -------
  Normal  Scheduled               <unknown>  default-scheduler        Successfully assigned default/csicephfs-demo-pod to k86-worker3
  Normal  SuccessfulAttachVolume  2m33s      attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-f9764039-0945-4d23-8d21-db29f11536b4"
  Normal  Pulling                 2m29s      kubelet, k86-worker3     Pulling image "nginx"
  Normal  Pulled                  2m24s      kubelet, k86-worker3     Successfully pulled image "nginx"
  Normal  Created                 2m24s      kubelet, k86-worker3     Created container web-server
  Normal  Started                 2m24s      kubelet, k86-worker3     Started container web-server
```

- rbd pv:
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM             STORAGECLASS      REASON   AGE
pvc-60722f9e-f2c3-4f33-994c-f91c7b988a40   1Gi        RWO            Delete           Bound    default/rbd-pvc   rook-ceph-block            18m
```


- POD using rbd pv:
```
NAME              READY   STATUS    RESTARTS   AGE   IP                      NODE          
csirbd-demo-pod   1/1     Running   0          19m   fd00:f00d::103:0:0:16   k86-worker3 
```

```
Events:
  Type    Reason                  Age        From                     Message
  ----    ------                  ----       ----                     -------
  Normal  Scheduled               <unknown>  default-scheduler        Successfully assigned default/csirbd-demo-pod to k86-worker3
  Normal  SuccessfulAttachVolume  18m        attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-60722f9e-f2c3-4f33-994c-f91c7b988a40"
  Normal  Pulling                 18m        kubelet, k86-worker3     Pulling image "nginx"
  Normal  Pulled                  18m        kubelet, k86-worker3     Successfully pulled image "nginx"
  Normal  Created                 18m        kubelet, k86-worker3     Created container web-server
  Normal  Started                 18m        kubelet, k86-worker3     Started container web-server
```


- Ceph status:
```
  cluster:
    id:     0c5acc9b-47ed-4053-a0c4-18c1b4817baa
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 4m)
    mgr: a(active, since 10m)
    mds: myfs:1 {0=myfs-a=up:active} 1 up:standby-replay
    osd: 9 osds: 9 up (since 42m), 9 in (since 42m)
    rgw: 1 daemon active (my.store.a)

  task status:
    scrub status:
        mds.myfs-a: idle
        mds.myfs-b: idle

  data:
    pools:   11 pools, 177 pgs
    objects: 280 objects, 7.3 MiB
    usage:   9.3 GiB used, 81 GiB / 90 GiB avail
    pgs:     177 active+clean

  io:
    client:   937 B/s rd, 170 B/s wr, 1 op/s rd, 0 op/s wr
```


2. OSD on PVC:
```
NAME                                                    READY   STATUS      RESTARTS   AGE     IP                      NODE          
csi-cephfsplugin-ls4rn                                  3/3     Running     0          140m    fd00:f00d::103          k86-worker3   
csi-cephfsplugin-provisioner-559f57dff6-6xptn           6/6     Running     0          140m    fd00:f00d::103:0:0:b    k86-worker3   
csi-cephfsplugin-provisioner-559f57dff6-vmwtf           6/6     Running     0          140m    fd00:f00d::102:0:0:a    k86-worker2   
csi-cephfsplugin-sgcq5                                  3/3     Running     0          140m    fd00:f00d::102          k86-worker2   
csi-cephfsplugin-w65gx                                  3/3     Running     0          140m    fd00:f00d::101          k86-worker1   
csi-rbdplugin-m2fzn                                     3/3     Running     0          140m    fd00:f00d::103          k86-worker3   
csi-rbdplugin-provisioner-65f85f795c-cxwfg              6/6     Running     0          140m    fd00:f00d::101:0:0:9    k86-worker1   
csi-rbdplugin-provisioner-65f85f795c-nmtcf              6/6     Running     0          140m    fd00:f00d::103:0:0:a    k86-worker3   
csi-rbdplugin-rhhsk                                     3/3     Running     0          140m    fd00:f00d::101          k86-worker1   
csi-rbdplugin-xwp8z                                     3/3     Running     0          140m    fd00:f00d::102          k86-worker2   
rook-ceph-crashcollector-k86-worker1-74d56bd998-tnbsr   1/1     Running     0          139m    fd00:f00d::101:0:0:d    k86-worker1   
rook-ceph-crashcollector-k86-worker2-67d5fc7c79-xz759   1/1     Running     0          143m    fd00:f00d::102:0:0:f    k86-worker2   
rook-ceph-crashcollector-k86-worker3-79bbf74db4-g87t4   1/1     Running     0          139m    fd00:f00d::103:0:0:d    k86-worker3   
rook-ceph-mgr-a-6b8877cf4b-pll9j                        1/1     Running     0          136m    fd00:f00d::102:0:0:c    k86-worker2   
rook-ceph-mon-a-64665c69fb-8qktk                        1/1     Running     0          10m     fd00:f00d::102:0:0:13   k86-worker2   
rook-ceph-mon-b-54549c779c-c8r4l                        1/1     Running     0          10m     fd00:f00d::103:0:0:12   k86-worker3   
rook-ceph-mon-c-7d67554f46-2j9q2                        1/1     Running     0          42m     fd00:f00d::101:0:0:14   k86-worker1   
rook-ceph-operator-57d594bb7f-5rdcm                     1/1     Running     0          154m    fd00:f00d::102:0:0:6    k86-worker2   
rook-ceph-osd-0-5ddd44769f-fhsnb                        1/1     Running     0          135m    fd00:f00d::102:0:0:e    k86-worker2   
rook-ceph-osd-1-7b7b94f54f-v4hfq                        1/1     Running     0          132m    fd00:f00d::101:0:0:e    k86-worker1   
rook-ceph-osd-2-64597d9458-4rxwt                        1/1     Running     0          132m    fd00:f00d::101:0:0:f    k86-worker1   
rook-ceph-osd-prepare-set1-data-0-9728q-h99lq           0/1     Completed   0          136m    fd00:f00d::102:0:0:d    k86-worker2   
rook-ceph-osd-prepare-set1-data-1-722jf-vf9rw           0/1     Completed   0          136m    fd00:f00d::101:0:0:b    k86-worker1   
rook-ceph-osd-prepare-set1-data-2-9fk7s-ktmr9           0/1     Completed   0          136m    fd00:f00d::101:0:0:c    k86-worker1   
rook-ceph-rgw-my-store-a-66f68bcd47-g2crh               1/1     Running     0          2m19s   fd00:f00d::102:0:0:14   k86-worker2   
rook-ceph-tools-6b4889fdfd-c6pk9                        1/1     Running     0          108m    fd00:f00d::101:0:0:10   k86-worker1   
rook-discover-4msb2                                     1/1     Running     0          152m    fd00:f00d::102:0:0:7    k86-worker2   
rook-discover-vb5ss                                     1/1     Running     0          152m    fd00:f00d::101:0:0:7    k86-worker1   
rook-discover-zdfjw                                     1/1     Running     0          152m    fd00:f00d::103:0:0:6    k86-worker3   
```

- ceph status:
```
cluster:
    id:     d769c6c3-edbb-43f0-bcad-b9906cf37e27
    health: HEALTH_OK

  services:
    mon: 3 daemons, quorum a,b,c (age 12m)
    mgr: a(active, since 15m)
    osd: 3 osds: 3 up (since 2h), 3 in (since 2h)
    rgw: 1 daemon active (my.store.a)

  task status:

  data:
    pools:   8 pools, 81 pgs
    objects: 239 objects, 10 KiB
    usage:   3.1 GiB used, 27 GiB / 30 GiB avail
    pgs:     81 active+clean

  io:
    client:   5.1 KiB/s rd, 511 B/s wr, 5 op/s rd, 3 op/s wr
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
