### PR TITLE
ceph: tune fast device class for OSD on PVC in the Azure

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -69,7 +69,6 @@ spec:
     - name: set1
       count: 3
       portable: false
-      tuneDeviceClass: false
       encrypted: false
       volumeClaimTemplates:
       - metadata:
@@ -314,7 +313,8 @@ The following are the settings for Storage Class Device Sets which can be config
 * `preparePlacement`: The placement criteria for the preparation of the OSD devices. Creating OSDs is a two-step process and the prepare job may require different placement than the OSD daemons. If the `preparePlacement` is not specified, the `placement` will instead be applied for consistent placement for the OSD prepare jobs and OSD deployments. The `preparePlacement` is only useful for `portable` OSDs in the device sets. OSDs that are not portable will be tied to the host where the OSD prepare job initially runs.
    * For example, provisioning may require topology spread constraints across zones, but the OSD daemons may require constraints across hosts within the zones.
 * `portable`: If `true`, the OSDs will be allowed to move between nodes during failover. This requires a storage class that supports portability (e.g. `aws-ebs`, but not the local storage provisioner). If `false`, the OSDs will be assigned to a node permanently. Rook will configure Ceph's CRUSH map to support the portability.
-* `tuneDeviceClass`: If `true`, because the OSD can be on a slow device class, Rook will adapt to that by tuning the OSD process. This will make Ceph perform better under that slow device.
+* `tuneDeviceClass`: For example, Ceph cannot detect AWS volumes as HDDs from the storage class "gp2", so you can improve Ceph performance by setting this to true.
+* `tuneFastDeviceClass`: For example, Ceph cannot detect Azure disks as SSDs from the storage class "managed-premium", so you can improve Ceph performance by setting this to true..
 * `volumeClaimTemplates`: A list of PVC templates to use for provisioning the underlying storage devices.
   * `resources.requests.storage`: The desired capacity for the underlying storage devices.
   * `storageClassName`: The StorageClass to provision PVCs from. Default would be to use the cluster-default StorageClass. This StorageClass should provide a raw block device, multipath device, or logical volume. Other types are not supported. If you want to use logical volume, please see [known issue of OSD on LV-backed PVC](ceph-common-issues.md#lvm-metadata-can-be-corrupted-with-osd-on-lv-backed-pvc)
@@ -810,7 +810,6 @@ spec:
     - name: set1
       count: 3
       portable: false
-      tuneDeviceClass: false
       resources:
         limits:
           cpu: "500m"
@@ -864,7 +863,6 @@ So just taking the `storage` section this will give something like:
     - name: set1
       count: 3
       portable: false
-      tuneDeviceClass: false
       volumeClaimTemplates:
       - metadata:
           name: data
@@ -909,7 +907,6 @@ The bluestore partition has the following reference combinations supported by th
       - name: set1
         count: 3
         portable: false
-        tuneDeviceClass: false
         volumeClaimTemplates:
         - metadata:
             name: data
@@ -932,7 +929,6 @@ The bluestore partition has the following reference combinations supported by th
       - name: set1
         count: 3
         portable: false
-        tuneDeviceClass: false
         volumeClaimTemplates:
         - metadata:
             name: data
@@ -969,7 +965,6 @@ There is no separate "metadata" device in this case, the data of main OSD block 
       - name: set1
         count: 3
         portable: false
-        tuneDeviceClass: false
         volumeClaimTemplates:
         - metadata:
             name: data
@@ -1004,7 +999,6 @@ There is no separate "metadata" device in this case, the data of main OSD block 
       - name: set1
         count: 3
         portable: false
-        tuneDeviceClass: false
         volumeClaimTemplates:
         - metadata:
             name: data

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -58,6 +58,10 @@ spec:
       # Rook can configure the OSD running on PVC to accommodate that by tuning some of the Ceph internal
       # Currently, "gp2" has been identified as such
       tuneDeviceClass: true
+      # Certain storage class in the Cloud are fast
+      # Rook can configure the OSD running on PVC to accommodate that by tuning some of the Ceph internal
+      # Currently, "managed-premium" has been identified as such
+      tuneFastDeviceClass: false
       # whether to encrypt the deviceSet or not
       encrypted: false
       # Since the OSDs could end up on any node, an effort needs to be made to spread the OSDs

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -125,6 +125,7 @@ type StorageClassDeviceSet struct {
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"` // List of PVC templates for the underlying storage devices
 	Portable             bool                       `json:"portable,omitempty"`             // OSD portability across the hosts
 	TuneSlowDeviceClass  bool                       `json:"tuneDeviceClass,omitempty"`      // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
+	TuneFastDeviceClass  bool                       `json:"tuneFastDeviceClass,omitempty"`  // TuneFastDeviceClass Tune the OSD when running on a fast Device Class
 	SchedulerName        string                     `json:"schedulerName,omitempty"`        // Scheduler name for OSD pod placement
 	Encrypted            bool                       `json:"encrypted,omitempty"`            // Whether to encrypt the deviceSet
 }
@@ -137,10 +138,11 @@ type VolumeSource struct {
 	Placement           Placement                                       `json:"placement,omitempty"`
 	PreparePlacement    *Placement                                      `json:"preparePlacement,omitempty"`
 	Config              map[string]string                               `json:"config,omitempty"`
-	Portable            bool                                            `json:"portable,omitempty"`         // Portable OSD portability across the hosts
-	TuneSlowDeviceClass bool                                            `json:"tuneDeviceClass,omitempty"`  // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
-	SchedulerName       string                                          `json:"schedulerName,omitempty"`    // Scheduler name for OSD pod placement
-	CrushDeviceClass    string                                          `json:"crushDeviceClass,omitempty"` // CrushDeviceClass represents the crush device class for an OSD
-	Size                string                                          `json:"size,omitempty"`             // Size represents the size requested for the PVC
-	Encrypted           bool                                            `json:"encrypted,omitempty"`        // Whether to encrypt the deviceSet
+	Portable            bool                                            `json:"portable,omitempty"`            // Portable OSD portability across the hosts
+	TuneSlowDeviceClass bool                                            `json:"tuneDeviceClass,omitempty"`     // TuneSlowDeviceClass Tune the OSD when running on a slow Device Class
+	TuneFastDeviceClass bool                                            `json:"tuneFastDeviceClass,omitempty"` // TuneFastDeviceClass Tune the OSD when running on a Fast Device Class
+	SchedulerName       string                                          `json:"schedulerName,omitempty"`       // Scheduler name for OSD pod placement
+	CrushDeviceClass    string                                          `json:"crushDeviceClass,omitempty"`    // CrushDeviceClass represents the crush device class for an OSD
+	Size                string                                          `json:"size,omitempty"`                // Size represents the size requested for the PVC
+	Encrypted           bool                                            `json:"encrypted,omitempty"`           // Whether to encrypt the deviceSet
 }

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -94,6 +94,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 				PVCSources:          pvcSources,
 				Portable:            storageClassDeviceSet.Portable,
 				TuneSlowDeviceClass: storageClassDeviceSet.TuneSlowDeviceClass,
+				TuneFastDeviceClass: storageClassDeviceSet.TuneFastDeviceClass,
 				SchedulerName:       storageClassDeviceSet.SchedulerName,
 				CrushDeviceClass:    crushDeviceClass,
 				Encrypted:           storageClassDeviceSet.Encrypted,

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -135,6 +135,7 @@ type osdProperties struct {
 	metadataDevice      string
 	portable            bool
 	tuneSlowDeviceClass bool
+	tuneFastDeviceClass bool
 	schedulerName       string
 	crushDeviceClass    string
 	encrypted           bool
@@ -705,6 +706,7 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				preparePlacement:    volumeSource.PreparePlacement,
 				portable:            volumeSource.Portable,
 				tuneSlowDeviceClass: volumeSource.TuneSlowDeviceClass,
+				tuneFastDeviceClass: volumeSource.TuneFastDeviceClass,
 				pvcSize:             volumeSource.Size,
 				schedulerName:       volumeSource.SchedulerName,
 				encrypted:           volumeSource.Encrypted,

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -331,6 +331,22 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 1, len(blkInitCont.VolumeDevices))
 	blkMetaInitCont = deployment.Spec.Template.Spec.InitContainers[8]
 	assert.Equal(t, 1, len(blkMetaInitCont.VolumeDevices))
+
+	// Test tune Fast settings when OSD on PVC
+	osdProp.tuneFastDeviceClass = true
+	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
+	assert.NoError(t, err)
+	for flag, val := range defaultTuneFastSettings {
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, opconfig.NewFlag(flag, val))
+	}
+
+	// Test tune Slow settings when OSD on PVC
+	osdProp.tuneSlowDeviceClass = true
+	deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
+	assert.NoError(t, err)
+	for flag, val := range defaultTuneSlowSettings {
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, opconfig.NewFlag(flag, val))
+	}
 }
 
 func verifyEnvVar(t *testing.T, envVars []v1.EnvVar, expectedName, expectedValue string, expectedFound bool) {


### PR DESCRIPTION
On Azure, all SSDs are reporting as a rotational disk.
This commit will add `tuneFastDeviceClass` flag which will
tune for an SSD even if the cloud provider is reporting
rotational.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6153 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
