### PR TITLE
ceph: Allow osd pvc template name set to any value (bp #6307)

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -56,12 +56,19 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 					continue
 				}
 
-				if pvcTemplate.Name == bluestorePVCData {
+				// The PVC type must be from a predefined set such as "data" and "metadata". These names must be enforced if the wal/db are specified
+				// with a separate device, but if there is a single volume template we can assume it is always the data template.
+				pvcType := pvcTemplate.Name
+				if len(storageClassDeviceSet.VolumeClaimTemplates) == 1 {
+					pvcType = bluestorePVCData
+				}
+
+				if pvcType == bluestorePVCData {
 					pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
 					dataSize = pvcSize.String()
 					crushDeviceClass = pvcTemplate.Annotations["crushDeviceClass"]
 				}
-				pvcSources[pvcTemplate.Name] = v1.PersistentVolumeClaimVolumeSource{
+				pvcSources[pvcType] = v1.PersistentVolumeClaimVolumeSource{
 					ClaimName: pvc.GetName(),
 					ReadOnly:  false,
 				}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The pvc template name has either been require to be empty, or one of the expected values such as data and metadata. Those who upgrade from 1.1 may find that if they changed it to something else, their upgrade will fail when not one of these values. If there is only a single template, always treat it as the data template.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
