### PR TITLE
ceph: minor bugfix with multiple filesystems

### DIFF
--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -282,7 +282,7 @@ spec:
 {{- end }}
 {{- if .Values.allowMultipleFilesystems }}
         - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
-          value: {{ .Values.allowMultipleFilesystems }}
+          value: {{ .Values.allowMultipleFilesystems | quote }}
 {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}


### PR DESCRIPTION
The multiple filesystems parameter needed to be quoted for kubernetes to accept the parameter, without quotes the environment variable is rejected.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The value needs to be quoted to take effect.

**Which issue is resolved by this Pull Request:**
Resolves #7223

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
