### PR TITLE
ceph: add kms api spec for ceph-csi

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -321,6 +321,8 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
                           type: string
+                        csiConnectionDetailsCMName:
+                          type: string
                 logCollector:
                   type: object
                   properties:

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -182,6 +182,8 @@ spec:
          #VAULT_BACKEND_PATH: "rook"
   #     # name of the secret containing the kms authentication token
   #     tokenSecretName: rook-vault-token
+  #     # name of the config map containing the kms connection details and token for ceph-csi
+  #     csiConnectionDetailsCMName: rook-csi-vault
 # UNCOMMENT THIS TO ENABLE A KMS CONNECTION
 # Also, do not forget to replace both:
 #   * ROOK_TOKEN_CHANGE_ME: with a base64 encoded value of the token to use

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -323,6 +323,8 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
                           type: string
+                        csiConnectionDetailsCMName:
+                          type: string
                 logCollector:
                   type: object
                   properties:

--- a/pkg/apis/ceph.rook.io/v1/security.go
+++ b/pkg/apis/ceph.rook.io/v1/security.go
@@ -25,3 +25,7 @@ func (kms *KeyManagementServiceSpec) IsEnabled() bool {
 func (kms *KeyManagementServiceSpec) IsTokenAuthEnabled() bool {
 	return kms.TokenSecretName != ""
 }
+
+func (kms *KeyManagementServiceSpec) IsCSIEnabled() bool {
+	return kms.CSIConnectionDetailsCMName != ""
+}

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -150,8 +150,9 @@ type SecuritySpec struct {
 
 // KeyManagementServiceSpec represent various details of the KMS server
 type KeyManagementServiceSpec struct {
-	ConnectionDetails map[string]string `json:"connectionDetails,omitempty"`
-	TokenSecretName   string            `json:"tokenSecretName,omitempty"`
+	ConnectionDetails          map[string]string `json:"connectionDetails,omitempty"`
+	TokenSecretName            string            `json:"tokenSecretName,omitempty"`
+	CSIConnectionDetailsCMName string            `json:"csiConnectionDetailsCMName,omitempty"`
 }
 
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.

--- a/pkg/daemon/ceph/osd/kms/k8s.go
+++ b/pkg/daemon/ceph/osd/kms/k8s.go
@@ -38,6 +38,9 @@ const (
 
 	// KMSTokenSecretNameKey is the key name of the Secret that contains the KMS authentication token
 	KMSTokenSecretNameKey = "token"
+
+	// kmsCSIConfigMapNameKey is the key name of the Secret that contains the KMS authentication token
+	kmsCSIConfigMapNameKey = "csiConfig"
 )
 
 // storeSecretInKubernetes stores the dmcrypt key in a Kubernetes Secret

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1605,6 +1605,8 @@ spec:
                       type: object
                     tokenSecretName:
                       type: string
+                    csiConnectionDetailsCMName:
+                      type: string
             placement: {}
             resources: {}
   additionalPrinterColumns:


### PR DESCRIPTION
**Description of your changes:**

Adding the API spec for ceph-csi to consume a config map that contains
the connection details to the KMS as well as the token. Implementation
to follow soon.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
