### PR TITLE
ceph: #6796 Operator loops forever over existing nodes

### DIFF
--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -22,12 +22,10 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -201,13 +199,11 @@ func formatProperty(name, value string) string {
 
 // GetOSDOnHost returns the list of osds running on a given host
 func GetOSDOnHost(context *clusterd.Context, clusterInfo *ClusterInfo, node string) (string, error) {
+	node = NormalizeCrushName(node)
 	args := []string{"osd", "crush", "ls", node}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
-		// ENOENT as error means that node is not (yet) part of the ceph cluster
-		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
-			return "", nil
-		}
+		err = errors.Wrapf(err, "failed to get osd list on host. %s", string(buf))
 		return "", errors.Wrapf(err, "failed to get osd list on host. %s", string(buf))
 	}
 


### PR DESCRIPTION
As describe in #6796 `ceph osd crush ls [node name]` is expecting node names with `-` instead of `.`

This means without the fix every node will be recognized as a new one.

Signed-off-by: Stefan Haas <shaas@suse.com>
