### PR TITLE
core: fix label merge

### DIFF
--- a/pkg/apis/rook.io/v1/labels.go
+++ b/pkg/apis/rook.io/v1/labels.go
@@ -40,9 +40,11 @@ func (a Labels) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 // original Labels with the attributes of the supplied one. The supplied
 // Labels attributes will override the original ones if defined.
 func (a Labels) Merge(with Labels) Labels {
-	ret := a
-	if ret == nil {
-		ret = map[string]string{}
+	ret := Labels{}
+	for k, v := range a {
+		if _, ok := ret[k]; !ok {
+			ret[k] = v
+		}
 	}
 	for k, v := range with {
 		if _, ok := ret[k]; !ok {


### PR DESCRIPTION
**Description of your changes:**

This makes it so the label merging function returns a new Labels object
with the merged content instead of modifying the existing one, which
would cause previously merged labels to be returned for a different set
of input labels.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.