### PR TITLE
docs: clarify the meaning of cleanup policy of ceph cluster crd

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -1300,16 +1300,17 @@ spec:
 
 ### Cleanup policy
 
-Rook has the ability to cleanup resources and data that were deployed when a `delete cephcluster` command is issued.
-The policy represents the confirmation that cluster data should be forcibly deleted.
-The cleanupPolicy should only be added to the cluster when the cluster is about to be deleted.
-After the `confirmation` field of the cleanup policy is set, Rook will stop configuring the cluster as if the cluster is about to be destroyed in order to prevent these settings from being deployed unintentionally.
-The `cleanupPolicy` CR settings has different fields:
+Rook has the ability to cleanup resources and data that were deployed when a CephCluster is removed.
+The policy settings indicate which data should be forcibly deleted and in what way the data should be wiped.
+The `cleanupPolicy` has several fields:
 
-* `confirmation`: Only an empty string and `yes-really-destroy-data` are valid values for this field. If an empty string is set, Rook will only remove Ceph's metadata. A re-installation will not be possible unless the hosts are cleaned first. If `yes-really-destroy-data` the operator will automatically delete data on the hostpath of cluster nodes and clean devices with OSDs. The cluster can then be re-installed if desired with no further steps.
-* `sanitizeDisks`: sanitizeDisks represents advanced settings that can be used to sanitize drives.
-This field only affects if `confirmation` is set to `yes-really-destroy-data`.
-However, the administrator might want to sanitize the drives in more depth with the following flags:
+* `confirmation`: Only an empty string and `yes-really-destroy-data` are valid values for this field.
+  If this setting is empty, the cleanupPolicy settings will be ignored and Rook will not cleanup any resources during cluster removal.
+  To reinstall the cluster, the admin would then be required to follow the [cleanup guide](ceph-teardown.md) to delete the data on hosts.
+  If this setting is `yes-really-destroy-data`, the operator will automatically delete the data on hosts.
+  Because this cleanup policy is destructive, after the confirmation is set to `yes-really-destroy-data`
+  Rook will stop configuring the cluster as if the cluster is about to be destroyed.
+* `sanitizeDisks`: sanitizeDisks represents advanced settings that can be used to delete data on drives.
   * `method`: indicates if the entire disk should be sanitized or simply ceph's metadata. Possible choices are 'quick' (default) or 'complete'
   * `dataSource`: indicate where to get random bytes from to write on the disk. Possible choices are 'zero' (default) or 'random'.
   Using random sources will consume entropy from the system and will take much more time then the zero source

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -89,12 +89,13 @@ spec:
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false
+  # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
   cleanupPolicy:
-    # cleanup should only be added to the cluster when the cluster is about to be deleted.
-    # After any field of the cleanup policy is set, Rook will stop configuring the cluster as if the cluster is about
-    # to be destroyed in order to prevent these settings from being deployed unintentionally.
-    # To signify that automatic deletion is desired, use the value "yes-really-destroy-data". Only this and an empty
-    # string are valid values for this field.
+    # Since cluster cleanup is destructive to data, confirmation is required.
+    # To destroy all Rook data on hosts during uninstall, confirmation must be set to "yes-really-destroy-data".
+    # This value should only be set when the cluster is about to be deleted. After the confirmation is set,
+    # Rook will immediately stop configuring the cluster and only wait for the delete command.
+    # If the empty string is set, Rook will not destroy any data on hosts during uninstall.
     confirmation: ""
     # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
     sanitizeDisks:


### PR DESCRIPTION
**Description of your changes:**

The description of cleanupPolicy is a bit ambiguous. First, we should clarify that both skipping orchestration and data cleanup will happen iff "yes-really-destroy-data" is set to `confirmation`. Second, We should also describe wiping devices will happen even if user don't specify `sanitizeDisks` explicitly.

**Which issue is resolved by this Pull Request:**

Nothing

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]