### PR TITLE
helm: use get.helm.sh instead of storage.googleapis.com

### DIFF
--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -31,7 +31,7 @@ $(HELM_OUTPUT_DIR):
 $(HELM):
 	@echo === installing helm
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@curl -sL https://storage.googleapis.com/kubernetes-helm/helm-$(HELM_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
+	@curl -sL https://get.helm.sh/helm-$(HELM_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
 	@mv $(TOOLS_HOST_DIR)/tmp/$(GOHOSTOS)-$(GOHOSTARCH)/helm $(HELM)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 	@$(HELM) init -c

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -35,7 +35,7 @@ install() {
         dist="$(uname -s)"
         dist=$(echo "${dist}" | tr "[:upper:]" "[:lower:]")
         mkdir -p "${temp}"
-        wget "https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-${dist}-${arch}.tar.gz" -O "${temp}/helm.tar.gz"
+        wget "https://get.helm.sh/helm-v2.13.1-${dist}-${arch}.tar.gz" -O "${temp}/helm.tar.gz"
         tar -C "${temp}" -xvf "${temp}/helm.tar.gz" --strip-components 1
         # The following lines are workaround of a CI failure caused by the old-Jenkins-file-is-used-in-CI problem.
         # These lines will be removed as soom as PR5991 is merged..


### PR DESCRIPTION
To be able to switch to helm v3, helm itself needs to be downloaded from
get.helm.sh. The old location from googleapis.com will only contain
helm v2 binaries. See [1].

[1] https://helm.sh/blog/get-helm-sh/

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>

