### PR TITLE
ceph: do not print pointer memory address

### DIFF
--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -103,7 +103,10 @@ func DiscoverDevices(executor exec.Executor) ([]*sys.LocalDisk, error) {
 
 		disks = append(disks, disk)
 	}
-	logger.Debugf("discovered disks are %v", disks)
+	logger.Debug("discovered disks are:")
+	for _, disk := range disks {
+		logger.Debugf("%+v", disk)
+	}
 
 	return disks, nil
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -331,7 +331,11 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsdMapping, error) {
 	desiredDevices := agent.devices
 	logger.Debugf("desiredDevices are %+v", desiredDevices)
-	logger.Debugf("context.Devices are %+v", context.Devices)
+
+	logger.Debug("context.Devices are:")
+	for _, disk := range context.Devices {
+		logger.Debugf("%+v", disk)
+	}
 
 	available := &DeviceOsdMapping{Entries: map[string]*DeviceOsdIDEntry{}}
 	for _, device := range context.Devices {


### PR DESCRIPTION
When printing pointers of struct (regardless if it is also a slice or
not) we must implement a stringer interface so they can be displayed
properly, this is especially useful when looking at the prepare job
logs.

Before this patch:

```
2021-02-10 06:39:06.783508 D | inventory: discovered disks are [0xc00029c240 0xc00024a000 0xc00086c480 0xc00024a480]
```

After this patch:

```
2021-02-11 13:05:15.730500 D | inventory: discovered disks are:
2021-02-11 13:05:15.730636 D | inventory: &{Name:dm-0 Parent: HasChildren:false DevLinks:/dev/disk/by-id/dm-uuid-LVM-aIFRq5P3hwE2YhukbOmsEZoLY61HxvX62A1xxb6ajTymVE0N8S4Ga0KWlHSgpvNw /dev/disk/by-id/dm-name-ceph--e29bf82e--86f1--4c8e--8412--c468def5a844-osd--block--2044a1ea--6e5e--4423--88cf--8947bf6957d1 Size:32208060416 UUID:91a852c2-8727-4277-9d92-879ee1996503 Serial: Type:lvm Rotational:true Readonly:false Partitions:[] Filesystem:ceph_bluestore Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/mapper/ceph--e29bf82e--86f1--4c8e--8412--c468def5a844-osd--block--2044a1ea--6e5e--4423--88cf--8947bf6957d1 KernelName:dm-0 Encrypted:false}
2021-02-11 13:05:15.730657 D | inventory: &{Name:dm-1 Parent: HasChildren:false DevLinks:/dev/disk/by-id/dm-uuid-LVM-GyLVW5UxDRcws8PwsbQuY2CjrQwdn1VxgPQjsKZ2pGVaS1r2Ct0OGZ4P80yEMtqW /dev/disk/by-id/dm-name-ceph--334c640f--7a7f--4fdb--9db4--2f9459e19f9a-osd--block--66ce11c8--20f0--4600--ae50--e8849c9a0af6 Size:32208060416 UUID:cdbcb218-1b03-4d8c-b7d2-25cb88e33b6a Serial: Type:lvm Rotational:true Readonly:false Partitions:[] Filesystem:ceph_bluestore Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/mapper/ceph--334c640f--7a7f--4fdb--9db4--2f9459e19f9a-osd--block--66ce11c8--20f0--4600--ae50--e8849c9a0af6 KernelName:dm-1 Encrypted:false}
2021-02-11 13:05:15.730686 D | inventory: &{Name:dm-2 Parent: HasChildren:false DevLinks:/dev/disk/by-id/dm-name-ceph--a011b5c2--cc3f--497a--b19a--6d284461cbc4-osd--block--4de5491c--ecf8--455d--9858--547001fd0321 /dev/disk/by-id/dm-uuid-LVM-QGzgO4E228fvT3NsighNABGdvAKxQEhFOh9rKiDLnSOTk7jLZWu2r1RIMXe5GNqW Size:32208060416 UUID:2238ce24-79e4-41a0-b8ce-e381ac41d5b0 Serial: Type:lvm Rotational:true Readonly:false Partitions:[] Filesystem:ceph_bluestore Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/mapper/ceph--a011b5c2--cc3f--497a--b19a--6d284461cbc4-osd--block--4de5491c--ecf8--455d--9858--547001fd0321 KernelName:dm-2 Encrypted:false}
2021-02-11 13:05:15.730713 D | inventory: &{Name:vda1 Parent:vda HasChildren:false DevLinks:/dev/disk/by-path/pci-0000:00:05.0-part1 /dev/disk/by-path/virtio-pci-0000:00:05.0-part1 /dev/disk/by-uuid/0fdf5e49-6b3c-42f2-a1c5-bf77e490dfa4 /dev/disk/by-partuuid/f9dd32c9-a4a5-654f-aee4-651276fdc754 /dev/disk/by-label/boot2docker-data Size:19998934528 UUID: Serial: Type:part Rotational:true Readonly:false Partitions:[] Filesystem:ext4 Vendor: Model: WWN: WWNVendorExtension: Empty:false CephVolumeData: RealPath:/dev/vda1 KernelName:vda1 Encrypted:false}
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
