### PR TITLE
ceph: ability to configure prometheus port

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -187,6 +187,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
   * `ssl`: Whether to serve the dashboard via SSL, ignored on Ceph versions older than `13.2.2`
 * `monitoring`: Settings for monitoring Ceph using Prometheus. To enable monitoring on your cluster see the [monitoring guide](ceph-monitoring.md#prometheus-alerts).
   * `enabled`: Whether to enable prometheus based monitoring for this cluster
+  * `port`: prometheus exporter port
   * `rulesNamespace`: Namespace to deploy prometheusRule. If empty, namespace of the cluster will be used.
       Recommended:
     * If you have a single Rook Ceph cluster, set the `rulesNamespace` to the same namespace as the cluster or keep it empty.

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -273,6 +273,8 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    port:
+                      type: integer
                     rulesNamespace:
                       type: string
                     externalMgrEndpoints:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -62,6 +62,8 @@ spec:
   monitoring:
     # requires Prometheus to be pre-installed
     enabled: false
+    # Prometheus exporter port
+    port: 9283
     # namespace to deploy prometheusRule in. If empty, namespace of the cluster will be used.
     # Recommended:
     # If you have a single rook-ceph cluster, set the rulesNamespace to the same namespace as the cluster or keep it empty.

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -275,6 +275,8 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    port:
+                      type: integer
                     rulesNamespace:
                       type: string
                     externalMgrEndpoints:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -191,6 +191,9 @@ type MonitoringSpec struct {
 	// types must exist or the creation will fail.
 	Enabled bool `json:"enabled,omitempty"`
 
+	// Prometheus exporter port
+	Port uint16 `json:"port,omitempty"`
+
 	// The namespace where the prometheus rules and alerts should be created.
 	// If empty, the same namespace as the cluster will be used.
 	RulesNamespace string `json:"rulesNamespace,omitempty"`

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -65,6 +65,10 @@ func MgrDisableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name 
 func MgrSetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, mgrName string, key, val string, force bool) (bool, error) {
 	var getArgs, setArgs []string
 	mgrID := fmt.Sprintf("mgr.%s", mgrName)
+	// If the name is empty this means we want to apply the same configuration to all the mgr daemons
+	if mgrName == "" {
+		mgrID = "mgr"
+	}
 	getArgs = append(getArgs, "config", "get", mgrID, key)
 	if val == "" {
 		setArgs = append(setArgs, "config", "rm", mgrID, key)

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -372,6 +372,11 @@ func (c *ClusterController) preClusterStartValidation(cluster *cluster) error {
 		}
 	}
 
+	// Validate prometheus exporter port
+	if cluster.Spec.Monitoring.Port == 0 {
+		cluster.Spec.Monitoring.Port = mgr.DefaultMetricsPort
+	}
+
 	logger.Debug("cluster spec successfully validated")
 	return nil
 }

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -210,7 +210,7 @@ func (c *ClusterController) configureExternalClusterMonitoring(cluster *cluster)
 	}
 
 	// Create external monitoring Endpoints
-	endpoint := mgr.CreateExternalMetricsEndpoints(cluster.Namespace, cluster.Spec.Monitoring.ExternalMgrEndpoints, cluster.ownerRef)
+	endpoint := mgr.CreateExternalMetricsEndpoints(cluster.Namespace, cluster.Spec.Monitoring, cluster.ownerRef)
 	logger.Info("creating mgr external monitoring endpoints")
 	_, err = k8sutil.CreateOrUpdateEndpoint(c.context.Clientset, c.namespacedName.Namespace, endpoint)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -232,7 +232,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 			},
 			{
 				Name:          "http-metrics",
-				ContainerPort: int32(metricsPort),
+				ContainerPort: int32(c.spec.Monitoring.Port),
 				Protocol:      v1.ProtocolTCP,
 			},
 			{
@@ -247,7 +247,7 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 		),
 		Resources:       cephv1.GetMgrResources(c.spec.Resources),
 		SecurityContext: mon.PodSecurityContext(),
-		LivenessProbe:   getDefaultMgrLivenessProbe(),
+		LivenessProbe:   c.getDefaultMgrLivenessProbe(),
 	}
 
 	// If the liveness probe is enabled
@@ -264,12 +264,12 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 	return container
 }
 
-func getDefaultMgrLivenessProbe() *v1.Probe {
+func (c *Cluster) getDefaultMgrLivenessProbe() *v1.Probe {
 	return &v1.Probe{
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{
 				Path: "/",
-				Port: intstr.FromInt(metricsPort),
+				Port: intstr.FromInt(int(c.spec.Monitoring.Port)),
 			},
 		},
 		InitialDelaySeconds: 60,
@@ -290,7 +290,7 @@ func (c *Cluster) MakeMetricsService(name, servicePortMetricName string) *v1.Ser
 			Ports: []v1.ServicePort{
 				{
 					Name:     servicePortMetricName,
-					Port:     int32(metricsPort),
+					Port:     int32(c.spec.Monitoring.Port),
 					Protocol: v1.ProtocolTCP,
 				},
 			},
@@ -345,7 +345,7 @@ func (c *Cluster) applyPrometheusAnnotations(objectMeta *metav1.ObjectMeta) {
 	if len(cephv1.GetMgrAnnotations(c.spec.Annotations)) == 0 {
 		t := rookv1.Annotations{
 			"prometheus.io/scrape": "true",
-			"prometheus.io/port":   strconv.Itoa(metricsPort),
+			"prometheus.io/port":   strconv.Itoa(int(c.spec.Monitoring.Port)),
 		}
 
 		t.ApplyToObjectMeta(objectMeta)
@@ -364,7 +364,7 @@ func (c *Cluster) cephMgrOrchestratorModuleEnvs() []v1.EnvVar {
 }
 
 // CreateExternalMetricsEndpoints creates external metric endpoint
-func CreateExternalMetricsEndpoints(namespace string, externalMgrEndpoints []v1.EndpointAddress, ownerRef metav1.OwnerReference) *v1.Endpoints {
+func CreateExternalMetricsEndpoints(namespace string, monitoringSpec cephv1.MonitoringSpec, ownerRef metav1.OwnerReference) *v1.Endpoints {
 	labels := controller.AppLabels(AppName, namespace)
 
 	endpoints := &v1.Endpoints{
@@ -375,11 +375,11 @@ func CreateExternalMetricsEndpoints(namespace string, externalMgrEndpoints []v1.
 		},
 		Subsets: []v1.EndpointSubset{
 			{
-				Addresses: externalMgrEndpoints,
+				Addresses: monitoringSpec.ExternalMgrEndpoints,
 				Ports: []v1.EndpointPort{
 					{
 						Name:     ServiceExternalMetricName,
-						Port:     int32(metricsPort),
+						Port:     int32(monitoringSpec.Port),
 						Protocol: v1.ProtocolTCP,
 					},
 				},

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -368,6 +368,8 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    port:
+                      type: integer
                     rulesNamespace:
                       type: string
                     externalMgrEndpoints:


### PR DESCRIPTION
**Description of your changes:**

As part of the monitoring spec, we can now set a different port for the
Prometheus exporter.
It can be set like this:

```
spec:
  monitoring:
    enabled: true
    port: 9283
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
