### PR TITLE
ceph: Updated thresholds of OSD capacity alerts and added the device_class info

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml
@@ -114,27 +114,27 @@ spec:
     rules:
     - alert: CephOSDCriticallyFull
       annotations:
-        description: Utilization of back-end storage device {{ $labels.ceph_daemon
-          }} has crossed 85% on host {{ $labels.hostname }}. Immediately free up some
-          space or expand the storage cluster or contact support.
+        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class
+          type {{$labels.device_class}} has crossed 80% on host {{ $labels.hostname
+          }}. Immediately free up some space or add capacity of type {{$labels.device_class}}.
         message: Back-end storage device is critically full.
         severity_level: error
         storage_type: ceph
       expr: |
-        (ceph_osd_metadata * on (ceph_daemon) group_left() (ceph_osd_stat_bytes_used / ceph_osd_stat_bytes)) >= 0.85
+        (ceph_osd_metadata * on (ceph_daemon) group_right(device_class) (ceph_osd_stat_bytes_used / ceph_osd_stat_bytes)) >= 0.80
       for: 40s
       labels:
         severity: critical
     - alert: CephOSDNearFull
       annotations:
-        description: Utilization of back-end storage device {{ $labels.ceph_daemon
-          }} has crossed 75% on host {{ $labels.hostname }}. Free up some space or
-          expand the storage cluster or contact support.
+        description: Utilization of storage device {{ $labels.ceph_daemon }} of device_class
+          type {{$labels.device_class}} has crossed 75% on host {{ $labels.hostname
+          }}. Immediately free up some space or add capacity of type {{$labels.device_class}}.
         message: Back-end storage device is nearing full.
         severity_level: warning
         storage_type: ceph
       expr: |
-        (ceph_osd_metadata * on (ceph_daemon) group_left() (ceph_osd_stat_bytes_used / ceph_osd_stat_bytes)) >= 0.75
+        (ceph_osd_metadata * on (ceph_daemon) group_right(device_class) (ceph_osd_stat_bytes_used / ceph_osd_stat_bytes)) >= 0.75
       for: 40s
       labels:
         severity: warning


### PR DESCRIPTION
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This commit updates the OSD capacity thresholds to match the cluster capacity alert thresholds.
Also updated device_class info to provide info about which type of storage needs to be added.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
