### PR TITLE
ceph: disable admission controller for k8s older than v1.16.0

### DIFF
--- a/cluster/examples/kubernetes/ceph/config-admission-controller.sh
+++ b/cluster/examples/kubernetes/ceph/config-admission-controller.sh
@@ -4,6 +4,14 @@ BASE_DIR=$(cd "$(dirname "$0")"/../../../..; pwd)
 
 echo "$BASE_DIR"
 
+SERVER_VERSION=$(kubectl version --short | awk -F  "."  '/Server Version/ {print $2}')
+MINIMUM_VERSION=16
+
+if [ ${SERVER_VERSION} -le ${MINIMUM_VERSION} ]; then
+    echo "required minimum kubernetes version 1.$MINIMUM_VERSION.0"
+    exit 1
+fi
+
 if [  -f  "$BASE_DIR"/tests/scripts/deploy_admission_controller.sh ];then
     bash "$BASE_DIR"/tests/scripts/deploy_admission_controller.sh
 else

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -126,7 +126,7 @@ func (h *CephInstaller) CreateCephOperator(namespace string) (err error) {
 
 	// disable admission controller for upgrade test as api version v1 require minimum v0.7 controller runtime and upgrade test still using
 	// older version of controller runtime.
-	if !utils.IsPlatformOpenShift() && namespace != "upgrade-ns-system" {
+	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.16.0") && namespace != "upgrade-ns-system" {
 		err = h.startAdmissionController(namespace)
 		if err != nil {
 			return fmt.Errorf("Failed to start admission controllers: %v", err)
@@ -518,7 +518,7 @@ func (h *CephInstaller) InstallRook(namespace, storeType string, usePVC bool, st
 	}
 	logger.Infof("installed rook operator and cluster : %s on k8s %s", namespace, h.k8sVersion)
 
-	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.15.0") && namespace != "upgrade-ns" {
+	if !utils.IsPlatformOpenShift() && h.k8shelper.VersionAtLeast("v1.16.0") && namespace != "upgrade-ns" {
 		if !h.k8shelper.IsPodInExpectedState("rook-ceph-admission-controller", onamespace, "Running") {
 			assert.Fail(h.T(), "admission controller is not running")
 		}
@@ -635,7 +635,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(systemNamespace string, name
 		checkError(h.T(), err, "cannot uninstall rook-operator")
 	}
 
-	err = h.k8shelper.Clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(ctx, "rook-ceph-webhook", metav1.DeleteOptions{})
+	err = h.k8shelper.Clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, "rook-ceph-webhook", metav1.DeleteOptions{})
 	checkError(h.T(), err, "failed to delete webhook configuration")
 	err = h.k8shelper.Clientset.RbacV1().RoleBindings(systemNamespace).Delete(ctx, "rook-ceph-system", metav1.DeleteOptions{})
 	checkError(h.T(), err, "failed to delete role binding")


### PR DESCRIPTION
**Description of your changes:**
v1 version of `admissionregistration.k8s.io/v1` require minimum v1.16.0
of k8s. So, this commits disable admission controller when
k8s version older than v1.16.0.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #7047

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
