### PR TITLE
ceph: removed individual force delete pod code for mons and osds

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -222,7 +222,7 @@ func TestForceDeleteStuckRookPodsOnNotReadyNodes(t *testing.T) {
 			Name:      "stuck-pod",
 			Namespace: clusterName.Namespace,
 			Labels: map[string]string{
-				"rook_cluster": clusterName.Name,
+				"app": "rook-ceph-osd",
 			},
 		},
 	}
@@ -287,14 +287,17 @@ func TestGetRookPodsOnNode(t *testing.T) {
 
 	c := newCephStatusChecker(context, clusterInfo, &cephv1.ClusterSpec{})
 	labels := []map[string]string{
-		{"rook_cluster": clusterName.Name},
+		{"app": "rook-ceph-osd"},
 		{"app": "csi-rbdplugin-provisioner"},
 		{"app": "csi-rbdplugin"},
 		{"app": "csi-cephfsplugin-provisioner"},
 		{"app": "csi-cephfsplugin"},
 		{"app": "rook-ceph-operator"},
-		{"rook_cluster": "test", "app": "csi-cephfsplugin"},
+		{"app": "rook-ceph-crashcollector"},
+		{"app": "rook-ceph-mgr"},
+		{"app": "rook-ceph-mds"},
 		{"app": "user-app"},
+		{"app": "rook-ceph-mon"},
 	}
 
 	pod := v1.Pod{
@@ -322,7 +325,7 @@ func TestGetRookPodsOnNode(t *testing.T) {
 	pods, err := c.getRookPodsOnNode("node0")
 	assert.NoError(t, err)
 	// A pod is having two matching labels and its returned only once
-	assert.Equal(t, 7, len(pods))
+	assert.Equal(t, 10, len(pods))
 
 	podNames := []string{}
 	for _, pod := range pods {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/config"
-	"github.com/rook/rook/pkg/operator/k8sutil"
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
 	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -40,9 +39,7 @@ import (
 	"github.com/tevino/abool"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 func TestCheckHealth(t *testing.T) {
@@ -378,82 +375,6 @@ func TestAddOrRemoveExternalMonitor(t *testing.T) {
 	assert.True(t, changed)
 	// ClusterInfo should now have 2 monitors
 	assert.Equal(t, 2, len(c.ClusterInfo.Monitors))
-}
-
-func TestForceDeleteFailedMon(t *testing.T) {
-	ctx := context.TODO()
-	clientset := test.New(t, 1)
-	context := &clusterd.Context{
-		Clientset: clientset,
-	}
-	c := &Cluster{
-		context:   context,
-		Namespace: "ns",
-	}
-
-	failedMonName := "a"
-	monToFail := createTestMonPod(ctx, t, clientset, c.Namespace, failedMonName)
-	createTestMonPod(ctx, t, clientset, c.Namespace, "b")
-	createTestMonPod(ctx, t, clientset, c.Namespace, "c")
-
-	assert.NoError(t, c.restartMonIfStuckTerminating(failedMonName))
-
-	// The mon should still exist since it wasn't in a deleted state
-	p, err := context.Clientset.CoreV1().Pods(c.Namespace).Get(ctx, monToFail.Name, metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.NotNil(t, p)
-
-	// Add a deletion timestamp to the pod
-	monToFail.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-	_, err = context.Clientset.CoreV1().Pods(c.Namespace).Update(ctx, &monToFail, metav1.UpdateOptions{})
-	assert.NoError(t, err)
-
-	assert.NoError(t, c.restartMonIfStuckTerminating(failedMonName))
-
-	// The pod should still exist since the node is ready
-	p, err = context.Clientset.CoreV1().Pods(c.Namespace).Get(ctx, monToFail.Name, metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.NotNil(t, p)
-
-	// Set the node to a not ready state
-	nodes, err := context.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	assert.NoError(t, err)
-	for _, node := range nodes.Items {
-		node.Status.Conditions[0].Status = v1.ConditionFalse
-		localnode := node
-		_, err := context.Clientset.CoreV1().Nodes().Update(ctx, &localnode, metav1.UpdateOptions{})
-		assert.NoError(t, err)
-	}
-
-	assert.NoError(t, c.restartMonIfStuckTerminating(failedMonName))
-
-	// The pod should be deleted since the pod is marked as deleted and the node is not ready
-	_, err = context.Clientset.CoreV1().Pods(c.Namespace).Get(ctx, monToFail.Name, metav1.GetOptions{})
-	assert.Error(t, err)
-	assert.True(t, kerrors.IsNotFound(err))
-
-	// mons b and c should still exist
-	_, err = context.Clientset.CoreV1().Pods(c.Namespace).Get(ctx, "b-test", metav1.GetOptions{})
-	assert.NoError(t, err)
-	_, err = context.Clientset.CoreV1().Pods(c.Namespace).Get(ctx, "c-test", metav1.GetOptions{})
-	assert.NoError(t, err)
-}
-
-func createTestMonPod(ctx context.Context, t *testing.T, clientset kubernetes.Interface, namespace, name string) v1.Pod {
-	pod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "-test",
-			Namespace: namespace,
-			Labels: map[string]string{
-				k8sutil.AppAttr: AppName,
-				"mon":           name,
-			},
-		},
-	}
-	pod.Spec.NodeName = "node0"
-	_, err := clientset.CoreV1().Pods(namespace).Create(ctx, &pod, metav1.CreateOptions{})
-	assert.NoError(t, err)
-	return pod
 }
 
 func TestNewHealthChecker(t *testing.T) {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1169,11 +1169,6 @@ func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
 	logger.Infof("deployment for mon %s already exists. updating if needed",
 		d.Name)
 
-	// Restart the mon if it is stuck on a failed node
-	if err := c.restartMonIfStuckTerminating(m.DaemonName); err != nil {
-		logger.Error("failed to restart mon if it is stuck", err)
-	}
-
 	err := updateDeploymentAndWait(c.context, c.ClusterInfo, d, config.MonType, m.DaemonName, c.spec.SkipUpgradeChecks, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to update mon deployment %s", m.ResourceName)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With https://github.com/rook/rook/pull/6999 merged, we no longer need individual code paths to remove stuck osds and mons so removed the extra code.
removed condition check for "Health_Ok" before calling `forceDeleteStuckRookPodsOnNotReadyNodes()`, now we directly call the `forceDeleteStuckRookPodsOnNotReadyNodes()` as the function only advances if there are NotReady nodes.
Added some additional labels for pod filtering.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
