### PR TITLE
docs: dont set cleanup policy in the ceph cluster example

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -89,26 +89,26 @@ spec:
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false
-  cleanupPolicy:
+    #cleanupPolicy:
     # cleanup should only be added to the cluster when the cluster is about to be deleted.
     # After any field of the cleanup policy is set, Rook will stop configuring the cluster as if the cluster is about
     # to be destroyed in order to prevent these settings from being deployed unintentionally.
     # To signify that automatic deletion is desired, use the value "yes-really-destroy-data". Only this and an empty
     # string are valid values for this field.
-    confirmation: ""
+    #confirmation: ""
     # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
-    sanitizeDisks:
+    #sanitizeDisks:
       # method indicates if the entire disk should be sanitized or simply ceph's metadata
       # in both case, re-install is possible
       # possible choices are 'complete' or 'quick' (default)
-      method: quick
+      #method: quick
       # dataSource indicate where to get random bytes from to write on the disk
       # possible choices are 'zero' (default) or 'random'
       # using random sources will consume entropy from the system and will take much more time then the zero source
-      dataSource: zero
+      #dataSource: zero
       # iteration overwrite N times instead of the default (1)
       # takes an integer value
-      iteration: 1
+      #iteration: 1
     # allowUninstallWithVolumes defines how the uninstall should be performed
     # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
     allowUninstallWithVolumes: false


### PR DESCRIPTION
**Description of your changes:**

If cleanup policy is set, operator skips its orchestration.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]