### PR TITLE
ceph: reduce the number of provisioner pods in small K8s cluster

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -4,7 +4,7 @@ metadata:
   name: csi-cephfsplugin-provisioner
   namespace: {{ .Namespace }}
 spec:
-  replicas: 2
+  replicas: {{ .ProvisionerReplicas }}
   selector:
     matchLabels:
      app: csi-cephfsplugin-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -4,7 +4,7 @@ metadata:
   name: csi-rbdplugin-provisioner
   namespace: {{ .Namespace }}
 spec:
-  replicas: 2
+  replicas: {{ .ProvisionerReplicas }}
   selector:
     matchLabels:
      app: csi-rbdplugin-provisioner

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -57,6 +57,7 @@ type Param struct {
 	CephFSLivenessMetricsPort    uint16
 	RBDGRPCMetricsPort           uint16
 	RBDLivenessMetricsPort       uint16
+	ProvisionerReplicas          uint8
 }
 
 type templateParam struct {
@@ -313,6 +314,16 @@ func startDrivers(clientset kubernetes.Interface, rookclientset rookclient.Inter
 		} else {
 			tp.LogLevel = uint8(l)
 		}
+	}
+
+	tp.ProvisionerReplicas = 2
+	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err == nil {
+		if len(nodes.Items) == 1 {
+			tp.ProvisionerReplicas = 1
+		}
+	} else {
+		logger.Errorf("failed to get nodes. Defaulting the number of replicas of provisioner pods to 2. %v", err)
 	}
 
 	if EnableRBD {


### PR DESCRIPTION
**Description of your changes:**

The default number of provisioner pods are 2. When there is only one node, for example, the CI environment, one of these becomes Pending state. Although it's harmless, it's better to reduce this value to 1.

**Which issue is resolved by this Pull Request:**
Resolves #6294 

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]