### PR TITLE
ceph: create new osds on pvc before update existing

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -220,7 +220,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	}
 
 	// set the initial orchestration status
-	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusComputingDiff}
+	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating}
 	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 
 	if err := writeCephConfig(context, agent.clusterInfo); err != nil {
@@ -253,10 +253,6 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation string)
 	context.Devices = rawDevices
 
 	logger.Info("creating and starting the osds")
-
-	// orchestration is about to start, update the status
-	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating, PvcBackedOSD: agent.pvcBacked}
-	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
 
 	// Run Drive Group configuration
 	if err := agent.configureDriveGroups(context); err != nil {

--- a/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
@@ -1,0 +1,657 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/tevino/abool"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// make infof function for helping identify logs from unit test helpers versus from runtime code.
+func infof(t *testing.T, format string, args ...interface{}) {
+	logger.Infof(t.Name()+": "+format, args...)
+}
+
+// The definition for this test is a wrapper for the test function that adds a timeout
+func TestOSDsOnPVC(t *testing.T) {
+	oldLogger := *logger
+	defer func() { logger = &oldLogger }() // reset logger to default after this test
+	logger.SetLevel(capnslog.TRACE)        // want more log info for this test if it fails
+
+	oldOpportunisticDuration := osdOpportunisticUpdateDuration
+	defer func() { osdOpportunisticUpdateDuration = oldOpportunisticDuration }()
+	// lower the opportunistic update check duration for unit tests to speed them up
+	osdOpportunisticUpdateDuration = 1 * time.Millisecond
+
+	// This test runs in less than 150 milliseconds on a 6-core CPU w/ 16GB RAM
+	// GitHub CI runner can be a lot slower (~2.5 seconds)
+	done := make(chan bool)
+	timeout := time.After(50 * 150 * time.Millisecond)
+
+	go func() {
+		// use defer because t.Fatal will kill this goroutine, and we always want done set if the
+		// func stops running
+		defer func() { done <- true }()
+		// run the actual test
+		testOSDsOnPVC(t)
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Test timed out. This is a test failure.")
+	case <-done:
+	}
+}
+
+// This is the actual test. If it hangs, we should consider that an error. Writing a timeout in
+// tests requires running the test in a goroutine, so there is a timeout wrapper above
+func testOSDsOnPVC(t *testing.T) {
+	namespace := "osd-on-pvc"
+	ctx := context.TODO()
+	// we don't need to create actual nodes for this test, but this is the set of nodes which should
+	// we will use to create fake placements for OSD prepare job pods
+	osdIDGenerator := newOSDIDGenerator()
+
+	// set up a fake k8s client set and watcher to generate events that the operator will listen to
+	clientset := test.NewComplexClientset(t)
+	test.AddSomeReadyNodes(t, clientset, 3)
+	assignPodToNode := true
+	test.PrependComplexJobReactor(t, clientset, assignPodToNode)
+	test.SetFakeKubernetesVersion(clientset, "v1.13.2") // v1.13 or higher is required for OSDs on PVC
+
+	os.Setenv(k8sutil.PodNamespaceEnvVar, namespace)
+	defer os.Unsetenv(k8sutil.PodNamespaceEnvVar)
+
+	statusMapWatcher := watch.NewRaceFreeFake()
+	clientset.PrependWatchReactor("configmaps", k8stesting.DefaultWatchReactor(statusMapWatcher, nil))
+
+	// Helper methods to set "completed" status on "starting" ConfigMaps.
+	setStatusConfigMapToCompleted := func(cm *corev1.ConfigMap) {
+		// can't use mockNodeOrchestrationCompleted here b/c it uses a context.CoreV1() method that
+		// is mutex locked when a reactor is processing
+		status := parseOrchestrationStatus(cm.Data)
+		infof(t, "configmap reactor: updating configmap %q status to completed", cm.Name)
+		// configmap names are deterministic can be mapped indirectly to an OSD ID, and since the
+		// configmaps are used to report completion status of OSD provisioning, we use this property in
+		// thse unit tests
+		osdID := osdIDGenerator.osdID(t, cm.Name)
+		status.Status = OrchestrationStatusCompleted
+		status.PvcBackedOSD = true
+		status.OSDs = []OSDInfo{
+			{
+				ID:        osdID,
+				UUID:      fmt.Sprintf("%032d", osdID),
+				BlockPath: "/dev/path/to/block",
+			},
+		}
+		s, _ := json.Marshal(status)
+		cm.Data[orchestrationStatusKey] = string(s)
+	}
+
+	createConfigMapWithStatusStartingCallback := func(cm *corev1.ConfigMap) {
+		// placeholder to be defined later in tests
+	}
+	deleteConfigMapWithStatusAlreadyExistsCallback := func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
+		// placeholder to be defined later in tests
+	}
+
+	var cmReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action := action.(type) {
+		case k8stesting.CreateActionImpl:
+			obj := action.GetObject()
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				t.Fatal("err! action not a configmap")
+			}
+
+			status := parseOrchestrationStatus(cm.Data)
+			if status.Status == OrchestrationStatusStarting {
+				// allow tests to specify a custom callback for this case
+				createConfigMapWithStatusStartingCallback(cm)
+			}
+
+		case k8stesting.DeleteActionImpl:
+			// get the CM being deleted to figure out some info about it
+			obj, err := clientset.Tracker().Get(action.GetResource(), action.GetNamespace(), action.Name)
+			if err != nil {
+				t.Fatalf("err! could not get configmap %q", action.Name)
+			}
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				t.Fatal("err! action not a configmap")
+			}
+
+			status := parseOrchestrationStatus(cm.Data)
+			if status.Status == OrchestrationStatusAlreadyExists {
+				infof(t, "configmap reactor: delete: OSD for configmap %q was updated", cm.Name)
+				// allow tests to specify a custom callback for this case
+				deleteConfigMapWithStatusAlreadyExistsCallback(cm, action)
+			} else if status.Status == OrchestrationStatusCompleted {
+				infof(t, "configmap reactor: delete: OSD for configmap %q was created", cm.Name)
+			}
+		}
+
+		// modify it in-place and allow it to be created later with these changes
+		return false, nil, nil
+	}
+	clientset.PrependReactor("*", "configmaps", cmReactor)
+
+	deploymentOps := newResourceOperationList()
+
+	// make a very simple reactor to record when deployments were created
+	var deploymentReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			t.Fatal("err! action is not a create action")
+			return false, nil, nil
+		}
+		obj := createAction.GetObject()
+		d, ok := obj.(*appsv1.Deployment)
+		if !ok {
+			t.Fatal("err! action not a deployment")
+			return false, nil, nil
+		}
+		if o, _ := clientset.Tracker().Get(action.GetResource(), d.Namespace, d.Name); o != nil {
+			// deployment already exists, so this isn't be a valid create
+			return false, nil, nil
+		}
+		infof(t, "creating deployment %q", d.Name)
+		deploymentOps.Add(d.Name, "create")
+		return false, nil, nil
+	}
+	clientset.PrependReactor("create", "deployments", deploymentReactor)
+
+	// patch the updateDeploymentAndWait function to always report success and record when
+	// deployments are updated
+	oldUDAW := updateDeploymentAndWait
+	defer func() {
+		updateDeploymentAndWait = oldUDAW
+	}()
+	updateDeploymentAndWait = func(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, deployment *appsv1.Deployment, daemonType string, daemonName string, skipUpgradeChecks bool, continueUpgradeAfterChecksEvenIfNotHealthy bool) error {
+		infof(t, "updating deployment %q", deployment.Name)
+		deploymentOps.Add(deployment.Name, "update")
+		return nil
+	}
+
+	// wait for a number of deployments to be updated
+	waitForDeploymentOps := func(count int) {
+		for {
+			if deploymentOps.Len() >= count {
+				return
+			}
+			<-time.After(1 * time.Millisecond)
+		}
+	}
+
+	clusterInfo := &cephclient.ClusterInfo{
+		Namespace:   namespace,
+		CephVersion: cephver.Nautilus,
+	}
+	executor := osdPVCTestExecutor(t, clientset, namespace)
+
+	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: executor, RequestCancelOrchestration: abool.New()}
+	storageClassName := "test-storage-class"
+	volumeMode := corev1.PersistentVolumeBlock
+	spec := cephv1.ClusterSpec{
+		CephVersion: cephv1.CephVersionSpec{
+			Image: "ceph/ceph:v14.2.2",
+		},
+		DataDirHostPath: context.ConfigDir,
+		Storage: rookv1.StorageScopeSpec{
+			StorageClassDeviceSets: []rookv1.StorageClassDeviceSet{
+				{
+					Name:  "set1",
+					Count: 5,
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "data",
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: resource.MustParse("10Gi"),
+									},
+								},
+								StorageClassName: &storageClassName,
+								VolumeMode:       &volumeMode,
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// =============================================================================================
+	infof(t, "Step 1: create new PVCs")
+
+	// when creating new configmaps with status "starting", simulate them becoming "completed"
+	// before any opportunistic updates can happen by changing the status to "completed" before
+	// the config map gets created by the fake k8s clientset.
+	createConfigMapWithStatusStartingCallback = func(cm *corev1.ConfigMap) {
+		setStatusConfigMapToCompleted(cm)
+	}
+	deleteConfigMapWithStatusAlreadyExistsCallback = func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
+		// do nothing on CM deletes
+	}
+
+	var c *Cluster
+	run := func() {
+		// kick off the start of the orchestration in a goroutine so we can watch the results
+		// and manipulate confimaps in the test if needed
+		c = New(context, clusterInfo, spec, "myversion")
+		go func() {
+			provisionConfig := c.newProvisionConfig()
+			c.startProvisioningOverPVCs(provisionConfig)
+		}()
+	}
+	run()
+
+	numExpectedPVCs := 5
+	waitForNumPVCs(t, clientset, namespace, numExpectedPVCs)
+
+	waitForNumDeployments(t, clientset, namespace, numExpectedPVCs)
+	// 5 deployments should have been created
+	assert.Equal(t, 5, deploymentOps.Len())
+	// all 5 should be create operations
+	assert.Len(t, deploymentOps.ResourcesWithOperation("create"), 5)
+	infof(t, "deployments successfully created for new PVCs")
+
+	// =============================================================================================
+	infof(t, "Step 2: verify deployments are updated when run again")
+	// clean the create times maps
+	reset := func() {
+		deploymentOps = newResourceOperationList()
+		// fake 'watcher' can close the channel for long tests, so reset when we can
+		statusMapWatcher.Reset()
+	}
+	reset()
+
+	run()
+
+	waitForNumPVCs(t, clientset, namespace, numExpectedPVCs)
+
+	// 5 deployments should have been operated on
+	waitForDeploymentOps(numExpectedPVCs)
+	// all 5 should be update operations
+	updatedDeployments := deploymentOps.ResourcesWithOperation("update")
+	assert.Len(t, updatedDeployments, 5)
+
+	// use later to ensure existing deployments are updated
+	existingDeployments := updatedDeployments
+
+	// =============================================================================================
+	infof(t, "Step 3: verify new deployments are created before existing ones are updated")
+	reset()
+
+	spec.Storage.StorageClassDeviceSets[0].Count = 8
+	numExpectedPVCs = 8
+
+	run()
+
+	waitForNumPVCs(t, clientset, namespace, numExpectedPVCs)
+	waitForNumDeployments(t, clientset, namespace, numExpectedPVCs)
+	waitForDeploymentOps(numExpectedPVCs)
+
+	// the same deployments from before should be updated here also
+	updatedDeployments = deploymentOps.ResourcesWithOperation("update")
+	assert.Len(t, updatedDeployments, 5)
+	assert.ElementsMatch(t, existingDeployments, updatedDeployments)
+
+	createdDeployments := deploymentOps.ResourcesWithOperation("create")
+	assert.Len(t, createdDeployments, 3)
+
+	for i, do := range deploymentOps.List() {
+		if i < 3 {
+			// first 3 ops should be create ops
+			assert.Equal(t, "create", do.operation)
+		} else {
+			// final 5 ops should be update ops
+			assert.Equal(t, "update", do.operation)
+		}
+	}
+
+	existingDeployments = append(createdDeployments, updatedDeployments...)
+
+	// =============================================================================================
+	infof(t, "Step 4: verify updates can happen opportunistically")
+	reset()
+
+	spec.Storage.StorageClassDeviceSets[0].Count = 10
+	numExpectedPVCs = 10
+
+	// In this test we carefully control the configmaps. When a configmap with status
+	// "alreadyExisting" is deleted, we know an OSD deployment just finished updating. We then
+	// immediately set one of the configmaps in "starting" state to "completed" so that it should
+	// be the next status configmap to be processed; a new OSD should be created for it. We
+	// therefore know that the first operation should be an update and the second a create. Then on
+	// in update-then-create fashion until all creates are done, followed by all updates.
+	configMapsThatNeedUpdatedToCompleted := []string{}
+	createConfigMapWithStatusStartingCallback = func(cm *corev1.ConfigMap) {
+		infof(t, "configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
+		configMapsThatNeedUpdatedToCompleted = append(configMapsThatNeedUpdatedToCompleted, cm.Name)
+	}
+	deleteConfigMapWithStatusAlreadyExistsCallback = func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
+		if len(configMapsThatNeedUpdatedToCompleted) > 0 {
+			cmName := configMapsThatNeedUpdatedToCompleted[0]
+			obj, err := clientset.Tracker().Get(action.GetResource(), action.GetNamespace(), cmName)
+			if err != nil {
+				t.Fatalf("err! could not get configmap %q", cmName)
+			}
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				t.Fatal("err! action not a configmap")
+			}
+			setStatusConfigMapToCompleted(cm)
+			err = clientset.Tracker().Update(action.GetResource(), cm, action.GetNamespace())
+			if err != nil {
+				t.Fatalf("err! failed to update configmap to completed. %v", err)
+			}
+			statusMapWatcher.Modify(cm) // MUST inform the fake watcher we made a change
+			configMapsThatNeedUpdatedToCompleted = configMapsThatNeedUpdatedToCompleted[1:]
+		}
+	}
+
+	run()
+
+	waitForNumPVCs(t, clientset, namespace, numExpectedPVCs)
+	waitForNumDeployments(t, clientset, namespace, numExpectedPVCs)
+	waitForDeploymentOps(numExpectedPVCs)
+
+	updatedDeployments = deploymentOps.ResourcesWithOperation("update")
+	assert.Len(t, updatedDeployments, 8)
+	assert.ElementsMatch(t, existingDeployments, updatedDeployments)
+
+	createdDeployments = deploymentOps.ResourcesWithOperation("create")
+	assert.Len(t, createdDeployments, 2)
+
+	assert.Equal(t,
+		[]string{
+			"update",
+			"create",
+			"update",
+			"create",
+			"update",
+			"update",
+			"update",
+			"update",
+			"update",
+			"update",
+		}, deploymentOps.OperationsInOrder())
+
+	existingDeployments = append(createdDeployments, updatedDeployments...)
+
+	// =============================================================================================
+	infof(t, "Step 5: verify opportunistic updates can all happen before creates")
+	reset()
+
+	spec.Storage.StorageClassDeviceSets[0].Count = 12
+	numExpectedPVCs = 12
+
+	// In this test, we stop all configmaps from being moved from "starting" to "completed" status
+	// in the configmap reactor so that all opportunistic updates should happen before new OSDs
+	// get created.
+	configMapsThatNeedUpdatedToCompleted = []string{}
+	createConfigMapWithStatusStartingCallback = func(cm *corev1.ConfigMap) {
+		// re-define this behavior as a reminder for readers of the test
+		infof(t, "configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
+		configMapsThatNeedUpdatedToCompleted = append(configMapsThatNeedUpdatedToCompleted, cm.Name)
+	}
+	deleteConfigMapWithStatusAlreadyExistsCallback = func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
+		// do NOT automatically move configmaps from "starting" to "completed"
+	}
+
+	run()
+
+	waitForDeploymentOps(10) // wait for 10 updates
+
+	updatedDeployments = deploymentOps.ResourcesWithOperation("update")
+	assert.Len(t, updatedDeployments, 10)
+	assert.ElementsMatch(t, existingDeployments, updatedDeployments)
+
+	// update configmaps from "starting" to "completed"
+	for _, cmName := range configMapsThatNeedUpdatedToCompleted {
+		cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, cmName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		setStatusConfigMapToCompleted(cm)
+		cm, err = clientset.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+		statusMapWatcher.Modify(cm) // MUST inform the fake watcher we made a change
+	}
+
+	waitForNumPVCs(t, clientset, namespace, numExpectedPVCs)
+	waitForNumDeployments(t, clientset, namespace, numExpectedPVCs)
+	waitForDeploymentOps(numExpectedPVCs)
+
+	// should be 2 more create operations
+	createdDeployments = deploymentOps.ResourcesWithOperation("create")
+	assert.Len(t, createdDeployments, 2)
+
+	for i, do := range deploymentOps.List() {
+		if i < 10 {
+			// first 10 ops should be update ops
+			assert.Equal(t, "update", do.operation)
+		} else {
+			// final 2 ops should be update ops
+			assert.Equal(t, "create", do.operation)
+		}
+	}
+
+	infof(t, "success")
+}
+
+/*
+ * mock executor to handle ceph commands
+ */
+
+func osdPVCTestExecutor(t *testing.T, clientset *fake.Clientset, namespace string) *exectest.MockExecutor {
+	return &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+			infof(t, "command: %s %v", command, args)
+			if command != "ceph" {
+				return "", errors.Errorf("unexpected command %q with args %v", command, args)
+			}
+			if args[0] == "auth" {
+				if args[1] == "get-or-create-key" {
+					return "{\"key\": \"does-not-matter\"}", nil
+				}
+			}
+			if args[0] == "osd" {
+				if args[1] == "ok-to-stop" {
+					return "", nil // no need to return text, only output status is used
+				}
+				if args[1] == "ls" {
+					// ceph osd ls returns an array of osd IDs like [0,1,2]
+					// build this based on the number of deployments since they should be equal
+					// for this test
+					l, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
+					if err != nil {
+						t.Fatalf("failed to build 'ceph osd ls' output. %v", err)
+					}
+					num := len(l.Items)
+					a := []string{}
+					for i := 0; i < num; i++ {
+						a = append(a, strconv.Itoa(i))
+					}
+					return fmt.Sprintf("[%s]", strings.Join(a, ",")), nil
+				}
+				if args[1] == "tree" {
+					return `{"nodes":[{"id":-1,"name":"default","type":"root","type_id":11,"children":[-3]},{"id":-3,"name":"master","type":"host","type_id":1,"pool_weights":{},"children":[2,1,0]},{"id":0,"device_class":"hdd","name":"osd.0","type":"osd","type_id":0,"crush_weight":0.009796142578125,"depth":2,"pool_weights":{},"exists":1,"status":"up","reweight":1,"primary_affinity":1},{"id":1,"device_class":"hdd","name":"osd.1","type":"osd","type_id":0,"crush_weight":0.009796142578125,"depth":2,"pool_weights":{},"exists":1,"status":"up","reweight":1,"primary_affinity":1},{"id":2,"device_class":"hdd","name":"osd.2","type":"osd","type_id":0,"crush_weight":0.009796142578125,"depth":2,"pool_weights":{},"exists":1,"status":"up","reweight":1,"primary_affinity":1}],"stray":[]}`, nil
+				}
+			}
+			if args[0] == "versions" {
+				// the update deploy code only cares about the mons from the ceph version command results
+				v := `{"mon":{"ceph version 14.2.2 (somehash) nautilus (stable)":3}}`
+				return v, nil
+			}
+			return "", errors.Errorf("unexpected ceph command %q", args)
+		},
+	}
+}
+
+/*
+ * basic helper functions
+ */
+
+// node names for OSDs on PVC end up being the name of the PVC
+func waitForNumPVCs(t *testing.T, clientset *fake.Clientset, namespace string, count int) {
+	for {
+		l, err := clientset.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		if len(l.Items) >= count {
+			infof(t, "PVCs for OSDs on PVC all exist")
+			break
+		}
+		<-time.After(1 * time.Millisecond)
+	}
+}
+
+func waitForNumDeployments(t *testing.T, clientset *fake.Clientset, namespace string, count int) {
+	for {
+		l, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
+		assert.NoError(t, err)
+		if len(l.Items) >= count {
+			infof(t, "Deployments for OSDs on PVC all exist")
+			break
+		}
+		<-time.After(1 * time.Millisecond)
+	}
+}
+
+/*
+ * Unique and consistent OSD ID generator
+ */
+
+type osdIDGenerator struct {
+	nextOSDID int
+	osdIDMap  map[string]int
+}
+
+func newOSDIDGenerator() osdIDGenerator {
+	return osdIDGenerator{
+		nextOSDID: 0,
+		osdIDMap:  map[string]int{},
+	}
+}
+
+func (g *osdIDGenerator) osdID(t *testing.T, namedResource string) int {
+	if id, ok := g.osdIDMap[namedResource]; ok {
+		infof(t, "resource %q has existing OSD ID %d", namedResource, id)
+		return id
+	}
+	id := g.nextOSDID
+	g.osdIDMap[namedResource] = id
+	g.nextOSDID++
+	infof(t, "generated new OSD ID %d for resource %q", id, namedResource)
+	return id
+}
+
+/*
+ * resourceOperationList
+ * We want to keep track of the order in which some resources (notably deployments) are created and
+ * updated, and the tracker should be thread safe since there could be operations occurring in
+ * parallel.
+ */
+
+type resourceOperation struct {
+	resourceName string
+	operation    string // e.g., "create", "update"
+}
+
+func newResourceOperation(resourceName, operation string) resourceOperation {
+	return resourceOperation{resourceName, operation}
+}
+
+type resourceOperationList struct {
+	sync.Mutex
+	resourceOps []resourceOperation
+}
+
+func newResourceOperationList() *resourceOperationList {
+	return &resourceOperationList{
+		sync.Mutex{},
+		[]resourceOperation{},
+	}
+}
+
+func (r *resourceOperationList) Add(resourceName, operation string) {
+	r.Lock()
+	defer r.Unlock()
+	r.resourceOps = append(r.resourceOps, newResourceOperation(resourceName, operation))
+}
+
+func (r *resourceOperationList) Len() int {
+	r.Lock()
+	defer r.Unlock()
+	return len(r.resourceOps)
+}
+
+func (r *resourceOperationList) List() []resourceOperation {
+	return r.resourceOps
+}
+
+// Return only the resources which have a given operation
+func (r *resourceOperationList) ResourcesWithOperation(operation string) []string {
+	resources := []string{}
+	for _, ro := range r.List() {
+		if ro.operation == operation {
+			resources = append(resources, ro.resourceName)
+		}
+	}
+	return resources
+}
+
+// Return all operations in order without resource names
+func (r *resourceOperationList) OperationsInOrder() []string {
+	ops := []string{}
+	for _, ro := range r.List() {
+		ops = append(ops, ro.operation)
+	}
+	return ops
+}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package osd
 
 import (

--- a/pkg/operator/ceph/cluster/osd/status.go
+++ b/pkg/operator/ceph/cluster/osd/status.go
@@ -34,16 +34,29 @@ import (
 )
 
 const (
-	OrchestrationStatusStarting      = "starting"
-	OrchestrationStatusComputingDiff = "computingDiff"
+	// OrchestrationStatusStarting denotes the OSD provisioning is beginning.
+	OrchestrationStatusStarting = "starting"
+	// OrchestrationStatusOrchestrating denotes the OSD provisioning has begun and is running.
 	OrchestrationStatusOrchestrating = "orchestrating"
-	OrchestrationStatusCompleted     = "completed"
-	OrchestrationStatusFailed        = "failed"
-	orchestrationStatusMapName       = "rook-ceph-osd-%s-status"
-	orchestrationStatusKey           = "status"
-	provisioningLabelKey             = "provisioning"
-	nodeLabelKey                     = "node"
-	completeProvisionTimeout         = 20
+	// OrchestrationStatusCompleted denotes the OSD provisioning has completed. This does not imply
+	// the provisioning completed successfully in whole or in part.
+	OrchestrationStatusCompleted = "completed"
+	// OrchestrationStatusAlreadyExists denotes the OSD provisioning was not started because an OSD
+	// has already been provisioned and started.
+	OrchestrationStatusAlreadyExists = "alreadyExists"
+	// OrchestrationStatusFailed denotes the OSD provisioning has failed.
+	OrchestrationStatusFailed = "failed"
+
+	orchestrationStatusMapName = "rook-ceph-osd-%s-status"
+	orchestrationStatusKey     = "status"
+	provisioningLabelKey       = "provisioning"
+	nodeLabelKey               = "node"
+	completeProvisionTimeout   = 20
+)
+
+var (
+	// time to wait before updating OSDs opportunistically while waiting for OSDs to finish provisioning
+	osdOpportunisticUpdateDuration = 100 * time.Millisecond
 )
 
 type provisionConfig struct {
@@ -116,19 +129,21 @@ func (c *Cluster) completeProvision(config *provisionConfig) bool {
 	return c.completeOSDsForAllNodes(config, true, completeProvisionTimeout)
 }
 
-func (c *Cluster) checkNodesCompleted(selector string, config *provisionConfig, configOSDs bool) (int, *util.Set, bool, *v1.ConfigMapList, error) {
+func (c *Cluster) checkNodesCompleted(selector string, config *provisionConfig, configOSDs bool) (int, *util.Set, bool, *v1.ConfigMapList, []*v1.ConfigMap, error) {
 	ctx := context.TODO()
 	opts := metav1.ListOptions{
 		LabelSelector: selector,
 		Watch:         false,
 	}
 	remainingNodes := util.NewSet()
+	deferredConfigMaps := []*v1.ConfigMap{}
+
 	// check the status map to see if the node is already completed before we start watching
 	statuses, err := c.context.Clientset.CoreV1().ConfigMaps(c.clusterInfo.Namespace).List(ctx, opts)
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			config.addError("failed to get config status. %v", err)
-			return 0, remainingNodes, false, statuses, err
+			return 0, remainingNodes, false, statuses, deferredConfigMaps, err
 		}
 		// the status map doesn't exist yet, watching below is still an OK thing to do
 	}
@@ -141,16 +156,17 @@ func (c *Cluster) checkNodesCompleted(selector string, config *provisionConfig, 
 			logger.Warningf("missing node label on configmap %s", configMap.Name)
 			continue
 		}
+		var completed bool
 		localconfigMap := configMap
-		completed := c.handleStatusConfigMapStatus(node, config, &localconfigMap, configOSDs)
+		completed, deferredConfigMaps = c.handleStatusConfigMapStatus(node, config, &localconfigMap, deferredConfigMaps, configOSDs)
 		if !completed {
 			remainingNodes.Add(node)
 		}
 	}
 	if remainingNodes.Count() == 0 {
-		return originalNodes, remainingNodes, true, statuses, nil
+		return originalNodes, remainingNodes, true, statuses, deferredConfigMaps, nil
 	}
-	return originalNodes, remainingNodes, false, statuses, nil
+	return originalNodes, remainingNodes, false, statuses, deferredConfigMaps, nil
 }
 
 func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bool, timeoutMinutes int) bool {
@@ -160,12 +176,49 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 		orchestrationStatusKey, provisioningLabelKey,
 	)
 
-	originalNodes, remainingNodes, completed, statuses, err := c.checkNodesCompleted(selector, config, configOSDs)
+	// For OSDs that are definitely update operations, we want to be able to defer the update until
+	// after we have created new OSDs in order to speed up cluster scale-out. Allow us to defer
+	// updating by keeping a list of deferred configmaps and processing those after creates have
+	// been done. If OSD provisioning doesn't report "alreadyExists" status, then no configmaps will
+	// be deferred, and OSD create/update ops will be intermixed in whatever order is processed.
+	deferredConfigMaps := []*v1.ConfigMap{}
+	// handleDeferredConfigMaps NEEDS to happen before the outer function returns.
+	// The nested for loops make it hard to break out and handle the return value cleanly,
+	// so remember to call this before all return statements.
+	handleDeferredConfigMaps := func() {
+		logger.Debugf("handling all deferred OSD statuses")
+		for _, configMap := range deferredConfigMaps {
+			node, ok := configMap.Labels[nodeLabelKey]
+			if !ok {
+				logger.Infof("missing node label on deferred configmap %q", configMap.Name)
+				continue
+			}
+
+			c.handleDeferredStatusConfigMapStatus(node, config, configMap, configOSDs)
+		}
+	}
+
+	var originalNodes int
+	var remainingNodes *util.Set
+	var completed bool
+	var statuses *v1.ConfigMapList
+	var err error
+	originalNodes, remainingNodes, completed, statuses, deferredConfigMaps, err = c.checkNodesCompleted(selector, config, configOSDs)
 	if err == nil && completed {
+		handleDeferredConfigMaps()
 		return true
 	}
 
-	currentTimeoutMinutes := 0
+	// Make a timer to help us opportunistically handle OSD updates while waiting on OSD prepare
+	// jobs to finish. The timer value created here doesn't practically matter for the code below.
+	opportunityTimer := time.NewTimer(osdOpportunisticUpdateDuration)
+
+	// Make a timer that helps us log every minute that goes by without making progress and will
+	// be used to determine if we have gone past our timeout without making progress.
+	timeoutTimer := time.NewTimer(time.Minute)
+	shouldResetTimeoutTimer := true // set true when timeout timer should be reset
+	currentTimeoutMinutes := 0      // track how many minutes have gone by without progress
+
 	for {
 		// Check whether we need to cancel the orchestration
 		if err := controller.CheckForCancelledOrchestration(c.context); err != nil {
@@ -191,16 +244,48 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 
 	ResultLoop:
 		for {
+			// Reset the opportunity timer every time we start this loop. If the timer fires before
+			// there is a ConfigMap update (new OSD created), we opportunistically handle an OSD
+			// update and then return to the top of this loop. If the ConfigMap watcher has a result
+			// before the timeout, a new OSD will be created. The opportunity timer might fire while
+			// creation is happening. When the OSD is done being created, we return to the top of
+			// this loop and reset the timeout here to make sure a previous timer firing doesn't
+			// take update precedence away from any ConfigMap updates (new OSD) that need handled.
+			if !opportunityTimer.Stop() {
+				// the timer already fired
+				if len(opportunityTimer.C) > 0 {
+					// the timer fired, but the result channel needs drained before Reset below
+					<-opportunityTimer.C
+				}
+			}
+			opportunityTimer.Reset(osdOpportunisticUpdateDuration)
+
+			if shouldResetTimeoutTimer {
+				if !timeoutTimer.Stop() {
+					// the timer already fired
+					if len(timeoutTimer.C) > 0 {
+						// the timer fired, but the result channel needs drained before Reset below
+						<-timeoutTimer.C
+					}
+				}
+				timeoutTimer.Reset(time.Minute)
+			}
+			shouldResetTimeoutTimer = false // don't reset the timer unless a case below asks for it
+
 			select {
 			case e, ok := <-w.ResultChan():
 				if !ok {
 					logger.Infof("orchestration status config map result channel closed, will restart watch.")
 					w.Stop()
 					<-time.After(5 * time.Second)
-					leftNodes, leftRemainingNodes, completed, _, err := c.checkNodesCompleted(selector, config, configOSDs)
+					var leftNodes int
+					var leftRemainingNodes *util.Set
+					var completed bool
+					leftNodes, leftRemainingNodes, completed, _, deferredConfigMaps, err = c.checkNodesCompleted(selector, config, configOSDs)
 					if err == nil {
 						if completed {
 							logger.Infof("additional %d/%d node(s) completed osd provisioning", leftNodes, originalNodes)
+							handleDeferredConfigMaps()
 							return true
 						}
 						remainingNodes = leftRemainingNodes
@@ -224,17 +309,42 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 						logger.Infof("skipping event from node %s status update since it is already completed", node)
 						continue
 					}
-					completed := c.handleStatusConfigMapStatus(node, config, configMap, configOSDs)
+					var completed bool
+					completed, deferredConfigMaps = c.handleStatusConfigMapStatus(node, config, configMap, deferredConfigMaps, configOSDs)
 					if completed {
 						remainingNodes.Remove(node)
 						if remainingNodes.Count() == 0 {
 							logger.Infof("%d/%d node(s) completed osd provisioning", originalNodes, originalNodes)
+							handleDeferredConfigMaps()
 							return true
 						}
 					}
+					// made progress on creating/updating OSDs; reset the timeout timer
+					shouldResetTimeoutTimer = true
 				}
 
-			case <-time.After(time.Minute):
+			case <-opportunityTimer.C:
+				// We want to make a best-effort attempt to update configmaps while provisioning is
+				// ongoing. While there are deferred configmaps remaining, grab one and process it.
+				if len(deferredConfigMaps) > 0 {
+					configMap := deferredConfigMaps[0]
+					logger.Debugf("opportunistically handling deferred OSD status %q", configMap.Name)
+
+					node, ok := configMap.Labels[nodeLabelKey]
+					if !ok {
+						logger.Infof("missing node label on deferred configmap %q", configMap.Name)
+						continue
+					}
+
+					c.handleDeferredStatusConfigMapStatus(node, config, configMap, configOSDs)
+
+					// remove the configmap we just processed from the deferred configmap list
+					deferredConfigMaps = deferredConfigMaps[1:]
+					// made progress on updating OSDs; reset the timeout timer
+					shouldResetTimeoutTimer = true
+				}
+
+			case <-timeoutTimer.C:
 				// Check whether we need to cancel the orchestration
 				if err := controller.CheckForCancelledOrchestration(c.context); err != nil {
 					config.addError("%s", err.Error())
@@ -244,48 +354,84 @@ func (c *Cluster) completeOSDsForAllNodes(config *provisionConfig, configOSDs bo
 				currentTimeoutMinutes++
 				if currentTimeoutMinutes == timeoutMinutes {
 					config.addError("timed out waiting for %d nodes: %+v", remainingNodes.Count(), remainingNodes)
-					//start to remove remainingNodes waiting timeout.
+					// start to remove remainingNodes waiting timeout.
 					for remainingNode := range remainingNodes.Iter() {
 						clearNodeName := k8sutil.TruncateNodeName(orchestrationStatusMapName, remainingNode)
 						if err := c.kv.ClearStore(clearNodeName); err != nil {
 							config.addError("failed to clear node %q status with name %q. %v", remainingNode, clearNodeName, err)
 						}
 					}
+					handleDeferredConfigMaps()
 					return false
 				}
 				logger.Infof("waiting on orchestration status update from %d remaining nodes", remainingNodes.Count())
+				// made no progress, but the timer needs reset so we can timeout again
+				shouldResetTimeoutTimer = true
 			}
 		}
 	}
 }
 
-func (c *Cluster) handleStatusConfigMapStatus(nodeName string, config *provisionConfig, configMap *v1.ConfigMap, configOSDs bool) bool {
+func (c *Cluster) createOrUpdateOSDs(status *OrchestrationStatus, nodeName string, config *provisionConfig, configMap *v1.ConfigMap) {
+	if status.PvcBackedOSD {
+		c.startOSDDaemonsOnPVC(nodeName, config, configMap, status)
+	} else {
+		c.startOSDDaemonsOnNode(nodeName, config, configMap, status)
+	}
+	// remove the status configmap that indicated the progress
+	if err := c.kv.ClearStore(k8sutil.TruncateNodeName(orchestrationStatusMapName, nodeName)); err != nil {
+		logger.Errorf("failed to remove the status configmap %q. %v", orchestrationStatusMapName, err)
+	}
+}
+
+func (c *Cluster) handleStatusConfigMapStatus(nodeName string, config *provisionConfig, configMap *v1.ConfigMap, deferredConfigMaps []*v1.ConfigMap, configOSDs bool) (completed bool, updatedDeferredConfigMaps []*v1.ConfigMap) {
+	// by default, do not append the input configmap to output to be deferred for processing later
+	updatedDeferredConfigMaps = deferredConfigMaps
 
 	status := parseOrchestrationStatus(configMap.Data)
 	if status == nil {
-		return false
+		return false, deferredConfigMaps
 	}
 
 	logger.Infof("osd orchestration status for node %s is %s", nodeName, status.Status)
+
+	if status.Status == OrchestrationStatusAlreadyExists {
+		logger.Debugf("deferring OSD update for node %q", nodeName)
+
+		// in case where the OSD has already been provisioned, this is an update case which we want
+		// to defer until later
+		updatedDeferredConfigMaps = append(deferredConfigMaps, configMap)
+
+		// we report that the node finished provisioning here but still rely on the caller to make
+		// sure to process deferred configmaps at a later point
+		return true, updatedDeferredConfigMaps
+	}
+
 	if status.Status == OrchestrationStatusCompleted {
 		if configOSDs {
-			if status.PvcBackedOSD {
-				c.startOSDDaemonsOnPVC(nodeName, config, configMap, status)
-			} else {
-				c.startOSDDaemonsOnNode(nodeName, config, configMap, status)
-			}
-			// remove the status configmap that indicated the progress
-			if err := c.kv.ClearStore(k8sutil.TruncateNodeName(orchestrationStatusMapName, nodeName)); err != nil {
-				logger.Errorf("failed to remove the status configmap. %v", err)
-			}
+			c.createOrUpdateOSDs(status, nodeName, config, configMap)
 		}
 
-		return true
+		return true, updatedDeferredConfigMaps
 	}
 
 	if status.Status == OrchestrationStatusFailed {
 		config.addError("orchestration for node %s failed: %+v", nodeName, status)
-		return true
+		return true, updatedDeferredConfigMaps
 	}
-	return false
+	return false, updatedDeferredConfigMaps
+}
+
+// deferred configmaps are OSD update operations we want to defer until after new OSDs have been created
+func (c *Cluster) handleDeferredStatusConfigMapStatus(nodeName string, config *provisionConfig, configMap *v1.ConfigMap, configOSDs bool) {
+	status := parseOrchestrationStatus(configMap.Data)
+	if status == nil {
+		logger.Warningf("failed to handle deferred update of OSD for node %s. osd orchestration status for node %s is %s", nodeName, nodeName, status.Status)
+		return
+	}
+
+	if configOSDs {
+		logger.Infof("handling deferred update of OSD for node %q", nodeName)
+		c.createOrUpdateOSDs(status, nodeName, config, configMap)
+	}
 }

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -18,39 +18,234 @@ package test
 
 import (
 	"context"
+	"encoding/base32"
 	"fmt"
+	"math/rand"
+	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
-// New creates a fake K8s cluster
+// New creates a fake K8s cluster with some nodes added.
 func New(t *testing.T, nodes int) *fake.Clientset {
 	clientset := fake.NewSimpleClientset()
-	for i := 0; i < nodes; i++ {
-		ready := v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue}
-		name := fmt.Sprintf("node%d", i)
-		n := &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: name,
-			},
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{
-					ready,
-				},
-				Addresses: []v1.NodeAddress{
-					{
-						Type:    v1.NodeInternalIP,
-						Address: fmt.Sprintf("%d.%d.%d.%d", i, i, i, i),
-					},
-				},
-			},
-		}
-		_, err := clientset.CoreV1().Nodes().Create(context.TODO(), n, metav1.CreateOptions{})
-		assert.Nil(t, err)
-	}
+	AddSomeReadyNodes(t, clientset, nodes)
 	return clientset
+}
+
+// AddReadyNode adds a new Node with status "Ready" and the given name and IP.
+func AddReadyNode(t *testing.T, clientset *fake.Clientset, name, ip string) {
+	ready := v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionTrue}
+	n := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				ready,
+			},
+			Addresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: ip,
+				},
+			},
+		},
+	}
+	_, err := clientset.CoreV1().Nodes().Create(context.TODO(), n, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			infof(t, "AddReadyNode: node %q already exists; not treating this as an error")
+		}
+		panic(fmt.Errorf("failed to create node %q: %+v", name, err))
+	}
+}
+
+// AddSomeReadyNodes create a number of new, ready Nodes.
+//  - name from 0 to count-1
+//  - ip from 0.0.0.0 to <count-1>.<count-1>.<count-1>.<count-1>
+func AddSomeReadyNodes(t *testing.T, clientset *fake.Clientset, count int) {
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("node%d", i)
+		ip := fmt.Sprintf("%d.%d.%d.%d", i, i, i, i)
+		AddReadyNode(t, clientset, name, ip)
+	}
+}
+
+// SetFakeKubernetesVersion sets a fake K8s version on the clientset. Version must be in semver
+// format with a preceding "v" (e.g., "v1.13.2").
+func SetFakeKubernetesVersion(clientset *fake.Clientset, semver string) {
+	d := clientset.Discovery()
+	fd, ok := d.(*fakediscovery.FakeDiscovery)
+	if !ok {
+		panic(fmt.Errorf("failed to get fake clientset's fake discovery"))
+	}
+	numOnly := semver[1:] // remove preceding v
+	xyz := strings.Split(numOnly, ".")
+	if len(xyz) != 3 {
+		panic(fmt.Errorf("version not in 'vX.Y.Z' format: %s", semver))
+	}
+	fd.FakedServerVersion =
+		&version.Info{
+			Major:      xyz[0],
+			Minor:      xyz[1],
+			GitVersion: semver,
+		}
+}
+
+var (
+	// Change this if we move away from corev1.
+	podGVR schema.GroupVersionResource = corev1.SchemeGroupVersion.WithResource(corev1.ResourcePods.String())
+
+	// Change this if we move away from corev1. Name of the Kind is always the same name as the struct
+	// which the Go client lib references, capitalized (e.g. "Node" or "Pod").
+	nodeGVK schema.GroupVersionKind = corev1.SchemeGroupVersion.WithKind("Node")
+
+	// Change this if we move away from corev1. corev1 doesn't define ResourceNodes like it does
+	// ResourcePods so we must use the "nodes" string which is unlikely to change.
+	nodeGVR schema.GroupVersionResource = corev1.SchemeGroupVersion.WithResource("nodes")
+)
+
+// make infof function for helping identify logs from unit test helpers versus from runtime code.
+func infof(t *testing.T, format string, args ...interface{}) {
+	logger.Infof(t.Name()+": "+format, args...)
+}
+
+// NewComplexClientset is a reusable clientset for Rook unit tests that adds some complex behavior
+// to the clientset to mimic more of what K8s does in the real world.
+//  - Generate a name for resources that have 'generateName' set and 'name' unset.
+func NewComplexClientset(t *testing.T) *fake.Clientset {
+	clientset := fake.NewSimpleClientset()
+
+	// Some resources are created with generateName used, and we need to capture the create
+	// calls and generate a name for them in order for them to all have unique names and to
+	// replicate the behavior of k8s in the wild.
+	var generateNameReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction, ok := action.(k8stesting.CreateAction)
+		if !ok {
+			panic(fmt.Errorf("action is not a create action: %+v", action))
+		}
+		obj := createAction.GetObject()
+		objMeta, err := meta.Accessor(obj)
+		resource := action.GetResource().Resource
+		name := objMeta.GetName()
+
+		if name == "" {
+			genName := objMeta.GetGenerateName()
+			if genName == "" {
+				panic(fmt.Errorf("object does not have name or generateName set: %+v", obj))
+			}
+			// generate a uuid to add a random postfix to generateName
+			b := [16]byte(uuid.New())
+			// use base32 encoding to create a shorter uuid
+			b32 := base32.StdEncoding.EncodeToString(b[:])    // includes trailing equal signs
+			newName := genName + "-" + strings.Trim(b32, "=") // trim off the trailing equal signs
+			objMeta.SetName(newName)
+			infof(t, "generateName reactor: generated name for %s: %s", resource, objMeta.GetName())
+		}
+		// setting obj.Name above modifies the action in-place before future reactors occur
+		// we want the default reactor to create the resource, so return false as if we did nothing
+		return false, nil, nil
+	}
+	clientset.PrependReactor("create", "*", generateNameReactor)
+
+	return clientset
+}
+
+// PrependComplexJobReactor adds a Job reactor with the below behavior. If more or different
+// functionality than this is needed for a test, either make a custom Job reactor or add more
+// optional behavior to this reactor.
+//  - When a Job is created, create the Pod for the Job based on the Job's Pod template
+//  - Created pod.Name = "[job name]-[pod name in job template]"
+//  - When a Job is deleted, delete the Pod for the Job (Pod delete will not be handled by reactors)
+//  - Pod create/delete is done to the clientset tracker, so no Pod watch events will register.
+//  - Optionally look through the clientset Nodes to randomly assign created Pods to a node.
+func PrependComplexJobReactor(t *testing.T, clientset *fake.Clientset, assignPodToNode bool) {
+	var jobReactor k8stesting.ReactionFunc = func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		switch action := action.(type) {
+
+		case k8stesting.CreateActionImpl:
+			obj := action.GetObject()
+			job, ok := obj.(*batchv1.Job)
+			if !ok {
+				panic(fmt.Errorf("object is not a job: %+v", obj))
+			}
+			pod := corev1.Pod{
+				ObjectMeta: *job.Spec.Template.ObjectMeta.DeepCopy(),
+				Spec:       *job.Spec.Template.Spec.DeepCopy(),
+			}
+			pod.SetName(job.GetName() + "-" + pod.GetName())
+			if assignPodToNode {
+				pod.Spec.NodeName = pickNode(clientset)
+			}
+			// cannot use clientset.CoreV1().Pods(ns).Create() b/c the fake clientset locks the
+			// object tracker during reactors.
+			err := clientset.Tracker().Create(podGVR, &pod, action.GetNamespace())
+			if err != nil {
+				if errors.IsAlreadyExists(err) {
+					infof(t, "job reactor: pod %q is already created for job %q; not treating this as an error", pod.GetName(), job.GetName())
+				}
+				panic(fmt.Errorf("failed to create Pod %q for job %+v. %v", pod.Name, job, err))
+			}
+			infof(t, "job reactor: created pod %q for job %q", pod.Name, job.Name)
+
+		case k8stesting.DeleteActionImpl:
+			jobName := action.GetName()
+			obj, err := clientset.Tracker().Get(action.GetResource(), action.GetNamespace(), jobName)
+			if err != nil && !errors.IsNotFound(err) {
+				if errors.IsNotFound(err) {
+					infof(t, "job reactor: job %q being deleted does not exist; will not delete a pod", jobName)
+					return false, nil, nil
+				}
+				panic(fmt.Errorf("failed to get info about job %q being deleted. %+v", jobName, err))
+			}
+			job, ok := obj.(*batchv1.Job)
+			if !ok {
+				panic(fmt.Errorf("object not a job: %+v", obj))
+			}
+			podName := job.GetName() + "-" + job.Spec.Template.GetName()
+			err = clientset.Tracker().Delete(podGVR, action.GetNamespace(), podName)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					infof(t, "job reactor: pod %q does not exist to be deleted while deleting job %q", podName, jobName)
+					return false, nil, nil
+				}
+				panic(fmt.Errorf("failed to delete pod %q while deleting job %+v", podName, job))
+			}
+			infof(t, "job reactor: deleted pod %q while deleting job %q", podName, jobName)
+		}
+
+		return false, nil, nil
+	}
+	clientset.PrependReactor("*", "jobs", jobReactor)
+}
+
+// Pick a random node name from the nodes present in the fake K8s clientset cluster.
+func pickNode(clientset *fake.Clientset) string {
+	obj, err := clientset.Tracker().List(nodeGVR, nodeGVK, corev1.NamespaceAll)
+	if err != nil {
+		panic(fmt.Errorf("pickNode: failed to list nodes. %+v", err))
+	}
+	nodes, ok := obj.(*corev1.NodeList)
+	if !ok {
+		panic(fmt.Errorf("pickNode: tracker did not return valid NodeList: %+v", obj))
+	}
+	if len(nodes.Items) == 0 {
+		panic(fmt.Errorf("pickNode: no nodes are available in the fake clientset to pick from"))
+	}
+	randIdx := rand.Intn(len(nodes.Items))
+	return nodes.Items[randIdx].GetName()
 }


### PR DESCRIPTION
Add a new OSD provisioner status (reported by provisioner configmap)
that denotes that an OSD is preexisting and that OSD prepare does not
need to be run for the OSD. This only applies to OSDs on PVC currently
where existence of a deployment for the OSD indicates no further
provisioning needs to occur. New status is "preexisting".

Allow creating new OSDs on PVCs before updating existing ones by
allowing deferring OSDs during processing of OSD provisioning status
ConfigMaps. Deferral is identified by new "preexisting" status.

Add a unit test to ensure OSD on PVC provisioning occurs as expected
including deferring already-created OSDs to be updated after new PVCs
are created.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>
(cherry picked from commit a95734160e808d5536d55d7f0b3f2c0db967e07f)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
