### PR TITLE
ceph: silence harmless errors when the operator is not initialized

### DIFF
--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -208,6 +209,10 @@ func (r *ReconcileCephRBDMirror) reconcile(request reconcile.Request) (reconcile
 	daemon := string(opconfig.MonType)
 	currentCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, daemon)
 	if err != nil {
+		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
+			logger.Info("skipping reconcile since operator is still initializing")
+			return opcontroller.WaitForRequeueIfOperatorNotInitialized, nil
+		}
 		return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to retrieve current ceph %q version", daemon)
 	}
 	r.clusterInfo.CephVersion = currentCephVersion

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -33,8 +33,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// OperatorSettingConfigMapName refers to ConfigMap that configures rook ceph operator
-const OperatorSettingConfigMapName string = "rook-ceph-operator-config"
+const (
+	// OperatorSettingConfigMapName refers to ConfigMap that configures rook ceph operator
+	OperatorSettingConfigMapName string = "rook-ceph-operator-config"
+
+	// UninitializedCephConfigError refers to the error message printed by the Ceph CLI when there is no ceph configuration file
+	// This typically is raised when the operator has not finished initializing
+	UninitializedCephConfigError = "error calling conf_read_file"
+)
 
 var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
@@ -45,6 +51,9 @@ var (
 
 	// WaitForRequeueIfFinalizerBlocked waits for resources to be cleaned up before the finalizer can be removed
 	WaitForRequeueIfFinalizerBlocked = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+
+	// WaitForRequeueIfOperatorNotInitialized waits for resources to be cleaned up before the finalizer can be removed
+	WaitForRequeueIfOperatorNotInitialized = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 
 	// OperatorCephBaseImageVersion is the ceph version in the operator image
 	OperatorCephBaseImageVersion string

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -220,7 +220,7 @@ func (r *ReconcileClusterDisruption) reconcilePDBsForOSDs(
 	if err != nil {
 		// If the error contains that message, this means the cluster is not up and running
 		// No monitors are present and thus no ceph configuration has been created
-		if strings.Contains(err.Error(), "error calling conf_read_file") {
+		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
 			logger.Debugf("Ceph %q cluster not ready, cannot check Ceph status yet.", request.Namespace)
 			return nil
 		}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -240,6 +240,10 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	// Populate CephVersion
 	currentCephVersion, err := cephclient.LeastUptodateDaemonVersion(r.context, r.clusterInfo, opconfig.MonType)
 	if err != nil {
+		if strings.Contains(err.Error(), opcontroller.UninitializedCephConfigError) {
+			logger.Info("skipping reconcile since operator is still initializing")
+			return opcontroller.WaitForRequeueIfOperatorNotInitialized, nil
+		}
 		return reconcile.Result{}, errors.Wrapf(err, "failed to retrieve current ceph %q version", opconfig.MonType)
 	}
 	r.clusterInfo.CephVersion = currentCephVersion

--- a/pkg/util/exec/error_test.go
+++ b/pkg/util/exec/error_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestExitStatus(t *testing.T) {
+	e := &exec.ExitError{ProcessState: &os.ProcessState{}}
+	c := &CephCLIError{err: e}
+
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  int
+		want1 bool
+	}{
+		{"error type is unknown", args{err: errors.New("unknownerror")}, 0, false},
+		{"error type is ExitError", args{err: e}, 0, true},
+		{"error type is CephCLIError and contains ExitError ", args{err: c}, 0, true},
+		{"error type is CephCLIError and does not contain ExitError", args{err: &CephCLIError{err: errors.New("foo")}}, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := ExitStatus(tt.args.err)
+			if got != tt.want {
+				t.Errorf("ExitStatus() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ExitStatus() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 )
 
 // Executor is the main interface for all the exec commands
@@ -143,7 +144,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duratio
 
 	outFile, err := ioutil.TempFile("", "")
 	if err != nil {
-		return "", fmt.Errorf("failed to open output file: %+v", err)
+		return "", errors.Wrap(err, "failed to open output file")
 	}
 	defer outFile.Close()
 	defer os.Remove(outFile.Name())
@@ -187,7 +188,7 @@ func (*CommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string,
 	// it is cleaned up after this function is done
 	outFile, err := ioutil.TempFile("", "")
 	if err != nil {
-		return "", fmt.Errorf("failed to open output file: %+v", err)
+		return "", errors.Wrap(err, "failed to open output file")
 	}
 	defer outFile.Close()
 	defer os.Remove(outFile.Name())


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

See individual commits, but overall one the operator restarts this silences harmless errors.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
