### PR TITLE
ceph: ability to set external services ports

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -187,6 +187,8 @@ If this value is empty, each pod will get an ephemeral directory to store their 
   * `ssl`: Whether to serve the dashboard via SSL, ignored on Ceph versions older than `13.2.2`
 * `monitoring`: Settings for monitoring Ceph using Prometheus. To enable monitoring on your cluster see the [monitoring guide](ceph-monitoring.md#prometheus-alerts).
   * `enabled`: Whether to enable prometheus based monitoring for this cluster
+  * `externalMgrEndpoints`: external cluster manager endpoints
+  * `externalMgrPrometheusPort`: external prometheus manager module port. See [external cluster configuration](#external-cluster) for more details.
   * `rulesNamespace`: Namespace to deploy prometheusRule. If empty, namespace of the cluster will be used.
       Recommended:
     * If you have a single Rook Ceph cluster, set the `rulesNamespace` to the same namespace as the cluster or keep it empty.
@@ -1238,6 +1240,7 @@ spec:
     #rulesNamespace: rook-ceph
     #externalMgrEndpoints:
       #- ip: 192.168.39.182
+    #externalMgrPrometheusPort: 9283
 ```
 
 Choose the namespace carefully, if you have an existing cluster managed by Rook, you have likely already injected `common.yaml`.

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -282,6 +282,10 @@ spec:
                         properties:
                           ip:
                             type: string
+                    externalMgrPrometheusPort:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
                 removeOSDsIfOutAndSafeToRemove:
                   type: boolean
                 external:

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -30,3 +30,4 @@ spec:
   #   rulesNamespace: rook-ceph
   #   externalMgrEndpoints:
       #- ip: ip
+      # externalMgrPrometheusPort: 9283

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -284,6 +284,10 @@ spec:
                         properties:
                           ip:
                             type: string
+                    externalMgrPrometheusPort:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
                 removeOSDsIfOutAndSafeToRemove:
                   type: boolean
                 external:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -206,6 +206,9 @@ type MonitoringSpec struct {
 
 	// ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint
 	ExternalMgrEndpoints []v1.EndpointAddress `json:"externalMgrEndpoints,omitempty"`
+
+	// ExternalMgrPrometheusPort Prometheus exporter port
+	ExternalMgrPrometheusPort uint16 `json:"externalMgrPrometheusPort,omitempty"`
 }
 
 type ClusterStatus struct {

--- a/pkg/operator/ceph/cluster/cluster_external_test.go
+++ b/pkg/operator/ceph/cluster/cluster_external_test.go
@@ -36,4 +36,11 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	c.Spec.DataDirHostPath = "path"
 	err = validateExternalClusterSpec(c)
 	assert.NoError(t, err, err)
+	assert.Equal(t, uint16(0), c.Spec.Monitoring.ExternalMgrPrometheusPort)
+
+	c.Spec.Monitoring.Enabled = true
+	err = validateExternalClusterSpec(c)
+	assert.NoError(t, err, err)
+	assert.Equal(t, uint16(9283), c.Spec.Monitoring.ExternalMgrPrometheusPort)
+
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -53,16 +53,17 @@ const (
 	// AppName is the ceph mgr application name
 	AppName                = "rook-ceph-mgr"
 	serviceAccountName     = "rook-ceph-mgr"
-	prometheusModuleName   = "prometheus"
+	PrometheusModuleName   = "prometheus"
 	crashModuleName        = "crash"
 	PgautoscalerModuleName = "pg_autoscaler"
 	balancerModuleName     = "balancer"
 	balancerModuleMode     = "upmap"
-	metricsPort            = 9283
 	monitoringPath         = "/etc/ceph-monitoring/"
 	serviceMonitorFile     = "service-monitor.yaml"
 	// minimum amount of memory in MB to run the pod
 	cephMgrPodMinimumMemory uint64 = 512
+	// DefaultMetricsPort prometheus exporter port
+	DefaultMetricsPort uint16 = 9283
 )
 
 // Cluster represents the Rook and environment configuration settings needed to set up Ceph mgrs.
@@ -231,7 +232,7 @@ func startModuleConfiguration(description string, configureModules func() error)
 
 // Ceph docs about the prometheus module: http://docs.ceph.com/docs/master/mgr/prometheus/
 func (c *Cluster) enablePrometheusModule() error {
-	if err := client.MgrEnableModule(c.context, c.clusterInfo, prometheusModuleName, true); err != nil {
+	if err := client.MgrEnableModule(c.context, c.clusterInfo, PrometheusModuleName, true); err != nil {
 		return errors.Wrap(err, "failed to enable mgr prometheus module")
 	}
 	return nil
@@ -331,7 +332,7 @@ func (c *Cluster) moduleMeetsMinVersion(name string) (*cephver.CephVersion, bool
 }
 
 func wellKnownModule(name string) bool {
-	knownModules := []string{dashboardModuleName, prometheusModuleName, crashModuleName}
+	knownModules := []string{dashboardModuleName, PrometheusModuleName, crashModuleName}
 	for _, known := range knownModules {
 		if name == known {
 			return true

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -377,6 +377,10 @@ spec:
                         properties:
                           ip:
                             type: string
+                    externalMgrPrometheusPort:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
                 removeOSDsIfOutAndSafeToRemove:
                   type: boolean
                 external:


### PR DESCRIPTION
**Description of your changes:**

When the cluster is external we want to expose manager service port
along with the endpoints.
This allows us to connect but Rook will keep on using 9283 as a facing
port for Prometheus and more.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
