### PR TITLE
ceph: allow disable liveness check for mds daemonset

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	KeyMds        rook.KeyType = "mds"
 	KeyMon        rook.KeyType = "mon"
 	KeyMonArbiter rook.KeyType = "arbiter"
 	KeyMgr        rook.KeyType = "mgr"

--- a/pkg/apis/ceph.rook.io/v1/livenessprobe.go
+++ b/pkg/apis/ceph.rook.io/v1/livenessprobe.go
@@ -34,3 +34,8 @@ func GetMgrLivenessProbe(l CephClusterHealthCheckSpec) *corev1.Probe {
 func GetOSDLivenessProbe(l CephClusterHealthCheckSpec) *corev1.Probe {
 	return l.LivenessProbe[ResourcesKeyOSD].Probe
 }
+
+// GetMdsLivenessProbe returns the liveness probe for the MDS service
+func GetMdsLivenessProbe(l CephClusterHealthCheckSpec) *corev1.Probe {
+	return l.LivenessProbe[ResourcesKeyMDS].Probe
+}

--- a/pkg/operator/ceph/config/livenessprobe.go
+++ b/pkg/operator/ceph/config/livenessprobe.go
@@ -33,6 +33,7 @@ func ConfigureLivenessProbe(daemon rookv1.KeyType, container v1.Container, healt
 		cephv1.KeyMon: cephv1.GetMonLivenessProbe,
 		cephv1.KeyMgr: cephv1.GetMgrLivenessProbe,
 		cephv1.KeyOSD: cephv1.GetOSDLivenessProbe,
+		cephv1.KeyMds: cephv1.GetMdsLivenessProbe,
 	}
 
 	if _, ok := healthCheck.LivenessProbe[daemon]; ok {

--- a/pkg/operator/ceph/config/livenessprobe_test.go
+++ b/pkg/operator/ceph/config/livenessprobe_test.go
@@ -29,6 +29,19 @@ import (
 )
 
 func TestConfigureLivenessProbe(t *testing.T) {
+	keyTypes := []rookv1.KeyType{
+		cephv1.KeyMds,
+		cephv1.KeyMon,
+		cephv1.KeyMgr,
+		cephv1.KeyOSD,
+	}
+
+	for _, keyType := range keyTypes {
+		configLivenessProbeHelper(t, keyType)
+	}
+}
+
+func configLivenessProbeHelper(t *testing.T, keyType rookv1.KeyType) {
 	p := &v1.Probe{
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{
@@ -38,7 +51,7 @@ func TestConfigureLivenessProbe(t *testing.T) {
 		},
 	}
 	container := v1.Container{LivenessProbe: p}
-	l := map[rookv1.KeyType]*rookv1.ProbeSpec{cephv1.KeyMon: {Disabled: true}}
+	l := map[rookv1.KeyType]*rookv1.ProbeSpec{keyType: {Disabled: true}}
 	type args struct {
 		daemon      rookv1.KeyType
 		container   v1.Container
@@ -49,8 +62,8 @@ func TestConfigureLivenessProbe(t *testing.T) {
 		args args
 		want v1.Container
 	}{
-		{"probe-enabled", args{cephv1.KeyMon, container, cephv1.CephClusterHealthCheckSpec{}}, container},
-		{"probe-disabled", args{cephv1.KeyMon, container, cephv1.CephClusterHealthCheckSpec{LivenessProbe: l}}, v1.Container{}},
+		{"probe-enabled", args{keyType, container, cephv1.CephClusterHealthCheckSpec{}}, container},
+		{"probe-disabled", args{keyType, container, cephv1.CephClusterHealthCheckSpec{LivenessProbe: l}}, v1.Container{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Allow to disable liveness probes for mds pod

Signed-off-by: shenjiatong <yshxxsjt715@gmail.com>

**Description of your changes:**

Allow to disable liveness probes for mds pod

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
