### PR TITLE
ceph: Check for orphaned mon resources with every reconcile

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -245,21 +245,15 @@ func (c *Cluster) failMon(monCount, desiredMonCount int, name string) {
 			logger.Errorf("failed to failover mon %q. %v", name, err)
 		}
 	}
-
-	// Check if there are orphaned mon resources that should be cleaned up.
-	// This should only be checked infrequently such as during a mon failover
-	// so we never cleanup mon resources when they are still in use in the middle
-	// of a reconcile.
-	c.removeOrphanMonResources()
 }
 
 func (c *Cluster) removeOrphanMonResources() {
-	logger.Info("checking for orphaned mon resources")
-
 	if c.spec.Mon.VolumeClaimTemplate == nil {
-		logger.Info("skipping check for orphaned mon pvcs since using the host path")
+		logger.Debug("skipping check for orphaned mon pvcs since using the host path")
 		return
 	}
+
+	logger.Info("checking for orphaned mon resources")
 
 	opts := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", k8sutil.AppAttr, AppName)}
 	pvcs, err := c.context.Clientset.CoreV1().PersistentVolumeClaims(c.Namespace).List(opts)

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -282,6 +282,11 @@ func (c *Cluster) startMons(targetCount int) error {
 	}
 
 	logger.Debugf("mon endpoints used are: %s", FlattenMonEndpoints(c.ClusterInfo.Monitors))
+
+	// Check if there are orphaned mon resources that should be cleaned up at the end of a reconcile.
+	// There may be orphaned resources if a mon failover was aborted.
+	c.removeOrphanMonResources()
+
 	return nil
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon resources may be orphaned if there is a mon failover that was cancelled, for example a mon pvc may remain if the original mon comes up and the operator was restarted before the mon failover completed. The cleaning up of mon resources was only happening was each successful mon failover, now we perform the check with every reconcile since the resources were not being cleaned up predictably enough.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
