### PR TITLE
ceph: remove 'ganesha-' from nfs-ganesha config object name

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -78,7 +78,7 @@ spec:
 All daemons within a cluster will share configuration with no exports defined, and that includes a RADOS object via:
 
 ```ini
-%url  rados://<pool>/<namespace>/conf-nfs.ganesha-<clustername>
+%url  rados://<pool>/<namespace>/conf-nfs.<clustername>
 ```
 
 > **NOTE**: This format of nfs-ganesha config object name was introduced in Ceph Octopus Version. In older versions, each daemon has it's own config object and with the name as *conf-<clustername>.<nodeid>*. The nodeid is a value automatically assigned internally by rook. Nodeids start with "a" and go through "z", at which point they become two letters ("aa" to "az").

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -49,8 +49,12 @@ func getNFSNodeID(n *cephv1.CephNFS, name string) string {
 }
 
 func getGaneshaConfigObject(n *cephv1.CephNFS, version cephver.CephVersion, name string) string {
+	/* Exports created with Dashboard will not be affected by change in config object name.
+	 * As it looks for ganesha config object just by 'conf-'. Exports cannot be created by using
+	 * volume/nfs plugin in Octopus version. Because the ceph rook module is broken.
+	 */
 	if version.IsAtLeastOctopus() {
-		return fmt.Sprintf("conf-nfs.ganesha-%s", n.Name)
+		return fmt.Sprintf("conf-nfs.%s", n.Name)
 	}
 	return fmt.Sprintf("conf-%s", getNFSNodeID(n, name))
 }

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -264,7 +264,7 @@ func TestGetGaneshaConfigObject(t *testing.T) {
 		},
 	}
 	nodeid := "a"
-	expectedName := "conf-nfs.ganesha-my-nfs"
+	expectedName := "conf-nfs.my-nfs"
 
 	res := getGaneshaConfigObject(cephNFS, cephver.CephVersion{Major: 16}, nodeid)
 	logger.Infof("Config Object for Pacific is %s", res)


### PR DESCRIPTION
PR[1] in volume nfs plugin will remove it too. Since it can cause
inconsistencies.

This change will not affect exports created using dashboard. As it looks for
ganesha config object just by 'conf-' [2].  Exports cannot be created by using
volume/nfs plugin in Octopus version. Because the ceph rook module is broken.

[1] ceph/ceph#38510
[2] https://github.com/ceph/ceph/blob/octopus/src/pybind/mgr/dashboard/services/ganesha.py#L1111

Signed-off-by: Varsha Rao <varao@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
