### PR TITLE
ceph: Restore mon clusterIP if the service is missing

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -465,6 +465,7 @@ func (c *Cluster) clusterInfoToMonConfig(excludedMon string) []*monConfig {
 			ResourceName: resourceName(monitor.Name),
 			DaemonName:   monitor.Name,
 			Port:         cephutil.GetPortFromEndpoint(monitor.Endpoint),
+			PublicIP:     cephutil.GetIPFromEndpoint(monitor.Endpoint),
 			Zone:         zone,
 			DataPathMap: config.NewStatefulDaemonDataPathMap(
 				c.spec.DataDirHostPath, dataDirRelativeHostPath(monitor.Name), config.MonType, monitor.Name, c.Namespace),

--- a/pkg/operator/ceph/cluster/mon/service.go
+++ b/pkg/operator/ceph/cluster/mon/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -51,6 +52,17 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	// If deploying Nautilus or newer we need a new port for the monitor service
 	addServicePort(svcDef, "tcp-msgr2", DefaultMsgr2Port)
 
+	// Set the ClusterIP if the service does not exist and we expect a certain cluster IP
+	// For example, in disaster recovery the service might have been deleted accidentally, but we have the
+	// expected endpoint from the mon configmap.
+	if mon.PublicIP != "" {
+		_, err := c.context.Clientset.CoreV1().Services(c.Namespace).Get(svcDef.Name, metav1.GetOptions{})
+		if err != nil && kerrors.IsNotFound(err) {
+			logger.Infof("ensuring the clusterIP for mon %q is %q", mon.DaemonName, mon.PublicIP)
+			svcDef.Spec.ClusterIP = mon.PublicIP
+		}
+	}
+
 	s, err := k8sutil.CreateOrUpdateService(c.context.Clientset, c.Namespace, svcDef)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create service for mon %s", mon.DaemonName)
@@ -64,7 +76,7 @@ func (c *Cluster) createService(mon *monConfig) (string, error) {
 	// mon endpoint are not actually like, they remain with the mgrs1 format
 	// however it's interesting to show that monitors can be addressed via 2 different ports
 	// in the end the service has msgr1 and msgr2 ports configured so it's not entirely wrong
-	logger.Infof("mon %q endpoint are [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(DefaultMsgr2Port)), s.Spec.ClusterIP, mon.Port)
+	logger.Infof("mon %q endpoint is [v2:%s:%s,v1:%s:%d]", mon.DaemonName, s.Spec.ClusterIP, strconv.Itoa(int(DefaultMsgr2Port)), s.Spec.ClusterIP, mon.Port)
 
 	return s.Spec.ClusterIP, nil
 }

--- a/pkg/operator/ceph/cluster/mon/service_test.go
+++ b/pkg/operator/ceph/cluster/mon/service_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mon
+
+import (
+	"sync"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateService(t *testing.T) {
+	clientset := test.New(t, 1)
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	m := &monConfig{ResourceName: "rook-ceph-mon-b", DaemonName: "b"}
+	clusterIP, err := c.createService(m)
+	assert.NoError(t, err)
+	// the clusterIP will not be set in a mock service
+	assert.Equal(t, "", clusterIP)
+
+	m.PublicIP = "1.2.3.4"
+	clusterIP, err = c.createService(m)
+	assert.NoError(t, err)
+	// the clusterIP will not be set in the mock because the service already exists
+	assert.Equal(t, "", clusterIP)
+
+	// delete the service to mock a disaster recovery scenario
+	err = clientset.CoreV1().Services(c.Namespace).Delete(m.ResourceName, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+
+	clusterIP, err = c.createService(m)
+	assert.NoError(t, err)
+	// the clusterIP will now be set to the expected value
+	assert.Equal(t, m.PublicIP, clusterIP)
+}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In a disaster recovery scenario, the mon service may have been accidentally deleted, while the expected mon endpoint is still found in the mon endpoints configmap. In this case, we create the mon service with the same endpoint as previously.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
