### PR TITLE
ceph: Detect OSDs on PVCs in batches instead of with label selectors individually

### DIFF
--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -31,6 +31,12 @@ import (
 func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv1.VolumeSource {
 	volumeSources := []rookv1.VolumeSource{}
 
+	existingPVCs, err := c.getExistingOSDPVCs()
+	if err != nil {
+		config.addError("failed to detect existing OSD PVCs. %v", err)
+		return volumeSources
+	}
+
 	// Iterate over storageClassDeviceSet
 	for _, storageClassDeviceSet := range c.spec.Storage.StorageClassDeviceSets {
 		if err := controller.CheckPodMemory(cephv1.ResourcesKeyPrepareOSD, storageClassDeviceSet.Resources, cephOsdPodMinimumMemory); err != nil {
@@ -54,7 +60,7 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 					pvcTemplate.Name = bluestorePVCData
 				}
 
-				pvc, err := c.createStorageClassDeviceSetPVC(storageClassDeviceSet.Name, pvcTemplate, i)
+				pvc, newPVC, err := c.createStorageClassDeviceSetPVC(existingPVCs, storageClassDeviceSet.Name, pvcTemplate, i)
 				if err != nil {
 					config.addError("failed to create osd for storageClassDeviceSet %q for count %d. %v", storageClassDeviceSet.Name, i, err)
 					continue
@@ -76,7 +82,9 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 					ClaimName: pvc.GetName(),
 					ReadOnly:  false,
 				}
-				logger.Infof("successfully provisioned pvc %q for VolumeClaimTemplates %q for storageClassDeviceSet %q of set %v", pvc.GetName(), pvcTemplate.GetName(), storageClassDeviceSet.Name, i)
+				if newPVC {
+					logger.Infof("successfully provisioned pvc %q for VolumeClaimTemplates %q for storageClassDeviceSet %q of set %v", pvc.GetName(), pvcTemplate.GetName(), storageClassDeviceSet.Name, i)
+				}
 			}
 
 			volumeSources = append(volumeSources, rookv1.VolumeSource{
@@ -99,49 +107,34 @@ func (c *Cluster) prepareStorageClassDeviceSets(config *provisionConfig) []rookv
 	return volumeSources
 }
 
-func (c *Cluster) createStorageClassDeviceSetPVC(storageClassDeviceSetName string, pvcTemplate v1.PersistentVolumeClaim, setIndex int) (*v1.PersistentVolumeClaim, error) {
-	// old labels and PVC ID
-	pvcStorageClassDeviceSetPVCId, pvcStorageClassDeviceSetPVCIdLabelSelector := makeStorageClassDeviceSetPVCID(storageClassDeviceSetName, setIndex)
+func (c *Cluster) createStorageClassDeviceSetPVC(existingPVCs map[string]*v1.PersistentVolumeClaim, storageClassDeviceSetName string, pvcTemplate v1.PersistentVolumeClaim, setIndex int) (*v1.PersistentVolumeClaim, bool, error) {
+	// old labels and PVC ID for backward compatibility
+	pvcStorageClassDeviceSetPVCId := legacyDeviceSetPVCID(storageClassDeviceSetName, setIndex)
+
+	// check for the existence of the pvc
+	existingPVC, ok := existingPVCs[pvcStorageClassDeviceSetPVCId]
+	if !ok {
+		// The old name of the PVC didn't exist, now try the new PVC name and label
+		pvcStorageClassDeviceSetPVCId = deviceSetPVCID(storageClassDeviceSetName, pvcTemplate.GetName(), setIndex)
+		existingPVC = existingPVCs[pvcStorageClassDeviceSetPVCId]
+	}
 	pvc := makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId, setIndex, pvcTemplate)
-	oldPresentPVCs, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).List(metav1.ListOptions{LabelSelector: pvcStorageClassDeviceSetPVCIdLabelSelector})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list pvc %s for storageClassDeviceSet %s", pvcStorageClassDeviceSetPVCIdLabelSelector, storageClassDeviceSetName)
+
+	if existingPVC != nil {
+		logger.Infof("OSD PVC %q already exists", existingPVC.Name)
+
+		// Update the PVC in case the size changed
+		c.updatePVCIfChanged(pvc, existingPVC)
+		return existingPVC, false, nil
 	}
 
-	// return old labeled pvc, if we find any
-	if len(oldPresentPVCs.Items) == 1 {
-		logger.Debugf("old labeled pvc %q found", oldPresentPVCs.Items[0].Name)
-		c.updatePVCIfChanged(pvc, &oldPresentPVCs.Items[0])
-		return &oldPresentPVCs.Items[0], nil
-	}
-
-	// check again with the new label for the presence of updated pvc
-	pvcStorageClassDeviceSetPVCId, pvcStorageClassDeviceSetPVCIdLabelSelector = makeStorageClassDeviceSetPVCIDNew(storageClassDeviceSetName, pvcTemplate.GetName(), setIndex)
-	pvc = makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId, setIndex, pvcTemplate)
-	presentPVCs, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).List(metav1.ListOptions{LabelSelector: pvcStorageClassDeviceSetPVCIdLabelSelector})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list pvc %s for storageClassDeviceSet %s", pvcStorageClassDeviceSetPVCIdLabelSelector, storageClassDeviceSetName)
-	}
-
-	presentPVCsNum := len(presentPVCs.Items)
 	// No PVC found, creating a new one
-	if presentPVCsNum == 0 {
-		deployedPVC, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).Create(pvc)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create pvc %q for storageClassDeviceSet %q", pvc.GetGenerateName(), storageClassDeviceSetName)
-		}
-		logger.Debugf("just created pvc %q", deployedPVC.Name)
-		return deployedPVC, nil
-		// The PVC is already present
-	} else if presentPVCsNum == 1 {
-		logger.Debugf("already present pvc %q", presentPVCs.Items[0].Name)
-		c.updatePVCIfChanged(pvc, &presentPVCs.Items[0])
-
-		// Updating with the new label
-		return &presentPVCs.Items[0], nil
+	deployedPVC, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).Create(pvc)
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "failed to create pvc %q for storageClassDeviceSet %q", pvc.GetGenerateName(), storageClassDeviceSetName)
 	}
-	// More than one PVC exists with same labelSelector
-	return nil, errors.Errorf("more than one PVCs exists with label %q, pvcs %q", pvcStorageClassDeviceSetPVCIdLabelSelector, presentPVCs)
+	logger.Debugf("just created pvc %q", deployedPVC.Name)
+	return deployedPVC, true, nil
 }
 
 func (c *Cluster) updatePVCIfChanged(desiredPVC *v1.PersistentVolumeClaim, currentPVC *v1.PersistentVolumeClaim) {
@@ -186,14 +179,27 @@ func makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDevi
 	}
 }
 
-func makeStorageClassDeviceSetPVCID(storageClassDeviceSetName string, setIndex int) (pvcID, pvcLabelSelector string) {
-	pvcStorageClassDeviceSetPVCId := fmt.Sprintf("%s-%d", storageClassDeviceSetName, setIndex)
-	return pvcStorageClassDeviceSetPVCId, fmt.Sprintf("%s=%s", CephDeviceSetPVCIDLabelKey, pvcStorageClassDeviceSetPVCId)
+func (c *Cluster) getExistingOSDPVCs() (map[string]*v1.PersistentVolumeClaim, error) {
+	selector := metav1.ListOptions{LabelSelector: CephDeviceSetPVCIDLabelKey}
+	pvcs, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.clusterInfo.Namespace).List(selector)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to detect pvcs")
+	}
+	result := map[string]*v1.PersistentVolumeClaim{}
+	for i, pvc := range pvcs.Items {
+		pvcID := pvc.Labels[CephDeviceSetPVCIDLabelKey]
+		result[pvcID] = &pvcs.Items[i]
+	}
+
+	return result, nil
+}
+
+func legacyDeviceSetPVCID(storageClassDeviceSetName string, setIndex int) string {
+	return fmt.Sprintf("%s-%d", storageClassDeviceSetName, setIndex)
 }
 
 // This is the new function that generates the labels
 // It includes the pvcTemplateName in it
-func makeStorageClassDeviceSetPVCIDNew(storageClassDeviceSetName, pvcTemplateName string, setIndex int) (pvcID, pvcLabelSelector string) {
-	pvcStorageClassDeviceSetPVCId := fmt.Sprintf("%s-%s-%d", storageClassDeviceSetName, strings.Replace(pvcTemplateName, " ", "-", -1), setIndex)
-	return pvcStorageClassDeviceSetPVCId, fmt.Sprintf("%s=%s", CephDeviceSetPVCIDLabelKey, pvcStorageClassDeviceSetPVCId)
+func deviceSetPVCID(storageClassDeviceSetName, pvcTemplateName string, setIndex int) string {
+	return fmt.Sprintf("%s-%s-%d", storageClassDeviceSetName, strings.Replace(pvcTemplateName, " ", "-", -1), setIndex)
 }

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -223,6 +223,12 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 		return
 	}
 
+	existingDeployments, err := c.getExistingOSDDeploymentsOnPVCs()
+	if err != nil {
+		config.addError("failed to query existing OSD deployments on PVCs. %v", err)
+		return
+	}
+
 	for _, volume := range c.ValidStorage.VolumeSources {
 		dataSource, dataOK := volume.PVCSources[bluestorePVCData]
 
@@ -292,34 +298,23 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 			}
 		}
 
-		// Update the orchestration status of this pvc to the starting state
-		status := OrchestrationStatus{Status: OrchestrationStatusStarting, PvcBackedOSD: true}
-		c.updateOSDStatus(osdProps.crushHostname, status)
-
 		// Skip OSD prepare if deployment already exists for the PVC
-		listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
-			k8sutil.AppAttr, AppName,
-			OSDOverPVCLabelKey, dataSource.ClaimName,
-		)}
-
-		osdDeployments, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).List(listOpts)
-		if err != nil {
-			config.addError("failed to check if OSD daemon exists for pvc %q. %v", osdProps.crushHostname, err)
-			continue
-		}
-
-		if len(osdDeployments.Items) != 0 {
+		if osdDeployment, ok := existingDeployments[dataSource.ClaimName]; ok {
 			logger.Infof("skip OSD prepare pod creation as OSD daemon already exists for %q", osdProps.crushHostname)
-			osds, err := c.getOSDInfo(&osdDeployments.Items[0])
+			osds, err := c.getOSDInfo(osdDeployment)
 			if err != nil {
 				config.addError("failed to get osdInfo for pvc %q. %v", osdProps.crushHostname, err)
 				continue
 			}
 			// Update the orchestration status of this pvc to the completed state
-			status = OrchestrationStatus{OSDs: osds, Status: OrchestrationStatusCompleted, PvcBackedOSD: true}
+			status := OrchestrationStatus{OSDs: osds, Status: OrchestrationStatusCompleted, PvcBackedOSD: true}
 			c.updateOSDStatus(osdProps.crushHostname, status)
 			continue
 		}
+
+		// Update the orchestration status of this pvc to the starting state
+		status := OrchestrationStatus{Status: OrchestrationStatusStarting, PvcBackedOSD: true}
+		c.updateOSDStatus(osdProps.crushHostname, status)
 
 		job, err := c.makeJob(osdProps, config)
 		if err != nil {
@@ -340,6 +335,24 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 	}
 	logger.Infof("start osds after provisioning is completed, if needed")
 	c.completeProvision(config)
+}
+
+func (c *Cluster) getExistingOSDDeploymentsOnPVCs() (map[string]*apps.Deployment, error) {
+	listOpts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s,%s", k8sutil.AppAttr, AppName, OSDOverPVCLabelKey)}
+
+	deployments, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).List(listOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to query existing OSD deployments")
+	}
+
+	result := map[string]*apps.Deployment{}
+	for i, deployment := range deployments.Items {
+		if pvcID, ok := deployment.Labels[OSDOverPVCLabelKey]; ok {
+			result[pvcID] = &deployments.Items[i]
+		}
+	}
+
+	return result, nil
 }
 
 func (c *Cluster) startProvisioningOverNodes(config *provisionConfig) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The OSDs on PVCs were being reconciled inefficiently one by one with a label selector. This proves to be slow in large clusters. Instead, we now make this more efficient by querying for all existing PVCs and deployments and looking them up in memory with a map. This will save several minutes for the reconcile in a cluster with 100 OSDs.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
