### PR TITLE
ceph: allow deprecated fs  preservePoolsOnDelete

### DIFF
--- a/Documentation/ceph-filesystem-crd.md
+++ b/Documentation/ceph-filesystem-crd.md
@@ -115,7 +115,13 @@ The pools allow all of the settings defined in the Pool CRD spec. For more detai
 
 * `metadataPool`: The settings used to create the filesystem metadata pool. Must use replication.
 * `dataPools`: The settings to create the filesystem data pools. If multiple pools are specified, Rook will add the pools to the filesystem. Assigning users or files to a pool is left as an exercise for the reader with the [CephFS documentation](http://docs.ceph.com/docs/master/cephfs/file-layouts/). The data pools can use replication or erasure coding. If erasure coding pools are specified, the cluster must be running with bluestore enabled on the OSDs.
-* `preserveFilesystemOnDelete`: If it is set to 'true' the filesystem will remain when the Filesystem CRD is deleted. This is a security measure to avoid accidental loss of data. It is set to 'false' by default. If not specified is also deemed as 'false'. This option replaces `preservePoolsOnDelete` which should no longer be set.
+* `preserveFilesystemOnDelete`: If it is set to 'true' the filesystem will remain when the
+  CephFilesystem resource is deleted. This is a security measure to avoid loss of data if the
+  CephFilesystem resource is deleted accidentally. The default value is 'false'. This option
+  replaces `preservePoolsOnDelete` which should no longer be set.
+* (deprecated) `preservePoolsOnDelete`: This option is replaced by the above
+  `preserveFilesystemOnDelete`. For backwards compatibility and upgradeability, if this is set to
+  'true', Rook will treat `preserveFilesystemOnDelete` as being set to 'true'.
 
 ## Metadata Server Settings
 


### PR DESCRIPTION
Allow filesystems with preservePoolsOnDelete to be used without errors.
A deprecation warning will still appear in the operator logs, but
existing cephfilesystem resources with preservePoolsOnDelete will still
be updated, and Rook will assume the new, preferred
preserveFilesystemOnDelete is set.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
