### PR TITLE
ceph: Only commit the maxmonid after starting a mon daemon

### DIFF
--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -238,6 +238,8 @@ func loadMonConfig(clientset kubernetes.Interface, namespace string) (map[string
 		storedMaxMonID, err = strconv.Atoi(id)
 		if err != nil {
 			logger.Errorf("invalid max mon id %q. %v", id, err)
+		} else {
+			maxMonID = storedMaxMonID
 		}
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The maxMonId should only track the mons that have been committed to starting. Currently the maxMonId was tracking all mon scheduling. If the reconcile was aborted or failed, or the operator restarted in a reconcile, the maxMonId was being reset by analyzing the mon deployments that existed. This does not work for scenarios where mon quroum is lost and being reset to a single mon. Now the maxMonId will only be incremented when a mon daemon is started, and will never be decremented after that to ensure that new mons will be incremented to the next id.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
