### PR TITLE
ceph: merge rook-config-override to the default global config file

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -214,7 +214,8 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, forceFormat,
 		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, cfg.pvcBacked)
 
-	err = osddaemon.Provision(context, agent, crushLocation)
+	namespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
+	err = osddaemon.Provision(context, agent, crushLocation, namespace)
 	if err != nil {
 		// something failed in the OSD orchestration, update the status map with failure details
 		status := oposd.OrchestrationStatus{

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -144,7 +144,7 @@ func killCephOSDProcess(context *clusterd.Context, lvPath string) error {
 }
 
 // Provision provisions an OSD
-func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string) error {
+func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, namespace string) error {
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
 	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
@@ -156,7 +156,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	}
 
 	// write the latest config to the config dir
-	confFilePath, err := cephconfig.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig)
+	confFilePath, err := cephconfig.GenerateAdminConnectionConfigWithSettings(context, agent.cluster, cephConfig, namespace)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write connection config")
 	}

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -145,7 +145,7 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 	clusterInfo, _, _, err := mon.LoadClusterInfo(c.context, c.Namespace)
 	if err == nil {
 		// Write connection info (ceph config file and keyring) for ceph commands
-		err = mon.WriteConnectionConfig(c.context, clusterInfo)
+		err = mon.WriteConnectionConfig(c.context, clusterInfo, c.Namespace)
 		if err != nil {
 			logger.Errorf("failed to write config. attempting to continue. %v", err)
 		}

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -323,7 +323,7 @@ func (c *ClusterController) configureExternalCephCluster(namespace, name string,
 
 	// Write connection info (ceph config file and keyring) for ceph commands
 	if cluster.Spec.CephVersion.Image == "" {
-		err = mon.WriteConnectionConfig(c.context, cluster.Info)
+		err = mon.WriteConnectionConfig(c.context, cluster.Info, namespace)
 		if err != nil {
 			logger.Errorf("failed to write config. attempting to continue. %v", err)
 		}

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -172,9 +172,9 @@ func ValidateAndLoadExternalClusterSecrets(context *clusterd.Context, namespace 
 }
 
 // WriteConnectionConfig save monitor connection config to disk
-func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo) error {
+func WriteConnectionConfig(context *clusterd.Context, clusterInfo *cephconfig.ClusterInfo, namespace string) error {
 	// write the latest config to the config dir
-	if _, err := cephconfig.GenerateAdminConnectionConfig(context, clusterInfo); err != nil {
+	if _, err := cephconfig.GenerateAdminConnectionConfig(context, clusterInfo, namespace); err != nil {
 		return errors.Wrapf(err, "failed to write connection config")
 	}
 

--- a/pkg/operator/ceph/cluster/mon/env.go
+++ b/pkg/operator/ceph/cluster/mon/env.go
@@ -16,7 +16,15 @@ limitations under the License.
 
 package mon
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	v1 "k8s.io/api/core/v1"
+)
+
+// PodNamespaceEnvVar is the cluster namespace environment var
+func PodNamespaceEnvVar(namespace string) v1.EnvVar {
+	return v1.EnvVar{Name: k8sutil.PodNamespaceEnvVar, Value: namespace}
+}
 
 // ClusterNameEnvVar is the cluster name environment var
 func ClusterNameEnvVar(name string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -319,7 +319,7 @@ func (c *Cluster) ensureMonsRunning(mons []*monConfig, i, targetCount int, requi
 	}
 
 	// make sure we have the connection info generated so connections can happen
-	if err := WriteConnectionConfig(c.context, c.ClusterInfo); err != nil {
+	if err := WriteConnectionConfig(c.context, c.ClusterInfo, c.Namespace); err != nil {
 		return err
 	}
 
@@ -790,7 +790,7 @@ func (c *Cluster) saveMonConfig() error {
 	}
 
 	// write the latest config to the config dir
-	if err := WriteConnectionConfig(c.context, c.ClusterInfo); err != nil {
+	if err := WriteConnectionConfig(c.context, c.ClusterInfo, c.Namespace); err != nil {
 		return errors.Wrapf(err, "failed to write connection config for new mons")
 	}
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -764,6 +764,7 @@ func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string) []v1.
 		{Name: "ROOK_CLUSTER_ID", Value: string(c.ownerRef.UID)},
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
+		opmon.PodNamespaceEnvVar(c.Namespace),
 		opmon.ClusterNameEnvVar(c.Namespace),
 		opmon.EndpointEnvVar(),
 		opmon.SecretEnvVar(),


### PR DESCRIPTION
Some parameter like bluestore_min_alloc_size, bluestore_min_alloc_size_hdd need to be set during the bootstrap of the
ceph cluster in order to have bluestore created accordingly.
To do so rook users rely on the rook-config-override configmap.
Sadly the rook-ceph-osd-prepare job does not take in account this configmap to generate its ceph config.
Changing the behaviour to merge the config from rook-config-override configmap to the default ceph config

Signed-off-by: n.fraison <n.fraison@criteo.com>
(cherry picked from commit de7ca0193005c26b2c830df776fb1950cf76b64f)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In order to backport this commit to 1.3 branch I had to duplicate fake cluster creation and ConfigOverrideName var to avoid circular dependency issues on tests
I want to discuss this with you before to try doing this another way which could lead to big refacto perhaps not wanted for this release.
Let me know

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
