### PR TITLE
ceph: allow user decide num of mgrs

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -197,6 +197,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
 * `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health doc](ceph-mon-health.md).
 * `mgr`: manager top level section
+  * `count`: set number of ceph mangers between `1` to `2`. The default value is 1. This is only needed if plural ceph managers are needed.
   * `modules`: is the list of Ceph manager modules to enable
 * `crashCollector`: The settings for crash collector daemon(s).
   * `disable`: is set to `true`, the crash collector will not run on any node where a Ceph daemon runs

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -98,6 +98,11 @@ spec:
                 mgr:
                   type: object
                   properties:
+                    count:
+                      type: integer
+                      minimum: 1
+                      maximum: 2
+                      default: 1
                     modules:
                       type: array
                       items:
@@ -1422,6 +1427,10 @@ spec:
                 volumeClaimTemplate: {}
             mgr:
               properties:
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 2
                 modules:
                   items:
                     properties:

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -38,6 +38,7 @@ spec:
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   mgr:
+    count: 1
     modules:
     - name: pg_autoscaler
       enabled: true

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -44,6 +44,9 @@ spec:
     # Mons should only be allowed on the same node for test environments where data loss is acceptable.
     allowMultiplePerNode: false
   mgr:
+    # Set this number only when multiple ceph managers are needed. Due to mgr's mechanism, plural mgrs might cause issues
+    # when accessing dashboard through service cluster IP.
+    count: 1
     modules:
     # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
     # are already enabled by other settings in the cluster CR.

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -100,6 +100,11 @@ spec:
                 mgr:
                   type: object
                   properties:
+                    count:
+                      type: integer
+                      minimum: 1
+                      maximum: 2
+                      default: 1
                     modules:
                       type: array
                       items:

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -84,6 +84,10 @@ spec:
                 volumeClaimTemplate: {}
             mgr:
               properties:
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 2
                 modules:
                   items:
                     properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -310,6 +310,7 @@ type StretchClusterZoneSpec struct {
 
 // MgrSpec represents options to configure a ceph mgr
 type MgrSpec struct {
+	Count   int      `json:"count,omitempty"`
 	Modules []Module `json:"modules,omitempty"`
 }
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -132,8 +132,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
 	// the dashboard is enabled once with the new dashboard and modules
-	assert.Equal(t, 1, enables)
-	assert.Equal(t, 0, disables)
+	assert.Equal(t, 2, enables)
+	assert.Equal(t, 1, disables)
 	assert.Equal(t, 2, moduleRetries)
 
 	svc, err := c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
@@ -146,8 +146,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.Nil(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
-	assert.Equal(t, 1, enables)
-	assert.Equal(t, 1, disables)
+	assert.Equal(t, 2, enables)
+	assert.Equal(t, 2, disables)
 
 	svc, err = c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	assert.NotNil(t, err)

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -65,6 +65,7 @@ func TestStartMGR(t *testing.T) {
 		Labels:             map[rookv1.KeyType]rookv1.Labels{cephv1.KeyMgr: {"my-label-key": "value"}},
 		Dashboard:          cephv1.DashboardSpec{Enabled: true, SSL: true},
 		Monitoring:         cephv1.MonitoringSpec{Enabled: true, RulesNamespace: ""},
+		Mgr:                cephv1.MgrSpec{Count: 1},
 		PriorityClassNames: map[rookv1.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",
 	}
@@ -204,7 +205,7 @@ func TestConfigureModules(t *testing.T) {
 }
 
 func TestMgrDaemons(t *testing.T) {
-	c := &Cluster{Replicas: 3}
+	c := &Cluster{Replicas: 2}
 	daemons := c.getDaemonIDs()
 	require.Equal(t, 2, len(daemons))
 	assert.Equal(t, "a", daemons[0])


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Allow user to decide how many mgrs to be used
by make mgr replicas configurable

**Which issue is resolved by this Pull Request:**
Resolves #6955

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
