### PR TITLE
ceph: Require an odd number of mons and sufficient nodes for mons

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -170,8 +170,8 @@ A specific will contain a specific release of Ceph as well as security fixes fro
 
 ### Mon Settings
 
-* `count`: Set the number of mons to be started. The number should be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
-* `allowMultiplePerNode`: Enable (`true`) or disable (`false`) the placement of multiple mons on one node. Default is `false`.
+* `count`: Set the number of mons to be started. The number must be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
+* `allowMultiplePerNode`: Whether to allow the placement of multiple mons on a single node. Default is `false` for production. Should only be set to `true` in test environments.
 * `volumeClaimTemplate`: A `PersistentVolumeSpec` used by Rook to create PVCs
   for monitor storage. This field is optional, and when not provided, HostPath
   volume mounts are used.  The current set of fields from template that are used
@@ -538,7 +538,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   dashboard:
     enabled: true
   # cluster level storage configuration and selection
@@ -570,7 +570,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   dashboard:
     enabled: true
   # cluster level storage configuration and selection
@@ -611,7 +611,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true
@@ -658,7 +658,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -9,15 +9,15 @@ indent: true
 Rook allows creation and customization of storage clusters through the custom resource definitions (CRDs).
 There are two different modes to create your cluster, depending on whether storage can be dynamically provisioned on which to base the Ceph cluster.
 
-1. Specify host paths and raw devices
-2. Specify the storage class Rook should use to consume storage via PVCs
+1. Specify [host paths and raw devices](#host-based-cluster)
+2. Specify the storage class Rook should use to consume storage [via PVCs](#pvc-based-cluster)
 
-Following is an example for each of these approaches.
+Following is an example for each of these approaches. More examples are included [later in this doc](#samples).
 
 ## Host-based Cluster
 
-To get you started, here is a simple example of a CRD to configure a Ceph cluster with all nodes and all devices. Next example is where Mons and OSDs are backed by PVCs.
-More examples are included [later in this doc](#samples).
+To get you started, here is a simple example of a CRD to configure a Ceph cluster with all nodes and all devices.
+The Ceph persistent data is stored directly on a host path (Ceph Mons) and on raw devices (Ceph OSDs).
 
 > **NOTE**: In addition to your CephCluster object, you need to create the namespace, service accounts, and RBAC rules for the namespace you are going to create the CephCluster in.
 > These resources are defined in the example `common.yaml`.
@@ -35,13 +35,17 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
-    allowMultiplePerNode: true
+    allowMultiplePerNode: false
   storage:
     useAllNodes: true
     useAllDevices: true
 ```
 
 ## PVC-based Cluster
+
+In a "PVC-based cluster", the Ceph persistent data is stored on volumes requested from a storage class of your choice.
+This type of cluster is recommended in a cloud environment where volumes can be dynamically created and also
+in clusters where a local PV provisioner is available.
 
 > **NOTE**: Kubernetes version 1.13.0 or greater is required to provision OSDs on PVCs.
 
@@ -58,6 +62,7 @@ spec:
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
+    allowMultiplePerNode: false
     volumeClaimTemplate:
       spec:
         storageClassName: local-storage
@@ -170,7 +175,7 @@ A specific will contain a specific release of Ceph as well as security fixes fro
 
 ### Mon Settings
 
-* `count`: Set the number of mons to be started. The number must be odd and between `1` and `9`. If not specified the default is set to `3` and `allowMultiplePerNode` is also set to `true`.
+* `count`: Set the number of mons to be started. The number must be odd and between `1` and `9`. If not specified the default is set to `3`.
 * `allowMultiplePerNode`: Whether to allow the placement of multiple mons on a single node. Default is `false` for production. Should only be set to `true` in test environments.
 * `volumeClaimTemplate`: A `PersistentVolumeSpec` used by Rook to create PVCs
   for monitor storage. This field is optional, and when not provided, HostPath

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,8 @@ v1.5...
 
 ### Ceph
 
+- Ceph mons require an odd number for a healthy quorum. An even number of mons is now disallowed.
+
 ## Features
 
 ### Ceph

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -17,7 +17,10 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   mon:
+    # Set the number of mons to be started. Must be an odd number, and is generally recommended to be 3.
     count: 3
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
     allowMultiplePerNode: false
     # A volume claim template can be specified in which case new monitors (and
     # monitors created during fail over) will construct a PVC based on the

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -38,9 +38,11 @@ spec:
   skipUpgradeChecks: false
   # Whether or not continue if PGs are not clean during an upgrade
   continueUpgradeAfterChecksEvenIfNotHealthy: false
-  # set the amount of mons to be started
   mon:
+    # Set the number of mons to be started. Must be an odd number, and is generally recommended to be 3.
     count: 3
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
     allowMultiplePerNode: false
   mgr:
     modules:

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters.go
@@ -62,6 +62,10 @@ func (c *CephCluster) ValidateDelete() error {
 }
 
 func validateUpdatedCephCluster(updatedCephCluster *CephCluster, found *CephCluster) error {
+	if updatedCephCluster.Spec.Mon.Count > 0 && updatedCephCluster.Spec.Mon.Count%2 == 0 {
+		return errors.Errorf("mon count %d cannot be even, must be odd to support a healthy quorum", updatedCephCluster.Spec.Mon.Count)
+	}
+
 	if updatedCephCluster.Spec.DataDirHostPath != found.Spec.DataDirHostPath {
 		return errors.Errorf("invalid update: DataDirHostPath change from %q to %q is not allowed", found.Spec.DataDirHostPath, updatedCephCluster.Spec.DataDirHostPath)
 	}

--- a/pkg/apis/ceph.rook.io/v1/validate_clusters_test.go
+++ b/pkg/apis/ceph.rook.io/v1/validate_clusters_test.go
@@ -33,6 +33,9 @@ func Test_validateUpdatedCephCluster(t *testing.T) {
 		wantErr bool
 	}{
 		{"everything is ok", args{&CephCluster{}, &CephCluster{}}, false},
+		{"good mon count", args{&CephCluster{Spec: ClusterSpec{Mon: MonSpec{Count: 1}}}, &CephCluster{}}, false},
+		{"even mon count", args{&CephCluster{Spec: ClusterSpec{Mon: MonSpec{Count: 2}}}, &CephCluster{}}, true},
+		{"good mon count", args{&CephCluster{Spec: ClusterSpec{Mon: MonSpec{Count: 3}}}, &CephCluster{}}, false},
 		{"changed DataDirHostPath", args{&CephCluster{Spec: ClusterSpec{DataDirHostPath: "foo"}}, &CephCluster{Spec: ClusterSpec{DataDirHostPath: "bar"}}}, true},
 		{"changed HostNetwork", args{&CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: false}}}, &CephCluster{Spec: ClusterSpec{Network: NetworkSpec{HostNetwork: true}}}}, true},
 		{"changed storageClassDeviceSet encryption", args{&CephCluster{Spec: ClusterSpec{Storage: v1.StorageScopeSpec{StorageClassDeviceSets: []v1.StorageClassDeviceSet{{Name: "foo", Encrypted: false}}}}}, &CephCluster{Spec: ClusterSpec{Storage: v1.StorageScopeSpec{StorageClassDeviceSets: []v1.StorageClassDeviceSet{{Name: "foo", Encrypted: true}}}}}}, true},


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The ceph mons should never be started with an even number in quorum. The desired state should always be an odd number of mons to ensure a healthy majority quorum. The operator now rejects a request for an even number of mons.

If there is not a sufficient number of nodes for mons to be on a unique host, the operator also returns an early error instead of getting stuck waiting for a pending mon. This is not foolproof since there might in reality be fewer available nodes for the mons due to placement, but at least it is a quick check for the common case.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
