### PR TITLE
ceph: add option to preserve filesystem on CRD deletion

### DIFF
--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -40,7 +40,7 @@ spec:
     - failureDomain: host
       replicated:
         size: 3
-  preservePoolsOnDelete: true
+  preserveFilesystemOnDelete: true
   metadataServer:
     activeCount: 1
     activeStandby: true
@@ -115,7 +115,7 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 
 * `metadataPool`: The settings used to create the filesystem metadata pool. Must use replication.
 * `dataPools`: The settings to create the filesystem data pools. If multiple pools are specified, Rook will add the pools to the filesystem. Assigning users or files to a pool is left as an exercise for the reader with the [CephFS documentation](http://docs.ceph.com/docs/master/cephfs/file-layouts/). The data pools can use replication or erasure coding. If erasure coding pools are specified, the cluster must be running with bluestore enabled on the OSDs.
-* `preservePoolsOnDelete`: If it is set to 'true' the pools used to support the filesystem will remain when the filesystem will be deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'.
+* `preserveFilesystemOnDelete`: If it is set to 'true' the filesystem will remain when the Filesystem CRD is deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'. This option replaces `preservePoolsOnDelete` which should no longer be set.
 
 ## Metadata Server Settings
 

--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -46,7 +46,7 @@ spec:
   dataPools:
     - replicated:
         size: 3
-  preservePoolsOnDelete: true
+  preserveFilesystemOnDelete: true
   metadataServer:
     activeCount: 1
     activeStandby: true
@@ -240,13 +240,13 @@ kubectl delete -f kube-registry.yaml
 
 To delete the filesystem components and backing data, delete the Filesystem CRD.
 
-> **WARNING: Data will be deleted if preservePoolsOnDelete=false**.
+> **WARNING: Data will be deleted if preserveFilesystemOnDelete=false**.
 
 ```console
 kubectl -n rook-ceph delete cephfilesystem myfs
 ```
 
-Note: If the "preservePoolsOnDelete" filesystem attribute is set to true, the above command won't delete the pools. Creating again the filesystem with the same CRD will reuse again the previous pools.
+Note: If the "preserveFilesystemOnDelete" filesystem attribute is set to true, the above command won't delete the filesystem. Recreating the same CRD will reuse the existing filesystem.
 
 ## Flex Driver
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -12,6 +12,7 @@ v1.5...
 
 - Ceph mons require an odd number for a healthy quorum. An even number of mons is now disallowed.
 - Update deprecated CRD apiextensions.k8s.io/v1beta1 to v1 ([#6424](https://github.com/rook/rook/pull/6424))
+- preservePoolsOnDelete is deprecated for CephFilesystem and is no longer allowed because of data-loss concerns. preserveFilesystemOnDelete acts as a replacement and preserves the filesystem when the CephFilesystem CRD is deleted (which implicitly includes all associated pools). See [#6495](https://github.com/rook/rook/pull/6495) for more details.
 
 ## Features
 

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -567,6 +567,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                 preservePoolsOnDelete:
                   type: boolean
+                preserveFilesystemOnDelete:
+                  type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -1587,6 +1589,8 @@ spec:
                   parameters:
                     type: object
             preservePoolsOnDelete:
+              type: boolean
+            preserveFilesystemOnDelete:
               type: boolean
   subresources:
     status: {}

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -592,6 +592,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                 preservePoolsOnDelete:
                   type: boolean
+                preserveFilesystemOnDelete:
+                  type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
@@ -24,8 +24,8 @@ spec:
       # Inline compression mode for the data pool
       parameters:
         compression_mode: none
-  # Whether to preserve metadata and data pools on filesystem deletion
-  preservePoolsOnDelete: true
+  # Whether to preserve filesystem after CephFilesystem CRD deletion
+  preserveFilesystemOnDelete: true
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/ceph/filesystem-test.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-test.yaml
@@ -18,7 +18,7 @@ spec:
       replicated:
         size: 1
         requireSafeReplicaSize: false
-  preservePoolsOnDelete: false
+  preserveFilesystemOnDelete: false
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -37,8 +37,8 @@ spec:
           # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
         # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
         #target_size_ratio: ".5"
-  # Whether to preserve metadata and data pools on filesystem deletion
-  preservePoolsOnDelete: true
+  # Whether to preserve filesystem after CephFilesystem CRD deletion
+  preserveFilesystemOnDelete: true
   # The metadata service (mds) configuration
   metadataServer:
     # The number of active MDS instances

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crd.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crd.yaml
@@ -386,6 +386,8 @@ spec:
                     type: object
             preservePoolsOnDelete:
               type: boolean
+            preserveFilesystemOnDelete:
+              type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS
       type: string

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.3-crds.yaml
@@ -360,6 +360,8 @@ spec:
                     type: object
             preservePoolsOnDelete:
               type: boolean
+            preserveFilesystemOnDelete:
+              type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS
       type: string

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -378,7 +378,8 @@ metadata:
               "placement": {},
               "resources": {}
             },
-            "preservePoolsOnDelete": false
+            "preservePoolsOnDelete": false,
+            "preserveFilesystemOnDelete": false
           }
         },
         {

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -451,6 +451,9 @@ type FilesystemSpec struct {
 	// Preserve pools on filesystem deletion
 	PreservePoolsOnDelete bool `json:"preservePoolsOnDelete"`
 
+	// Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.
+	PreserveFilesystemOnDelete bool `json:"preserveFilesystemOnDelete"`
+
 	// The mds pod info
 	MetadataServer MetadataServerSpec `json:"metadataServer"`
 }

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -255,6 +255,11 @@ func (r *ReconcileCephFilesystem) reconcileCreateFilesystem(cephFilesystem *ceph
 		return reconcile.Result{}, errors.Wrapf(err, "failed to get controller %q owner reference", cephFilesystem.Name)
 	}
 
+	// preservePoolsOnDelete being set to true does not make sense because of data-loss concerns (see #6492).
+	if cephFilesystem.Spec.PreservePoolsOnDelete {
+		return reconcile.Result{}, errors.New("preservePoolsOnDelete has been deprecated. Set preserveFilesystemOnDelete instead")
+	}
+
 	err = createFilesystem(r.context, r.clusterInfo, *cephFilesystem, r.cephClusterSpec, *ref, r.cephClusterSpec.DataDirHostPath, r.scheme)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to create filesystem %q", cephFilesystem.Name)

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -128,8 +128,8 @@ func deleteFilesystem(
 		return errors.Wrapf(err, "failed to down filesystem %q", fs.Name)
 	}
 
-	// Permanently remove the filesystem if it was created by rook
-	if len(fs.Spec.DataPools) != 0 {
+	// Permanently remove the filesystem if it was created by rook and the spec does not prevent it.
+	if len(fs.Spec.DataPools) != 0 && !fs.Spec.PreserveFilesystemOnDelete {
 		if err := client.RemoveFilesystem(context, clusterInfo, fs.Name, fs.Spec.PreservePoolsOnDelete); err != nil {
 			return errors.Wrapf(err, "failed to remove filesystem %q", fs.Name)
 		}

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -664,6 +664,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                 preservePoolsOnDelete:
                   type: boolean
+                preserveFilesystemOnDelete:
+                  type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
@@ -1675,6 +1677,8 @@ spec:
                   parameters:
                     type: object
             preservePoolsOnDelete:
+              type: boolean
+            preserveFilesystemOnDelete:
               type: boolean
   additionalPrinterColumns:
     - name: ActiveMDS

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -110,7 +110,8 @@ func (s *CephFlexDriverSuite) AfterTest(suiteName, testName string) {
 
 func (s *CephFlexDriverSuite) TestFileSystem() {
 	useCSI := false
-	runFileE2ETest(s.testClient, s.kh, s.Suite, s.namespace, "smoke-test-fs", useCSI)
+	preserveFilesystemOnDelete := false
+	runFileE2ETest(s.testClient, s.kh, s.Suite, s.namespace, "smoke-test-fs", useCSI, preserveFilesystemOnDelete)
 }
 
 func (s *CephFlexDriverSuite) TestBlockStorageMountUnMountForStatefulSets() {

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -119,7 +119,8 @@ func (suite *SmokeSuite) TestBlockStorage_SmokeTest() {
 
 func (suite *SmokeSuite) TestFileStorage_SmokeTest() {
 	useCSI := true
-	runFileE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace, "smoke-test-fs", useCSI)
+	preserveFilesystemOnDelete := true
+	runFileE2ETest(suite.helper, suite.k8sh, suite.Suite, suite.namespace, "smoke-test-fs", useCSI, preserveFilesystemOnDelete)
 }
 
 func (suite *SmokeSuite) TestObjectStorage_SmokeTest() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Due to #6492, preservePoolsOnDelete is not useful at all for CephFS;
after the filesystem is deleted, the leftover pools cannot be
reassocaited with a newly created filesystem without wiping all
metadata. The only way we can actually preserve data is keeping around
the entire filesystem.

This commit implements a `preserveFsOnDelete` option which works similar
to the existing pool preservation option but instead keeps the whole
CephFS while taking it down and removing all MDSes.

This commit also changes all documentation to refer to this new option
with the intent of essentially deprecating `preservePoolsOnDelete`. IMO,
keeping around `preservePoolsOnDelete` is actively harmful because it
lulls users into thinking their data will be safe but, in reality,
recovering from this situation is highly complex and has large potential
for data loss.

Signed-off-by: Lalit Maganti <lalitm@google.com>

**Which issue is resolved by this Pull Request:**
Resolves #6492

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test full]