### PR TITLE
ceph: use deployment replicas instead of more deployments for rbd-mirror

### DIFF
--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
@@ -61,60 +62,58 @@ func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) erro
 
 	logger.Infof("configure rbd-mirroring with %d workers", cephRBDMirror.Spec.Count)
 
-	for i := 0; i < cephRBDMirror.Spec.Count; i++ {
-		daemonID := k8sutil.IndexToName(i)
-		resourceName := fmt.Sprintf("%s-%s", AppName, daemonID)
-		daemonConf := &daemonConfig{
-			DaemonID:     daemonID,
-			ResourceName: resourceName,
-			DataPathMap:  config.NewDatalessDaemonDataPathMap(cephRBDMirror.Namespace, r.cephClusterSpec.DataDirHostPath),
-			ownerRef:     *ref,
-		}
-
-		_, err := r.generateKeyring(r.clusterInfo, daemonConf)
-		if err != nil {
-			return errors.Wrapf(err, "failed to generate keyring for %q", resourceName)
-		}
-
-		// Start the deployment
-		d, err := r.makeDeployment(daemonConf, cephRBDMirror)
-		if err != nil {
-			return errors.Wrap(err, "failed to create rbd-mirror deployment")
-		}
-
-		// Set owner ref to cephRBDMirror object
-		err = controllerutil.SetControllerReference(cephRBDMirror, d, r.scheme)
-		if err != nil {
-			return errors.Wrapf(err, "failed to set owner reference for ceph rbd-mirror %q secret", d.Name)
-		}
-
-		// Set the deployment hash as an annotation
-		err = patch.DefaultAnnotator.SetLastAppliedAnnotation(d)
-		if err != nil {
-			return errors.Wrapf(err, "failed to set annotation for deployment %q", d.Name)
-		}
-
-		if _, err := r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Create(ctx, d, metav1.CreateOptions{}); err != nil {
-			if !kerrors.IsAlreadyExists(err) {
-				return errors.Wrapf(err, "failed to create %q deployment", resourceName)
-			}
-			logger.Infof("deployment for rbd-mirror %q already exists. updating if needed", resourceName)
-
-			if err := updateDeploymentAndWait(r.context, r.clusterInfo, d, config.RbdMirrorType, daemonConf.DaemonID, r.cephClusterSpec.SkipUpgradeChecks, false); err != nil {
-				// fail could be an issue updating label selector (immutable), so try del and recreate
-				logger.Debugf("updateDeploymentAndWait failed for rbd-mirror %q. Attempting del-and-recreate. %v", resourceName, err)
-				err = r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Delete(ctx, cephRBDMirror.Name, metav1.DeleteOptions{})
-				if err != nil {
-					return errors.Wrapf(err, "failed to delete rbd-mirror %q during del-and-recreate update attempt", resourceName)
-				}
-				if _, err := r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Create(ctx, d, metav1.CreateOptions{}); err != nil {
-					return errors.Wrapf(err, "failed to recreate rbd-mirror deployment %q during del-and-recreate update attempt", resourceName)
-				}
-			}
-		}
-
-		logger.Infof("%q deployment started", resourceName)
+	daemonID := k8sutil.IndexToName(0)
+	resourceName := fmt.Sprintf("%s-%s", AppName, daemonID)
+	daemonConf := &daemonConfig{
+		DaemonID:     daemonID,
+		ResourceName: resourceName,
+		DataPathMap:  config.NewDatalessDaemonDataPathMap(cephRBDMirror.Namespace, r.cephClusterSpec.DataDirHostPath),
+		ownerRef:     *ref,
 	}
+
+	_, err = r.generateKeyring(r.clusterInfo, daemonConf)
+	if err != nil {
+		return errors.Wrapf(err, "failed to generate keyring for %q", resourceName)
+	}
+
+	// Start the deployment
+	d, err := r.makeDeployment(daemonConf, cephRBDMirror)
+	if err != nil {
+		return errors.Wrap(err, "failed to create rbd-mirror deployment")
+	}
+
+	// Set owner ref to cephRBDMirror object
+	err = controllerutil.SetControllerReference(cephRBDMirror, d, r.scheme)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference for ceph rbd-mirror %q secret", d.Name)
+	}
+
+	// Set the deployment hash as an annotation
+	err = patch.DefaultAnnotator.SetLastAppliedAnnotation(d)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set annotation for deployment %q", d.Name)
+	}
+
+	if _, err := r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Create(ctx, d, metav1.CreateOptions{}); err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			return errors.Wrapf(err, "failed to create %q deployment", resourceName)
+		}
+		logger.Infof("deployment for rbd-mirror %q already exists. updating if needed", resourceName)
+
+		if err := updateDeploymentAndWait(r.context, r.clusterInfo, d, config.RbdMirrorType, daemonConf.DaemonID, r.cephClusterSpec.SkipUpgradeChecks, false); err != nil {
+			// fail could be an issue updating label selector (immutable), so try del and recreate
+			logger.Debugf("updateDeploymentAndWait failed for rbd-mirror %q. Attempting del-and-recreate. %v", resourceName, err)
+			err = r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Delete(ctx, cephRBDMirror.Name, metav1.DeleteOptions{})
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete rbd-mirror %q during del-and-recreate update attempt", resourceName)
+			}
+			if _, err := r.context.Clientset.AppsV1().Deployments(cephRBDMirror.Namespace).Create(ctx, d, metav1.CreateOptions{}); err != nil {
+				return errors.Wrapf(err, "failed to recreate rbd-mirror deployment %q during del-and-recreate update attempt", resourceName)
+			}
+		}
+	}
+
+	logger.Infof("%q deployment started", resourceName)
 
 	// Remove extra rbd-mirror deployments if necessary
 	err = r.removeExtraMirrors(cephRBDMirror)
@@ -133,24 +132,25 @@ func (r *ReconcileCephRBDMirror) removeExtraMirrors(cephRBDMirror *cephv1.CephRB
 		return errors.Wrap(err, "failed to get mirrors")
 	}
 
-	if len(d.Items) <= cephRBDMirror.Spec.Count {
-		logger.Info("no extra daemons to remove")
-		return nil
-	}
+	if len(d.Items) > 1 {
+		for _, deploy := range d.Items {
+			daemonName, ok := deploy.Labels["rbd-mirror"]
+			if !ok {
+				logger.Warningf("unrecognized rbdmirror %s", deploy.Name)
+				continue
+			}
+			index, err := k8sutil.NameToIndex(daemonName)
+			if err != nil {
+				logger.Warningf("unrecognized rbd-mirror %s with label %s", deploy.Name, daemonName)
+				continue
+			}
 
-	for _, deploy := range d.Items {
-		daemonName, ok := deploy.Labels["rbd-mirror"]
-		if !ok {
-			logger.Warningf("unrecognized rbdmirror %s", deploy.Name)
-			continue
-		}
-		index, err := k8sutil.NameToIndex(daemonName)
-		if err != nil {
-			logger.Warningf("unrecognized rbd-mirror %s with label %s", deploy.Name, daemonName)
-			continue
-		}
-		if index >= cephRBDMirror.Spec.Count {
-			logger.Infof("removing extra rbd-mirror %q", daemonName)
+			// This is rook-ceph-rbd-mirror-a, we must not touch it!
+			if index == 0 {
+				continue
+			}
+
+			logger.Infof("removing legacy rbd-mirror %q", daemonName)
 			var gracePeriod int64
 			propagation := metav1.DeletePropagationForeground
 			deleteOpts := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagation}
@@ -158,8 +158,15 @@ func (r *ReconcileCephRBDMirror) removeExtraMirrors(cephRBDMirror *cephv1.CephRB
 				logger.Warningf("failed to delete rbd-mirror %q. %v", daemonName, err)
 			}
 
-			logger.Infof("removed rbd-mirror %q", daemonName)
+			// remove the cephx key
+			err = client.AuthDelete(r.context, r.clusterInfo, fullDaemonName(daemonName))
+			if err != nil {
+				return err
+			}
+
+			logger.Infof("removed legacy rbd-mirror %q", daemonName)
 		}
 	}
+
 	return nil
 }

--- a/pkg/operator/ceph/cluster/rbd/mirror_test.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rbd for mirroring
+package rbd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	apps "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRemoveExtraMirrors(t *testing.T) {
+
+	name := "my-mirror"
+	namespace := "rook-ceph"
+
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			if args[0] == "auth" && args[1] == "del" {
+				return "success", nil
+			}
+			return "", nil
+		},
+	}
+	clientset := test.New(t, 3)
+	c := &clusterd.Context{
+		Executor:      executor,
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     clientset,
+	}
+
+	r := &ReconcileCephRBDMirror{
+		context:     c,
+		clusterInfo: &client.ClusterInfo{Namespace: namespace},
+	}
+
+	rbdMirror := &cephv1.CephRBDMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cephv1.RBDMirroringSpec{
+			Count: 1,
+		},
+		TypeMeta: controllerTypeMeta,
+	}
+
+	labels := map[string]string{
+		k8sutil.AppAttr:     AppName,
+		k8sutil.ClusterAttr: r.clusterInfo.Namespace,
+	}
+
+	ctx := context.TODO()
+	for _, d := range []string{"a", "b"} {
+		deployment := &apps.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("rbd-mirror-%s", d),
+				Namespace: r.clusterInfo.Namespace,
+				Labels:    labels,
+			},
+		}
+		deployment.Labels["rbd-mirror"] = d
+		_, err := r.context.Clientset.AppsV1().Deployments(r.clusterInfo.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+	deps, err := r.context.Clientset.AppsV1().Deployments(r.clusterInfo.Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", AppName)})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(deps.Items))
+
+	err = r.removeExtraMirrors(rbdMirror)
+	assert.NoError(t, err)
+
+	deps, err = r.context.Clientset.AppsV1().Deployments(r.clusterInfo.Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", AppName)})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(deps.Items))
+}

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -79,7 +79,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 		podSpec.Spec.Volumes[0].VolumeSource.Projected.Sources = append(podSpec.Spec.Volumes[0].VolumeSource.Projected.Sources, volProjection...)
 	}
 
-	replicas := int32(1)
+	replicas := int32(rbdMirror.Spec.Count)
 	d := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        daemonConfig.ResourceName,


### PR DESCRIPTION
**Description of your changes:**

We now rely on the "replica" setting in the Deployment spec when the
desired instance count is higher than 1 instead of creating another
deployment.
So now, we don't need to the number of deployments anymore and let
kubernetes handles the number of pods.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
