### PR TITLE
ceph: fix SIGSEGV when failing to get object store user

### DIFF
--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -138,7 +138,7 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 		if rgwerr == ErrorCodeFileExists {
 			user, _, err = GetUser(c.objContext, userConfig.UserID)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get details from ceph object user %q for object store %q", user.UserID, c.namespacedName.Name)
+				return errors.Wrapf(err, "failed to get details from ceph object user %q for object store %q", userConfig.UserID, c.namespacedName.Name)
 			}
 		} else {
 			return errors.Wrapf(err, "failed to create object user %q. error code %d for object store %q", userConfig.UserID, rgwerr, c.namespacedName.Name)


### PR DESCRIPTION
**Description of your changes:**

We shouldn't use `user.userID` if `GetUser()` failed.

**Which issue is resolved by this Pull Request:**
Resolves #7278 

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
