### PR TITLE
ci: clarify the supported vm-driver of minikube scripts

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,10 +24,12 @@ to your command line tool of choice.
 ### Install Kubernetes
 You can choose any Kubernetes flavor of your choice.  The test framework only depends on kubectl being configured.
 The framework also provides scripts to install Kubernetes. There are two scripts to start the cluster:
-1. **Minikube** (recommended for MacOS): Run [minikube.sh](/tests/scripts/minikube.sh) to setup a single-node Minikube Kubernetes.
 1. **Kubeadm** (recommended for Ubuntu): run [kubeadm.sh](/tests/scripts/kubeadm.sh) to setup a single-node K8s cluster using kubeadm
+1. **Minikube** (recommended for non-Ubuntu): Run [minikube.sh](/tests/scripts/minikube.sh) to setup a single-node Minikube Kubernetes.
 
-#### Minikube (recommended for MacOS)
+Minikube scripts only support "docker" and "none" as vm-driver.
+
+#### Minikube (recommended for non-Ubuntu)
 Starting the cluster on Minikube is as simple as running:
 ```console
 tests/scripts/minikube.sh up

--- a/tests/scripts/dind-cluster.sh
+++ b/tests/scripts/dind-cluster.sh
@@ -129,9 +129,6 @@ function dind::create-volume {
 # This includes virtlet, for instance. Also this may be
 # useful in future if we want DIND nodes to pass
 # preflight checks.
-# Unfortunately we can't do this when using Mac Docker
-# (unless a remote docker daemon on Linux is used)
-# NB: there's no /boot on recent Mac dockers
 function dind::prepare-sys-mounts {
   if [[ ! ${is_moby_linux} ]]; then
     sys_volume_args=()
@@ -146,7 +143,6 @@ function dind::prepare-sys-mounts {
   if ! dind::volume-exists kubeadm-dind-sys; then
     dind::step "Saving a copy of docker host's /lib/modules"
     dind::create-volume kubeadm-dind-sys
-    # Use a dirty nsenter trick to fool Docker on Mac and grab system
     # /lib/modules into sys.tar file on kubeadm-dind-sys volume.
     local nsenter="nsenter --mount=/proc/1/ns/mnt --"
     docker run \


### PR DESCRIPTION
**Description of your changes:**

We can't use vm-drivers other than "docker" or "none" in minikube scripts. It's because there is no device for OSD.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]