### PR TITLE
ceph: update admission controller to v1 from v1beta1

### DIFF
--- a/design/ceph/admission-controller.md
+++ b/design/ceph/admission-controller.md
@@ -104,7 +104,7 @@ Using the above approach, the dev/admins will have the responsibility of rotatin
 Below is an excerpt of what a ValidatingWebhookConfig looks like 
 
 ```
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: demo-webhook

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -123,7 +123,10 @@ func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 			return fmt.Errorf("failed to create namespace %q. %v", namespace, err)
 		}
 	}
-	if !utils.IsPlatformOpenShift() {
+
+	// disable admission controller for upgrade test as api version v1 require minimum v0.7 controller runtime and upgrade test still using
+	// older version of controller runtime.
+	if !utils.IsPlatformOpenShift() && namespace != "upgrade-ns-system" {
 		err = h.startAdmissionController(namespace)
 		if err != nil {
 			return fmt.Errorf("Failed to start admission controllers: %v", err)
@@ -515,7 +518,7 @@ func (h *CephInstaller) InstallRook(namespace, storeType string, usePVC bool, st
 	}
 	logger.Infof("installed rook operator and cluster : %s on k8s %s", namespace, h.k8sVersion)
 
-	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.15.0") {
+	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.15.0") && namespace != "upgrade-ns" {
 		if !h.k8shelper.IsPodInExpectedState("rook-ceph-admission-controller", onamespace, "Running") {
 			assert.Fail(h.T(), "admission controller is not running")
 		}

--- a/tests/scripts/webhook-config.yaml
+++ b/tests/scripts/webhook-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: ${WEBHOOK_CONFIG_NAME}
@@ -16,7 +16,7 @@ webhooks:
         namespace: ${NAMESPACE}
         path: /validate-ceph-rook-io-v1-cephcluster
       caBundle: ${CA_BUNDLE}
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1", "v1beta1"]  # API server will try to use first version in the list which it supports.
     sideEffects: None
     timeoutSeconds: 5
   - name: cephblockpool-wh-${SERVICE_NAME}-${NAMESPACE}.rook.io
@@ -31,6 +31,6 @@ webhooks:
         namespace: ${NAMESPACE}
         path: /validate-ceph-rook-io-v1-cephblockpool
       caBundle: ${CA_BUNDLE}
-    admissionReviewVersions: ["v1beta1"]
+    admissionReviewVersions: ["v1", "v1beta1"]  # API server will try to use first version in the list which it supports.
     sideEffects: None
     timeoutSeconds: 5

--- a/tests/scripts/webhook-create-signed-cert.sh
+++ b/tests/scripts/webhook-create-signed-cert.sh
@@ -132,4 +132,3 @@ kubectl create secret generic ${secret} \
         --from-file=tls.crt=${tmpdir}/server-cert.pem \
         --dry-run -o yaml |
     kubectl -n ${namespace} apply -f -
-


### PR DESCRIPTION
**Description of your changes:**

this commits update admission controller to v1 from
v1beta1. v1beta1 is deprecated in v1.16+ and unavailable
in v1.22+.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #6937 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
