### PR TITLE
ceph: fix obc upgrade from 1.3 to 1.4 external cluster

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -402,14 +402,23 @@ func (p *Provisioner) setObjectContext() error {
 		return errors.Errorf(msg, "name")
 	}
 
-	store, err := p.getObjectStore()
-	if err != nil {
-		return errors.Wrap(err, "failed to get cephObjectStore")
-	}
+	// We don't need the CephObjectStore if an endpoint is provided
+	// In 1.3, OBC external is working with an Endpoint (from the SC param) and in 1.4 we have a CephObjectStore but we must keep backward compatibility
+	// In 1.4, the Endpoint from the SC is not expected and never used so we will enter the "else" condition which gets a CephObjectStore and it is present
+	if p.endpoint != "" {
+		p.objectContext = cephObject.NewContext(p.context, p.clusterInfo, p.objectStoreName)
+	} else {
+		// Get CephObjectStore
+		store, err := p.getObjectStore()
+		if err != nil {
+			return errors.Wrap(err, "failed to get cephObjectStore")
+		}
 
-	p.objectContext, err = cephObject.NewMultisiteContext(p.context, p.clusterInfo, store)
-	if err != nil {
-		return errors.Wrapf(err, "failed to set multisite on provisioner's objectContext")
+		// Set multisite context
+		p.objectContext, err = cephObject.NewMultisiteContext(p.context, p.clusterInfo, store)
+		if err != nil {
+			return errors.Wrap(err, "failed to set multisite on provisioner's objectContext")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**Description of your changes:**

During the 1.3 cycle, we had implemented support for OBC external mode
through an Endpoint in the StorageClass parameter. In 1.4, this is not
the case anymore as we directly use the CephObjectStore external mode.
However, we must maintain backward compatibility with the cluster using the
Endpoint and not fail the upgrade.
Thus checking for a CephObjectStore is invalid and should not always be
assumed, now if we detect an Endpoint we return a simple context which
fixes the upgrade.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
