### PR TITLE
ceph: remove multithread option for obc provision

### DIFF
--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -503,10 +503,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 
-        #  Uncomment it to run lib bucket provisioner in multithreaded mode
-        #- name: LIB_BUCKET_PROVISIONER_THREADS
-        #  value: "5"
-
       volumes:
       - name: rook-config
         emptyDir: {}

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -450,10 +450,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 
-        #  Uncomment it to run lib bucket provisioner in multithreaded mode
-        #- name: LIB_BUCKET_PROVISIONER_THREADS
-        #  value: "5"
-
       # Uncomment it to run rook operator on the host network
       #hostNetwork: true
       volumes:


### PR DESCRIPTION
Remove documented option for running the OBC provisioner with multiple
threads. The lib-bucket-provisioner library is not safe for use with
multiple threads as noted in this bug:

https://github.com/kube-object-storage/lib-bucket-provisioner/issues/199

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

[skip ci]

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
