### PR TITLE
ceph: add support for VAULT_TLS_SERVER_NAME

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -182,6 +182,12 @@ if [ -n "$VAULT_CLIENT_KEY" ]; then
 	ARGS+=(--key "${VAULT_CLIENT_KEY}")
 fi
 
+# For a request to any host/port, connect to VAULT_TLS_SERVER_NAME:request's original port instead
+# Used for SNI validation and correct certificate matching
+if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
+	ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
+fi
+
 # Check KV backend
 if [ -z "$VAULT_BACKEND" ]; then
 	VAULT_BACKEND=$VAULT_DEFAULT_BACKEND


### PR DESCRIPTION
**Description of your changes:**

We now support VAULT_TLS_SERVER_NAME which represents the name to use as
the SNI host when connecting via TLS.
This is typically needed when a single host has multiple certificates,
same as virtual hosts but for SSL certificates.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
