### PR TITLE
docs: fix typo in ObjectMultisite docs

### DIFF
--- a/Documentation/ceph-object-multisite-crd.md
+++ b/Documentation/ceph-object-multisite-crd.md
@@ -78,7 +78,7 @@ metadata:
   name: zone-a
   namespace: rook-ceph
 spec:
-  zonegroup: zonegroup-a
+  zoneGroup: zonegroup-a
   metadataPool:
     failureDomain: host
     replicated:

--- a/Documentation/ceph-object-multisite.md
+++ b/Documentation/ceph-object-multisite.md
@@ -185,7 +185,7 @@ The Rook toolbox can modify the Ceph Multisite state via the radosgw-admin comma
 The following command, run via the toolbox, deletes the realm.
 
 ```console
-radosgw-admin realm rm --rgw-realm=realm-a
+radosgw-admin realm delete --rgw-realm=realm-a
 ```
 
 ## Zone Group Deletion
@@ -202,7 +202,7 @@ The following command, run via the toolbox, deletes the zone group.
 
 ```console
 radosgw-admin zonegroup delete --rgw-realm=realm-a --rgw-zonegroup=zone-group-a
-radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zone-group=zone-group-a
+radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zonegroup=zone-group-a
 ```
 
 ## Deleting and Reconfiguring the Ceph Object Zone
@@ -229,8 +229,8 @@ There are two scenarios possible when deleting a zone.
 The following commands, run via the toolbox, deletes the zone if there is only one zone in the zone group.
 
 ```console
-radosgw-admin zone rm --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
-radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
+radosgw-admin zone delete --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
+radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
 ```
 
 In the other scenario, there are more than one zones in a zone group.
@@ -242,10 +242,10 @@ Please read the following [documentation](https://docs.ceph.com/docs/master/rado
 The following commands, run via toolboxes, remove the zone from the zone group first, then delete the zone.
 
 ```console
-radosgw-admin zonegroup rm --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
-radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
-radosgw-admin zone rm --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
-radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zone-group=zone-group-a --rgw-zone=zone-a
+radosgw-admin zonegroup rm --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
+radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
+radosgw-admin zone delete --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
+radosgw-admin period update --commit --rgw-realm=realm-a --rgw-zonegroup=zone-group-a --rgw-zone=zone-a
 ```
 
 When a zone is deleted, the pools for that zone are not deleted.


### PR DESCRIPTION
**Description of your changes:**
* fix typo `zoneGroup` in ['Object Multisite CRDs' docs](https://rook.io/docs/rook/v1.4/ceph-object-multisite-crd.html#ceph-object-zone-crd)
* fix cleanup instruction in ['Object Multisite' docs](https://rook.io/docs/rook/v1.4/ceph-object-multisite.html)

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]