### PR TITLE
ceph: fix #6214 New node is not provisioned when useAllNodes: true

### DIFF
--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -22,10 +22,12 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -202,6 +204,10 @@ func GetOSDOnHost(context *clusterd.Context, clusterInfo *ClusterInfo, node stri
 	args := []string{"osd", "crush", "ls", node}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
+		// ENOENT as error means that node is not (yet) part of the ceph cluster
+		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
+			return "", nil
+		}
 		return "", errors.Wrapf(err, "failed to get osd list on host. %s", string(buf))
 	}
 


### PR DESCRIPTION
When a new node got added rook checks if there is already an OSD running on that host via `ceph osd crush ls`
As this is a new node `ceph` returns with the error `ENOENT`. Rook handles this wrongly as a fatal error and aborts the addition of nodes.

The fix checks in case of an error if `ENOENT` is the reason and simply proceeds.

Signed-off-by: Stefan Haas <shaas@suse.com>
