### PR TITLE
ceph: Reenable the mgr test suite in the Github action

### DIFF
--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -43,6 +43,8 @@ jobs:
     - name: TestCephMgrSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+       # Always run the mgr suite in the github action by indicating it's not an official build
+       export TEST_CEPH_MASTER=true
        go test -v -timeout 1800s -run CephMgrSuite github.com/rook/rook/tests/integration
 
     - name: Artifact

--- a/tests/framework/installer/environment.go
+++ b/tests/framework/installer/environment.go
@@ -35,6 +35,11 @@ func testStorageProvider() string {
 	return getEnvVarWithDefault("STORAGE_PROVIDER_TESTS", "")
 }
 
+// TestRunCephMaster gets whether tests can be run against ceph master
+func TestRunCephMaster() bool {
+	return getEnvVarWithDefault("TEST_CEPH_MASTER", "") == "true"
+}
+
 // TestIsOfficialBuild gets the storage provider for which tests should be run
 func TestIsOfficialBuild() bool {
 	// PRs will set this to "false", but the official build will not set it, so we compare against "false"

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -46,12 +46,10 @@ func TestCephMgrSuite(t *testing.T) {
 	}
 	// Skip this test suite in master and release builds. If there is an issue
 	// running against Ceph master we don't want to block the official builds.
-	if installer.TestIsOfficialBuild() {
+	if !installer.TestRunCephMaster() {
+		logger.Infof("Skipping tests against Ceph master")
 		t.Skip()
 	}
-
-	logger.Info("TEMPORARILY disable the mgr test suite until https://github.com/rook/rook/issues/5877 is resolved")
-	t.Skip()
 
 	s := new(CephMgrSuite)
 	defer func(s *CephMgrSuite) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mgr test suite had been disabled due to instability of the ceph master builds with the mgr module. Now we reenable it in the github action since we can more easily ignore the failed tests instead of it blocking the release builds. The tests will not be run in Jenkins.

**Which issue is resolved by this Pull Request:**
Resolves #5877

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
