### PR TITLE
ceph: avoid potential osd corruption due to wrong file-lock

### DIFF
--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -114,7 +114,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 
 	if osdProps.onPVC() {
 		// Create volume config for PVCs
-		volumes = append(volumes, getPVCOSDVolumes(&osdProps)...)
+		volumes = append(volumes, getPVCOSDVolumes(&osdProps, c.spec.DataDirHostPath, c.clusterInfo.Namespace, true)...)
 		if osdProps.encrypted {
 			// If a KMS is configured we populate
 			if c.spec.Security.KeyManagementService.IsEnabled() {

--- a/pkg/operator/ceph/cluster/osd/volumes_test.go
+++ b/pkg/operator/ceph/cluster/osd/volumes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package osd
 
 import (
+	"path/filepath"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -43,4 +44,16 @@ func TestGetEncryptionVolume(t *testing.T) {
 	v, vM = c.getEncryptionVolume(osdProps)
 	assert.Equal(t, v1.Volume{Name: "osd-encryption-key", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{Medium: "Memory"}}}, v)
 	assert.Equal(t, v1.VolumeMount{Name: "osd-encryption-key", ReadOnly: false, MountPath: "/etc/ceph"}, vM)
+}
+
+func TestGetDataBridgeVolumeSource(t *testing.T) {
+	claimName := "test-claim"
+	configDir := "/var/lib/rook"
+	namespace := "rook-ceph"
+
+	source := getDataBridgeVolumeSource(claimName, configDir, namespace, true)
+	assert.Equal(t, v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{Medium: "Memory"}}, source)
+	hostPathType := v1.HostPathDirectoryOrCreate
+	source = getDataBridgeVolumeSource(claimName, configDir, namespace, false)
+	assert.Equal(t, v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: filepath.Join(configDir, namespace, claimName), Type: &hostPathType}}, source)
 }


### PR DESCRIPTION
**Description of your changes:**

Multiple OSD pods for the same OSD might run simultaneously becasue OSD pod is managed by Deployment resource. However, OSD locking mechanism doens't work because the lock file (fsid file) exist for each OSD pod. It resutls in OSD corruption.

**Which issue is resolved by this Pull Request:**
Resolves #6530

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]