### PR TITLE
ceph: Enable pod disruption budgets by default

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -18,3 +18,4 @@ v1.6...
 
 * CephClient CRD has been converted to use the controller-runtime library
 * Extending the support of vault KMS configuration for Ceph RGW
+* Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -166,7 +166,7 @@ spec:
   #      cpu: "200m"
   #      memory: "200Mi"
   disruptionManagement:
-    managePodBudgets: false
+    managePodBudgets: true
     osdMaintenanceTimeout: 30
     pgHealthCheckTimeout: 0
     manageMachineDisruptionBudgets: false

--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -68,3 +68,5 @@ spec:
               values:
               - b
               - c
+  disruptionManagement:
+    managePodBudgets: true

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -44,3 +44,5 @@ spec:
       mon:
         interval: 45s
         timeout: 600s
+  disruptionManagement:
+    managePodBudgets: true

--- a/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-with-drive-groups.yaml
@@ -99,3 +99,5 @@ spec:
     #     tolerations:
     #       - key: storage-node
     #         operator: Exists
+  disruptionManagement:
+    managePodBudgets: true

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -221,7 +221,7 @@ spec:
     # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically
     # via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph/ceph-managed-disruptionbudgets.md). The operator will
     # block eviction of OSDs by default and unblock them safely when drains are detected.
-    managePodBudgets: false
+    managePodBudgets: true
     # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
     # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
     osdMaintenanceTimeout: 30

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -3472,7 +3472,7 @@ spec:
           accessModes:
             - ReadWriteOnce
   disruptionManagement:
-    managePodBudgets: false
+    managePodBudgets: true
     osdMaintenanceTimeout: 30
     pgHealthCheckTimeout: 0
     manageMachineDisruptionBudgets: false


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The PDBs have been stabilizing for a good length of time now since they were created in v1.1, and later redesigned in v1.5. The time has come to enable the feature by default so everyone can enjoy the stable Rook storage even while draining K8s nodes. This change will be in the v1.6 release, rather than backport to 1.5.

@sp98 Any reason not to enable the PDBs by default now? 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
