### PR TITLE
ceph: change external rgw detection, not relying on cluster

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -20,6 +20,10 @@ func (s *ObjectStoreSpec) IsMultisite() bool {
 	return s.Zone.Name != ""
 }
 
+func (s *ObjectStoreSpec) IsExternal() bool {
+	return len(s.Gateway.ExternalRgwEndpoints) != 0
+}
+
 func (s *ObjectRealmSpec) IsPullRealm() bool {
 	return s.Pull.Endpoint != ""
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -308,7 +308,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 	var serviceIP string
 	var err error
 
-	if r.clusterSpec.External.Enable {
+	if cephObjectStore.Spec.IsExternal() {
 		logger.Info("reconciling external object store")
 
 		// RECONCILE SERVICE

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -305,13 +305,6 @@ func (r *ReconcileCephObjectStore) validateStore(s *cephv1.CephObjectStore) erro
 		}
 	}
 
-	// Fail if we detected an external CephCluster CR and the list of endpoints is empty
-	if r.clusterSpec.External.Enable && r.clusterInfo.CephCred.Username != cephclient.AdminUsername {
-		if len(s.Spec.Gateway.ExternalRgwEndpoints) == 0 {
-			return errors.New("ceph cluster is external but externalRgwEndpoints list is empty")
-		}
-	}
-
 	return nil
 }
 

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -259,7 +259,7 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 	destPort := c.generateLiveProbePort()
 
 	// When the cluster is external we must use the same one as the gateways are listening on
-	if c.clusterSpec.External.Enable {
+	if cephObjectStore.Spec.IsExternal() {
 		destPort.IntVal = cephObjectStore.Spec.Gateway.Port
 	} else {
 		// If the cluster is not external we add the Selector

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -189,16 +189,6 @@ func TestValidateSpec(t *testing.T) {
 	err = r.validateStore(s)
 	assert.Nil(t, err)
 
-	// external with no endpoints but ok since client.admin is used
-	r.clusterSpec.External.Enable = true
-	err = r.validateStore(s)
-	assert.NoError(t, err)
-
-	// external with no endpoints, failure
-	r.clusterInfo.CephCred.Username = "client.external"
-	err = r.validateStore(s)
-	assert.NotNil(t, err)
-
 	// external with endpoints, success
 	s.Spec.Gateway.ExternalRgwEndpoints = []v1.EndpointAddress{
 		{


### PR DESCRIPTION
Following #6217, allow rgw to created for external cluster

Signed-off-by: Julien Girardin <jugirardin@free.fr>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

Took me some time to test #6226, but this was not still working, operator claiming: 
```
ceph-object-controller: failed to reconcile failed to create object store deployments: failed to reconcile external endpoint: failed to create or update object store "arch-cloud" endpoint: failed to create endpoint "rook-ceph-rgw-arch-cloud". Endpoints "rook-ceph-rgw-arch-cloud" is invalid: subsets[0]: Required value: must specify `addresses` or `notReadyAddresses`
```

Change external rgw detection, not relying on cluster. Now there is multiple posibilities:
- internal cluster and internal rgw pods: "normal case"
- external cluster and internal rgw pods: <= now working with the PR
- external cluster and external rgw pods: the external case
- internal cluster and external rgw pods: new case that could exist, don't know if needed to be preventing or not

**Which issue is resolved by this Pull Request:**
Resolves #6217

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
