### PR TITLE
ceph: apply OSD resources and placement for device sets

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -719,6 +719,10 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				logger.Infof("OSD will have its wal device on %q", walSource.ClaimName)
 			}
 
+			if volumeSource.Resources.Limits == nil && volumeSource.Resources.Requests == nil {
+				volumeSource.Resources = cephv1.GetOSDResources(c.spec.Resources)
+			}
+
 			osdProps := osdProperties{
 				crushHostname:       dataSource.ClaimName,
 				pvc:                 dataSource,

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -153,10 +153,13 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	if c.spec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
+
+	p := cephv1.GetOSDPlacement(c.spec.Placement)
 	if !osdProps.onPVC() {
-		cephv1.GetOSDPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec)
+		p.ApplyToPodSpec(&podSpec)
 	} else {
 		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec)
+		p.ApplyToPodSpec(&podSpec)
 	}
 	k8sutil.RemoveDuplicateEnvVars(&podSpec)
 

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -609,10 +609,12 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.clusterInfo.OwnerRef)
+	p := cephv1.GetOSDPlacement(c.spec.Placement)
 	if !osdProps.onPVC() {
-		cephv1.GetOSDPlacement(c.spec.Placement).ApplyToPodSpec(&deployment.Spec.Template.Spec)
+		p.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	} else {
 		osdProps.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
+		p.ApplyToPodSpec(&deployment.Spec.Template.Spec)
 	}
 
 	// Change TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES if the OSD has been annotated with a value


### PR DESCRIPTION
`.spec.resources.osd ` resources and `placement: all:` placements
parameters for the OSD pod did not reflect the value like
it has for other pods mon, mgr.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
this commit will allow setting above parameters for the OSD pod also.

**Which issue is resolved by this Pull Request:**
Resolves #6789

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
