### PR TITLE
ceph: Update examples and operator to Ceph v15.2.8 and fix integration tests on partitions (bp #6847)

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -46,6 +46,8 @@ jobs:
         kubectl create -f cluster/examples/kubernetes/ceph/common.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/operator.yaml
         sed -i "s|#deviceFilter:|deviceFilter: $(lsblk|awk '/14G/ {print $1}'| head -1)|g" cluster/examples/kubernetes/ceph/cluster-test.yaml
+        # recent c-v changes don't allow OSDs on a partition, so we stick with v15.2.7 until that is resolved
+        sed -i "s|:v15|:v15.2.7|g" cluster/examples/kubernetes/ceph/cluster-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/cluster-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/object-test.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/pool-test.yaml

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -32,7 +32,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -59,7 +59,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -168,7 +168,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 * `external`:
   * `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs if an image is provided and will refuse otherwise. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster). If `cephVersion.image` is left blank, Rook will refuse the creation of extra CRs like object, file and nfs.
 * `cephVersion`: The version information for launching the ceph daemons.
-  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v14.2.12` or `ceph/ceph:v15.2.7`. For more details read the [container images section](#ceph-container-images).
+  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v14.2.12` or `ceph/ceph:v15.2.8`. For more details read the [container images section](#ceph-container-images).
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
   To ensure a consistent version of the image is running across all nodes in the cluster, it is recommended to use a very specific image version.
   Tags also exist that would give the latest version, but they are only recommended for test environments. For example, the tag `v14` will be updated each time a new nautilus build is released.
@@ -661,7 +661,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -693,7 +693,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -734,7 +734,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -781,7 +781,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -884,7 +884,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -930,7 +930,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -1343,7 +1343,7 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v15.2.7 # Should match external cluster version
+    image: ceph/ceph:v15.2.8 # Should match external cluster version
 ```
 
 ### Cleanup policy

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -379,7 +379,7 @@ until all the daemons have been updated.
 Official Ceph container images can be found on [Docker Hub](https://hub.docker.com/r/ceph/ceph/tags/).
 These images are tagged in a few ways:
 
-* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v15.2.7-20201201`).
+* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v15.2.8-20201201`).
   These tags are recommended for production clusters, as there is no possibility for the cluster to
   be heterogeneous with respect to the version of Ceph running in containers.
 * Ceph major version tags (e.g., `v15`) are useful for development and test clusters so that the
@@ -395,7 +395,7 @@ The majority of the upgrade will be handled by the Rook operator. Begin the upgr
 Ceph image field in the cluster CRD (`spec.cephVersion.image`).
 
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v15.2.7-20201201'
+NEW_CEPH_IMAGE='ceph/ceph:v15.2.8-20201201'
 CLUSTER_NAME="$ROOK_CLUSTER_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_CLUSTER_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,6 +240,7 @@ def RunIntegrationTest(k, v) {
                                   STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
                                   TEST_ARGUMENTS='''+"${env.testArgs}"+''' \
                                   TEST_IS_OFFICIAL_BUILD='''+"${env.isOfficialBuild}"+''' \
+                                  TEST_OSDS_ON_PARTITIONS="false" \
                                   TEST_SCRATCH_DEVICE=/dev/nvme0n1
                               kubectl config view
                               _output/tests/linux_amd64/integration -test.v -test.timeout 7200s 2>&1 | tee _output/tests/integrationTests.log'''

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -19,4 +19,4 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is required, if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v15.2.7 # Should match external cluster version
+    image: ceph/ceph:v15.2.8 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -33,7 +33,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: rook-ceph # namespace:cluster
 spec:
   cephVersion:
-      image: ceph/ceph:v15.2.7
+      image: ceph/ceph:v15.2.8
       allowUnsupported: false
   skipUpgradeChecks: false
   dataDirHostPath: /var/lib/rook

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -19,9 +19,9 @@ spec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.7-20201201
+    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.8-20201217
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
     # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -216,7 +216,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v15.2.7"
+              "image": "ceph/ceph:v15.2.8"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/design/ceph/ceph-cluster-cleanup.md
+++ b/design/ceph/ceph-cluster-cleanup.md
@@ -34,7 +34,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.7
+    image: ceph/ceph:v15.2.8
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v15.2.7-20201201
+CEPH_VERSION = v15.2.8-20201217
 else
-CEPH_VERSION = v15.2.7-20201201
+CEPH_VERSION = v15.2.8-20201217
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -156,7 +156,7 @@ type KeyManagementServiceSpec struct {
 
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.
 type CephVersionSpec struct {
-	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.7
+	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.8
 	Image string `json:"image,omitempty"`
 
 	// Whether to allow unsupported versions (do not set to true in production)

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -42,19 +42,24 @@ import (
 
 const (
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14.2.12"
+	nautilusTestImage = "ceph/ceph:v14"
+	// test with the latest nautilus build. ceph-volume is not allowing OSDs on partitions on v14.2.13 and newer.
+	nautilusTestImageOnPartitions = "ceph/ceph:v14.2.12"
 	// test with the latest octopus build
 	octopusTestImage = "ceph/ceph:v15"
+	// test with the latest octopus build. ceph-volume is not allowing OSDs on partitions on v15.2.8 and newer.
+	octopusTestImageOnPartitions = "ceph/ceph:v15.2.7"
 	// test with the latest master image
 	masterTestImage    = "ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"
 	defaultclusterName = "test-cluster"
+	// if false, expect to create OSDs on raw devices,
+	// otherwise use a version of ceph that is compatible with OSDs on partitions
+	usePartitionEnvVar = "TEST_OSDS_ON_PARTITIONS"
 )
 
 var (
-	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage}
-	OctopusVersion  = cephv1.CephVersionSpec{Image: octopusTestImage}
-	MasterVersion   = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
+	MasterVersion = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
 )
 
 // CephInstaller wraps installing and uninstalling rook on a platform
@@ -70,6 +75,20 @@ type CephInstaller struct {
 	CephVersion      cephv1.CephVersionSpec
 	T                func() *testing.T
 	cleanupHost      bool
+}
+
+func NautilusVersion() cephv1.CephVersionSpec {
+	if os.Getenv(usePartitionEnvVar) == "false" {
+		return cephv1.CephVersionSpec{Image: nautilusTestImage}
+	}
+	return cephv1.CephVersionSpec{Image: nautilusTestImageOnPartitions}
+}
+
+func OctopusVersion() cephv1.CephVersionSpec {
+	if os.Getenv(usePartitionEnvVar) == "false" {
+		return cephv1.CephVersionSpec{Image: octopusTestImage}
+	}
+	return cephv1.CephVersionSpec{Image: octopusTestImageOnPartitions}
 }
 
 // CreateCephOperator creates rook-operator via kubectl

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -51,7 +51,7 @@ var (
 func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite.Suite, namespace string) {
 	ctx := context.TODO()
 	storeName := "teststore"
-	defer objectTestDataCleanUp(helper, k8sh, namespace, storeName)
+	defer objectStoreCleanUp(s, helper, k8sh, namespace, storeName)
 
 	logger.Infof("Object Storage End To End Integration Test - Create Object Store, User,Bucket and read/write to bucket")
 	logger.Infof("Running on Rook Cluster %s", namespace)
@@ -217,12 +217,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	assert.Nil(s.T(), dobErr)
 	logger.Infof("Delete Object Bucket Claim successfully")
 
-	// TODO : Add case for brownfield/cleanup s3 client
-
-	logger.Infof("Delete Object Store")
-	dobsErr := helper.ObjectClient.Delete(namespace, storeName)
-	assert.Nil(s.T(), dobsErr)
-	logger.Infof("Done deleting object store")
+	// TODO : Add case for brownfield/cleanup s3 client}
 }
 
 // Test Object StoreCreation on Rook that was installed via helm
@@ -249,19 +244,11 @@ func runObjectE2ETestLite(helper *clients.TestClient, k8sh *utils.K8sHelper, s s
 		require.Nil(s.T(), err)
 		logger.Infof("Done deleting object store")
 	}
-
 }
 
-func objectTestDataCleanUp(helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, storeName string) {
-	logger.Infof("FIX: Cleaning up object store")
-	/*oc := helper.ObjectClient
-	userinfo, err := helper.ObjectClient.ObjectGetUser(storeName, userid)
-	if err != nil {
-		return //when user is not found
-	}
-	s3endpoint, _ := k8sh.GetRGWServiceURL(storeName, namespace)
-	s3client := utils.CreateNewS3Helper(s3endpoint, *userinfo.AccessKey, *userinfo.SecretKey)
-	s3client.DeleteObjectInBucket(bucketname, objectKey)
-	s3client.DeleteBucket(bucketname)
-	helper.ObjectClient.DeleteUser(storeName, userid)*/
+func objectStoreCleanUp(s suite.Suite, helper *clients.TestClient, k8sh *utils.K8sHelper, namespace, storeName string) {
+	logger.Infof("Delete Object Store (will fail if users and buckets still exist)")
+	err := helper.ObjectClient.Delete(namespace, storeName)
+	assert.Nil(s.T(), err)
+	logger.Infof("Done deleting object store")
 }

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -96,7 +96,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.OctopusVersion,
+		cephVersion:             installer.OctopusVersion(),
 	}
 
 	s.clusterInfo = client.AdminClusterInfo(s.namespace)

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -74,7 +74,7 @@ func (hs *HelmSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: helmMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.NautilusVersion,
+		cephVersion:             installer.NautilusVersion(),
 	}
 
 	hs.op, hs.kh = StartTestCluster(hs.T, &helmTestCluster)

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -142,7 +142,7 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
 
 	cleanupHost := false
-	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion, cleanupHost)
+	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion(), cleanupHost)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1), "", false}
 	if kh.VersionAtLeast("v1.13.0") {
@@ -199,7 +199,7 @@ func (o MCTestOperations) Teardown() {
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
 	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
-		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, installer.NautilusVersion)
+		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, installer.NautilusVersion())
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -99,7 +99,7 @@ func (suite *SmokeSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
-		cephVersion:             installer.OctopusVersion,
+		cephVersion:             installer.OctopusVersion(),
 	}
 
 	suite.op, suite.k8sh = StartTestCluster(suite.T, &smokeTestCluster)

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -86,7 +86,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		skipOSDCreation:         false,
 		minimalMatrixK8sVersion: upgradeMinimalTestVersion,
 		rookVersion:             installer.Version1_4,
-		cephVersion:             installer.NautilusVersion,
+		cephVersion:             installer.NautilusVersion(),
 	}
 
 	s.op, s.k8sh = StartTestCluster(s.T, &upgradeTestCluster)
@@ -177,7 +177,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	//
 	logger.Infof("*** UPGRADING CEPH FROM Nautilus TO Octopus ***")
 	s.gatherLogs(systemNamespace, "_before_octopus_upgrade")
-	s.upgradeCephVersion(installer.OctopusVersion.Image, numOSDs)
+	s.upgradeCephVersion(installer.OctopusVersion().Image, numOSDs)
 	// Verify reading and writing to the test clients
 	newFile = "post-octopus-upgrade-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Backport the fix for integration tests and ceph v15.2.8 to release-1.5 since mergify missed it...

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
