### PR TITLE
ceph: delete discovery daemon if it is disabled

### DIFF
--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -472,3 +472,12 @@ func GetAvailableDevices(clusterdContext *clusterd.Context, nodeName, clusterNam
 	}
 	return results, nil
 }
+
+// Stop the discover
+func (d *Discover) Stop(ctx context.Context, namespace string) error {
+	err := d.clientset.AppsV1().DaemonSets(namespace).Delete(ctx, discoverDaemonsetName, metav1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**Description of your changes:**

discovery-daemon still exists even if it's disabled.

**Which issue is resolved by this Pull Request:**
Resolves #6936

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[test ceph]
