### PR TITLE
ceph: remove allNode option for rgw

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -540,9 +540,6 @@ type GatewaySpec struct {
 	// The number of pods in the rgw replicaset. If "allNodes" is specified, a daemonset is created.
 	Instances int32 `json:"instances"`
 
-	// Whether the rgw pods should be started as a daemonset on all nodes
-	AllNodes bool `json:"allNodes"`
-
 	// The name of the secret that stores the ssl certificate for secure rgw connections
 	SSLCertificateRef string `json:"sslCertificateRef"`
 

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -83,12 +83,6 @@ func (c *clusterConfig) createOrUpdateStore(realmName, zoneGroupName, zoneName s
 
 func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) error {
 	// backward compatibility, triggered during updates
-	if c.store.Spec.Gateway.AllNodes {
-		// log we don't support that anymore
-		logger.Warningf(
-			"setting 'AllNodes' to %t is not supported anymore, please use 'instances' instead, removing old DaemonSets if any and replace them with Deployments in object store %s",
-			c.store.Spec.Gateway.AllNodes, c.store.Name)
-	}
 	if c.store.Spec.Gateway.Instances < 1 {
 		// Set the minimum of at least one instance
 		logger.Warning("spec.gateway.instances must be set to at least 1")


### PR DESCRIPTION
this commit removes unnecessary allNodes option
from rgw as it's already been removed.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
