### PR TITLE
docs: link to master branch for ceph-csi-snapshot

### DIFF
--- a/Documentation/ceph-csi-snapshot.md
+++ b/Documentation/ceph-csi-snapshot.md
@@ -9,7 +9,7 @@ indent: true
 * Requires Kubernetes v1.17+ which supports snapshot beta.
 
 * Install the new snapshot controller and snapshot beta CRD. More info can be found
-[here](https://github.com/kubernetes-csi/external-snapshotter/tree/v2.1.1#usage)
+[here](https://github.com/kubernetes-csi/external-snapshotter/tree/master#usage)
 
 Note: If the Kubernetes distributor you are using does not supports the snapshot beta,
 still you can use the Alpha snapshots. refer to


### PR DESCRIPTION
Due to upstream code motion, the current link to the upstream
ceph-csi-snapshot documentation no longer points to the correct
location of their CRDs. Fix this by just using the master branch.

Signed-off-by: Mike Latimer <mlatimer@suse.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]