### PR TITLE
ceph: do not merge nodeAffinity

### DIFF
--- a/pkg/apis/rook.io/v1/placement.go
+++ b/pkg/apis/rook.io/v1/placement.go
@@ -24,12 +24,12 @@ func (p PlacementSpec) All() Placement {
 }
 
 // ApplyToPodSpec adds placement to a pod spec
-func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
+func (p Placement) ApplyToPodSpec(t *v1.PodSpec, merge bool) {
 	if t.Affinity == nil {
 		t.Affinity = &v1.Affinity{}
 	}
 	if p.NodeAffinity != nil {
-		t.Affinity.NodeAffinity = p.mergeNodeAffinity(t.Affinity.NodeAffinity)
+		t.Affinity.NodeAffinity = p.mergeNodeAffinity(t.Affinity.NodeAffinity, merge)
 	}
 	if p.PodAffinity != nil {
 		t.Affinity.PodAffinity = p.PodAffinity.DeepCopy()
@@ -45,7 +45,7 @@ func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
 	}
 }
 
-func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity) *v1.NodeAffinity {
+func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity, merge bool) *v1.NodeAffinity {
 	// no node affinity is specified yet, so return the placement's nodeAffinity
 	result := p.NodeAffinity.DeepCopy()
 	if nodeAffinity == nil {
@@ -53,9 +53,11 @@ func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity) *v1.NodeAffi
 	}
 
 	// merge the preferred node affinity that was already specified, and the placement's nodeAffinity
-	result.PreferredDuringSchedulingIgnoredDuringExecution = append(
-		nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
-		p.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	if merge {
+		result.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			p.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution...)
+	}
 
 	// nothing to merge if no affinity was passed in
 	if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
@@ -80,14 +82,16 @@ func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity) *v1.NodeAffi
 
 	// merge the match expressions together since they are defined in both placements
 	// this will only work if we want an "and" between all the expressions, more complex conditions won't work with this merge
-	var nodeTerm v1.NodeSelectorTerm
-	nodeTerm.MatchExpressions = append(
-		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions,
-		p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions...)
-	nodeTerm.MatchFields = append(
-		nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields,
-		p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields...)
-	result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0] = nodeTerm
+	if merge {
+		var nodeTerm v1.NodeSelectorTerm
+		nodeTerm.MatchExpressions = append(
+			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions,
+			p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions...)
+		nodeTerm.MatchFields = append(
+			nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields,
+			p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchFields...)
+		result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0] = nodeTerm
+	}
 
 	return result
 }

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -157,7 +157,7 @@ func (c *ClusterController) cleanUpJobTemplateSpec(cluster *cephv1.CephCluster, 
 	cephv1.GetCleanupLabels(cluster.Spec.Labels).ApplyToObjectMeta(&podSpec.ObjectMeta)
 
 	// Apply placement
-	cephv1.GetCleanupPlacement(cluster.Spec.Placement).ApplyToPodSpec(&podSpec.Spec)
+	cephv1.GetCleanupPlacement(cluster.Spec.Placement).ApplyToPodSpec(&podSpec.Spec, true)
 
 	return podSpec
 }

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -85,7 +85,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 	cephv1.GetMgrAnnotations(c.spec.Annotations).ApplyToObjectMeta(&podSpec.ObjectMeta)
 	c.applyPrometheusAnnotations(&podSpec.ObjectMeta)
 	cephv1.GetMgrLabels(c.spec.Labels).ApplyToObjectMeta(&podSpec.ObjectMeta)
-	cephv1.GetMgrPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec.Spec)
+	cephv1.GetMgrPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec.Spec, true)
 
 	replicas := int32(1)
 

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -153,14 +153,13 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 	if c.spec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
-
+	// we are passing false in case of osd and prepare pods because we don't want to overlap placement of osd on PVC's and non-PVC's.
 	p := cephv1.GetOSDPlacement(c.spec.Placement)
-	if !osdProps.onPVC() {
-		p.ApplyToPodSpec(&podSpec)
-	} else {
-		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec)
-		p.ApplyToPodSpec(&podSpec)
+	if osdProps.onPVC() {
+		osdProps.getPreparePlacement().ApplyToPodSpec(&podSpec, false)
 	}
+	p.ApplyToPodSpec(&podSpec, false)
+
 	k8sutil.RemoveDuplicateEnvVars(&podSpec)
 
 	podMeta := metav1.ObjectMeta{

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -639,13 +639,13 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.clusterInfo.OwnerRef)
+
+	// we are passing false in case of osd and prepare pods because we don't want to overlap placement of osd on PVC's and non-PVC's.
 	p := cephv1.GetOSDPlacement(c.spec.Placement)
-	if !osdProps.onPVC() {
-		p.ApplyToPodSpec(&deployment.Spec.Template.Spec)
-	} else {
-		osdProps.placement.ApplyToPodSpec(&deployment.Spec.Template.Spec)
-		p.ApplyToPodSpec(&deployment.Spec.Template.Spec)
+	if osdProps.onPVC() {
+		osdProps.getPreparePlacement().ApplyToPodSpec(&deployment.Spec.Template.Spec, false)
 	}
+	p.ApplyToPodSpec(&deployment.Spec.Template.Spec, false)
 
 	// Change TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES if the OSD has been annotated with a value
 	osdAnnotations := cephv1.GetOSDAnnotations(c.spec.Annotations)

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -67,7 +67,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 			return nil, err
 		}
 	}
-	rbdMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec)
+	rbdMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec, true)
 
 	// If the rbd mirror has a peer we must add the relevant ceph config file and key to connect to it
 	// Both cm and secret have been created already, so it's fine to just reference them

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -131,7 +131,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 	job.Spec.Template.Spec.ServiceAccountName = "rook-ceph-cmd-reporter"
 
 	// Apply the same placement for the ceph version detection as the mon daemons except for PodAntiAffinity
-	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)
+	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec, true)
 	job.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
 
 	stdout, stderr, retcode, err := versionReporter.Run(timeout)

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -75,7 +75,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) (*apps.Deployment, error)
 
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&podSpec.ObjectMeta)
 	c.fs.Spec.MetadataServer.Labels.ApplyToObjectMeta(&podSpec.ObjectMeta)
-	c.fs.Spec.MetadataServer.Placement.ApplyToPodSpec(&podSpec.Spec)
+	c.fs.Spec.MetadataServer.Placement.ApplyToPodSpec(&podSpec.Spec, true)
 
 	replicas := int32(1)
 	d := &apps.Deployment{

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -67,7 +67,7 @@ func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, f
 			return nil, err
 		}
 	}
-	fsMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec)
+	fsMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec, true)
 
 	replicas := int32(1)
 	d := &apps.Deployment{

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -138,7 +138,7 @@ func (r *ReconcileCephNFS) makeDeployment(nfs *cephv1.CephNFS, cfg daemonConfig)
 	if r.cephClusterSpec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
-	nfs.Spec.Server.Placement.ApplyToPodSpec(&podSpec)
+	nfs.Spec.Server.Placement.ApplyToPodSpec(&podSpec, true)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -324,7 +324,7 @@ func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 // SetNodeAntiAffinityForPod assign pod anti-affinity when pod should not be co-located
 func SetNodeAntiAffinityForPod(pod *v1.PodSpec, p rookv1.Placement, requiredDuringScheduling bool,
 	labels, nodeSelector map[string]string) {
-	p.ApplyToPodSpec(pod)
+	p.ApplyToPodSpec(pod, true)
 	pod.NodeSelector = nodeSelector
 
 	// when a node selector is being used, skip the affinity business below


### PR DESCRIPTION
we don't want to merge the node affinity if specified in both
storageClassDeviceSet and placement. 

**Description of your changes:**
Now, we are passing new
a boolean argument in `ApplyToPodSpec` which will be false in 
case of osd and prepare pods only because we don't want to overlap 
placement of osd on PVC's and non-PVC's.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #7176 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
