### PR TITLE
ceph: Added Ceph admin scripts for creating read affinity pools.

### DIFF
--- a/cluster/examples/kubernetes/ceph/read-affinity-config/README.md
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/README.md
@@ -1,0 +1,14 @@
+# read-affinity-config
+
+This repo holds the scripts for Ceph/RHCS admin to prepare the cluster for implementing read affinity as part of the Metro DR high availability feature in Red Hat OCS 4.7 release.
+
+In OCS 4.7 this feature is released in dev preview (minimal testing) mode.
+
+The repo holds the following scripts:
+* create-affinity-rules.sh - This scripts creates rules for pools with affinity to data center or availability zone. Currently 2 flavors are supported:
+  * 3 AZs and replica-3: In this case every copy of the data is stored in a different AZ, but all the primary OSDs for the pool are from the same AZ. 
+  * 2 AZs and replica-4: In this case every AZ holds 2 copies of the data, and all the primaries are in the same AZ. In case there are multiple hosts in the AZ, no host will keep 2 versions of the data.
+* check-pool-affinity.sh - This scripts checks if a specified pool has affinity to AZ - this means that all the primary OSDs belong to the same fault domain in the crush tree.
+* add-rules-to-cluster.sh - This script adds one or more rules (which may have been created by create-affinity-rules.sh) to the ceph cluster. This script is separated from the create-affinity-rules.sh, because at the level of maturity of this repo (dev-preview) there is a need for manual review of the created files before applying them to the cluster.
+
+A comprehensive documentation on how to use these tools to create pools with affinity for ceph cluster can be found in https://access.redhat.com/articles/5792521

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/Readme.txt
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/Readme.txt
@@ -1,0 +1,9 @@
+
+This directory includes scripts that help Ceph or RHCS admins
+to manually configure pools with read affinity in multi availability
+zone Ceph cluster.
+
+The complete documentation on how to configure read affinity pools 
+with these scripts can be found in 
+https://access.redhat.com/articles/5792521
+

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/add-rules-to-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/add-rules-to-cluster.sh
@@ -100,7 +100,7 @@ function get_rule_data() {
 	##
 	# get arrays with the existing rule names and ids so we can check that new rules do not contradict
 	# with existing ones (can happen if running the scripts more than once). Fixing is not automated yet since
-	# rules might be used, and overrriding them can be dangerous.
+	# rules might be used, and overriding them can be dangerous.
 	##
 	rule_ids=( $($CEPH osd crush rule dump | awk ' /rule_id/ { gsub(",",""); print $2}') ) 
 	(( $verbose == 1 )) && echo " Rule ids=<${rule_ids[@]}>"
@@ -111,15 +111,15 @@ function get_rule_data() {
 
 function check_and_append_rule() {
 	##
-	# Check that the rule in the rule file is a new rule (meaning the rule name or id are not alreasy used
+	# Check that the rule in the rule file is a new rule (meaning the rule name or id are not already used
 	# in the ceph cluster). Additionally this rule increment the counter for valid rules (processed_rules) or for 
 	# duplicate rules (warnings)
 	# This function returns:
 	#     0 - If the file was processed (appended to the rules text file)
 	#     1 - The rule in the file has id of an existing rule 
 	#     2 - The rule in the file has name of an existing rule
-	#     3 - The file does not contain a vaild rule
-	#     4 - The file contains more than one rule - this is not supported in this verison of
+	#     3 - The file does not contain a valid rule
+	#     4 - The file contains more than one rule - this is not supported in this version of
 	#         the script.
 	#
 	# NOTE:

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/add-rules-to-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/add-rules-to-cluster.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# vim: set ts=4 sw=4 smartindent autoindent:
+
+base_dir=$(dirname "$0")
+data_dir=$base_dir/data
+
+. $data_dir/crush-utils.sh
+
+verbose=0
+
+##
+# create files in the temp directory
+##
+crush_compiled_file=$(mktemp --tmpdir "XXXXXXXX.crush.compiled")
+crush_text_file=$(echo $crush_compiled_file | sed "s/compiled/text/")
+
+orig_crush_ver=0
+new_crush_ver=0
+
+function usage() {
+    #
+    # This function always exits, it never returns
+    #
+	echo
+	echo "Usage: $0 rule-file-name { rule-file-names }"
+	echo "  Take the rule files (text files) and add them to the cluster"
+	echo 
+	exit 1
+}
+
+function cleanup() {
+	##
+	# Remove the temp files
+	##
+	rm -f $crush_text_file
+	rm -f $crush_compiled_file
+}
+
+
+##
+# Find if a value ($1) appears in an array of values ($2)
+# return 1 if the value was found and 0 if the value was not found
+##
+function find_value_in_array() {
+	if [[ -z $1 ]]; then
+		echo_error "Internal problem: No value passed to ${FUNCNAME}()"
+		exit 1
+	fi
+	if [[ -z $2 ]]; then 
+		echo_error "Internal problem: No array passed to ${FUNCNAME}()"
+		exit 1
+	fi
+	element=$1
+	shift 1
+	arr=("$@")
+	arr_str="${arr[@]}"
+    for e in "${arr[@]}"; do
+		if [[ $element == $e ]]; then
+			(( $verbose == 1 )) && echo_dbg "Found $element in $arr_str"
+			return 1
+		fi
+	done
+	(( $verbose == 1 )) && echo_dbg "Could not find $element in $arr_str"
+	return  0
+
+}
+
+function decompile_crush() {
+	## 
+	# get the crush text file,it will be modified by the new affinity based rules 
+	##
+	orig_crush_ver=$($CEPH osd getcrushmap -o $crush_compiled_file 2>&1)
+	(( $verbose == 1 )) && echo " Original crushmap version is $orig_crush_ver"
+	crushtool -d $crush_compiled_file -o $crush_text_file
+	if [[ $? != 0 ]]; then
+		echo_error "Could not decompile $crush_compiled_file"
+		exit 1
+	fi
+}
+
+function compile_and_set_crush() {
+	##
+	# Compile the updated crush text file and then update the crushmap with the compiled file
+	##
+	crushtool -c $crush_text_file -o $crush_compiled_file
+	if [[ $? != 0 ]]; then
+		echo_error "Could not compile file $crush_text_file, exiting"
+		exit 1
+	fi
+	new_crush_ver=$($CEPH osd setcrushmap -i $crush_compiled_file 2>&1)
+	if [[ $? != 0 ]]; then
+		echo_error "Could not set the crushmap from file $crush_text_file, exiting"
+		exit 1
+	fi
+	assert "$orig_crush_ver < $new_crush_ver" $LINENO
+}
+
+function get_rule_data() {
+	##
+	# get arrays with the existing rule names and ids so we can check that new rules do not contradict
+	# with existing ones (can happen if running the scripts more than once). Fixing is not automated yet since
+	# rules might be used, and overrriding them can be dangerous.
+	##
+	rule_ids=( $($CEPH osd crush rule dump | awk ' /rule_id/ { gsub(",",""); print $2}') ) 
+	(( $verbose == 1 )) && echo " Rule ids=<${rule_ids[@]}>"
+	rule_names=( $($CEPH osd crush rule ls) )
+	(( $verbose == 1 )) && echo " Rule names=<${rule_names[@]}>"
+
+}
+
+function check_and_append_rule() {
+	##
+	# Check that the rule in the rule file is a new rule (meaning the rule name or id are not alreasy used
+	# in the ceph cluster). Additionally this rule increment the counter for valid rules (processed_rules) or for 
+	# duplicate rules (warnings)
+	# This function returns:
+	#     0 - If the file was processed (appended to the rules text file)
+	#     1 - The rule in the file has id of an existing rule 
+	#     2 - The rule in the file has name of an existing rule
+	#     3 - The file does not contain a vaild rule
+	#     4 - The file contains more than one rule - this is not supported in this verison of
+	#         the script.
+	#
+	# NOTE:
+	#    At this point the script does not support files with more than one rule in them and 
+	#    rejects such files.
+	##
+	if [[ -z $1 ]]; then
+		echo_error "Internal problem: No parameters passed to ${FUNCNAME}()"
+		exit 1
+	fi
+	local rname=$(cat $1 | awk ' /^rule\s/ {print $2}')
+	local n_rules=$(echo $rname | wc -w)
+	if [[ $n_rules == 0 ]]; then
+		echo " ** No rules found in file $1, skipping the file"
+		return 3
+	elif [[ $n_rules > 1 ]]; then
+		echo " ** File $1 contain more than one rule, this is currently not supported by $0."
+		echo " ** Consider splitting the file, or removing some of the rules."
+		echo " ** skipping file $1"
+		return 4
+	fi
+	find_value_in_array $rname "${rule_names[@]}"
+	if [[ $? == 1 ]]; then
+		echo " ** The ceph cluster already has a rule with name $rname"
+		echo " ** Skipping file $1"
+		return 2
+	fi
+	local rid=$(cat $1 | awk ' /\sid\s/ {print $2}')
+	find_value_in_array $rid "${rule_ids[@]}"
+	if [[ $? == 1 ]]; then
+		echo " ** The ceph cluster already has a rule with id $rid"
+		echo " ** Skipping file $1"
+		return 1 
+	fi
+	if [[ $first_time == 0 ]]; then
+		echo "" >>  $crush_text_file
+		echo "## Read affinity rules" >> $crush_text_file
+		echo "" >>  $crush_text_file
+		first_time=1
+	fi
+	cat $1 >> $crush_text_file
+	return 0
+
+}
+
+##
+# Enable verbose mode without getopt
+##
+if [[ "$1" == "debug" ]]; then
+	echo "running in debug mode"
+	verbose=1
+	shift 1
+fi
+
+if [[ -z $1 ]]; then 
+	echo_error "At least one rule file is required"
+	usage
+fi
+
+(( $verbose == 1 )) && echo " Crush compiled file name is $crush_compiled_file"
+(( $verbose == 1 )) && echo " Crush text file name is $crush_text_file"
+
+decompile_crush
+get_rule_data
+
+##
+# Loop over all the files
+##
+
+first_time=0
+warnings=0
+processed_rules=0
+for fn in "$@"; do
+	(( $verbose == 1 )) && echo_dbg "processing file $fn"
+	check_and_append_rule $fn
+	if [[ $? == 0 ]]; then
+		(( processed_rules++ ))
+	else
+		(( warnings++ ))
+	fi
+done
+
+(( $verbose == 1 )) && (( $processed_rules > 0 )) && echo_dbg "Updated crush text file is ready in $crush_text_file"
+
+##
+# If we have warning - ask the user how to continue
+##
+if [[ $processed_rules == 0 ]]; then
+	echo " ** No rules were added to the cluster, exiting"
+	cleanup
+	exit 0
+else
+	if [[ $warnings > 0 ]]; then
+		while true; do
+			read -n 1 -p " Some rules were not applied to the cluster. Continue?[Y/n]" resp
+			echo	## just add a new line
+			if [[ "$resp" == "n" ]]; then
+				echo " Exiting"
+				cleanup
+				exit 0
+			elif [[ "$resp" != "Y" ]]; then
+				echo " Illegal choice $resp, please retry"
+			else
+				break
+			fi
+		done
+	fi
+fi
+
+##
+# Finalize the work 
+##
+compile_and_set_crush
+
+if [[ $verbose == 0 ]]; then
+	echo " Command ended successfully, cleaning temporary files"
+	cleanup
+fi

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/check-pool-affinity.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/check-pool-affinity.sh
@@ -143,7 +143,7 @@ else
     if [ -r $input_file ]; then
         crush_tree_json=$(cat $input_file)
     else 
-        echo_error "Cant read $input_file"  
+        echo_error "Can't read $input_file"  
         exit      
     fi
 fi

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/check-pool-affinity.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/check-pool-affinity.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# vim: ts=4 sw=4
+
+#####
+# Note to reader:
+# This script should have been written in Python. In order to make it more portable and not to mess
+# with various dependencies and installation, I decided to develop it in bash, with only one 
+# dependency, (jq version 1.6). It makes the sctipt more complex, and a bit more difficult to 
+# develop and possibly maintain, but it should prevent many of the typical version/dependencies 
+# issues with Python and since this script is meant to be used very rarely, it was worth this 
+# extra development effort.
+#####
+
+base_dir=$(dirname "$0")
+data_dir=$base_dir/data
+
+. $data_dir/crush-utils.sh
+
+debug=0
+verbose=0
+input_file=""
+
+function usage() {
+    #
+    echo 
+    if [[ $debug == 0 ]]; then
+       echo "Usage: $(basename "$0") <pool_name>"
+    else
+       echo "Usage: $(basename "$0") {debug} <pool_name> {-v} {-x} {-d}"
+    fi
+    echo
+    echo "Check if pool_name has read affinity (all its primary OSDs are from the same datacenter"
+    echo "or availability zone)"
+    if [[ $debug > 0 ]]; then
+        echo "  debug      Enable the debug options below"
+        echo "  -v  Debug: Turn verbosity on"
+        echo "  -x  Debug: Print command traces before executing command"
+        echo "  -d  Debug: Print shell input lines as they are read"
+    fi
+    echo
+    exit 1
+}
+
+
+function has_read_affinity() {
+	##
+	# loop over all OSDs in $primaries and check if they belong to the same top level failure domein 
+	# Return:
+	#   0 - No affinity
+    #   1 - Pool has affinity ti a failure domain
+	##
+    local failure_domain=""
+    IFS=':' read -ra prim_array <<< "$primaries"
+    for p in "${prim_array[@]}"; do
+        local node_id=$p
+        while [[ "${crush_node_type_by_id[$node_id]}" != "$failure_domain_type"  ]]; do
+            if [[ "${crush_node_type_by_id[$node_id]}" == "root"  ]]; then
+                echo_error "Failed to analyze crush tree for pool $pool_name"
+                return 1
+            fi
+            node_id=${crush_parents_by_id[$node_id]}
+        done
+        
+        if [[ "$failure_domain" == "" ]]; then
+            failure_domain=${crush_node_name_by_id[$node_id]}
+        elif [[ $failure_domain !=  ${crush_node_name_by_id[$node_id]} ]]; then
+            echo -e "\n$red_text =>$reset_text Pool $pool_name does not have read affinity\n";
+            return 0
+        fi
+
+    done
+    echo -e "\n$green_text =>$reset_text Pool $pool_name has read affinity to failure domain $failure_domain\n";    
+    return 1
+}
+
+###
+# Start of script execution (main if you like)
+###
+
+if [[ "$1" = "debug" ]]; then
+    debug=1
+    shift 1
+fi
+
+
+if [[ -z "$1" ]]; then
+    echo ""
+    echo_error "Missing mandatory parameter <pool_name>p"
+    usage
+fi
+
+pool_name=$1
+shift 1
+
+if [[ -n "$1" && "${1:0:1}" != "-" ]]; then
+    input_file=$1
+    shift 1
+fi
+
+if [[ $debug > 0 ]]; then
+    while getopts "vxdh" o; do
+        case "${o}" in
+            v)
+                verbose=1
+                echo "Running in verbose mode" 
+                ;;
+            x)
+                set -x
+                echo "Expansion mode on"
+                ;;
+            d)
+                set -v
+                echo "Shell verbose mode on"
+                ;;
+            h)  usage 
+                ;;
+            *)
+                echo_error "Urecognized parameter "${o}
+                usage
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+fi
+
+###
+# Check that the pool exists
+#
+$CEPH osd pool get $pool_name size &> /dev/null
+if [[ $? != 0 ]]; then
+    echo
+    echo_error "Pool $pool_name does not exist"
+    usage
+fi
+
+echo " == Checking affinity for pool $pool_name"
+
+if [[ "$input_file" == "" ]]; then
+    crush_tree_json=$($CEPH osd crush tree -f json)
+else
+    echo " == debug mode - reading crush info from file $input_file"
+    if [ -r $input_file ]; then
+        crush_tree_json=$(cat $input_file)
+    else 
+        echo_error "Cant read $input_file"  
+        exit      
+    fi
+fi
+
+build_crush_tree $crush_tree_json
+find_failure_domains $crush_tree_json
+
+(($verbose == 1)) && echo " == Failure domain type is $failure_domain_type"
+
+pool_num=$($CEPH osd pool stats | awk -v PN="$pool_name" '{ if ($1 == "pool" && $2 == PN) { print $4 } }')
+
+(($verbose == 1)) && echo " == Pool num = $pool_num"
+
+##
+# Get the list of primary OSDs for this pool, string of OSD IDs separated by ':' sign
+#
+
+primaries=$($CEPH pg dump pgs_brief 2>/dev/null  | awk "/^$pool_num./ {print  \$4 }")
+#
+# Create a list with a single copy of each primary so the test is much faster. The primary list 
+# separatoe is colon ':'. This is broken into 2 lines since for some reason the sed in the second 
+# line does not work well when piped to the first line 
+#
+primaries=$(echo $primaries | sed "s/ /\n/g" | sort | uniq )
+primaries=$(echo $primaries | sed "s/ /:/g")
+
+has_read_affinity
+

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/create-affinity-rules.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/create-affinity-rules.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+
+# vim: set ts=4 sw=4 smartindent autoindent:
+
+##
+#TODO:
+# 1. Add option to create a pool for specific OSD class (hdd/ssd)
+#
+##
+base_dir=$(dirname "$0")
+data_dir=$base_dir/data
+
+. $data_dir/crush-utils.sh
+
+verbose=0
+template_dir=data
+template_3azs=3az-template-rule.txt
+template_2azs=2az-template-rule.txt
+rule_file_suffix=-affinity.rule
+rule_suffix=""
+choseleaf_type=""
+json_file=""
+
+debug=0
+opts="1:2:3:s:t:h"
+dbg_opts="vxdj:"
+base_dir="."
+
+function get_max_rule()
+{
+    #
+    # This function prints the largest rule_id
+    # use it as max_rule=$(get_max_rule) - so any rule_id larger than $max-rule is guaranteed
+    # to not exist
+    #
+    
+    $CEPH osd crush rule dump |  awk 'BEGIN {max=-1000} /rule_id/ {gsub(",",""); if ($2 > max) {max=$2;} } END {print max}'
+}
+
+function usage() {
+    #
+    # This function always exits, it never returns
+    #
+    echo 
+    if [[ $debug == 0 ]]; then
+        echo "Usage: $0 -1 az1-class -2 az2-class {-3 az3-class} {-s rule-name-suffix} {-t crush-choose-type}"
+    else
+        echo "Usage: $0 debug -1 az1-class -2 az2-class {-3 az3-class} {-s rule-name-suffix} {-t crush-choose-type} {-v} {-x} {-d}"
+    fi
+    echo "  -1  Name of the first AZ bucket (for the crush rules)"
+    echo "  -2  Name of the second AZ bucket (for the crush rules)"
+    echo "  -3  Name of the third AZ bucket (for the crush rules) - optional"
+	echo "  -s  Add suffix to the generated rule names (in case your cluster already has rules with the generated names)"
+	echo "  -t  Change the type of the chooseleaf step. Default is host and the script should manage this correctly"
+    if [[ $debug > 0 ]]; then
+        echo "  -v  Debug: Turn verbosity on"
+        echo "  -x  Debug: Print command traces before executing command"
+        echo "  -d  Debug: Print shell input lines as they are read"
+    fi
+    (($verbose == 1)) && echo "Verbosity on"
+    (($verbose == 1)) && echo "Exiting script"
+    echo
+    exit 1
+}
+
+function check_params() {
+    #
+    # Check script parameters, if there are errors a message is printed and the script exits (in usage)
+    # If the function returns the parameters are OK
+    #
+    (($verbose == 1)) && echo "az1-class="$az1
+    (($verbose == 1)) && echo "az2-class="$az2
+    if [ -n "${az3}" ]; then
+        (($verbose == 1)) && echo "az3-class="$az3
+    fi
+    
+    if [[ "${az1}" == "" || "${az2}" = "" ]]; then
+    
+        echo_error "az1-class and az2-class are mandatory parameters"
+        usage
+    fi
+
+    if [[ "$az1" == "$az2" || "$az1" == "$az3"  ||  "$az2" == "$az3" ]]; then
+        echo_error "az-class names should be unique"
+        usage
+    fi
+}
+
+function create_3azs_rule() {
+    local id=$1
+    local az1=$2
+    local az2=$3
+    local az3=$4
+	assert " -n $az1" $LINENO silent
+	assert " -n $az2" $LINENO silent
+	assert " -n $az3" $LINENO silent
+    cat $base_dir/$template_dir/$template_3azs | sed -e "s/<<AZ1>>/$az1/;s/<<AZ2>>/$az2/;s/<<AZ3>>/$az3/;s/<<ID>>/$id/;s/<<SFX>>/$rule_suffix/;s/<<TYP>>/$choseleaf_type/"
+    
+}
+
+function create_2azs_rule() {
+    local id=$1
+    local az1=$2
+    local az2=$3
+	assert " -n $az1" $LINENO silent
+	assert " -n $az2" $LINENO silent
+    cat $base_dir/$template_dir/$template_2azs | sed -e "s/<<AZ1>>/$az1/;s/<<AZ2>>/$az2/;s/<<ID>>/$id/;s/<<SFX>>/$rule_suffix/;s/<<TYP>>/$choseleaf_type/"
+    
+}
+
+function check_file() {
+	if [[ -z $1 ]]; then
+		echo_error "Internal problem: No parameters passed to ${FUNCNAME}()"
+		exit 1
+	fi
+	local file=$1
+	local rule_name=$(cat $file | awk ' /^rule / { print $2 }')
+	if [[ -z $rule_name ]]; then
+		echo_error "Could not find rule name in file $file"
+		exit 1
+	fi
+	check_rule_by_name $rule_name
+	local rule_exists=$?
+	(($verbose == 1)) && echo_dbg "Checking for existence of rule $rule_name $rule_exists" 
+	if [[ $rule_exists -eq 1 ]]; then
+		echo_error "Rule $rule_name already exists, consider using -s to add rule name suffix"
+		usage
+	fi
+
+}
+
+###
+# Start of script execution (main if you like)
+###
+base_dir=$(dirname "$0")
+
+if [[ "$1" == "debug" ]]; then
+    opts=$opts$dbg_opts
+    debug=1
+    shift 1
+fi
+
+while getopts $opts o; do
+    case "${o}" in
+        1)
+            az1=${OPTARG}
+            (($verbose == 1)) && echo "az1-class="$az1
+            ;;
+        2)
+            az2=${OPTARG}
+            (($verbose == 1)) && echo "az2-class="$az2
+            ;;
+        3)
+            az3=${OPTARG}
+            (($verbose == 1)) && echo "az3-class="$az3
+            ;;
+        v)
+            verbose=1
+            echo "Running in verbose mode" 
+            ;;
+		s)
+			rule_suffix=${OPTARG}
+			(($verbose == 1)) && echo "Rule name suffix="$rule_suffix
+			;;
+		t)
+			choseleaf_type=${OPTARG}
+			(($verbose == 1)) && echo "Choose leaf type="$choseleaf_type
+			;;
+		j)
+			json_file=${OPTARG}
+			(($verbose == 1)) && echo "Reading CRUSH tree from="$json_file
+			;;
+        x)
+            set -x
+            echo "Expansion mode on"
+            ;;
+        d)
+            set -v
+            echo "Shell verbose mode on"
+            ;;
+        h)  usage nosapce
+            ;;
+        *)
+            echo_error "Urecognized parameter "${o}
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+check_params
+
+(($verbose == 1)) && echo "*** Parsed command line ***"
+
+max_rule=$(get_max_rule)
+(( $verbose == 1)) && echo "max_rule="$max_rule
+
+error=0
+
+if [[ -z $choseleaf_type ]]; then
+	##
+	# If the user set this parameter, don't change it
+	##
+	json_str=""
+	if [[ ! -z $json_file ]]; then
+		json_str=$(cat $json_file)
+	fi
+	find_failure_domains $json_str
+	if [[ "$failure_domain_type" == "host" ]]; then
+		choseleaf_type="osd"
+	else
+		choseleaf_type="host"
+	fi
+fi
+
+(( $verbose == 1 )) && echo "Choseleaf type="$choseleaf_type
+
+if [[ "$az3" == "" ]]; then
+    (($verbose == 1)) && echo "==> 2 AZs"
+    azs=($az1 $az2)
+    for i in 0 1;
+    do
+        ((max_rule++))
+        i2=$(( (1-i) ))
+        ofile=$base_dir/${azs[$i]}$rule_file_suffix
+        create_2azs_rule $max_rule ${azs[$i]} ${azs[$i2]}  > $ofile
+        if [[ $? == 0 ]]; then
+            echo "Rule file $ofile created successfully." 
+        else
+            echo_error "Failed writing $ofile, error code is $?"
+            error=1
+        fi
+		check_file $ofile
+    done
+else
+    (($verbose == 1)) && echo "==> 3 AZs"
+    azs=($az1 $az2 $az3)
+    for i in 0 1 2;
+    do
+        ((max_rule++))
+        i2=$(( (i+1) % 3 ))
+        i3=$(( (i+2) % 3 ))
+        ofile=$base_dir/${azs[$i]}$rule_file_suffix
+        create_3azs_rule $max_rule ${azs[$i]} ${azs[$i2]} ${azs[$i3]} > $ofile
+        if [[ $? == 0 ]]; then
+            echo "Rule file $ofile created successfully." 
+        else
+            echo_error "Failed writing $ofile, error code is $?"
+            error=1
+        fi
+		check_file $ofile
+    done
+fi
+
+if [[ $error == 1 ]]; then 
+    echo "Errors found, exiting"
+    exit 1
+fi
+
+echo "$0 completed successfully."
+
+

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/data/2az-template-rule.txt
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/data/2az-template-rule.txt
@@ -1,0 +1,13 @@
+rule replicated_affinity2_<<AZ1>><<SFX>> {
+    id <<ID>>
+	type replicated   
+	min_size 1
+	max_size 10
+	step take <<AZ1>>
+	step chooseleaf firstn 2 type <<TYP>>
+	step emit
+	step take <<AZ2>>
+	step chooseleaf firstn 2 type <<TYP>>
+	step emit
+}
+

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/data/3az-template-rule.txt
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/data/3az-template-rule.txt
@@ -1,0 +1,16 @@
+rule replicated_affinity3_<<AZ1>><<SFX>> {
+    id <<ID>>
+	type replicated   
+	min_size 1
+	max_size 10
+	step take <<AZ1>>
+	step chooseleaf firstn 1 type <<TYP>>
+	step emit
+	step take <<AZ2>>
+	step chooseleaf firstn 1 type <<TYP>>
+	step emit
+	step take <<AZ3>>
+	step chooseleaf firstn 1 type <<TYP>>
+	step emit
+}
+

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/data/crush-utils.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/data/crush-utils.sh
@@ -22,7 +22,7 @@ failure_domain_num=0
 declare -A failure_domains
 
 ##
-# Common efinitions for nicer outout
+# Common efinitions for nicer output
 ##
 red_text="\e[1;31m"
 green_text="\e[1;32m"
@@ -105,7 +105,7 @@ function check_rule_by_name() {
     # Check if a rule with the name $1 exists in $CEPH
     #
     # WARNING:
-    #   This function should NOT be called in command substitution "$(check_rule_by_name)" rather it shoudl be called as 
+    #   This function should NOT be called in command substitution "$(check_rule_by_name)" rather it should be called as 
     #   check_rule_by_name
     #   result = $?
     ##
@@ -160,7 +160,7 @@ function build_crush_tree() {
 
 function assert() {     #  If condition false,
                         #+ exit from script with error message.
-						#+ If 3rd parameter exists, debug messages are supressed
+						#+ If 3rd parameter exists, debug messages are suppressed
   	E_PARAM_ERR=98
   	E_ASSERT_FAILED=99
   	if [[ -z "$2" ]]; then    # Not enough parameters passed.
@@ -169,7 +169,7 @@ function assert() {     #  If condition false,
 
 	lineno=$2
 
-	if [[ -z $3 ]]; then  ## if this parametr exists supress debug messages
+	if [[ -z $3 ]]; then  ## if this parameter exists suppress debug messages
 		(( $verbose == 1 )) && echo_dbg "Asserting $1"
 	fi
 

--- a/cluster/examples/kubernetes/ceph/read-affinity-config/data/crush-utils.sh
+++ b/cluster/examples/kubernetes/ceph/read-affinity-config/data/crush-utils.sh
@@ -1,0 +1,185 @@
+
+# vim: set ts=4 sw=4 smartindent autoindent:
+
+#
+# The following 4 arrays represent a single array with structure elements that we use for holding
+# crush bucket information (parent, node name, node type, node index) - this is enough information
+# for testing later whether a pool has read affinity (in addition to the type of the failure domain
+# level).
+#
+
+crush_tree_initialized=0
+declare -A crush_parents_by_id
+declare -A crush_node_type_by_id
+declare -A crush_node_name_by_id
+declare -A node_indices_by_id
+
+rules_initialized=0
+declare -A rules_by_name 
+
+failure_domain_type=""
+failure_domain_num=0
+declare -A failure_domains
+
+##
+# Common efinitions for nicer outout
+##
+red_text="\e[1;31m"
+green_text="\e[1;32m"
+blue_text="\e[1;34m"
+reset_text="\e[0m"
+
+function echo_error() {
+    echo -e "$red_text*Error*: $reset_text$1"
+}
+
+function echo_dbg() {
+    echo -e "$blue_text$1$reset_text"
+}
+
+##
+# Cluster control of the scripts via CEPH_CLUSTER_NAME env variable
+##
+CEPH=ceph
+
+if [[ -n $CEPH_CLUSTER_NAME ]]; then
+	CEPH="ceph --cluster $CEPH_CLUSTER_NAME"
+fi
+$CEPH -s >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+	echo_error "Could not connect to cluster $CEPH_CLUSTER_NAME (command $CEPH -s failed)"
+	exit 1
+fi
+
+#
+function find_failure_domains()
+{
+    # 
+    # This function finds the first level in the tree which has more than one node. (so root/region/AZ works 
+    # as well as root/AZ or root/datacenter and marks it as the failure domain level)
+    # It gets one input parameter which is the json file which is the output of the command
+    # "ceph osd crush tree -f json"
+    #
+	local json=""
+    if [ -z "$1" ]; then
+    	json=$($CEPH osd crush tree -f json)
+	else 
+		json=$1
+    fi
+	build_crush_tree $json
+    local node_idx=0
+    while true; do
+        local node_info=$(echo $json | jq .nodes[$node_idx])
+        local n_children=$(echo $node_info | jq ".children | length")
+        
+        first_child=$(echo $json | jq .nodes[$node_idx].children[0])
+        if [ $n_children -gt 1 ]; then
+            failure_domain_type=${crush_node_type_by_id[$first_child]}
+            break
+        elif [ $n_children -eq 1 ]; then
+			##
+			# Assume this only child is the root of the tree and look for its children in the next iteration
+			##
+            node_idx=${node_indices_by_id[$first_child]}
+        else 
+            echo_error "Did not find a failure domain in tree. Is this a production-like system?"
+            exit 0
+        fi
+    done
+}
+
+function build_rules_by_name() {
+    if [[ $rules_initialized -eq 0 ]]; then 
+        local rules=$($CEPH osd crush rule ls)
+        (($verbose == 1)) && echo_dbg "in build rules by name" 
+        for rn in ${rules[@]}; do 
+            rules_by_name[$rn]=1
+            (($verbose == 1)) && echo_dbg "Added $rn to rules name hash"
+        done
+        rules_initialized=1
+    fi
+}
+
+function check_rule_by_name() {
+    ##
+    # Check if a rule with the name $1 exists in $CEPH
+    #
+    # WARNING:
+    #   This function should NOT be called in command substitution "$(check_rule_by_name)" rather it shoudl be called as 
+    #   check_rule_by_name
+    #   result = $?
+    ##
+    if [[ -z $1 ]]; then
+        echo_error "Internal problem: No argument passed to ${FUNCNAME}()"
+        exit 1
+    fi
+    build_rules_by_name
+    if [[ ${rules_by_name[$1]} -eq 1 ]]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+function build_crush_tree() {
+    ## 
+    # This function builds the crush tree information in the 4 arrays
+    # crush_node_name_by_id, crush_node_type_by_id, node_indices_by_id and crush_parents_by_id
+    ##
+    if [[ $crush_tree_initialized -eq 0 ]]; then
+		(( $verbose == 1 )) && echo_dbg "*** Building crush tree ***"
+		local json=""
+		if [[ -z "$1" ]]; then
+			json=$($CEPH osd crush tree -f json)
+		else 
+			json=$1
+		fi
+		(( $verbose == 1 )) && echo $json
+
+        local num_nodes=$(echo $json | jq ".nodes | length")
+
+        for  (( i = 0 ; i < $num_nodes ; i++ ))
+        do
+            local node_info=$(echo $json | jq .nodes[$i])
+            local n_children=$(echo $node_info | jq ".children | length")
+            local id=$(echo $node_info | jq .id)
+            local type=$(echo $node_info | jq .type | sed 's/"//g')
+            local name=$(echo $node_info | jq .name | sed 's/"//g')
+            crush_node_name_by_id[$id]=$name
+            crush_node_type_by_id[$id]=$type
+            node_indices_by_id[$id]=$i
+            for (( child = 0 ; child < $n_children ; child++ ))
+            do
+                local ch_id=$(echo $node_info | jq .children[$child])
+                crush_parents_by_id[$ch_id]=$id
+            done
+        done    
+        crush_tree_initialized=1
+    fi
+}
+
+function assert() {     #  If condition false,
+                        #+ exit from script with error message.
+						#+ If 3rd parameter exists, debug messages are supressed
+  	E_PARAM_ERR=98
+  	E_ASSERT_FAILED=99
+  	if [[ -z "$2" ]]; then    # Not enough parameters passed.
+ 	   return $E_PARAM_ERR    # No damage done.
+	fi
+
+	lineno=$2
+
+	if [[ -z $3 ]]; then  ## if this parametr exists supress debug messages
+		(( $verbose == 1 )) && echo_dbg "Asserting $1"
+	fi
+
+  	if [ ! $1 ]; then
+    	echo_error "Assertion failed:  \"$1\""
+    	echo "File \"$0\", line $lineno"
+    	exit $E_ASSERT_FAILED
+  	# else
+  	#   return
+  	#   and continue executing script.
+  	fi
+}
+


### PR DESCRIPTION
Scripts for a Ceph admin for creating pools with read affinity in
a multi availability zone cluster. This is in order to support the
metro-dr high availability use case in OCS 4.7

Signed-off-by: josh.salomon@gmail.com <josh.salomon@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

3 Scripts to partially automate the creation of read affinity pools for an external Ceph cluster used by OCS in Metro DR 
configuration. 

Creating read affinty pools for multile availability zones Ceph cluster is supported by Ceph, but the process for creating 
them is long and error prone. This is the first phase for supporting the process, and it is currently partially autometed so the 
process contains places for manual checkpoints. This is due to the fact that this feature is in dev preview mode, and with 
almost no tests. 

Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
