### PR TITLE
build: Set manifest versions to v1.5.0

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -38,7 +38,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: deploy rook
       run: |
@@ -118,7 +118,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -198,7 +198,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -278,7 +278,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -348,7 +348,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -428,7 +428,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -508,7 +508,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prerequisites
       run: |
@@ -577,7 +577,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/ceph:v1.5.0
 
     - name: rook prereq
       run: |

--- a/Documentation/cassandra.md
+++ b/Documentation/cassandra.md
@@ -21,7 +21,7 @@ To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [fo
 First deploy the Rook Cassandra Operator using the following commands:
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/cassandra
 kubectl apply -f operator.yaml
 ```

--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -38,7 +38,7 @@ With the Prometheus operator running, we can create a service monitor that will 
 From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/ceph/monitoring
 ```
 

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -46,7 +46,7 @@ If the `FSTYPE` field is not empty, there is a filesystem on top of the correspo
 If you're feeling lucky, a simple Rook cluster can be created with the following kubectl commands and [example yaml files](https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph). For the more detailed install, skip to the next section to [deploy the Rook operator](#deploy-the-rook-operator).
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/ceph
 kubectl create -f crds.yaml -f common.yaml -f operator.yaml
 kubectl create -f cluster.yaml

--- a/Documentation/ceph-toolbox.md
+++ b/Documentation/ceph-toolbox.md
@@ -43,7 +43,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent
@@ -133,7 +133,7 @@ spec:
     spec:
       initContainers:
       - name: config-init
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         command: ["/usr/local/bin/toolbox.sh"]
         args: ["--skip-watch"]
         imagePullPolicy: IfNotPresent
@@ -155,7 +155,7 @@ spec:
           mountPath: /etc/rook
       containers:
       - name: script
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         volumeMounts:
         - mountPath: /etc/ceph
           name: ceph-config

--- a/Documentation/cockroachdb.md
+++ b/Documentation/cockroachdb.md
@@ -20,7 +20,7 @@ To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [fo
 First deploy the Rook CockroachDB operator using the following commands:
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/cockroachdb
 kubectl create -f operator.yaml
 ```

--- a/Documentation/edgefs-csi.md
+++ b/Documentation/edgefs-csi.md
@@ -108,7 +108,7 @@ By using `k8sEdgefsNamespaces` and `k8sEdgefsMgmtPrefix` parameters, driver is c
 Check configuration options and create kubernetes secret for Edgefs CSI NFS plugin
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/edgefs/csi/nfs
 kubectl create secret generic edgefs-nfs-csi-driver-config --from-file=./edgefs-nfs-csi-driver-config.yaml
 ```

--- a/Documentation/edgefs-monitoring.md
+++ b/Documentation/edgefs-monitoring.md
@@ -38,7 +38,7 @@ With the Prometheus operator running, we can create a service monitor that will 
 From the root of your locally cloned Rook repo, go the monitoring directory:
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/edgefs/monitoring
 ```
 

--- a/Documentation/edgefs-quickstart.md
+++ b/Documentation/edgefs-quickstart.md
@@ -50,7 +50,7 @@ To turn off this node adjustment need to enable `skipHostPrepare` option in clus
 If you're feeling lucky, a simple EdgeFS Rook cluster can be created with the following kubectl commands. For the more detailed install, skip to the next section to [deploy the Rook operator](#deploy-the-rook-operator).
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/edgefs
 kubectl create -f operator.yaml
 kubectl create -f cluster.yaml

--- a/Documentation/nfs.md
+++ b/Documentation/nfs.md
@@ -23,7 +23,7 @@ You can read further about the details and limitations of these volumes in the [
 First deploy the Rook NFS operator using the following commands:
 
 ```console
-git clone --single-branch --branch v1.5.0-beta.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/nfs
 kubectl create -f common.yaml
 kubectl create -f operator.yaml

--- a/cluster/examples/coreos/after-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/after-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-after-reboot-check
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/coreos/before-reboot-daemonset.yaml
+++ b/cluster/examples/coreos/before-reboot-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: ceph-before-reboot-check
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         imagePullPolicy: IfNotPresent
         command: ["/scripts/status-check.sh"]
         env:

--- a/cluster/examples/kubernetes/cassandra/operator.yaml
+++ b/cluster/examples/kubernetes/cassandra/operator.yaml
@@ -188,7 +188,7 @@ subjects:
        serviceAccountName: rook-cassandra-operator
        containers:
        - name: rook-cassandra-operator
-         image: rook/cassandra:v1.5.0-beta.0
+         image: rook/cassandra:v1.5.0
          imagePullPolicy: "Always"
          args: ["cassandra", "operator"]
          env:

--- a/cluster/examples/kubernetes/ceph/direct-mount.yaml
+++ b/cluster/examples/kubernetes/ceph/direct-mount.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-direct-mount
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -288,7 +288,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
       - name: rook-ceph-operator
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         args: ["ceph", "operator"]
         volumeMounts:
         - mountPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: osd-removal
-          image: rook/ceph:v1.5.0-beta.0
+          image: rook/ceph:v1.5.0
           # TODO: Insert the OSD ID in the last parameter that is to be removed
           # The OSD IDs are a comma-separated list. For example: "0" or "0,2".
           args: ["ceph", "osd", "remove", "--osd-ids", "<OSD-IDs>"]

--- a/cluster/examples/kubernetes/ceph/toolbox-job.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       initContainers:
       - name: config-init
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         command: ["/usr/local/bin/toolbox.sh"]
         args: ["--skip-watch"]
         imagePullPolicy: IfNotPresent
@@ -32,7 +32,7 @@ spec:
           mountPath: /etc/rook
       containers:
       - name: script
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         volumeMounts:
         - mountPath: /etc/ceph
           name: ceph-config

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: rook-ceph-tools
-        image: rook/ceph:v1.5.0-beta.0
+        image: rook/ceph:v1.5.0
         command: ["/tini"]
         args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
         imagePullPolicy: IfNotPresent

--- a/cluster/examples/kubernetes/cockroachdb/operator.yaml
+++ b/cluster/examples/kubernetes/cockroachdb/operator.yaml
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: rook-cockroachdb-operator
       containers:
       - name: rook-cockroachdb-operator
-        image: rook/cockroachdb:v1.5.0-beta.0
+        image: rook/cockroachdb:v1.5.0
         args: ["cockroachdb", "operator"]
         env:
         - name: POD_NAME

--- a/cluster/examples/kubernetes/edgefs/operator.yaml
+++ b/cluster/examples/kubernetes/edgefs/operator.yaml
@@ -414,7 +414,7 @@ spec:
       serviceAccountName: rook-edgefs-system
       containers:
       - name: rook-edgefs-operator
-        image: rook/edgefs:v1.5.0-beta.0
+        image: rook/edgefs:v1.5.0
         imagePullPolicy: "Always"
         args: ["edgefs", "operator"]
         env:

--- a/cluster/examples/kubernetes/nfs/operator.yaml
+++ b/cluster/examples/kubernetes/nfs/operator.yaml
@@ -117,7 +117,7 @@ spec:
       serviceAccountName: rook-nfs-operator
       containers:
       - name: rook-nfs-operator
-        image: rook/nfs:v1.5.0-beta.0
+        image: rook/nfs:v1.5.0
         imagePullPolicy: IfNotPresent
         args: ["nfs", "operator"]
         env:

--- a/cluster/examples/kubernetes/nfs/webhook.yaml
+++ b/cluster/examples/kubernetes/nfs/webhook.yaml
@@ -111,7 +111,7 @@ spec:
     spec:
       containers:
       - name: rook-nfs-webhook
-        image: rook/nfs:v1.5.0-beta.0
+        image: rook/nfs:v1.5.0
         imagePullPolicy: IfNotPresent
         args: ["nfs", "webhook"]
         ports:

--- a/cluster/examples/kubernetes/yugabytedb/operator.yaml
+++ b/cluster/examples/kubernetes/yugabytedb/operator.yaml
@@ -99,7 +99,7 @@ spec:
       serviceAccountName: rook-yugabytedb-operator
       containers:
       - name: rook-yugabytedb-operator
-        image: rook/yugabytedb:v1.5.0-beta.0
+        image: rook/yugabytedb:v1.5.0
         args: ["yugabytedb", "operator"]
         env:
         - name: POD_NAME


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
For the minor release we set the documentation and manifests
to use the v1.5.0 tag.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
