### PR TITLE
ceph: Only restart ceph dashboard module if settings changed

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -176,7 +176,7 @@ func (c *Cluster) initializeSecureDashboard() (bool, error) {
 		return false, errors.Wrap(err, "failed to set login credentials for the ceph dashboard")
 	}
 
-	return true, nil
+	return false, nil
 }
 
 func (c *Cluster) createSelfSignedCert() (bool, error) {

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -131,10 +131,9 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.NoError(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
-	// the dashboard is enabled, then disabled and enabled again to restart
-	// it with the cert, and another restart when setting the dashboard port
-	assert.Equal(t, 2, enables)
-	assert.Equal(t, 1, disables)
+	// the dashboard is enabled once with the new dashboard and modules
+	assert.Equal(t, 1, enables)
+	assert.Equal(t, 0, disables)
 	assert.Equal(t, 2, moduleRetries)
 
 	svc, err := c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
@@ -147,8 +146,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.Nil(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
-	assert.Equal(t, 2, enables)
-	assert.Equal(t, 2, disables)
+	assert.Equal(t, 1, enables)
+	assert.Equal(t, 1, disables)
 
 	svc, err = c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	assert.NotNil(t, err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If ssl was not enabled, the dashboard was being restarted with every reconcile. Instead, the dashboard should only be restarted when the settings have changed in order to reduce the frequency that the dashboard is restarted.

**Which issue is resolved by this Pull Request:**
Resolves #6527 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
