### PR TITLE
ceph: add namespace meta-comments to manifests

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -10,6 +10,7 @@ These examples show how to perform advanced configuration tasks on your Rook
 storage cluster.
 
 * [Prerequisites](#prerequisites)
+* [Using alternate namespaces](#using-alternate-namespaces)
 * [Use custom Ceph user and secret for mounting](#use-custom-ceph-user-and-secret-for-mounting)
 * [Log Collection](#log-collection)
 * [OSD Information](#osd-information)
@@ -29,6 +30,37 @@ the Ceph client suite is from a [Rook Toolbox container](ceph-toolbox.md).
 The Kubernetes based examples assume Rook OSD pods are in the `rook-ceph` namespace.
 If you run them in a different namespace, modify `kubectl -n rook-ceph [...]` to fit
 your situation.
+
+## Using alternate namespaces
+
+If you wish to deploy the Rook Operator and/or Ceph clusters to namespaces other than the default
+`rook-ceph`, the manifests are commented to allow for easy `sed` replacements. Change
+`ROOK_CLUSTER_NAMESPACE` to tailor the manifests for additional Ceph clusters. You can choose
+to also change `ROOK_OPERATOR_NAMESPACE` to create a new Rook Operator for each Ceph cluster (don't
+forget to set `ROOK_CURRENT_NAMESPACE_ONLY`), or you can leave it at the same value for every
+Ceph cluster if you only wish to have one Operator manage all Ceph clusters.
+
+This will help you manage namespaces more easily, but you should still make sure the resources are
+configured to your liking.
+
+```sh
+cd cluster/examples/kubernetes/ceph
+
+export ROOK_OPERATOR_NAMESPACE="rook-ceph"
+export ROOK_CLUSTER_NAMESPACE="rook-ceph"
+
+sed -i.bak \
+    -e "s/\(.*\):.*# namespace:operator/\1: $ROOK_OPERATOR_NAMESPACE # namespace:operator/g" \
+    -e "s/\(.*\):.*# namespace:cluster/\1: $ROOK_CLUSTER_NAMESPACE # namespace:cluster/g" \
+    -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:operator/\1:$ROOK_OPERATOR_NAMESPACE:\2 # serviceaccount:namespace:operator/g" \
+    -e "s/\(.*serviceaccount\):.*:\(.*\) # serviceaccount:namespace:cluster/\1:$ROOK_CLUSTER_NAMESPACE:\2 # serviceaccount:namespace:cluster/g" \
+    -e "s/\(.*\): [-_A-Za-z0-9]*\.\(.*\) # driver:namespace:operator/\1: $ROOK_OPERATOR_NAMESPACE.\2 # driver:namespace:operator/g" \
+    -e "s/\(.*\): [-_A-Za-z0-9]*\.\(.*\) # driver:namespace:cluster/\1: $ROOK_CLUSTER_NAMESPACE.\2 # driver:namespace:cluster/g" \
+  common.yaml operator.yaml cluster.yaml # add other files or change these as desired for your config
+
+# You need to use `apply` for all Ceph clusters after the first if you have only one Operator
+kubectl apply -f common.yaml -f operator.yaml -f cluster.yaml # add other files as desired for yourconfig
+```
 
 ## Use custom Ceph user and secret for mounting
 

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -86,6 +86,9 @@ Before you start the operator in production, there are some settings that you ma
    2. Flex driver: The flex driver is deprecated in favor of the CSI driver, but can still be enabled with the `ROOK_ENABLE_FLEX_DRIVER` setting.
    3. Node affinity and tolerations: The CSI driver by default will run on any node in the cluster. To configure the CSI driver affinity, several settings are available.
 
+If you wish to deploy into a namespace other than the default `rook-ceph`, see the [Ceph advanced
+configuration section](ceph-advanced-configuration.md#using-alternate-namespaces) on the topic.
+
 ## Create a Rook Ceph Cluster
 
 Now that the Rook operator is running we can create the Ceph cluster. For the cluster to survive reboots,

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -50,12 +50,12 @@ With this upgrade guide, there are a few notes to consider:
 ## Patch Release Upgrades
 
 Unless otherwise noted due to extenuating requirements, upgrades from one patch release of Rook to
-another are as simple as updating the common resources and the image of the Rook operator. For example, when Rook v1.5.1 is
+another are as simple as updating the common resources and the image of the Rook operator. For example, when Rook v1.5.3 is
 released, the process of updating from v1.5.0 is as simple as running the following:
 
 ```console
 kubectl apply -f common.yaml -f crds.yaml
-kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.1
+kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.3
 ```
 
 As exemplified above, it is a good practice to update Rook-Ceph common resources from the example
@@ -232,7 +232,7 @@ Any pod that is using a Rook volume should also remain healthy:
 ## Rook Operator Upgrade Process
 
 In the examples given in this guide, we will be upgrading a live Rook cluster running `v1.4.7` to
-the version `v1.5.0`. This upgrade should work from any official patch release of Rook v1.4 to any
+the version `v1.5.3`. This upgrade should work from any official patch release of Rook v1.4 to any
 official patch release of v1.5.
 
 **Rook release from `master` are expressly unsupported.** It is strongly recommended that you use
@@ -256,7 +256,7 @@ needed by the Operator. Also update the Custom Resource Definitions (CRDs).
 > You will also need to apply `pre-k8s-1.16/crds.yaml` instead of `crds.yaml`.
 
 ```sh
-git clone --single-branch --branch v1.5.0 https://github.com/rook/rook.git
+git clone --single-branch --branch v1.5.3 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/ceph
 kubectl apply -f common.yaml -f crds.yaml
 ```
@@ -277,7 +277,7 @@ The largest portion of the upgrade is triggered when the operator's image is upd
 When the operator is updated, it will proceed to update all of the Ceph daemons.
 
 ```sh
-kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.0
+kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.3
 ```
 
 ## 4. Wait for the upgrade to complete
@@ -293,17 +293,17 @@ watch --exec kubectl -n $ROOK_NAMESPACE get deployments -l rook_cluster=$ROOK_NA
 ```
 
 As an example, this cluster is midway through updating the OSDs from v1.4 to v1.5. When all
-deployments report `1/1/1` availability and `rook-version=v1.5.0`, the Ceph cluster's core
+deployments report `1/1/1` availability and `rook-version=v1.5.3`, the Ceph cluster's core
 components are fully updated.
 
 ```console
 Every 2.0s: kubectl -n rook-ceph get deployment -o j...
 
-rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.5.0
-rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.5.0
-rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.5.0
-rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.5.0
-rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.5.0
+rook-ceph-mgr-a         req/upd/avl: 1/1/1      rook-version=v1.5.3
+rook-ceph-mon-a         req/upd/avl: 1/1/1      rook-version=v1.5.3
+rook-ceph-mon-b         req/upd/avl: 1/1/1      rook-version=v1.5.3
+rook-ceph-mon-c         req/upd/avl: 1/1/1      rook-version=v1.5.3
+rook-ceph-osd-0         req/upd/avl: 1//        rook-version=v1.5.3
 rook-ceph-osd-1         req/upd/avl: 1/1/1      rook-version=v1.4.7
 rook-ceph-osd-2         req/upd/avl: 1/1/1      rook-version=v1.4.7
 ```
@@ -315,14 +315,14 @@ An easy check to see if the upgrade is totally finished is to check that there i
 # kubectl -n $ROOK_NAMESPACE get deployment -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
   rook-version=v1.4.7
-  rook-version=v1.5.0
+  rook-version=v1.5.3
 This cluster is finished:
-  rook-version=v1.5.0
+  rook-version=v1.5.3
 ```
 
 ## 5. Verify the updated cluster
 
-At this point, your Rook operator should be running version `rook/ceph:v1.5.0`.
+At this point, your Rook operator should be running version `rook/ceph:v1.5.3`.
 
 Verify the Ceph cluster's health using the [health verification section](#health-verification).
 

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -50,9 +50,21 @@ With this upgrade guide, there are a few notes to consider:
 ## Patch Release Upgrades
 
 Unless otherwise noted due to extenuating requirements, upgrades from one patch release of Rook to
-another are as simple as updating the common resources and the image of the Rook operator. For example, when Rook v1.5.3 is
-released, the process of updating from v1.5.0 is as simple as running the following:
+another are as simple as updating the common resources and the image of the Rook operator. For
+example, when Rook v1.5.3 is released, the process of updating from v1.5.0 is as simple as running
+the following:
 
+First get the latest common resources manifests that contain the latest changes for Rook v1.5.
+```sh
+git clone --single-branch --branch v1.5.3 https://github.com/rook/rook.git
+cd rook/cluster/examples/kubernetes/ceph
+```
+
+If you have deployed the Rook Operator or the Ceph cluster into a different namespace than
+`rook-ceph`, see the [Update common resources and CRDs](#1-update-common-resources-and-crds)
+section for instructions on how to change the default namespaces in `common.yaml`.
+
+Then apply the latest changes from v1.5 and update the Rook Operator image.
 ```console
 kubectl apply -f common.yaml -f crds.yaml
 kubectl -n rook-ceph set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.3
@@ -102,8 +114,8 @@ environment variables throughout this document.
 
 ```sh
 # Parameterize the environment
-export ROOK_SYSTEM_NAMESPACE="rook-ceph"
-export ROOK_NAMESPACE="rook-ceph"
+export ROOK_OPERATOR_NAMESPACE="rook-ceph"
+export ROOK_CLUSTER_NAMESPACE="rook-ceph"
 ```
 
 In order to successfully upgrade a Rook cluster, the following prerequisites must be met:
@@ -133,7 +145,7 @@ In a healthy Rook cluster, the operator, the agents and all Rook namespace pods 
 `Running` state and have few, if any, pod restarts. To verify this, run the following commands:
 
 ```sh
-kubectl -n $ROOK_NAMESPACE get pods
+kubectl -n $ROOK_CLUSTER_NAMESPACE get pods
 ```
 
 ### Status Output
@@ -142,8 +154,8 @@ The Rook toolbox contains the Ceph tools that can give you status details of the
 `ceph status` command. Let's look at an output sample and review some of the details:
 
 ```sh
-TOOLS_POD=$(kubectl -n $ROOK_NAMESPACE get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}')
-kubectl -n $ROOK_NAMESPACE exec -it $TOOLS_POD -- ceph status
+TOOLS_POD=$(kubectl -n $ROOK_CLUSTER_NAMESPACE get pod -l "app=rook-ceph-tools" -o jsonpath='{.items[0].metadata.name}')
+kubectl -n $ROOK_CLUSTER_NAMESPACE exec -it $TOOLS_POD -- ceph status
 ```
 
 ```console
@@ -197,16 +209,16 @@ output. For example for the monitor pod `mon-b`, we can verify the container ver
 with the below commands:
 
 ```sh
-POD_NAME=$(kubectl -n $ROOK_NAMESPACE get pod -o custom-columns=name:.metadata.name --no-headers | grep rook-ceph-mon-b)
-kubectl -n $ROOK_NAMESPACE get pod ${POD_NAME} -o jsonpath='{.spec.containers[0].image}'
+POD_NAME=$(kubectl -n $ROOK_CLUSTER_NAMESPACE get pod -o custom-columns=name:.metadata.name --no-headers | grep rook-ceph-mon-b)
+kubectl -n $ROOK_CLUSTER_NAMESPACE get pod ${POD_NAME} -o jsonpath='{.spec.containers[0].image}'
 ```
 
 The status and container versions for all Rook pods can be collected all at once with the following
 commands:
 
 ```sh
-kubectl -n $ROOK_SYSTEM_NAMESPACE get pod -o jsonpath='{range .items[*]}{.metadata.name}{"\n\t"}{.status.phase}{"\t\t"}{.spec.containers[0].image}{"\t"}{.spec.initContainers[0]}{"\n"}{end}' && \
-kubectl -n $ROOK_NAMESPACE get pod -o jsonpath='{range .items[*]}{.metadata.name}{"\n\t"}{.status.phase}{"\t\t"}{.spec.containers[0].image}{"\t"}{.spec.initContainers[0].image}{"\n"}{end}'
+kubectl -n $ROOK_OPERATOR_NAMESPACE get pod -o jsonpath='{range .items[*]}{.metadata.name}{"\n\t"}{.status.phase}{"\t\t"}{.spec.containers[0].image}{"\t"}{.spec.initContainers[0]}{"\n"}{end}' && \
+kubectl -n $ROOK_CLUSTER_NAMESPACE get pod -o jsonpath='{range .items[*]}{.metadata.name}{"\n\t"}{.status.phase}{"\t\t"}{.spec.containers[0].image}{"\t"}{.spec.initContainers[0].image}{"\n"}{end}'
 ```
 
 The `rook-version` label exists on Ceph controller resources. For various resource controllers, a
@@ -216,9 +228,9 @@ the version of Rook for resources managed by the updated Rook-Ceph operator. Not
 and toolbox deployments do not have a `rook-version` label set.
 
 ```sh
-kubectl -n $ROOK_NAMESPACE get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+kubectl -n $ROOK_CLUSTER_NAMESPACE get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
 
-kubectl -n $ROOK_NAMESPACE get jobs -o jsonpath='{range .items[*]}{.metadata.name}{"  \tsucceeded: "}{.status.succeeded}{"      \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+kubectl -n $ROOK_CLUSTER_NAMESPACE get jobs -o jsonpath='{range .items[*]}{.metadata.name}{"  \tsucceeded: "}{.status.succeeded}{"      \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
 ```
 
 ### Rook Volume Health
@@ -241,6 +253,11 @@ master branch are subject to changes and incompatibilities that will not be supp
 official releases. Builds from the master branch can have functionality changed or removed at any
 time without compatibility support and without prior notice.
 
+These methods should work for any number of Rook-Ceph clusters and Rook Operators as long as you
+parameterize the environment correctly. Merely repeat these steps for each Rook-Ceph cluster
+(`ROOK_CLUSTER_NAMESPACE`), and be sure to update the `ROOK_OPERATOR_NAMESPACE` parameter each time
+if applicable.
+
 Let's get started!
 
 ## 1. Update common resources and CRDs
@@ -255,9 +272,24 @@ needed by the Operator. Also update the Custom Resource Definitions (CRDs).
 > `rbac.authorization.k8s.io/v1beta1` instead of `rbac.authorization.k8s.io/v1`
 > You will also need to apply `pre-k8s-1.16/crds.yaml` instead of `crds.yaml`.
 
+First get the latest common resources manifests that contain the latest changes for Rook v1.5.
 ```sh
 git clone --single-branch --branch v1.5.3 https://github.com/rook/rook.git
 cd rook/cluster/examples/kubernetes/ceph
+```
+
+If you have deployed the Rook Operator or the Ceph cluster into a different namespace than
+`rook-ceph`, update the common resource manifests to use your `ROOK_OPERATOR_NAMESPACE` and
+`ROOK_CLUSTER_NAMESPACE` using `sed`.
+```sh
+sed -i.bak \
+    -e "s/\(.*\):.*# namespace:operator/\1: $ROOK_OPERATOR_NAMESPACE # namespace:operator/g" \
+    -e "s/\(.*\):.*# namespace:cluster/\1: $ROOK_CLUSTER_NAMESPACE # namespace:cluster/g" \
+  common.yaml
+```
+
+Then apply the latest changes from v1.5.
+```sh
 kubectl apply -f common.yaml -f crds.yaml
 ```
 
@@ -277,7 +309,7 @@ The largest portion of the upgrade is triggered when the operator's image is upd
 When the operator is updated, it will proceed to update all of the Ceph daemons.
 
 ```sh
-kubectl -n $ROOK_SYSTEM_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.3
+kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.5.3
 ```
 
 ## 4. Wait for the upgrade to complete
@@ -289,7 +321,7 @@ and the Ceph Filesystem may fall offline a few times while the MDSes are upgradi
 The versions of the components can be viewed as they are updated:
 
 ```sh
-watch --exec kubectl -n $ROOK_NAMESPACE get deployments -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
+watch --exec kubectl -n $ROOK_CLUSTER_NAMESPACE get deployments -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \trook-version="}{.metadata.labels.rook-version}{"\n"}{end}'
 ```
 
 As an example, this cluster is midway through updating the OSDs from v1.4 to v1.5. When all
@@ -312,7 +344,7 @@ An easy check to see if the upgrade is totally finished is to check that there i
 `rook-version` reported across the cluster.
 
 ```console
-# kubectl -n $ROOK_NAMESPACE get deployment -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
+# kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"rook-version="}{.metadata.labels.rook-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
   rook-version=v1.4.7
   rook-version=v1.5.3
@@ -364,8 +396,8 @@ Ceph image field in the cluster CRD (`spec.cephVersion.image`).
 
 ```sh
 NEW_CEPH_IMAGE='ceph/ceph:v15.2.7-20201201'
-CLUSTER_NAME="$ROOK_NAMESPACE"  # change if your cluster name is not the Rook namespace
-kubectl -n $ROOK_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
+CLUSTER_NAME="$ROOK_CLUSTER_NAMESPACE"  # change if your cluster name is not the Rook namespace
+kubectl -n $ROOK_CLUSTER_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```
 
 #### 2. Wait for the daemon pod updates to complete
@@ -374,13 +406,13 @@ As with upgrading Rook, you must now wait for the upgrade to complete. Status ca
 similar way to the Rook upgrade as well.
 
 ```sh
-watch --exec kubectl -n $ROOK_NAMESPACE get deployments -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
+watch --exec kubectl -n $ROOK_CLUSTER_NAMESPACE get deployments -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{.metadata.name}{"  \treq/upd/avl: "}{.spec.replicas}{"/"}{.status.updatedReplicas}{"/"}{.status.readyReplicas}{"  \tceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}'
 ```
 
 Determining when the Ceph has fully updated is rather simple.
 
 ```console
-# kubectl -n $ROOK_NAMESPACE get deployment -l rook_cluster=$ROOK_NAMESPACE -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq
+# kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
     ceph-version=14.2.7-0
     ceph-version=15.2.4-0
@@ -403,7 +435,7 @@ The operator configuration variables have recently moved from the operator deplo
 but if the ConfigMap settings are applied, they will override the operator deployment settings.
 
 ```console
-kubectl -n $ROOK_NAMESPACE edit configmap rook-ceph-operator-config
+kubectl -n $ROOK_OPERATOR_NAMESPACE edit configmap rook-ceph-operator-config
 ```
 
 The default upstream images are included below, which you can change to your desired images.

--- a/cluster/examples/kubernetes/ceph/ceph-client.yaml
+++ b/cluster/examples/kubernetes/ceph/ceph-client.yaml
@@ -3,7 +3,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephClient
 metadata:
   name: glance
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   caps:
     mon: 'profile rbd'
@@ -13,7 +13,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephClient
 metadata:
   name: cinder
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   caps:
     mon: 'profile rbd'

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -12,7 +12,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph-external
-  namespace: rook-ceph-external
+  namespace: rook-ceph-external # namespace:cluster
 spec:
   external:
     enable: true

--- a/cluster/examples/kubernetes/ceph/cluster-external.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external.yaml
@@ -13,7 +13,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph-external
-  namespace: rook-ceph-external
+  namespace: rook-ceph-external # namespace:cluster
 spec:
   external:
     enable: true

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -11,7 +11,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   dataDirHostPath: /var/lib/rook
   mon:
@@ -191,6 +191,6 @@ spec:
 # kind: Secret
 # metadata:
 #   name: rook-vault-token
-#   namespace: rook-ceph
+#   namespace: rook-ceph # namespace:cluster
 # data:
 #   token: ROOK_TOKEN_CHANGE_ME

--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -12,7 +12,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   dataDirHostPath: /var/lib/rook
   mon:

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -11,7 +11,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rook-config-override
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 data:
   config: |
     [global]
@@ -22,7 +22,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: my-cluster
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:

--- a/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
@@ -12,7 +12,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   cephVersion:
       image: ceph/ceph:v15.2.7

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -12,7 +12,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
   name: rook-ceph
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).

--- a/cluster/examples/kubernetes/ceph/common-external.yaml
+++ b/cluster/examples/kubernetes/ceph/common-external.yaml
@@ -21,13 +21,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cluster-mgmt
-  namespace: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -35,13 +35,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -49,19 +49,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph-external
+  name: rook-ceph-external # namespace:cluster
 rules:
 - apiGroups:
   - ""

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -14,7 +14,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rook-ceph
+  name: rook-ceph # namespace:cluster
 # OLM: BEGIN OBJECTBUCKET ROLEBINDING
 ---
 kind: ClusterRoleBinding
@@ -28,7 +28,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 # OLM: END OBJECTBUCKET ROLEBINDING
 # OLM: BEGIN OPERATOR ROLE
 ---
@@ -36,7 +36,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-admission-controller
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -55,7 +55,7 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-admission-controller
     apiGroup: ""
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: ClusterRole
   name: rook-ceph-admission-controller-role
@@ -96,7 +96,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph
@@ -323,7 +323,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph
@@ -338,7 +338,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph
@@ -349,7 +349,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 # Grant the rook system daemons cluster-wide access to manage the Rook CRDs, PVCs, and storage classes
 kind: ClusterRoleBinding
@@ -366,7 +366,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 # OLM: END OPERATOR ROLEBINDING
 #################################################################################################################
 # Beginning of cluster-specific resources. The example will assume the cluster will be created in the "rook-ceph"
@@ -380,7 +380,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 # imagePullSecrets:
 # - name: my-registry-secret
 
@@ -392,7 +392,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 # imagePullSecrets:
 # - name: my-registry-secret
 
@@ -403,7 +403,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 # OLM: END CMD REPORTER SERVICE ACCOUNT
 # OLM: BEGIN CLUSTER ROLE
 ---
@@ -411,7 +411,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -453,7 +453,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 rules:
 - apiGroups:
   - ""
@@ -490,7 +490,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 rules:
 - apiGroups:
   - ""
@@ -512,7 +512,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cluster-mgmt
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -520,14 +520,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 # Allow the osd pods in this namespace to work with configmaps
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -535,14 +535,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 # Allow the ceph mgr to access the cluster-specific resources necessary for the mgr modules
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -550,14 +550,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 # Allow the ceph mgr to access the rook system resources necessary for the mgr modules
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-system
-  namespace: rook-ceph
+  namespace: rook-ceph  # namespace:operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -565,7 +565,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 # Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
 kind: ClusterRoleBinding
@@ -579,7 +579,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 
 ---
 # Allow the ceph osd to access cluster-wide resources necessary for determining their topology location
@@ -594,7 +594,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 
 # OLM: END CLUSTER ROLEBINDING
 # OLM: BEGIN CMD REPORTER ROLEBINDING
@@ -603,7 +603,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -611,7 +611,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 # OLM: END CMD REPORTER ROLEBINDING
 #################################################################################################################
 # Beginning of pod security policy resources. The example will assume the cluster will be created in the
@@ -718,13 +718,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-default-psp
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -732,13 +732,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-osd-psp
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -746,13 +746,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-mgr-psp
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -760,13 +760,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-mgr
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rook-ceph-cmd-reporter-psp
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -774,7 +774,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-cmd-reporter
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 # OLM: END CLUSTER POD SECURITY POLICY BINDINGS
 # OLM: BEGIN CSI CEPHFS SERVICE ACCOUNT
 ---
@@ -782,21 +782,21 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 # OLM: END CSI CEPHFS SERVICE ACCOUNT
 # OLM: BEGIN CSI CEPHFS ROLE
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: rook-ceph
   name: cephfs-external-provisioner-cfg
+  namespace: rook-ceph # namespace:operator
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -814,11 +814,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-csi-provisioner-role-cfg
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: Role
   name: cephfs-external-provisioner-cfg
@@ -911,7 +911,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -924,7 +924,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -933,7 +933,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: ClusterRole
   name: cephfs-csi-nodeplugin
@@ -947,7 +947,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: ClusterRole
   name: cephfs-external-provisioner-runner
@@ -959,21 +959,21 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 # OLM: END CSI RBD SERVICE ACCOUNT
 # OLM: BEGIN CSI RBD ROLE
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: rook-ceph
   name: rbd-external-provisioner-cfg
+  namespace: rook-ceph # namespace:operator
 rules:
   - apiGroups: [""]
     resources: ["endpoints"]
@@ -991,11 +991,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-csi-provisioner-role-cfg
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg
@@ -1091,7 +1091,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1104,7 +1104,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1113,7 +1113,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: ClusterRole
   name: rbd-csi-nodeplugin
@@ -1126,7 +1126,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: rook-ceph
+    namespace: rook-ceph # namespace:operator
 roleRef:
   kind: ClusterRole
   name: rbd-external-provisioner-runner

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml
@@ -3,12 +3,12 @@ apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cephfsplugin-snapclass
-driver: rook-ceph.cephfs.csi.ceph.com
+driver: rook-ceph.cephfs.csi.ceph.com # provisioner:namespace:operator
 parameters:
   # Specify a string that identifies your cluster. Ceph CSI supports any
   # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
   # for example "rook-ceph".
-  clusterID: rook-ceph
+  clusterID: rook-ceph # namespace:cluster
   csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
-  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
 deletionPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml
@@ -3,7 +3,7 @@ apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-cephfsplugin-snapclass
-driver: rook-ceph.cephfs.csi.ceph.com # provisioner:namespace:operator
+driver: rook-ceph.cephfs.csi.ceph.com # driver:namespace:operator
 parameters:
   # Specify a string that identifies your cluster. Ceph CSI supports any
   # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -2,10 +2,10 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
-provisioner: rook-ceph.cephfs.csi.ceph.com
+provisioner: rook-ceph.cephfs.csi.ceph.com # provisioner:namespace:operator
 parameters:
   # clusterID is the namespace where operator is deployed.
-  clusterID: rook-ceph
+  clusterID: rook-ceph # namespace:cluster
 
   # CephFS filesystem name into which the volume shall be created
   fsName: myfs
@@ -21,11 +21,11 @@ parameters:
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
   csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
 
   # (optional) The driver can use either ceph-fuse (fuse) or ceph kernel client (kernel)
   # If omitted, default volume mounter will be used - this is determined by probing for ceph-fuse

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
-provisioner: rook-ceph.cephfs.csi.ceph.com # provisioner:namespace:operator
+provisioner: rook-ceph.cephfs.csi.ceph.com # driver:namespace:operator
 parameters:
   # clusterID is the namespace where operator is deployed.
   clusterID: rook-ceph # namespace:cluster

--- a/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
@@ -3,7 +3,7 @@ apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass
-driver: rook-ceph.rbd.csi.ceph.com # provisioner:namespace:operator
+driver: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
 parameters:
   # Specify a string that identifies your cluster. Ceph CSI supports any
   # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,

--- a/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
@@ -3,12 +3,12 @@ apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass
-driver: rook-ceph.rbd.csi.ceph.com
+driver: rook-ceph.rbd.csi.ceph.com # provisioner:namespace:operator
 parameters:
   # Specify a string that identifies your cluster. Ceph CSI supports any
   # unique string. When Ceph CSI is deployed by Rook use the Rook namespace,
   # for example "rook-ceph".
-  clusterID: rook-ceph
+  clusterID: rook-ceph # namespace:cluster
   csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
-  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph
+  csi.storage.k8s.io/snapshotter-secret-namespace: rook-ceph # namespace:cluster
 deletionPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-ec.yaml
@@ -31,7 +31,7 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
-provisioner: rook-ceph.rbd.csi.ceph.com  # provisioner:namespace:operatoror
+provisioner: rook-ceph.rbd.csi.ceph.com  # driver:namespace:operator
 parameters:
     # clusterID is the namespace where the rook cluster is running
     # If you change this namespace, also change the namespace below where the secret namespaces are defined

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-ec.yaml
@@ -9,7 +9,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: replicated-metadata-pool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   replicated:
     size: 2
@@ -18,7 +18,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: ec-data-pool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # Make sure you have enough nodes and OSDs running bluestore to support the replica size or erasure code chunks.
   # For the below settings, you need at least 3 OSDs on different nodes (because the `failureDomain` is `host` by default).
@@ -31,11 +31,11 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
-provisioner: rook-ceph.rbd.csi.ceph.com
+provisioner: rook-ceph.rbd.csi.ceph.com  # provisioner:namespace:operatoror
 parameters:
     # clusterID is the namespace where the rook cluster is running
     # If you change this namespace, also change the namespace below where the secret namespaces are defined
-    clusterID: rook-ceph
+    clusterID: rook-ceph # namespace:cluster
 
     # If you want to use erasure coded pool with RBD, you need to create
     # two pools. one erasure coded and one replicated.
@@ -54,11 +54,11 @@ parameters:
     # The secrets contain Ceph admin credentials. These are generated automatically by the operator
     # in the same namespace as the cluster.
     csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.
     csi.storage.k8s.io/fstype: ext4

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
@@ -19,7 +19,7 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
-provisioner: rook-ceph.rbd.csi.ceph.com  # provisioner:namespace:operator
+provisioner: rook-ceph.rbd.csi.ceph.com  # driver:namespace:operator
 parameters:
     # clusterID is the namespace where the rook cluster is running
     # If you change this namespace, also change the namespace below where the secret namespaces are defined

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass-test.yaml
@@ -2,7 +2,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: replicapool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   failureDomain: host
   replicated:
@@ -19,11 +19,11 @@ kind: StorageClass
 metadata:
    name: rook-ceph-block
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
-provisioner: rook-ceph.rbd.csi.ceph.com
+provisioner: rook-ceph.rbd.csi.ceph.com  # provisioner:namespace:operator
 parameters:
     # clusterID is the namespace where the rook cluster is running
     # If you change this namespace, also change the namespace below where the secret namespaces are defined
-    clusterID: rook-ceph
+    clusterID: rook-ceph # namespace:cluster
 
     # If you want to use erasure coded pool with RBD, you need to create
     # two pools. one erasure coded and one replicated.
@@ -42,11 +42,11 @@ parameters:
     # The secrets contain Ceph admin credentials. These are generated automatically by the operator
     # in the same namespace as the cluster.
     csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`.
     csi.storage.k8s.io/fstype: ext4

--- a/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/storageclass.yaml
@@ -23,7 +23,7 @@ provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
     # clusterID is the namespace where the rook cluster is running
     # If you change this namespace, also change the namespace below where the secret namespaces are defined
-    clusterID: rook-ceph
+    clusterID: rook-ceph # namespace:cluster
 
     # If you want to use erasure coded pool with RBD, you need to create
     # two pools. one erasure coded and one replicated.
@@ -42,11 +42,11 @@ parameters:
     # The secrets contain Ceph admin credentials. These are generated automatically by the operator
     # in the same namespace as the cluster.
     csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
     csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
     # Specify the filesystem type of the volume. If not specified, csi-provisioner
     # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
     # in hyperconverged settings where the volume is mounted on the same node as the osds.

--- a/cluster/examples/kubernetes/ceph/dashboard-external-http.yaml
+++ b/cluster/examples/kubernetes/ceph/dashboard-external-http.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rook-ceph-mgr-dashboard-external-http
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-mgr
-    rook_cluster: rook-ceph
+    rook_cluster: rook-ceph # namespace:cluster
 spec:
   ports:
   - name: dashboard

--- a/cluster/examples/kubernetes/ceph/dashboard-external-https.yaml
+++ b/cluster/examples/kubernetes/ceph/dashboard-external-https.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rook-ceph-mgr-dashboard-external-https
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-mgr
-    rook_cluster: rook-ceph
+    rook_cluster: rook-ceph # namespace:cluster
 spec:
   ports:
   - name: dashboard

--- a/cluster/examples/kubernetes/ceph/dashboard-ingress-https.yaml
+++ b/cluster/examples/kubernetes/ceph/dashboard-ingress-https.yaml
@@ -9,7 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: rook-ceph-mgr-dashboard
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   annotations:
     kubernetes.io/ingress.class: "nginx"
     kubernetes.io/tls-acme: "true"

--- a/cluster/examples/kubernetes/ceph/dashboard-loadbalancer.yaml
+++ b/cluster/examples/kubernetes/ceph/dashboard-loadbalancer.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rook-ceph-mgr-dashboard-loadbalancer
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-mgr
-    rook_cluster: rook-ceph
+    rook_cluster: rook-ceph # namespace:cluster
 spec:
   ports:
   - name: dashboard

--- a/cluster/examples/kubernetes/ceph/direct-mount.yaml
+++ b/cluster/examples/kubernetes/ceph/direct-mount.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-direct-mount
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-direct-mount
 spec:

--- a/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-ec.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
   name: myfs-ec
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The metadata pool spec
   metadataPool:

--- a/cluster/examples/kubernetes/ceph/filesystem-test.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem-test.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
   name: myfs
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   metadataPool:
     replicated:

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
   name: myfs
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The metadata pool spec. Must use replication.
   metadataPool:

--- a/cluster/examples/kubernetes/ceph/nfs-test.yaml
+++ b/cluster/examples/kubernetes/ceph/nfs-test.yaml
@@ -2,7 +2,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephNFS
 metadata:
   name: my-nfs
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   rados:
     # RADOS pool where NFS client recovery data is stored.

--- a/cluster/examples/kubernetes/ceph/nfs.yaml
+++ b/cluster/examples/kubernetes/ceph/nfs.yaml
@@ -2,7 +2,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephNFS
 metadata:
   name: my-nfs
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   rados:
     # RADOS pool where NFS client recovery data is stored.

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: my-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The pool spec used to create the metadata pools. Must use replication.
   metadataPool:

--- a/cluster/examples/kubernetes/ceph/object-external.yaml
+++ b/cluster/examples/kubernetes/ceph/object-external.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: external-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   gateway:
     # The port on which **ALL** the gateway(s) are listening on.

--- a/cluster/examples/kubernetes/ceph/object-multisite.yaml
+++ b/cluster/examples/kubernetes/ceph/object-multisite.yaml
@@ -6,13 +6,13 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectRealm
 metadata:
   name: realm-a
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup
 metadata:
   name: zonegroup-a
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   realm: realm-a
 ---
@@ -20,7 +20,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectZone
 metadata:
   name: zone-a
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   zoneGroup: zonegroup-a
   metadataPool:
@@ -40,7 +40,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: multisite-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   gateway:
     type: s3

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: my-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The pool spec used to create the metadata pools. Must use replication.
   metadataPool:

--- a/cluster/examples/kubernetes/ceph/object-test.yaml
+++ b/cluster/examples/kubernetes/ceph/object-test.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: my-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   metadataPool:
     replicated:

--- a/cluster/examples/kubernetes/ceph/object-user.yaml
+++ b/cluster/examples/kubernetes/ceph/object-user.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStoreUser
 metadata:
   name: my-user
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   store: my-store
   displayName: "my display name"

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: my-store
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The pool spec used to create the metadata pools. Must use replication.
   metadataPool:

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -45,10 +45,10 @@ users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
-  - system:serviceaccount:rook-ceph:rook-ceph-system
-  - system:serviceaccount:rook-ceph:default
-  - system:serviceaccount:rook-ceph:rook-ceph-mgr
-  - system:serviceaccount:rook-ceph:rook-ceph-osd
+  - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:default # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster
 ---
 # scc for the CSI driver
 kind: SecurityContextConstraints
@@ -82,10 +82,10 @@ users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
-  - system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa
-  - system:serviceaccount:rook-ceph:rook-csi-rbd-provisioner-sa
-  - system:serviceaccount:rook-ceph:rook-csi-cephfs-plugin-sa
-  - system:serviceaccount:rook-ceph:rook-csi-cephfs-provisioner-sa
+  - system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-rbd-provisioner-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-cephfs-plugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-cephfs-provisioner-sa # serviceaccount:namespace:operator
 ---
 # Rook Ceph Operator Config
 # Use this ConfigMap to override operator configurations
@@ -96,7 +96,7 @@ apiVersion: v1
 metadata:
   name: rook-ceph-operator-config
   # should be in the namespace of the operator
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 data:
   # Enable the CSI driver.
   # To run the non-default version of the CSI driver, see the override-able image properties in operator.yaml
@@ -347,7 +347,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 metadata:
   name: rook-ceph-operator-config
   # should be in the namespace of the operator
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
 data:
   # Enable the CSI driver.
   # To run the non-default version of the CSI driver, see the override-able image properties in operator.yaml
@@ -271,7 +271,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     operator: rook
     storage-backend: ceph

--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: rook-ceph-purge-osd
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:operator
   labels:
     app: rook-ceph-purge-osd
 spec:

--- a/cluster/examples/kubernetes/ceph/pool-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/pool-ec.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: ec-pool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The failure domain will spread the replicas of the data across different failure zones
   failureDomain: osd

--- a/cluster/examples/kubernetes/ceph/pool-test.yaml
+++ b/cluster/examples/kubernetes/ceph/pool-test.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: replicapool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   replicated:
     size: 1

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -8,7 +8,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: replicapool
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # The failure domain will spread the replicas of the data across different failure zones
   failureDomain: host

--- a/cluster/examples/kubernetes/ceph/rbdmirror.yaml
+++ b/cluster/examples/kubernetes/ceph/rbdmirror.yaml
@@ -7,7 +7,7 @@ apiVersion: ceph.rook.io/v1
 kind: CephRBDMirror
 metadata:
   name: my-rbd-mirror
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
 spec:
   # the number of rbd-mirror daemons to deploy
   count: 1

--- a/cluster/examples/kubernetes/ceph/rgw-external.yaml
+++ b/cluster/examples/kubernetes/ceph/rgw-external.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rook-ceph-rgw-my-store-external
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-rgw
-    rook_cluster: rook-ceph
+    rook_cluster: rook-ceph # namespace:cluster
     rook_object_store: my-store
 spec:
   ports:
@@ -15,7 +15,7 @@ spec:
     targetPort: 8080
   selector:
     app: rook-ceph-rgw
-    rook_cluster: rook-ceph
+    rook_cluster: rook-ceph # namespace:cluster
     rook_object_store: my-store
   sessionAffinity: None
   type: NodePort

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -38,10 +38,10 @@ users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
-  - system:serviceaccount:rook-ceph:rook-ceph-system
-  - system:serviceaccount:rook-ceph:default
-  - system:serviceaccount:rook-ceph:rook-ceph-mgr
-  - system:serviceaccount:rook-ceph:rook-ceph-osd
+  - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:default # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster
 ---
 # scc for the CSI driver
 kind: SecurityContextConstraints
@@ -75,7 +75,7 @@ users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
-  - system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa
-  - system:serviceaccount:rook-ceph:rook-csi-rbd-provisioner-sa
-  - system:serviceaccount:rook-ceph:rook-csi-cephfs-plugin-sa
-  - system:serviceaccount:rook-ceph:rook-csi-cephfs-provisioner-sa
+  - system:serviceaccount:rook-ceph:rook-csi-rbd-plugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-rbd-provisioner-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-cephfs-plugin-sa # serviceaccount:namespace:operator
+  - system:serviceaccount:rook-ceph:rook-csi-cephfs-provisioner-sa # serviceaccount:namespace:operator

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-delete-bucket
-provisioner: rook-ceph.ceph.rook.io/bucket # provisioner:namespace:cluster
+provisioner: rook-ceph.ceph.rook.io/bucket # driver:namespace:cluster
 # set the reclaim policy to delete the bucket and all objects
 # when its OBC is deleted.
 reclaimPolicy: Delete

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-delete.yaml
@@ -2,13 +2,13 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-delete-bucket
-provisioner: rook-ceph.ceph.rook.io/bucket
+provisioner: rook-ceph.ceph.rook.io/bucket # provisioner:namespace:cluster
 # set the reclaim policy to delete the bucket and all objects
 # when its OBC is deleted.
 reclaimPolicy: Delete
 parameters:
   objectStoreName: my-store
-  objectStoreNamespace: rook-ceph
+  objectStoreNamespace: rook-ceph # namespace:cluster
   region: us-east-1
   # To accommodate brownfield cases reference the existing bucket name here instead
   # of in the ObjectBucketClaim (OBC). In this case the provisioner will grant

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-retain.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-retain.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-retain-bucket
-provisioner: rook-ceph.ceph.rook.io/bucket # provisioner:namespace:cluster
+provisioner: rook-ceph.ceph.rook.io/bucket # driver:namespace:cluster
 # set the reclaim policy to retain the bucket when its OBC is deleted
 reclaimPolicy: Retain
 parameters:

--- a/cluster/examples/kubernetes/ceph/storageclass-bucket-retain.yaml
+++ b/cluster/examples/kubernetes/ceph/storageclass-bucket-retain.yaml
@@ -2,12 +2,12 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-retain-bucket
-provisioner: rook-ceph.ceph.rook.io/bucket
+provisioner: rook-ceph.ceph.rook.io/bucket # provisioner:namespace:cluster
 # set the reclaim policy to retain the bucket when its OBC is deleted
 reclaimPolicy: Retain
 parameters:
   objectStoreName: my-store # port 80 assumed
-  objectStoreNamespace: rook-ceph
+  objectStoreNamespace: rook-ceph # namespace:cluster
   region: us-east-1
   # To accommodate brownfield cases reference the existing bucket name here instead
   # of in the ObjectBucketClaim (OBC). In this case the provisioner will grant

--- a/cluster/examples/kubernetes/ceph/toolbox-job.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox-job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: rook-ceph-toolbox-job
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: ceph-toolbox-job
 spec:

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-tools
-  namespace: rook-ceph
+  namespace: rook-ceph # namespace:cluster
   labels:
     app: rook-ceph-tools
 spec:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -33,17 +33,17 @@ const (
 type CephManifests interface {
 	GetRookCRDs(v1ExtensionsSupported bool) string
 	GetRookOperator(namespace string) string
-	GetClusterRoles(namespace, systemNamespace string) string
-	GetClusterExternalRoles(namespace, systemNamespace string) string
+	GetClusterRoles(namespace, operatorNamespace string) string
+	GetClusterExternalRoles(namespace, operatorNamespace string) string
 	GetRookCluster(settings *clusterSettings) string
 	GetRookExternalCluster(settings *clusterExternalSettings) string
 	GetRookToolBox(namespace string) string
 	GetBlockPoolDef(poolName, namespace, replicaSize string) string
-	GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, systemNamespace string) string
-	GetFileStorageClassDef(fsName, storageClassName, systemNamespace, namespace string) string
+	GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, operatorNamespace string) string
+	GetFileStorageClassDef(fsName, storageClassName, operatorNamespace, namespace string) string
 	GetPVC(claimName, namespace, storageClassName, accessModes, size string) string
-	GetBlockSnapshotClass(snapshotClassName, namespace, systemNamespace, reclaimPolicy string) string
-	GetFileStorageSnapshotClass(snapshotClassName, namespace, systemNamespace, reclaimPolicy string) string
+	GetBlockSnapshotClass(snapshotClassName, namespace, operatorNamespace, reclaimPolicy string) string
+	GetFileStorageSnapshotClass(snapshotClassName, namespace, operatorNamespace, reclaimPolicy string) string
 	GetPVCRestore(claimName, snapshotName, namespace, storageClassName, accessModes, size string) string
 	GetPVCClone(cloneClaimName, parentClaimName, namespace, storageClassName, accessModes, size string) string
 	GetSnapshot(snapshotName, claimName, snapshotClassName, namespace string) string
@@ -2256,7 +2256,7 @@ users:
 }
 
 // GetRookOperator returns rook Operator manifest
-func (m *CephManifestsMaster) GetRookOperator(namespace string) string {
+func (m *CephManifestsMaster) GetRookOperator(operatorNamespace string) string {
 	var operatorManifest string
 	openshiftEnv := ""
 
@@ -2266,7 +2266,7 @@ func (m *CephManifestsMaster) GetRookOperator(namespace string) string {
           value: "true"
         - name: FLEXVOLUME_DIR_PATH
           value: "/etc/kubernetes/kubelet-plugins/volume/exec"`
-		operatorManifest = getOpenshiftSCC(namespace)
+		operatorManifest = getOpenshiftSCC(operatorNamespace)
 	}
 
 	operatorManifest = operatorManifest + `---
@@ -2274,7 +2274,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: rook-ceph-system
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   labels:
     operator: rook
     storage-backend: ceph
@@ -2573,13 +2573,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-system
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   labels:
     operator: rook
     storage-backend: ceph
@@ -2588,7 +2588,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-system
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   labels:
     operator: rook
     storage-backend: ceph
@@ -2599,7 +2599,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2615,13 +2615,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-plugin-sa
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2654,7 +2654,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: ClusterRole
   name: rbd-csi-nodeplugin
@@ -2664,7 +2664,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-rbd-provisioner-sa
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2724,7 +2724,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: ClusterRole
   name: rbd-external-provisioner-runner
@@ -2733,7 +2733,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   name: rbd-external-provisioner-cfg
 rules:
   - apiGroups: [""]
@@ -2750,11 +2750,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-csi-provisioner-role-cfg
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg
@@ -2764,7 +2764,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-plugin-sa
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2795,7 +2795,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: ClusterRole
   name: cephfs-csi-nodeplugin
@@ -2805,7 +2805,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-csi-cephfs-provisioner-sa
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -2865,7 +2865,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: ClusterRole
   name: cephfs-external-provisioner-runner
@@ -2874,7 +2874,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   name: cephfs-external-provisioner-cfg
 rules:
   - apiGroups: [""]
@@ -2891,11 +2891,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-csi-provisioner-role-cfg
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: Role
   name: cephfs-external-provisioner-cfg
@@ -2992,7 +2992,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3005,7 +3005,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3018,7 +3018,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-rbd-plugin-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3031,7 +3031,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-provisioner-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -3044,13 +3044,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-csi-cephfs-plugin-sa
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-admission-controller
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -3069,7 +3069,7 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-admission-controller
     apiGroup: ""
-    namespace: ` + namespace + `
+    namespace: ` + operatorNamespace + `
 roleRef:
   kind: ClusterRole
   name: rook-ceph-admission-controller-role
@@ -3079,7 +3079,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rook-ceph-operator
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
   labels:
     operator: rook
     storage-backend: ceph
@@ -3134,7 +3134,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: rook-ceph-operator-config
-  namespace: ` + namespace + `
+  namespace: ` + operatorNamespace + `
 data:
   ROOK_CSI_ENABLE_CEPHFS: "true"
   ROOK_CSI_ENABLE_RBD: "true"
@@ -3146,7 +3146,7 @@ data:
 }
 
 // GetClusterRoles returns rook-cluster manifest
-func (m *CephManifestsMaster) GetClusterRoles(namespace, systemNamespace string) string {
+func (m *CephManifestsMaster) GetClusterRoles(namespace, operatorNamespace string) string {
 	return `apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -3274,7 +3274,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-system
-  namespace: ` + systemNamespace + `
+  namespace: ` + operatorNamespace + `
 ---
 # Allow the osd pods in this namespace to work with configmaps
 kind: RoleBinding
@@ -3311,7 +3311,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-mgr-system ` + namespace + `
-  namespace: ` + systemNamespace + `
+  namespace: ` + operatorNamespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -3571,14 +3571,14 @@ spec:
           path: mon-endpoints`
 }
 
-func (m *CephManifestsMaster) GetBlockSnapshotClass(snapshotClassName, namespace, systemNamespace, reclaimPolicy string) string {
+func (m *CephManifestsMaster) GetBlockSnapshotClass(snapshotClassName, namespace, operatorNamespace, reclaimPolicy string) string {
 	// Create a CSI driver snapshotclass
 	return `
 apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: ` + snapshotClassName + `
-driver: ` + systemNamespace + `.rbd.csi.ceph.com
+driver: ` + operatorNamespace + `.rbd.csi.ceph.com
 deletionPolicy: ` + reclaimPolicy + `
 parameters:
   clusterID: ` + namespace + `
@@ -3587,14 +3587,14 @@ parameters:
 `
 }
 
-func (m *CephManifestsMaster) GetFileStorageSnapshotClass(snapshotClassName, namespace, systemNamespace, reclaimPolicy string) string {
+func (m *CephManifestsMaster) GetFileStorageSnapshotClass(snapshotClassName, namespace, operatorNamespace, reclaimPolicy string) string {
 	// Create a CSI driver snapshotclass
 	return `
 apiVersion: snapshot.storage.k8s.io/v1beta1
 kind: VolumeSnapshotClass
 metadata:
   name: ` + snapshotClassName + `
-driver: ` + systemNamespace + `.cephfs.csi.ceph.com
+driver: ` + operatorNamespace + `.cephfs.csi.ceph.com
 deletionPolicy: ` + reclaimPolicy + `
 parameters:
   clusterID: ` + namespace + `
@@ -3698,7 +3698,7 @@ spec:
       interval: 10s`
 }
 
-func (m *CephManifestsMaster) GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, systemNamespace string) string {
+func (m *CephManifestsMaster) GetBlockStorageClassDef(csi bool, poolName, storageClassName, reclaimPolicy, namespace, operatorNamespace string) string {
 	// Create a CSI driver storage class
 	if csi {
 		return `
@@ -3706,7 +3706,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ` + storageClassName + `
-provisioner: ` + systemNamespace + `.rbd.csi.ceph.com
+provisioner: ` + operatorNamespace + `.rbd.csi.ceph.com
 reclaimPolicy: ` + reclaimPolicy + `
 parameters:
   pool: ` + poolName + `
@@ -3732,7 +3732,7 @@ parameters:
     clusterNamespace: ` + namespace
 }
 
-func (m *CephManifestsMaster) GetFileStorageClassDef(fsName, storageClassName, systemNamespace, namespace string) string {
+func (m *CephManifestsMaster) GetFileStorageClassDef(fsName, storageClassName, operatorNamespace, namespace string) string {
 	// Create a CSI driver storage class
 	csiCephFSNodeSecret := "rook-csi-cephfs-node"               //nolint:gosec // We safely suppress gosec in tests file
 	csiCephFSProvisionerSecret := "rook-csi-cephfs-provisioner" //nolint:gosec // We safely suppress gosec in tests file
@@ -3741,7 +3741,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ` + storageClassName + `
-provisioner: ` + systemNamespace + `.cephfs.csi.ceph.com
+provisioner: ` + operatorNamespace + `.cephfs.csi.ceph.com
 parameters:
   clusterID: ` + namespace + `
   fsName: ` + fsName + `


### PR DESCRIPTION
Add meta-comments to manifests to allow basic templating via `sed`.

Add meta-comments to manifests to allow basic templating via `sed`.

Add the following types of meta-comments:
- `# namespace:X`
  - A basic namespace
  - replace the field with a namespace for X
- `# serviceaccount:namespace:X`
  - A service account namespace for SCC
  - e.g., "`system:serviceaccount:<ns>:rook-ceph-system`"
  - Replace the namespace "`<ns>`" with with a namespace for X
- `# provisioner:namespace:X`
  - A provisioner identifier with namespace prefix
  - e.g., "`<ns>.cephfs.csi.ceph.com`"
  - e.g., "`<ns>.ceph.rook.io/bucket`"
  - Replace the namespace "`<ns>`" with a namespace for X


In order to allow this PR to backport properly to release-1.5, checkout
the ceph-upgrad.md file from the release-1.5 branch.


Update the upgrade docs to allow users with different cluster/operator
namespaces to use a `sed` command and the new manifest meta-comments for
updates.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

@alimaredia are you able to take a look at object manifests, especially the multisite ones?
@Madhu-1 are you able to take a look at the CSI manifests including the `provisoner` lines?
@travisn are you able to provide a sanity check the following things?
  - SCC `servicaccount` lines
  - toolbox manifests
  - dashboard manifests
  - osd purge job

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6730 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
