### PR TITLE
ceph: remove unnecessary generate key for osd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -20,45 +20,17 @@ import (
 	"encoding/base64"
 	"fmt"
 	"path"
-	"strconv"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
 	v1 "k8s.io/api/core/v1"
 )
 
 const (
-	// don't list caps in keyring; allow OSD to get those from mons
-	keyringTemplate = `[osd.%s]
-key = %s
-`
-
-	// OsdEncryptionSecretNameKeyName is the key name of the Secret that contains the OSD encryption key
-	// #nosec G101 since this is not leaking any hardcoded credentials, it's just the secret key name
-	OsdEncryptionSecretNameKeyName = "dmcrypt-key"
 	dmCryptKeySize                 = 128
 )
-
-func (c *Cluster) generateKeyring(osdID int) (string, error) {
-	deploymentName := fmt.Sprintf(osdAppNameFmt, osdID)
-	osdIDStr := strconv.Itoa(osdID)
-
-	user := fmt.Sprintf("osd.%s", osdIDStr)
-	access := []string{"osd", "allow *", "mon", "allow profile osd"}
-
-	s := keyring.GetSecretStore(c.context, c.clusterInfo, &c.clusterInfo.OwnerRef)
-
-	key, err := s.GenerateKey(user, access)
-	if err != nil {
-		return "", err
-	}
-
-	keyring := fmt.Sprintf(keyringTemplate, osdIDStr, key)
-	return keyring, s.CreateOrUpdate(deploymentName, keyring)
-}
 
 // PrivilegedContext returns a privileged Pod security context
 func PrivilegedContext() *v1.SecurityContext {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -590,15 +590,6 @@ func (c *Cluster) startOSDDaemonsOnPVC(pvcName string, config *provisionConfig, 
 	for _, osd := range osds {
 		logger.Debugf("start osd %v", osd)
 
-		// keyring must be generated before deployment creation in order to avoid a race condition resulting
-		// in intermittent failure of first-attempt OSD pods.
-		_, err := c.generateKeyring(osd.ID)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to create keyring for pvc %q, osd %v. %v", osdProps.crushHostname, osd, err)
-			config.addError(errMsg)
-			continue
-		}
-
 		dp, err := c.makeDeployment(osdProps, osd, config)
 		if err != nil {
 			errMsg := fmt.Sprintf("failed to create deployment for pvc %q. %v", osdProps.crushHostname, err)
@@ -659,15 +650,6 @@ func (c *Cluster) startOSDDaemonsOnNode(nodeName string, config *provisionConfig
 	for _, osd := range osds {
 		logger.Debugf("start osd %v", osd)
 		opconfig.ConditionExport(c.context, c.clusterInfo.NamespacedName(), cephv1.ConditionProgressing, v1.ConditionTrue, "ClusterProgressing", fmt.Sprintf("Processing node %s osd %d", nodeName, osd.ID))
-
-		// keyring must be generated before deployment creation in order to avoid a race condition resulting
-		// in intermittent failure of first-attempt OSD pods.
-		_, err := c.generateKeyring(osd.ID)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to create keyring for node %q, osd %v. %v", n.Name, osd, err)
-			config.addError(errMsg)
-			continue
-		}
 
 		dp, err := c.makeDeployment(osdProps, osd, config)
 		if err != nil {


### PR DESCRIPTION
keyring for osd.x is generated by `ceph volume` command, thus it is
not necessary to try to create it in operator.

Signed-off-by: shenjiatong <yshxxsjt715@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
