### PR TITLE
ceph: fix pod labels set on csi components

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -14,7 +14,7 @@ spec:
         app: csi-cephfsplugin-provisioner
         contains: csi-cephfsplugin-metrics
         {{ range $key, $value := .CSICephFSPodLabels }}
-        $key: "$value"
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
       serviceAccount: rook-csi-cephfs-provisioner-sa

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -15,7 +15,7 @@ spec:
         app: csi-cephfsplugin
         contains: csi-cephfsplugin-metrics
         {{ range $key, $value := .CSICephFSPodLabels }}
-        $key: "$value"
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
       serviceAccount: rook-csi-cephfs-plugin-sa

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -14,7 +14,7 @@ spec:
         app: csi-rbdplugin-provisioner
         contains: csi-rbdplugin-metrics
         {{ range $key, $value := .CSIRBDPodLabels }}
-        $key: "$value"
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
       serviceAccount: rook-csi-rbd-provisioner-sa

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -15,7 +15,7 @@ spec:
         app: csi-rbdplugin
         contains: csi-rbdplugin-metrics
         {{ range $key, $value := .CSIRBDPodLabels }}
-        $key: "$value"
+        {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
       serviceAccount: rook-csi-rbd-plugin-sa


### PR DESCRIPTION
**Description of your changes:**

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

This fixes the pod labels variable usage in the Ceph CSI templates.

Added backport to 1.5 label.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.