### PR TITLE
ceph: clean pods stuck in terminating state on a failed node

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -18,7 +18,10 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
+	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -26,7 +29,11 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -196,4 +203,135 @@ func Test_cephStatusChecker_conditionMessageReason(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestForceDeleteStuckRookPodsOnNotReadyNodes(t *testing.T) {
+	ctx := context.TODO()
+	clientset := optest.New(t, 1)
+	clusterInfo := client.NewClusterInfo("test", "test")
+	clusterName := clusterInfo.NamespacedName()
+
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	c := newCephStatusChecker(context, clusterInfo, &cephv1.ClusterSpec{})
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stuck-pod",
+			Namespace: clusterName.Namespace,
+			Labels: map[string]string{
+				"rook_cluster": clusterName.Name,
+			},
+		},
+	}
+	pod.Spec.NodeName = "node0"
+	_, err := context.Clientset.CoreV1().Pods(clusterName.Namespace).Create(ctx, &pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create a non matching pod
+	notDeletePod := pod
+	notDeletePod.ObjectMeta.Labels = map[string]string{"app": "not-to-be-deleted"}
+	notDeletePod.ObjectMeta.Name = "not-to-be-deleted"
+	notDeletePod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	_, err = context.Clientset.CoreV1().Pods(clusterName.Namespace).Create(ctx, &notDeletePod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Set the node to NotReady state
+	nodes, err := context.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	assert.NoError(t, err)
+	for _, node := range nodes.Items {
+		node.Status.Conditions[0].Status = v1.ConditionFalse
+		localnode := node
+		_, err := context.Clientset.CoreV1().Nodes().Update(ctx, &localnode, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+	}
+
+	// There should be no error
+	err = c.forceDeleteStuckRookPodsOnNotReadyNodes()
+	assert.NoError(t, err)
+
+	// The pod should still exist since its not deleted.
+	p, err := context.Clientset.CoreV1().Pods(clusterInfo.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	// Add a deletion timestamp to the pod
+	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	_, err = clientset.CoreV1().Pods(clusterName.Namespace).Update(ctx, &pod, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+
+	// There should be no error as the pod is deleted
+	err = c.forceDeleteStuckRookPodsOnNotReadyNodes()
+	assert.NoError(t, err)
+
+	// The pod should be deleted since the pod is marked as deleted and the node is in NotReady state
+	_, err = clientset.CoreV1().Pods(clusterName.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	assert.Error(t, err)
+	assert.True(t, kerrors.IsNotFound(err))
+
+	// The pod should not be deleted as it does not have the matching labels
+	_, err = clientset.CoreV1().Pods(clusterName.Namespace).Get(ctx, notDeletePod.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+}
+
+func TestGetRookPodsOnNode(t *testing.T) {
+	ctx := context.TODO()
+	clientset := optest.New(t, 1)
+	clusterInfo := client.NewClusterInfo("test", "test")
+	clusterName := clusterInfo.NamespacedName()
+	context := &clusterd.Context{
+		Clientset: clientset,
+	}
+
+	c := newCephStatusChecker(context, clusterInfo, &cephv1.ClusterSpec{})
+	labels := []map[string]string{
+		{"rook_cluster": clusterName.Name},
+		{"app": "csi-rbdplugin-provisioner"},
+		{"app": "csi-rbdplugin"},
+		{"app": "csi-cephfsplugin-provisioner"},
+		{"app": "csi-cephfsplugin"},
+		{"app": "rook-ceph-operator"},
+		{"rook_cluster": "test", "app": "csi-cephfsplugin"},
+		{"app": "user-app"},
+	}
+
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-with-no-label",
+			Namespace: clusterName.Namespace,
+		},
+	}
+	pod.Spec.NodeName = "node0"
+	_, err := context.Clientset.CoreV1().Pods(clusterName.Namespace).Create(ctx, &pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	expectedPodNames := []string{}
+	for i, label := range labels {
+		pod.ObjectMeta.Name = fmt.Sprintf("pod-%d", i)
+		pod.ObjectMeta.Namespace = clusterName.Namespace
+		pod.ObjectMeta.Labels = label
+		if label["app"] != "user-app" {
+			expectedPodNames = append(expectedPodNames, pod.Name)
+		}
+		_, err := context.Clientset.CoreV1().Pods(clusterName.Namespace).Create(ctx, &pod, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	pods, err := c.getRookPodsOnNode("node0")
+	assert.NoError(t, err)
+	// A pod is having two matching labels and its returned only once
+	assert.Equal(t, 7, len(pods))
+
+	podNames := []string{}
+	for _, pod := range pods {
+		// Check if the pods has labels
+		assert.NotEmpty(t, pod.Labels)
+		podNames = append(podNames, pod.Name)
+	}
+
+	sort.Strings(expectedPodNames)
+	sort.Strings(podNames)
+	assert.Equal(t, expectedPodNames, podNames)
 }


### PR DESCRIPTION
Clean up all the Rook and CSI pods that are stuck in terminating
state on a failed node.

Signed-off-by: rohan47 <rohgupta@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Added code to check if there are `NotReady` nodes when Ceph status is not `HEALTH_OK` and force delete the pods that are stuck in `Terminating` on the `NotReady` node.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
