### PR TITLE
build: try sha256sum if shasum is not present

### DIFF
--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -16,7 +16,13 @@
 .SUFFIXES:
 
 SHELL := /bin/bash
+ifneq (, $(shell command -v shasum))
 SHA256CMD := shasum -a 256
+else ifneq (, $(shell command -v sha256sum))
+SHA256CMD := sha256sum
+else
+$(error "please install 'shasum' or 'sha256sum'")
+endif
 
 ifeq ($(origin PLATFORM), undefined)
 ifeq ($(origin GOOS), undefined)


### PR DESCRIPTION
**Description of your changes:**

shasum is not always available and sha256sum seems to exist more often
since it's part of coreutils where sha256sum comes with perl.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
