### PR TITLE
ceph: Revert new node is not provisioned when useAllNodes is true

### DIFF
--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -22,12 +22,10 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -204,10 +202,6 @@ func GetOSDOnHost(context *clusterd.Context, clusterInfo *ClusterInfo, node stri
 	args := []string{"osd", "crush", "ls", node}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
-		// ENOENT as error means that node is not (yet) part of the ceph cluster
-		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.ENOENT) {
-			return "", nil
-		}
 		return "", errors.Wrapf(err, "failed to get osd list on host. %s", string(buf))
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This reverts commit a6ee5657aeeee505964fe263b21b974426921891.
The operator reconcile of the cephcluster was staying in an endless loop in clusters that did not have OSDs configured on all nodes. Now we revert this change for the patch release and will follow up with a more complete fix in #6813.

**Which issue is resolved by this Pull Request:**
Resolves #6796

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
