### PR TITLE
ceph: skip pdb reconcile on create and delete events

### DIFF
--- a/pkg/operator/ceph/disruption/clusterdisruption/add.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/add.go
@@ -46,7 +46,7 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 		return errors.Wrap(err, "failed to add ceph scheme to manager scheme")
 	}
 
-	// this will be used to associate namespaces and cephclusters.
+	// This will be used to associate namespaces and cephclusters.
 	sharedClusterMap := &ClusterMap{}
 
 	reconcileClusterDisruption := &ReconcileClusterDisruption{
@@ -86,14 +86,23 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 		return err
 	}
 
+	// Only reconcile for PDB update event when allowed disruptions for the main OSD PDB is 0.
+	// This means that one of the OSD is down due to node drain or any other reason
 	pdbPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Do not reconcile when PDB is created
+			return false
+		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			pdb, ok := e.ObjectNew.DeepCopyObject().(*policyv1beta1.PodDisruptionBudget)
 			if !ok {
 				return false
 			}
-			// only reconcile if allowed disruptions is 0 in the main PDB
 			return pdb.Name == osdPDBAppName && pdb.Status.DisruptionsAllowed == 0
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Do not reconcile when PDB is deleted
+			return false
 		},
 	}
 


### PR DESCRIPTION
This PR makes create and delete events on pdb a no-op. Update event only triggers reconcile if its the main OSD pdb and allowed disruptions is 0.
This prevents controller to reconcile on pdb events namespaces outside rook ceph.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit b780e5b5c052bac61d8b6498c4e68c1d103d202e)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
