### PR TITLE
ci: helm integration test is failing on pre-k8s-1.16

### DIFF
--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -71,7 +71,7 @@ func TestScratchDevice() string {
 
 // getDeviceFilter get the device name used for OSD
 func getDeviceFilter() string {
-	return getEnvVarWithDefault("DEVICE_FILTER", "")
+	return getEnvVarWithDefault("DEVICE_FILTER", `""`)
 }
 
 func getEnvVarWithDefault(env, defaultValue string) string {


### PR DESCRIPTION
**Description of your changes:**
testCephHelmSuite is failing in pre-k8s v1.16
due to invalid schema. v1beta1 doesn't support
the null value so returning quotes instead of an empty
string.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #6755 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
