### PR TITLE
ceph: add ability to set pool quotas

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -192,6 +192,11 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
     * `disabled`: whether to enable or disable pool mirroring status
     * `interval`: time interval to refresh the mirroring status (default 60s)
 
+* `quotas`: Set byte and object quotas. See the [ceph documentation](https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas) for more info.
+  * `maxBytes`: quota in bytes (default: 0)
+  * `maxObjects`: quota in objects (default: 0)
+    > **NOTE**: A value of 0 disables the quota.
+
 ### Add specific pool properties
 
 With `poolProperties` you can set any pool property:

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -1216,6 +1216,16 @@ spec:
                             type: string
                           startTime:
                             type: string
+                quotas:
+                  type: object
+                  nullable: true
+                  properties:
+                    maxBytes:
+                      type: integer
+                      minimum: 0
+                    maxObjects:
+                      type: integer
+                      minimum: 0
                 statusCheck:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -1263,6 +1263,16 @@ spec:
                             type: string
                           startTime:
                             type: string
+                quotas:
+                  type: object
+                  nullable: true
+                  properties:
+                    maxBytes:
+                      type: integer
+                      minimum: 0
+                    maxObjects:
+                      type: integer
+                      minimum: 0
                 statusCheck:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -54,6 +54,11 @@ spec:
     mirror:
       disabled: false
       interval: 60s
+  # quota in bytes and/or objects, default value is 0 (unlimited)
+  # see https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas
+  # quotas:
+    # maxBytes: 10737418240 # 10GiB = 10 * 1024 * 1024 * 1024
+    # maxObjects: 1000000000 # 1 billion objects
   # A key/value list of annotations
   annotations:
   #  key: value

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -393,6 +393,9 @@ type PoolSpec struct {
 
 	// The mirroring statusCheck
 	StatusCheck MirrorHealthCheckSpec `json:"statusCheck"`
+
+	// The quota settings
+	Quotas QuotaSpec `json:"quotas"`
 }
 
 type MirrorHealthCheckSpec struct {
@@ -475,6 +478,15 @@ type SnapshotScheduleSpec struct {
 
 	// StartTime indicates when to start the snapshot
 	StartTime string `json:"startTime,omitempty"`
+}
+
+// QuotaSpec represents the spec for quotas in a pool
+type QuotaSpec struct {
+	// MaxBytes represents the quota in bytes
+	MaxBytes *uint64 `json:"maxBytes,omitempty"`
+
+	// MaxObjects represents the quota in objects
+	MaxObjects *uint64 `json:"maxObjects,omitempty"`
 }
 
 // ErasureCodeSpec represents the spec for erasure code in a pool

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1269,6 +1269,16 @@ spec:
                             type: string
                           startTime:
                             type: string
+                quotas:
+                  type: object
+                  nullable: true
+                  properties:
+                    maxBytes:
+                      type: integer
+                      minimum: 0
+                    maxObjects:
+                      type: integer
+                      minimum: 0
                 statusCheck:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -3769,6 +3779,9 @@ spec:
   mirroring:
     enabled: true
     mode: image
+  quotas:
+    maxBytes: 10737418240
+    maxObjects: 1000000
   statusCheck:
     mirror:
       disabled: false


### PR DESCRIPTION
This will allow setting ceph pool quotas in bytes and/or objects.

Ceph documentation: https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas

Signed-off-by: Frank Ritchie <12985912+fritchie@users.noreply.github.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
