### PR TITLE
docs: updating nfs quickstart docs

### DIFF
--- a/Documentation/nfs.md
+++ b/Documentation/nfs.md
@@ -74,7 +74,6 @@ kubectl -n rook-nfs-system get pod
 
 NAME                                    READY   STATUS    RESTARTS   AGE
 rook-nfs-operator-78d86bf969-k7lqp      1/1     Running   0          102s
-rook-nfs-provisioner-7b5ff479f6-688dm   1/1     Running   0          102s
 rook-nfs-webhook-74749cbd46-6jw2w       1/1     Running   0          102s
 ```
 
@@ -485,7 +484,7 @@ parameters:
   exportName: share1
   nfsServerName: rook-nfs
   nfsServerNamespace: rook-nfs
-provisioner: rook.io/nfs-provisioner
+provisioner: nfs.rook.io/rook-nfs-provisioner
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 ```
@@ -579,7 +578,6 @@ kubectl delete -f rbac.yaml
 kubectl delete -f psp.yaml
 kubectl delete -f scc.yaml # if deployed
 kubectl delete -f operator.yaml
-kubectl delete -f provisioner.yaml
 kubectl delete -f webhook.yaml # if deployed
 kubectl delete -f common.yaml
 ```


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The nfs quickstart docs have references to nfs-provisioner which no longer exist and the storage class example uses the wrong provisioner value. The changes remove the lines the nfs-provisioner references that seem to no longer exist and updates the storage class to use the provisioner specified in the example [here](https://github.com/rook/rook/blob/4e151a7e78ce8246851df6b3add64594fbf964ef/cluster/examples/kubernetes/nfs/sc.yaml#L11)

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]