### PR TITLE
ceph: return errors properly in createBucket()

### DIFF
--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -90,10 +90,10 @@ func (s *S3Agent) createBucket(name string, infoLogging bool) error {
 			switch aerr.Code() {
 			case s3.ErrCodeBucketAlreadyExists:
 				logger.Debugf("bucket %q already exists", name)
-				return nil
+				return errors.Wrapf(err, "bucket %q already exists", name)
 			case s3.ErrCodeBucketAlreadyOwnedByYou:
 				logger.Debugf("bucket %q already owned by you", name)
-				return nil
+				return errors.Wrapf(err, "bucket %q already owned by you", name)
 			}
 		}
 		return errors.Wrapf(err, "failed to create bucket %q", name)


### PR DESCRIPTION
Currently `createBucket()` api ignores errors like `BucketAlreadyExists`
and `BucketAlreadyOwnedByYou`.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
