### PR TITLE
ceph: rework unit test

### DIFF
--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -18,7 +18,6 @@ package kms
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -27,83 +26,23 @@ import (
 )
 
 func TestVaultTLSEnvVarFromSecret(t *testing.T) {
-	type args struct {
-		kmsConfig map[string]string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []v1.EnvVar
-	}{
-		{"no tls", args{kmsConfig: map[string]string{"foo": "bar"}}, []v1.EnvVar{}},
-		{"ca cert tls", args{kmsConfig: map[string]string{"foo": "bar", "VAULT_CACERT": "vault-ca-cert-secret"}}, []v1.EnvVar{{Name: "VAULT_CACERT", Value: "/etc/vault/vault.ca"}}},
-		{"ca cert tls and client ca/key", args{kmsConfig: map[string]string{
-			"foo":               "bar",
-			"VAULT_CACERT":      "vault-ca-cert-secret",
-			"VAULT_CLIENT_CERT": "vault-client-cert-secret",
-			"VAULT_CLIENT_KEY":  "vault-key-cert-secret",
-		}},
-			[]v1.EnvVar{
-				{Name: "VAULT_CACERT", Value: "/etc/vault/vault.ca"},
-				{Name: "VAULT_CLIENT_CERT", Value: "/etc/vault/vault.crt"},
-				{Name: "VAULT_CLIENT_KEY", Value: "/etc/vault/vault.key"},
-			}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := vaultTLSEnvVarFromSecret(tt.args.kmsConfig); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("vaultTLSEnvVarFromSecret() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+	// No TLS
+	spec := cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200"}}}}
+	envVars := VaultConfigToEnvVar(spec)
+	assert.Equal(t, 3, len(envVars))
+	assert.Contains(t, envVars, v1.EnvVar{Name: "KMS_PROVIDER", Value: "vault"})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Key: "token"}}})
 
-func TestVaultConfigToEnvVar(t *testing.T) {
-	type args struct {
-		spec cephv1.ClusterSpec
-	}
-	tests := []struct {
-		name string
-		args args
-		want []v1.EnvVar
-	}{
-		{"no tls", args{spec: cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200"}}}}}, []v1.EnvVar{
-			{Name: "KMS_PROVIDER", Value: "vault"},
-			{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"},
-			{Name: "VAULT_TOKEN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: "vault-token",
-					},
-					Key: "token",
-				},
-			},
-			},
-		},
-		},
-		{" tls", args{spec: cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200", "VAULT_CACERT": "vault-ca-cert-secret"}}}}}, []v1.EnvVar{
-			{Name: "KMS_PROVIDER", Value: "vault"},
-			{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"},
-			{Name: "VAULT_TOKEN", ValueFrom: &v1.EnvVarSource{
-				SecretKeyRef: &v1.SecretKeySelector{
-					LocalObjectReference: v1.LocalObjectReference{
-						Name: "vault-token",
-					},
-					Key: "token",
-				},
-			},
-			},
-			{Name: "VAULT_CACERT", Value: "/etc/vault/vault.ca"},
-		},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := VaultConfigToEnvVar(tt.args.spec); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("VaultConfigToEnvVar() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	// TLS
+	spec = cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200", "VAULT_CACERT": "vault-ca-cert-secret"}}}}
+	envVars = VaultConfigToEnvVar(spec)
+	assert.Equal(t, 4, len(envVars))
+	assert.Contains(t, envVars, v1.EnvVar{Name: "KMS_PROVIDER", Value: "vault"})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_CACERT", Value: "/etc/vault/vault.ca"})
+	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_TOKEN", ValueFrom: &v1.EnvVarSource{SecretKeyRef: &v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "vault-token"}, Key: "token"}}})
+
 }
 
 func TestConfigEnvsToMapString(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

Golang maps order is not always guaranteed to be identical, which makes
the table-driven test to fail. Because of the nature of the maps, it is
hard to predict the exact position of an element on the map. This
makes the table-driven test flappy.
Reworked the unit test using a contains statement which achieves the
same validation.

Closes: https://github.com/rook/rook/issues/6522
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6522

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
