### PR TITLE
ceph: always override existing block for blkdevmapper

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -200,6 +200,35 @@ curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_KV_VERS"/"$VAULT_BACKEND_PATH"/"$KEK_NAM
 # Put the KEK in a file for cryptsetup to read
 python3 -c "import sys, json; print(json.load(sys.stdin)[\"data\"][\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
 `
+
+	// If the disk identifier changes (different major and minor) we must force copy
+	// --remove-destination will remove each existing destination file before attempting to open it
+	// We **MUST** do this otherwise in environment where PVCs are dynamic, restarting the deployment will cause conflicts
+	// When restarting the OSD, the PVC block might end up with a different Kernel disk allocation
+	// For instance, prior to restart the block was mapped to 8:32 and when re-attached it was on 8:16
+	// The previous "block" is still 8:32 so if we don't override it we will try to initialize on a disk that is not an OSD or worse another OSD
+	// This is mainly because in https://github.com/rook/rook/commit/ae8dcf7cc3b51cf8ca7da22f48b7a58887536c4f we switched to use HostPath to store the OSD data
+	// Since HostPath is not ephemeral, the block file must be re-hydrated each time the deployment starts
+	blockDevMapper = `
+set -xe
+
+PVC_SOURCE=%s
+PVC_DEST=%s
+CP_ARGS=(--archive --dereference --verbose)
+
+if [ -b "$PVC_DEST" ]; then
+	PVC_SOURCE_MAJ_MIN=$(stat --format '%%t%%T' $PVC_SOURCE)
+	PVC_DEST_MAJ_MIN=$(stat --format '%%t%%T' $PVC_DEST)
+	if [[ "$PVC_SOURCE_MAJ_MIN" == "$PVC_DEST_MAJ_MIN" ]]; then
+		CP_ARGS+=(--no-clobber)
+	else
+		echo "PVC's source major/minor numbers changed"
+		CP_ARGS+=(--remove-destination)
+	fi
+fi
+
+cp "${CP_ARGS[@]}" "$PVC_SOURCE" "$PVC_DEST"
+`
 )
 
 // OSDs on PVC using a certain fast storage class need to do some tuning
@@ -224,13 +253,6 @@ var defaultTuneSlowSettings = []string{
 	"--osd-recovery-sleep=0.1", // Time in seconds to sleep before next recovery or backfill op
 	"--osd-snap-trim-sleep=2",  // Time in seconds to sleep before next snap trim
 	"--osd-delete-sleep=2",     // Time in seconds to sleep before next removal transaction
-}
-
-var cpArgs = []string{
-	"--archive",     // Archive mode preserves the specified attributes
-	"--dereference", // always follow symbolic links in SOURCE to avoid broken links when copying dm devs
-	"--no-clobber",  // do not overwrite an existing file
-	"--verbose",
 }
 
 func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionConfig *provisionConfig) (*apps.Deployment, error) {
@@ -706,9 +728,10 @@ func (c *Cluster) getPVCInitContainer(osdProps osdProperties) v1.Container {
 		Name:  blockPVCMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.pvc.ClaimName), fmt.Sprintf("/mnt/%s", osdProps.pvc.ClaimName)),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.pvc.ClaimName), fmt.Sprintf("/mnt/%s", osdProps.pvc.ClaimName)),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.pvc.ClaimName,
@@ -737,9 +760,10 @@ func (c *Cluster) getPVCInitContainerActivate(mountPath string, osdProps osdProp
 		Name:  blockPVCMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.pvc.ClaimName), cpDestinationName),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.pvc.ClaimName), cpDestinationName),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.pvc.ClaimName,
@@ -840,9 +864,10 @@ func (c *Cluster) generateEncryptionCopyBlockContainer(resources v1.ResourceRequ
 		Name:  containerName,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, encryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
 		},
-		Args: append(cpArgs, encryptionDMPath(pvcName, blockType), path.Join(mountPath, blockName)),
 		// volumeMountPVCName is crucial, especially when the block we copy is the metadata block
 		// its value must be the name of the block PV so that all init containers use the same bridge (the emptyDir shared by all the init containers)
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, volumeMountPVCName), getDeviceMapperMount()},
@@ -877,9 +902,10 @@ func (c *Cluster) getPVCMetadataInitContainer(mountPath string, osdProps osdProp
 		Name:  blockPVCMetadataMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.metadataPVC.ClaimName), fmt.Sprintf("/srv/%s", osdProps.metadataPVC.ClaimName)),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.metadataPVC.ClaimName), fmt.Sprintf("/srv/%s", osdProps.metadataPVC.ClaimName)),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.metadataPVC.ClaimName,
@@ -913,9 +939,10 @@ func (c *Cluster) getPVCMetadataInitContainerActivate(mountPath string, osdProps
 		Name:  blockPVCMetadataMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.metadataPVC.ClaimName), cpDestinationName),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.metadataPVC.ClaimName), cpDestinationName),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.metadataPVC.ClaimName,
@@ -935,9 +962,10 @@ func (c *Cluster) getPVCWalInitContainer(mountPath string, osdProps osdPropertie
 		Name:  blockPVCWalMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.walPVC.ClaimName), fmt.Sprintf("/wal/%s", osdProps.walPVC.ClaimName)),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.walPVC.ClaimName), fmt.Sprintf("/wal/%s", osdProps.walPVC.ClaimName)),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.walPVC.ClaimName,
@@ -971,9 +999,10 @@ func (c *Cluster) getPVCWalInitContainerActivate(mountPath string, osdProps osdP
 		Name:  blockPVCWalMapperInitContainer,
 		Image: c.spec.CephVersion.Image,
 		Command: []string{
-			"cp",
+			"/bin/bash",
+			"-c",
+			fmt.Sprintf(blockDevMapper, fmt.Sprintf("/%s", osdProps.walPVC.ClaimName), cpDestinationName),
 		},
-		Args: append(cpArgs, fmt.Sprintf("/%s", osdProps.walPVC.ClaimName), cpDestinationName),
 		VolumeDevices: []v1.VolumeDevice{
 			{
 				Name:       osdProps.walPVC.ClaimName,


### PR DESCRIPTION
**Description of your changes:**

When the blkdevmapper init container initializes we must override any
existing special block. This will prevent re-using a different disk on
the OSD on PVC scenario.

Adding "--remove-destination" to the cp line will remove each existing
destination file before attempting to open it.
We **MUST** do this otherwise in an environment where PVCs are dynamic, restarting the deployment will cause conflicts
When restarting the OSD, the PVC block might end up with a different Kernel disk allocation
For instance, prior to restart, the block was mapped to 8:32 and when re-attached it was on 8:16
The previous "block" is still 8:32 so if we don't override it we will try to initialize on a disk that is not an OSD or worse another OSD
This is mainly because in https://github.com/rook/rook/commit/ae8dcf7cc3b51cf8ca7da22f48b7a58887536c4f we switched to use HostPath to store the OSD data
Since HostPath is not ephemeral, the block file must be re-hydrated each time the deployment starts

The test uses "==" instead of numbers since the stat command will print
a hex number and thus we won't always get an integer, e,g: major/minor
value 202:13312 will be return ca:3400.

Example run:

```
+ PVC_SOURCE=/set1-data-168h7m
+ PVC_DEST=/var/lib/ceph/osd/ceph-0/block
+ CP_ARGS=(--archive --dereference --verbose)
+ '[' -b /var/lib/ceph/osd/ceph-0/block ']'
++ stat -c %t%T /set1-data-168h7m
+ PVC_SOURCE_MAJ_MIN=ca6100
++ stat -c %t%T /var/lib/ceph/osd/ceph-0/block
PVC's source major/minor numbers changed
removed '/var/lib/ceph/osd/ceph-0/block'
'/set1-data-168h7m' -> '/var/lib/ceph/osd/ceph-0/block'
+ PVC_DEST_MAJ_MIN=ca4000
+ [[ ca6100 == \c\a\4\0\0\0 ]]
+ echo 'PVC'\''s source major/minor numbers changed'
+ CP_ARGS+=(--remove-destination)
+ cp --archive --dereference --verbose --remove-destination /set1-data-168h7m /var/lib/ceph/osd/ceph-0/block
```

Test procedure:

```
$ oc -n rook-ceph scale deployment rook-ceph-osd-0 --replicas=2
deployment.apps/rook-ceph-osd-0 scaled
```

Now we have 2 OSDs and one is crashlooping, which is expected:

```
rook-ceph-osd-0-66964f6d-2cwqq                              0/1     Init:CrashLoopBackOff   4          2m12s
rook-ceph-osd-0-66964f6d-pmhlq                              1/1     Running                 0          6m7s
```

The logs from the failing container is pretty clear:

```
$ oc logs rook-ceph-osd-0-66964f6d-2cwqq --all-containers
+ PVC_SOURCE=/set1-data-168h7m
+ PVC_DEST=/var/lib/ceph/osd/ceph-0/block
+ CP_ARGS=(--archive --dereference --verbose)
+ '[' -b /var/lib/ceph/osd/ceph-0/block ']'
++ stat -c %t%T /set1-data-168h7m
+ PVC_SOURCE_MAJ_MIN=ca6100
++ stat -c %t%T /var/lib/ceph/osd/ceph-0/block
+ PVC_DEST_MAJ_MIN=ca6100
+ [[ ca6100 == \c\a\6\1\0\0 ]]
+ CP_ARGS+=(--no-clobber)
+ cp --archive --dereference --verbose --no-clobber /set1-data-168h7m /var/lib/ceph/osd/ceph-0/block
inferring bluefs devices from bluestore path
/home/jenkins-build/build/workspace/ceph-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/15.2.8/rpm/el8/BUILD/ceph-15.2.8/src/os/bluestore/BlueStore.cc: In function 'int BlueStore::expand_devices(std::ostream&)' thread 7f2a52d18240 time 2021-02-09T13:27:46.011397+0000
/home/jenkins-build/build/workspace/ceph-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos8/DIST/centos8/MACHINE_SIZE/gigantic/release/15.2.8/rpm/el8/BUILD/ceph-15.2.8/src/os/bluestore/BlueStore.cc: 7090: FAILED ceph_assert(r == 0)
2021-02-09T13:27:46.010+0000 7f2a52d18240 -1 bluestore(/var/lib/ceph/osd/ceph-0) _lock_fsid failed to lock /var/lib/ceph/osd/ceph-0/fsid (is another ceph-osd still running?)(11) Resource temporarily unavailable
 ceph version 15.2.8 (bdf3eebcd22d7d0b3dd4d5501bee5bac354d5b55) octopus (stable)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x158) [0x7f2a48e236e4]
```

 Acquiring the lock fails, so the OSD won't run.
 Now we scale back down:

```
$ oc -n rook-ceph scale deployment rook-ceph-osd-0 --replicas=1
deployment.apps/rook-ceph-osd-0 scaled
```

And we can see the last created OSD (the one crash looping) disappears:

```
rook-ceph-osd-0-66964f6d-2cwqq                              0/1     Terminating   5          3m6s
rook-ceph-osd-0-66964f6d-pmhlq                              1/1     Running       0          7m1s
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
