### PR TITLE
ceph: Remove obsolete init containers from mgr that were used to init the binding addresses

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -25,7 +25,6 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
-	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -113,31 +112,6 @@ func TestHostNetwork(t *testing.T) {
 
 	assert.Equal(t, true, c.spec.Network.IsHost())
 	assert.Equal(t, v1.DNSClusterFirstWithHostNet, d.Spec.Template.Spec.DNSPolicy)
-}
-
-func TestHttpBindFix(t *testing.T) {
-	clientset := optest.New(t, 1)
-	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
-	clusterInfo.SetName("test")
-	clusterSpec := cephv1.ClusterSpec{
-		Dashboard:       cephv1.DashboardSpec{Enabled: true, Port: 1234},
-		DataDirHostPath: "/var/lib/rook/",
-	}
-	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")
-
-	mgrTestConfig := mgrConfig{
-		DaemonID:     "a",
-		ResourceName: "mgr-a",
-		DataPathMap:  config.NewStatelessDaemonDataPathMap(config.MgrType, "a", "rook-ceph", "/var/lib/rook/"),
-	}
-
-	c.clusterInfo.CephVersion = cephver.Nautilus
-	expectedInitContainers := 3
-	d, err := c.makeDeployment(&mgrTestConfig)
-	assert.NoError(t, err)
-	assert.NotNil(t, d)
-	assert.Equal(t, expectedInitContainers,
-		len(d.Spec.Template.Spec.InitContainers))
 }
 
 func TestApplyPrometheusAnnotations(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The pod IP address is no longer needed for port binding for the dashboard and prometheus endpoints in the mgr modules. The default binding to localhost will be sufficient. This will allow the endpoints to be more reliable in some environments where today the podIP is not working.

This is the follow-up PR to #7151 that should stay in master to be included in v1.6. Let's merge #7151 before this one...

See the analysis [here](https://github.com/rook/rook/issues/2526#issuecomment-764976286) for why this change is needed.

**Which issue is resolved by this Pull Request:**
Resolves #2526  

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
