### PR TITLE
ceph: Two step crush rule with device class

### DIFF
--- a/pkg/daemon/ceph/client/crush_rule.go
+++ b/pkg/daemon/ceph/client/crush_rule.go
@@ -32,7 +32,7 @@ rule %s {
         type replicated
         min_size %d
         max_size %d
-        step take %s
+        step take %s %s
         step choose firstn 0 type %s
         step chooseleaf firstn 2 type %s
         step emit
@@ -45,6 +45,10 @@ var (
 )
 
 func buildTwoStepPlainCrushRule(crushMap CrushMap, ruleName string, pool cephv1.PoolSpec) string {
+	var crushRuleInsert string
+	if pool.DeviceClass != "" {
+		crushRuleInsert = fmt.Sprintf("class %s", pool.DeviceClass)
+	}
 	return fmt.Sprintf(
 		twoStepCRUSHRuleTemplate,
 		ruleName,
@@ -52,6 +56,7 @@ func buildTwoStepPlainCrushRule(crushMap CrushMap, ruleName string, pool cephv1.
 		ruleMinSizeDefault,
 		ruleMaxSizeDefault,
 		pool.CrushRoot,
+		crushRuleInsert,
 		pool.FailureDomain,
 		pool.Replicated.SubFailureDomain,
 	)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Pass 'device-class' when adding two-steps crush-rule from template

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
