### PR TITLE
ceph: add namespace note in storageclass documentation

### DIFF
--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -140,7 +140,7 @@ parameters:
   objectStoreNamespace: rook-ceph
   region: us-east-1
 ```
-If you’ve deployed the Rook operator in a namespace other than “rook-ceph”, change the prefix in the provisioner to match the namespace you used. For example, if the Rook operator is running in the namespace “my-namespace” the provisioner value should be “my-namespace.ceph.rook.io/bucket”.
+If you’ve deployed the Rook operator in a namespace other than `rook-ceph`, change the prefix in the provisioner to match the namespace you used. For example, if the Rook operator is running in the namespace `my-namespace` the provisioner value should be `my-namespace.ceph.rook.io/bucket`.
 ```console
 kubectl create -f storageclass-bucket-delete.yaml
 ```

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -132,6 +132,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: rook-ceph-bucket
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
 provisioner: rook-ceph.ceph.rook.io/bucket
 reclaimPolicy: Delete
 parameters:
@@ -139,7 +140,7 @@ parameters:
   objectStoreNamespace: rook-ceph
   region: us-east-1
 ```
-
+If you’ve deployed the Rook operator in a namespace other than “rook-ceph”, change the prefix in the provisioner to match the namespace you used. For example, if the Rook operator is running in the namespace “my-namespace” the provisioner value should be “my-namespace.ceph.rook.io/bucket”.
 ```console
 kubectl create -f storageclass-bucket-delete.yaml
 ```


### PR DESCRIPTION
add namespace note in object storage StorageClass documentation

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Add little note about namespace in provisioner when creating StorageClass required for creating ObjectBucketClaim

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]
