### PR TITLE
docs: Delete 'rootPath' in cephfs storageclass yaml

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -95,10 +95,6 @@ parameters:
   # Required for provisionVolume: "true"
   pool: myfs-data0
 
-  # Root path of an existing CephFS volume
-  # Required for provisionVolume: "false"
-  # rootPath: /absolute/path
-
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/storageclass.yaml
@@ -14,10 +14,6 @@ parameters:
   # Required for provisionVolume: "true"
   pool: myfs-data0
 
-  # Root path of an existing CephFS volume
-  # Required for provisionVolume: "false"
-  # rootPath: /absolute/path
-
   # The secrets contain Ceph admin credentials. These are generated automatically by the operator
   # in the same namespace as the cluster.
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner


### PR DESCRIPTION
The pre-provisioned volume or static-PV support in cephfs-csi has changed.
Delete 'rootPath' field which is no longer used
related with #4064

