### PR TITLE
ci: Enable K8s 1.20.0 to run the integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,9 +161,9 @@ pipeline {
                     def data = [
                         "aws_1.15.x": "v1.15.12",
                         "aws_1.16.x": "v1.16.15",
-                        "aws_1.17.x": "v1.17.9",
-                        "aws_1.18.x": "v1.18.6",
-                        "aws_1.19.x": "v1.19.0"
+                        "aws_1.18.x": "v1.18.12",
+                        "aws_1.19.x": "v1.19.4",
+                        "aws_1.20.x": "v1.20.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {

--- a/tests/framework/installer/cassandra_installer.go
+++ b/tests/framework/installer/cassandra_installer.go
@@ -51,7 +51,7 @@ func (ci *CassandraInstaller) InstallCassandra(systemNamespace, namespace string
 		return err
 	}
 	if !defaultExists {
-		if err := InstallHostPathProvisioner(ci.k8sHelper); err != nil {
+		if err := CreateHostPathPVs(ci.k8sHelper, 3, true, "5Gi"); err != nil {
 			return err
 		}
 	} else {

--- a/tests/framework/installer/nfs_installer.go
+++ b/tests/framework/installer/nfs_installer.go
@@ -49,10 +49,9 @@ func (h *NFSInstaller) InstallNFSServer(systemNamespace, namespace string, count
 	if err != nil {
 		return err
 	} else if !defaultExists {
-		if err := InstallHostPathProvisioner(h.k8shelper); err != nil {
+		if err := CreateHostPathPVs(h.k8shelper, 2, false, "2Mi"); err != nil {
 			return err
 		}
-		storageClassName = "hostpath"
 	} else {
 		logger.Info("skipping install of host path provisioner because a default storage class already exists")
 	}
@@ -181,7 +180,7 @@ func (h *NFSInstaller) UninstallNFSServer(systemNamespace, namespace string) {
 	_, err = h.k8shelper.KubectlWithStdin(nfsOperator, deleteFromStdinArgs...)
 	checkError(h.T(), err, "cannot uninstall rook-nfs-operator")
 
-	err = UninstallHostPathProvisioner(h.k8shelper)
+	err = DeleteHostPathPVs(h.k8shelper)
 	checkError(h.T(), err, "cannot uninstall hostpath provisioner")
 
 	h.k8shelper.Clientset.RbacV1().ClusterRoleBindings().Delete(ctx, "anon-user-access", metav1.DeleteOptions{})           //nolint, asserting this failing in CI

--- a/tests/framework/installer/yugabytedb_installer.go
+++ b/tests/framework/installer/yugabytedb_installer.go
@@ -54,7 +54,7 @@ func (y *YugabyteDBInstaller) InstallYugabyteDB(systemNS, ns string, count int) 
 		// Mark the installation attempt of a host path provisioner, for removal later.
 		y.hostPathProvisionerInstalled = true
 
-		if err := InstallHostPathProvisioner(y.k8sHelper); err != nil {
+		if err := CreateHostPathPVs(y.k8sHelper, 3, true, "5Gi"); err != nil {
 			return err
 		}
 	} else {
@@ -153,7 +153,7 @@ func (y *YugabyteDBInstaller) RemoveAllYugabyteDBResources(systemNS, namespace s
 
 	// Remove host path provisioner resources, if installed.
 	if y.hostPathProvisionerInstalled {
-		err = UninstallHostPathProvisioner(y.k8sHelper)
+		err = DeleteHostPathPVs(y.k8sHelper)
 		checkError(y.T(), err, "cannot uninstall hostpath provisioner")
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests need to run on all the supported version of K8s. With the release of 1.20.0, we now enable the tests there. To keep the tests running in master on 5 versions, we drop 1.17 and keep 1.15 so we can keep testing against v1beta1 extensions in master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
