### PR TITLE
ci: fix an intermittent failure in uninstalling cluster.

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -956,7 +956,7 @@ func (h *CephInstaller) waitForCleanupJobs(namespace string) error {
 	}
 
 	logger.Info("waiting for job(s) to cleanup the host...")
-	err := wait.Poll(5*time.Second, 90*time.Second, allRookCephCleanupJobs)
+	err := wait.Poll(5*time.Second, 180*time.Second, allRookCephCleanupJobs)
 	if err != nil {
 		return fmt.Errorf("failed to wait for clean up jobs to complete. %+v", err)
 	}


### PR DESCRIPTION
**Description of your changes:**

Sometimes test suites of Ceph fail due to waiting for cleanup job in Rook uninstallation. In many cases, it doesn't mean this job's hangup. Otherwise, it comes from creating jobs takes a bit long time. Extending timeout resolves this problem.


Here is a log in failure.

```
...
2020-09-30 21:56:05.641957 D | exec: Running command: kubectl delete -n helm-ns cephcluster test-cluster --wait=false
2020-09-30 21:56:06.729630 I | installer: waiting for job(s) to cleanup the host...
2020-09-30 21:56:11.732103 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:16.731761 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:21.731816 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:26.731965 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:31.732026 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:36.732128 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:41.731997 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:46.732277 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:51.731917 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:56:56.731976 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:01.731952 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:06.732089 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:11.731916 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:16.731865 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:21.731984 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:26.732296 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:31.731969 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:36.732916 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:36.734590 I | installer: no jobs with label selector "app=rook-ceph-cleanup" found.
2020-09-30 21:57:36.734731 I | testutil: Running kubectl [delete -f -]
serviceaccount "rook-ceph-osd" deleted
serviceaccount "rook-ceph-mgr" deleted
serviceaccount "rook-ceph-cmd-reporter" deleted
role.rbac.authorization.k8s.io "rook-ceph-osd" deleted
role.rbac.authorization.k8s.io "rook-ceph-mgr" deleted
role.rbac.authorization.k8s.io "rook-ceph-cmd-reporter" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cluster-mgmt" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-osd" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-mgr" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cmd-reporter" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-default-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-osd-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-mgr-psp" deleted
rolebinding.rbac.authorization.k8s.io "rook-ceph-cmd-reporter-psp" deleted
Error from server (NotFound): error when deleting "STDIN": clusterrolebindings.rbac.authorization.k8s.io "rook-ceph-osd-helm-ns" not found
Error from server (NotFound): error when deleting "STDIN": clusterrolebindings.rbac.authorization.k8s.io "rook-ceph-mgr-cluster-helm-ns" not found
Error from server (NotFound): error when deleting "STDIN": rolebindings.rbac.authorization.k8s.io "rook-ceph-mgr-system helm-ns" not found
2020-09-30 21:57:36.861635 E | utils: Failed to execute stdin: kubectl [delete -f -] : exit status 1
2020-09-30 21:57:36.861658 E | installer: failed to delete cluster roles.  "" not found
2020-09-30 21:57:38.920475 I | installer: removed finalizers from cluster test-cluster
2020-09-30 21:57:38.920494 I | testutil: custom resource helm-ns still exists
2020-09-30 21:57:40.935153 E | installer: failed to remove finalizer. failed to get cluster. cephclusters.ceph.rook.io "test-cluster" not found
2020-09-30 21:57:40.935173 I | testutil: custom resource helm-ns deleted
2020-09-30 21:57:40.935184 D | exec: Running command: kubectl delete namespace helm-ns --wait=false
2020-09-30 21:57:41.015036 D | exec: Running command: kubectl delete namespace helm-ns-system --wait=false
2020-09-30 21:57:41.106870 E | utils: Failed to execute: kubectl [delete namespace helm-ns-system --wait=false] : exit status 1. Error from server (NotFound): namespaces "helm-ns-system" not found
2020-09-30 21:57:41.106909 I | installer: removing the operator from namespace helm-ns-system
2020-09-30 21:57:41.106928 D | exec: Running command: kubectl delete crd cephclusters.ceph.rook.io cephblockpools.ceph.rook.io cephobjectstores.ceph.rook.io cephobjectstoreusers.ceph.rook.io cephobjectrealms.ceph.rook.io cephobjectzonegroups.ceph.rook.io cephobjectzones.ceph.rook.io cephfilesystems.ceph.rook.io cephnfses.ceph.rook.io ceph
clients.ceph.rook.io volumes.rook.io objectbuckets.objectbucket.io objectbucketclaims.objectbucket.io cephrbdmirrors.ceph.rook.io
2020-09-30 21:57:42.997439 D | exec: Running command: /tmp/rook-tests-scripts-helm/linux-amd64/helm delete --purge rook-ceph
2020-09-30 21:57:46.435176 I | installer: done removing the operator from namespace helm-ns-system
2020-09-30 21:57:46.435199 I | installer: removing host data dir /home/ubuntu/workspace/rook_rook_PR-6184/rook-test
2020-09-30 21:57:46.437019 I | testutil: Running kubectl [create -f -]
job.batch/rook-verify-cleanup-8ac78269-0e9d-4d33-93d0-b2bda731b373 created
2020-09-30 21:57:47.282245 I | installer: verifying clean up of /home/ubuntu/workspace/rook_rook_PR-6184/rook-test from node ip-172-31-46-223. err=<nil>
2020-09-30 21:57:47.286042 I | installer: system namespace "helm-ns-system" removed
--- FAIL: TestCephHelmSuite (411.12s)
    ceph_installer.go:568:
                Error Trace:    ceph_installer.go:568
                                                        ceph_installer.go:522
                                                        ceph_base_deploy_test.go:188
                                                        ceph_base_deploy_test.go:178
                                                        ceph_base_deploy_test.go:161
                                                        ceph_helm_test.go:80
                                                        suite.go:102
                                                        ceph_helm_test.go:52
                Error:          Received unexpected error:
                                failed to wait for clean up jobs to complete. timed out waiting for the condition
                Test:           TestCephHelmSuite
```

Related issue: 6358

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]