### PR TITLE
DNM: ceph: improve owner reference management

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	osddaemon "github.com/rook/rook/pkg/daemon/ceph/osd"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
@@ -227,9 +228,10 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	logger.Infof("crush location of osd: %s", crushLocation)
 
 	forceFormat := false
+
 	ownerRef := opcontroller.ClusterOwnerRef(clusterInfo.Namespace, ownerRefID)
-	clusterInfo.OwnerRef = ownerRef
-	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerRef)
+	clusterInfo.OwnerInfo = *client.NewOwnerInfoWithRef(ownerRef)
+	kv := client.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, &clusterInfo.OwnerInfo)
 	agent := osddaemon.NewAgent(context, dgs, dataDevices, cfg.metadataDevice, forceFormat,
 		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, cfg.pvcBacked)
 

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/test"
@@ -160,7 +161,7 @@ func TestAttach(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &client.OwnerInfo{})
 	assert.NoError(t, err)
 	devicePath, err := vm.Attach("image1", "testpool", "admin", "never-gonna-give-you-up", clusterNamespace)
 	assert.Equal(t, "/dev/rbd3", devicePath)
@@ -241,7 +242,7 @@ func TestDetach(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &client.OwnerInfo{})
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "admin", "", clusterNamespace, false)
 	assert.Nil(t, err)
@@ -296,7 +297,7 @@ func TestDetachCustomKeyring(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &client.OwnerInfo{})
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "user1", "", clusterNamespace, false)
 	assert.Nil(t, err)

--- a/pkg/daemon/ceph/client/kvstore_test.go
+++ b/pkg/daemon/ceph/client/kvstore_test.go
@@ -15,16 +15,15 @@ limitations under the License.
 */
 
 // Package k8sutil for Kubernetes helpers.
-package k8sutil
+package client
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -168,5 +167,5 @@ func newKVStore(stores ...*v1.ConfigMap) (*ConfigMapKVStore, string) {
 	}
 
 	clientset := fake.NewSimpleClientset(objects...)
-	return NewConfigMapKVStore(namespace, clientset, metav1.OwnerReference{}), storeName
+	return NewConfigMapKVStore(namespace, clientset, &OwnerInfo{}), storeName
 }

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -20,7 +20,6 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
 const (
@@ -36,13 +35,13 @@ type OsdAgent struct {
 	devices        []DesiredDevice
 	metadataDevice string
 	storeConfig    config.StoreConfig
-	kv             *k8sutil.ConfigMapKVStore
+	kv             *cephclient.ConfigMapKVStore
 	pvcBacked      bool
 }
 
 // NewAgent is the instantiation of the OSD agent
 func NewAgent(context *clusterd.Context, driveGroups config.DriveGroupBlobs, devices []DesiredDevice, metadataDevice string, forceFormat bool,
-	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *k8sutil.ConfigMapKVStore, pvcBacked bool) *OsdAgent {
+	storeConfig config.StoreConfig, clusterInfo *cephclient.ClusterInfo, nodeName string, kv *cephclient.ConfigMapKVStore, pvcBacked bool) *OsdAgent {
 
 	return &OsdAgent{
 		driveGroups:    driveGroups,

--- a/pkg/daemon/ceph/osd/kms/k8s.go
+++ b/pkg/daemon/ceph/osd/kms/k8s.go
@@ -43,10 +43,13 @@ const (
 // storeSecretInKubernetes stores the dmcrypt key in a Kubernetes Secret
 func (c *Config) storeSecretInKubernetes(pvcName, key string) error {
 	ctx := context.TODO()
-	s := generateOSDEncryptedKeySecret(pvcName, key, c.clusterInfo)
+	s, err := generateOSDEncryptedKeySecret(pvcName, key, c.clusterInfo)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference of secret %q", s.Name)
+	}
 
 	// Create the Kubernetes Secret
-	_, err := c.context.Clientset.CoreV1().Secrets(c.clusterInfo.Namespace).Create(ctx, s, metav1.CreateOptions{})
+	_, err = c.context.Clientset.CoreV1().Secrets(c.clusterInfo.Namespace).Create(ctx, s, metav1.CreateOptions{})
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "failed to save ceph osd encryption key as a secret for pvc %q", pvcName)
 	}
@@ -54,7 +57,7 @@ func (c *Config) storeSecretInKubernetes(pvcName, key string) error {
 	return nil
 }
 
-func generateOSDEncryptedKeySecret(pvcName, key string, clusterInfo *cephclient.ClusterInfo) *v1.Secret {
+func generateOSDEncryptedKeySecret(pvcName, key string, clusterInfo *cephclient.ClusterInfo) (*v1.Secret, error) {
 	s := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GenerateOSDEncryptionSecretName(pvcName),
@@ -70,9 +73,12 @@ func generateOSDEncryptedKeySecret(pvcName, key string, clusterInfo *cephclient.
 	}
 
 	// Set the ownerref to the Secret
-	k8sutil.SetOwnerRef(&s.ObjectMeta, &clusterInfo.OwnerRef)
+	err := clusterInfo.OwnerInfo.SetOwnerReference(s)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference of secret %q", s.Name)
+	}
 
-	return s
+	return s, nil
 }
 
 // GenerateOSDEncryptionSecretName generate the Kubernetes Secret name of the encrypted key

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -370,7 +370,7 @@ func updateDeviceCM(clusterdContext *clusterd.Context) error {
 		if err != nil {
 			logger.Warningf("failed to get discover pod to set ownerref. %+v", err)
 		} else {
-			k8sutil.SetOwnerRefsWithoutBlockOwner(&cm.ObjectMeta, discoverPod.OwnerReferences)
+			k8sutil.SetOwnerRefsWithoutBlockOwner(cm, discoverPod.OwnerReferences)
 		}
 
 		cm, err = clusterdContext.Clientset.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{})

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -140,7 +141,7 @@ func TestCreateClient(t *testing.T) {
 	err := os.MkdirAll(configDir, 0755)
 	assert.NoError(t, err)
 	defer os.RemoveAll(configDir)
-	clusterInfo, _, _, err := mon.CreateOrLoadClusterInfo(context, namespace, &metav1.OwnerReference{})
+	clusterInfo, _, _, err := mon.CreateOrLoadClusterInfo(context, namespace, &client.OwnerInfo{})
 	assert.NoError(t, err)
 
 	exists, _ := clientExists(context, clusterInfo, p)

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -294,14 +294,8 @@ func (r *ReconcileCephCluster) reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, nil
 	}
 
-	// Create the controller owner ref
-	ref, err := opcontroller.GetControllerObjectOwnerReference(cephCluster, r.scheme)
-	if err != nil || ref == nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get controller %q owner reference", cephCluster.Name)
-	}
-
 	// Do reconcile here!
-	if err := r.clusterController.onAdd(cephCluster, ref); err != nil {
+	if err := r.clusterController.onAdd(cephCluster, cephclient.NewOwnerInfo(cephCluster, true, r.scheme)); err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "failed to reconcile cluster %q", cephCluster.Name)
 	}
 
@@ -322,7 +316,7 @@ func NewClusterController(context *clusterd.Context, rookImage string, volumeAtt
 	}
 }
 
-func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ref *metav1.OwnerReference) error {
+func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ownerInfo *cephclient.OwnerInfo) error {
 	if clusterObj.Spec.CleanupPolicy.HasDataDirCleanPolicy() {
 		logger.Infof("skipping orchestration for cluster object %q in namespace %q because its cleanup policy is set", clusterObj.Name, clusterObj.Namespace)
 		return nil
@@ -331,7 +325,7 @@ func (c *ClusterController) onAdd(clusterObj *cephv1.CephCluster, ref *metav1.Ow
 	cluster, ok := c.clusterMap[clusterObj.Namespace]
 	if !ok {
 		// It's a new cluster so let's populate the struct
-		cluster = newCluster(clusterObj, c.context, c.csiConfigMutex, ref)
+		cluster = newCluster(clusterObj, c.context, c.csiConfigMutex, ownerInfo)
 	}
 
 	// Note that this lock is held through the callback process, as this creates CSI resources, but we must lock in

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"reflect"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -45,13 +43,6 @@ const (
 	pruneSchedule = "0 0 * * *"
 )
 
-// ClusterResource operator-kit Custom Resource Definition
-var clusterResource = k8sutil.CustomResource{
-	Group:   cephv1.CustomResourceGroup,
-	Version: cephv1.Version,
-	Kind:    reflect.TypeOf(cephv1.CephCluster{}).Name(),
-}
-
 // createOrUpdateCephCrash is a wrapper around controllerutil.CreateOrUpdate
 func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []corev1.Toleration, cephCluster cephv1.CephCluster, cephVersion *version.CephVersion) (controllerutil.OperationResult, error) {
 	// Create or Update the deployment default/foo
@@ -61,10 +52,13 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 	}
 	deploy := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            k8sutil.TruncateNodeName(fmt.Sprintf("%s-%%s", AppName), nodeHostnameLabel),
-			Namespace:       cephCluster.GetNamespace(),
-			OwnerReferences: []metav1.OwnerReference{clusterOwnerRef(cephCluster.GetName(), string(cephCluster.GetUID()))},
+			Name:      k8sutil.TruncateNodeName(fmt.Sprintf("%s-%%s", AppName), nodeHostnameLabel),
+			Namespace: cephCluster.GetNamespace(),
 		},
+	}
+	err := controllerutil.SetControllerReference(&cephCluster, deploy, r.scheme)
+	if err != nil {
+		return controllerutil.OperationResultNone, errors.Wrapf(err, "failed to set owner reference of deployment %q", deploy.Name)
 	}
 
 	volumes := controller.DaemonVolumesBase(config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath), "")
@@ -133,10 +127,13 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 func (r *ReconcileNode) createOrUpdateCephCron(cephCluster cephv1.CephCluster, cephVersion *version.CephVersion) (controllerutil.OperationResult, error) {
 	cronJob := &v1beta1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            prunerName,
-			Namespace:       cephCluster.GetNamespace(),
-			OwnerReferences: []metav1.OwnerReference{clusterOwnerRef(cephCluster.GetName(), string(cephCluster.GetUID()))},
+			Name:      prunerName,
+			Namespace: cephCluster.GetNamespace(),
 		},
+	}
+	err := controllerutil.SetControllerReference(&cephCluster, cronJob, r.scheme)
+	if err != nil {
+		return controllerutil.OperationResultNone, errors.Wrapf(err, "failed to set owner reference of cronjob %q", cronJob.Name)
 	}
 
 	// Adding volumes to pods containing data needed to connect to the ceph cluster.
@@ -262,17 +259,6 @@ func getCrashPruneContainer(cephCluster cephv1.CephCluster, cephVersion version.
 	}
 
 	return container
-}
-
-func clusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
-	blockOwner := true
-	return metav1.OwnerReference{
-		APIVersion:         fmt.Sprintf("%s/%s", clusterResource.Group, clusterResource.Version),
-		Kind:               clusterResource.Kind,
-		Name:               clusterName,
-		UID:                types.UID(clusterID),
-		BlockOwnerDeletion: &blockOwner,
-	}
 }
 
 func generateCrashEnvVar() corev1.EnvVar {

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -40,7 +40,7 @@ const (
 
 // CreateCrashCollectorSecret creates the Kubernetes Crash Collector Secret
 func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.ClusterInfo) error {
-	k := keyring.GetSecretStore(context, clusterInfo, &clusterInfo.OwnerRef)
+	k := keyring.GetSecretStore(context, clusterInfo, &clusterInfo.OwnerInfo)
 
 	// Create CrashCollector Ceph key
 	crashCollectorSecretKey, err := createCrashCollectorKeyring(k)
@@ -88,10 +88,12 @@ func createOrUpdateCrashCollectorSecret(clusterInfo *client.ClusterInfo, crashCo
 		Data: crashCollectorSecret,
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(&s.ObjectMeta, &clusterInfo.OwnerRef)
-
+	err := clusterInfo.OwnerInfo.SetOwnerReference(s)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference of secret %q", s.Name)
+	}
 	// Create Kubernetes Secret
-	err := k.CreateSecret(s)
+	err = k.CreateSecret(s)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", crashCollectorSecret, clusterInfo.Namespace)
 	}

--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -60,7 +60,7 @@ func (c *Cluster) generateKeyring(m *mgrConfig) (string, error) {
 	ctx := context.TODO()
 	user := fmt.Sprintf("mgr.%s", m.DaemonID)
 	access := []string{"mon", "allow profile mgr", "mds", "allow *", "osd", "allow *"}
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -85,7 +85,8 @@ func TestServiceSpec(t *testing.T) {
 	clusterSpec := cephv1.ClusterSpec{}
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")
 
-	s := c.MakeMetricsService("rook-mgr", serviceMetricName)
+	s, err := c.MakeMetricsService("rook-mgr", serviceMetricName)
+	assert.NoError(t, err)
 	assert.NotNil(t, s)
 	assert.Equal(t, "rook-mgr", s.Name)
 	assert.Equal(t, 1, len(s.Spec.Ports))

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -83,7 +83,7 @@ func LoadClusterInfo(context *clusterd.Context, namespace string) (*cephclient.C
 }
 
 // CreateOrLoadClusterInfo constructs or loads a clusterinfo and returns it along with the maxMonID
-func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, namespace string, ownerRef *metav1.OwnerReference) (*cephclient.ClusterInfo, int, *Mapping, error) {
+func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, namespace string, ownerInfo *cephclient.OwnerInfo) (*cephclient.ClusterInfo, int, *Mapping, error) {
 	ctx := context.TODO()
 	var clusterInfo *cephclient.ClusterInfo
 	maxMonID := -1
@@ -96,7 +96,7 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, namespace string
 		if !kerrors.IsNotFound(err) {
 			return nil, maxMonID, monMapping, errors.Wrap(err, "failed to get mon secrets")
 		}
-		if ownerRef == nil {
+		if ownerInfo == nil {
 			return nil, maxMonID, monMapping, errors.New("not expected to create new cluster info and did not find existing secret")
 		}
 
@@ -105,7 +105,7 @@ func CreateOrLoadClusterInfo(clusterdContext *clusterd.Context, namespace string
 			return nil, maxMonID, monMapping, errors.Wrap(err, "failed to create mon secrets")
 		}
 
-		err = createClusterAccessSecret(clusterdContext.Clientset, namespace, clusterInfo, ownerRef)
+		err = createClusterAccessSecret(clusterInfo, clusterdContext.Clientset, ownerInfo)
 		if err != nil {
 			return nil, maxMonID, monMapping, err
 		}
@@ -257,7 +257,7 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string
 	return monEndpointMap, maxMonID, monMapping, nil
 }
 
-func createClusterAccessSecret(clientset kubernetes.Interface, namespace string, clusterInfo *cephclient.ClusterInfo, ownerRef *metav1.OwnerReference) error {
+func createClusterAccessSecret(clusterInfo *cephclient.ClusterInfo, clientset kubernetes.Interface, ownerInfo *client.OwnerInfo) error {
 	ctx := context.TODO()
 	logger.Infof("creating mon secrets for a new cluster")
 	var err error
@@ -272,13 +272,16 @@ func createClusterAccessSecret(clientset kubernetes.Interface, namespace string,
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      AppName,
-			Namespace: namespace,
+			Namespace: clusterInfo.Namespace,
 		},
 		Data: secrets,
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(&secret.ObjectMeta, ownerRef)
-	if _, err = clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+	err = ownerInfo.SetOwnerReference(secret)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference of secret %q", secret.Name)
+	}
+	if _, err = clientset.CoreV1().Secrets(clusterInfo.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return errors.Wrap(err, "failed to save mon secrets")
 	}
 
@@ -361,7 +364,7 @@ func ExtractKey(contents string) (string, error) {
 }
 
 // PopulateExternalClusterInfo Add validation in the code to fail if the external cluster has no OSDs keep waiting
-func PopulateExternalClusterInfo(context *clusterd.Context, namespace string, ownerRef metav1.OwnerReference) *cephclient.ClusterInfo {
+func PopulateExternalClusterInfo(context *clusterd.Context, namespace string, ownerInfo *cephclient.OwnerInfo) *cephclient.ClusterInfo {
 	for {
 		clusterInfo, _, _, err := LoadClusterInfo(context, namespace)
 		if err != nil {
@@ -371,7 +374,7 @@ func PopulateExternalClusterInfo(context *clusterd.Context, namespace string, ow
 			continue
 		}
 		logger.Infof("found the cluster info to connect to the external cluster. will use %q to check health and monitor status. mons=%+v", clusterInfo.CephCred.Username, clusterInfo.Monitors)
-		clusterInfo.OwnerRef = ownerRef
+		clusterInfo.OwnerInfo = *ownerInfo
 		return clusterInfo
 	}
 }

--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,8 +56,8 @@ func TestCreateClusterSecrets(t *testing.T) {
 		Executor:  executor,
 	}
 	namespace := "ns"
-	ownerRef := &metav1.OwnerReference{}
-	info, maxID, mapping, err := CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	ownerInfo := &client.OwnerInfo{}
+	info, maxID, mapping, err := CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, -1, maxID)
 	require.NotNil(t, info)
@@ -79,7 +80,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that the cluster info can now be loaded
-	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, "client.admin", info.CephCred.Username)
 	assert.Equal(t, adminSecret, info.CephCred.Secret)
@@ -88,7 +89,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	secret.Data[adminSecretNameKey] = []byte(adminSecretNameKey)
 	_, err = clientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 	assert.NoError(t, err)
-	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.Error(t, err)
 
 	// Load the external cluster with the legacy external creds
@@ -99,7 +100,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	}
 	_, err = clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, "testid", info.CephCred.Username)
 	assert.Equal(t, "testkey", info.CephCred.Secret)

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -64,7 +64,7 @@ func TestCheckHealth(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(context, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	// clusterInfo is nil so we return err
 	err := c.checkHealth()
 	assert.NotNil(t, err)
@@ -155,7 +155,7 @@ func TestScaleMonDeployment(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
 	context := &clusterd.Context{Clientset: clientset}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(context, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 0, AllowMultiplePerNode: true}, "myversion")
 
 	name := "a"
@@ -202,7 +202,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(context, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -260,7 +260,7 @@ func TestAddRemoveMons(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(context, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0 // "a" is max mon id
 	c.waitForStart = false

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -125,7 +125,7 @@ func newCluster(context *clusterd.Context, namespace string, allowMultiplePerNod
 		mapping: &Mapping{
 			Schedule: map[string]*MonScheduleInfo{},
 		},
-		ownerRef: metav1.OwnerReference{},
+		ownerInfo: &client.OwnerInfo{},
 	}
 }
 
@@ -236,7 +236,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// create the initial config map

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -25,6 +25,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/test"
@@ -37,7 +38,7 @@ import (
 func TestNodeAffinity(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 4)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Placement = map[rookv1.KeyType]rookv1.Placement{}
@@ -167,7 +168,7 @@ func TestPodMemory(t *testing.T) {
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(t, 3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Network.HostNetwork = true

--- a/pkg/operator/ceph/cluster/mon/service_test.go
+++ b/pkg/operator/ceph/cluster/mon/service_test.go
@@ -23,6 +23,7 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ import (
 func TestCreateService(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &client.OwnerInfo{}, &sync.Mutex{})
 	m := &monConfig{ResourceName: "rook-ceph-mon-b", DaemonName: "b"}
 	clusterIP, err := c.createService(m)
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -23,6 +23,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPodSpecs(t *testing.T) {
@@ -46,7 +46,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
 		cephv1.ClusterSpec{},
-		metav1.OwnerReference{},
+		&client.OwnerInfo{},
 		&sync.Mutex{},
 	)
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
@@ -95,7 +95,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 		&clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook"},
 		"ns",
 		cephv1.ClusterSpec{},
-		metav1.OwnerReference{},
+		&client.OwnerInfo{},
 		&sync.Mutex{},
 	)
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
@@ -155,7 +155,7 @@ func testRequiredDuringScheduling(t *testing.T, hostNetwork, allowMultiplePerNod
 		&clusterd.Context{},
 		"ns",
 		cephv1.ClusterSpec{},
-		metav1.OwnerReference{},
+		&client.OwnerInfo{},
 		&sync.Mutex{},
 	)
 

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -49,7 +49,7 @@ func (c *Cluster) generateKeyring(osdID int) (string, error) {
 	user := fmt.Sprintf("osd.%s", osdIDStr)
 	access := []string{"osd", "allow *", "mon", "allow profile osd"}
 
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/osd/config_test.go
+++ b/pkg/operator/ceph/cluster/osd/config_test.go
@@ -22,9 +22,9 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,17 +65,17 @@ func TestClusterIsCephVolumeRAwModeSupported(t *testing.T) {
 		rookVersion  string
 		spec         cephv1.ClusterSpec
 		ValidStorage rookv1.StorageScopeSpec
-		kv           *k8sutil.ConfigMapKVStore
+		kv           *client.ConfigMapKVStore
 	}
 	tests := []struct {
 		name   string
 		fields fields
 		want   bool
 	}{
-		{"nok-14.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, false},
-		{"ok-14.2.11", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, true},
-		{"nok-15.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, false},
-		{"ok-15.2.5", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &k8sutil.ConfigMapKVStore{}}, true},
+		{"nok-14.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &client.ConfigMapKVStore{}}, false},
+		{"ok-14.2.11", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 11}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &client.ConfigMapKVStore{}}, true},
+		{"nok-15.2.4", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 4}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &client.ConfigMapKVStore{}}, false},
+		{"ok-15.2.5", fields{&clusterd.Context{}, &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}}, "", cephv1.ClusterSpec{}, rookv1.StorageScopeSpec{}, &client.ConfigMapKVStore{}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -26,7 +26,6 @@ import (
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -121,7 +120,10 @@ func (c *Cluster) createStorageClassDeviceSetPVC(existingPVCs map[string]*v1.Per
 		existingPVC = existingPVCs[pvcStorageClassDeviceSetPVCId]
 	}
 	pvc := makeStorageClassDeviceSetPVC(storageClassDeviceSetName, pvcStorageClassDeviceSetPVCId, setIndex, pvcTemplate)
-	k8sutil.SetOwnerRef(&pvc.ObjectMeta, &c.clusterInfo.OwnerRef)
+	err := c.clusterInfo.OwnerInfo.SetOwnerReference(pvc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference of pvc %q", pvc.Name)
+	}
 
 	if existingPVC != nil {
 		logger.Infof("OSD PVC %q already exists", existingPVC.Name)

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -56,7 +56,7 @@ var (
 func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string) []v1.EnvVar {
 	envVars := []v1.EnvVar{
 		nodeNameEnvVar(osdProps.crushHostname),
-		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerRef.UID)},
+		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerInfo.GetUID())},
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 		opmon.PodNamespaceEnvVar(c.clusterInfo.Namespace),

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -82,7 +82,7 @@ type Cluster struct {
 	rookVersion  string
 	spec         cephv1.ClusterSpec
 	ValidStorage rookv1.StorageScopeSpec // valid subset of `Storage`, computed at runtime
-	kv           *k8sutil.ConfigMapKVStore
+	kv           *cephclient.ConfigMapKVStore
 }
 
 // New creates an instance of the OSD manager
@@ -92,7 +92,7 @@ func New(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, spec ce
 		clusterInfo: clusterInfo,
 		spec:        spec,
 		rookVersion: rookVersion,
-		kv:          k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, clusterInfo.OwnerRef),
+		kv:          cephclient.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, &clusterInfo.OwnerInfo),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -139,7 +139,9 @@ func TestAddRemoveNode(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{
 		Namespace:   "ns-add-remove",
 		CephVersion: cephver.Nautilus,
+		OwnerInfo:   *client.NewOwnerInfoWithRef(metav1.OwnerReference{}),
 	}
+
 	generateKey := "expected key"
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -76,7 +76,10 @@ func (c *Cluster) makeJob(osdProps osdProperties, provisionConfig *provisionConf
 
 	k8sutil.AddRookVersionLabelToJob(job)
 	controller.AddCephVersionLabelToJob(c.clusterInfo.CephVersion, job)
-	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.clusterInfo.OwnerRef)
+	err = c.clusterInfo.OwnerInfo.SetOwnerReference(job)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference of job %q", job.Name)
+	}
 
 	// override the resources of all the init containers and main container with the expected osd prepare resources
 	c.applyResourcesToAllContainers(&podSpec.Spec, cephv1.GetPrepareOSDResources(c.spec.Resources))

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -601,7 +601,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	cephv1.GetOSDLabels(c.spec.Labels).ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
-	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.clusterInfo.OwnerRef)
+	err := c.clusterInfo.OwnerInfo.SetOwnerReference(deployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference of deployment %q", deployment.Name)
+	}
+
 	if !osdProps.onPVC() {
 		cephv1.GetOSDPlacement(c.spec.Placement).ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	} else {

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util"
@@ -65,7 +66,7 @@ func (c *Cluster) updateOSDStatus(node string, status OrchestrationStatus) {
 	UpdateNodeStatus(c.kv, node, status)
 }
 
-func UpdateNodeStatus(kv *k8sutil.ConfigMapKVStore, node string, status OrchestrationStatus) {
+func UpdateNodeStatus(kv *client.ConfigMapKVStore, node string, status OrchestrationStatus) {
 	labels := map[string]string{
 		k8sutil.AppAttr:        AppName,
 		orchestrationStatusKey: provisioningLabelKey,

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -24,9 +24,9 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +45,7 @@ func TestOrchestrationStatus(t *testing.T) {
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{}
 	c := New(context, clusterInfo, spec, "myversion")
-	kv := k8sutil.NewConfigMapKVStore(c.clusterInfo.Namespace, clientset, metav1.OwnerReference{})
+	kv := client.NewConfigMapKVStore(c.clusterInfo.Namespace, clientset, &client.OwnerInfo{})
 	nodeName := "mynode"
 	cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)
 

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -24,10 +24,10 @@ import (
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
-	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,13 +52,6 @@ func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) erro
 		return errors.Wrap(err, "error checking pod memory")
 	}
 
-	// Create the controller owner ref
-	// It will be associated to all resources of the CephRBDMirror
-	ref, err := opcontroller.GetControllerObjectOwnerReference(cephRBDMirror, r.scheme)
-	if err != nil || ref == nil {
-		return errors.Wrapf(err, "failed to get controller %q owner reference", cephRBDMirror.Name)
-	}
-
 	logger.Infof("configure rbd-mirroring with %d workers", cephRBDMirror.Spec.Count)
 
 	for i := 0; i < cephRBDMirror.Spec.Count; i++ {
@@ -68,7 +61,7 @@ func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) erro
 			DaemonID:     daemonID,
 			ResourceName: resourceName,
 			DataPathMap:  config.NewDatalessDaemonDataPathMap(cephRBDMirror.Namespace, r.cephClusterSpec.DataDirHostPath),
-			ownerRef:     *ref,
+			ownerInfo:    client.NewOwnerInfo(cephRBDMirror, true, r.scheme),
 		}
 
 		_, err := r.generateKeyring(r.clusterInfo, daemonConf)

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -119,7 +119,7 @@ func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion,
 func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Duration) (*cephver.CephVersion, error) {
 	logger.Infof("detecting the ceph image version for image %s...", cephImage)
 	versionReporter, err := cmdreporter.New(
-		c.context.Clientset, &c.ownerRef,
+		c.context.Clientset, c.ownerInfo,
 		detectVersionName, detectVersionName, c.Namespace,
 		[]string{"ceph"}, []string{"--version"},
 		rookImage, cephImage)

--- a/pkg/operator/ceph/config/keyring/admin_test.go
+++ b/pkg/operator/ceph/config/keyring/admin_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -37,10 +38,10 @@ func TestAdminKeyringStore(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "test-ns"
-	owner := metav1.OwnerReference{}
+	ownerInfo := client.OwnerInfo{}
 	clusterInfo := clienttest.CreateTestClusterInfo(1)
 	clusterInfo.Namespace = ns
-	k := GetSecretStore(ctx, clusterInfo, &owner)
+	k := GetSecretStore(ctx, clusterInfo, &ownerInfo)
 
 	assertKeyringData := func(expectedKeyring string) {
 		s, e := clientset.CoreV1().Secrets(ns).Get(ctxt, "rook-ceph-admin-keyring", metav1.GetOptions{})
@@ -68,9 +69,9 @@ func TestAdminVolumeAndMount(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
+	ownerInfo := client.OwnerInfo{}
 	clusterInfo := clienttest.CreateTestClusterInfo(1)
-	s := GetSecretStore(ctx, clusterInfo, &owner)
+	s := GetSecretStore(ctx, clusterInfo, &ownerInfo)
 
 	clusterInfo.CephCred.Secret = "adminsecretkey"
 	err := s.Admin().CreateOrUpdate(clusterInfo)

--- a/pkg/operator/ceph/config/keyring/store.go
+++ b/pkg/operator/ceph/config/keyring/store.go
@@ -42,15 +42,15 @@ const (
 type SecretStore struct {
 	context     *clusterd.Context
 	clusterInfo *client.ClusterInfo
-	ownerRef    *metav1.OwnerReference
+	ownerInfo   *client.OwnerInfo
 }
 
 // GetSecretStore returns a new SecretStore struct.
-func GetSecretStore(context *clusterd.Context, clusterInfo *client.ClusterInfo, ownerRef *metav1.OwnerReference) *SecretStore {
+func GetSecretStore(context *clusterd.Context, clusterInfo *client.ClusterInfo, ownerInfo *client.OwnerInfo) *SecretStore {
 	return &SecretStore{
 		context:     context,
 		clusterInfo: clusterInfo,
-		ownerRef:    ownerRef,
+		ownerInfo:   ownerInfo,
 	}
 }
 
@@ -92,7 +92,10 @@ func (k *SecretStore) CreateOrUpdate(resourceName string, keyring string) error 
 		},
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(&secret.ObjectMeta, k.ownerRef)
+	err := k.ownerInfo.SetOwnerReference(secret)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference of secret %q", secret.Name)
+	}
 
 	return k.CreateSecret(secret)
 }

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -49,8 +49,8 @@ func TestGenerateKey(t *testing.T) {
 		Executor:  executor,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
-	s := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &owner)
+	ownerInfo := client.OwnerInfo{}
+	s := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &ownerInfo)
 
 	generateKey = "generatedsecretkey"
 	failGenerateKey = false
@@ -77,9 +77,9 @@ func TestKeyringStore(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
+	ownerInfo := client.OwnerInfo{}
 	ns := "rook-ceph"
-	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &owner)
+	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &ownerInfo)
 
 	assertKeyringData := func(keyringName, expectedKeyring string) {
 		s, e := clientset.CoreV1().Secrets(ns).Get(ctxt, keyringName, metav1.GetOptions{})
@@ -123,8 +123,8 @@ func TestResourceVolumeAndMount(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
-	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: "ns"}, &owner)
+	ownerInfo := client.OwnerInfo{}
+	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: "ns"}, &ownerInfo)
 	err := k.CreateOrUpdate("test-resource", "qwertyuiop")
 	assert.NoError(t, err)
 	err = k.CreateOrUpdate("second-resource", "asdfgyhujkl")

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -37,9 +38,9 @@ func TestStore(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
+	ownerInfo := client.OwnerInfo{}
 
-	s := GetStore(ctx, ns, &owner)
+	s := GetStore(ctx, ns, &ownerInfo)
 
 	assertConfigStore := func(ci *cephclient.ClusterInfo) {
 		sec, e := clientset.CoreV1().Secrets(ns).Get(ctxt, StoreName, metav1.GetOptions{})
@@ -81,9 +82,9 @@ func TestEnvVarsAndFlags(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
+	ownerInfo := client.OwnerInfo{}
 
-	s := GetStore(ctx, ns, &owner)
+	s := GetStore(ctx, ns, &ownerInfo)
 	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3))
 	assert.NoError(t, err)
 

--- a/pkg/operator/ceph/controller/owner.go
+++ b/pkg/operator/ceph/controller/owner.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // OwnerMatcher is a struct representing the controller owner reference
@@ -99,20 +98,4 @@ func (e *OwnerMatcher) setOwnerTypeGroupKind() error {
 
 	e.ownerTypeGroupKind = schema.GroupKind{Group: kinds[0].Group, Kind: kinds[0].Kind}
 	return nil
-}
-
-// GetControllerObjectOwnerReference returns the owner reference that should be used by all child objects of a given controller
-func GetControllerObjectOwnerReference(object metav1.Object, scheme *runtime.Scheme) (*metav1.OwnerReference, error) {
-	ro, ok := object.(runtime.Object)
-	if !ok {
-		return nil, errors.Errorf("%T is not a runtime.Object", object)
-	}
-
-	gvk, err := apiutil.GVKForObject(ro, scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new ref
-	return metav1.NewControllerRef(object, schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind}), nil
 }

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -21,16 +21,16 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	controllerutil "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 )
 
-func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerRef *metav1.OwnerReference) {
+func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerInfo *client.OwnerInfo) {
 	if !AllowUnsupported {
-		if err := validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
+		if err := validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerInfo); err != nil {
 			logger.Errorf("invalid csi version. %+v", err)
 			return
 		}
@@ -38,7 +38,7 @@ func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage
 		logger.Info("Skipping csi version check, since unsupported versions are allowed")
 	}
 
-	if err := startDrivers(context.Clientset, context.RookClientset, namespace, serverVersion, ownerRef); err != nil {
+	if err := startDrivers(context.Clientset, context.RookClientset, namespace, serverVersion, ownerInfo); err != nil {
 		logger.Errorf("failed to start Ceph csi drivers. %v", err)
 		return
 	}

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -30,8 +30,6 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/file/mds"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -51,9 +49,8 @@ func createFilesystem(
 	clusterInfo *cephclient.ClusterInfo,
 	fs cephv1.CephFilesystem,
 	clusterSpec *cephv1.ClusterSpec,
-	ownerRefs metav1.OwnerReference,
 	dataDirHostPath string,
-	scheme *runtime.Scheme,
+	ownerInfo *cephclient.OwnerInfo,
 ) error {
 	if len(fs.Spec.DataPools) != 0 {
 		f := newFS(fs.Name, fs.Namespace)
@@ -81,7 +78,7 @@ func createFilesystem(
 	}
 
 	logger.Infof("start running mdses for filesystem %q", fs.Name)
-	c := mds.NewCluster(clusterInfo, context, clusterSpec, fs, filesystem, ownerRefs, dataDirHostPath, scheme)
+	c := mds.NewCluster(clusterInfo, context, clusterSpec, fs, filesystem, dataDirHostPath, ownerInfo)
 	if err := c.Start(); err != nil {
 		return err
 	}
@@ -95,9 +92,8 @@ func deleteFilesystem(
 	clusterInfo *cephclient.ClusterInfo,
 	fs cephv1.CephFilesystem,
 	clusterSpec *cephv1.ClusterSpec,
-	ownerRefs metav1.OwnerReference,
 	dataDirHostPath string,
-	scheme *runtime.Scheme,
+	ownerInfo *cephclient.OwnerInfo,
 ) error {
 	filesystem, err := client.GetFilesystem(context, clusterInfo, fs.Name)
 	if err != nil {
@@ -107,7 +103,7 @@ func deleteFilesystem(
 		}
 		return errors.Wrapf(err, "failed to get filesystem %q", fs.Name)
 	}
-	c := mds.NewCluster(clusterInfo, context, clusterSpec, fs, filesystem, ownerRefs, dataDirHostPath, scheme)
+	c := mds.NewCluster(clusterInfo, context, clusterSpec, fs, filesystem, dataDirHostPath, ownerInfo)
 
 	// Delete mds CephX keys and configuration in centralized mon database
 	replicas := fs.Spec.MetadataServer.ActiveCount * 2

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
@@ -167,14 +166,14 @@ func TestCreateFilesystem(t *testing.T) {
 	clusterInfo := &client.ClusterInfo{FSID: "myfsid"}
 
 	// start a basic cluster
-	err := createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err := createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
 	assert.ElementsMatch(t, []string{}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
 	// starting again should be a no-op
-	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
 	assert.ElementsMatch(t, []string{"rook-ceph-mds-myfs-a", "rook-ceph-mds-myfs-b"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
@@ -214,7 +213,7 @@ func TestCreateFilesystem(t *testing.T) {
 		Clientset: clientset}
 	fs.Spec.DataPools = append(fs.Spec.DataPools, cephv1.PoolSpec{Replicated: cephv1.ReplicatedSpec{Size: 1, RequireSafeReplicaSize: false}})
 
-	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
 	assert.ElementsMatch(t, []string{"rook-ceph-mds-myfs-a", "rook-ceph-mds-myfs-b"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
@@ -237,7 +236,7 @@ func TestCreateFilesystem(t *testing.T) {
 		Clientset: clientset}
 
 	//Create another filesystem which should fail
-	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Equal(t, "failed to create filesystem \"myfs\": cannot create multiple filesystems. enable ROOK_ALLOW_MULTIPLE_FILESYSTEMS env variable to create more than one", err.Error())
 }
 
@@ -274,12 +273,12 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 	clusterInfo := &client.ClusterInfo{FSID: "myfsid"}
 
 	// start a basic cluster
-	err := createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err := createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
 
 	// starting again should be a no-op
-	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, metav1.OwnerReference{}, "/var/lib/rook/", scheme.Scheme)
+	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, "/var/lib/rook/", &client.OwnerInfo{})
 	assert.Nil(t, err)
 	validateStart(ctx, t, context, fs)
 }

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -44,7 +44,7 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 	access := []string{"osd", "allow *", "mds", "allow", "mon", "allow profile mds"}
 
 	// At present
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.ownerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -19,7 +19,6 @@ package mds
 import (
 	"testing"
 
-	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -73,9 +72,8 @@ func testDeploymentObject(t *testing.T, network cephv1.NetworkSpec) (*apps.Deplo
 		},
 		fs,
 		&client.CephFilesystemDetails{ID: 15},
-		metav1.OwnerReference{},
 		"/var/lib/rook/",
-		scheme.Scheme,
+		&client.OwnerInfo{},
 	)
 	mdsTestConfig := &mdsConfig{
 		DaemonID:     "myfs-a",

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -80,7 +80,7 @@ func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {
 	user := generateCephXUser(rgwConfig.ResourceName)
 	/* TODO: this says `osd allow rwx` while template says `osd allow *`; which is correct? */
 	access := []string{"osd", "allow rwx", "mon", "allow rw"}
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -21,7 +21,7 @@ import (
 	"path"
 
 	"github.com/pkg/errors"
-	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -45,7 +45,7 @@ func mimeTypesMountPath() string {
 
 // store mime.types file in a config map
 func (c *clusterConfig) generateMimeTypes() error {
-	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, *c.ownerRef)
+	k := client.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, c.ownerInfo)
 	if _, err := k.GetValue(c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
 		logger.Infof("config map for object pool %s already exists, not overwriting", c.store.Name)
 		return nil

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -29,6 +29,7 @@ import (
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -288,12 +289,10 @@ func (r *ReconcileObjectRealm) createRealmKeys(realm *cephv1.CephObjectRealm) (r
 		Type: k8sutil.RookType,
 	}
 
-	ownerRef, err := opcontroller.GetControllerObjectOwnerReference(realm, r.scheme)
-	if err != nil || ownerRef == nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to get controller %q owner reference", realm.Name)
+	err = controllerutil.SetControllerReference(realm, secret, r.scheme)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference of secret %q", secret.Name)
 	}
-
-	k8sutil.SetOwnerRef(&secret.ObjectMeta, ownerRef)
 	if _, err = r.context.Clientset.CoreV1().Secrets(realm.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to save rgw secrets")
 	}

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume"
 	"github.com/rook/rook/pkg/daemon/ceph/agent/flexvolume/attachment"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/agent"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
@@ -243,10 +244,10 @@ func (o *Operator) updateDrivers() error {
 		blockOwnerDeletion := false
 		ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 	}
-
+	ownerInfo := client.NewOwnerInfoWithRef(*ownerRef)
 	// create an empty config map. config map will be filled with data
 	// later when clusters have mons
-	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerRef)
+	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerInfo, false)
 	if err != nil {
 		return errors.Wrap(err, "failed creating csi config map")
 	}
@@ -255,7 +256,7 @@ func (o *Operator) updateDrivers() error {
 		return errors.Wrap(err, "invalid csi params")
 	}
 
-	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerRef)
+	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerInfo)
 	return nil
 }
 

--- a/pkg/operator/cockroachdb/controller.go
+++ b/pkg/operator/cockroachdb/controller.go
@@ -222,7 +222,7 @@ func (c *ClusterController) createClientService(cluster *cluster) error {
 			Ports:    createServicePorts(httpPort, grpcPort),
 		},
 	}
-	k8sutil.SetOwnerRef(&clientService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(clientService, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(ctx, clientService, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -273,7 +273,7 @@ func (c *ClusterController) createReplicaService(cluster *cluster) error {
 			Ports:                    createServicePorts(httpPort, grpcPort),
 		},
 	}
-	k8sutil.SetOwnerRef(&replicaService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(replicaService, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(ctx, replicaService, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -304,7 +304,7 @@ func (c *ClusterController) createPodDisruptionBudget(cluster *cluster) error {
 			MaxUnavailable: &maxUnavailable,
 		},
 	}
-	k8sutil.SetOwnerRef(&pdb.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(pdb, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.PolicyV1beta1().PodDisruptionBudgets(cluster.namespace).Create(ctx, pdb, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -354,7 +354,7 @@ func (c *ClusterController) createStatefulSet(cluster *cluster) error {
 	}
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.Spec.Template.ObjectMeta)
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.ObjectMeta)
-	k8sutil.SetOwnerRef(&statefulSet.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(statefulSet, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.AppsV1().StatefulSets(cluster.namespace).Create(ctx, statefulSet, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -182,7 +182,7 @@ func (d *Discover) createDiscoverDaemonSet(namespace, discoverImage, securityAcc
 	if err != nil {
 		logger.Errorf("failed to get operator pod. %+v", err)
 	} else {
-		k8sutil.SetOwnerRefsWithoutBlockOwner(&ds.ObjectMeta, operatorPod.OwnerReferences)
+		k8sutil.SetOwnerRefsWithoutBlockOwner(ds, operatorPod.OwnerReferences)
 	}
 
 	// Add toleration if any

--- a/pkg/operator/edgefs/cluster/cluster.go
+++ b/pkg/operator/edgefs/cluster/cluster.go
@@ -91,7 +91,7 @@ func (c *cluster) createInstance(rookImage string, isClusterUpdate bool) (bool, 
 		},
 		Data: placeholderConfig,
 	}
-	k8sutil.SetOwnerRef(&cm.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(cm, &c.ownerRef)
 	_, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(ctx, cm, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {

--- a/pkg/operator/edgefs/cluster/configmap.go
+++ b/pkg/operator/edgefs/cluster/configmap.go
@@ -230,7 +230,7 @@ func (c *cluster) createClusterConfigMap(deploymentConfig edgefsv1.ClusterDeploy
 		Data: dataMap,
 	}
 
-	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(configMap, &c.ownerRef)
 	if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {
 		if errors.IsAlreadyExists(err) {
 			if _, err := c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Update(ctx, configMap, metav1.UpdateOptions{}); err != nil {

--- a/pkg/operator/edgefs/cluster/mgr/mgr.go
+++ b/pkg/operator/edgefs/cluster/mgr/mgr.go
@@ -201,7 +201,7 @@ func (c *Cluster) makeMgrService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -236,7 +236,7 @@ func (c *Cluster) makeRestapiService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -266,7 +266,7 @@ func (c *Cluster) makeUIService(name string) *v1.Service {
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 
 	if c.dashboardSpec.LocalAddr != "" {
 		ip := net.ParseIP(c.dashboardSpec.LocalAddr)
@@ -367,7 +367,7 @@ func (c *Cluster) makeDeployment(name, clusterName, rookImage string, replicas i
 			Replicas: &replicas,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	c.annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/cluster/prepare/prepare.go
+++ b/pkg/operator/edgefs/cluster/prepare/prepare.go
@@ -150,7 +150,7 @@ func (c *Cluster) makeJob(name, clusterName, rookImage string, nodeName string) 
 		},
 		Spec: batch.JobSpec{Template: podSpec},
 	}
-	k8sutil.SetOwnerRef(&ds.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(ds, &c.ownerRef)
 	return ds
 }
 

--- a/pkg/operator/edgefs/cluster/target/pod.go
+++ b/pkg/operator/edgefs/cluster/target/pod.go
@@ -637,7 +637,7 @@ func (c *Cluster) makeStatefulSet(replicas int32, rookImage string, dro edgefsv1
 		}
 	}
 
-	k8sutil.SetOwnerRef(&statefulSet.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(statefulSet, &c.ownerRef)
 
 	if c.NetworkSpec.IsMultus() {
 		if err := k8sutil.ApplyMultus(c.NetworkSpec, &statefulSet.ObjectMeta); err != nil {
@@ -675,7 +675,7 @@ func (c *Cluster) makeHeadlessService() (*v1.Service, error) {
 			ClusterIP:                "None",
 		},
 	}
-	k8sutil.SetOwnerRef(&headlessService.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(headlessService, &c.ownerRef)
 
 	return headlessService, nil
 }

--- a/pkg/operator/edgefs/iscsi/iscsi.go
+++ b/pkg/operator/edgefs/iscsi/iscsi.go
@@ -124,7 +124,7 @@ func (c *ISCSIController) makeISCSIService(name, svcname, namespace string, iscs
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -201,7 +201,7 @@ func (c *ISCSIController) makeDeployment(svcname, namespace, rookImage string, i
 			Replicas: &instancesCount,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	iscsiSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 
 	return d

--- a/pkg/operator/edgefs/isgw/isgw.go
+++ b/pkg/operator/edgefs/isgw/isgw.go
@@ -195,7 +195,7 @@ func (c *ISGWController) makeISGWService(name, svcname, namespace string, isgwSp
 		svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{Name: "dfport", Port: int32(lport), Protocol: v1.ProtocolTCP})
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -267,7 +267,7 @@ func (c *ISGWController) makeDeployment(svcname, namespace, rookImage string, is
 			Replicas: &instancesCount,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	return d
 }
 

--- a/pkg/operator/edgefs/nfs/nfs.go
+++ b/pkg/operator/edgefs/nfs/nfs.go
@@ -129,7 +129,7 @@ func (c *NFSController) makeNFSService(name, svcname, namespace string) *v1.Serv
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -205,7 +205,7 @@ func (c *NFSController) makeDeployment(svcname, namespace, rookImage string, nfs
 			Replicas: &nfsSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	nfsSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/s3/s3.go
+++ b/pkg/operator/edgefs/s3/s3.go
@@ -163,7 +163,7 @@ func (c *S3Controller) makeS3Service(name, svcname, namespace string, s3Spec edg
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -261,7 +261,7 @@ func (c *S3Controller) makeDeployment(svcname, namespace, rookImage, imageArgs s
 			Replicas: &s3Spec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	s3Spec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/s3x/s3x.go
+++ b/pkg/operator/edgefs/s3x/s3x.go
@@ -147,7 +147,7 @@ func (c *S3XController) makeS3XService(name, svcname, namespace string, s3xSpec 
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -246,7 +246,7 @@ func (c *S3XController) makeDeployment(svcname, namespace, rookImage string, s3x
 			Replicas: &s3xSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	s3xSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/smb/smb.go
+++ b/pkg/operator/edgefs/smb/smb.go
@@ -124,7 +124,7 @@ func (c *SMBController) makeSMBService(name, svcname, namespace string) *v1.Serv
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -208,7 +208,7 @@ func (c *SMBController) makeDeployment(svcname, namespace, rookImage string, smb
 			Replicas: &smbSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	smbSpec.Annotations.ApplyToObjectMeta(&d.ObjectMeta)
 	return d
 }

--- a/pkg/operator/edgefs/swift/swift.go
+++ b/pkg/operator/edgefs/swift/swift.go
@@ -152,7 +152,7 @@ func (c *SWIFTController) makeSWIFTService(name, svcname, namespace string, swif
 		},
 	}
 
-	k8sutil.SetOwnerRef(&svc.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(svc, &c.ownerRef)
 	return svc
 }
 
@@ -244,7 +244,7 @@ func (c *SWIFTController) makeDeployment(svcname, namespace, rookImage, imageArg
 			Replicas: &swiftSpec.Instances,
 		},
 	}
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	k8sutil.SetOwnerRef(d, &c.ownerRef)
 	return d
 }
 

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -24,8 +24,10 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/daemon/util"
 
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -64,7 +66,7 @@ type CmdReporter struct {
 
 type cmdReporterCfg struct {
 	clientset    kubernetes.Interface
-	ownerRef     *metav1.OwnerReference
+	ownerInfo    *client.OwnerInfo
 	appName      string
 	jobName      string
 	jobNamespace string
@@ -88,14 +90,14 @@ type cmdReporterCfg struct {
 // then the command will run without the binaries being copied from the same Rook image.
 func New(
 	clientset kubernetes.Interface,
-	ownerRef *metav1.OwnerReference,
+	ownerInfo *client.OwnerInfo,
 	appName, jobName, jobNamespace string,
 	cmd, args []string,
 	rookImage, runImage string,
 ) (*CmdReporter, error) {
 	cfg := &cmdReporterCfg{
 		clientset:    clientset,
-		ownerRef:     ownerRef,
+		ownerInfo:    ownerInfo,
 		appName:      appName,
 		jobName:      jobName,
 		jobNamespace: jobNamespace,
@@ -107,8 +109,8 @@ func New(
 
 	// Validate contents of config struct, not inputs to function to catch any developer errors
 	// mis-assigning config items to the struct.
-	if cfg.clientset == nil || cfg.ownerRef == nil {
-		return nil, fmt.Errorf("clientset [%+v] and owner reference [%+v] must be specified", cfg.clientset, cfg.ownerRef)
+	if cfg.clientset == nil || cfg.ownerInfo == nil {
+		return nil, fmt.Errorf("clientset [%+v] and owner reference [%+v] must be specified", cfg.clientset, cfg.ownerInfo)
 	}
 	if cfg.appName == "" || cfg.jobName == "" || cfg.jobNamespace == "" {
 		return nil, fmt.Errorf("app name [%s], job name [%s], and job namespace [%s] must be specified", cfg.appName, cfg.jobName, cfg.jobNamespace)
@@ -315,7 +317,10 @@ func (cr *cmdReporterCfg) initJobSpec() (*batch.Job, error) {
 		},
 	}
 	k8sutil.AddRookVersionLabelToJob(job)
-	k8sutil.SetOwnerRef(&job.ObjectMeta, cr.ownerRef)
+	err = cr.ownerInfo.SetOwnerReference(job)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference of job %q", job.Name)
+	}
 
 	return job, nil
 }

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -63,14 +63,14 @@ func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.Resourc
 	return first
 }
 
-func SetOwnerRef(object *metav1.ObjectMeta, ownerRef *metav1.OwnerReference) {
+func SetOwnerRef(object metav1.Object, ownerRef *metav1.OwnerReference) {
 	if ownerRef == nil {
 		return
 	}
 	SetOwnerRefs(object, []metav1.OwnerReference{*ownerRef})
 }
 
-func SetOwnerRefsWithoutBlockOwner(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+func SetOwnerRefsWithoutBlockOwner(object metav1.Object, ownerRefs []metav1.OwnerReference) {
 	if ownerRefs == nil {
 		return
 	}
@@ -89,7 +89,7 @@ func SetOwnerRefsWithoutBlockOwner(object *metav1.ObjectMeta, ownerRefs []metav1
 	SetOwnerRefs(object, newOwners)
 }
 
-func SetOwnerRefs(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+func SetOwnerRefs(object metav1.Object, ownerRefs []metav1.OwnerReference) {
 	object.SetOwnerReferences(ownerRefs)
 }
 

--- a/pkg/operator/yugabytedb/create_controller.go
+++ b/pkg/operator/yugabytedb/create_controller.go
@@ -126,7 +126,7 @@ func (c *ClusterController) createUIService(cluster *cluster, isTServerService b
 			Ports:    createUIServicePorts(ports, isTServerService),
 		},
 	}
-	k8sutil.SetOwnerRef(&uiService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(uiService, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(ctx, uiService, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -182,7 +182,7 @@ func (c *ClusterController) createHeadlessService(cluster *cluster, isTServerSer
 		},
 	}
 
-	k8sutil.SetOwnerRef(&headlessService.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(headlessService, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.CoreV1().Services(cluster.namespace).Create(ctx, headlessService, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -258,7 +258,7 @@ func (c *ClusterController) createStatefulSet(cluster *cluster, isTServerStatefu
 	}
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.Spec.Template.ObjectMeta)
 	cluster.annotations.ApplyToObjectMeta(&statefulSet.ObjectMeta)
-	k8sutil.SetOwnerRef(&statefulSet.ObjectMeta, &cluster.ownerRef)
+	k8sutil.SetOwnerRef(statefulSet, &cluster.ownerRef)
 
 	if _, err := c.context.Clientset.AppsV1().StatefulSets(cluster.namespace).Create(ctx, statefulSet, metav1.CreateOptions{}); err != nil {
 		if !errors.IsAlreadyExists(err) {


### PR DESCRIPTION
**Description of your changes:**

It's better to use controllerutil.Set{Owner,Controller}Reference() as possible because these functions have verifications, for example, whether the owner object is in the same namespace as the target object. With this verification, we can avoid bugs as follows.

The rook-ceph-csi-config cm disappeared after host reboot
https://github.com/rook/rook/issues/6162

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
