### PR TITLE
#7007 Ability to configure ROOK_ALLOW_MULTIPLE_FILESYSTEMS environment to rook operator pod in helm chart

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -139,6 +139,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `agent.nodeAffinity`               | The node labels for affinity of `rook-agent` (***)                                                                             | <none>                                                    |
 | `admissionController.tolerations`  | Array of tolerations in YAML format which will be added to admission controller deployment.                                    | <none>                                                    |
 | `admissionController.nodeAffinity` | The node labels for affinity of the admission controller deployment (***)                                                      | <none>                                                    |
+| `allowMultipleFilesystems`         | **(experimental)** Allows multiple filesystems to be deployed to a Ceph cluster. Octopus (v15) or Nautilus (v14)               | `false`                                                   |
 
 &ast; For information on what to set `agent.flexVolumeDirPath` to, please refer to the [Rook flexvolume documentation](flexvolume.md)
 

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -268,6 +268,10 @@ spec:
         - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
           value: {{ .Values.unreachableNodeTolerationSeconds | quote }}
 {{- end }}
+{{- if .Values.allowMultipleFilesystems }}
+        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
+          value: {{ .Values.allowMultipleFilesystems }}
+{{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.useOperatorHostNetwork }}

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -271,6 +271,11 @@ csi:
 enableFlexDriver: false
 enableDiscoveryDaemon: false
 
+# enable the ability to have multiple Ceph filesystems in the same cluster
+# WARNING: Experimental feature in Ceph Releases Octopus (v15) and Nautilus (v14)
+# https://docs.ceph.com/en/octopus/cephfs/experimental-features/#multiple-file-systems-within-a-ceph-cluster
+allowMultipleFilesystems: false
+
 ## if true, run rook operator on the host network
 # useOperatorHostNetwork: true
 


### PR DESCRIPTION
This will give us the ability to configure the environment variable ROOK_ALLOW_MULTIPLE_FILESYSTEM, as that configuration cannot currently be set using the existing rook-operator helm chart.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7007

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
