### PR TITLE
ceph: allow osd pvc template name set to any value

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package osd
 
 import (
+	"fmt"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -30,6 +31,11 @@ import (
 )
 
 func TestPrepareDeviceSets(t *testing.T) {
+	testPrepareDeviceSets(t, true)
+	testPrepareDeviceSets(t, false)
+}
+
+func testPrepareDeviceSets(t *testing.T, setTemplateName bool) {
 	clientset := testexec.New(t, 1)
 	context := &clusterd.Context{
 		Clientset: clientset,
@@ -38,6 +44,9 @@ func TestPrepareDeviceSets(t *testing.T) {
 	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
 		StorageClassName: &storageClass,
 	}}
+	if setTemplateName {
+		claim.Name = "randomname"
+	}
 	deviceSet := rookv1.StorageClassDeviceSet{
 		Name:                 "mydata",
 		Count:                1,
@@ -68,7 +77,11 @@ func TestPrepareDeviceSets(t *testing.T) {
 	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(pvcs.Items))
-	assert.Equal(t, "mydata-data-0-", pvcs.Items[0].GenerateName)
+	expectedName := claim.Name
+	if !setTemplateName {
+		expectedName = "data"
+	}
+	assert.Equal(t, fmt.Sprintf("mydata-%s-0-", expectedName), pvcs.Items[0].GenerateName)
 	assert.Equal(t, cluster.clusterInfo.Namespace, pvcs.Items[0].Namespace)
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The pvc template name has either been require to be empty, or one of the expected values such as data and metadata. Those who upgrade from 1.1 may find that if they changed it to something else, their upgrade will fail when not one of these values. If there is only a single template, always treat it as the data template.

This is related to #5639 where names started being enforced in the templates.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
