### PR TITLE
docs: describe osd purge job in the document of OSD management

### DIFF
--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -1,3 +1,17 @@
+#################################################################################################################
+# We need many operations to remove OSDs as written in Documentation/ceph-osd-mgmt.md.
+# This job can automate some of that operations: mark OSDs as `out`, purge these OSDs,
+# and delete the corresponding resources like OSD deployments, OSD prepare jobs, and PVCs.
+#
+# Please note the following.
+#
+# - This job only works for `down` OSDs.
+# - This job doesn't wait for backfilling to be completed.
+#
+# If you want to remove `up` OSDs and/or want to wait for backfilling to be completed between each OSD removal,
+# please do it by hand.
+#################################################################################################################
+
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
**Description of your changes:**

Describe `rook-ceph-purge-osd` job in the document of OSD management to ease day2 operations.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]