### PR TITLE
ceph: rados pool namespace is optional for nfs deployments

### DIFF
--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -268,9 +268,6 @@ func validateGanesha(context *clusterd.Context, clusterInfo *cephclient.ClusterI
 	if n.Spec.RADOS.Pool == "" {
 		return errors.New("missing RADOS.pool")
 	}
-	if n.Spec.RADOS.Namespace == "" {
-		return errors.New("missing RADOS.namespace")
-	}
 
 	// Ganesha server properties
 	if n.Spec.Server.Active == 0 {


### PR DESCRIPTION
There is no need to validate rados pool namespace, it is optional[1]. And if in
case rados namespace is not specified, it is appropriately handled.

[1] https://github.com/nfs-ganesha/nfs-ganesha/blob/next/src/doc/man/ganesha-core-config.rst

Signed-off-by: Varsha Rao <varao@redhat.com>