### PR TITLE
ceph: generate cephCluster reconcile result as events

### DIFF
--- a/pkg/operator/k8sutil/events.go
+++ b/pkg/operator/k8sutil/events.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package k8sutil for Kubernetes helpers.
+package k8sutil
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+// EventReporter is custom events reporter type which allows user to limit the events
+type EventReporter struct {
+	recorder record.EventRecorder
+
+	// lastReportedEvent will have a last captured event
+	lastReportedEvent map[string]string
+
+	// lastReportedEventTime will be the time of lastReportedEvent
+	lastReportedEventTime map[string]time.Time
+}
+
+// NewEventReporter returns EventReporter object
+func NewEventReporter(recorder record.EventRecorder) *EventReporter {
+	return &EventReporter{
+		recorder:              recorder,
+		lastReportedEvent:     make(map[string]string),
+		lastReportedEventTime: make(map[string]time.Time),
+	}
+}
+
+// ReportIfNotPresent will report event if lastReportedEvent is not the same in last 60 minutes
+func (rep *EventReporter) ReportIfNotPresent(instance runtime.Object, eventType, eventReason, msg string) {
+
+	nameSpacedName, err := getNameSpacedName(instance)
+	if err != nil {
+		return
+	}
+
+	eventKey := getEventKey(eventType, eventReason, msg)
+
+	if rep.lastReportedEvent[nameSpacedName] != eventKey || rep.lastReportedEventTime[nameSpacedName].Add(time.Minute*60).Before(time.Now()) {
+		logger.Info("Reporting Event ", nameSpacedName, " ", eventKey)
+		rep.lastReportedEvent[nameSpacedName] = eventKey
+		rep.lastReportedEventTime[nameSpacedName] = time.Now()
+		rep.recorder.Event(instance, eventType, eventReason, msg)
+	} else {
+		logger.Debug("Not Reporting Event because event is same as the old one:", nameSpacedName, " ", eventKey)
+	}
+}
+
+func getNameSpacedName(instance runtime.Object) (string, error) {
+	objMeta, err := meta.Accessor(instance)
+	if err != nil {
+		return "", err
+	}
+	return objMeta.GetNamespace() + ":" + objMeta.GetName(), nil
+}
+
+func getEventKey(eventType, eventReason, msg string) string {
+	return fmt.Sprintf("%s:%s:%s", eventType, eventReason, msg)
+}

--- a/pkg/operator/k8sutil/events_test.go
+++ b/pkg/operator/k8sutil/events_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package k8sutil for Kubernetes helpers.
+package k8sutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func getEventsOccurences(channel chan string) map[string]int {
+
+	foundEvents := make(map[string]int)
+
+	for len(channel) > 0 {
+		e := <-channel
+		foundEvents[e]++
+	}
+
+	return foundEvents
+}
+
+func TestReportIfNotPresent(t *testing.T) {
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "rook-ceph",
+		},
+	}
+
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod2",
+			Namespace: "rook-ceph",
+		},
+	}
+
+	testCases := []struct {
+		eventReported                 int
+		changeTime                    bool
+		ReportAnotherEvent            bool
+		ReportEventForDifferentObject bool
+	}{
+		{
+			// verify ReportIfNotPresent is called once and event is reported once
+			eventReported: 1,
+		},
+		{
+			// verify ReportIfNotPresent is called twice and event is reported once
+			eventReported: 2,
+		},
+		{
+			// verify ReportIfNotPresent report same event again when event is not present on cluster
+			eventReported: 1,
+			changeTime:    true,
+		},
+		{
+			// verify ReportIfNotPresent report same event again when event is not present on cluster
+			eventReported: 2,
+			changeTime:    true,
+		},
+		{
+			// verify it report event "a" both the times if events came like "a", "b", "a"
+			eventReported:      1,
+			ReportAnotherEvent: true,
+		},
+		{
+			// verify it report event "a" both the times if events came like "a", "b", "a"
+			eventReported:      2,
+			ReportAnotherEvent: true,
+		},
+		{
+			// verify it does not report the same event for same objects if multiple objects come into the picture
+			eventReported:                 1,
+			ReportEventForDifferentObject: true,
+		},
+		{
+			// verify it does not report the same event for same objects if multiple objects come into the picture
+			eventReported:                 2,
+			ReportEventForDifferentObject: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		eventType, eventReason, eventMsg := corev1.EventTypeNormal, "Created", "Pod has been created"
+
+		frecorder := record.NewFakeRecorder(1024)
+		reporter := NewEventReporter(frecorder)
+
+		for i := 0; i < tc.eventReported; i++ {
+			reporter.ReportIfNotPresent(pod1, eventType, eventReason, eventMsg)
+		}
+
+		foundEvents := getEventsOccurences(frecorder.Events)
+		assert.Equal(t, 1, foundEvents[eventType+" "+eventReason+" "+eventMsg])
+
+		if tc.changeTime {
+			nameSpacedName, err := getNameSpacedName(pod1)
+			assert.NoError(t, err)
+			ftime := reporter.lastReportedEventTime[nameSpacedName].Add(time.Minute * -60)
+			reporter.lastReportedEventTime[nameSpacedName] = ftime
+
+			reporter.ReportIfNotPresent(pod1, eventType, eventReason, eventMsg)
+			foundEvents := getEventsOccurences(frecorder.Events)
+			assert.Equal(t, 1, foundEvents[eventType+" "+eventReason+" "+eventMsg])
+		}
+
+		if tc.ReportAnotherEvent {
+			reporter.ReportIfNotPresent(pod1, corev1.EventTypeWarning, eventReason, eventMsg)
+			foundEvents := getEventsOccurences(frecorder.Events)
+			assert.Equal(t, 1, foundEvents[corev1.EventTypeWarning+" "+eventReason+" "+eventMsg])
+
+			reporter.ReportIfNotPresent(pod1, eventType, eventReason, eventMsg)
+			foundEvents = getEventsOccurences(frecorder.Events)
+			assert.Equal(t, 1, foundEvents[eventType+" "+eventReason+" "+eventMsg])
+		}
+
+		if tc.ReportEventForDifferentObject {
+			reporter.ReportIfNotPresent(pod2, eventType, eventReason, eventMsg)
+			foundEvents := getEventsOccurences(frecorder.Events)
+			assert.Equal(t, 1, foundEvents[eventType+" "+eventReason+" "+eventMsg])
+
+			reporter.ReportIfNotPresent(pod1, eventType, eventReason, eventMsg)
+			foundEvents = getEventsOccurences(frecorder.Events)
+			assert.Equal(t, 0, foundEvents[eventType+" "+eventReason+" "+eventMsg])
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

**Description of your changes:**
PR will add functionality to generate k8s events for the cephCluster

**Which issue is resolved by this Pull Request:**
Resolves #6042

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
