### PR TITLE
ceph: Label mon pods

### DIFF
--- a/pkg/apis/rook.io/v1/annotations.go
+++ b/pkg/apis/rook.io/v1/annotations.go
@@ -24,7 +24,7 @@ func (a AnnotationsSpec) All() Annotations {
 	return a[KeyAll]
 }
 
-// ApplyToObjectMeta adds or overwrites if exists annotations to object meta.
+// ApplyToObjectMeta adds annotations to object meta unless the keys are already defined.
 func (a Annotations) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 	if t.Annotations == nil {
 		t.Annotations = map[string]string{}

--- a/pkg/apis/rook.io/v1/labels.go
+++ b/pkg/apis/rook.io/v1/labels.go
@@ -24,7 +24,7 @@ func (a LabelsSpec) All() Labels {
 	return a[KeyAll]
 }
 
-// ApplyToObjectMeta adds or overwrites if exists Labels to object meta.
+// ApplyToObjectMeta adds labels to object meta unless the keys are already defined.
 func (a Labels) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 	if t.Labels == nil {
 		t.Labels = map[string]string{}

--- a/pkg/apis/rook.io/v1/labels_test.go
+++ b/pkg/apis/rook.io/v1/labels_test.go
@@ -54,17 +54,57 @@ mon:
 }
 
 func TestLabelsApply(t *testing.T) {
-	objMeta := &metav1.ObjectMeta{}
-	testLabels := Labels{
-		"foo":   "bar",
-		"hello": "world",
+	tcs := []struct {
+		name     string
+		target   *metav1.ObjectMeta
+		input    Labels
+		expected Labels
+	}{
+		{
+			name:   "it should be able to update meta with no label",
+			target: &metav1.ObjectMeta{},
+			input: Labels{
+				"foo": "bar",
+			},
+			expected: Labels{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "it should keep the original labels when new labels are set",
+			target: &metav1.ObjectMeta{
+				Labels: Labels{
+					"foo": "bar",
+				},
+			},
+			input: Labels{
+				"hello": "world",
+			},
+			expected: Labels{
+				"foo":   "bar",
+				"hello": "world",
+			},
+		},
+		{
+			name: "it should NOT overwrite the existing keys",
+			target: &metav1.ObjectMeta{
+				Labels: Labels{
+					"foo": "bar",
+				},
+			},
+			input: Labels{
+				"foo": "baz",
+			},
+			expected: Labels{
+				"foo": "bar",
+			},
+		},
 	}
-	testLabels.ApplyToObjectMeta(objMeta)
-	assert.Equal(t, testLabels.getMapStringString(), objMeta.Labels)
 
-	testLabels["isthisatest"] = "test"
-	testLabels.ApplyToObjectMeta(objMeta)
-	assert.Equal(t, testLabels.getMapStringString(), objMeta.Labels)
+	for _, tc := range tcs {
+		tc.input.ApplyToObjectMeta(tc.target)
+		assert.Equal(t, tc.expected.getMapStringString(), tc.target.Labels)
+	}
 }
 
 func TestLabelsMerge(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -169,6 +169,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*v1.Pod, error)
 		Spec: podSpec,
 	}
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&pod.ObjectMeta)
+	cephv1.GetMonLabels(c.spec.Labels).ApplyToObjectMeta(&pod.ObjectMeta)
 
 	if c.spec.Network.IsHost() {
 		pod.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet


### PR DESCRIPTION
[test ceph]

**Description of your changes:**

#6084 enables users to add custom labels to rook-managed pods. It, however, does not propagate them to mon pods.
This PR fixes that and also improves comments and tests for `ApplyToObjectMeta` to mitigate my confusion while making this PR.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
