### PR TITLE
ceph: Remove unused operator namespace parameter

### DIFF
--- a/pkg/operator/ceph/cluster/operator_watchers.go
+++ b/pkg/operator/ceph/cluster/operator_watchers.go
@@ -27,7 +27,7 @@ import (
 )
 
 // StartOperatorSettingsWatch starts the operator settings watcher
-func (c *ClusterController) StartOperatorSettingsWatch(namespace string, stopCh chan struct{}) {
+func (c *ClusterController) StartOperatorSettingsWatch(stopCh chan struct{}) {
 	operatorNamespace := os.Getenv(k8sutil.PodNamespaceEnvVar)
 	// watch for "rook-ceph-operator-config" ConfigMap
 	k8sutil.StartOperatorSettingsWatch(c.context, operatorNamespace, opcontroller.OperatorSettingConfigMapName,

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -168,7 +168,7 @@ func (o *Operator) Run() error {
 	go o.startManager(namespaceToWatch, stopChan, mgrErrorChan)
 
 	// Start the operator setting watcher
-	go o.clusterController.StartOperatorSettingsWatch(namespaceToWatch, stopChan)
+	go o.clusterController.StartOperatorSettingsWatch(stopChan)
 
 	// Signal handler to stop the operator
 	for {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The operator namespace is not used in the StartOperatorSettingsWatch() method. Instead, the method looks up the namespace from the POD_NAMESPACE env var.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
