### PR TITLE
ci: Upgrade actions-setup-minikube to v2.2.0

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -23,7 +23,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -109,7 +109,7 @@ jobs:
         sudo chmod +x /usr/bin/yq
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -181,7 +181,7 @@ jobs:
         sudo apt-get install -y gdisk
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -260,7 +260,7 @@ jobs:
         sudo apt-get install -y gdisk
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -335,7 +335,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -410,7 +410,7 @@ jobs:
         sudo apt-get install -y gdisk
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -491,7 +491,7 @@ jobs:
         sudo apt-get install -y gdisk
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -564,7 +564,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -14,7 +14,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -64,7 +64,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -114,7 +114,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -164,7 +164,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -214,7 +214,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'
@@ -266,7 +266,7 @@ jobs:
         go-version: 1.15
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.0.1
+      uses: manusa/actions-setup-minikube@v2.2.0
       with:
         minikube version: 'v1.13.1'
         kubernetes version: 'v1.19.2'


### PR DESCRIPTION
**Description of your changes:**

Upgrade `manusa/actions-setup-minikube` to use the latest version.

GitHub is rolling out Ubuntu 20.04 as the default environment. GitHub actions workflows using `ubuntu-latest` will [soon ](https://github.com/actions/virtual-environments/issues/1816) start an Ubuntu 20,04 instance instead of 18.04.

Prior versions of `manusa/actions-setup-minikube` have a check which won't allow the workflow job to run. Starting on `2.2.0`, Ubuntu 20.04 is supported too (https://github.com/manusa/actions-setup-minikube/issues/26).

**Which issue is resolved by this Pull Request:**

Resolves n/a

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
