### PR TITLE
ceph: reduce the number of admission controller pods in small cluster

### DIFF
--- a/pkg/operator/ceph/webhook.go
+++ b/pkg/operator/ceph/webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package operator
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/csi"
@@ -26,7 +28,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
 )
 
 const (
@@ -122,7 +123,7 @@ func createWebhookDeployment(context *clusterd.Context, admissionImage string) e
 	secretVolumeMount := getSecretVolumeMount()
 
 	antiAffinity := csi.GetPodAntiAffinity(k8sutil.AppAttr, appName)
-	admissionControllerDeployment := getDeployment(secretVolume, antiAffinity, admissionImage, admission_parameters, secretVolumeMount)
+	admissionControllerDeployment := getDeployment(context, secretVolume, antiAffinity, admissionImage, admission_parameters, secretVolumeMount)
 
 	err := k8sutil.CreateDeployment(context.Clientset, appName, namespace, &admissionControllerDeployment)
 	if err != nil {
@@ -132,8 +133,17 @@ func createWebhookDeployment(context *clusterd.Context, admissionImage string) e
 	return nil
 }
 
-func getDeployment(secretVolume corev1.Volume, antiAffinity corev1.PodAntiAffinity, admissionImage string, admission_parameters []string, secretVolumeMount corev1.VolumeMount) v1.Deployment {
+func getDeployment(context *clusterd.Context, secretVolume corev1.Volume, antiAffinity corev1.PodAntiAffinity,
+	admissionImage string, admission_parameters []string, secretVolumeMount corev1.VolumeMount) v1.Deployment {
 	var replicas int32 = 2
+	nodes, err := context.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err == nil {
+		if len(nodes.Items) == 1 {
+			replicas = 1
+		}
+	} else {
+		logger.Errorf("failed to get nodes. Defaulting the number of replicas of admission controller pods to 2. %v", err)
+	}
 
 	admissionControllerDeployment := v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**Description of your changes:**

The number of admission controller pods is 2. When there is only one node as the CI environment, one of these becomes Pending state. Although it's harmless, it's better to reduce this value to 1.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]