### PR TITLE
docs: better Ceph toolbox kubectl commands

### DIFF
--- a/Documentation/ceph-toolbox.md
+++ b/Documentation/ceph-toolbox.md
@@ -88,13 +88,13 @@ kubectl create -f toolbox.yaml
 Wait for the toolbox pod to download its container and get to the `running` state:
 
 ```console
-kubectl -n rook-ceph get pod -l "app=rook-ceph-tools"
+kubectl -n rook-ceph rollout status deploy/rook-ceph-tools
 ```
 
 Once the rook-ceph-tools pod is running, you can connect to it with:
 
 ```console
-kubectl -n rook-ceph exec -it $(kubectl -n rook-ceph get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}') bash
+kubectl -n rook-ceph exec -it deploy/rook-ceph-tools -- bash
 ```
 
 All available tools in the toolbox are ready for your troubleshooting needs.
@@ -109,7 +109,7 @@ All available tools in the toolbox are ready for your troubleshooting needs.
 When you are done with the toolbox, you can remove the deployment:
 
 ```console
-kubectl -n rook-ceph delete deployment rook-ceph-tools
+kubectl -n rook-ceph delete deploy/rook-ceph-tools
 ```
 
 ## Toolbox Job


### PR DESCRIPTION
**Description of your changes:**

Adjusts the kubectl commands for working with Ceph toolbox to make them more readable and fixes a warning with `kubectl exec` (specifying command-line arguments without the `--` separator is deprecated).

**Which issue is resolved by this Pull Request:**
Resolves none

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]