### PR TITLE
ceph: add an encryption check

### DIFF
--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -126,6 +126,16 @@ func ListDevices(executor exec.Executor) ([]string, error) {
 	return strings.Split(devices, "\n"), nil
 }
 
+// GetDiskType returns the filesystem type associated with the disk
+func GetDiskType(executor exec.Executor, device string) (string, error) {
+	diskType, err := executor.ExecuteCommandWithOutput("blkid", "-o", "value", "-s", "TYPE", device)
+	if err != nil {
+		return "", fmt.Errorf("failed to get disk type. %v", err)
+	}
+
+	return diskType, nil
+}
+
 // GetDevicePartitions gets partitions on a given device
 func GetDevicePartitions(device string, executor exec.Executor) (partitions []Partition, unusedSpace uint64, err error) {
 

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -195,4 +196,20 @@ func TestListDevicesChildListDevicesChild(t *testing.T) {
 	child, err := ListDevicesChild(executor, device)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(child))
+}
+
+func TestGetDiskType(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+			logger.Infof("command %s", command)
+			if command == "blkid" {
+				return "crypto_LUKS", nil
+			}
+			return "", errors.Errorf("unknown command %q", command)
+		},
+	}
+
+	device := "/dev/vdb"
+	_, err := GetDiskType(executor, device)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
**Description of your changes:**

When a disk is encrypted, c-v will not be able to report the OSD if the
encrypted disk is not opened. Thus, the "c-v raw list" command will
return nothing when we check if the disk is available.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
