### PR TITLE
ceph: Add 'ganesha-' to nfs-ganesha config object name

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -78,8 +78,10 @@ spec:
 All daemons within a cluster will share configuration with no exports defined, and that includes a RADOS object via:
 
 ```ini
-%url  rados://<pool>/<namespace>/conf-nfs.<clustername>
+%url  rados://<pool>/<namespace>/conf-nfs.ganesha-<clustername>
 ```
+
+> **NOTE**: This format of nfs-ganesha config object name was introduced in Ceph Octopus Version. In older versions, each daemon has it's own config object and with the name as *conf-<clustername>.<nodeid>*. The nodeid is a value automatically assigned internally by rook. Nodeids start with "a" and go through "z", at which point they become two letters ("aa" to "az").
 
 The pool and namespace are configured via the spec's RADOS block.
 


### PR DESCRIPTION
The expected nfs-ganesha config object name by mgr/volumes/nfs[1] plugin is
"conf-nfs.ganesha-\<clustername\>".

[1] https://github.com/ceph/ceph/blob/master/src/pybind/mgr/volumes/fs/nfs.py#L648-L655

Signed-off-by: Varsha Rao <varao@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
