### PR TITLE
ceph: fix typos in ob doc

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -60,7 +60,7 @@ spec:
   bucketName: photo-booth-c1178d61-1517-431f-8408-ec4c9fa50bee [3]
   storageClassName: rook-ceph-bucket [4]
 status:
-  Phase: bound [5]
+  phase: Bound [5]
 ```
 1. `namespace` where OBC got created.
 1. `ObjectBucketName` generated OB name created using name space and OBC name.


### PR DESCRIPTION
**Description of your changes:**

`phase` field name is not capitalized and its values are capitalized. Here is an example.

```
apiVersion: objectbucket.io/v1alpha1
kind: ObjectBucketClaim
...
status:
  phase: Pending
```

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]