### PR TITLE
ceph: remove user unlink while deleting OBC

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -203,11 +203,6 @@ func (p Provisioner) Delete(ob *bktv1alpha1.ObjectBucket) error {
 	}
 	logger.Infof("Delete: deleting bucket %q for OB %q", p.bucketName, ob.Name)
 
-	_, _, err = cephObject.UnlinkUser(p.objectContext, p.cephUserName, p.bucketName)
-	if err != nil {
-		return err
-	}
-
 	if err := p.deleteOBCResource(p.bucketName); err != nil {
 		return errors.Wrapf(err, "error deleting OBCResource bucket %q", p.bucketName)
 	}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -224,20 +224,6 @@ func LinkUser(c *Context, id, bucket string) (string, int, error) {
 	return result, RGWErrorNone, nil
 }
 
-// UnlinkUser will unlink the user from a bucket
-func UnlinkUser(c *Context, id, bucket string) (string, int, error) {
-	logger.Infof("Unlinking (user: %s) (bucket: %s)", id, bucket)
-	args := []string{"bucket", "unlink", "--uid", id, "--bucket", bucket}
-	result, err := runAdminCommand(c, args...)
-	if err != nil {
-		return "", RGWErrorUnknown, err
-	}
-	if strings.Contains(result, "bucket entry point user mismatch") {
-		return "", RGWErrorNotFound, err
-	}
-	return result, RGWErrorNone, nil
-}
-
 // EnableUserQuota will allows to enable quota defined for a user
 func EnableUserQuota(c *Context, id string) (string, error) {
 	logger.Debug("Enabling user quota for %q", id)


### PR DESCRIPTION
User unlink is performed just before deleting OBC resources.
Since user is internal to OBC and next to remove to delete user,
unlinking user is not necessary.

Resolves: #6300
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
