### PR TITLE
ceph: assert error type before using it

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -200,7 +200,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 	cmd := exec.Command(command, arg...)
 	cmdOut, err := cmd.CombinedOutput()
 	if err != nil {
-		cmdOut = []byte(fmt.Sprintf("%s. %s", string(cmdOut), string(err.(*exec.ExitError).Stderr)))
+		cmdOut = []byte(fmt.Sprintf("%s. %s", string(cmdOut), assertErrorType(err)))
 	}
 	// if there was anything that went to stdout/stderr then log it, even before we return an error
 	if string(cmdOut) != "" {
@@ -282,7 +282,7 @@ func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 	} else {
 		output, err = cmd.Output()
 		if err != nil {
-			output = []byte(fmt.Sprintf("%s. %s", string(output), string(err.(*exec.ExitError).Stderr)))
+			output = []byte(fmt.Sprintf("%s. %s", string(output), assertErrorType(err)))
 		}
 	}
 
@@ -297,4 +297,15 @@ func runCommandWithOutput(cmd *exec.Cmd, combinedOutput bool) (string, error) {
 
 func logCommand(command string, arg ...string) {
 	logger.Debugf("Running command: %s %s", command, strings.Join(arg, " "))
+}
+
+func assertErrorType(err error) string {
+	switch errType := err.(type) {
+	case *exec.ExitError:
+		return string(errType.Stderr)
+	case *exec.Error:
+		return errType.Error()
+	}
+
+	return ""
 }

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func Test_assertErrorType(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"unknown error type", args{err: errors.New("i don't know this error")}, ""},
+		{"exec.exitError type", args{err: &exec.ExitError{Stderr: []byte("this is an error")}}, "this is an error"},
+		{"exec.Error type", args{err: &exec.Error{Name: "my error", Err: errors.New("this is an error")}}, "exec: \"my error\": this is an error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assertErrorType(tt.args.err); got != tt.want {
+				t.Errorf("assertErrorType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

We don't always get an error of the type "*exec.ExitError" so we must
validate the type before printing it otherwise the interface conversion
will fail.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/pull/5483#discussion_r506942433

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
