### PR TITLE
ceph: Allow using lvm batch for ceph 14.2.15

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -633,19 +633,16 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 			"json",
 		}...)
 
-		cephVersion := a.clusterInfo.CephVersion
+		cvOut, err := context.Executor.ExecuteCommandWithOutput(baseCommand, reportArgs...)
+		if err != nil {
+			return errors.Wrapf(err, "failed ceph-volume json report: %s", cvOut) // fail return here as validation provided by ceph-volume
+		}
 
-		// ceph version v14.2.13 ~ v14.2.16 changes output of `lvm batch --prepare --report`
+		logger.Debugf("ceph-volume reports: %+v", cvOut)
+
+		// ceph version v14.2.13 and v15.2.8 changed the changed output format of `lvm batch --prepare --report`
 		// use previous logic if ceph version does not fall into this range
-		if !isNewStyledLvmBatch(cephVersion) {
-
-			cvOut, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, reportArgs...)
-			if err != nil {
-				return errors.Wrapf(err, "failed ceph-volume json report: %s", cvOut) // fail return here as validation provided by ceph-volume
-			}
-
-			logger.Debugf("ceph-volume report: %+v", cvOut)
-
+		if !isNewStyledLvmBatch(a.clusterInfo.CephVersion) {
 			var cvReport cephVolReport
 			if err = json.Unmarshal([]byte(cvOut), &cvReport); err != nil {
 				return errors.Wrap(err, "failed to unmarshal ceph-volume report json")
@@ -655,13 +652,6 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 				return errors.Errorf("ceph-volume did not use the expected metadataDevice [%s]", mdPath)
 			}
 		} else {
-			cvOut, err := context.Executor.ExecuteCommandWithOutput(baseCommand, reportArgs...)
-			if err != nil {
-				return errors.Wrapf(err, "failed ceph-volume json report: %s", cvOut) // fail return here as validation provided by ceph-volume
-			}
-
-			logger.Debugf("ceph-volume reports: %+v", cvOut)
-
 			var cvReports []cephVolReportV2
 			if err = json.Unmarshal([]byte(cvOut), &cvReports); err != nil {
 				return errors.Wrap(err, "failed to unmarshal ceph-volume report json")
@@ -669,11 +659,11 @@ func (a *OsdAgent) initializeDevices(context *clusterd.Context, devices *DeviceO
 
 			if len(strings.Split(conf["devices"], " ")) != len(cvReports) {
 				return fmt.Errorf("failed to create enough required devices, required: %s, actual: %v", cvOut, cvReports)
-			} else {
-				for _, report := range cvReports {
-					if report.BlockDB != mdPath {
-						return fmt.Errorf("wrong db device for %s, required: %s, actual: %s", report.Data, mdPath, report.BlockDB)
-					}
+			}
+
+			for _, report := range cvReports {
+				if report.BlockDB != mdPath {
+					return fmt.Errorf("wrong db device for %s, required: %s, actual: %s", report.Data, mdPath, report.BlockDB)
 				}
 			}
 		}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -1195,3 +1195,53 @@ Running command: /usr/bin/ceph --cluster ceph --name client.bootstrap-osd --keyr
 		})
 	}
 }
+
+func TestIsNewStyledLvmBatch(t *testing.T) {
+	newStyleLvmBatchVersion := cephver.CephVersion{Major: 14, Minor: 2, Extra: 15}
+	legacyLvmBatchVersion := cephver.CephVersion{Major: 14, Minor: 2, Extra: 8}
+	assert.Equal(t, true, isNewStyledLvmBatch(newStyleLvmBatchVersion))
+	assert.Equal(t, false, isNewStyledLvmBatch(legacyLvmBatchVersion))
+}
+
+func TestInitializeBlockWithMD(t *testing.T) {
+	// Common vars for all the tests
+	devices := &DeviceOsdMapping{
+		Entries: map[string]*DeviceOsdIDEntry{
+			"sda": {Data: -1, Metadata: nil, Config: DesiredDevice{Name: "/dev/sda", MetadataDevice: "/dev/sdd"}},
+		},
+	}
+
+	// Test default behavior
+	{
+		executor := &exectest.MockExecutor{}
+		executor.MockExecuteCommand = func(command string, args ...string) error {
+			logger.Infof("%s %v", command, args)
+
+			// Validate base common args
+			err := testBaseArgs(args)
+			if err != nil {
+				return err
+			}
+
+			// Second command
+			if args[9] == "--osds-per-device" && args[10] == "1" && args[11] == "/dev/sda" {
+				return nil
+			}
+
+			return errors.Errorf("unknown command %s %s", command, args)
+		}
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			// First command
+			if args[9] == "--osds-per-device" && args[10] == "1" && args[11] == "/dev/sda" && args[12] == "--db-devices" && args[13] == "/dev/sdd" && args[14] == "--report" {
+				return `[{"block_db": "/dev/sdd", "encryption": "None", "data": "/dev/sda", "data_size": "100.00 GB", "block_db_size": "100.00 GB"}]`, nil
+			}
+
+			return "", errors.Errorf("unknown command %s %s", command, args)
+		}
+		a := &OsdAgent{clusterInfo: &cephclient.ClusterInfo{CephVersion: cephver.CephVersion{Major: 14, Minor: 2, Extra: 15}}, nodeName: "node1"}
+		context := &clusterd.Context{Executor: executor}
+
+		err := a.initializeDevices(context, devices)
+		assert.NoError(t, err, "failed default behavior test")
+	}
+}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -710,7 +710,7 @@ func TestInitializeBlock(t *testing.T) {
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
 
-		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			logger.Infof("%s %v", command, args)
 
 			// Validate base common args
@@ -765,7 +765,7 @@ func TestInitializeBlock(t *testing.T) {
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
 
-		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			logger.Infof("%s %v", command, args)
 
 			// Validate base common args


### PR DESCRIPTION
14.2.15 lvm batch command prepare report changes
output format. This commit skips md check if ceph version
is greater than 14.2.13.

Signed-off-by: shenjiatong <yshxxsjt715@gmail.com>

**Description of your changes:**

In 14.2.15, `lvm batch --prepare --report` breaks report format which causes
creating osd failed.


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test full]