### PR TITLE
ceph: do not force go path in unit tests

### DIFF
--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -22,12 +22,13 @@ import (
 	"path"
 	"testing"
 
+	"github.com/rook/rook/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetServiceMonitor(t *testing.T) {
-	gopath := os.Getenv("GOPATH")
-	filePath := path.Join(gopath, "src/github.com/rook/rook/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml")
+	projectRoot := util.PathToProjectRoot()
+	filePath := path.Join(projectRoot, "/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml")
 	servicemonitor, err := GetServiceMonitor(filePath)
 	assert.Nil(t, err)
 	assert.Equal(t, "rook-ceph-mgr", servicemonitor.GetName())

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (
@@ -21,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/coreos/pkg/capnslog"
 )
@@ -47,4 +49,14 @@ func WriteFileToLog(logger *capnslog.PackageLogger, path string) {
 	}
 
 	logger.Infof("Config file %s:\n%s", path, string(contents))
+}
+
+// PathToProjectRoot returns the path to the root of the rook repo on the current host.
+// This is primarily useful for tests.
+func PathToProjectRoot() string {
+	_, path, _, _ := runtime.Caller(0) // get path to current file (<root>/pkg/util/file.go)
+	util := filepath.Dir(path)         // <root>/pkg/util
+	pkg := filepath.Dir(util)          // <root>/pkg
+	root := filepath.Dir(pkg)          // <root>
+	return root
 }

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (

--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 type Set struct {

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package util
 
 import (


### PR DESCRIPTION
Do not force unit tests to be run while the rook repo is in the GOPATH.
Now that Rook uses go modules, this is no longer necessary. Allow this
by creating a helper function that unit tests can use that return the
on-host path to the `rook` project root.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
