### PR TITLE
ceph: add unit test for ceph-volume batch mode and warn about unsupported ceph version

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -524,10 +524,10 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 					deviceArg,
 				}...)
 
-				if device.Config.DeviceClass != "" {
+				if a.storeConfig.DeviceClass != "" {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						crushDeviceClassFlag,
-						device.Config.DeviceClass,
+						a.storeConfig.DeviceClass,
 					}...)
 				}
 

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -537,8 +537,8 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 				}...)
 
 				logger.Infof("Base command - %+v", baseCommand)
-				logger.Infof("immediateReportArgs - %+v", baseCommand)
 				logger.Infof("immediateExecuteArgs - %+v", immediateExecuteArgs)
+				logger.Infof("immediateReportArgs - %+v", immediateReportArgs)
 				if err := context.Executor.ExecuteCommand(baseCommand, immediateReportArgs...); err != nil {
 					return errors.Wrap(err, "failed ceph-volume report") // fail return here as validation provided by ceph-volume
 				}

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -55,8 +55,7 @@ var (
 	cvLogDir      = ""
 	// The "ceph-volume raw" command is available since Ceph 14.2.8 as well as partition support in ceph-volume
 	cephVolumeRawModeMinCephVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 8}
-
-	isEncrypted = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
+	isEncrypted                     = os.Getenv(oposd.EncryptedDeviceEnvVarName) == "true"
 )
 
 type osdInfoBlock struct {

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -164,6 +164,10 @@ func (c *cluster) validateCephVersion(version *cephver.CephVersion) error {
 			}
 			logger.Warningf("unsupported ceph version detected: %q, pursuing", version)
 		}
+
+		if version.Unsupported() {
+			logger.Errorf("UNSUPPORTED: ceph version %q detected, it is recommended to rollback to the previous pin-point stable release, pursuing anyways", version)
+		}
 	}
 
 	// The following tries to determine if the operator can proceed with an upgrade because we come from an OnAdd() call

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -47,9 +47,14 @@ var (
 	// Pacific Ceph version
 	Pacific = CephVersion{16, 0, 0, 0}
 
+	// cephVolumeLVMDiskSortingCephVersion introduced a major regression in c-v and thus is not suitable for production
+	cephVolumeLVMDiskSortingCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 13}
+
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions   = []CephVersion{Nautilus, Octopus}
-	unsupportedVersions = []CephVersion{Pacific}
+	supportedVersions = []CephVersion{Nautilus, Octopus}
+
+	// unsupportedVersions are possibly Ceph pin-point release that introduced breaking changes and not recommended
+	unsupportedVersions = []CephVersion{cephVolumeLVMDiskSortingCephVersion}
 
 	// for parsing the output of `ceph --version`
 	versionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)`)
@@ -130,8 +135,22 @@ func (v *CephVersion) Supported() bool {
 	return false
 }
 
+// Unsupported checks if a given release is supported
+func (v *CephVersion) Unsupported() bool {
+	for _, sv := range unsupportedVersions {
+		if v.isExactly(sv) {
+			return true
+		}
+	}
+	return false
+}
+
 func (v *CephVersion) isRelease(other CephVersion) bool {
 	return v.Major == other.Major
+}
+
+func (v *CephVersion) isExactly(other CephVersion) bool {
+	return v.Major == other.Major && v.Minor == other.Minor && v.Extra == other.Extra
 }
 
 // IsNautilus checks if the Ceph version is Nautilus

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -97,9 +97,6 @@ func TestSupported(t *testing.T) {
 	for _, v := range supportedVersions {
 		assert.True(t, v.Supported())
 	}
-	for _, v := range unsupportedVersions {
-		assert.False(t, v.Supported())
-	}
 }
 
 func TestIsRelease(t *testing.T) {
@@ -202,4 +199,37 @@ func TestValidateCephVersionsBetweenLocalAndExternalClusters(t *testing.T) {
 	externalCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 2}
 	err = ValidateCephVersionsBetweenLocalAndExternalClusters(localCephVersion, externalCephVersion)
 	assert.NoError(t, err)
+}
+
+func TestCephVersion_Unsupported(t *testing.T) {
+	type fields struct {
+		Major int
+		Minor int
+		Extra int
+		Build int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"supported", fields{Major: 14, Minor: 2, Extra: 1, Build: 0}, false},
+		{"supported", fields{Major: 14, Minor: 2, Extra: 12, Build: 0}, false},
+		{"supported", fields{Major: 15, Minor: 2, Extra: 1, Build: 0}, false},
+		{"supported", fields{Major: 15, Minor: 2, Extra: 6, Build: 0}, false},
+		{"unsupported", fields{Major: 14, Minor: 2, Extra: 13, Build: 0}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &CephVersion{
+				Major: tt.fields.Major,
+				Minor: tt.fields.Minor,
+				Extra: tt.fields.Extra,
+				Build: tt.fields.Build,
+			}
+			if got := v.Unsupported(); got != tt.want {
+				t.Errorf("CephVersion.Unsupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->
**Description of your changes:**

We now use the recommended flag '--no-auto' when calling batch mode.
More details in https://tracker.ceph.com/issues/48106.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #6532

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
