### PR TITLE
ceph: stop using hosnetwork for ceph-csi rbd

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -16,7 +16,6 @@ spec:
         contains: csi-cephfsplugin-metrics
     spec:
       serviceAccount: rook-csi-cephfs-plugin-sa
-      hostNetwork: true
       {{ if .PluginPriorityClassName }}
       priorityClassName: {{ .PluginPriorityClassName }}
       {{ end }}

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -19,7 +19,6 @@ spec:
       {{ if .PluginPriorityClassName }}
       priorityClassName: {{ .PluginPriorityClassName }}
       {{ end }}
-      hostNetwork: true
       hostPID: true
       # to use e.g. Rook orchestrated cluster, and mons' FQDN is
       # resolved through k8s service, set dns policy to cluster first

--- a/cluster/examples/kubernetes/ceph/direct-mount.yaml
+++ b/cluster/examples/kubernetes/ceph/direct-mount.yaml
@@ -44,8 +44,6 @@ spec:
             name: libmodules
           - name: mon-endpoint-volume
             mountPath: /etc/rook
-      # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
-      hostNetwork: true
       volumes:
         - name: dev
           hostPath:


### PR DESCRIPTION
**Description of your changes:**

To properly support multus in ceph-csi work was done to remove the usage
of hostnetworking.
Thus removing it from the templates.

Relies on https://github.com/ceph/ceph-csi/pull/1450

Signed-off-by: Sébastien Han <seb@redhat.com>

**WARNING: We must wait for a ceph-csi release that Rook will incorporate before merging this.**
