### PR TITLE
ceph: requeue clusterDisruption controller more proactively

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/add.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/add.go
@@ -17,16 +17,21 @@ limitations under the License.
 package clusterdisruption
 
 import (
+	"reflect"
+
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -57,6 +62,63 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 		return err
 	}
 
+	cephClusterPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			logger.Info("create event from ceph cluster CR")
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, ok := e.ObjectOld.DeepCopyObject().(*cephv1.CephCluster)
+			if !ok {
+				return false
+			}
+			newCluster, ok := e.ObjectNew.DeepCopyObject().(*cephv1.CephCluster)
+			if !ok {
+				return false
+			}
+			return !reflect.DeepEqual(oldCluster.Spec, newCluster.Spec)
+		},
+	}
+
+	// Watch for CephClusters
+	err = c.Watch(&source.Kind{Type: &cephv1.CephCluster{}}, &handler.EnqueueRequestForObject{}, cephClusterPredicate)
+	if err != nil {
+		return err
+	}
+
+	pdbPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			pdb, ok := e.ObjectNew.DeepCopyObject().(*policyv1beta1.PodDisruptionBudget)
+			if !ok {
+				return false
+			}
+			// only reconcile if allowed disruptions is 0 in the main PDB
+			return pdb.Name == osdPDBAppName && pdb.Status.DisruptionsAllowed == 0
+		},
+	}
+
+	// Watch for main PodDisruptionBudget and enqueue the CephCluster in the namespace
+	err = c.Watch(
+		&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}},
+		&handler.EnqueueRequestsFromMapFunc{
+			ToRequests: handler.ToRequestsFunc(func(obj handler.MapObject) []reconcile.Request {
+				pdb, ok := obj.Object.(*policyv1beta1.PodDisruptionBudget)
+				if !ok {
+					// not a pdb, returning empty
+					logger.Errorf("PDB handler received non-PDB")
+					return []reconcile.Request{}
+				}
+				namespace := pdb.GetNamespace()
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
+				return []reconcile.Request{req}
+			}),
+		},
+		pdbPredicate,
+	)
+	if err != nil {
+		return err
+	}
+
 	// enqueues with an empty name that is populated by the reconciler.
 	// There is a one-per-namespace limit on CephClusters
 	enqueueByNamespace := &handler.EnqueueRequestsFromMapFunc{
@@ -64,18 +126,12 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 			// The name will be populated in the reconcile
 			namespace := obj.Meta.GetNamespace()
 			if len(namespace) == 0 {
-				logger.Errorf("enqueByNamespace received an obj without a namespace. %+v", obj)
+				logger.Errorf("enqueueByNamespace received an obj without a namespace. %+v", obj)
 				return []reconcile.Request{}
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
 			return []reconcile.Request{req}
 		}),
-	}
-
-	// Watch for CephClusters
-	err = c.Watch(&source.Kind{Type: &cephv1.CephCluster{}}, &handler.EnqueueRequestForObject{})
-	if err != nil {
-		return err
 	}
 
 	// Watch for CephBlockPools and enqueue the CephCluster in the namespace

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -89,7 +89,7 @@ func (r *ReconcileClusterDisruption) createOverallPDBforOSD(namespace string) er
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &intstr.IntOrString{IntVal: 1},
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{k8sutil.AppAttr: osd.AppName},
+				MatchLabels: map[string]string{k8sutil.AppAttr: osdPDBAppName},
 			},
 		},
 	}


### PR DESCRIPTION
Currently the reconcile of the clusterDisruption controller was triggered mainly due to the
ceph status update in the cephCluster CR. This PR reconciles the cluster more proactively.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Current reconcile strategies:
1. Reconcile when the cluster is created. (This will trigger the first reconcile)
2. Reconcile only when the clusterSpec is updated. (This will avoid reconciles when cluster status is updated) 
3. Reconcile for events on cephblockpool, cephfilesystem and cephObjectStore.  
4. Reconcile for events on Main PDB and when `DisruptionsAllowed` is 0. (that is, when one of the OSD goes down).
5. Reconcile after 30 seconds when there is an active drain going on, that is, pdbStateMap has `draining-failure-domain` as not empty.
 1, 3 and 5 are the existing behaviours. 2 and 4 are newly added changes.

**Which issue is resolved by this Pull Request:**
Resolves #6682

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
