### PR TITLE
ceph: flex test failing in CI

### DIFF
--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -329,7 +329,7 @@ func cleanupFilesystemConsumer(helper *clients.TestClient, k8sh *utils.K8sHelper
 		assert.Fail(s.T(), fmt.Sprintf("make sure %s pod is terminated", podName))
 	}
 	err = helper.FSClient.DeletePVC(namespace, podName)
-	assert.NoError(s.T(), err)
+	assertNoErrorUnlessNotFound(s, err)
 	logger.Infof("File system consumer deleted")
 }
 

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -167,9 +167,9 @@ func (s *CephFlexDriverSuite) statefulSetDataCleanup(poolName, storageClassName,
 	listOpts := metav1.ListOptions{LabelSelector: "app=" + statefulSetName}
 	// Delete stateful set
 	err := s.kh.Clientset.CoreV1().Services(defaultNamespace).Delete(statefulSetName, &delOpts)
-	assert.NoError(s.T(), err)
+	assertNoErrorUnlessNotFound(s.Suite, err)
 	err = s.kh.Clientset.AppsV1().StatefulSets(defaultNamespace).Delete(statefulPodsName, &delOpts)
-	assert.NoError(s.T(), err)
+	assertNoErrorUnlessNotFound(s.Suite, err)
 	err = s.kh.Clientset.CoreV1().Pods(defaultNamespace).DeleteCollection(&delOpts, listOpts)
 	assert.NoError(s.T(), err)
 
@@ -236,9 +236,9 @@ func (s *CephFlexDriverSuite) TearDownSuite() {
 		"rwo-block-ro-two", "rwx-block-rw-one", "rwx-block-rw-two", "rwx-block-ro-one", "rwx-block-ro-two")
 	assert.NoError(s.T(), err)
 	err = s.testClient.BlockClient.DeletePVC(s.namespace, s.pvcNameRWO)
-	assert.NoError(s.T(), err)
+	assertNoErrorUnlessNotFound(s.Suite, err)
 	err = s.testClient.BlockClient.DeletePVC(s.namespace, s.pvcNameRWX)
-	assert.NoError(s.T(), err)
+	assertNoErrorUnlessNotFound(s.Suite, err)
 	err = s.testClient.BlockClient.DeleteStorageClass("rook-ceph-block-rwo")
 	assert.NoError(s.T(), err)
 	err = s.testClient.BlockClient.DeleteStorageClass("rook-ceph-block-rwx")


### PR DESCRIPTION
this commit will add error not found condition
check before assert delete on PVC and
statefulset due to whch flex test was failing.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6361

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
[test full]
