### PR TITLE
ceph: Allow two mgr daemons and actively reconcile the mgr services with a sidecar

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -197,6 +197,7 @@ If this value is empty, each pod will get an ephemeral directory to store their 
 * `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health doc](ceph-mon-health.md).
 * `mgr`: manager top level section
+  * `count`: set number of ceph managers between `1` to `2`. The default value is 1. This is only needed if plural ceph managers are needed.
   * `modules`: is the list of Ceph manager modules to enable
 * `crashCollector`: The settings for crash collector daemon(s).
   * `disable`: is set to `true`, the crash collector will not run on any node where a Ceph daemon runs

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -517,9 +517,12 @@ This allows to keep Rook components running when for example a node runs out of 
 
 You can set resource requests/limits for Rook components through the [Resource Requirements/Limits](#resource-requirementslimits) structure in the following keys:
 
-* `mgr`: Set resource requests/limits for MGRs
 * `mon`: Set resource requests/limits for mons
 * `osd`: Set resource requests/limits for OSDs
+* `mgr`: Set resource requests/limits for MGRs
+* `mgr-sidecar`: Set resource requests/limits for the MGR sidecar, which is only created when `mgr.count: 2`.
+  The sidecar requires very few resources since it only executes every 15 seconds to query Ceph for the active
+  mgr and update the mgr services if the active mgr changed.
 * `prepareosd`: Set resource requests/limits for OSD prepare job
 * `crashcollector`: Set resource requests/limits for crash. This pod runs wherever there is a Ceph pod running.
 It scrapes for Ceph daemon core dumps and sends them to the Ceph manager crash module so that core dumps are centralized and can be easily listed/accessed.
@@ -536,6 +539,7 @@ If a user configures a limit or request value that is too low, Rook will still r
 * `mds`: 4096MB
 * `prepareosd`: 50MB
 * `crashcollector`: 60MB
+* `mgr-sidecar`: 100MB limit, 40MB requests
 
 ### Resource Requirements/Limits
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -9,7 +9,7 @@ v1.6...
 ## Breaking Changes
 
 ### Ceph
-* Support for adding OSDs via Drive Groups was removed. Please refer to the 
+* Support for adding OSDs via Drive Groups was removed. Please refer to the
   [Ceph upgrade guide](Documentation/ceph-upgrade.md#migrate-the-drive-group-spec) for migration
   instructions.
   See https://github.com/rook/rook/issues/7275 for more information.
@@ -26,5 +26,6 @@ v1.6...
 * Extending the support of vault KMS configuration for Ceph RGW
 * Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons
 * Add CephFilesystemMirror CRD to deploy cephfs-mirror daemon
+* Multiple Ceph mgr daemons are supported for stretch clusters and other clusters where HA of the mgr is more critical
 * Ceph OSD: as of Nautilus 14.2.14 and Octopus 15.2.9 if the OSD scenario is simple (one OSD per disk) we won't use LVM to prepare the disk anymore
 * Disable CSI GRPC metrics by default

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -104,9 +104,10 @@ spec:
                   properties:
                     count:
                       type: integer
-                      minimum: 1
+                      minimum: 0
                       maximum: 2
-                      default: 1
+                    allowMultiplePerNode:
+                      type: boolean
                     modules:
                       type: array
                       items:
@@ -1518,8 +1519,10 @@ spec:
               properties:
                 count:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 2
+                allowMultiplePerNode:
+                  type: boolean
                 modules:
                   items:
                     properties:

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -102,6 +102,11 @@ spec:
                 mgr:
                   type: object
                   properties:
+                    count:
+                      type: integer
+                      minimum: 1
+                      maximum: 2
+                      default: 1
                     modules:
                       type: array
                       items:
@@ -1511,6 +1516,10 @@ spec:
                 volumeClaimTemplate: {}
             mgr:
               properties:
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 2
                 modules:
                   items:
                     properties:

--- a/cluster/charts/rook-ceph/templates/role.yaml
+++ b/cluster/charts/rook-ceph/templates/role.yaml
@@ -92,6 +92,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
   - delete
 - apiGroups:
   - batch

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -38,6 +38,7 @@ spec:
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false
   mgr:
+    count: 1
     modules:
     - name: pg_autoscaler
       enabled: true

--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -35,6 +35,8 @@ spec:
         arbiter: true
       - name: b
       - name: c
+  mgr:
+    count: 2
   cephVersion:
     # Stretch cluster support upstream is only planned starting in Ceph Pacific
     image: ceph/daemon-base:latest-master

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -31,6 +31,9 @@ spec:
   mon:
     count: 1
     allowMultiplePerNode: true
+  mgr:
+    count: 1
+    allowMultiplePerNode: true
   dashboard:
     enabled: true
   crashCollector:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -181,10 +181,11 @@ spec:
 #      requests:
 #        cpu: "500m"
 #        memory: "1024Mi"
-# The above example requests/limits can also be added to the mon and osd components
+# The above example requests/limits can also be added to the other components
 #    mon:
 #    osd:
 #    prepareosd:
+#    mgr-sidecar:
 #    crashcollector:
 #    logcollector:
 #    cleanup:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -50,6 +50,10 @@ spec:
     # Mons should only be allowed on the same node for test environments where data loss is acceptable.
     allowMultiplePerNode: false
   mgr:
+    # When higher availability of the mgr is needed, increase the count to 2.
+    # In that case, one mgr will be active and one in standby. When Ceph updates which
+    # mgr is active, Rook will update the mgr services to match the active mgr.
+    count: 1
     modules:
     # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
     # are already enabled by other settings in the cluster CR.

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -465,6 +465,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
   - delete
 - apiGroups:
   - batch

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -104,9 +104,11 @@ spec:
                   properties:
                     count:
                       type: integer
-                      minimum: 1
+                      # 0 will be interpreted as a default of 1 for backward compatibility
+                      minimum: 0
                       maximum: 2
-                      default: 1
+                    allowMultiplePerNode:
+                      type: boolean
                     modules:
                       type: array
                       items:

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -102,6 +102,11 @@ spec:
                 mgr:
                   type: object
                   properties:
+                    count:
+                      type: integer
+                      minimum: 1
+                      maximum: 2
+                      default: 1
                     modules:
                       type: array
                       items:

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -88,7 +88,7 @@ spec:
               properties:
                 count:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 2
                 modules:
                   items:

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -86,6 +86,10 @@ spec:
                 volumeClaimTemplate: {}
             mgr:
               properties:
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 2
                 modules:
                   items:
                     properties:

--- a/cmd/rook/ceph/ceph.go
+++ b/cmd/rook/ceph/ceph.go
@@ -61,6 +61,7 @@ func init() {
 		agentCmd,
 		admissionCmd,
 		osdCmd,
+		mgrCmd,
 		configCmd)
 }
 

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -39,6 +39,7 @@ var (
 	updateMgrServicesInterval string
 	daemonName                string
 	clusterSpec               cephv1.ClusterSpec
+	mgrStatSupported          bool
 )
 
 func init() {
@@ -53,6 +54,7 @@ func init() {
 	mgrSidecarCmd.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CR that owns this cluster")
 	mgrSidecarCmd.Flags().StringVar(&clusterName, "cluster-name", "", "the name of the cluster CR that owns this cluster")
 	mgrSidecarCmd.Flags().StringVar(&daemonName, "daemon-name", "", "the name of the local mgr daemon")
+	mgrSidecarCmd.Flags().BoolVar(&mgrStatSupported, "mgr-stat-supported", false, "whether the version of ceph supports mgr stat")
 
 	flags.SetFlagsFromEnv(mgrCmd.Flags(), rook.RookEnvVarPrefix)
 	flags.SetFlagsFromEnv(mgrSidecarCmd.Flags(), rook.RookEnvVarPrefix)
@@ -81,7 +83,7 @@ func runMgrSidecar(cmd *cobra.Command, args []string) error {
 
 	m := mgr.New(context, &clusterInfo, clusterSpec, "")
 	for {
-		err := m.ReconcileMultipleServices(daemonName)
+		err := m.ReconcileMultipleServices(daemonName, mgrStatSupported)
 		if err != nil {
 			logger.Errorf("failed to reconcile services. %v", err)
 		} else {

--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ceph
+
+import (
+	"time"
+
+	"github.com/rook/rook/cmd/rook/rook"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
+	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/util/flags"
+	"github.com/spf13/cobra"
+)
+
+var mgrCmd = &cobra.Command{
+	Use: "mgr",
+}
+var mgrSidecarCmd = &cobra.Command{
+	Use: "watch-active",
+}
+var (
+	updateMgrServicesInterval string
+	daemonName                string
+	clusterSpec               cephv1.ClusterSpec
+)
+
+func init() {
+	addCephFlags(mgrCmd)
+
+	// add the subcommands to the parent mgr command
+	mgrCmd.AddCommand(mgrSidecarCmd)
+
+	mgrSidecarCmd.Flags().BoolVar(&clusterSpec.Dashboard.Enabled, "dashboard-enabled", false, "whether the dashboard is enabled")
+	mgrSidecarCmd.Flags().BoolVar(&clusterSpec.Monitoring.Enabled, "monitoring-enabled", false, "whether the monitoring is enabled")
+	mgrSidecarCmd.Flags().StringVar(&updateMgrServicesInterval, "update-interval", "", "the interval at which to update the mgr services")
+	mgrSidecarCmd.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CR that owns this cluster")
+	mgrSidecarCmd.Flags().StringVar(&clusterName, "cluster-name", "", "the name of the cluster CR that owns this cluster")
+	mgrSidecarCmd.Flags().StringVar(&daemonName, "daemon-name", "", "the name of the local mgr daemon")
+
+	flags.SetFlagsFromEnv(mgrCmd.Flags(), rook.RookEnvVarPrefix)
+	flags.SetFlagsFromEnv(mgrSidecarCmd.Flags(), rook.RookEnvVarPrefix)
+	mgrSidecarCmd.RunE = runMgrSidecar
+}
+
+// Start the mgr daemon sidecar
+func runMgrSidecar(cmd *cobra.Command, args []string) error {
+	rook.SetLogLevel()
+
+	context := createContext()
+	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)
+	rook.LogStartupInfo(mgrSidecarCmd.Flags())
+
+	ownerRef := opcontroller.ClusterOwnerRef(clusterName, ownerRefID)
+	clusterInfo.OwnerRef = ownerRef
+
+	if err := client.WriteCephConfig(context, &clusterInfo); err != nil {
+		rook.TerminateFatal(err)
+	}
+
+	interval, err := time.ParseDuration(updateMgrServicesInterval)
+	if err != nil {
+		rook.TerminateFatal(err)
+	}
+
+	m := mgr.New(context, &clusterInfo, clusterSpec, "")
+	for {
+		err := m.ReconcileMultipleServices(daemonName)
+		if err != nil {
+			logger.Errorf("failed to reconcile services. %v", err)
+		} else {
+			logger.Infof("successfully reconciled services. checking again in %ds", (int)(interval.Seconds()))
+		}
+		time.Sleep(interval)
+	}
+}

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -60,6 +60,7 @@ var (
 	osdDataDeviceFilter     string
 	osdDataDevicePathFilter string
 	ownerRefID              string
+	clusterName             string
 	osdID                   int
 	osdStoreType            string
 	osdStringID             string
@@ -106,7 +107,8 @@ func addOSDFlags(command *cobra.Command) {
 }
 
 func addOSDConfigFlags(command *cobra.Command) {
-	command.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CRD that owns this cluster")
+	command.Flags().StringVar(&ownerRefID, "cluster-id", "", "the UID of the cluster CR that owns this cluster")
+	command.Flags().StringVar(&clusterName, "cluster-name", "", "the name of the cluster CR that owns this cluster")
 	command.Flags().StringVar(&cfg.location, "location", "", "location of this node for CRUSH placement")
 	command.Flags().StringVar(&cfg.nodeName, "node-name", os.Getenv("HOSTNAME"), "the host name of the node")
 
@@ -218,7 +220,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	logger.Infof("crush location of osd: %s", crushLocation)
 
 	forceFormat := false
-	ownerRef := opcontroller.ClusterOwnerRef(clusterInfo.Namespace, ownerRefID)
+	ownerRef := opcontroller.ClusterOwnerRef(clusterName, ownerRefID)
 	clusterInfo.OwnerRef = ownerRef
 	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerRef)
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, forceFormat,

--- a/pkg/apis/ceph.rook.io/v1/resources.go
+++ b/pkg/apis/ceph.rook.io/v1/resources.go
@@ -26,6 +26,8 @@ const (
 	ResourcesKeyMon = "mon"
 	// ResourcesKeyMgr represents the name of resource in the CR for a mgr
 	ResourcesKeyMgr = "mgr"
+	// ResourcesKeyMgrSidecar represents the name of resource in the CR for a mgr
+	ResourcesKeyMgrSidecar = "mgr-sidecar"
 	// ResourcesKeyOSD represents the name of resource in the CR for an osd
 	ResourcesKeyOSD = "osd"
 	// ResourcesKeyPrepareOSD represents the name of resource in the CR for the osd prepare job
@@ -47,6 +49,11 @@ const (
 // GetMgrResources returns the placement for the MGR service
 func GetMgrResources(p rook.ResourceSpec) v1.ResourceRequirements {
 	return p[ResourcesKeyMgr]
+}
+
+// GetMgrSidecarResources returns the placement for the MGR sidecar container
+func GetMgrSidecarResources(p rook.ResourceSpec) v1.ResourceRequirements {
+	return p[ResourcesKeyMgrSidecar]
 }
 
 // GetMonResources returns the placement for the monitors

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -301,6 +301,7 @@ type StretchClusterZoneSpec struct {
 
 // MgrSpec represents options to configure a ceph mgr
 type MgrSpec struct {
+	Count   int      `json:"count,omitempty"`
 	Modules []Module `json:"modules,omitempty"`
 }
 

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -301,8 +301,9 @@ type StretchClusterZoneSpec struct {
 
 // MgrSpec represents options to configure a ceph mgr
 type MgrSpec struct {
-	Count   int      `json:"count,omitempty"`
-	Modules []Module `json:"modules,omitempty"`
+	Count                int      `json:"count,omitempty"`
+	AllowMultiplePerNode bool     `json:"allowMultiplePerNode,omitempty"`
+	Modules              []Module `json:"modules,omitempty"`
 }
 
 // Module represents mgr modules that the user wants to enable or disable

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -81,6 +81,7 @@ func AdminClusterInfo(namespace string) *ClusterInfo {
 		CephCred: CephCred{
 			Username: AdminUsername,
 		},
+		name: "testing",
 	}
 }
 

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -48,6 +48,24 @@ func CephMgrMap(context *clusterd.Context, clusterInfo *ClusterInfo) (*MgrMap, e
 	return &mgrMap, nil
 }
 
+func CephMgrStat(context *clusterd.Context, clusterInfo *ClusterInfo) (*MgrStat, error) {
+	args := []string{"mgr", "stat"}
+	buf, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		if len(buf) > 0 {
+			return nil, errors.Wrapf(err, "failed to get mgr stat. %s", string(buf))
+		}
+		return nil, errors.Wrap(err, "failed to get mgr stat")
+	}
+
+	var mgrStat MgrStat
+	if err := json.Unmarshal([]byte(buf), &mgrStat); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal mgr stat")
+	}
+
+	return &mgrStat, nil
+}
+
 // MgrEnableModule enables a mgr module
 func MgrEnableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name string, force bool) error {
 	retryCount := 5

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -30,22 +30,22 @@ var (
 	moduleEnableWaitTime = 5 * time.Second
 )
 
-func CephMgrMap(context *clusterd.Context, clusterInfo *ClusterInfo) (MgrMap, error) {
+func CephMgrMap(context *clusterd.Context, clusterInfo *ClusterInfo) (*MgrMap, error) {
 	args := []string{"mgr", "dump"}
 	buf, err := NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {
 		if len(buf) > 0 {
-			return MgrMap{}, errors.Wrapf(err, "failed to get status. %s", string(buf))
+			return nil, errors.Wrapf(err, "failed to get mgr dump. %s", string(buf))
 		}
-		return MgrMap{}, errors.Wrap(err, "failed to get ceph status")
+		return nil, errors.Wrap(err, "failed to get mgr dump")
 	}
 
 	var mgrMap MgrMap
 	if err := json.Unmarshal([]byte(buf), &mgrMap); err != nil {
-		return MgrMap{}, errors.Wrap(err, "failed to unmarshal status response")
+		return nil, errors.Wrap(err, "failed to unmarshal mgr dump")
 	}
 
-	return mgrMap, nil
+	return &mgrMap, nil
 }
 
 // MgrEnableModule enables a mgr module

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -78,6 +78,13 @@ type MonMap struct {
 	Mons         []MonMapEntry `json:"mons"`
 }
 
+type MgrStat struct {
+	Epoch      int    `json:"epoch"`
+	Available  bool   `json:"available"`
+	ActiveName string `json:"active_name"`
+	NumStandby int    `json:"num_standby"`
+}
+
 type MgrMap struct {
 	Epoch      int          `json:"epoch"`
 	ActiveGID  int          `json:"active_gid"`

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -35,7 +35,7 @@ import (
 func RemoveOSDs(context *clusterd.Context, clusterInfo *client.ClusterInfo, osdsToRemove []string) error {
 
 	// Generate the ceph config for running ceph commands similar to the operator
-	if err := writeCephConfig(context, clusterInfo); err != nil {
+	if err := client.WriteCephConfig(context, clusterInfo); err != nil {
 		return errors.Wrap(err, "failed to write the ceph config")
 	}
 

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -204,7 +204,7 @@ func (c *ClusterController) configureExternalClusterMonitoring(cluster *cluster)
 	)
 
 	// Create external monitoring Service
-	service := manager.MakeMetricsService(mgr.ExternalMgrAppName, mgr.ServiceExternalMetricName)
+	service := manager.MakeMetricsService(mgr.ExternalMgrAppName, "", mgr.ServiceExternalMetricName)
 	logger.Info("creating mgr external monitoring service")
 	_, err := k8sutil.CreateOrUpdateService(c.context.Clientset, cluster.Namespace, service)
 	if err != nil && !kerrors.IsAlreadyExists(err) {
@@ -223,7 +223,7 @@ func (c *ClusterController) configureExternalClusterMonitoring(cluster *cluster)
 	// Deploy external ServiceMonittor
 	logger.Info("creating external service monitor")
 	// servicemonitor takes some metadata from the service for easy mapping
-	err = manager.EnableServiceMonitor(service)
+	err = manager.EnableServiceMonitor("")
 	if err != nil {
 		logger.Errorf("failed to enable external service monitor. %v", err)
 	} else {

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -72,7 +72,7 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 			NodeNameLabel:        node.GetName(),
 		}
 		deploymentLabels[config.CrashType] = "crash"
-		deploymentLabels["ceph_daemon_id"] = "crash"
+		deploymentLabels[controller.DaemonIDLabel] = "crash"
 		deploymentLabels[k8sutil.ClusterAttr] = cephCluster.GetNamespace()
 
 		selectorLabels := map[string]string{

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -127,7 +127,7 @@ func TestStartSecureDashboard(t *testing.T) {
 	}
 
 	dashboardInitWaitTime = 0
-	err := c.configureDashboardService()
+	err := c.configureDashboardService("a")
 	assert.NoError(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
@@ -142,7 +142,7 @@ func TestStartSecureDashboard(t *testing.T) {
 
 	// disable the dashboard
 	c.spec.Dashboard.Enabled = false
-	err = c.configureDashboardService()
+	err = c.configureDashboardService("a")
 	assert.Nil(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -132,8 +132,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
 	// the dashboard is enabled once with the new dashboard and modules
-	assert.Equal(t, 1, enables)
-	assert.Equal(t, 0, disables)
+	assert.Equal(t, 2, enables)
+	assert.Equal(t, 1, disables)
 	assert.Equal(t, 2, moduleRetries)
 
 	svc, err := c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
@@ -146,8 +146,8 @@ func TestStartSecureDashboard(t *testing.T) {
 	assert.Nil(t, err)
 	err = c.configureDashboardModules()
 	assert.NoError(t, err)
-	assert.Equal(t, 1, enables)
-	assert.Equal(t, 1, disables)
+	assert.Equal(t, 2, enables)
+	assert.Equal(t, 2, disables)
 
 	svc, err = c.context.Clientset.CoreV1().Services(clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	assert.NotNil(t, err)

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -35,12 +35,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tevino/abool"
 	apps "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestStartMgr(t *testing.T) {
-	ctx := context.TODO()
 	var deploymentsUpdated *[]*apps.Deployment
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
@@ -49,11 +50,15 @@ func TestStartMgr(t *testing.T) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
+	waitForDeploymentToStart = func(clusterdContext *clusterd.Context, deployment *v1.Deployment) error {
+		logger.Infof("simulated mgr deployment starting")
+		return nil
+	}
 
 	clientset := testop.New(t, 3)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	context := &clusterd.Context{
+	ctx := &clusterd.Context{
 		Executor:                   executor,
 		ConfigDir:                  configDir,
 		Clientset:                  clientset,
@@ -68,13 +73,13 @@ func TestStartMgr(t *testing.T) {
 		PriorityClassNames: map[rookv1.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",
 	}
-	c := New(context, clusterInfo, clusterSpec, "myversion")
+	c := New(ctx, clusterInfo, clusterSpec, "myversion")
 	defer os.RemoveAll(c.spec.DataDirHostPath)
 
 	// start a basic service
 	err := c.Start()
 	assert.Nil(t, err)
-	validateStart(ctx, t, c)
+	validateStart(t, c)
 	assert.ElementsMatch(t, []string{}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
@@ -82,40 +87,64 @@ func TestStartMgr(t *testing.T) {
 	c.spec.Dashboard.Port = 12345
 	err = c.Start()
 	assert.Nil(t, err)
-	validateStart(ctx, t, c)
+	validateStart(t, c)
 	assert.ElementsMatch(t, []string{"rook-ceph-mgr-a"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
 
-	// starting again with more replicas
-	c.Replicas = 3
+	// starting with more replicas
+	c.spec.Mgr.Count = 2
 	c.spec.Dashboard.Enabled = false
+	// delete the previous mgr since the mocked test won't update the existing one
+	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-a", metav1.DeleteOptions{})
+	assert.Nil(t, err)
 	err = c.Start()
 	assert.Nil(t, err)
-	validateStart(ctx, t, c)
-	assert.ElementsMatch(t, []string{"rook-ceph-mgr-a"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
-	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
+	// trigger the sidecar reconcile since the operator didn't do it so we can perform the full validation
+	err = c.reconcileService("a")
+	assert.Nil(t, err)
+	validateStart(t, c)
+
+	// the dashboard service is only deleted by the operator reconcile if the replicas are 1,
+	// otherwise the sidecar has the responsibility
+	c.spec.Mgr.Count = 1
+	c.spec.Dashboard.Enabled = false
+	// clean the previous deployments
+	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-a", metav1.DeleteOptions{})
+	assert.Nil(t, err)
+	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-b", metav1.DeleteOptions{})
+	assert.Nil(t, err)
+	err = c.Start()
+	assert.Nil(t, err)
+	validateStart(t, c)
 }
 
-func validateStart(ctx context.Context, t *testing.T, c *Cluster) {
+func validateStart(t *testing.T, c *Cluster) {
 	mgrNames := []string{"a", "b"}
-	for i := 0; i < c.Replicas; i++ {
-		if i == 2 {
-			logger.Warning("cannot have more than 2 mgrs")
-			break
-		}
+	for i := 0; i < c.spec.Mgr.Count; i++ {
 		logger.Infof("Looking for cephmgr replica %d", i)
 		daemonName := mgrNames[i]
-		d, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Get(ctx, fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
+		d, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Get(context.TODO(), fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]string{"my": "annotation"}, d.Spec.Template.Annotations)
 		assert.Contains(t, d.Spec.Template.Labels, "my-label-key")
 		assert.Equal(t, "my-priority-class", d.Spec.Template.Spec.PriorityClassName)
+		if c.spec.Mgr.Count == 1 {
+			assert.Equal(t, 1, len(d.Spec.Template.Spec.Containers))
+		} else {
+			// The sidecar container is only there when multiple mgrs are enabled
+			assert.Equal(t, 2, len(d.Spec.Template.Spec.Containers))
+			assert.Equal(t, "watch-active", d.Spec.Template.Spec.Containers[1].Name)
+		}
 	}
 
-	_, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr", metav1.GetOptions{})
+	validateServices(t, c)
+}
+
+func validateServices(t *testing.T, c *Cluster) {
+	_, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr", metav1.GetOptions{})
 	assert.Nil(t, err)
 
-	ds, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(ctx, "rook-ceph-mgr-dashboard", metav1.GetOptions{})
+	ds, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	if c.spec.Dashboard.Enabled {
 		assert.NoError(t, err)
 		if c.spec.Dashboard.Port == 0 {
@@ -128,6 +157,65 @@ func validateStart(ctx context.Context, t *testing.T, c *Cluster) {
 	} else {
 		assert.True(t, errors.IsNotFound(err))
 	}
+}
+
+func TestMgrSidecarReconcile(t *testing.T) {
+	activeMgr := "a"
+	spec := cephv1.ClusterSpec{
+		Mgr: cephv1.MgrSpec{Count: 1},
+		Dashboard: cephv1.DashboardSpec{
+			Enabled: true,
+			Port:    7000,
+		},
+	}
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+			return fmt.Sprintf(`{"active_name":"%s"}`, activeMgr), nil
+		},
+	}
+	clientset := testop.New(t, 3)
+	configDir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(configDir)
+	ctx := &clusterd.Context{
+		Executor:  executor,
+		ConfigDir: configDir,
+		Clientset: clientset,
+	}
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
+	clusterInfo.SetName("test")
+	c := &Cluster{spec: spec, context: ctx, clusterInfo: clusterInfo}
+
+	// Update services according to the active mgr
+	err := c.ReconcileMultipleServices(activeMgr)
+	assert.NoError(t, err)
+	validateServices(t, c)
+	validateServiceMatches(t, c, "a")
+
+	// nothing is created or updated when the requested mgr is not the active mgr
+	err = c.ReconcileMultipleServices("b")
+	assert.NoError(t, err)
+	_, err = c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr", metav1.GetOptions{})
+	assert.True(t, kerrors.IsNotFound(err))
+
+	// nothing is updated when the requested mgr is not the active mgr
+	activeMgr = "b"
+	err = c.ReconcileMultipleServices("b")
+	assert.NoError(t, err)
+	validateServices(t, c)
+	validateServiceMatches(t, c, "b")
+}
+
+func validateServiceMatches(t *testing.T, c *Cluster, expectedActive string) {
+	// The service labels should match the active mgr
+	svc, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr", metav1.GetOptions{})
+	assert.NoError(t, err)
+	matchDaemon, ok := svc.Spec.Selector["ceph_daemon_id"]
+	assert.True(t, ok)
+	assert.Equal(t, expectedActive, matchDaemon)
+
+	// clean up the service for the next test
+	err = c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr", metav1.DeleteOptions{})
+	assert.NoError(t, err)
 }
 
 func TestConfigureModules(t *testing.T) {
@@ -205,8 +293,16 @@ func TestConfigureModules(t *testing.T) {
 }
 
 func TestMgrDaemons(t *testing.T) {
-	c := &Cluster{Replicas: 2}
+	spec := cephv1.ClusterSpec{
+		Mgr: cephv1.MgrSpec{Count: 1},
+	}
+	c := &Cluster{spec: spec}
 	daemons := c.getDaemonIDs()
+	require.Equal(t, 1, len(daemons))
+	assert.Equal(t, "a", daemons[0])
+
+	c.spec.Mgr.Count = 2
+	daemons = c.getDaemonIDs()
 	require.Equal(t, 2, len(daemons))
 	assert.Equal(t, "a", daemons[0])
 	assert.Equal(t, "b", daemons[1])

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -111,7 +111,6 @@ func TestStartMgr(t *testing.T) {
 	// clean the previous deployments
 	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-a", metav1.DeleteOptions{})
 	assert.Nil(t, err)
-	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-b", metav1.DeleteOptions{})
 	assert.Nil(t, err)
 	err = c.Start()
 	assert.Nil(t, err)
@@ -136,6 +135,13 @@ func validateStart(t *testing.T, c *Cluster) {
 			assert.Equal(t, "watch-active", d.Spec.Template.Spec.Containers[1].Name)
 		}
 	}
+
+	// verify we have exactly the expected number of deployments and not extra
+	// the expected deployments were already retrieved above, but now we check for no extra deployments
+	options := metav1.ListOptions{LabelSelector: "app=rook-ceph-mgr"}
+	deployments, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).List(context.TODO(), options)
+	assert.NoError(t, err)
+	assert.Equal(t, c.spec.Mgr.Count, len(deployments.Items))
 
 	validateServices(t, c)
 }

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -39,7 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestStartMGR(t *testing.T) {
+func TestStartMgr(t *testing.T) {
 	ctx := context.TODO()
 	var deploymentsUpdated *[]*apps.Deployment
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
@@ -64,7 +64,6 @@ func TestStartMGR(t *testing.T) {
 		Annotations:        map[rookv1.KeyType]rookv1.Annotations{cephv1.KeyMgr: {"my": "annotation"}},
 		Labels:             map[rookv1.KeyType]rookv1.Labels{cephv1.KeyMgr: {"my-label-key": "value"}},
 		Dashboard:          cephv1.DashboardSpec{Enabled: true, SSL: true},
-		Monitoring:         cephv1.MonitoringSpec{Enabled: true, RulesNamespace: ""},
 		Mgr:                cephv1.MgrSpec{Count: 1},
 		PriorityClassNames: map[rookv1.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -65,6 +65,7 @@ func TestStartMGR(t *testing.T) {
 		Labels:             map[rookv1.KeyType]rookv1.Labels{cephv1.KeyMgr: {"my-label-key": "value"}},
 		Dashboard:          cephv1.DashboardSpec{Enabled: true, SSL: true},
 		Monitoring:         cephv1.MonitoringSpec{Enabled: true, RulesNamespace: ""},
+		Mgr:                cephv1.MgrSpec{Count: 1},
 		PriorityClassNames: map[rookv1.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",
 	}
@@ -100,6 +101,7 @@ func validateStart(ctx context.Context, t *testing.T, c *Cluster) {
 	mgrNames := []string{"a", "b"}
 	for i := 0; i < c.Replicas; i++ {
 		if i == 2 {
+			logger.Warning("cannot have more than 2 mgrs")
 			break
 		}
 		logger.Infof("Looking for cephmgr replica %d", i)
@@ -204,7 +206,7 @@ func TestConfigureModules(t *testing.T) {
 }
 
 func TestMgrDaemons(t *testing.T) {
-	c := &Cluster{Replicas: 3}
+	c := &Cluster{Replicas: 2}
 	daemons := c.getDaemonIDs()
 	require.Equal(t, 2, len(daemons))
 	assert.Equal(t, "a", daemons[0])

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -219,11 +219,11 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 	}
 
 	return v1.Container{
-		Args:  []string{"ceph", "mgr", "watch-active"},
-		Name:  "watch-active",
-		Image: c.rookVersion,
-		Env:   envVars,
-		//Resources:   **TODO**,
+		Args:      []string{"ceph", "mgr", "watch-active"},
+		Name:      "watch-active",
+		Image:     c.rookVersion,
+		Env:       envVars,
+		Resources: cephv1.GetMgrSidecarResources(c.spec.Resources),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookcephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opmon "github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
@@ -62,6 +61,9 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 			HostNetwork:        c.spec.Network.IsHost(),
 			PriorityClassName:  cephv1.GetMgrPriorityClassName(c.spec.PriorityClassNames),
 		},
+	}
+	if c.spec.Mgr.Count > 1 {
+		podSpec.Spec.Containers = append(podSpec.Spec.Containers, c.makeMgrSidecarContainer(mgrConfig))
 	}
 
 	// If the log collector is enabled we add the side-car container
@@ -111,42 +113,6 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, d)
 	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.clusterInfo.OwnerRef)
 	return d, nil
-}
-
-// if we do not need the http bind fix, then we need to be careful. if we are
-// upgrading from a cluster that had the fix applied, then the fix is no longer
-// needed, and furthermore, needs to be removed so that there is not a lingering
-// ceph configuration option that contains an old ip.  by clearing the option,
-// we let ceph bind to its default ANYADDR address.  However, since we don't
-// know which version of Ceph we are may be upgrading _from_ we need to (a)
-// always do this and (b) make sure that all forms of the configuration option
-// are removed (see the init container factory method). Once the minimum
-// supported version of Rook contains the fix, all of this can be removed.
-func (c *Cluster) clearHTTPBindFix() error {
-	// We only need to apply these changes once. No harm in once each time the operator restarts.
-	if c.appliedHttpBind {
-		return nil
-	}
-	for _, daemonID := range c.getDaemonIDs() {
-		for _, module := range []string{"dashboard", "prometheus"} {
-			// there are two forms of the configuration key that might exist which
-			// depends not on the current version, but on the version that may be
-			// the version being upgraded from.
-			if _, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID,
-				fmt.Sprintf("mgr/%s/server_addr", module), "", false); err != nil {
-				return errors.Wrap(err, "failed to set config for an mgr daemon using v2 format")
-			}
-
-			// this is for the format used in v1.0
-			// https://github.com/rook/rook/commit/11d318fb2f77a6ac9a8f2b9be42c826d3b4a93c3
-			if _, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID,
-				fmt.Sprintf("mgr/%s/%s/server_addr", module, daemonID), "", false); err != nil {
-				return errors.Wrap(err, "failed to set config for an mgr daemon using v1 format")
-			}
-		}
-	}
-	c.appliedHttpBind = true
-	return nil
 }
 
 func (c *Cluster) makeChownInitContainer(mgrConfig *mgrConfig) v1.Container {
@@ -215,6 +181,39 @@ func (c *Cluster) makeMgrDaemonContainer(mgrConfig *mgrConfig) v1.Container {
 	}
 
 	return container
+}
+
+func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
+	envVars := []v1.EnvVar{
+		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerRef.UID)},
+		{Name: "ROOK_CLUSTER_NAME", Value: string(c.clusterInfo.NamespacedName().Name)},
+		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
+		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
+		opmon.PodNamespaceEnvVar(c.clusterInfo.Namespace),
+		opmon.EndpointEnvVar(),
+		opmon.SecretEnvVar(),
+		opmon.CephUsernameEnvVar(),
+		opmon.CephSecretEnvVar(),
+		k8sutil.ConfigOverrideEnvVar(),
+		{Name: "ROOK_FSID", ValueFrom: &v1.EnvVarSource{
+			SecretKeyRef: &v1.SecretKeySelector{
+				LocalObjectReference: v1.LocalObjectReference{Name: "rook-ceph-mon"},
+				Key:                  "fsid",
+			},
+		}},
+		{Name: "ROOK_DASHBOARD_ENABLED", Value: strconv.FormatBool(c.spec.Dashboard.Enabled)},
+		{Name: "ROOK_MONITORING_ENABLED", Value: strconv.FormatBool(c.spec.Monitoring.Enabled)},
+		{Name: "ROOK_UPDATE_INTERVAL", Value: "15s"},
+		{Name: "ROOK_DAEMON_NAME", Value: mgrConfig.DaemonID},
+	}
+
+	return v1.Container{
+		Args:  []string{"ceph", "mgr", "watch-active"},
+		Name:  "watch-active",
+		Image: c.rookVersion,
+		Env:   envVars,
+		//Resources:   **TODO**,
+	}
 }
 
 func getDefaultMgrLivenessProbe() *v1.Probe {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -216,6 +216,7 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 		{Name: "ROOK_MONITORING_ENABLED", Value: strconv.FormatBool(c.spec.Monitoring.Enabled)},
 		{Name: "ROOK_UPDATE_INTERVAL", Value: "15s"},
 		{Name: "ROOK_DAEMON_NAME", Value: mgrConfig.DaemonID},
+		{Name: "ROOK_MGR_STAT_SUPPORTED", Value: strconv.FormatBool(c.clusterInfo.CephVersion.IsAtLeastPacific())},
 	}
 
 	return v1.Container{

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
@@ -83,10 +84,13 @@ func TestServiceSpec(t *testing.T) {
 	clusterSpec := cephv1.ClusterSpec{}
 	c := New(&clusterd.Context{Clientset: clientset}, clusterInfo, clusterSpec, "myversion")
 
-	s := c.MakeMetricsService("rook-mgr", serviceMetricName)
+	s := c.MakeMetricsService("rook-mgr", "foo", serviceMetricName)
 	assert.NotNil(t, s)
 	assert.Equal(t, "rook-mgr", s.Name)
 	assert.Equal(t, 1, len(s.Spec.Ports))
+	assert.Equal(t, 2, len(s.Labels))
+	assert.Equal(t, 3, len(s.Spec.Selector))
+	assert.Equal(t, "foo", s.Spec.Selector[controller.DaemonIDLabel])
 }
 
 func TestHostNetwork(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -661,7 +661,8 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 
 	// setup affinity settings for pod scheduling
 	p := c.getMonPlacement(mon.Zone)
-	k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, p, requiredDuringScheduling(&c.spec),
+	p.ApplyToPodSpec(&d.Spec.Template.Spec, true)
+	k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
 		map[string]string{k8sutil.AppAttr: AppName}, nil)
 
 	// setup storage on the canary since scheduling will be affected when
@@ -1256,6 +1257,7 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 	}
 	p := c.getMonPlacement(zone)
 
+	p.ApplyToPodSpec(&d.Spec.Template.Spec, true)
 	if deploymentExists {
 		// the existing deployment may have a node selector. if the cluster
 		// isn't using host networking and the deployment is using pvc storage,
@@ -1264,10 +1266,10 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 		if c.spec.Network.IsHost() || !pvcExists {
 			p.PodAffinity = nil
 			p.PodAntiAffinity = nil
-			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, p, requiredDuringScheduling(&c.spec),
+			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
 				map[string]string{k8sutil.AppAttr: AppName}, existingDeployment.Spec.Template.Spec.NodeSelector)
 		} else {
-			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, p, requiredDuringScheduling(&c.spec),
+			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
 				map[string]string{k8sutil.AppAttr: AppName}, nil)
 		}
 		return c.updateMon(m, d)
@@ -1289,12 +1291,12 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 	}
 
 	if schedule == nil || schedule.Zone != "" {
-		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, p, requiredDuringScheduling(&c.spec),
+		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
 			map[string]string{k8sutil.AppAttr: AppName}, nil)
 	} else {
 		p.PodAffinity = nil
 		p.PodAntiAffinity = nil
-		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, p, requiredDuringScheduling(&c.spec),
+		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
 			map[string]string{k8sutil.AppAttr: AppName}, map[string]string{v1.LabelHostname: schedule.Hostname})
 	}
 

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -662,7 +662,7 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 	// setup affinity settings for pod scheduling
 	p := c.getMonPlacement(mon.Zone)
 	p.ApplyToPodSpec(&d.Spec.Template.Spec, true)
-	k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
+	k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 		map[string]string{k8sutil.AppAttr: AppName}, nil)
 
 	// setup storage on the canary since scheduling will be affected when
@@ -1266,10 +1266,10 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 		if c.spec.Network.IsHost() || !pvcExists {
 			p.PodAffinity = nil
 			p.PodAntiAffinity = nil
-			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
+			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 				map[string]string{k8sutil.AppAttr: AppName}, existingDeployment.Spec.Template.Spec.NodeSelector)
 		} else {
-			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
+			k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 				map[string]string{k8sutil.AppAttr: AppName}, nil)
 		}
 		return c.updateMon(m, d)
@@ -1291,12 +1291,12 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 	}
 
 	if schedule == nil || schedule.Zone != "" {
-		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
+		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 			map[string]string{k8sutil.AppAttr: AppName}, nil)
 	} else {
 		p.PodAffinity = nil
 		p.PodAntiAffinity = nil
-		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec),
+		k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 			map[string]string{k8sutil.AppAttr: AppName}, map[string]string{v1.LabelHostname: schedule.Hostname})
 	}
 

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -362,6 +362,6 @@ func UpdateCephDeploymentAndWait(context *clusterd.Context, clusterInfo *client.
 		return nil
 	}
 
-	_, err := k8sutil.UpdateDeploymentAndWait(context, deployment, clusterInfo.Namespace, callback)
+	err := k8sutil.UpdateDeploymentAndWait(context, deployment, clusterInfo.Namespace, callback)
 	return err
 }

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -62,7 +62,7 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 }
 
 func (c *Cluster) stretchFailureDomainName() string {
-	label := c.stretchFailureDomainLabel()
+	label := StretchFailureDomainLabel(c.spec)
 	index := strings.Index(label, "/")
 	if index == -1 {
 		return label
@@ -70,9 +70,9 @@ func (c *Cluster) stretchFailureDomainName() string {
 	return label[index+1:]
 }
 
-func (c *Cluster) stretchFailureDomainLabel() string {
-	if c.spec.Mon.StretchCluster.FailureDomainLabel != "" {
-		return c.spec.Mon.StretchCluster.FailureDomainLabel
+func StretchFailureDomainLabel(spec cephv1.ClusterSpec) string {
+	if spec.Mon.StretchCluster.FailureDomainLabel != "" {
+		return spec.Mon.StretchCluster.FailureDomainLabel
 	}
 	// The default topology label is for a zone
 	return corev1.LabelZoneFailureDomainStable
@@ -210,7 +210,7 @@ func (c *Cluster) makeMonPod(monConfig *monConfig, canary bool) (*v1.Pod, error)
 	}
 
 	if c.spec.IsStretchCluster() {
-		nodeAffinity, err := k8sutil.GenerateNodeAffinity(fmt.Sprintf("%s=%s", c.stretchFailureDomainLabel(), monConfig.Zone))
+		nodeAffinity, err := k8sutil.GenerateNodeAffinity(fmt.Sprintf("%s=%s", StretchFailureDomainLabel(c.spec), monConfig.Zone))
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to generate mon %q node affinity", monConfig.DaemonName)
 		}

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -57,6 +57,7 @@ func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string) []v1.
 	envVars := []v1.EnvVar{
 		nodeNameEnvVar(osdProps.crushHostname),
 		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerRef.UID)},
+		{Name: "ROOK_CLUSTER_NAME", Value: string(c.clusterInfo.NamespacedName().Name)},
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),
 		opmon.PodNamespaceEnvVar(c.clusterInfo.Namespace),

--- a/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
@@ -224,6 +224,7 @@ func testOSDsOnPVC(t *testing.T) {
 		Namespace:   namespace,
 		CephVersion: cephver.Nautilus,
 	}
+	clusterInfo.SetName("mycluster")
 	executor := osdPVCTestExecutor(t, clientset, namespace)
 
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: executor, RequestCancelOrchestration: abool.New()}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -295,6 +295,7 @@ func TestAddNodeFailure(t *testing.T) {
 		Namespace:   "ns-add-remove",
 		CephVersion: cephver.Nautilus,
 	}
+	clusterInfo.SetName("testcluster")
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}, RequestCancelOrchestration: abool.New()}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: context.ConfigDir,
@@ -381,6 +382,7 @@ func TestGetPVCHostName(t *testing.T) {
 
 func TestGetOSDInfo(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
+	clusterInfo.SetName("test")
 	context := &clusterd.Context{}
 	spec := cephv1.ClusterSpec{DataDirHostPath: "/rook"}
 	c := New(context, clusterInfo, spec, "myversion")
@@ -517,6 +519,7 @@ func TestDetectCrushLocation(t *testing.T) {
 
 func TestGetOSDInfoWithCustomRoot(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
+	clusterInfo.SetName("test")
 	context := &clusterd.Context{}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: "/rook",

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -488,7 +488,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			v1.Container{
 				Args:            []string{"ceph", "osd", "init"},
 				Name:            controller.ConfigInitContainerName,
-				Image:           k8sutil.MakeRookImage(c.rookVersion),
+				Image:           c.rookVersion,
 				VolumeMounts:    configVolumeMounts,
 				Env:             configEnvVars,
 				SecurityContext: securityContext,
@@ -708,7 +708,7 @@ func (c *Cluster) getCopyBinariesContainer() (v1.Volume, *v1.Container) {
 			"copy-binaries",
 			"--copy-to-dir", rookBinariesMountPath},
 		Name:         "copy-bins",
-		Image:        k8sutil.MakeRookImage(c.rookVersion),
+		Image:        c.rookVersion,
 		VolumeMounts: []v1.VolumeMount{mount},
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -88,6 +88,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		Namespace:   "ns",
 		CephVersion: cephver.Nautilus,
 	}
+	clusterInfo.SetName("test")
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
@@ -430,6 +431,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 			Namespace:   "ns",
 			CephVersion: cephver.Octopus,
 		}
+		clusterInfo.SetName("test")
 		c := New(context, clusterInfo, spec, "rook/rook:myversion")
 		deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 		assert.NoError(t, err)
@@ -464,6 +466,7 @@ func TestStorageSpecConfig(t *testing.T) {
 		Namespace:   "ns",
 		CephVersion: cephver.Nautilus,
 	}
+	clusterInfo.SetName("testing")
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: context.ConfigDir,
@@ -545,6 +548,7 @@ func TestHostNetwork(t *testing.T) {
 		Namespace:   "ns",
 		CephVersion: cephver.Nautilus,
 	}
+	clusterInfo.SetName("test")
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		Storage: storageSpec,
@@ -583,6 +587,7 @@ func TestOsdPrepareResources(t *testing.T) {
 
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
+	clusterInfo.SetName("test")
 	spec := cephv1.ClusterSpec{
 		Resources: map[string]v1.ResourceRequirements{"prepareosd": {
 			Limits: v1.ResourceList{

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -44,6 +44,8 @@ const (
 	initialDelaySecondsNonOSDDaemon int32 = 10
 	initialDelaySecondsOSDDaemon    int32 = 45
 	logCollector                          = "log-collector"
+	DaemonIDLabel                         = "ceph_daemon_id"
+	daemonTypeLabel                       = "ceph_daemon_type"
 )
 
 type daemonConfig struct {
@@ -359,9 +361,9 @@ func CephDaemonAppLabels(appName, namespace, daemonType, daemonID string, includ
 
 	// New labels cannot be applied to match selectors during upgrade
 	if includeNewLabels {
-		labels["ceph_daemon_type"] = daemonType
+		labels[daemonTypeLabel] = daemonType
 	}
-	labels["ceph_daemon_id"] = daemonID
+	labels[DaemonIDLabel] = daemonID
 	// Also report the daemon id keyed by its daemon type: "mon: a", "mds: c", etc.
 	labels[daemonType] = daemonID
 	return labels

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -134,10 +134,11 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 				c.vaultTokenInitContainer(rgwConfig))
 		}
 	}
+	c.store.Spec.Gateway.Placement.ApplyToPodSpec(&podSpec, true)
 
 	// If host networking is not enabled, preferred pod anti-affinity is added to the rgw daemons
 	labels := getLabels(c.store.Name, c.store.Namespace, false)
-	k8sutil.SetNodeAntiAffinityForPod(&podSpec, c.store.Spec.Gateway.Placement, c.clusterSpec.Network.IsHost(), labels, nil)
+	k8sutil.SetNodeAntiAffinityForPod(&podSpec, c.clusterSpec.Network.IsHost(), labels, nil)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -138,7 +138,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 
 	// If host networking is not enabled, preferred pod anti-affinity is added to the rgw daemons
 	labels := getLabels(c.store.Name, c.store.Namespace, false)
-	k8sutil.SetNodeAntiAffinityForPod(&podSpec, c.clusterSpec.Network.IsHost(), labels, nil)
+	k8sutil.SetNodeAntiAffinityForPod(&podSpec, c.clusterSpec.Network.IsHost(), v1.LabelHostname, labels, nil)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/test/spec.go
+++ b/pkg/operator/ceph/test/spec.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	e "github.com/pkg/errors"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	optest "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,7 +64,7 @@ func VerifyAppLabels(appName, namespace string, labels map[string]string) error 
 // VerifyPodLabels returns a descriptive error if pod labels are not present or not as expected.
 func VerifyPodLabels(appName, namespace, daemonType, daemonID string, labels map[string]string) error {
 	errA := VerifyAppLabels(appName, namespace, labels)
-	errB := checkLabel("ceph_daemon_id", daemonID, labels)
+	errB := checkLabel(controller.DaemonIDLabel, daemonID, labels)
 	errC := checkLabel(daemonType, daemonID, labels)
 	return combineErrors(errA, errB, errC)
 }

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -311,7 +311,7 @@ func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 }
 
 // SetNodeAntiAffinityForPod assign pod anti-affinity when pod should not be co-located
-func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, labels, nodeSelector map[string]string) {
+func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, topologyKey string, labels, nodeSelector map[string]string) {
 	pod.NodeSelector = nodeSelector
 
 	// when a node selector is being used, skip the affinity business below
@@ -324,7 +324,7 @@ func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, l
 		LabelSelector: &metav1.LabelSelector{
 			MatchLabels: labels,
 		},
-		TopologyKey: v1.LabelHostname,
+		TopologyKey: topologyKey,
 	}
 
 	// Ensures that pod.Affinity is non-nil

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -51,7 +51,6 @@ const (
 	ConfigOverrideName = "rook-config-override"
 	// ConfigOverrideVal config override value
 	ConfigOverrideVal = "config"
-	defaultVersion    = "rook/rook:latest"
 	configMountDir    = "/etc/rook/config"
 	overrideFilename  = "override.conf"
 )
@@ -201,15 +200,6 @@ func GetMatchingContainer(containers []v1.Container, name string) (v1.Container,
 	}
 
 	return *result, nil
-}
-
-// MakeRookImage formats the container name
-func MakeRookImage(version string) string {
-	if version == "" {
-		return defaultVersion
-	}
-
-	return version
 }
 
 // PodsRunningWithLabel returns the number of running pods with the given label

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -312,9 +311,7 @@ func ClusterDaemonEnvVars(image string) []v1.EnvVar {
 }
 
 // SetNodeAntiAffinityForPod assign pod anti-affinity when pod should not be co-located
-func SetNodeAntiAffinityForPod(pod *v1.PodSpec, p rookv1.Placement, requiredDuringScheduling bool,
-	labels, nodeSelector map[string]string) {
-	p.ApplyToPodSpec(pod, true)
+func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, labels, nodeSelector map[string]string) {
 	pod.NodeSelector = nodeSelector
 
 	// when a node selector is being used, skip the affinity business below

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -26,11 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestMakeRookImage(t *testing.T) {
-	assert.Equal(t, "rook/rook:v1", MakeRookImage("rook/rook:v1"))
-	assert.Equal(t, defaultVersion, MakeRookImage(""))
-}
-
 func TestGetContainerInPod(t *testing.T) {
 	expectedName := "mycontainer"
 	imageName := "myimage"

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -180,7 +180,7 @@ func testPodSpecPlacement(t *testing.T, requiredDuringScheduling bool, req, pref
 	}
 
 	placement.ApplyToPodSpec(&spec, true)
-	SetNodeAntiAffinityForPod(&spec, requiredDuringScheduling, map[string]string{"app": "mon"}, nil)
+	SetNodeAntiAffinityForPod(&spec, requiredDuringScheduling, v1.LabelHostname, map[string]string{"app": "mon"}, nil)
 
 	// should have a required anti-affinity and no preferred anti-affinity
 	assert.Equal(t,

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -179,7 +179,8 @@ func testPodSpecPlacement(t *testing.T, requiredDuringScheduling bool, req, pref
 		RestartPolicy:  v1.RestartPolicyAlways,
 	}
 
-	SetNodeAntiAffinityForPod(&spec, *placement, requiredDuringScheduling, map[string]string{"app": "mon"}, nil)
+	placement.ApplyToPodSpec(&spec, true)
+	SetNodeAntiAffinityForPod(&spec, requiredDuringScheduling, map[string]string{"app": "mon"}, nil)
 
 	// should have a required anti-affinity and no preferred anti-affinity
 	assert.Equal(t,

--- a/pkg/operator/k8sutil/service.go
+++ b/pkg/operator/k8sutil/service.go
@@ -33,6 +33,7 @@ func CreateOrUpdateService(
 	ctx := context.TODO()
 	name := serviceDefinition.Name
 	logger.Debugf("creating service %s", name)
+
 	s, err := clientset.CoreV1().Services(namespace).Create(ctx, serviceDefinition, metav1.CreateOptions{})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
@@ -42,6 +43,8 @@ func CreateOrUpdateService(
 		if err != nil {
 			return nil, fmt.Errorf("failed to update service %s. %+v", name, err)
 		}
+	} else {
+		logger.Debugf("created service %s", s.Name)
 	}
 	return s, err
 }

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1061,6 +1061,8 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
   - delete
 - apiGroups:
   - batch

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -62,6 +62,7 @@ type clusterSettings struct {
 	StoreType        string
 	DataDirHostPath  string
 	Mons             int
+	MultipleMgrs     bool
 	RBDMirrorWorkers int
 	UsePVCs          bool
 	StorageClassName string
@@ -1278,6 +1279,10 @@ func (m *CephManifestsMaster) GetRookCluster(settings *clusterSettings) string {
 		pruner = "daysToRetain: 5"
 	}
 
+	mgrCount := 1
+	if settings.MultipleMgrs {
+		mgrCount = 2
+	}
 	if settings.UsePVCs {
 		return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
@@ -1301,6 +1306,9 @@ spec:
     allowUnsupported: ` + strconv.FormatBool(settings.CephVersion.AllowUnsupported) + `
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false
+  mgr:
+    count: ` + strconv.Itoa(mgrCount) + `
+    allowMultiplePerNode: true
   dashboard:
     enabled: true
   network:

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -198,8 +198,9 @@ func (o MCTestOperations) Teardown() {
 
 func (o MCTestOperations) startCluster(namespace, store string) error {
 	logger.Infof("starting cluster %s", namespace)
+	multipleManagers := true
 	err := o.installer.CreateRookCluster(namespace, o.systemNamespace, store, o.testOverPVC, o.storageClassName,
-		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, false, false, installer.NautilusVersion)
+		cephv1.MonSpec{Count: 1, AllowMultiplePerNode: true}, true, multipleManagers, false, false, installer.NautilusVersion)
 	if err != nil {
 		o.T().Fail()
 		o.installer.GatherAllRookLogs(o.T().Name(), namespace, o.systemNamespace)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Rook now allows two Ceph mgr daemons to be started in the cluster. By default, one mgr will still be configured. If two are requested with the `mgr.count` setting in the cluster CR, a sidecar will be started on each mgr that will periodically update the metrics and dashboard services with the active mgr. The label selectors on the services will only match the single active mgr. The services cannot direct traffic to the standby mgr or else they will be incorrectly redirected to the active mgr.
    
@jshen28 This PR pulls in your changes from #6995, then makes the additional changes to update the services with the sidecar.

Remaining:
- [x] More unit testing
- [x] Add resources to the sidecar
- [x] Add zone anti-affinity when running in a stretch cluster
    
**Which issue is resolved by this Pull Request:**
Resolves #6955 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
