### PR TITLE
ceph: expose vault curl errors

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -160,7 +160,7 @@ KEK_NAME=%s
 KEY_PATH=%s
 VAULT_DEFAULT_KV_VERS=v1
 CURL_PAYLOAD=$(mktemp)
-ARGS=(--request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
+ARGS=(--silent --request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
 
 # If a vault namespace is set
 if [ -n "$VAULT_NAMESPACE" ]; then

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -197,6 +197,11 @@ fi
 # Get the Key Encryption Key
 curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_KV_VERS"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
 
+# Check for errors in the payload
+if python3 -c "import sys, json; print(json.load(sys.stdin)[\"errors\"], end='')" 2> /dev/null < a; then
+	exit 1
+fi
+
 # Put the KEK in a file for cryptsetup to read
 python3 -c "import sys, json; print(json.load(sys.stdin)[\"data\"][\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
 `


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

    If the Vault server returns an error, we must report it in the init
    container. With this we can properly debug a failing init container.
    
    Resulting container log:
    
    ```
    oc logs rook-ceph-osd-0-dc6d4d4d-445dg -c encryption-kms-get-kek                                                                                                                                                                                                        
    ['error performing token check: Vault is sealed']%
    ```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
