### PR TITLE
ceph: update nfs ganesha rados config object

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -75,13 +75,13 @@ spec:
 
 ## EXPORT Block Configuration
 
-Each daemon will have a stock configuration with no exports defined, and that includes a RADOS object via:
+All daemons within a cluster will share configuration with no exports defined, and that includes a RADOS object via:
 
 ```ini
-%url  rados://<pool>/<namespace>/conf-<nodeid>
+%url  rados://<pool>/<namespace>/conf-nfs.<clustername>
 ```
 
-The pool and namespace are configured via the spec's RADOS block. The nodeid is a value automatically assigned internally by rook. Nodeids start with "a" and go through "z", at which point they become two letters ("aa" to "az").
+The pool and namespace are configured via the spec's RADOS block.
 
 When a server is started, it will create the included object if it does not already exist. It is possible to prepopulate the included objects prior to starting the server. The format for these objects is documented in the [NFS Ganesha](https://github.com/nfs-ganesha/nfs-ganesha/wiki) project.
 

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -47,18 +47,18 @@ func getNFSNodeID(n *cephv1.CephNFS, name string) string {
 	return fmt.Sprintf("%s.%s", n.Name, name)
 }
 
-func getGaneshaConfigObject(nodeID string) string {
-	return fmt.Sprintf("conf-%s", nodeID)
+func getGaneshaConfigObject(clusterName string) string {
+	return fmt.Sprintf("conf-nfs.%s", clusterName)
 }
 
-func getRadosURL(n *cephv1.CephNFS, nodeID string) string {
+func getRadosURL(n *cephv1.CephNFS) string {
 	url := fmt.Sprintf("rados://%s/", n.Spec.RADOS.Pool)
 
 	if n.Spec.RADOS.Namespace != "" {
 		url += n.Spec.RADOS.Namespace + "/"
 	}
 
-	url += getGaneshaConfigObject(nodeID)
+	url += getGaneshaConfigObject(n.Name)
 	return url
 }
 
@@ -91,7 +91,7 @@ func (r *ReconcileCephNFS) generateKeyring(n *cephv1.CephNFS, name string) error
 func getGaneshaConfig(n *cephv1.CephNFS, name string) string {
 	nodeID := getNFSNodeID(n, name)
 	userID := getNFSUserID(nodeID)
-	url := getRadosURL(n, nodeID)
+	url := getRadosURL(n)
 	return `
 NFS_CORE_PARAM {
 	Enable_NLM = false;

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -57,7 +57,7 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS, oldActive int) error {
 			return errors.Wrap(err, "failed to create config")
 		}
 
-		err = r.addRADOSConfigFile(n, id)
+		err = r.addRADOSConfigFile(n)
 		if err != nil {
 			return errors.Wrap(err, "failed to create RADOS config object")
 		}
@@ -125,9 +125,8 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS, oldActive int) error {
 }
 
 // Create empty config file for new ganesha server
-func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS, name string) error {
-	nodeID := getNFSNodeID(n, name)
-	config := getGaneshaConfigObject(nodeID)
+func (r *ReconcileCephNFS) addRADOSConfigFile(n *cephv1.CephNFS) error {
+	config := getGaneshaConfigObject(n.Name)
 	cmd := "rados"
 	args := []string{
 		"--pool", n.Spec.RADOS.Pool,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

In cephadm and volume/nfs module, all ganesha daemons within a cluster watch
single config object. Each ganesha daemon in rook watches it's own config
object. These patches updates the ganesha config object name to maintain
uniformity.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
