### PR TITLE
ceph: remove suffix _sdd for tuneFastDeviceClass

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -148,19 +148,19 @@ fi
 
 // OSDs on PVC using a certain fast storage class need to do some tuning
 var defaultTuneFastSettings = map[string]string{
-	"osd_op_num_threads_per_shard_ssd":        "2",          // Default value of osd_op_num_threads_per_shard for SSDs
-	"osd_op_num_shards_ssd":                   "8",          // Default value of osd_op_num_shards for SSDs
-	"osd_recovery_sleep_ssd":                  "0",          // Time in seconds to sleep before next recovery or backfill op for SSDs
-	"osd_snap_trim_sleep_ssd":                 "0",          // Time in seconds to sleep before next snap trim for SSDs
-	"osd_delete_sleep_ssd":                    "0",          // Time in seconds to sleep before next removal transaction for SSDs
-	"bluestore_min_alloc_size_ssd":            "4096",       // Default min_alloc_size value for SSDs
-	"bluestore_prefer_deferred_size_ssd":      "0",          // Default value of bluestore_prefer_deferred_size for SSDs
-	"bluestore_compression_min_blob_size_ssd": "8912",       // Default value of bluestore_compression_min_blob_size for SSDs
-	"bluestore_compression_max_blob_size_ssd": "65536",      // Default value of bluestore_compression_max_blob_size for SSDs
-	"bluestore_max_blob_size_ssd":             "65536",      // Default value of bluestore_max_blob_size for SSDs
-	"bluestore_cache_size_ssd":                "3221225472", // Default value of bluestore_cache_size for SSDs
-	"bluestore_throttle_cost_per_io_ssd":      "4000",       // Default value of bluestore_throttle_cost_per_io for SSDs
-	"bluestore_deferred_batch_ops_ssd":        "16",         // Default value of bluestore_deferred_batch_ops for SSDs
+	"osd_op_num_threads_per_shard":        "2",          // Default value of osd_op_num_threads_per_shard for SSDs
+	"osd_op_num_shards":                   "8",          // Default value of osd_op_num_shards for SSDs
+	"osd_recovery_sleep":                  "0",          // Time in seconds to sleep before next recovery or backfill op for SSDs
+	"osd_snap_trim_sleep":                 "0",          // Time in seconds to sleep before next snap trim for SSDs
+	"osd_delete_sleep":                    "0",          // Time in seconds to sleep before next removal transaction for SSDs
+	"bluestore_min_alloc_size":            "4096",       // Default min_alloc_size value for SSDs
+	"bluestore_prefer_deferred_size":      "0",          // Default value of bluestore_prefer_deferred_size for SSDs
+	"bluestore_compression_min_blob_size": "8912",       // Default value of bluestore_compression_min_blob_size for SSDs
+	"bluestore_compression_max_blob_size": "65536",      // Default value of bluestore_compression_max_blob_size for SSDs
+	"bluestore_max_blob_size":             "65536",      // Default value of bluestore_max_blob_size for SSDs
+	"bluestore_cache_size":                "3221225472", // Default value of bluestore_cache_size for SSDs
+	"bluestore_throttle_cost_per_io":      "4000",       // Default value of bluestore_throttle_cost_per_io for SSDs
+	"bluestore_deferred_batch_ops":        "16",         // Default value of bluestore_deferred_batch_ops for SSDs
 }
 
 // OSDs on PVC using a certain slow storage class need to do some tuning


### PR DESCRIPTION
this commit remove _ssd  suffix from
tuneFastDeviceClass setting as with _ssd
won't affect disk.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
