### PR TITLE
ceph: remove overlapping env values

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -202,10 +202,7 @@ func (c *Cluster) makeSetServerAddrInitContainer(mgrConfig *mgrConfig, mgrModule
 			keyring.VolumeMount().Admin(),
 		),
 		Env: append(
-			append(
-				controller.DaemonEnvVars(c.spec.CephVersion.Image),
-				k8sutil.PodIPEnvVar(podIPEnvVar),
-			),
+			controller.DaemonEnvVars(c.spec.CephVersion.Image),
 			c.cephMgrOrchestratorModuleEnvs()...,
 		),
 		Resources: cephv1.GetMgrResources(c.spec.Resources),

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -76,7 +76,6 @@ func TestPodSpec(t *testing.T) {
 		"200", "100", "500", "250", /* resources */
 		"my-priority-class")
 	assert.Equal(t, 2, len(d.Spec.Template.Annotations))
-
 }
 
 func TestServiceSpec(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -17,7 +17,6 @@ package osd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -394,7 +393,7 @@ func TestGetOSDInfo(t *testing.T) {
 	}
 	d1, _ := c.makeDeployment(osdProp, osd1, dataPathMap)
 	osds1, _ := c.getOSDInfo(d1)
-	findDuplicateEnvVars(t, d1.Spec.Template.Spec)
+
 	assert.Equal(t, 1, len(osds1))
 	assert.Equal(t, osd1.ID, osds1[0].ID)
 	assert.Equal(t, osd1.BlockPath, osds1[0].BlockPath)
@@ -413,17 +412,6 @@ func TestGetOSDInfo(t *testing.T) {
 	osds3, err := c.getOSDInfo(d3)
 	assert.Equal(t, 0, len(osds3))
 	assert.NotNil(t, err)
-}
-
-func findDuplicateEnvVars(t *testing.T, pod v1.PodSpec) {
-	for _, container := range pod.Containers {
-		envVars := map[string]string{}
-		for _, v := range container.Env {
-			_, ok := envVars[v.Name]
-			assert.False(t, ok, fmt.Sprintf("env var duplicated: %s", v.Name))
-			envVars[v.Name] = v.Value
-		}
-	}
 }
 
 func TestOSDPlacement(t *testing.T) {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -158,7 +158,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	} else {
 		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec)
 	}
-	removeDuplicateEnvVars(&podSpec)
+	k8sutil.RemoveDuplicateEnvVars(&podSpec)
 
 	podMeta := metav1.ObjectMeta{
 		Name: AppName,

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -564,7 +564,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		}
 	}
 
-	removeDuplicateEnvVars(&podTemplateSpec.Spec)
+	k8sutil.RemoveDuplicateEnvVars(&podTemplateSpec.Spec)
 
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -623,30 +623,6 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	}
 
 	return deployment, nil
-}
-
-func removeDuplicateEnvVars(pod *v1.PodSpec) {
-	for i := range pod.Containers {
-		removeDuplicateEnvVarsFromContainer(&pod.Containers[i])
-	}
-	for i := range pod.InitContainers {
-		removeDuplicateEnvVarsFromContainer(&pod.InitContainers[i])
-	}
-}
-
-func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
-	foundVars := map[string]string{}
-	vars := []v1.EnvVar{}
-	for _, v := range container.Env {
-		if _, ok := foundVars[v.Name]; ok {
-			logger.Debugf("duplicate env var %q skipped on container %q", v.Name, container.Name)
-			continue
-		}
-
-		vars = append(vars, v)
-		foundVars[v.Name] = v.Value
-	}
-	container.Env = vars
 }
 
 // To get rook inside the container, the config init container needs to copy "tini" and "rook" binaries into a volume.

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -27,6 +27,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
+	operatortest "github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,11 @@ func TestPodContainer(t *testing.T) {
 	assert.Equal(t, "ceph", container.Args[2])
 	assert.Equal(t, "osd", container.Args[3])
 	assert.Equal(t, "provision", container.Args[4])
-	findDuplicateEnvVars(t, c.Spec)
+
+	for _, c := range c.Spec.Containers {
+		vars := operatortest.FindDuplicateEnvVars(c)
+		assert.Equal(t, 0, len(vars))
+	}
 }
 
 func TestDaemonset(t *testing.T) {

--- a/pkg/operator/ceph/test/containers.go
+++ b/pkg/operator/ceph/test/containers.go
@@ -132,6 +132,8 @@ func (ct *ContainersTester) AssertEnvVarsContainCephRequirements() {
 					"POD_CPU_REQUEST env var does not have the appropriate source:", e)
 			}
 		}
+		vars := FindDuplicateEnvVars(c)
+		assert.Equal(ct.t, 0, len(vars), fmt.Sprintf("found duplicate env vars: %v", vars))
 	}
 }
 
@@ -246,4 +248,18 @@ func (ct *ContainersTester) allNonrequiredVarNames() []string {
 		}
 	}
 	return all
+}
+
+// FindDuplicateEnvVars finds duplicated environment variables and return the variable name list.
+func FindDuplicateEnvVars(container v1.Container) []string {
+	var duplicateEnvVars []string
+	envVars := map[string]string{}
+	for _, v := range container.Env {
+		_, ok := envVars[v.Name]
+		if ok {
+			duplicateEnvVars = append(duplicateEnvVars, v.Name)
+		}
+		envVars[v.Name] = v.Value
+	}
+	return duplicateEnvVars
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Currently, mgr deployment has two overlapping environment variables, ROOK_POD_IP.
Like below
```
...
    - name: ROOK_POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
    - name: ROOK_OPERATOR_NAMESPACE
      value: flex-ns-system
    - name: ROOK_CEPH_CLUSTER_CRD_VERSION
      value: v1
    - name: ROOK_CEPH_CLUSTER_CRD_NAME
      value: test-cluster
    - name: ROOK_POD_IP
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: status.podIP
...
```

This causes kube-apiserver to create error logs like below
```
E1209 06:06:50.382252       1 fieldmanager.go:159] [SHOULD NOT HAPPEN] failed to update managedFields for /, Kind=: failed to convert new object (apps/v1, Kind=Deployment) to smd typed: errors:
  .spec.template.spec.initContainers[name="init-set-dashboard-server-addr"].env: duplicate entries for key [name="ROOK_POD_IP"]
  .spec.template.spec.initContainers[name="init-set-prometheus-server-addr"].env: duplicate entries for key [name="ROOK_POD_IP"]
```



**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
