### PR TITLE
ceph: added discover devices interval to helm charts

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -97,6 +97,8 @@ spec:
           value: {{ .Values.discover.podLabels }}
 {{- end }}
 {{- end }}
+        - name: ROOK_DISCOVER_DEVICES_INTERVAL
+          value: "{{ .Values.discoverDevicesInterval }}"
         - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
           value: "{{ .Values.hostpathRequiresPrivileged }}"
         - name: ROOK_LOG_LEVEL
@@ -300,3 +302,4 @@ spec:
 {{- if .Values.rbacEnable }}
       serviceAccountName: rook-ceph-system
 {{- end }}
+

--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -332,6 +332,9 @@ allowMultipleFilesystems: false
 # For more details see https://github.com/rook/rook/issues/2417
 enableSelinuxRelabeling: true
 
+# The duration between discovering devices in the rook-discover daemonset.
+discoverDevicesInterval: 60m
+
 # Writing to the hostPath is required for the Ceph mon and osd pods. Given the restricted permissions in OpenShift with SELinux,
 # the pod must be running privileged in order to write to the hostPath volume, this must be set to true then.
 hostpathRequiresPrivileged: false
@@ -357,3 +360,4 @@ admissionController:
   #      operator: Exists
   #      effect: NoSchedule
   # nodeAffinity: key1=value1,value2; key2=value3
+


### PR DESCRIPTION
On request from Alexander Trost, I have added the ROOK_DISCOVER_DEVICES_INTERVAL variable to cluster/charts/rook-ceph/values.yaml and to cluster/charts/rook-ceph/templates/deployment.yaml.

Signed-off-by: Jesper Axelsen <jesperbaxelsen@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:
On request from Alexander Trost, I have added the ROOK_DISCOVER_DEVICES_INTERVAL variable to cluster/charts/rook-ceph/values.yaml and to cluster/charts/rook-ceph/templates/deployment.yaml.**

**Which issue is resolved by this Pull Request: ROOK_DISCOVER_DEVICES_INTERVAL not included in the Helm charts**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
