### PR TITLE
ceph: associate newly created pools to existing filesystem

### DIFF
--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -154,14 +154,22 @@ func CreateFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, name,
 
 	// add each additional pool
 	for i := 1; i < len(dataPools); i++ {
-		poolName := dataPools[i]
-		args = []string{"fs", "add_data_pool", name, poolName}
-		_, err = NewCephCommand(context, clusterInfo, args).Run()
+		err = AddDataPoolToFilesystem(context, clusterInfo, name, dataPools[i])
 		if err != nil {
-			logger.Errorf("failed to add pool %q to file system %q. %v", poolName, name, err)
+			logger.Errorf("%v", err)
 		}
 	}
 
+	return nil
+}
+
+// AddDataPoolToFilesystem associates the provided data pool with the filesystem.
+func AddDataPoolToFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, name, poolName string) error {
+	args := []string{"fs", "add_data_pool", name, poolName}
+	_, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to add pool %q to file system %q. (%v)", poolName, name, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
When new pools are added to an already existing filesystem, we would
create them but not actually associate them to the filesystem. Ensure
that we do this.

Also, while we're here, we refactor the CreateFilesystem test: before,
we were not properly testing creating the filesystem from scratch
because we would return valid JSON for *every* ceph command. Change this
by making the first run return an error so that we get some better
coverage.

After this, we also add a check for the correctness of adding new pools
to the CreateFilesystem unittest.

Fixes #5876

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]