### PR TITLE
ceph: Prevent operator crash with host networking and node not found

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -789,8 +789,8 @@ func (c *Cluster) initMonIPs(mons []*monConfig) error {
 		if c.spec.Network.IsHost() {
 			logger.Infof("setting mon endpoints for hostnetwork mode")
 			node, ok := c.mapping.Schedule[m.DaemonName]
-			if !ok {
-				return errors.New("mon doesn't exist in assignment map")
+			if !ok || node == nil {
+				return fmt.Errorf("node for mon %q doesn't exist in assignment map", m.DaemonName)
 			}
 			m.PublicIP = node.Address
 		} else {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the node is not found for mon assignment with host networking enabled, the operator may crash. This change ensures the node is not nil and returns an error instead of crashing.

The error was found based on the 1.4 release, as seen on [line 563 of mon.go](https://github.com/rook/rook/blob/release-1.4/pkg/operator/ceph/cluster/mon/mon.go#L563) where `node` must be nil:
```
2021-01-15T06:29:08.081677455Z 2021-01-15 06:29:08.081608 I | op-mon: targeting the mon count 3
2021-01-15T06:29:09.654766574Z 2021-01-15 06:29:09.654706 I | op-mon: checking for basic quorum with existing mons
2021-01-15T06:29:09.654766574Z 2021-01-15 06:29:09.654743 I | op-mon: setting mon endpoints for hostnetwork mode
2021-01-15T06:29:09.654943096Z E0115 06:29:09.654900       7 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2021-01-15T06:29:09.654943096Z goroutine 791 [running]:
2021-01-15T06:29:09.654943096Z k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1e96dc0, 0x32861d0)
2021-01-15T06:29:09.654943096Z  /remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/runtime/runtime.go:74 +0xa6
2021-01-15T06:29:09.654943096Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
2021-01-15T06:29:09.654943096Z  /remote-source/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.17.2/pkg/util/runtime/runtime.go:48 +0x89
2021-01-15T06:29:09.654943096Z panic(0x1e96dc0, 0x32861d0)
2021-01-15T06:29:09.654943096Z  /usr/lib/golang/src/runtime/panic.go:969 +0x1b9
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster/mon.(*Cluster).initMonIPs(0xc001413400, 0xc001e00ae0, 0x3, 0x4, 0x1, 0x1)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/mon/mon.go:563 +0x118
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster/mon.(*Cluster).ensureMonsRunning(0xc001413400, 0xc001e00ae0, 0x3, 0x4, 0x2, 0x3, 0x0, 0x0, 0xc001697e58)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/mon/mon.go:321 +0x135
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster/mon.(*Cluster).startMons(0xc001413400, 0x3, 0x2186782, 0x1a)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/mon/mon.go:279 +0x497
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster/mon.(*Cluster).Start(0xc001413400, 0xc001653960, 0xc0000b4e80, 0x78, 0xe, 0x2, 0x8, 0x73, 0xc0008f2460, 0x70, ...)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/mon/mon.go:218 +0x389
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*cluster).doOrchestration(0xc0013df760, 0xc0000b4e80, 0x78, 0xe, 0x2, 0x8, 0x73, 0xc000ecf318, 0x4, 0x2173a0a)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/cluster.go:95 +0x1bc
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*ClusterController).configureLocalCephCluster(0xc000b326e0, 0xc0013df760, 0xc000ecf200, 0x0, 0x0)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/cluster.go:233 +0x297
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*ClusterController).initializeCluster(0xc000b326e0, 0xc0013df760, 0xc000ecf200, 0x28, 0xc000c0db00)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/cluster.go:194 +0x517
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*ClusterController).onAdd(0xc000b326e0, 0xc000ecf200, 0xc0013bb860, 0xc0013bb860, 0x0)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/controller.go:359 +0x29d
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*ReconcileCephCluster).reconcile(0xc00081f860, 0xc000d16020, 0x11, 0xc000d16000, 0x1e, 0x46d01b, 0x75c69beb082e, 0x1620dee1, 0x1620dee101f3a6a0)
2021-01-15T06:29:09.654943096Z  /remote-source/app/pkg/operator/ceph/cluster/controller.go:311 +0x4d3
2021-01-15T06:29:09.654943096Z github.com/rook/rook/pkg/operator/ceph/cluster.(*ReconcileCephCluster).Reconcile(0xc00081f860, 0xc000d16020, 0x11, 0xc000d16000, 0x1e, 0xf67e684e, 0xc000c84120, 0xc000c84518, 0xc000c84510)
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
