### PR TITLE
ceph: update Jenkins to skip Ceph tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,12 @@ pipeline {
                     if (body.contains("[test cassandra]") || title.contains("cassandra:")) {
                         env.testProvider = "cassandra"
                     } else if (body.contains("[test ceph]") || title.contains("ceph:")) {
-                        env.testProvider = "ceph"
+                        // For Ceph storage provider we are using GitHub actions to run test
+                        if (body.contains("[test full]")) {
+                          env.testProvider = "ceph"
+                        } else {
+                          env.shouldBuild = "false"
+                        }
                     } else if (body.contains("[test cockroachdb]") || title.contains("cockroachdb:")) {
                         env.testProvider = "cockroachdb"
                     } else if (body.contains("[test edgefs]") || title.contains("edgefs:")) {


### PR DESCRIPTION
we now run our ceph test or ceph suite
using GitHub actions, we can skip
Jenkins test for the same.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
