### PR TITLE
ceph: timeout `radosgw-admin` cli commands

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -41,7 +41,7 @@ const (
 	// CrushTool is the name of the CLI tool for 'crushtool'
 	CrushTool             = "crushtool"
 	CmdExecuteTimeout     = 1 * time.Minute
-	cephConnectionTimeout = "15" // in seconds
+	CephConnectionTimeout = "15" // in seconds
 	// DefaultPGCount will cause Ceph to use the internal default PG count
 	DefaultPGCount = "0"
 )
@@ -62,7 +62,7 @@ func FinalizeCephCommandArgs(command string, clusterInfo *ClusterInfo, args []st
 	// we could use a slice and iterate over it but since we have only 3 elements
 	// I don't think this is worth a loop
 	if command != "rbd" && command != "crushtool" && command != "radosgw-admin" {
-		args = append(args, "--connect-timeout="+cephConnectionTimeout)
+		args = append(args, "--connect-timeout="+CephConnectionTimeout)
 	}
 
 	// If the command should be run inside the toolbox pod, include the kubectl args to call the toolbox

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -269,10 +269,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 				clusterSpec: r.clusterSpec,
 				clusterInfo: r.clusterInfo,
 			}
-			err = cfg.deleteStore()
-			if err != nil {
-				return reconcile.Result{}, errors.Wrapf(err, "failed to delete store %q", cephObjectStore.Name)
-			}
+			cfg.deleteStore()
 
 			// Close the channel to stop the healthcheck of the endpoint
 			close(r.objectStoreChannels[cephObjectStore.Name].stopChan)

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -424,7 +425,7 @@ func TestCephObjectStoreController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "realm" && args[1] == "list" {
 				return realmListJSON, nil
 			}
@@ -603,7 +604,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "realm" && args[1] == "list" {
 				return realmListMultisiteJSON, nil
 			}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -218,7 +218,7 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 
 // Delete the object store.
 // WARNING: This is a very destructive action that deletes all metadata and data pools.
-func (c *clusterConfig) deleteStore() error {
+func (c *clusterConfig) deleteStore() {
 	logger.Infof("deleting object store %q from namespace %q", c.store.Name, c.store.Namespace)
 
 	if !c.clusterSpec.External.Enable {
@@ -229,14 +229,14 @@ func (c *clusterConfig) deleteStore() error {
 
 			err := c.deleteRgwCephObjects(depNameToRemove)
 			if err != nil {
-				return err
+				logger.Errorf("failed to delete rgw CephX keys and configuration. Error: %v", err)
 			}
 		}
 
 		// Delete the realm and pools
 		objContext, err := NewMultisiteContext(c.context, c.clusterInfo, c.store)
 		if err != nil {
-			return errors.Wrapf(err, "failed to set multisite on object store %q", c.store.Name)
+			logger.Errorf("failed to set multisite on object store %q. Error: %v", c.store.Name, err)
 		}
 
 		objContext.Endpoint = c.store.Status.Info["endpoint"]
@@ -245,12 +245,11 @@ func (c *clusterConfig) deleteStore() error {
 
 		err = deleteRealmAndPools(objContext, c.store.Spec)
 		if err != nil {
-			return errors.Wrap(err, "failed to delete the realm and pools")
+			logger.Errorf("failed to delete the realm and pools. Error: %v", err)
 		}
 	}
 
-	logger.Infof("successfully deleted object store %q from namespace %q", c.store.Name, c.store.Namespace)
-	return nil
+	logger.Infof("done deleting object store %q from namespace %q", c.store.Name, c.store.Namespace)
 }
 
 func (c *clusterConfig) deleteRgwCephObjects(depNameToRemove string) error {

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -20,6 +20,7 @@ package objectuser
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -221,7 +222,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "user" {
 				return userCreateJSON, nil
 			}

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -20,6 +20,7 @@ package zone
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -267,7 +268,7 @@ func TestCephObjectZoneController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "zonegroup" && args[1] == "get" {
 				return zoneGroupGetJSON, nil
 			}
@@ -313,7 +314,7 @@ func TestCephObjectZoneController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "zonegroup" && args[1] == "get" {
 				return zoneGroupGetJSON, nil
 			}

--- a/pkg/operator/ceph/object/zonegroup/controller_test.go
+++ b/pkg/operator/ceph/object/zonegroup/controller_test.go
@@ -20,6 +20,7 @@ package zonegroup
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -261,7 +262,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "realm" && args[1] == "get" {
 				return realmGetJSON, nil
 			}
@@ -315,7 +316,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 			}
 			return "", nil
 		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "zonegroup" && args[1] == "get" {
 				return zoneGroupGetJSON, nil
 			}


### PR DESCRIPTION
When creating object store, `radosgw-admin realm get ..` command is stuck forever when required number of OSDs are not available. Because of this the uninstall of object store is also stuck. User has to manually remove the finalizer to delete the object store.

This PR uses `ExecuteCommandWithTimeout` for running `radosgw-admin` command. Timeout during installation will be reconciled. Cleanup will be treated as best effort and timeout during unisntall will be ignored.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
