### PR TITLE
ceph: improve owner reference management

### DIFF
--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/flags"
 	"github.com/spf13/cobra"
 )
@@ -70,7 +71,7 @@ func runMgrSidecar(cmd *cobra.Command, args []string) error {
 	rook.LogStartupInfo(mgrSidecarCmd.Flags())
 
 	ownerRef := opcontroller.ClusterOwnerRef(clusterName, ownerRefID)
-	clusterInfo.OwnerRef = ownerRef
+	clusterInfo.OwnerInfo = k8sutil.NewOwnerInfoWithOwnerRef(&ownerRef, clusterInfo.Namespace)
 
 	if err := client.WriteCephConfig(context, &clusterInfo); err != nil {
 		rook.TerminateFatal(err)

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -220,9 +220,11 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 	logger.Infof("crush location of osd: %s", crushLocation)
 
 	forceFormat := false
+
 	ownerRef := opcontroller.ClusterOwnerRef(clusterName, ownerRefID)
-	clusterInfo.OwnerRef = ownerRef
-	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerRef)
+	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(&ownerRef, clusterInfo.Namespace)
+	clusterInfo.OwnerInfo = ownerInfo
+	kv := k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, ownerInfo)
 	agent := osddaemon.NewAgent(context, dataDevices, cfg.metadataDevice, forceFormat,
 		cfg.storeConfig, &clusterInfo, cfg.nodeName, kv, cfg.pvcBacked)
 

--- a/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
+++ b/pkg/daemon/ceph/agent/flexvolume/manager/ceph/manager_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/test"
@@ -160,7 +161,8 @@ func TestAttach(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
 	assert.NoError(t, err)
 	devicePath, err := vm.Attach("image1", "testpool", "admin", "never-gonna-give-you-up", clusterNamespace)
 	assert.Equal(t, "/dev/rbd3", devicePath)
@@ -241,7 +243,8 @@ func TestDetach(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "admin", "", clusterNamespace, false)
 	assert.Nil(t, err)
@@ -296,7 +299,8 @@ func TestDetachCustomKeyring(t *testing.T) {
 			called:   0,
 		},
 	}
-	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, &metav1.OwnerReference{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	_, _, _, err = mon.CreateOrLoadClusterInfo(context, clusterNamespace, ownerInfo)
 	assert.NoError(t, err)
 	err = vm.Detach("image1", "testpool", "user1", "", clusterNamespace, false)
 	assert.Nil(t, err)

--- a/pkg/daemon/ceph/client/test/info.go
+++ b/pkg/daemon/ceph/client/test/info.go
@@ -42,6 +42,7 @@ func CreateConfigDir(configDir string) error {
 // CreateTestClusterInfo creates a test cluster info
 // This would be best in a test package, but is included here to avoid cyclic dependencies
 func CreateTestClusterInfo(monCount int) *client.ClusterInfo {
+	ownerInfo := client.NewMinimumOwnerInfoWithOwnerRef()
 	c := &client.ClusterInfo{
 		FSID:          "12345",
 		Namespace:     "default",
@@ -50,7 +51,8 @@ func CreateTestClusterInfo(monCount int) *client.ClusterInfo {
 			Username: client.AdminUsername,
 			Secret:   "adminkey",
 		},
-		Monitors: map[string]*client.MonInfo{},
+		Monitors:  map[string]*client.MonInfo{},
+		OwnerInfo: ownerInfo,
 	}
 	mons := []string{"a", "b", "c", "d", "e"}
 	for i := 0; i < monCount; i++ {

--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -263,7 +263,7 @@ func (r *ReconcileCephClient) createOrUpdateClient(cephClient *cephv1.CephClient
 	// Set CephClient owner ref to the Secret
 	err = controllerutil.SetControllerReference(cephClient, secret, r.scheme)
 	if err != nil {
-		return errors.Wrap(err, "failed to set owner reference to ceph client secret")
+		return errors.Wrapf(err, "failed to set owner reference to ceph client secret %q", secret.Name)
 	}
 
 	// Create or Update Kubernetes Secret

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -61,7 +61,7 @@ type cluster struct {
 	mons               *mon.Cluster
 	stopCh             chan struct{}
 	closedStopCh       bool
-	ownerRef           metav1.OwnerReference
+	ownerInfo          *k8sutil.OwnerInfo
 	isUpgrade          bool
 	watchersActivated  bool
 	monitoringChannels map[string]*clusterHealth
@@ -72,7 +72,7 @@ type clusterHealth struct {
 	monitoringRunning bool
 }
 
-func newCluster(c *cephv1.CephCluster, context *clusterd.Context, csiMutex *sync.Mutex, ownerRef *metav1.OwnerReference) *cluster {
+func newCluster(c *cephv1.CephCluster, context *clusterd.Context, csiMutex *sync.Mutex, ownerInfo *k8sutil.OwnerInfo) *cluster {
 	return &cluster{
 		// at this phase of the cluster creation process, the identity components of the cluster are
 		// not yet established. we reserve this struct which is filled in as soon as the cluster's
@@ -84,15 +84,15 @@ func newCluster(c *cephv1.CephCluster, context *clusterd.Context, csiMutex *sync
 		namespacedName:     types.NamespacedName{Namespace: c.Namespace, Name: c.Name},
 		monitoringChannels: make(map[string]*clusterHealth),
 		stopCh:             make(chan struct{}),
-		ownerRef:           *ownerRef,
-		mons:               mon.New(context, c.Namespace, c.Spec, *ownerRef, csiMutex),
+		ownerInfo:          ownerInfo,
+		mons:               mon.New(context, c.Namespace, c.Spec, ownerInfo, csiMutex),
 	}
 }
 
 func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVersion, spec *cephv1.ClusterSpec) error {
 	// Create a configmap for overriding ceph config settings
 	// These settings should only be modified by a user after they are initialized
-	err := populateConfigOverrideConfigMap(c.context, c.Namespace, c.ownerRef)
+	err := populateConfigOverrideConfigMap(c.context, c.Namespace, c.ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to populate config override config map")
 	}
@@ -103,7 +103,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 	if err != nil {
 		return errors.Wrap(err, "failed to start ceph monitors")
 	}
-	clusterInfo.OwnerRef = c.ownerRef
+	clusterInfo.OwnerInfo = c.ownerInfo
 	clusterInfo.SetName(c.namespacedName.Name)
 	c.ClusterInfo = clusterInfo
 
@@ -186,7 +186,7 @@ func (c *ClusterController) initializeCluster(cluster *cluster, clusterObj *ceph
 	if err != nil {
 		logger.Infof("clusterInfo not yet found, must be a new cluster")
 	} else {
-		clusterInfo.OwnerRef = cluster.ownerRef
+		clusterInfo.OwnerInfo = cluster.ownerInfo
 		clusterInfo.SetName(c.namespacedName.Name)
 		cluster.ClusterInfo = clusterInfo
 	}

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -47,7 +47,8 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 
 	// loop until we find the secret necessary to connect to the external cluster
 	// then populate clusterInfo
-	cluster.ClusterInfo = mon.PopulateExternalClusterInfo(c.context, c.namespacedName.Namespace, cluster.ownerRef)
+
+	cluster.ClusterInfo = mon.PopulateExternalClusterInfo(c.context, c.namespacedName.Namespace, cluster.ownerInfo)
 	cluster.ClusterInfo.SetName(c.namespacedName.Name)
 
 	if !client.IsKeyringBase64Encoded(cluster.ClusterInfo.CephCred.Secret) {
@@ -75,13 +76,13 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		//
 		// Only do this when doing a bit of management...
 		logger.Infof("creating %q configmap", k8sutil.ConfigOverrideName)
-		err = populateConfigOverrideConfigMap(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerRef)
+		err = populateConfigOverrideConfigMap(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to populate config override config map")
 		}
 
 		logger.Infof("creating %q secret", config.StoreName)
-		err = config.GetStore(c.context, c.namespacedName.Namespace, &cluster.ClusterInfo.OwnerRef).CreateOrUpdate(cluster.ClusterInfo)
+		err = config.GetStore(c.context, c.namespacedName.Namespace, cluster.ClusterInfo.OwnerInfo).CreateOrUpdate(cluster.ClusterInfo)
 		if err != nil {
 			return errors.Wrap(err, "failed to update the global config")
 		}
@@ -102,7 +103,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 	}
 
 	// Create CSI config map
-	err = csi.CreateCsiConfigMap(c.namespacedName.Namespace, c.context.Clientset, &cluster.ownerRef)
+	err = csi.CreateCsiConfigMap(c.namespacedName.Namespace, c.context.Clientset, cluster.ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to create csi config map")
 	}
@@ -204,16 +205,22 @@ func (c *ClusterController) configureExternalClusterMonitoring(cluster *cluster)
 	)
 
 	// Create external monitoring Service
-	service := manager.MakeMetricsService(mgr.ExternalMgrAppName, "", mgr.ServiceExternalMetricName)
+	service, err := manager.MakeMetricsService(mgr.ExternalMgrAppName, "", mgr.ServiceExternalMetricName)
+	if err != nil {
+		return err
+	}
 	logger.Info("creating mgr external monitoring service")
-	_, err := k8sutil.CreateOrUpdateService(c.context.Clientset, cluster.Namespace, service)
+	_, err = k8sutil.CreateOrUpdateService(c.context.Clientset, cluster.Namespace, service)
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create or update mgr service")
 	}
 	logger.Info("mgr external metrics service created")
 
 	// Create external monitoring Endpoints
-	endpoint := mgr.CreateExternalMetricsEndpoints(cluster.Namespace, cluster.Spec.Monitoring, cluster.ownerRef)
+	endpoint, err := mgr.CreateExternalMetricsEndpoints(cluster.Namespace, cluster.Spec.Monitoring, cluster.ownerInfo)
+	if err != nil {
+		return err
+	}
 	logger.Info("creating mgr external monitoring endpoints")
 	_, err = k8sutil.CreateOrUpdateEndpoint(c.context.Clientset, c.namespacedName.Namespace, endpoint)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -57,7 +57,7 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 	}
 	err := controllerutil.SetControllerReference(&cephCluster, deploy, r.scheme)
 	if err != nil {
-		return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of deployment %q", deploy.Name)
+		return controllerutil.OperationResultNone, errors.Errorf("failed to set owner reference of crashcollector deployment %q", deploy.Name)
 	}
 
 	volumes := controller.DaemonVolumesBase(config.NewDatalessDaemonDataPathMap(cephCluster.GetNamespace(), cephCluster.Spec.DataDirHostPath), "")

--- a/pkg/operator/ceph/cluster/crash/keyring.go
+++ b/pkg/operator/ceph/cluster/crash/keyring.go
@@ -40,7 +40,7 @@ const (
 
 // CreateCrashCollectorSecret creates the Kubernetes Crash Collector Secret
 func CreateCrashCollectorSecret(context *clusterd.Context, clusterInfo *client.ClusterInfo) error {
-	k := keyring.GetSecretStore(context, clusterInfo, &clusterInfo.OwnerRef)
+	k := keyring.GetSecretStore(context, clusterInfo, clusterInfo.OwnerInfo)
 
 	// Create CrashCollector Ceph key
 	crashCollectorSecretKey, err := createCrashCollectorKeyring(k)
@@ -88,10 +88,13 @@ func createOrUpdateCrashCollectorSecret(clusterInfo *client.ClusterInfo, crashCo
 		Data: crashCollectorSecret,
 		Type: k8sutil.RookType,
 	}
-	k8sutil.SetOwnerRef(&s.ObjectMeta, &clusterInfo.OwnerRef)
+	err := clusterInfo.OwnerInfo.SetControllerReference(s)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference to crash controller secret %q", s.Name)
+	}
 
 	// Create Kubernetes Secret
-	err := k.CreateSecret(s)
+	err = k.CreateSecret(s)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", crashCollectorSecret, clusterInfo.Namespace)
 	}

--- a/pkg/operator/ceph/cluster/mgr/config.go
+++ b/pkg/operator/ceph/cluster/mgr/config.go
@@ -60,7 +60,7 @@ func (c *Cluster) generateKeyring(m *mgrConfig) (string, error) {
 	ctx := context.TODO()
 	user := fmt.Sprintf("mgr.%s", m.DaemonID)
 	access := []string{"mon", "allow profile mgr", "mds", "allow *", "osd", "allow *"}
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.clusterInfo.OwnerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -53,7 +53,8 @@ func TestGeneratePassword(t *testing.T) {
 func TestGetOrGeneratePassword(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 3)
-	clusterInfo := &client.ClusterInfo{Namespace: "myns"}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	clusterInfo := &client.ClusterInfo{Namespace: "myns", OwnerInfo: ownerInfo}
 	c := &Cluster{context: &clusterd.Context{Clientset: clientset}, clusterInfo: clusterInfo}
 	_, err := c.context.Clientset.CoreV1().Secrets(clusterInfo.Namespace).Get(ctx, dashboardPasswordName, metav1.GetOptions{})
 	assert.True(t, kerrors.IsNotFound(err))
@@ -109,9 +110,11 @@ func TestStartSecureDashboard(t *testing.T) {
 		return executor.MockExecuteCommandWithOutputFile(command, outfileArg, arg...)
 	}
 
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	clusterInfo := &cephclient.ClusterInfo{
 		Namespace:   "myns",
 		CephVersion: cephver.Nautilus,
+		OwnerInfo:   ownerInfo,
 	}
 	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: clientset, Executor: executor},
 		spec: cephv1.ClusterSpec{

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -63,7 +64,8 @@ func TestStartMgr(t *testing.T) {
 		ConfigDir:                  configDir,
 		Clientset:                  clientset,
 		RequestCancelOrchestration: abool.New()}
-	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid"}
+	ownerInfo := cephclient.NewMinimumOwnerInfo(t)
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo}
 	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Annotations:        map[rookv1.KeyType]rookv1.Annotations{cephv1.KeyMgr: {"my": "annotation"}},
@@ -195,7 +197,8 @@ func TestMgrSidecarReconcile(t *testing.T) {
 		ConfigDir: configDir,
 		Clientset: clientset,
 	}
-	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
+	ownerInfo := cephclient.NewMinimumOwnerInfo(t)
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", OwnerInfo: ownerInfo}
 	clusterInfo.SetName("test")
 	c := &Cluster{spec: spec, context: ctx, clusterInfo: clusterInfo}
 

--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,8 +56,8 @@ func TestCreateClusterSecrets(t *testing.T) {
 		Executor:  executor,
 	}
 	namespace := "ns"
-	ownerRef := &metav1.OwnerReference{}
-	info, maxID, mapping, err := CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	info, maxID, mapping, err := CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, -1, maxID)
 	require.NotNil(t, info)
@@ -79,7 +80,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that the cluster info can now be loaded
-	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, "client.admin", info.CephCred.Username)
 	assert.Equal(t, adminSecret, info.CephCred.Secret)
@@ -88,7 +89,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	secret.Data[adminSecretNameKey] = []byte(adminSecretNameKey)
 	_, err = clientset.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
 	assert.NoError(t, err)
-	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	_, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.Error(t, err)
 
 	// Load the external cluster with the legacy external creds
@@ -99,7 +100,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	}
 	_, err = clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerRef)
+	info, _, _, err = CreateOrLoadClusterInfo(context, namespace, ownerInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, "testid", info.CephCred.Username)
 	assert.Equal(t, "testkey", info.CephCred.Secret)

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -29,6 +29,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
@@ -61,7 +62,8 @@ func TestCheckHealth(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 	// clusterInfo is nil so we return err
 	err := c.checkHealth()
 	assert.NotNil(t, err)
@@ -152,7 +154,8 @@ func TestScaleMonDeployment(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
 	context := &clusterd.Context{Clientset: clientset}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 0, AllowMultiplePerNode: true}, "myversion")
 
 	name := "a"
@@ -199,7 +202,8 @@ func TestCheckHealthNotFound(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
 	defer os.RemoveAll(c.context.ConfigDir)
@@ -257,7 +261,8 @@ func TestAddRemoveMons(t *testing.T) {
 		Executor:                   executor,
 		RequestCancelOrchestration: abool.New(),
 	}
-	c := New(context, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0 // "a" is max mon id
 	c.waitForStart = false

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -120,7 +120,7 @@ type Cluster struct {
 	waitForStart       bool
 	monTimeoutList     map[string]time.Time
 	mapping            *Mapping
-	ownerRef           metav1.OwnerReference
+	ownerInfo          *k8sutil.OwnerInfo
 	csiConfigMutex     *sync.Mutex
 	isUpgrade          bool
 	arbiterMon         string
@@ -165,7 +165,7 @@ type SchedulingResult struct {
 }
 
 // New creates an instance of a mon cluster
-func New(context *clusterd.Context, namespace string, spec cephv1.ClusterSpec, ownerRef metav1.OwnerReference, csiConfigMutex *sync.Mutex) *Cluster {
+func New(context *clusterd.Context, namespace string, spec cephv1.ClusterSpec, ownerInfo *k8sutil.OwnerInfo, csiConfigMutex *sync.Mutex) *Cluster {
 	return &Cluster{
 		context:        context,
 		spec:           spec,
@@ -176,7 +176,7 @@ func New(context *clusterd.Context, namespace string, spec cephv1.ClusterSpec, o
 		mapping: &Mapping{
 			Schedule: map[string]*MonScheduleInfo{},
 		},
-		ownerRef:       ownerRef,
+		ownerInfo:      ownerInfo,
 		csiConfigMutex: csiConfigMutex,
 	}
 }
@@ -188,7 +188,7 @@ func (c *Cluster) Start(clusterInfo *cephclient.ClusterInfo, rookVersion string,
 	c.acquireOrchestrationLock()
 	defer c.releaseOrchestrationLock()
 
-	clusterInfo.OwnerRef = c.ownerRef
+	clusterInfo.OwnerInfo = c.ownerInfo
 	c.ClusterInfo = clusterInfo
 	c.rookVersion = rookVersion
 	c.spec = spec
@@ -517,20 +517,20 @@ func (c *Cluster) initClusterInfo(cephVersion cephver.CephVersion) error {
 	var err error
 
 	// get the cluster info from secret
-	c.ClusterInfo, c.maxMonID, c.mapping, err = CreateOrLoadClusterInfo(c.context, c.Namespace, &c.ownerRef)
+	c.ClusterInfo, c.maxMonID, c.mapping, err = CreateOrLoadClusterInfo(c.context, c.Namespace, c.ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster info")
 	}
 
 	c.ClusterInfo.CephVersion = cephVersion
-	c.ClusterInfo.OwnerRef = c.ownerRef
+	c.ClusterInfo.OwnerInfo = c.ownerInfo
 
 	// save cluster monitor config
 	if err = c.saveMonConfig(); err != nil {
 		return errors.Wrap(err, "failed to save mons")
 	}
 
-	k := keyring.GetSecretStore(c.context, c.ClusterInfo, &c.ownerRef)
+	k := keyring.GetSecretStore(c.context, c.ClusterInfo, c.ownerInfo)
 	// store the keyring which all mons share
 	if err := k.CreateOrUpdate(keyringStoreName, c.genMonSharedKeyring()); err != nil {
 		return errors.Wrap(err, "failed to save mon keyring secret")
@@ -1054,7 +1054,10 @@ func (c *Cluster) saveMonConfig() error {
 			Namespace: c.Namespace,
 		},
 	}
-	k8sutil.SetOwnerRef(&configMap.ObjectMeta, &c.ownerRef)
+	err := c.ownerInfo.SetControllerReference(configMap)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set owner reference mon configmap %q", configMap.Name)
+	}
 
 	monMapping, err := json.Marshal(c.mapping)
 	if err != nil {
@@ -1099,7 +1102,7 @@ func (c *Cluster) saveMonConfig() error {
 
 	// Every time the mon config is updated, must also update the global config so that all daemons
 	// have the most updated version if they restart.
-	if err := config.GetStore(c.context, c.Namespace, &c.ownerRef).CreateOrUpdate(c.ClusterInfo); err != nil {
+	if err := config.GetStore(c.context, c.Namespace, c.ownerInfo).CreateOrUpdate(c.ClusterInfo); err != nil {
 		return errors.Wrap(err, "failed to update the global config")
 	}
 

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -34,6 +34,7 @@ import (
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -106,6 +107,7 @@ func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monRe
 }
 
 func newCluster(context *clusterd.Context, namespace string, allowMultiplePerNode bool, resources v1.ResourceRequirements) *Cluster {
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	return &Cluster{
 		ClusterInfo: nil,
 		context:     context,
@@ -124,7 +126,7 @@ func newCluster(context *clusterd.Context, namespace string, allowMultiplePerNod
 		mapping: &Mapping{
 			Schedule: map[string]*MonScheduleInfo{},
 		},
-		ownerRef: metav1.OwnerReference{},
+		ownerInfo: ownerInfo,
 	}
 }
 
@@ -235,7 +237,8 @@ func TestSaveMonEndpoints(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	// create the initial config map
@@ -282,7 +285,8 @@ func TestMaxMonID(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(configDir)
-	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo, &sync.Mutex{})
 
 	// when the configmap is not found, the maxMonID is -1
 	maxMonID, err := c.getStoredMaxMonID()

--- a/pkg/operator/ceph/cluster/mon/node_test.go
+++ b/pkg/operator/ceph/cluster/mon/node_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +38,7 @@ import (
 func TestNodeAffinity(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 4)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Placement = map[rookv1.KeyType]rookv1.Placement{}
@@ -167,7 +168,7 @@ func TestPodMemory(t *testing.T) {
 
 func TestHostNetwork(t *testing.T) {
 	clientset := test.New(t, 3)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{}, &sync.Mutex{})
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 
 	c.spec.Network.HostNetwork = true

--- a/pkg/operator/ceph/cluster/mon/service_test.go
+++ b/pkg/operator/ceph/cluster/mon/service_test.go
@@ -23,6 +23,7 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +32,7 @@ import (
 func TestCreateService(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
-	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, metav1.OwnerReference{}, &sync.Mutex{})
+	c := New(&clusterd.Context{Clientset: clientset}, "ns", cephv1.ClusterSpec{}, &k8sutil.OwnerInfo{}, &sync.Mutex{})
 	m := &monConfig{ResourceName: "rook-ceph-mon-b", DaemonName: "b"}
 	clusterIP, err := c.createService(m)
 	assert.NoError(t, err)

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -90,7 +90,10 @@ func (c *Cluster) makeDeployment(monConfig *monConfig, canary bool) (*apps.Deplo
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&d.ObjectMeta)
 	cephv1.GetMonLabels(c.spec.Labels).ApplyToObjectMeta(&d.ObjectMeta)
 	controller.AddCephVersionLabelToDeployment(c.ClusterInfo.CephVersion, d)
-	k8sutil.SetOwnerRef(&d.ObjectMeta, &c.ownerRef)
+	err := c.ownerInfo.SetControllerReference(d)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference to mon deployment %q", d.Name)
+	}
 
 	pod, err := c.makeMonPod(monConfig, canary)
 	if err != nil {
@@ -135,7 +138,10 @@ func (c *Cluster) makeDeploymentPVC(m *monConfig, canary bool) (*v1.PersistentVo
 	k8sutil.AddRookVersionLabelToObjectMeta(&pvc.ObjectMeta)
 	cephv1.GetMonAnnotations(c.spec.Annotations).ApplyToObjectMeta(&pvc.ObjectMeta)
 	controller.AddCephVersionLabelToObjectMeta(c.ClusterInfo.CephVersion, &pvc.ObjectMeta)
-	k8sutil.SetOwnerRef(&pvc.ObjectMeta, &c.ownerRef)
+	err := c.ownerInfo.SetControllerReference(pvc)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference to mon pvc %q", pvc.Name)
+	}
 
 	// k8s uses limit as the resource request fallback
 	if _, ok := pvc.Spec.Resources.Limits[v1.ResourceStorage]; ok {

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -56,7 +56,7 @@ var (
 func (c *Cluster) getConfigEnvVars(osdProps osdProperties, dataDir string) []v1.EnvVar {
 	envVars := []v1.EnvVar{
 		nodeNameEnvVar(osdProps.crushHostname),
-		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerRef.UID)},
+		{Name: "ROOK_CLUSTER_ID", Value: string(c.clusterInfo.OwnerInfo.GetUID())},
 		{Name: "ROOK_CLUSTER_NAME", Value: string(c.clusterInfo.NamespacedName().Name)},
 		k8sutil.PodIPEnvVar(k8sutil.PrivateIPEnvVar),
 		k8sutil.PodIPEnvVar(k8sutil.PublicIPEnvVar),

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -95,7 +95,7 @@ func New(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, spec ce
 		clusterInfo: clusterInfo,
 		spec:        spec,
 		rookVersion: rookVersion,
-		kv:          k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, clusterInfo.OwnerRef),
+		kv:          k8sutil.NewConfigMapKVStore(clusterInfo.Namespace, context.Clientset, clusterInfo.OwnerInfo),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
@@ -225,6 +225,7 @@ func testOSDsOnPVC(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("mycluster")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	executor := osdPVCTestExecutor(t, clientset, namespace)
 
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: executor, RequestCancelOrchestration: abool.New()}

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -142,6 +142,7 @@ func TestAddRemoveNode(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("rook-ceph-test")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	generateKey := "expected key"
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
@@ -296,6 +297,7 @@ func TestAddNodeFailure(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("testcluster")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}, RequestCancelOrchestration: abool.New()}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: context.ConfigDir,
@@ -383,6 +385,7 @@ func TestGetPVCHostName(t *testing.T) {
 func TestGetOSDInfo(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
 	clusterInfo.SetName("test")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{}
 	spec := cephv1.ClusterSpec{DataDirHostPath: "/rook"}
 	c := New(context, clusterInfo, spec, "myversion")
@@ -520,6 +523,7 @@ func TestDetectCrushLocation(t *testing.T) {
 func TestGetOSDInfoWithCustomRoot(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
 	clusterInfo.SetName("test")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: "/rook",

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -76,7 +76,10 @@ func (c *Cluster) makeJob(osdProps osdProperties, provisionConfig *provisionConf
 
 	k8sutil.AddRookVersionLabelToJob(job)
 	controller.AddCephVersionLabelToJob(c.clusterInfo.CephVersion, job)
-	k8sutil.SetOwnerRef(&job.ObjectMeta, &c.clusterInfo.OwnerRef)
+	err = c.clusterInfo.OwnerInfo.SetControllerReference(job)
+	if err != nil {
+		return nil, err
+	}
 
 	// override the resources of all the init containers and main container with the expected osd prepare resources
 	c.applyResourcesToAllContainers(&podSpec.Spec, cephv1.GetPrepareOSDResources(c.spec.Resources))

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -653,7 +653,10 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 	cephv1.GetOSDLabels(c.spec.Labels).ApplyToObjectMeta(&deployment.Spec.Template.ObjectMeta)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
 	controller.AddCephVersionLabelToDeployment(c.clusterInfo.CephVersion, deployment)
-	k8sutil.SetOwnerRef(&deployment.ObjectMeta, &c.clusterInfo.OwnerRef)
+	err := c.clusterInfo.OwnerInfo.SetControllerReference(deployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set owner reference to osd deployment %q", deployment.Name)
+	}
 
 	// we are passing false in case of osd and prepare pods because we don't want to overlap placement of osd on PVC's and non-PVC's.
 	p := cephv1.GetOSDPlacement(c.spec.Placement)

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -29,6 +29,7 @@ import (
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	operatortest "github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ import (
 
 func TestPodContainer(t *testing.T) {
 	cluster := &Cluster{rookVersion: "23", clusterInfo: client.AdminClusterInfo("myosd")}
+	cluster.clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	osdProps := osdProperties{
 		crushHostname: "node",
 		devices:       []rookv1.Device{},
@@ -89,6 +91,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("test")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
@@ -432,6 +435,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 			CephVersion: cephver.Octopus,
 		}
 		clusterInfo.SetName("test")
+		clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 		c := New(context, clusterInfo, spec, "rook/rook:myversion")
 		deployment, err = c.makeDeployment(osdProp, osd, dataPathMap)
 		assert.NoError(t, err)
@@ -467,6 +471,7 @@ func TestStorageSpecConfig(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("testing")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		DataDirHostPath: context.ConfigDir,
@@ -549,6 +554,8 @@ func TestHostNetwork(t *testing.T) {
 		CephVersion: cephver.Nautilus,
 	}
 	clusterInfo.SetName("test")
+
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
 		Storage: storageSpec,
@@ -588,6 +595,7 @@ func TestOsdPrepareResources(t *testing.T) {
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
 	clusterInfo.SetName("test")
+	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	spec := cephv1.ClusterSpec{
 		Resources: map[string]v1.ResourceRequirements{"prepareosd": {
 			Limits: v1.ResourceList{
@@ -609,7 +617,7 @@ func TestOsdPrepareResources(t *testing.T) {
 }
 
 func TestClusterGetPVCEncryptionOpenInitContainerActivate(t *testing.T) {
-	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{}, cephv1.ClusterSpec{}, "rook/rook:myversion")
+	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{OwnerInfo: &k8sutil.OwnerInfo{}}, cephv1.ClusterSpec{}, "rook/rook:myversion")
 	osdProperties := osdProperties{
 		pvc: v1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "pvc1",
@@ -633,7 +641,7 @@ func TestClusterGetPVCEncryptionOpenInitContainerActivate(t *testing.T) {
 }
 
 func TestClusterGetPVCEncryptionInitContainerActivate(t *testing.T) {
-	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{}, cephv1.ClusterSpec{}, "rook/rook:myversion")
+	c := New(&clusterd.Context{}, &cephclient.ClusterInfo{OwnerInfo: &k8sutil.OwnerInfo{}}, cephv1.ClusterSpec{}, "rook/rook:myversion")
 	osdProperties := osdProperties{
 		pvc: v1.PersistentVolumeClaimVolumeSource{
 			ClaimName: "pvc1",

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -45,7 +45,8 @@ func TestOrchestrationStatus(t *testing.T) {
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{}
 	c := New(context, clusterInfo, spec, "myversion")
-	kv := k8sutil.NewConfigMapKVStore(c.clusterInfo.Namespace, clientset, metav1.OwnerReference{})
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	kv := k8sutil.NewConfigMapKVStore(c.clusterInfo.Namespace, clientset, ownerInfo)
 	nodeName := "mynode"
 	cmName := fmt.Sprintf(orchestrationStatusMapName, nodeName)
 

--- a/pkg/operator/ceph/cluster/rbd/config.go
+++ b/pkg/operator/ceph/cluster/rbd/config.go
@@ -64,7 +64,7 @@ type daemonConfig struct {
 	ResourceName string              // the name rook gives to mirror resources in k8s metadata
 	DaemonID     string              // the ID of the Ceph daemon ("a", "b", ...)
 	DataPathMap  *config.DataPathMap // location to store data in container
-	ownerRef     metav1.OwnerReference
+	ownerInfo    *k8sutil.OwnerInfo
 }
 
 // PeerToken is the content of the peer token
@@ -79,7 +79,7 @@ func (r *ReconcileCephRBDMirror) generateKeyring(clusterInfo *client.ClusterInfo
 	ctx := context.TODO()
 	user := fullDaemonName(daemonConfig.DaemonID)
 	access := []string{"mon", "profile rbd-mirror", "osd", "profile rbd"}
-	s := keyring.GetSecretStore(r.context, clusterInfo, &daemonConfig.ownerRef)
+	s := keyring.GetSecretStore(r.context, clusterInfo, daemonConfig.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/cluster/rbd/mirror.go
+++ b/pkg/operator/ceph/cluster/rbd/mirror.go
@@ -62,13 +62,14 @@ func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) erro
 
 	logger.Infof("configure rbd-mirroring with %d workers", cephRBDMirror.Spec.Count)
 
+	ownerInfo := k8sutil.NewOwnerInfo(cephRBDMirror, r.scheme)
 	daemonID := k8sutil.IndexToName(0)
 	resourceName := fmt.Sprintf("%s-%s", AppName, daemonID)
 	daemonConf := &daemonConfig{
 		DaemonID:     daemonID,
 		ResourceName: resourceName,
 		DataPathMap:  config.NewDatalessDaemonDataPathMap(cephRBDMirror.Namespace, r.cephClusterSpec.DataDirHostPath),
-		ownerRef:     *ref,
+		ownerInfo:    ownerInfo,
 	}
 
 	_, err = r.generateKeyring(r.clusterInfo, daemonConf)
@@ -85,7 +86,7 @@ func (r *ReconcileCephRBDMirror) start(cephRBDMirror *cephv1.CephRBDMirror) erro
 	// Set owner ref to cephRBDMirror object
 	err = controllerutil.SetControllerReference(cephRBDMirror, d, r.scheme)
 	if err != nil {
-		return errors.Wrapf(err, "failed to set owner reference for ceph rbd-mirror %q secret", d.Name)
+		return errors.Wrapf(err, "failed to set owner reference for ceph rbd-mirror deployment %q", d.Name)
 	}
 
 	// Set the deployment hash as an annotation

--- a/pkg/operator/ceph/cluster/rbd/spec_test.go
+++ b/pkg/operator/ceph/cluster/rbd/spec_test.go
@@ -23,7 +23,8 @@ import (
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
+
+	"github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -91,10 +92,10 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, 4, len(d.Spec.Template.Spec.Containers[0].VolumeMounts))
 
 	// Deployment should have Ceph labels
-	cephtest.AssertLabelsContainCephRequirements(t, d.ObjectMeta.Labels,
+	test.AssertLabelsContainCephRequirements(t, d.ObjectMeta.Labels,
 		config.RbdMirrorType, "a", AppName, "ns")
 
-	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
+	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.RbdMirrorType, "a", AppName, "ns", "ceph/ceph:myceph",
 		"200", "100", "600", "300", /* resources */
 		"my-priority-class")

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -119,7 +119,7 @@ func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion,
 func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Duration) (*cephver.CephVersion, error) {
 	logger.Infof("detecting the ceph image version for image %s...", cephImage)
 	versionReporter, err := cmdreporter.New(
-		c.context.Clientset, &c.ownerRef,
+		c.context.Clientset, c.ownerInfo,
 		detectVersionName, detectVersionName, c.Namespace,
 		[]string{"ceph"}, []string{"--version"},
 		rookImage, cephImage)

--- a/pkg/operator/ceph/config/keyring/admin_test.go
+++ b/pkg/operator/ceph/config/keyring/admin_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -37,10 +38,10 @@ func TestAdminKeyringStore(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "test-ns"
-	owner := metav1.OwnerReference{}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	clusterInfo := clienttest.CreateTestClusterInfo(1)
 	clusterInfo.Namespace = ns
-	k := GetSecretStore(ctx, clusterInfo, &owner)
+	k := GetSecretStore(ctx, clusterInfo, ownerInfo)
 
 	assertKeyringData := func(expectedKeyring string) {
 		s, e := clientset.CoreV1().Secrets(ns).Get(ctxt, "rook-ceph-admin-keyring", metav1.GetOptions{})
@@ -68,9 +69,9 @@ func TestAdminVolumeAndMount(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	clusterInfo := clienttest.CreateTestClusterInfo(1)
-	s := GetSecretStore(ctx, clusterInfo, &owner)
+	s := GetSecretStore(ctx, clusterInfo, ownerInfo)
 
 	clusterInfo.CephCred.Secret = "adminsecretkey"
 	err := s.Admin().CreateOrUpdate(clusterInfo)

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	testop "github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -49,8 +50,8 @@ func TestGenerateKey(t *testing.T) {
 		Executor:  executor,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
-	s := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &owner)
+	ownerInfo := k8sutil.OwnerInfo{}
+	s := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &ownerInfo)
 
 	generateKey = "generatedsecretkey"
 	failGenerateKey = false
@@ -77,9 +78,9 @@ func TestKeyringStore(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	ns := "rook-ceph"
-	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, &owner)
+	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: ns}, ownerInfo)
 
 	assertKeyringData := func(keyringName, expectedKeyring string) {
 		s, e := clientset.CoreV1().Secrets(ns).Get(ctxt, keyringName, metav1.GetOptions{})
@@ -123,8 +124,8 @@ func TestResourceVolumeAndMount(t *testing.T) {
 	ctx := &clusterd.Context{
 		Clientset: clientset,
 	}
-	owner := metav1.OwnerReference{}
-	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: "ns"}, &owner)
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
+	k := GetSecretStore(ctx, &client.ClusterInfo{Namespace: "ns"}, ownerInfo)
 	err := k.CreateOrUpdate("test-resource", "qwertyuiop")
 	assert.NoError(t, err)
 	err = k.CreateOrUpdate("second-resource", "asdfgyhujkl")

--- a/pkg/operator/ceph/config/store_test.go
+++ b/pkg/operator/ceph/config/store_test.go
@@ -37,9 +37,9 @@ func TestStore(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 
-	s := GetStore(ctx, ns, &owner)
+	s := GetStore(ctx, ns, ownerInfo)
 
 	assertConfigStore := func(ci *cephclient.ClusterInfo) {
 		sec, e := clientset.CoreV1().Secrets(ns).Get(ctxt, StoreName, metav1.GetOptions{})
@@ -81,9 +81,9 @@ func TestEnvVarsAndFlags(t *testing.T) {
 		Clientset: clientset,
 	}
 	ns := "rook-ceph"
-	owner := metav1.OwnerReference{}
+	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 
-	s := GetStore(ctx, ns, &owner)
+	s := GetStore(ctx, ns, ownerInfo)
 	err := s.CreateOrUpdate(clienttest.CreateTestClusterInfo(3))
 	assert.NoError(t, err)
 

--- a/pkg/operator/ceph/controller/controller_utils.go
+++ b/pkg/operator/ceph/controller/controller_utils.go
@@ -136,12 +136,14 @@ func IsReadyToReconcile(c client.Client, clustercontext *clusterd.Context, names
 // ClusterOwnerRef represents the owner reference of the CephCluster CR
 func ClusterOwnerRef(clusterName, clusterID string) metav1.OwnerReference {
 	blockOwner := true
+	controller := true
 	return metav1.OwnerReference{
 		APIVersion:         fmt.Sprintf("%s/%s", ClusterResource.Group, ClusterResource.Version),
 		Kind:               ClusterResource.Kind,
 		Name:               clusterName,
 		UID:                types.UID(clusterID),
 		BlockOwnerDeletion: &blockOwner,
+		Controller:         &controller,
 	}
 }
 

--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -23,16 +23,15 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	controllerutil "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/k8sutil"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 )
 
-func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerRef *metav1.OwnerReference) {
+func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo) {
 	var v *CephCSIVersion
 	var err error
 	if !AllowUnsupported && CSIEnabled() {
-		if v, err = validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerRef); err != nil {
+		if v, err = validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerInfo); err != nil {
 			logger.Errorf("invalid csi version. %+v", err)
 			return
 		}
@@ -41,7 +40,7 @@ func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage
 	}
 
 	if CSIEnabled() {
-		if err := startDrivers(context.Clientset, context.RookClientset, namespace, serverVersion, ownerRef, v); err != nil {
+		if err := startDrivers(context.Clientset, context.RookClientset, namespace, serverVersion, ownerInfo, v); err != nil {
 			logger.Errorf("failed to start Ceph csi drivers. %v", err)
 			return
 		}

--- a/pkg/operator/ceph/csi/secrets.go
+++ b/pkg/operator/ceph/csi/secrets.go
@@ -151,10 +151,13 @@ func createOrUpdateCSISecret(clusterInfo *client.ClusterInfo, csiRBDProvisionerS
 			Data: secret,
 			Type: k8sutil.RookType,
 		}
-		k8sutil.SetOwnerRef(&s.ObjectMeta, &clusterInfo.OwnerRef)
+		err := clusterInfo.OwnerInfo.SetControllerReference(s)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set owner reference to keyring secret %q", secretName)
+		}
 
 		// Create Kubernetes Secret
-		err := k.CreateSecret(s)
+		err = k.CreateSecret(s)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create kubernetes secret %q for cluster %q", secret, clusterInfo.Namespace)
 		}
@@ -167,7 +170,7 @@ func createOrUpdateCSISecret(clusterInfo *client.ClusterInfo, csiRBDProvisionerS
 
 // CreateCSISecrets creates all the Kubernetes CSI Secrets
 func CreateCSISecrets(context *clusterd.Context, clusterInfo *client.ClusterInfo) error {
-	k := keyring.GetSecretStore(context, clusterInfo, &clusterInfo.OwnerRef)
+	k := keyring.GetSecretStore(context, clusterInfo, clusterInfo.OwnerInfo)
 
 	// Create CSI RBD Provisioner Ceph key
 	csiRBDProvisionerSecretKey, err := createCSIKeyringRBDProvisioner(k)

--- a/pkg/operator/ceph/file/mds/config.go
+++ b/pkg/operator/ceph/file/mds/config.go
@@ -44,7 +44,7 @@ func (c *Cluster) generateKeyring(m *mdsConfig) (string, error) {
 	access := []string{"osd", "allow *", "mds", "allow", "mon", "allow profile mds"}
 
 	// At present
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.ownerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -37,8 +37,6 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-mds")
@@ -59,9 +57,8 @@ type Cluster struct {
 	clusterSpec     *cephv1.ClusterSpec
 	fs              cephv1.CephFilesystem
 	fsID            string
-	ownerRef        metav1.OwnerReference
+	ownerInfo       *k8sutil.OwnerInfo
 	dataDirHostPath string
-	scheme          *runtime.Scheme
 }
 
 type mdsConfig struct {
@@ -77,9 +74,8 @@ func NewCluster(
 	clusterSpec *cephv1.ClusterSpec,
 	fs cephv1.CephFilesystem,
 	fsdetails *client.CephFilesystemDetails,
-	ownerRef metav1.OwnerReference,
+	ownerInfo *k8sutil.OwnerInfo,
 	dataDirHostPath string,
-	scheme *runtime.Scheme,
 ) *Cluster {
 	return &Cluster{
 		clusterInfo:     clusterInfo,
@@ -87,9 +83,8 @@ func NewCluster(
 		clusterSpec:     clusterSpec,
 		fs:              fs,
 		fsID:            strconv.Itoa(fsdetails.ID),
-		ownerRef:        ownerRef,
+		ownerInfo:       ownerInfo,
 		dataDirHostPath: dataDirHostPath,
-		scheme:          scheme,
 	}
 }
 
@@ -157,14 +152,14 @@ func (c *Cluster) Start() error {
 		}
 
 		// start the deployment
-		d, err := c.makeDeployment(mdsConfig)
+		d, err := c.makeDeployment(mdsConfig, c.fs.Namespace)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create deployment")
 		}
 		// Set owner ref to cephFilesystem object
-		err = controllerutil.SetControllerReference(&c.fs, d, c.scheme)
+		err = c.ownerInfo.SetControllerReference(d)
 		if err != nil {
-			return errors.Wrapf(err, "failed to set owner reference for ceph filesystem %q secret", d.Name)
+			return errors.Wrapf(err, "failed to set owner reference for mds deployment %q", d.Name)
 		}
 
 		// Set the deployment hash as an annotation

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -39,15 +39,16 @@ const (
 	mdsCacheMemoryLimitFactor = 0.5
 )
 
-func (c *Cluster) makeDeployment(mdsConfig *mdsConfig) (*apps.Deployment, error) {
+func (c *Cluster) makeDeployment(mdsConfig *mdsConfig, namespace string) (*apps.Deployment, error) {
 
 	mdsContainer := c.makeMdsDaemonContainer(mdsConfig)
 	mdsContainer = config.ConfigureLivenessProbe(cephv1.KeyMds, mdsContainer, c.clusterSpec.HealthCheck)
 
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   mdsConfig.ResourceName,
-			Labels: c.podLabels(mdsConfig, true),
+			Name:      mdsConfig.ResourceName,
+			Namespace: namespace,
+			Labels:    c.podLabels(mdsConfig, true),
 		},
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{

--- a/pkg/operator/ceph/file/mirror/config.go
+++ b/pkg/operator/ceph/file/mirror/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
 const (
@@ -43,7 +43,7 @@ const (
 type daemonConfig struct {
 	ResourceName string              // the name rook gives to mirror resources in k8s metadata
 	DataPathMap  *config.DataPathMap // location to store data in container
-	ownerRef     metav1.OwnerReference
+	ownerInfo    *k8sutil.OwnerInfo
 }
 
 // PeerToken is the content of the peer token
@@ -61,7 +61,7 @@ func (r *ReconcileFilesystemMirror) generateKeyring(clusterInfo *client.ClusterI
 		"mds", "allow r",
 		"osd", "allow rw tag cephfs metadata=*, allow r tag cephfs data=*",
 	}
-	s := keyring.GetSecretStore(r.context, clusterInfo, &daemonConfig.ownerRef)
+	s := keyring.GetSecretStore(r.context, clusterInfo, daemonConfig.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -31,8 +31,9 @@ import (
 func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, fsMirror *cephv1.CephFilesystemMirror) (*apps.Deployment, error) {
 	podSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   daemonConfig.ResourceName,
-			Labels: controller.CephDaemonAppLabels(AppName, fsMirror.Namespace, config.FilesystemMirrorType, userID, true),
+			Name:      daemonConfig.ResourceName,
+			Namespace: fsMirror.Namespace,
+			Labels:    controller.CephDaemonAppLabels(AppName, fsMirror.Namespace, config.FilesystemMirrorType, userID, true),
 		},
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{

--- a/pkg/operator/ceph/file/mirror/spec_test.go
+++ b/pkg/operator/ceph/file/mirror/spec_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
+	"github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -89,10 +89,10 @@ func TestPodSpec(t *testing.T) {
 	assert.Equal(t, 4, len(d.Spec.Template.Spec.Containers[0].VolumeMounts))
 
 	// Deployment should have Ceph labels
-	cephtest.AssertLabelsContainCephRequirements(t, d.ObjectMeta.Labels,
+	test.AssertLabelsContainCephRequirements(t, d.ObjectMeta.Labels,
 		config.FilesystemMirrorType, userID, AppName, "ns")
 
-	podTemplate := cephtest.NewPodTemplateSpecTester(t, &d.Spec.Template)
+	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
 	podTemplate.RunFullSuite(config.FilesystemMirrorType, userID, AppName, "ns", "ceph/ceph:v16",
 		"200", "100", "600", "300", /* resources */
 		"my-priority-class")

--- a/pkg/operator/ceph/nfs/config.go
+++ b/pkg/operator/ceph/nfs/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 )
 
 const (
@@ -85,7 +86,8 @@ func (r *ReconcileCephNFS) generateKeyring(n *cephv1.CephNFS, name string) error
 		return errors.Wrapf(err, "failed to get controller %q owner reference", n.Name)
 	}
 
-	s := keyring.GetSecretStore(r.context, r.clusterInfo, ref)
+	ownerInfo := k8sutil.NewOwnerInfo(n, r.scheme)
+	s := keyring.GetSecretStore(r.context, r.clusterInfo, ownerInfo)
 
 	key, err := s.GenerateKey(user, caps)
 	if err != nil {

--- a/pkg/operator/ceph/nfs/nfs.go
+++ b/pkg/operator/ceph/nfs/nfs.go
@@ -87,7 +87,7 @@ func (r *ReconcileCephNFS) upCephNFS(n *cephv1.CephNFS) error {
 		// Set owner ref to cephNFS object
 		err = controllerutil.SetControllerReference(n, deployment, r.scheme)
 		if err != nil {
-			return errors.Wrapf(err, "failed to set owner reference for ceph nfs %q secret", deployment.Name)
+			return errors.Wrapf(err, "failed to set owner reference for ceph nfs deployment %q", deployment.Name)
 		}
 
 		// Set the deployment hash as an annotation
@@ -197,7 +197,7 @@ func (r *ReconcileCephNFS) createConfigMap(n *cephv1.CephNFS, name string) (stri
 	// Set owner reference
 	err := controllerutil.SetControllerReference(n, configMap, r.scheme)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to set owner reference for ceph nfs %q config map", configMap.Name)
+		return "", errors.Wrapf(err, "failed to set owner reference for ceph ganesha configmap %q", configMap.Name)
 	}
 
 	if _, err := r.context.Clientset.CoreV1().ConfigMaps(n.Namespace).Create(ctx, configMap, metav1.CreateOptions{}); err != nil {

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -77,7 +77,7 @@ func (r *ReconcileCephNFS) createCephNFSService(nfs *cephv1.CephNFS, cfg daemonC
 	// Set owner ref to the parent object
 	err := controllerutil.SetControllerReference(nfs, s, r.scheme)
 	if err != nil {
-		return errors.Wrap(err, "failed to set owner reference to ceph object store")
+		return errors.Wrapf(err, "failed to set owner reference to ceph nfs %q", s)
 	}
 
 	svc, err := r.context.Clientset.CoreV1().Services(nfs.Namespace).Create(ctx, s, metav1.CreateOptions{})

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -80,7 +80,7 @@ func (c *clusterConfig) generateKeyring(rgwConfig *rgwConfig) (string, error) {
 	user := generateCephXUser(rgwConfig.ResourceName)
 	/* TODO: this says `osd allow rwx` while template says `osd allow *`; which is correct? */
 	access := []string{"osd", "allow rwx", "mon", "allow rw"}
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerRef)
+	s := keyring.GetSecretStore(c.context, c.clusterInfo, c.ownerInfo)
 
 	key, err := s.GenerateKey(user, access)
 	if err != nil {

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/pkg/util/exec"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -312,6 +313,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 }
 
 func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *cephv1.CephObjectStore, namespacedName types.NamespacedName, cluster cephv1.ClusterSpec) (reconcile.Result, error) {
+	ownerInfo := k8sutil.NewOwnerInfo(cephObjectStore, r.scheme)
 	cfg := clusterConfig{
 		context:     r.context,
 		clusterInfo: r.clusterInfo,
@@ -320,7 +322,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 		clusterSpec: r.clusterSpec,
 		DataPathMap: opconfig.NewStatelessDaemonDataPathMap(opconfig.RgwType, cephObjectStore.Name, cephObjectStore.Namespace, r.clusterSpec.DataDirHostPath),
 		client:      r.client,
-		scheme:      r.scheme,
+		ownerInfo:   ownerInfo,
 	}
 	objContext := NewContext(r.context, r.clusterInfo, cephObjectStore.Name)
 	objContext.UID = string(cephObjectStore.UID)

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -45,7 +45,7 @@ func mimeTypesMountPath() string {
 
 // store mime.types file in a config map
 func (c *clusterConfig) generateMimeTypes() error {
-	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, *c.ownerRef)
+	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, c.ownerInfo)
 	if _, err := k.GetValue(c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
 		logger.Infof("config map for object pool %s already exists, not overwriting", c.store.Name)
 		return nil

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -290,7 +290,7 @@ func (r *ReconcileObjectRealm) createRealmKeys(realm *cephv1.CephObjectRealm) (r
 	}
 	err = controllerutil.SetControllerReference(realm, secret, r.scheme)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference of secret %q", secret.Name)
+		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference of rgw secret %q", secret.Name)
 	}
 
 	if _, err = r.context.Clientset.CoreV1().Secrets(realm.Namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -33,7 +33,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -369,9 +368,9 @@ func (c *clusterConfig) reconcileExternalEndpoint(cephObjectStore *cephv1.CephOb
 
 	endpoint := c.generateEndpoint(cephObjectStore)
 	// Set owner ref to the parent object
-	err := controllerutil.SetControllerReference(cephObjectStore, endpoint, c.scheme)
+	err := c.ownerInfo.SetControllerReference(endpoint)
 	if err != nil {
-		return errors.Wrap(err, "failed to set owner reference to ceph object store endpoint")
+		return errors.Wrapf(err, "failed to set owner reference to ceph object store endpoint %q", endpoint.Name)
 	}
 
 	_, err = k8sutil.CreateOrUpdateEndpoint(c.context.Clientset, cephObjectStore.Namespace, endpoint)
@@ -385,9 +384,9 @@ func (c *clusterConfig) reconcileExternalEndpoint(cephObjectStore *cephv1.CephOb
 func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore) (string, error) {
 	service := c.generateService(cephObjectStore)
 	// Set owner ref to the parent object
-	err := controllerutil.SetControllerReference(cephObjectStore, service, c.scheme)
+	err := c.ownerInfo.SetControllerReference(service)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to set owner reference to ceph object store service")
+		return "", errors.Wrapf(err, "failed to set owner reference to ceph object store service %q", service.Name)
 	}
 
 	svc, err := k8sutil.CreateOrUpdateService(c.context.Clientset, cephObjectStore.Namespace, service)

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
+	"github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -80,7 +80,7 @@ func TestPodSpecs(t *testing.T) {
 		getLabels(c.store.Name, c.store.Namespace, false),
 		s.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels)
 
-	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
+	podTemplate := test.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
@@ -125,7 +125,7 @@ func TestSSLPodSpec(t *testing.T) {
 	s, err := c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
 
-	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
+	podTemplate := test.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -379,7 +379,7 @@ func (r *ReconcileObjectStoreUser) reconcileCephUserSecret(cephObjectStoreUser *
 	// Set owner ref to the object store user object
 	err := controllerutil.SetControllerReference(cephObjectStoreUser, secret, r.scheme)
 	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference for ceph object user %q secret", secret.Name)
+		return reconcile.Result{}, errors.Wrapf(err, "failed to set owner reference of ceph object user secret %q", secret.Name)
 	}
 
 	// Create Kubernetes Secret

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -249,9 +249,10 @@ func (o *Operator) updateDrivers() error {
 		ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 	}
 
+	ownerInfo := k8sutil.NewOwnerInfoWithOwnerRef(ownerRef, o.operatorNamespace)
 	// create an empty config map. config map will be filled with data
 	// later when clusters have mons
-	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerRef)
+	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed creating csi config map")
 	}
@@ -260,7 +261,7 @@ func (o *Operator) updateDrivers() error {
 		return errors.Wrap(err, "invalid csi params")
 	}
 
-	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerRef)
+	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerInfo)
 	return nil
 }
 

--- a/pkg/operator/ceph/pool/config.go
+++ b/pkg/operator/ceph/pool/config.go
@@ -55,7 +55,7 @@ func (r *ReconcileCephBlockPool) createBootstrapPeerSecret(cephBlockPool *cephv1
 	// set ownerref to the Secret
 	err = controllerutil.SetControllerReference(cephBlockPool, s, r.scheme)
 	if err != nil {
-		return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to set owner reference for rbd-mirror bootstrap peer %q secret", s.Name)
+		return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to set owner reference for rbd-mirror bootstrap peer secret %q", s.Name)
 	}
 
 	// Create Secret

--- a/pkg/operator/ceph/test/ownerinfo/resources.go
+++ b/pkg/operator/ceph/test/ownerinfo/resources.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func NewTestOwnerInfo(t *testing.T) *k8sutil.OwnerInfo {
+	cluster := &cephv1.CephCluster{}
+	scheme := runtime.NewScheme()
+	err := cephv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+	return k8sutil.NewOwnerInfo(cluster, scheme)
+}
+
+func NewTestOwnerInfoWithOwnerRef() *k8sutil.OwnerInfo {
+	return k8sutil.NewOwnerInfoWithOwnerRef(&metav1.OwnerReference{}, "")
+}

--- a/pkg/operator/k8sutil/kvstore_test.go
+++ b/pkg/operator/k8sutil/kvstore_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,5 +168,6 @@ func newKVStore(stores ...*v1.ConfigMap) (*ConfigMapKVStore, string) {
 	}
 
 	clientset := fake.NewSimpleClientset(objects...)
-	return NewConfigMapKVStore(namespace, clientset, metav1.OwnerReference{}), storeName
+	ownerInfo := NewOwnerInfoWithOwnerRef(&metav1.OwnerReference{}, "")
+	return NewConfigMapKVStore(namespace, clientset, ownerInfo), storeName
 }

--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -20,11 +20,102 @@ package k8sutil
 // MergeResourceRequirements merges two resource requirements together (first overrides second values)
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+// OwnerInfo is to set owner references. Only one of owner and ownerRef must be valid.
+type OwnerInfo struct {
+	owner             metav1.Object
+	scheme            *runtime.Scheme
+	ownerRef          *metav1.OwnerReference
+	ownerRefNamespace string
+}
+
+// NewOwnerInfo create a new ownerInfo to set ownerReference by controllerutil
+func NewOwnerInfo(owner metav1.Object, scheme *runtime.Scheme) *OwnerInfo {
+	return &OwnerInfo{owner: owner, scheme: scheme}
+}
+
+// NewOwnerInfoWithOwnerRef create a new ownerInfo to set ownerReference by rook itself
+func NewOwnerInfoWithOwnerRef(ownerRef *metav1.OwnerReference, namespace string) *OwnerInfo {
+	return &OwnerInfo{ownerRef: ownerRef, ownerRefNamespace: namespace}
+}
+
+func (info *OwnerInfo) validateOwner(object metav1.Object) error {
+	if info.ownerRefNamespace == "" {
+		return nil
+	}
+	objectNamespace := object.GetNamespace()
+	if objectNamespace == "" {
+		return fmt.Errorf("cluster-scoped resource %q must not have a namespaced resource %q in namespace %q",
+			object.GetName(), info.ownerRef.Name, info.ownerRefNamespace)
+
+	}
+	if info.ownerRefNamespace != objectNamespace {
+		return fmt.Errorf("cross-namespaced owner references are disallowed. resource %q is in namespace %q, owner %q is in %q",
+			object.GetName(), object.GetNamespace(), info.ownerRef.Name, info.ownerRefNamespace)
+	}
+	return nil
+}
+
+func (info *OwnerInfo) validateController(object metav1.Object) error {
+	existingController := metav1.GetControllerOf(object)
+	if existingController != nil && existingController.UID != info.ownerRef.UID {
+		return fmt.Errorf("%q already set its controller %q", object.GetName(), info.ownerRef.Name)
+	}
+	return nil
+}
+
+// SetOwnerReference set the owner reference of object
+func (info *OwnerInfo) SetOwnerReference(object metav1.Object) error {
+	if info.owner != nil {
+		return controllerutil.SetOwnerReference(info.owner, object, info.scheme)
+	}
+	err := info.validateOwner(object)
+	if err != nil {
+		return err
+	}
+	SetOwnerRef(object, info.ownerRef)
+	return nil
+}
+
+// SetControllerReference set the controller reference of object
+func (info *OwnerInfo) SetControllerReference(object metav1.Object) error {
+	if info.owner != nil {
+		return controllerutil.SetControllerReference(info.owner, object, info.scheme)
+	}
+	err := info.validateOwner(object)
+	if err != nil {
+		return err
+	}
+	err = info.validateController(object)
+	if err != nil {
+		return err
+	}
+	blockOwnerDeletion := true
+	controller := true
+	info.ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
+	info.ownerRef.Controller = &controller
+	SetOwnerRef(object, info.ownerRef)
+	return nil
+}
+
+// GetUID gets the UID of the owner
+func (info *OwnerInfo) GetUID() types.UID {
+	return info.owner.GetUID()
+}
+
+// GetUID gets the UID of the owner
+func (info *OwnerInfo) GetOwnerRef() *metav1.OwnerReference {
+	return info.ownerRef
+}
 
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {
 	// if the first has a value not set check if second has and set it in first
@@ -63,14 +154,14 @@ func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.Resourc
 	return first
 }
 
-func SetOwnerRef(object *metav1.ObjectMeta, ownerRef *metav1.OwnerReference) {
+func SetOwnerRef(object metav1.Object, ownerRef *metav1.OwnerReference) {
 	if ownerRef == nil {
 		return
 	}
 	SetOwnerRefs(object, []metav1.OwnerReference{*ownerRef})
 }
 
-func SetOwnerRefsWithoutBlockOwner(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+func SetOwnerRefsWithoutBlockOwner(object metav1.Object, ownerRefs []metav1.OwnerReference) {
 	if ownerRefs == nil {
 		return
 	}
@@ -89,7 +180,7 @@ func SetOwnerRefsWithoutBlockOwner(object *metav1.ObjectMeta, ownerRefs []metav1
 	SetOwnerRefs(object, newOwners)
 }
 
-func SetOwnerRefs(object *metav1.ObjectMeta, ownerRefs []metav1.OwnerReference) {
+func SetOwnerRefs(object metav1.Object, ownerRefs []metav1.OwnerReference) {
 	object.SetOwnerReferences(ownerRefs)
 }
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -232,7 +232,8 @@ osd_pool_default_size = 1
 `}
 	customCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "rook-config-override",
+			Name:      "rook-config-override",
+			Namespace: namespace,
 		},
 		Data: customSettings,
 	}


### PR DESCRIPTION
**Description of your changes:**

It's better to validate ownerReferences when setting them. In addition, we should use controllerrutil.Set{Controller,Owner}Reference, that have such validation, as possible.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
