### PR TITLE
ceph: upgrade test Rook only from v1.4 to master

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -349,9 +349,13 @@ available with Ceph-CSI v3.0.
 First apply new resources. This includes slightly modified privileges (RBAC) needed by the Operator
 and updates to the Custom Resource Definitions (CRDs).
 
+> **IMPORTANT:** If you are using Kubernetes version v1.15 or lower, you will need to manually
+> modify the `upgrade-from-v1.4-apply.yaml` file to use
+> `rbac.authorization.k8s.io/v1beta1` instead of `rbac.authorization.k8s.io/v1`
+> You will also need to apply `pre-k8s-1.16/crd.yaml` instead of `upgrade-from-v1.4-crds.yaml`.
+
 ```sh
-kubectl delete -f upgrade-from-v1.3-delete.yaml
-kubectl apply -f upgrade-from-v1.3-apply.yaml -f upgrade-from-v1.3-crds.yaml
+kubectl apply -f upgrade-from-v1.4-apply.yaml -f upgrade-from-v1.4-crds.yaml
 ```
 
 ## 3. Update Ceph CSI version to v3.0

--- a/cluster/examples/kubernetes/ceph/upgrade-from-v1.4-crds.yaml
+++ b/cluster/examples/kubernetes/ceph/upgrade-from-v1.4-crds.yaml
@@ -1,76 +1,388 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cephblockpools.ceph.rook.io
+  name: cephclusters.ceph.rook.io
 spec:
   group: ceph.rook.io
   names:
-    kind: CephBlockPool
-    listKind: CephBlockPoolList
-    plural: cephblockpools
-    singular: cephblockpool
+    kind: CephCluster
+    plural: cephclusters
+    singular: cephcluster
   scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            failureDomain:
-                type: string
-            crushRoot:
-                type: string
-            replicated:
-              properties:
-                size:
-                  type: integer
-                  minimum: 0
-                  maximum: 9
-                targetSizeRatio:
-                  type: number
-                requireSafeReplicaSize:
-                  type: boolean
-                replicasPerFailureDomain:
-                  type: integer
-                subFailureDomain:
-                  type: string
-            erasureCoded:
-              properties:
-                dataChunks:
-                  type: integer
-                  minimum: 0
-                  maximum: 9
-                codingChunks:
-                  type: integer
-                  minimum: 0
-                  maximum: 9
-            compressionMode:
-              type: string
-              enum:
-              - ""
-              - none
-              - passive
-              - aggressive
-              - force
-            enableRBDStats:
-              description: EnableRBDStats is used to enable gathering of statistics
-                for all RBD images in the pool
-              type: boolean
-            parameters:
+            spec:
               type: object
-            mirroring:
               properties:
-                enabled:
-                  type: boolean
-                mode:
+                cephVersion:
+                  type: object
+                  properties:
+                    allowUnsupported:
+                      type: boolean
+                    image:
+                      type: string
+                dashboard:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    urlPrefix:
+                      type: string
+                    port:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
+                    ssl:
+                      type: boolean
+                dataDirHostPath:
+                  pattern: ^/(\S+)
                   type: string
-                  enum:
-                  - image
-                  - pool
-  subresources:
-    status: {}
+                disruptionManagement:
+                  type: object
+                  properties:
+                    machineDisruptionBudgetNamespace:
+                      type: string
+                    managePodBudgets:
+                      type: boolean
+                    osdMaintenanceTimeout:
+                      type: integer
+                    manageMachineDisruptionBudgets:
+                      type: boolean
+                skipUpgradeChecks:
+                  type: boolean
+                continueUpgradeAfterChecksEvenIfNotHealthy:
+                  type: boolean
+                mon:
+                  type: object
+                  properties:
+                    allowMultiplePerNode:
+                      type: boolean
+                    count:
+                      maximum: 9
+                      minimum: 0
+                      type: integer
+                    volumeClaimTemplate:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                mgr:
+                  type: object
+                  properties:
+                    modules:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          enabled:
+                            type: boolean
+                crashCollector:
+                  type: object
+                  properties:
+                    disable:
+                      type: boolean
+                network:
+                  type: object
+                  nullable: true
+                  properties:
+                    hostNetwork:
+                      type: boolean
+                    provider:
+                      type: string
+                    selectors:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    ipFamily:
+                      type: string
+                storage:
+                  type: object
+                  properties:
+                    disruptionManagement:
+                      type: object
+                      nullable: true
+                      properties:
+                        machineDisruptionBudgetNamespace:
+                          type: string
+                        managePodBudgets:
+                          type: boolean
+                        osdMaintenanceTimeout:
+                          type: integer
+                        manageMachineDisruptionBudgets:
+                          type: boolean
+                    useAllNodes:
+                      type: boolean
+                    nodes:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          config:
+                            type: object
+                            nullable: true
+                            properties:
+                              metadataDevice:
+                                type: string
+                              storeType:
+                                type: string
+                                pattern: ^(bluestore)$
+                              databaseSizeMB:
+                                type: string
+                              walSizeMB:
+                                type: string
+                              journalSizeMB:
+                                type: string
+                              osdsPerDevice:
+                                type: string
+                              encryptedDevice:
+                                type: string
+                                pattern: ^(true|false)$
+                          useAllDevices:
+                            type: boolean
+                          deviceFilter:
+                            type: string
+                            nullable: true
+                          devicePathFilter:
+                            type: string
+                          devices:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                config:
+                                  type: object
+                                  nullable: true
+                                  x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            type: object
+                            nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                    useAllDevices:
+                      type: boolean
+                    deviceFilter:
+                      type: string
+                      nullable: true
+                    devicePathFilter:
+                      type: string
+                    config:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    storageClassDeviceSets:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          count:
+                            type: integer
+                            format: int32
+                          portable:
+                            type: boolean
+                          tuneDeviceClass:
+                            type: boolean
+                          tuneFastDeviceClass:
+                            type: boolean
+                          encrypted:
+                            type: boolean
+                          schedulerName:
+                            type: string
+                          config:
+                            type: object
+                            nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          placement:
+                            type: object
+                            nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          preparePlacement:
+                            type: object
+                            nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          resources:
+                            type: object
+                            nullable: true
+                            x-kubernetes-preserve-unknown-fields: true
+                          volumeClaimTemplates:
+                            type: array
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                driveGroups:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      spec:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      placement:
+                        type: object
+                        nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - name
+                      - spec
+                monitoring:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    rulesNamespace:
+                      type: string
+                    externalMgrEndpoints:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          ip:
+                            type: string
+                removeOSDsIfOutAndSafeToRemove:
+                  type: boolean
+                external:
+                  type: object
+                  properties:
+                    enable:
+                      type: boolean
+                cleanupPolicy:
+                  type: object
+                  properties:
+                    allowUninstallWithVolumes:
+                      type: boolean
+                    confirmation:
+                      type: string
+                      pattern: ^$|^yes-really-destroy-data$
+                    sanitizeDisks:
+                      type: object
+                      properties:
+                        method:
+                          type: string
+                          pattern: ^(complete|quick)$
+                        dataSource:
+                          type: string
+                          pattern: ^(zero|random)$
+                        iteration:
+                          type: integer
+                          format: int32
+                security:
+                  type: object
+                  properties:
+                    kms:
+                      type: object
+                      properties:
+                        connectionDetails:
+                          type: object
+                          nullable: true
+                          x-kubernetes-preserve-unknown-fields: true
+                        tokenSecretName:
+                          type: string
+                annotations:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                placement:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                labels:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                healthCheck:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                priorityClassNames:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: DataDirHostPath
+          type: string
+          description: Directory used on the K8s nodes
+          jsonPath: .spec.dataDirHostPath
+        - name: MonCount
+          type: string
+          description: Number of MONs
+          jsonPath: .spec.mon.count
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Phase
+          type: string
+          description: Phase
+          jsonPath: .status.phase
+        - name: Message
+          type: string
+          description: Message
+          jsonPath: .status.message
+        - name: Health
+          type: string
+          description: Ceph Health
+          jsonPath: .status.ceph.health
+      subresources:
+        status: {}
+# OLM: END CEPH CRD
+# OLM: BEGIN CEPH CLIENT CRD
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephclients.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephClient
+    listKind: CephClientList
+    plural: cephclients
+    singular: cephclient
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                caps:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH CLIENT CRD
+# OLM: BEGIN CEPH RBD MIRROR CRD
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cephrbdmirrors.ceph.rook.io
@@ -82,242 +394,924 @@ spec:
     plural: cephrbdmirrors
     singular: cephrbdmirror
   scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            count:
-              type: integer
-              minimum: 1
-              maximum: 100
-            peers:
+            spec:
+              type: object
               properties:
-                secretNames:
-                  type: array
-  subresources:
-    status: {}
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                peers:
+                  type: object
+                  properties:
+                    secretNames:
+                      type: array
+                      items:
+                        type: string
+                resources:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                priorityClassName:
+                  type: string
+                placement:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                annotations:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+
+# OLM: END CEPH RBD MIRROR CRD
+# OLM: BEGIN CEPH FS CRD
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cephclusters.ceph.rook.io
+  name: cephfilesystems.ceph.rook.io
 spec:
   group: ceph.rook.io
   names:
-    kind: CephCluster
-    listKind: CephClusterList
-    plural: cephclusters
-    singular: cephcluster
+    kind: CephFilesystem
+    listKind: CephFilesystemList
+    plural: cephfilesystems
+    singular: cephfilesystem
   scope: Namespaced
-  version: v1
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            annotations: {}
-            cephVersion:
+            spec:
+              type: object
               properties:
-                allowUnsupported:
-                  type: boolean
-                image:
-                  type: string
-            dashboard:
-              properties:
-                enabled:
-                  type: boolean
-                urlPrefix:
-                  type: string
-                port:
-                  type: integer
-                  minimum: 0
-                  maximum: 65535
-                ssl:
-                  type: boolean
-            dataDirHostPath:
-              pattern: ^/(\S+)
-              type: string
-            disruptionManagement:
-              properties:
-                machineDisruptionBudgetNamespace:
-                  type: string
-                managePodBudgets:
-                  type: boolean
-                osdMaintenanceTimeout:
-                  type: integer
-                manageMachineDisruptionBudgets:
-                  type: boolean
-            skipUpgradeChecks:
-              type: boolean
-            continueUpgradeAfterChecksEvenIfNotHealthy:
-              type: boolean
-            mon:
-              properties:
-                allowMultiplePerNode:
-                  type: boolean
-                count:
-                  maximum: 9
-                  minimum: 0
-                  type: integer
-                volumeClaimTemplate: {}
-            mgr:
-              properties:
-                modules:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      enabled:
-                        type: boolean
-            network:
-              properties:
-                hostNetwork:
-                  type: boolean
-                provider:
-                  type: string
-                selectors: {}
-            storage:
-              properties:
-                disruptionManagement:
+                metadataServer:
+                  type: object
                   properties:
-                    machineDisruptionBudgetNamespace:
-                      type: string
-                    managePodBudgets:
-                      type: boolean
-                    osdMaintenanceTimeout:
+                    activeCount:
+                      minimum: 1
+                      maximum: 10
                       type: integer
-                    manageMachineDisruptionBudgets:
+                    activeStandby:
                       type: boolean
-                useAllNodes:
-                  type: boolean
-                nodes:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                      config:
-                        properties:
-                          metadataDevice:
-                            type: string
-                          storeType:
-                            type: string
-                            pattern: ^(bluestore)$
-                          databaseSizeMB:
-                            type: string
-                          walSizeMB:
-                            type: string
-                          journalSizeMB:
-                            type: string
-                          osdsPerDevice:
-                            type: string
-                          encryptedDevice:
-                            type: string
-                            pattern: ^(true|false)$
-                      useAllDevices:
-                        type: boolean
-                      deviceFilter:
-                        type: string
-                      devicePathFilter:
-                        type: string
-                      devices:
-                        type: array
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            config: {}
-                      resources: {}
-                  type: array
-                useAllDevices:
-                  type: boolean
-                deviceFilter:
-                  type: string
-                devicePathFilter:
-                  type: string
-                config: {}
-                storageClassDeviceSets: {}
-            driveGroups:
-              type: array
-              nullable: true
-              items:
-                properties:
-                  name:
-                    type: string
-                  spec: {}
-                  placement: {}
-                required:
-                - name
-                - spec
-            monitoring:
-              properties:
-                enabled:
-                  type: boolean
-                rulesNamespace:
-                  type: string
-                externalMgrEndpoints:
-                  type: array
-                  items:
-                    properties:
-                      ip:
-                        type: string
-            removeOSDsIfOutAndSafeToRemove:
-              type: boolean
-            external:
-              properties:
-                enable:
-                  type: boolean
-            cleanupPolicy:
-              properties:
-                confirmation:
-                  type: string
-                  pattern: ^$|^yes-really-destroy-data$
-                sanitizeDisks:
+                    annotations:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    placement:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    priorityClassName:
+                      type: string
+                    labels:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                metadataPool:
+                  type: object
+                  nullable: true
                   properties:
-                    method:
+                    failureDomain:
                       type: string
-                      pattern: ^(complete|quick)$
-                    dataSource:
+                    deviceClass:
                       type: string
-                      pattern: ^(zero|random)$
-                    iteration:
+                    crushRoot:
+                      type: string
+                    replicated:
+                      type: object
+                      nullable: true
+                      properties:
+                        size:
+                          minimum: 0
+                          maximum: 10
+                          type: integer
+                        requireSafeReplicaSize:
+                          type: boolean
+                        replicasPerFailureDomain:
+                          type: integer
+                        subFailureDomain:
+                          type: string
+                    parameters:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    erasureCoded:
+                      type: object
+                      nullable: true
+                      properties:
+                        dataChunks:
+                          minimum: 0
+                          maximum: 10
+                          type: integer
+                        codingChunks:
+                          minimum: 0
+                          maximum: 10
+                          type: integer
+                    compressionMode:
+                      type: string
+                      enum:
+                        - ""
+                        - none
+                        - passive
+                        - aggressive
+                        - force
+                dataPools:
+                  type: array
+                  nullable: true
+                  items:
+                    type: object
+                    properties:
+                      failureDomain:
+                        type: string
+                      deviceClass:
+                        type: string
+                      crushRoot:
+                        type: string
+                      replicated:
+                        type: object
+                        nullable: true
+                        properties:
+                          size:
+                            minimum: 0
+                            maximum: 10
+                            type: integer
+                          requireSafeReplicaSize:
+                            type: boolean
+                          replicasPerFailureDomain:
+                            type: integer
+                          subFailureDomain:
+                            type: string
+                      erasureCoded:
+                        type: object
+                        nullable: true
+                        properties:
+                          dataChunks:
+                            minimum: 0
+                            maximum: 10
+                            type: integer
+                          codingChunks:
+                            minimum: 0
+                            maximum: 10
+                            type: integer
+                      compressionMode:
+                        type: string
+                        enum:
+                          - ""
+                          - none
+                          - passive
+                          - aggressive
+                          - force
+                      parameters:
+                        type: object
+                        nullable: true
+                        x-kubernetes-preserve-unknown-fields: true
+                preservePoolsOnDelete:
+                  type: boolean
+                preserveFilesystemOnDelete:
+                  type: boolean
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: ActiveMDS
+          type: string
+          description: Number of desired active MDS daemons
+          jsonPath: .spec.metadataServer.activeCount
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+# OLM: END CEPH FS CRD
+# OLM: BEGIN CEPH NFS CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephnfses.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephNFS
+    listKind: CephNFSList
+    plural: cephnfses
+    singular: cephnfs
+    shortNames:
+      - nfs
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                rados:
+                  type: object
+                  properties:
+                    pool:
+                      type: string
+                    namespace:
+                      type: string
+                server:
+                  type: object
+                  properties:
+                    active:
+                      type: integer
+                    annotations:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    placement:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    priorityClassName:
+                      type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH NFS CRD
+# OLM: BEGIN CEPH OBJECT STORE CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstores.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStore
+    listKind: CephObjectStoreList
+    plural: cephobjectstores
+    singular: cephobjectstore
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                gateway:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    sslCertificateRef:
+                      type: string
+                      nullable: true
+                    port:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
+                    securePort:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
+                    instances:
+                      type: integer
+                    externalRgwEndpoints:
+                      type: array
+                      nullable: true
+                      items:
+                        type: object
+                        properties:
+                          ip:
+                            type: string
+                    annotations:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    placement:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    resources:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    labels:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                    priorityClassName:
+                      type: string
+                metadataPool:
+                  type: object
+                  nullable: true
+                  properties:
+                    failureDomain:
+                      type: string
+                    crushRoot:
+                      type: string
+                    replicated:
+                      type: object
+                      nullable: true
+                      properties:
+                        size:
+                          type: integer
+                        requireSafeReplicaSize:
+                          type: boolean
+                        replicasPerFailureDomain:
+                          type: integer
+                        subFailureDomain:
+                          type: string
+                    erasureCoded:
+                      type: object
+                      nullable: true
+                      properties:
+                        dataChunks:
+                          type: integer
+                        codingChunks:
+                          type: integer
+                    compressionMode:
+                      type: string
+                      enum:
+                        - ""
+                        - none
+                        - passive
+                        - aggressive
+                        - force
+                    parameters:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                zone:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                dataPool:
+                  type: object
+                  nullable: true
+                  properties:
+                    failureDomain:
+                      type: string
+                    crushRoot:
+                      type: string
+                    replicated:
+                      type: object
+                      nullable: true
+                      properties:
+                        size:
+                          type: integer
+                        requireSafeReplicaSize:
+                          type: boolean
+                        replicasPerFailureDomain:
+                          type: integer
+                        subFailureDomain:
+                          type: string
+                    erasureCoded:
+                      type: object
+                      nullable: true
+                      properties:
+                        dataChunks:
+                          type: integer
+                        codingChunks:
+                          type: integer
+                    compressionMode:
+                      type: string
+                      enum:
+                        - ""
+                        - none
+                        - passive
+                        - aggressive
+                        - force
+                    parameters:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                preservePoolsOnDelete:
+                  type: boolean
+                healthCheck:
+                  type: object
+                  nullable: true
+                  properties:
+                    bucket:
+                      type: object
+                      nullable: true
+                      properties:
+                        enabled:
+                          type: boolean
+                        interval:
+                          type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+
+# OLM: END CEPH OBJECT STORE CRD
+# OLM: BEGIN CEPH OBJECT STORE USERS CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectstoreusers.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectStoreUser
+    listKind: CephObjectStoreUserList
+    plural: cephobjectstoreusers
+    singular: cephobjectstoreuser
+    shortNames:
+      - rcou
+      - objectuser
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                store:
+                  type: string
+                displayName:
+                  type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH OBJECT STORE USERS CRD
+# OLM: BEGIN CEPH OBJECT REALM CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectrealms.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectRealm
+    listKind: CephObjectRealmList
+    plural: cephobjectrealms
+    singular: cephobjectrealm
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                pull:
+                  type: object
+                  properties:
+                    endpoint:
+                      type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH OBJECT REALM CRD
+# OLM: BEGIN CEPH OBJECT ZONEGROUP CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectzonegroups.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectZoneGroup
+    listKind: CephObjectZoneGroupList
+    plural: cephobjectzonegroups
+    singular: cephobjectzonegroup
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                realm:
+                  type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH OBJECT ZONEGROUP CRD
+# OLM: BEGIN CEPH OBJECT ZONE CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephobjectzones.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephObjectZone
+    listKind: CephObjectZoneList
+    plural: cephobjectzones
+    singular: cephobjectzone
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                zoneGroup:
+                  type: string
+                metadataPool:
+                  type: object
+                  nullable: true
+                  properties:
+                    failureDomain:
+                      type: string
+                    crushRoot:
+                      type: string
+                    replicated:
+                      type: object
+                      nullable: true
+                      properties:
+                        size:
+                          type: integer
+                        requireSafeReplicaSize:
+                          type: boolean
+                    erasureCoded:
+                      type: object
+                      nullable: true
+                      properties:
+                        dataChunks:
+                          type: integer
+                        codingChunks:
+                          type: integer
+                    compressionMode:
+                      type: string
+                      enum:
+                        - ""
+                        - none
+                        - passive
+                        - aggressive
+                        - force
+                    parameters:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                dataPool:
+                  type: object
+                  properties:
+                    failureDomain:
+                      type: string
+                    crushRoot:
+                      type: string
+                    replicated:
+                      type: object
+                      nullable: true
+                      properties:
+                        size:
+                          type: integer
+                        requireSafeReplicaSize:
+                          type: boolean
+                    erasureCoded:
+                      type: object
+                      nullable: true
+                      properties:
+                        dataChunks:
+                          type: integer
+                        codingChunks:
+                          type: integer
+                    compressionMode:
+                      type: string
+                      enum:
+                        - ""
+                        - none
+                        - passive
+                        - aggressive
+                        - force
+                    parameters:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                preservePoolsOnDelete:
+                  type: boolean
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH OBJECT ZONE CRD
+# OLM: BEGIN CEPH BLOCK POOL CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cephblockpools.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephBlockPool
+    listKind: CephBlockPoolList
+    plural: cephblockpools
+    singular: cephblockpool
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                failureDomain:
+                  type: string
+                deviceClass:
+                  type: string
+                crushRoot:
+                  type: string
+                replicated:
+                  type: object
+                  nullable: true
+                  properties:
+                    size:
+                      type: integer
+                      minimum: 0
+                      maximum: 9
+                    targetSizeRatio:
+                      type: number
+                    requireSafeReplicaSize:
+                      type: boolean
+                    replicasPerFailureDomain:
+                      type: integer
+                    subFailureDomain:
+                      type: string
+                erasureCoded:
+                  type: object
+                  nullable: true
+                  properties:
+                    dataChunks:
+                      type: integer
+                      minimum: 0
+                      maximum: 9
+                    codingChunks:
+                      type: integer
+                      minimum: 0
+                      maximum: 9
+                compressionMode:
+                  type: string
+                  enum:
+                    - ""
+                    - none
+                    - passive
+                    - aggressive
+                    - force
+                enableRBDStats:
+                  description:
+                    EnableRBDStats is used to enable gathering of statistics
+                    for all RBD images in the pool
+                  type: boolean
+                parameters:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                mirroring:
+                  type: object
+                  nullable: true
+                  properties:
+                    enabled:
+                      type: boolean
+                    mode:
+                      type: string
+                      enum:
+                        - image
+                        - pool
+                statusCheck:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                annotations:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+
+# OLM: END CEPH BLOCK POOL CRD
+# OLM: BEGIN CEPH VOLUME POOL CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: volumes.rook.io
+spec:
+  group: rook.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    singular: volume
+    shortNames:
+      - rv
+  scope: Namespaced
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            attachments:
+              type: array
+              items:
+                type: object
+                properties:
+                  node:
+                    type: string
+                  podNamespace:
+                    type: string
+                  podName:
+                    type: string
+                  clusterName:
+                    type: string
+                  mountDir:
+                    type: string
+                  readOnly:
+                    type: boolean
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END CEPH VOLUME POOL CRD
+# OLM: BEGIN OBJECTBUCKET CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  group: objectbucket.io
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    singular: objectbucket
+    shortNames:
+      - ob
+      - obs
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                storageClassName:
+                  type: string
+                endpoint:
+                  type: object
+                  nullable: true
+                  properties:
+                    bucketHost:
+                      type: string
+                    bucketPort:
                       type: integer
                       format: int32
-            security:
-              properties:
-                kms:
-                  properties:
-                    connectionDetails:
-                      type: object
-                    tokenSecretName:
+                    bucketName:
                       type: string
-            placement: {}
-            resources: {}
-            healthCheck: {}
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-    - name: DataDirHostPath
-      type: string
-      description: Directory used on the K8s nodes
-      JSONPath: .spec.dataDirHostPath
-    - name: MonCount
-      type: string
-      description: Number of MONs
-      JSONPath: .spec.mon.count
-    - name: Age
-      type: date
-      JSONPath: .metadata.creationTimestamp
-    - name: Phase
-      type: string
-      description: Phase
-      JSONPath: .status.phase
-    - name: Message
-      type: string
-      description: Message
-      JSONPath: .status.message
-    - name: Health
-      type: string
-      description: Ceph Health
-      JSONPath: .status.ceph.health
+                    region:
+                      type: string
+                    subRegion:
+                      type: string
+                    additionalConfig:
+                      type: object
+                      nullable: true
+                      x-kubernetes-preserve-unknown-fields: true
+                authentication:
+                  type: object
+                  nullable: true
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                additionalState:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                reclaimPolicy:
+                  type: string
+                claimRef:
+                  type: object
+                  nullable: true
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END OBJECTBUCKET CRD
+# OLM: BEGIN OBJECTBUCKETCLAIM CRD
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    singular: objectbucketclaim
+    shortNames:
+      - obc
+      - obcs
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                storageClassName:
+                  type: string
+                bucketName:
+                  type: string
+                generateBucketName:
+                  type: string
+                additionalConfig:
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+# OLM: END OBJECTBUCKETCLAIM CRD

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -516,7 +516,7 @@ func (h *CephInstaller) InstallRook(namespace, storeType string, usePVC bool, st
 	}
 	logger.Infof("installed rook operator and cluster : %s on k8s %s", namespace, h.k8sVersion)
 
-	if !utils.IsPlatformOpenShift() && rookVersion != Version1_2 && h.k8shelper.VersionAtLeast("v1.15.0") {
+	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.15.0") {
 		if !h.k8shelper.IsPodInExpectedState("rook-ceph-admission-controller", onamespace, "Running") {
 			assert.Fail(h.T(), "admission controller is not running")
 		}
@@ -843,7 +843,7 @@ func NewCephInstaller(t func() *testing.T, clientset *kubernetes.Clientset, useH
 		k8sVersion:      version.String(),
 		CephVersion:     cephVersion,
 		cleanupHost:     cleanupHost,
-		changeHostnames: rookVersion != Version1_2 && k8shelp.VersionAtLeast("v1.13.0"),
+		changeHostnames: k8shelp.VersionAtLeast("v1.18.0"),
 		T:               t,
 	}
 	flag.Parse()

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -26,10 +26,8 @@ import (
 )
 
 const (
-	// Version1_2 rook version 1.2
-	Version1_2 = "v1.2.7"
-	// Version1_3 rook version 1.3
-	Version1_3 = "v1.3.8"
+	// Version1_4 rook version 1.4
+	Version1_4 = "v1.4.7"
 )
 
 type CephManifests interface {
@@ -89,8 +87,8 @@ func NewCephManifests(version string) CephManifests {
 	switch version {
 	case VersionMaster:
 		return &CephManifestsMaster{imageTag: VersionMaster}
-	case Version1_2:
-		return &CephManifestsV1_2{imageTag: Version1_2}
+	case Version1_4:
+		return &CephManifestsV1_4{imageTag: Version1_4}
 	}
 	panic(fmt.Errorf("unrecognized ceph manifest version: %s", version))
 }


### PR DESCRIPTION
Since Rook no longer supports legacy filestore devices, there is
no need to keep testing upgrades from v1.2 all the way to master.
We can now just test v1.4 to master.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

// for better coverage before merge
[test full]