### PR TITLE
ceph: fix malformations in common-external.yaml

### DIFF
--- a/cluster/examples/kubernetes/ceph/common-external.yaml
+++ b/cluster/examples/kubernetes/ceph/common-external.yaml
@@ -27,7 +27,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cluster-mgmt
-  name: rook-ceph-external # namespace:cluster
+  namespace: rook-ceph-external # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -41,7 +41,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  name: rook-ceph-external # namespace:cluster
+  namespace: rook-ceph-external # namespace:cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -49,19 +49,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: rook-ceph-cmd-reporter
-  name: rook-ceph-external # namespace:cluster
+  namespace: rook-ceph-external # namespace:cluster
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
-  name: rook-ceph-external # namespace:cluster
+  namespace: rook-ceph-external # namespace:cluster
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-cmd-reporter
-  name: rook-ceph-external # namespace:cluster
+  namespace: rook-ceph-external # namespace:cluster
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
Fix accidental malformations in common-external.yaml manifest.
Find-replace operations seemingly replaced `namespace` with `name` in
some instances. Fix this.

This seems to have happened in https://github.com/rook/rook/pull/6809
Backport this to v1.5 since 6809's changes also were backported to v1.5.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
