### PR TITLE
ceph: add kubectl-check-ownerreferences in ci

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -93,6 +93,13 @@ jobs:
         # copy the test file
         # execute the test file
 
+    - name: run kubectl-check-ownerreferences
+      run: |
+        curl -L https://github.com/kubernetes-sigs/kubectl-check-ownerreferences/releases/download/v0.2.0/kubectl-check-ownerreferences-linux-amd64.tar.gz -o kubectl-check-ownerreferences-linux-amd64.tar.gz
+        tar xzvf kubectl-check-ownerreferences-linux-amd64.tar.gz
+        chmod +x kubectl-check-ownerreferences
+        ./kubectl-check-ownerreferences -n rook-ceph
+
     - name: Upload canary test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -172,6 +179,13 @@ jobs:
         mkdir test
         tests/scripts/validate_cluster.sh osd
         kubectl -n rook-ceph get pods
+
+    - name: run kubectl-check-ownerreferences
+      run: |
+        curl -L https://github.com/kubernetes-sigs/kubectl-check-ownerreferences/releases/download/v0.2.0/kubectl-check-ownerreferences-linux-amd64.tar.gz -o kubectl-check-ownerreferences-linux-amd64.tar.gz
+        tar xzvf kubectl-check-ownerreferences-linux-amd64.tar.gz
+        chmod +x kubectl-check-ownerreferences
+        ./kubectl-check-ownerreferences -n rook-ceph
 
     - name: Upload  pvc test result
       uses: actions/upload-artifact@v2
@@ -348,7 +362,7 @@ jobs:
         mkdir test
         tests/scripts/validate_cluster.sh osd
         kubectl -n rook-ceph get pods
-    
+
     - name: Upload pvc-db-wal test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -423,8 +437,8 @@ jobs:
         mkdir test
         tests/scripts/validate_cluster.sh osd
         kubectl -n rook-ceph get pods
-        kubectl -n rook-ceph get secrets 
-        sudo lsblk 
+        kubectl -n rook-ceph get secrets
+        sudo lsblk
 
     - name: Upload encryption-pvc test result
       uses: actions/upload-artifact@v2
@@ -513,7 +527,7 @@ jobs:
         mkdir test
         tests/scripts/validate_cluster.sh osd
         kubectl -n rook-ceph get pods
-        kubectl -n rook-ceph get secrets 
+        kubectl -n rook-ceph get secrets
 
     - name: Upload encryption-pvc-db test result
       uses: actions/upload-artifact@v2
@@ -600,7 +614,7 @@ jobs:
         mkdir test
         tests/scripts/validate_cluster.sh osd
         kubectl -n rook-ceph get pods
-        kubectl -n rook-ceph get secrets 
+        kubectl -n rook-ceph get secrets
 
     - name: Upload encryption-pvc-db-wal test result
       uses: actions/upload-artifact@v2
@@ -687,8 +701,8 @@ jobs:
 
     - name: validate vault
       run: |
-        tests/scripts/deploy-validate-vault.sh validate 
-        sudo lsblk 
+        tests/scripts/deploy-validate-vault.sh validate
+        sudo lsblk
 
     - name: Upload encryption-pvc-kms-vault-token-auth test result
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Description of your changes:**

After each non-pvc and pvc scenario we run the
kubectl-check-ownerreferences tool to analyze potential incorrect owner
references. We had issues in the past with incorrect owner ref so this
tool might help us ensure we are doing things right.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
