### PR TITLE
build: fix error when building rook in centos7

### DIFF
--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -36,7 +36,7 @@ install() {
         dist=$(echo "${dist}" | tr "[:upper:]" "[:lower:]")
         mkdir -p "${temp}"
         wget "https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-${dist}-${arch}.tar.gz" -O "${temp}/helm.tar.gz"
-        tar -C "${temp}" -zxvf "${temp}/helm.tar.gz" --strip-components 1
+        tar -C "${temp}" -xvf "${temp}/helm.tar.gz" --strip-components 1
         # The following lines are workaround of a CI failure caused by the old-Jenkins-file-is-used-in-CI problem.
         # These lines will be removed as soom as PR5991 is merged..
         mkdir "${temp}/${dist}-${arch}"


### PR DESCRIPTION
The reason why I start this pull request is that when I use 'make -j4' to build rook, if I don't delete arg 'z' in 'tar -zxvf',  compile process while return compilation fails in centos7. And this is my solution to fix it.

Signed-off-by: ZhenLiu94 <zhenliu94@163.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
