### PR TITLE
ceph: Remove unexpected array type in v1beta1 crd schema

### DIFF
--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -151,7 +151,6 @@ spec:
                               type: string
                             config: {}
                       resources: {}
-                  type: array
                 useAllDevices:
                   type: boolean
                 deviceFilter:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1565,8 +1565,7 @@ spec:
                             name:
                               type: string
                             config: {}
-                resources: {}
-                  type: array
+                      resources: {}
                 useAllDevices:
                   type: boolean
                 deviceFilter: {}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Clean up an unexpected array type in the schema for pre-k8s-1.16 clusters. The tests were failing in pre-1.16 for the past couple days due to a related regression in #6938.

The error in the CI was:
```
[2021-01-13T17:27:13.774Z] Could Not create resource in args : [apply -f -] -- 
Failed to run stdin: kubectl [apply -f -] : error: error parsing STDIN: error converting YAML to JSON: yaml: line 130: did not find expected key
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
