### PR TITLE
ceph: remove endpoint related changes from obc workflow

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner_test.go
+++ b/pkg/operator/ceph/object/bucket/provisioner_test.go
@@ -44,29 +44,6 @@ func TestPopulateDomainAndPort(t *testing.T) {
 		},
 	}
 
-	// No endpoint and no CephObjectStore
-	err := p.populateDomainAndPort(sc)
-	assert.Error(t, err)
-
-	// Endpoint is set but port is missing
-	sc.Parameters["endpoint"] = "192.168.0.1"
-	err = p.populateDomainAndPort(sc)
-	assert.Error(t, err)
-
-	// Endpoint is set but IP is missing
-	sc.Parameters["endpoint"] = ":80"
-	err = p.populateDomainAndPort(sc)
-	assert.Error(t, err)
-
-	// Endpoint is correct
-	sc.Parameters["endpoint"] = "192.168.0.1:80"
-	err = p.populateDomainAndPort(sc)
-	assert.NoError(t, err)
-	assert.Equal(t, "192.168.0.1", p.storeDomainName)
-	assert.Equal(t, int32(80), p.storePort)
-
-	// No endpoint but a CephObjectStore
-	sc.Parameters["endpoint"] = ""
 	sc.Parameters["objectStoreNamespace"] = namespace
 	sc.Parameters["objectStoreName"] = store
 	cephObjectStore := &cephv1.CephObjectStore{
@@ -93,7 +70,7 @@ func TestPopulateDomainAndPort(t *testing.T) {
 		},
 	}
 
-	_, err = p.context.RookClientset.CephV1().CephObjectStores(namespace).Create(cephObjectStore)
+	_, err := p.context.RookClientset.CephV1().CephObjectStores(namespace).Create(cephObjectStore)
 	assert.NoError(t, err)
 	_, err = p.context.Clientset.CoreV1().Services(namespace).Create(svc)
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -42,7 +42,6 @@ const (
 	cephUser             = "cephUser"
 	objectStoreName      = "objectStoreName"
 	objectStoreNamespace = "objectStoreNamespace"
-	objectStoreEndpoint  = "endpoint"
 )
 
 func NewBucketController(cfg *rest.Config, p *Provisioner) (*provisioner.Provisioner, error) {
@@ -59,10 +58,6 @@ func getObjectStoreName(sc *storagev1.StorageClass) string {
 
 func getObjectStoreNameSpace(sc *storagev1.StorageClass) string {
 	return sc.Parameters[objectStoreNamespace]
-}
-
-func getObjectStoreEndpoint(sc *storagev1.StorageClass) string {
-	return sc.Parameters[objectStoreEndpoint]
 }
 
 func getBucketName(ob *bktv1alpha1.ObjectBucket) string {


### PR DESCRIPTION
For external cluster the end point info is saved as part of storageclass of the obc,
which is no longer required. Removing those code changes.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
