### PR TITLE
ceph: re-enable ceph manager suite

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -32,7 +32,7 @@ const (
 
 type CephManifests interface {
 	GetRookCRDs(v1ExtensionsSupported bool) string
-	GetRookOperator(namespace string) string
+	GetRookOperator(namespace string, enableDiscoveryDaemon bool) string
 	GetClusterRoles(namespace, operatorNamespace string) string
 	GetClusterExternalRoles(namespace, operatorNamespace string) string
 	GetRookCluster(settings *clusterSettings) string
@@ -2253,7 +2253,7 @@ users:
 }
 
 // GetRookOperator returns rook Operator manifest
-func (m *CephManifestsMaster) GetRookOperator(operatorNamespace string) string {
+func (m *CephManifestsMaster) GetRookOperator(operatorNamespace string, enableDiscoveryDaemon bool) string {
 	var operatorManifest string
 	openshiftEnv := ""
 
@@ -3115,7 +3115,7 @@ spec:
         - name: ROOK_CURRENT_NAMESPACE_ONLY
           value: "false"` + openshiftEnv + `
         - name: ROOK_ENABLE_DISCOVERY_DAEMON
-          value: "true"
+          value: "` + strconv.FormatBool(enableDiscoveryDaemon) + `"
         volumeMounts:
         - mountPath: /var/lib/rook
           name: rook-config

--- a/tests/framework/installer/ceph_manifests_v1.4.go
+++ b/tests/framework/installer/ceph_manifests_v1.4.go
@@ -723,7 +723,7 @@ spec:
 }
 
 // GetRookOperator returns rook Operator manifest
-func (m *CephManifestsV1_4) GetRookOperator(namespace string) string {
+func (m *CephManifestsV1_4) GetRookOperator(namespace string, enableDiscoveryDaemon bool) string {
 	return `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -112,6 +112,7 @@ type TestCluster struct {
 	rbdMirrorWorkers        int
 	rookCephCleanup         bool
 	skipOSDCreation         bool
+	enableDiscoveryDaemon   bool
 	minimalMatrixK8sVersion string
 	rookVersion             string
 	cephVersion             cephv1.CephVersionSpec
@@ -146,7 +147,8 @@ func StartTestCluster(t func() *testing.T, cluster *TestCluster) (*TestCluster, 
 	require.NoError(t(), err)
 	checkIfShouldRunForMinimalTestMatrix(t, kh, cluster.minimalMatrixK8sVersion)
 
-	cluster.installer = installer.NewCephInstaller(t, kh.Clientset, cluster.useHelm, cluster.clusterName, cluster.rookVersion, cluster.cephVersion, cluster.rookCephCleanup)
+	cluster.installer = installer.NewCephInstaller(t, kh.Clientset, cluster.useHelm, cluster.clusterName, cluster.rookVersion,
+		cluster.cephVersion, cluster.rookCephCleanup, cluster.enableDiscoveryDaemon)
 	cluster.kh = kh
 	cluster.helper = nil
 	cluster.T = t

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -94,6 +94,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         true,
 		skipOSDCreation:         false,
+		enableDiscoveryDaemon:   false,
 		minimalMatrixK8sVersion: flexDriverMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.OctopusVersion(),

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -72,6 +72,7 @@ func (hs *HelmSuite) SetupSuite() {
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         true,
 		skipOSDCreation:         false,
+		enableDiscoveryDaemon:   false,
 		minimalMatrixK8sVersion: helmMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.NautilusVersion(),

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -50,9 +50,6 @@ func TestCephMgrSuite(t *testing.T) {
 		t.Skip()
 	}
 
-	logger.Info("TEMPORARILY disable the mgr test suite until https://github.com/rook/rook/issues/5877 is resolved")
-	t.Skip()
-
 	s := new(CephMgrSuite)
 	defer func(s *CephMgrSuite) {
 		HandlePanics(recover(), s.cluster, s.T)
@@ -101,6 +98,7 @@ func (suite *CephMgrSuite) SetupSuite() {
 		rbdMirrorWorkers:        0,
 		rookCephCleanup:         true,
 		skipOSDCreation:         true,
+		enableDiscoveryDaemon:   true,
 		minimalMatrixK8sVersion: cephMasterSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.MasterVersion,

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -142,7 +142,9 @@ func NewMCTestOperations(t func() *testing.T, namespace1 string, namespace2 stri
 	checkIfShouldRunForMinimalTestMatrix(t, kh, multiClusterMinimalTestVersion)
 
 	cleanupHost := false
-	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion(), cleanupHost)
+	enableDiscoveryDaemon := false
+	i := installer.NewCephInstaller(t, kh.Clientset, false, "", installer.VersionMaster, installer.NautilusVersion(),
+		cleanupHost, enableDiscoveryDaemon)
 
 	op := &MCTestOperations{i, kh, t, namespace1, namespace2, installer.SystemNamespace(namespace1), "", false}
 	if kh.VersionAtLeast("v1.13.0") {

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -97,6 +97,7 @@ func (suite *SmokeSuite) SetupSuite() {
 		rbdMirrorWorkers:        1,
 		rookCephCleanup:         true,
 		skipOSDCreation:         false,
+		enableDiscoveryDaemon:   false,
 		minimalMatrixK8sVersion: smokeSuiteMinimalTestVersion,
 		rookVersion:             installer.VersionMaster,
 		cephVersion:             installer.OctopusVersion(),

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -84,6 +84,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		rbdMirrorWorkers:        0,
 		rookCephCleanup:         false,
 		skipOSDCreation:         false,
+		enableDiscoveryDaemon:   false,
 		minimalMatrixK8sVersion: upgradeMinimalTestVersion,
 		rookVersion:             installer.Version1_4,
 		cephVersion:             installer.NautilusVersion(),


### PR DESCRIPTION
**Description of your changes:**

The discovery daemon must be enabled to work rook ceph-mgr module.

**Which issue is resolved by this Pull Request:**
Resolves #5877

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
[test full]