### PR TITLE
ceph: vault kms configuration for ceph object store

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -683,6 +683,7 @@ jobs:
         cat tests/manifests/test-kms-vault.yaml >> tests/manifests/test-cluster-on-pvc-encrypted.yaml
         yq merge --inplace --arrays append tests/manifests/test-cluster-on-pvc-encrypted.yaml tests/manifests/test-kms-vault-spec.yaml
         kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
+        kubectl create -f cluster/examples/kubernetes/ceph/object-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/toolbox.yaml
 
     - name: wait for prepare pod
@@ -696,6 +697,7 @@ jobs:
       run: |
         mkdir test
         tests/scripts/validate_cluster.sh osd
+        tests/scripts/validate_cluster.sh rgw
         kubectl -n rook-ceph get pods
         kubectl -n rook-ceph get secrets
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -17,3 +17,4 @@ v1.6...
 ### Ceph
 
 * CephClient CRD has been converted to use the controller-runtime library
+* Extending the support of vault KMS configuration for Ceph RGW

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -180,6 +180,7 @@ spec:
          #KMS_PROVIDER: "vault"
          #VAULT_ADDR: VAULT_ADDR_CHANGE_ME # e,g: https://vault.my-domain.com:8200
          #VAULT_BACKEND_PATH: "rook"
+         #VAULT_BACKEND: "kv"
   #     # name of the secret containing the kms authentication token
   #     tokenSecretName: rook-vault-token
 # UNCOMMENT THIS TO ENABLE A KMS CONNECTION

--- a/pkg/daemon/ceph/osd/kms/volumes.go
+++ b/pkg/daemon/ceph/osd/kms/volumes.go
@@ -31,6 +31,9 @@ const (
 	vaultCAFileName   = "vault.ca"
 	vaultCertFileName = "vault.crt"
 	vaultKeyFileName  = "vault.key"
+
+	// File name for token file
+	VaultFileName = "vault.token"
 )
 
 // TLSSecretVolumeAndMount return the volume and matching volume mount for mounting the secrets into /etc/vault
@@ -87,4 +90,16 @@ func tlsSecretPath(tlsOption string) string {
 	}
 
 	return ""
+}
+
+// VaultTokenFileVolume save token from secret as volume mount
+func VaultTokenFileVolume(tokenSecretName string) v1.Volume {
+	return v1.Volume{
+		Name: secrets.TypeVault,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: tokenSecretName,
+				Items: []v1.KeyToPath{
+					{Key: KMSTokenSecretNameKey, Path: VaultFileName},
+				}}}}
 }

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -158,7 +158,7 @@ set -e
 
 KEK_NAME=%s
 KEY_PATH=%s
-VAULT_DEFAULT_BACKEND=v1
+VAULT_DEFAULT_KV_VERS=v1
 CURL_PAYLOAD=$(mktemp)
 ARGS=(--request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
 
@@ -189,13 +189,13 @@ if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
 	ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
 fi
 
-# Check KV backend
-if [ -z "$VAULT_BACKEND" ]; then
-	VAULT_BACKEND=$VAULT_DEFAULT_BACKEND
+# Check KV engine version
+if [ -z "$VAULT_KV_VERS" ]; then
+	VAULT_KV_VERS=$VAULT_DEFAULT_KV_VERS
 fi
 
 # Get the Key Encryption Key
-curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_BACKEND"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
+curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_KV_VERS"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
 
 # Put the KEK in a file for cryptsetup to read
 python3 -c "import sys, json; print(json.load(sys.stdin)[\"data\"][\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"

--- a/tests/manifests/test-kms-vault-spec.yaml
+++ b/tests/manifests/test-kms-vault-spec.yaml
@@ -5,5 +5,6 @@ spec:
         KMS_PROVIDER: vault
         VAULT_ADDR: https://vault.default.svc.cluster.local:8200
         VAULT_BACKEND_PATH: rook
+        VAULT_BACKEND: kv
         VAULT_SKIP_VERIFY: "true"
       tokenSecretName: rook-vault-token


### PR DESCRIPTION
**Description of your changes:**

The first patch to configure vault for ceph object store. If the `security.kms` configured in
`clusterSpec` CRD, RGW will be configured with vault kms settings to handle SSE request from s3 clients.

TODO : 
- configuring tls authentication between vault and rgw, dependency on [patch](https://github.com/ceph/ceph/pull/37730)


Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
