### PR TITLE
ceph: periodically prune crash entries older than user-provided days

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -198,6 +198,7 @@ For more details on the mons and when to choose a number other than `3`, see the
   * `modules`: is the list of Ceph manager modules to enable
 * `crashCollector`: The settings for crash collector daemon(s).
   * `disable`: is set to `true`, the crash collector will not run on any node where a Ceph daemon runs
+  * `daysToRetain`: specifies the number of days to keep crash entries in the Ceph cluster. By default the entries are kept indefinitely.
 * `annotations`: [annotations configuration settings](#annotations-and-labels)
 * `labels`: [labels configuration settings](#annotations-and-labels)
 * `placement`: [placement configuration settings](#placement-configuration-settings)

--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -79,6 +79,7 @@ rules:
   - batch
   resources:
   - jobs
+  - cronjobs
   verbs:
   - get
   - list

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -112,6 +112,8 @@ spec:
                   properties:
                     disable:
                       type: boolean
+                    daysToRetain:
+                      type: integer
                 network:
                   type: object
                   nullable: true

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -88,6 +88,9 @@ spec:
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false
+    # Uncomment daysToRetain to prune ceph crash entries older than the
+    # specified number of days.
+    #daysToRetain: 30
   # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
   cleanupPolicy:
     # Since cluster cleanup is destructive to data, confirmation is required.

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -180,6 +180,7 @@ rules:
   - batch
   resources:
   - jobs
+  - cronjobs
   verbs:
   - get
   - list

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -114,6 +114,8 @@ spec:
                   properties:
                     disable:
                       type: boolean
+                    daysToRetain:
+                      type: integer
                 network:
                   type: object
                   nullable: true

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -314,7 +314,8 @@ type ExternalSpec struct {
 
 // CrashCollectorSpec represents options to configure the crash controller
 type CrashCollectorSpec struct {
-	Disable bool `json:"disable"`
+	Disable      bool `json:"disable"`
+	DaysToRetain uint `json:"daysToRetain,omitempty"`
 }
 
 // +genclient

--- a/pkg/operator/ceph/cluster/crash/add.go
+++ b/pkg/operator/ceph/cluster/crash/add.go
@@ -39,7 +39,8 @@ import (
 const (
 	controllerName = "ceph-crashcollector-controller"
 	// AppName is the value to the "app" label for the ceph-crash pods
-	AppName = "rook-ceph-crashcollector"
+	AppName    = "rook-ceph-crashcollector"
+	prunerName = "rook-ceph-crashcollector-pruner"
 	// NodeNameLabel is a node name label
 	NodeNameLabel = "node_name"
 )

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,6 +41,8 @@ import (
 const (
 	crashCollectorKeyringUsername = "client.crash"
 	crashCollectorKeyName         = "rook-ceph-crash-collector-keyring"
+	// pruneSchedule is scheduled to run every day at midnight.
+	pruneSchedule = "0 0 * * *"
 )
 
 // ClusterResource operator-kit Custom Resource Definition
@@ -126,6 +129,56 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 	return controllerutil.CreateOrUpdate(context.TODO(), r.client, deploy, mutateFunc)
 }
 
+// createOrUpdateCephCron is a wrapper around controllerutil.CreateOrUpdate
+func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, cephVersion *version.CephVersion) (controllerutil.OperationResult, error) {
+	cronJob := &v1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            prunerName,
+			Namespace:       cephCluster.GetNamespace(),
+			OwnerReferences: []metav1.OwnerReference{clusterOwnerRef(cephCluster.GetName(), string(cephCluster.GetUID()))},
+		},
+	}
+
+	// Adding volumes to pods containing data needed to connect to the ceph cluster.
+	volumes := controller.DaemonVolumesBase(config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath), "")
+	volumes = append(volumes, keyring.Volume().CrashCollector())
+
+	mutateFunc := func() error {
+
+		// labels for the pod, the deployment, and the deploymentSelector
+		cronJobLabels := map[string]string{
+			k8sutil.AppAttr: prunerName,
+		}
+		cronJobLabels[k8sutil.ClusterAttr] = cephCluster.GetNamespace()
+
+		cronJob.ObjectMeta.Labels = cronJobLabels
+		cronJob.Spec.JobTemplate.Spec.Template = corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: cronJobLabels,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					getCrashPruneContainer(cephCluster, *cephVersion),
+				},
+				RestartPolicy: corev1.RestartPolicyNever,
+				HostNetwork:   cephCluster.Spec.Network.IsHost(),
+				Volumes:       volumes,
+			},
+		}
+
+		cronJob.Spec.Schedule = pruneSchedule
+		// After 100 failures, the cron job will no longer run.
+		// To avoid this, the cronjob is configured to only count the failures
+		// that occurred in the last hour.
+		deadline := int64(60)
+		cronJob.Spec.StartingDeadlineSeconds = &deadline
+
+		return nil
+	}
+
+	return controllerutil.CreateOrUpdate(context.TODO(), r.client, cronJob, mutateFunc)
+}
+
 func getCrashDirInitContainer(cephCluster cephv1.CephCluster) corev1.Container {
 	dataPathMap := config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath)
 	crashPostedDir := path.Join(dataPathMap.ContainerCrashDir(), "posted")
@@ -171,6 +224,35 @@ func getCrashDaemonContainer(cephCluster cephv1.CephCluster, cephVersion version
 		Name: "ceph-crash",
 		Command: []string{
 			"ceph-crash",
+		},
+		Image:           cephImage,
+		Env:             envVars,
+		VolumeMounts:    volumeMounts,
+		Resources:       cephv1.GetCrashCollectorResources(cephCluster.Spec.Resources),
+		SecurityContext: mon.PodSecurityContext(),
+	}
+
+	return container
+}
+
+func getCrashPruneContainer(cephCluster cephv1.CephCluster, cephVersion version.CephVersion) corev1.Container {
+	cephImage := cephCluster.Spec.CephVersion.Image
+	envVars := append(controller.DaemonEnvVars(cephImage), generateCrashEnvVar())
+	dataPathMap := config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath)
+	volumeMounts := controller.DaemonVolumeMounts(dataPathMap, "")
+	volumeMounts = append(volumeMounts, keyring.VolumeMount().CrashCollector())
+
+	container := corev1.Container{
+		Name: "ceph-crash-pruner",
+		Command: []string{
+			"ceph",
+			"-n",
+			crashClient,
+			"crash",
+			"prune",
+		},
+		Args: []string{
+			fmt.Sprintf("%d", cephCluster.Spec.CrashCollector.DaysToRetain),
 		},
 		Image:           cephImage,
 		Env:             envVars,

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -29,11 +29,12 @@ import (
 )
 
 const (
+	crashClient          = `client.crash`
 	crashKeyringTemplate = `
 [client.crash]
 	key = %s
 	caps mon = "allow profile crash"
-	caps mgr = "allow profile crash"
+	caps mgr = "allow rw"
 `
 )
 
@@ -58,7 +59,7 @@ func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.C
 func cephCrashCollectorKeyringCaps() []string {
 	return []string{
 		"mon", "allow profile crash",
-		"mgr", "allow profile crash",
+		"mgr", "allow rw",
 	}
 }
 

--- a/pkg/operator/ceph/cluster/crash/keyring_test.go
+++ b/pkg/operator/ceph/cluster/crash/keyring_test.go
@@ -24,5 +24,5 @@ import (
 
 func TestCephCrashCollectorKeyringCaps(t *testing.T) {
 	caps := cephCrashCollectorKeyringCaps()
-	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow profile crash"})
+	assert.Equal(t, caps, []string{"mon", "allow profile crash", "mgr", "allow rw"})
 }

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -199,7 +199,7 @@ func (o MCTestOperations) Teardown() {
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
 	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
-		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, installer.NautilusVersion)
+		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, false, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)


### PR DESCRIPTION
Signed-off-by: Renan Campos <rcampos@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Rook's crashcollector pod posts entries to the ceph cluster when a crash occurs. 
Over time the number cluster may hold crash entries needlessly. 
To clean up old crash entries, this PR adds a field to the ceph cluster CR for the user to specify the number of days a crash entry should be kept for. 
Providing a value for the field keepXDays creates a cronjob that runs every day at midnight, calling "ceph crash prune <keepXDays>". 

**Which issue is resolved by this Pull Request:**
Resolves #6332 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test full]