### PR TITLE
ceph: Simplify the log-collector container name

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -583,7 +582,7 @@ func PodSecurityContext() *v1.SecurityContext {
 // LogCollectorContainer runs a cron job to rotate logs
 func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec) *v1.Container {
 	return &v1.Container{
-		Name: logCollectorContainerName(daemonID),
+		Name: logCollector,
 		Command: []string{
 			"/bin/bash",
 			"-c",
@@ -594,8 +593,4 @@ func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec) *v1.Contai
 		SecurityContext: PodSecurityContext(),
 		Resources:       cephv1.GetLogCollectorResources(c.Resources),
 	}
-}
-
-func logCollectorContainerName(daemon string) string {
-	return fmt.Sprintf("%s-%s", strings.Replace(daemon, ".", "-", -1), logCollector)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The log-collector container name was exceeding the 63-char limit if the parent CR name was too long. The container name just needs to be unique to the pod spec, so we simplify it to remove the parent name and avoid hitting the limit in the pod spec.

For example:
```
2021-02-02 19:07:49.641184 E | ceph-object-controller: failed to reconcile failed to create object store deployments: 
failed to create object store "ocs-storagecluster-cephobjectstore": failed to start rgw pods: failed to create rgw deployment: 
  Deployment.apps "rook-ceph-rgw-ocs-storagecluster-cephobjectstore-a" is invalid: spec.template.spec.containers[1].name:   
  Invalid value: "rgwceph-client-rook-ceph-rgw-ocs-storagecluster-cephobjectstore-a-log-collector": must be no more than 63 characters
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
