### PR TITLE
docs: extend timeout in readme

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -125,14 +125,14 @@ Please note that the integration test erases the contents of TEST_SCRATCH_DEVICE
 
 To run all integration tests:
 ```console
-go test -v -timeout 1800s github.com/rook/rook/tests/integration
+go test -v -timeout 7200s github.com/rook/rook/tests/integration
 ```
 
 In addition, you can choose to test only one storage provider. For example, you can run Ceph tests as follows.
 
 ```console
 export STORAGE_PROVIDER_TESTS=ceph
-go test -v -timeout 1800s github.com/rook/rook/tests/integration
+go test -v -timeout 7200s github.com/rook/rook/tests/integration
 ```
 
 To run a specific suite (uses regex):


### PR DESCRIPTION
**Description of your changes:**

1800s is too short to complete all suites. Let's make it the same value as CI.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]