### PR TITLE
ceph: Allow removal of arbitrary osds on pvcs and simplify pvc names

### DIFF
--- a/cluster/examples/kubernetes/ceph/osd-purge.yaml
+++ b/cluster/examples/kubernetes/ceph/osd-purge.yaml
@@ -63,7 +63,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/ceph
               name: ceph-conf-emptydir
+            - mountPath: /var/lib/rook
+              name: rook-config
       volumes:
         - emptyDir: {}
           name: ceph-conf-emptydir
+        - emptyDir: {}
+          name: rook-config
       restartPolicy: Never

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -284,6 +284,7 @@ func commonOSDInit(cmd *cobra.Command) {
 func getLocation(clientset kubernetes.Interface) (string, error) {
 	// get the value the operator instructed to use as the host name in the CRUSH map
 	hostNameLabel := os.Getenv("ROOK_CRUSHMAP_HOSTNAME")
+
 	rootLabel := os.Getenv(oposd.CrushRootVarName)
 
 	loc, err := oposd.GetLocationWithNode(clientset, os.Getenv(k8sutil.NodeNameEnvVar), rootLabel, hostNameLabel)

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -547,7 +547,7 @@ func (c *ClusterController) deleteOSDEncryptionKeyFromKMS(currentCluster *cephv1
 	}
 
 	// Fetch PVCs
-	osdPVCs, err := osd.GetExistingOSDPVCs(c.context, currentCluster.Namespace)
+	osdPVCs, _, err := osd.GetExistingPVCs(c.context, currentCluster.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to list osd pvc")
 	}

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -26,9 +26,13 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	testexec "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestPrepareDeviceSets(t *testing.T) {
@@ -42,10 +46,7 @@ func testPrepareDeviceSets(t *testing.T, setTemplateName bool) {
 	context := &clusterd.Context{
 		Clientset: clientset,
 	}
-	storageClass := "mysource"
-	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
-		StorageClassName: &storageClass,
-	}}
+	claim := testVolumeClaim("")
 	if setTemplateName {
 		claim.Name = "randomname"
 	}
@@ -83,8 +84,155 @@ func testPrepareDeviceSets(t *testing.T, setTemplateName bool) {
 	if !setTemplateName {
 		expectedName = "data"
 	}
-	assert.Equal(t, fmt.Sprintf("mydata-%s-0-", expectedName), pvcs.Items[0].GenerateName)
+	assert.Equal(t, fmt.Sprintf("mydata-%s-0", expectedName), pvcs.Items[0].GenerateName)
 	assert.Equal(t, cluster.clusterInfo.Namespace, pvcs.Items[0].Namespace)
+}
+
+func TestPrepareDeviceSetWithHolesInPVCs(t *testing.T) {
+	ctx := context.TODO()
+	clientset := testexec.New(t, 1)
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	deviceSet := rookv1.StorageClassDeviceSet{
+		Name:                 "mydata",
+		Count:                1,
+		Portable:             true,
+		VolumeClaimTemplates: []v1.PersistentVolumeClaim{testVolumeClaim("data"), testVolumeClaim("metadata"), testVolumeClaim("wal")},
+		SchedulerName:        "custom-scheduler",
+	}
+	spec := cephv1.ClusterSpec{
+		Storage: rookv1.StorageScopeSpec{StorageClassDeviceSets: []rookv1.StorageClassDeviceSet{deviceSet}},
+	}
+	ns := "testns"
+	cluster := &Cluster{
+		context:     context,
+		clusterInfo: client.AdminClusterInfo(ns),
+		spec:        spec,
+	}
+
+	pvcSuffix := 0
+	var pvcReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// PVCs are created with generateName used, and we need to capture the create calls and
+		// generate a name for them in order for PVCs to all have unique names.
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			t.Fatal("err! action is not a create action")
+			return false, nil, nil
+		}
+		obj := createAction.GetObject()
+		pvc, ok := obj.(*corev1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatal("err! action not a PVC")
+			return false, nil, nil
+		}
+		if pvc.Name == "" {
+			pvc.Name = fmt.Sprintf("%s-%d", pvc.GenerateName, pvcSuffix)
+			logger.Info("generated name for PVC:", pvc.Name)
+			pvcSuffix++
+		} else {
+			logger.Info("PVC already has a name:", pvc.Name)
+		}
+		// setting pvc.Name above modifies the action in-place before future reactors occur
+		// we want the default reactor to create the resource, so return false as if we did nothing
+		return false, nil, nil
+	}
+	clientset.PrependReactor("create", "persistentvolumeclaims", pvcReactor)
+
+	// Create 3 PVCs for two OSDs in the device set
+	config := &provisionConfig{}
+	volumeSources := cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 1, len(volumeSources))
+	assert.Equal(t, 0, len(config.errorMessages))
+	assert.Equal(t, "mydata", volumeSources[0].Name)
+	assert.True(t, volumeSources[0].Portable)
+	_, dataOK := volumeSources[0].PVCSources["data"]
+	assert.True(t, dataOK)
+
+	// Verify the PVCs all exist
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-0-0")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-0-1")
+	assertPVCExists(t, clientset, ns, "mydata-wal-0-2")
+
+	// Create 3 more PVCs (6 total) for two OSDs in the device set
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 2
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	assert.Equal(t, 0, len(config.errorMessages))
+
+	// Verify the PVCs all exist
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-0-0")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-0-1")
+	assertPVCExists(t, clientset, ns, "mydata-wal-0-2")
+	assertPVCExists(t, clientset, ns, "mydata-data-1-3")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-1-4")
+	assertPVCExists(t, clientset, ns, "mydata-wal-1-5")
+
+	// Verify the same number of PVCs exist after calling the reconcile again on the PVCs
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+
+	// Delete a single PVC and verify it will be re-created
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete(ctx, "mydata-wal-0-2", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+
+	// Delete the PVCs for an OSD and verify it will not be re-created if the count is reduced
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 1
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete(ctx, "mydata-data-0-0", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete(ctx, "mydata-metadata-0-1", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).Delete(ctx, "mydata-wal-0-6", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 1, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pvcs.Items))
+
+	// Scale back up to a count of two and confirm that a new index is used for the PVCs
+	cluster.spec.Storage.StorageClassDeviceSets[0].Count = 2
+	volumeSources = cluster.prepareStorageClassDeviceSets(config)
+	assert.Equal(t, 2, len(volumeSources))
+	pvcs, err = clientset.CoreV1().PersistentVolumeClaims(cluster.clusterInfo.Namespace).List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 6, len(pvcs.Items))
+	assertPVCExists(t, clientset, ns, "mydata-data-1-3")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-1-4")
+	assertPVCExists(t, clientset, ns, "mydata-wal-1-5")
+	assertPVCExists(t, clientset, ns, "mydata-data-2-7")
+	assertPVCExists(t, clientset, ns, "mydata-metadata-2-8")
+	assertPVCExists(t, clientset, ns, "mydata-wal-2-9")
+}
+
+func assertPVCExists(t *testing.T, clientset kubernetes.Interface, namespace, name string) {
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, pvc)
+}
+
+func testVolumeClaim(name string) v1.PersistentVolumeClaim {
+	storageClass := "mysource"
+	claim := v1.PersistentVolumeClaim{Spec: v1.PersistentVolumeClaimSpec{
+		StorageClassName: &storageClass,
+	}}
+	claim.Name = name
+	return claim
 }
 
 func TestUpdatePVCSize(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
OSDs on PVCs previously were always replaced with PVCs of a given name. For on-prem scenarios where the OSDs might need to be removed instead of replaced, the operator now allows holes to exist in the PVC index names as long as there are a sufficient number of PVCs to meet the criteria for the deviceSet.count.

At the same time, we use predictable PVC names for the ODSs such as rook-ceph-osd-set1-data-3 as there is no need for a generated pvc suffix name

**Which issue is resolved by this Pull Request:**
Resolves #6287 #6948 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
