### PR TITLE
ceph: only support one external cluster secret

### DIFF
--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -65,6 +65,10 @@ function checkEnvVars() {
             exit 1
         fi
     fi
+    if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ] ; then
+        echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
+        exit 1
+    fi
 }
 
 function importSecret() {


### PR DESCRIPTION
**Description of your changes:**

We do not support providing both ROOK_EXTERNAL_USER_SECRET and
ROOK_EXTERNAL_ADMIN_SECRET. When both are provided in the mon secret,
the operator code will use the client.admin user for all its operations.
This will break some of the logic when creating OBC since if
client.admin is detected we assume the cluster is converged and thus
pass args like this:

```
--rgw-realm=external-store --rgw-zonegroup=external-store --rgw-zone=external-store
```

To the radosgw-admin command, which won't work since Rook has no idea
what the external realm/zonegroup/zone are, if any are configured.

This fix should be sufficient for now, but moving forward we should
probably enhance clusterInfo with an "isExternal" property to make
things easier. Also supporting external realm/zonegroup/zone would be
nice. This will probanly hit 1.5 once this code is promoted to stable.
See: https://github.com/rook/rook/issues/6342

Closes: https://github.com/rook/rook/issues/6329
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6342

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]