### PR TITLE
ceph: do not force go path in unit tests

### DIFF
--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -18,7 +18,6 @@ limitations under the License.
 package k8sutil
 
 import (
-	"os"
 	"path"
 	"testing"
 
@@ -38,8 +37,8 @@ func TestGetServiceMonitor(t *testing.T) {
 }
 
 func TestGetPrometheusRule(t *testing.T) {
-	gopath := os.Getenv("GOPATH")
-	filePath := path.Join(gopath, "src/github.com/rook/rook/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml")
+	projectRoot := util.PathToProjectRoot()
+	filePath := path.Join(projectRoot, "/cluster/examples/kubernetes/ceph/monitoring/prometheus-ceph-v14-rules.yaml")
 	rules, err := GetPrometheusRule(filePath)
 	assert.Nil(t, err)
 	assert.Equal(t, "prometheus-ceph-rules", rules.GetName())


### PR DESCRIPTION
**Description of your changes:**

Do not force unit tests to be run while the rook repo is in the GOPATH.
Now that Rook uses go modules, this is no longer necessary. Allow this
by creating a helper function that unit tests can use that return the
on-host path to the `rook` project root.

Followup of https://github.com/rook/rook/pull/7119/commits/15a487cd5aa5d4dc59bc15ef610cb182257d9287

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
