### PR TITLE
ceph: Apply deviceClass properly to new osds

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -118,6 +118,7 @@ func addOSDConfigFlags(command *cobra.Command) {
 	command.Flags().StringVar(&cfg.storeConfig.StoreType, "osd-store", "", "type of backing OSD store to use (bluestore or filestore)")
 	command.Flags().IntVar(&cfg.storeConfig.OSDsPerDevice, "osds-per-device", 1, "the number of OSDs per device")
 	command.Flags().BoolVar(&cfg.storeConfig.EncryptedDevice, "encrypted-device", false, "whether to encrypt the OSD with dmcrypt")
+	command.Flags().StringVar(&cfg.storeConfig.DeviceClass, "osd-crush-device-class", "", "The device class for all OSDs configured on this node")
 }
 
 func init() {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -524,10 +524,16 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 					deviceArg,
 				}...)
 
-				if a.storeConfig.DeviceClass != "" {
+				// assign the device class specific to the device
+				deviceClass := device.Config.DeviceClass
+				if deviceClass == "" {
+					// fall back to the device class for all devices on the node
+					deviceClass = a.storeConfig.DeviceClass
+				}
+				if deviceClass != "" {
 					immediateExecuteArgs = append(immediateExecuteArgs, []string{
 						crushDeviceClassFlag,
-						a.storeConfig.DeviceClass,
+						deviceClass,
 					}...)
 				}
 

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -139,7 +139,6 @@ type osdProperties struct {
 	tuneSlowDeviceClass bool
 	tuneFastDeviceClass bool
 	schedulerName       string
-	crushDeviceClass    string
 	encrypted           bool
 	deviceSetName       string
 	// Drive Groups which apply to the node
@@ -268,11 +267,11 @@ func (c *Cluster) startProvisioningOverPVCs(config *provisionConfig) {
 			placement:        volume.Placement,
 			preparePlacement: volume.PreparePlacement,
 			portable:         volume.Portable,
-			crushDeviceClass: volume.CrushDeviceClass,
 			schedulerName:    volume.SchedulerName,
 			encrypted:        volume.Encrypted,
 			deviceSetName:    volume.Name,
 		}
+		osdProps.storeConfig.DeviceClass = volume.CrushDeviceClass
 
 		logger.Debugf("osdProps are %+v", osdProps)
 

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -233,6 +233,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		envVars = append(envVars, deviceFilterEnvVar("all"))
 	}
 	envVars = append(envVars, v1.EnvVar{Name: "ROOK_CEPH_VERSION", Value: c.clusterInfo.CephVersion.CephVersionFormatted()})
+	envVars = append(envVars, crushDeviceClassEnvVar(osdProps.storeConfig.DeviceClass))
 
 	if osdProps.metadataDevice != "" {
 		envVars = append(envVars, metadataDeviceEnvVar(osdProps.metadataDevice))
@@ -281,7 +282,6 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		}
 		envVars = append(envVars, dataDevicesEnvVar(string(marshalledDevices)))
 		envVars = append(envVars, pvcBackedOSDEnvVar("true"))
-		envVars = append(envVars, crushDeviceClassEnvVar(osdProps.crushDeviceClass))
 		envVars = append(envVars, encryptedDeviceEnvVar(osdProps.encrypted))
 		envVars = append(envVars, pvcNameEnvVar(osdProps.pvc.ClaimName))
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The deviceClass property was being ignored when creating the non-pvc OSDs. Now the deviceClass will be specified as a property for individual devices, all devices on a node, or all OSDs in the cluster, depending on the level where the config is applied in the cluster CR.

**Which issue is resolved by this Pull Request:**
Resolves #6814 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
