### PR TITLE
ceph: helm test for k8s 1.15 failing

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -282,6 +282,18 @@ spec:
                         iteration:
                           type: integer
                           format: int32
+                security:
+                  type: object
+                  properties:
+                    kms:
+                      type: object
+                      properties:
+                        connectionDetails:
+                          type: object
+                          nullable: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        tokenSecretName:
+                          type: string
                 annotations:
                   type: object
                   nullable: true
@@ -1272,7 +1284,9 @@ spec:
               x-kubernetes-preserve-unknown-fields: true
       subresources:
         status: {}
+---    
 {{- else }}
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -1438,6 +1452,7 @@ spec:
                   type: boolean
             placement: {}
             resources: {}
+            security: {}
             cleanupPolicy:
               properties:
                 confirmation:
@@ -1454,16 +1469,6 @@ spec:
                     iteration:
                       type: integer
                       format: int32
-            security:
-              properties:
-                kms:
-                  properties:
-                    connectionDetails:
-                      type: object
-                      nullable: true
-                      x-kubernetes-preserve-unknown-fields: true
-                    tokenSecretName:
-                      type: string
   additionalPrinterColumns:
     - name: DataDirHostPath
       type: string

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crd.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crd.yaml
@@ -202,6 +202,7 @@ spec:
                     iteration:
                       type: integer
                       format: int32
+            security: {}
             placement: {}
             resources: {}
             healthCheck: {}


### PR DESCRIPTION
helm test for k8s 1.15 failing showing errors
CRDs not found, after some latest changes to CRDS.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6531 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test full]