### PR TITLE
ceph: add quincy version

### DIFF
--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -46,6 +46,8 @@ var (
 	Octopus = CephVersion{15, 0, 0, 0}
 	// Pacific Ceph version
 	Pacific = CephVersion{16, 0, 0, 0}
+	// Quincy Ceph version
+	Quincy = CephVersion{17, 0, 0, 0}
 
 	// cephVolumeLVMDiskSortingCephVersion introduced a major regression in c-v and thus is not suitable for production
 	cephVolumeLVMDiskSortingCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 13}
@@ -86,6 +88,8 @@ func (v *CephVersion) ReleaseName() string {
 		return "octopus"
 	case Pacific.Major:
 		return "pacific"
+	case Quincy.Major:
+		return "quincy"
 	default:
 		return unknownVersionString
 	}
@@ -170,6 +174,11 @@ func (v *CephVersion) IsPacific() bool {
 	return v.isRelease(Pacific)
 }
 
+// IsQuincy checks if the Ceph version is Quincy
+func (v *CephVersion) IsQuincy() bool {
+	return v.isRelease(Quincy)
+}
+
 // IsAtLeast checks a given Ceph version is at least a given one
 func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	if v.Major > other.Major {
@@ -191,6 +200,11 @@ func (v *CephVersion) IsAtLeast(other CephVersion) bool {
 	}
 	// If we arrive here then both versions are identical
 	return true
+}
+
+// IsAtLeastQuincy check that the Ceph version is at least Quincy
+func (v *CephVersion) IsAtLeastQuincy() bool {
+	return v.IsAtLeast(Quincy)
 }
 
 // IsAtLeastPacific check that the Ceph version is at least Pacific

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -102,6 +102,8 @@ func TestSupported(t *testing.T) {
 func TestIsRelease(t *testing.T) {
 	assert.True(t, Nautilus.isRelease(Nautilus))
 	assert.True(t, Octopus.isRelease(Octopus))
+	assert.True(t, Pacific.isRelease(Pacific))
+	assert.True(t, Quincy.isRelease(Quincy))
 
 	assert.False(t, Octopus.isRelease(Nautilus))
 


### PR DESCRIPTION
**Description of your changes:**

Quincy just started https://github.com/ceph/ceph/pull/38996 so let's add
it to our version code.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
