### PR TITLE
ceph: configure health check timeout for OSDs when upgrading

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -63,6 +63,8 @@ spec:
                   type: boolean
                 continueUpgradeAfterChecksEvenIfNotHealthy:
                   type: boolean
+                waitTimeoutForHealthyOSDInMinutes:
+                  type: integer
                 mon:
                   type: object
                   properties:
@@ -1411,6 +1413,8 @@ spec:
               type: boolean
             continueUpgradeAfterChecksEvenIfNotHealthy:
               type: boolean
+            waitTimeoutForHealthyOSDInMinutes:
+              type: integer
             mon:
               properties:
                 allowMultiplePerNode:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -37,6 +37,12 @@ spec:
   skipUpgradeChecks: false
   # Whether or not continue if PGs are not clean during an upgrade
   continueUpgradeAfterChecksEvenIfNotHealthy: false
+  # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
+  # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
+  # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+  # The default wait timeout is 10 minutes.
+  waitTimeoutForHealthyOSDInMinutes: 10
   mon:
     # Set the number of mons to be started. Must be an odd number, and is generally recommended to be 3.
     count: 3

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -65,6 +65,8 @@ spec:
                   type: boolean
                 continueUpgradeAfterChecksEvenIfNotHealthy:
                   type: boolean
+                waitTimeoutForHealthyOSDInMinutes:
+                  type: integer
                 mon:
                   type: object
                   properties:

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -73,6 +73,8 @@ spec:
               type: boolean
             continueUpgradeAfterChecksEvenIfNotHealthy:
               type: boolean
+            waitTimeoutForHealthyOSDInMinutes:
+              type: integer
             mon:
               properties:
                 allowMultiplePerNode:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -98,6 +98,13 @@ type ClusterSpec struct {
 	// ContinueUpgradeAfterChecksEvenIfNotHealthy defines if an upgrade should continue even if PGs are not clean
 	ContinueUpgradeAfterChecksEvenIfNotHealthy bool `json:"continueUpgradeAfterChecksEvenIfNotHealthy,omitempty"`
 
+	// WaitTimeoutForHealthyOSDInMinutes defines the time the operator would wait before an OSD can be stopped for upgrade or restart.
+	// If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
+	// if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
+	// continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+	// The default wait timeout is 10 minutes.
+	WaitTimeoutForHealthyOSDInMinutes time.Duration `json:"waitTimeoutForHealthyOSDInMinutes,omitempty"`
+
 	// A spec for configuring disruption management.
 	DisruptionManagement DisruptionManagementSpec `json:"disruptionManagement,omitempty"`
 

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -19,6 +19,7 @@ package client
 import (
 	"fmt"
 	"net"
+	"time"
 
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,8 @@ type ClusterInfo struct {
 	OwnerRef      metav1.OwnerReference
 	// Hide the name of the cluster since in 99% of uses we want to use the cluster namespace.
 	// If the CR name is needed, access it through the NamespacedName() method.
-	name string
+	name              string
+	OsdUpgradeTimeout time.Duration
 }
 
 // MonInfo is a collection of information about a Ceph mon.

--- a/pkg/operator/k8sutil/deployment.go
+++ b/pkg/operator/k8sutil/deployment.go
@@ -24,7 +24,6 @@ import (
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/util"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -84,10 +83,7 @@ func UpdateDeploymentAndWait(clusterdContext *clusterd.Context, modifiedDeployme
 		logger.Infof("updating deployment %q after verifying it is safe to stop", modifiedDeployment.Name)
 
 		// Let's verify the deployment can be stopped
-		// retry for 5 times, every minute
-		err = util.Retry(5, 60*time.Second, func() error {
-			return verifyCallback("stop")
-		})
+		err = verifyCallback("stop")
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if deployment %q can be updated. %v", modifiedDeployment.Name, err)
 		}


### PR DESCRIPTION
added WaitTimeoutForHealthyOSDUpgrade in the cluster crd that defines the time (in minutes) the operator would wait before an OSD can be stopped for
upgrade. It also defines the time the rook will wait for PGs to become active+clean after an OSD daemon is upgraded. The default value is 5 minutes.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #5790

Tested on multi-node local minikube cluster by upgrading from ceph 15.2.7 to 15.2.8

```Every 2.0s: kubectl -n rook-ceph get deployments -l rook_cluster=ro...  localhost.localdomain: Wed Jan 27 11:41:26 2021

rook-ceph-crashcollector-minikube-m02   req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-crashcollector-minikube-m03   req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-crashcollector-minikube-m04   req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-mgr-a         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-mon-a         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-mon-b         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-mon-c         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-0         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-1         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-2         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-3         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-4         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
rook-ceph-osd-5         req/upd/avl: 1/1/1      ceph-version=15.2.7-0
```


```Every 2.0s: kubectl -n rook-ceph get deployments -l rook_cluster=ro...  localhost.localdomain: Wed Jan 27 11:45:16 2021

rook-ceph-crashcollector-minikube-m02   req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-crashcollector-minikube-m03   req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-crashcollector-minikube-m04   req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-mgr-a         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-mon-a         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-mon-b         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-mon-c         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-0         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-1         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-2         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-3         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-4         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
rook-ceph-osd-5         req/upd/avl: 1/1/1      ceph-version=15.2.8-0
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
