### PR TITLE
ceph: filesystem is not required for nfs server deployment

### DIFF
--- a/Documentation/ceph-nfs-crd.md
+++ b/Documentation/ceph-nfs-crd.md
@@ -12,9 +12,9 @@ Rook allows exporting NFS shares of the filesystem or object store through the C
 
 ## Samples
 
-The following sample will create a two-node active-active cluster of NFS Ganesha gateways. A CephFS named `myfs` is used, and the recovery objects are stored in a RADOS pool named `myfs-data0` with a RADOS namespace of `nfs-ns`.
+The following sample will create a two-node active-active cluster of NFS Ganesha gateways. The recovery objects are stored in a RADOS pool named `myfs-data0` with a RADOS namespace of `nfs-ns`.
 
-This example requires the filesystem to first be configured by the [Filesystem](ceph-filesystem-crd.md).
+This example requires the filesystem to first be configured by the [Filesystem](ceph-filesystem-crd.md) because here recovery objects are stored in filesystem data pool.
 
 > **NOTE**: For an RGW object store, a data pool of `my-store.rgw.buckets.data` can be used after configuring the [Object Store](ceph-object-store-crd.md).
 

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -277,11 +277,10 @@ func validateGanesha(context *clusterd.Context, clusterInfo *cephclient.ClusterI
 		return errors.New("at least one active server required")
 	}
 
-	// We cannot run an NFS server if no MDS is running
 	// The existence of the pool provided in n.Spec.RADOS.Pool is necessary otherwise addRADOSConfigFile() will fail
 	_, err := client.GetPoolDetails(context, clusterInfo, n.Spec.RADOS.Pool)
 	if err != nil {
-		return errors.Wrapf(err, "pool %q not found, did the filesystem cr successfully complete?", n.Spec.RADOS.Pool)
+		return errors.Wrapf(err, "pool %q not found", n.Spec.RADOS.Pool)
 	}
 
 	return nil


### PR DESCRIPTION
nfs server requires valid pool for storing nfs-ganesha recovery objects. Only
when filesystem exports are created, filesystem should be configured first.

Signed-off-by: Varsha Rao <varao@redhat.com>