### PR TITLE
ceph: update smoke & upgrade tests to verify obc is bound

### DIFF
--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -20,6 +20,7 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
 )
@@ -56,10 +57,12 @@ func (b *BucketOperation) DeleteObc(obcName string, storageClassName string, buc
 // and returns false if any of these resources are not in the "check" state.
 // Check state values:
 //   "created", all must exist,
+//   "bound", all must exist and OBC in Bound phase
 //   "deleted", all must be missing.
 func (b *BucketOperation) CheckOBC(obcName, check string) bool {
 	resources := []string{"obc", "secret", "configmap"}
-	shouldExist := (check == "created")
+	shouldBeBound := (check == "bound")
+	shouldExist := (shouldBeBound || check == "created") // bound implies created
 
 	for _, res := range resources {
 		_, err := b.k8sh.GetResource(res, obcName)
@@ -71,14 +74,29 @@ func (b *BucketOperation) CheckOBC(obcName, check string) bool {
 	}
 	logger.Infof("%s resources %v all %s", obcName, resources, check)
 
-	if shouldExist {
+	if shouldBeBound {
 		// OBC should be in bound phase as well as existing
 		state, _ := b.k8sh.GetResource("obc", obcName, "--output", "jsonpath={.status.phase}")
-		if state != "Bound" {
-			logger.Infof("resources exist, but OBC is not in \"Bound\" phase: %s", state)
+		boundPhase := bktv1alpha1.ObjectBucketClaimStatusPhaseBound // i.e., "Bound"
+		if state != boundPhase {
+			logger.Infof(`resources exist, but OBC is not in %q phase: %q`, boundPhase, state)
 			return false
 		}
-		logger.Infof("OBC is \"Bound\"")
+
+		// Regression test: OBC should have spec.objectBucketName set
+		obName, _ := b.k8sh.GetResource("obc", obcName, "--output", "jsonpath={.spec.objectBucketName}")
+		if obName == "" {
+			logger.Error("failed regression: OBC spec.objectBucketName is not set")
+			return false
+		}
+		// Regression test: OB should have claim ref to OBC
+		refName, _ := b.k8sh.GetResource("ob", obName, "--output", "jsonpath={.spec.claimRef.name}")
+		if refName != obcName {
+			logger.Errorf("failed regression: OB spec.claimRef.name (%q) does not match expected OBC name (%q)", refName, obcName)
+			return false
+		}
+
+		logger.Infof("OBC is %q", boundPhase)
 	}
 
 	return true

--- a/tests/framework/clients/bucket.go
+++ b/tests/framework/clients/bucket.go
@@ -71,6 +71,16 @@ func (b *BucketOperation) CheckOBC(obcName, check string) bool {
 	}
 	logger.Infof("%s resources %v all %s", obcName, resources, check)
 
+	if shouldExist {
+		// OBC should be in bound phase as well as existing
+		state, _ := b.k8sh.GetResource("obc", obcName, "--output", "jsonpath={.status.phase}")
+		if state != "Bound" {
+			logger.Infof("resources exist, but OBC is not in \"Bound\" phase: %s", state)
+			return false
+		}
+		logger.Infof("OBC is \"Bound\"")
+	}
+
 	return true
 }
 

--- a/tests/framework/utils/k8s_helper.go
+++ b/tests/framework/utils/k8s_helper.go
@@ -423,7 +423,6 @@ func (k8sh *K8sHelper) GetResource(args ...string) (string, error) {
 		return result, nil
 	}
 	return "", fmt.Errorf("Could Not get resource in k8s -- %v", err)
-
 }
 
 func (k8sh *K8sHelper) CreateNamespace(namespace string) error {

--- a/tests/framework/utils/retry.go
+++ b/tests/framework/utils/retry.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "time"
+
+// Retry executes the function ('f') 'count' times waiting for 'wait' duration between
+// each attempt to run the function. Print the 'description' before all test info messages.
+// Returns true the first time function 'f' returns true or false if 'f' never returns true.
+func Retry(count uint16, wait time.Duration, description string, f func() bool) bool {
+	for i := uint16(1); i < count+1; i++ {
+		if f() {
+			logger.Infof(description+": TRUE on attempt %d", i)
+			return true
+		}
+		logger.Infof(description+": false on attempt %d. waiting %s seconds to retry", i, wait.String())
+		time.Sleep(wait)
+	}
+	logger.Infof(description+": FALSE on all %d attempts", count)
+	return false
+}

--- a/tests/framework/utils/retry.go
+++ b/tests/framework/utils/retry.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Rook Authors. All rights reserved.
+Copyright 2021 The Rook Authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -133,11 +133,10 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	cobcErr := helper.BucketClient.CreateObc(obcName, bucketStorageClassName, bucketname, maxObject, true)
 	require.Nil(s.T(), cobcErr)
 
-	for i = 0; i < 4 && !helper.BucketClient.CheckOBC(obcName, "created"); i++ {
-		logger.Infof("(%d) obc created check, sleeping for 5 seconds ...", i)
-		time.Sleep(5 * time.Second)
-	}
-	require.NotEqual(s.T(), i, 4)
+	created := utils.Retry(12, 2*time.Second, "OBC is created", func() bool {
+		return helper.BucketClient.CheckOBC(obcName, "created")
+	})
+	require.True(s.T(), created)
 
 	logger.Infof("Check if bucket was created")
 	context := k8sh.MakeContext()

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -134,7 +134,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	require.Nil(s.T(), cobcErr)
 
 	created := utils.Retry(12, 2*time.Second, "OBC is created", func() bool {
-		return helper.BucketClient.CheckOBC(obcName, "created")
+		return helper.BucketClient.CheckOBC(obcName, "bound")
 	})
 	require.True(s.T(), created)
 


### PR DESCRIPTION
When verifying OBC creation, validating that secret and configmap exist
is good, but the definitive validation is to check that the OBC's phase
is "Bound".

Add object bucket claim to Ceph upgrade test.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
