### PR TITLE
ceph: ignore MDS_ALL_DOWN during reconciliation

### DIFF
--- a/pkg/operator/ceph/controller/controller_utils_test.go
+++ b/pkg/operator/ceph/controller/controller_utils_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func CreateTestClusterFromStatusDetails(details map[string]cephv1.CephHealthMessage) cephv1.CephCluster {
+	return cephv1.CephCluster{
+		Status: cephv1.ClusterStatus{
+			CephStatus: &cephv1.CephStatus{
+				Details: details,
+			},
+		},
+	}
+}
+
+func TestCanIgnoreHealthErrStatusInReconcile(t *testing.T) {
+	var cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MDS_ALL_DOWN": {
+			Severity: "HEALTH_ERR",
+			Message:  "MDS_ALL_DOWN",
+		},
+		"TEST_OTHER": {
+			Severity: "HEALTH_WARN",
+			Message:  "TEST_OTHER",
+		},
+		"TEST_ANOTHER": {
+			Severity: "HEALTH_OK",
+			Message:  "TEST_ANOTHER",
+		},
+	})
+	assert.True(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"MDS_ALL_DOWN": {
+			Severity: "HEALTH_ERR",
+			Message:  "MDS_ALL_DOWN",
+		},
+		"TEST_UNIGNORABLE": {
+			Severity: "HEALTH_ERR",
+			Message:  "TEST_UNIGNORABLE",
+		},
+	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+
+	cluster = CreateTestClusterFromStatusDetails(map[string]cephv1.CephHealthMessage{
+		"TEST_UNIGNORABLE": {
+			Severity: "HEALTH_ERR",
+			Message:  "TEST_UNIGNORABLE",
+		},
+	})
+	assert.False(t, canIgnoreHealthErrStatusInReconcile(cluster, "controller"))
+}


### PR DESCRIPTION
This allows the catch-22 situation where the filesystem cannot be
reconciled because there is no MDS but there is no MDS because the
operator has not reconciled the filesystem and brought up the MDS pods.

Closes #5967, #5846

Signed-off-by: Lalit Maganti <lalitm@google.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This allows the catch-22 situation where the filesystem cannot be
reconciled because there is no MDS but there is no MDS because the
operator has not reconciled the filesystem and brought up the MDS pods.

**Which issue is resolved by this Pull Request:**
Resolves #5967, #5846

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
