### PR TITLE
ceph: fix nfs daemons not updating

### DIFF
--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -48,8 +48,8 @@ type daemonConfig struct {
 }
 
 // Create the ganesha server
-func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS, oldActive int) error {
-	for i := oldActive; i < n.Spec.Server.Active; i++ {
+func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
+	for i := 0; i < n.Spec.Server.Active; i++ {
 		id := k8sutil.IndexToName(i)
 
 		configName, err := r.createConfigMap(n, id)


### PR DESCRIPTION
The NFS reconciler was not updating NFS daemons that already existed.
The controller would fail to update daemons if the number of active
daemons did not increase or decrease.

Resolves #6611

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
