### PR TITLE
ceph: tune osd tcmalloc thread cache bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200319210407-521f4a0cd458 // indirect
 	google.golang.org/grpc v1.26.0 // indirect
-	gopkg.in/ini.v1 v1.51.1 // indirect
+	gopkg.in/ini.v1 v1.51.1
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/pkg/operator/ceph/cluster/osd/envs_test.go
+++ b/pkg/operator/ceph/cluster/osd/envs_test.go
@@ -17,9 +17,32 @@ limitations under the License.
 package osd
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	sysconfig = []byte(`# /etc/sysconfig/ceph
+#
+# Environment file for ceph daemon systemd unit files.
+#
+
+# Increase tcmalloc cache size
+TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
+
+## automatically restart systemd units on upgrade
+#
+# By default, it is left to the administrator to restart
+# ceph daemons (or their related systemd units) manually
+# when the 'ceph' package is upgraded. By setting this
+# parameter to "yes", package upgrade will trigger a
+# "systemctl try-restart" on all the ceph systemd units
+# currently active on the node.
+#
+CEPH_AUTO_RESTART_ON_UPGRADE=no`)
 )
 
 func TestCephVolumeEnvVar(t *testing.T) {
@@ -44,4 +67,28 @@ func TestOsdActivateEnvVar(t *testing.T) {
 	assert.Equal(t, "ROOK_CEPH_MON_HOST", osdActivateEnv[3].Name)
 	assert.Equal(t, "CEPH_ARGS", osdActivateEnv[4].Name)
 	assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST)", osdActivateEnv[4].Value)
+}
+
+func TestGetTcmallocMaxTotalThreadCacheBytes(t *testing.T) {
+	// No file, nothing
+	v := getTcmallocMaxTotalThreadCacheBytes("")
+	assert.Equal(t, "", v.Value)
+
+	// File and arg are empty so we can an empty value
+	file, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+	cephEnvConfigFile = file.Name()
+	v = getTcmallocMaxTotalThreadCacheBytes("")
+	assert.Equal(t, "", v.Value)
+
+	// Arg is not empty
+	v = getTcmallocMaxTotalThreadCacheBytes("67108864")
+	assert.Equal(t, "67108864", v.Value)
+
+	// Read the file now
+	err = ioutil.WriteFile(file.Name(), sysconfig, 0444)
+	assert.NoError(t, err)
+	v = getTcmallocMaxTotalThreadCacheBytes("")
+	assert.Equal(t, "134217728", v.Value)
 }


### PR DESCRIPTION
**Description of your changes:**

We can now tune the value of TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES by
setting an annotation on the CephCluster CRD like so:

```
annotation:
  osd:
    TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES: "134217728"
```

Alternatively, if nothing is specified Rook will read the value of the
file `/etc/sysconfig/ceph`.

Closes: https://github.com/rook/rook/issues/6134
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
