### PR TITLE
ceph: fix typo in resource name in the snapshot instructions

### DIFF
--- a/Documentation/ceph-csi-snapshot.md
+++ b/Documentation/ceph-csi-snapshot.md
@@ -16,7 +16,7 @@ still you can use the Alpha snapshots. refer to
 [snapshot](https://github.com/rook/rook/blob/release-1.3/Documentation/ceph-csi-drivers.md#rbd-snapshots)
 on how to use snapshots.
 
-* We also need a `SnapshotClass` for volume snapshot to work. The purpose of a `SnapshotClass` is
+* We also need a `VolumeSnapshotClass` for volume snapshot to work. The purpose of a `VolumeSnapshotClass` is
 defined in [the kubernetes
 documentation](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/).
 In short, as the documentation describes it:
@@ -29,9 +29,9 @@ In short, as the documentation describes it:
 
 ## RBD Snapshots
 
-### SnapshotClass
+### VolumeSnapshotClass
 
-In [snapshotClass](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml),
+In [VolumeSnapshotClass](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml),
 the `csi.storage.k8s.io/snapshotter-secret-name` parameter should reference the
 name of the secret created for the rbdplugin and `pool` to reflect the Ceph pool name.
 
@@ -104,13 +104,13 @@ kubectl delete -f cluster/examples/kubernetes/ceph/csi/rbd/snapshotclass.yaml
 
 ## CephFS Snapshots
 
-### SnapshotClass
+### VolumeSnapshotClass
 
-In [snapshotClass](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml),
+In [VolumeSnapshotClass](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/cephfs/snapshotclass.yaml),
 the `csi.storage.k8s.io/snapshotter-secret-name` parameter should reference the
 name of the secret created for the cephfsplugin.
 
-In the snapshotclass, update the value of the `clusterID` field to match the namespace that Rook is
+In the volumesnapshotclass, update the value of the `clusterID` field to match the namespace that Rook is
 running in. When Ceph CSI is deployed by Rook, the operator will automatically
 maintain a configmap whose contents will match this key. By default this is
 "rook-ceph".


### PR DESCRIPTION

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

updated few resource names in CSI snapshot documentation.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/pull/6292
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
[skip ci]