### PR TITLE
ceph: Merge placement node affinity for stretch clusters

### DIFF
--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -55,7 +55,7 @@ func CheckForCancelledOrchestration(context *clusterd.Context) error {
 
 	// Check whether we need to cancel the orchestration
 	if context.RequestCancelOrchestration.IsSet() {
-		return errors.New("CANCELLING CURRENT ORCHESTATION")
+		return errors.New("CANCELLING CURRENT ORCHESTRATION")
 	}
 
 	return nil

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -289,7 +289,6 @@ func ExtractTopologyFromLabels(labels map[string]string, additionalTopologyIDs [
 	}
 
 	// check for the region k8s topology label that is GA in 1.17.
-	// TODO: Replace with a const when we update to the K8s 1.17 go-client.
 	region, ok = labels[corev1.LabelZoneRegionStable]
 	if ok {
 		topology[regionLabel] = region
@@ -303,7 +302,6 @@ func ExtractTopologyFromLabels(labels map[string]string, additionalTopologyIDs [
 	}
 
 	// check for the zone k8s topology label that is GA in 1.17.
-	// TODO: Replace with a const when we update to the K8s 1.17 go-client.
 	zone, ok = labels[corev1.LabelZoneFailureDomainStable]
 	if ok {
 		topology[zoneLabel] = zone


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Stretch clusters require certain node affinity for the mons and must also be merged with the required node affinity in the placement of the cluster CR. All conditions, both requested and generated must be met, rather than one overriding the other.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
