### PR TITLE
ceph: add pacific release name support and do no turn on the balancer since it is only on

### DIFF
--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -34,7 +34,13 @@ func MgrEnableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name s
 	retryCount := 5
 	var err error
 	for i := 0; i < retryCount; i++ {
-		if name == "balancer" {
+		/* In Pacific the balancer is now on by default in upmap mode.
+		In earlier versions, the balancer was included in the ``always_on_modules`` list, but needed to be
+		turned on explicitly using the ``ceph balancer on`` command. */
+		if name == "balancer" && clusterInfo.CephVersion.IsAtLeastPacific() {
+			logger.Debug("balancer module is already 'on' on pacific, doing nothing", name)
+			return nil
+		} else if name == "balancer" {
 			err = enableDisableBalancerModule(context, clusterInfo, "on")
 		} else {
 			err = enableModule(context, clusterInfo, name, force, "enable")

--- a/pkg/daemon/ceph/client/mgr_test.go
+++ b/pkg/daemon/ceph/client/mgr_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -59,7 +60,13 @@ func TestEnableModuleRetries(t *testing.T) {
 	_ = MgrEnableModule(&clusterd.Context{Executor: executor}, clusterInfo, "pg_autoscaler", false)
 	assert.Equal(t, 0, moduleEnableRetries)
 
+	// Balancer not on Ceph Pacific
 	moduleEnableRetries = 0
+	_ = MgrEnableModule(&clusterd.Context{Executor: executor}, clusterInfo, "balancer", false)
+	assert.Equal(t, 0, moduleEnableRetries)
+
+	// Balancer skipped on Pacific
+	clusterInfo.CephVersion = version.Pacific
 	_ = MgrEnableModule(&clusterd.Context{Executor: executor}, clusterInfo, "balancer", false)
 	assert.Equal(t, 0, moduleEnableRetries)
 

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -80,10 +80,12 @@ func (v *CephVersion) CephVersionFormatted() string {
 // ReleaseName is the name of the Ceph release
 func (v *CephVersion) ReleaseName() string {
 	switch v.Major {
-	case Octopus.Major:
-		return "octopus"
 	case Nautilus.Major:
 		return "nautilus"
+	case Octopus.Major:
+		return "octopus"
+	case Pacific.Major:
+		return "pacific"
 	default:
 		return unknownVersionString
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

When the version is detected it will print the name of the release
Pacific correctly where previously it was showing <unknown version>".

As of Pacific the balancer is now on by default in upmap mode.
In earlier versions, the balancer was included in the `always_on_modules` list, but needed to be
turned on explicitly using the ``ceph balancer on command.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
