### PR TITLE
ceph: Add unit tests for object store controller with multisite

### DIFF
--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -401,7 +401,8 @@ func (r *ReconcileCephObjectStore) reconcileCephZone(store *cephv1.CephObjectSto
 func (r *ReconcileCephObjectStore) reconcileMultisiteCRs(cephObjectStore *cephv1.CephObjectStore) (string, string, string, reconcile.Result, error) {
 	if cephObjectStore.Spec.IsMultisite() {
 		zoneName := cephObjectStore.Spec.Zone.Name
-		zone, err := r.context.RookClientset.CephV1().CephObjectZones(cephObjectStore.Namespace).Get(zoneName, metav1.GetOptions{})
+		zone := &cephv1.CephObjectZone{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{Name: zoneName, Namespace: cephObjectStore.Namespace}, zone)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				return "", "", "", waitForRequeueIfObjectStoreNotReady, err
@@ -410,7 +411,8 @@ func (r *ReconcileCephObjectStore) reconcileMultisiteCRs(cephObjectStore *cephv1
 		}
 		logger.Debugf("CephObjectZone resource %s found", zone.Name)
 
-		zonegroup, err := r.context.RookClientset.CephV1().CephObjectZoneGroups(cephObjectStore.Namespace).Get(zone.Spec.ZoneGroup, metav1.GetOptions{})
+		zonegroup := &cephv1.CephObjectZoneGroup{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: zone.Spec.ZoneGroup, Namespace: cephObjectStore.Namespace}, zonegroup)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				return "", "", "", waitForRequeueIfObjectStoreNotReady, err
@@ -419,7 +421,8 @@ func (r *ReconcileCephObjectStore) reconcileMultisiteCRs(cephObjectStore *cephv1
 		}
 		logger.Debugf("CephObjectZoneGroup resource %s found", zonegroup.Name)
 
-		realm, err := r.context.RookClientset.CephV1().CephObjectRealms(cephObjectStore.Namespace).Get(zonegroup.Spec.Realm, metav1.GetOptions{})
+		realm := &cephv1.CephObjectRealm{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: zonegroup.Spec.Realm, Namespace: cephObjectStore.Namespace}, realm)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				return "", "", "", waitForRequeueIfObjectStoreNotReady, err

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -297,7 +297,7 @@ func (r *ReconcileObjectZone) reconcileObjectZoneGroup(zone *cephv1.CephObjectZo
 		return "", waitForRequeueIfObjectZoneGroupNotReady, errors.Wrapf(err, "error getting cephObjectZoneGroup %v", zone.Spec.ZoneGroup)
 	}
 
-	logger.Infof("CephObjectZoneGroup %v found", zoneGroup.Name)
+	logger.Debugf("CephObjectZoneGroup %v found", zoneGroup.Name)
 	return zoneGroup.Spec.Realm, reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
Add unit tests for when the "Zone" is configured
in an object store so that the object store joins
the CephObjectZone and the zone's corresponding
multisite configuration.

Signed-off-by: Ali Maredia <amaredia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6387

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
