### PR TITLE
nfs: Adding Image to the ServerSpec.

### DIFF
--- a/pkg/apis/nfs.rook.io/v1alpha1/types.go
+++ b/pkg/apis/nfs.rook.io/v1alpha1/types.go
@@ -119,6 +119,9 @@ type ServerSpec struct {
 	// The clients allowed to access the NFS export
 	// +optional
 	AllowedClients []AllowedClientsSpec `json:"allowedClients,omitempty"`
+
+        // The image to use for the NFS server container.
+	Image string `json:"image,omitempty"`
 }
 
 // AllowedClientsSpec represents the client specs for accessing the NFS export

--- a/pkg/apis/nfs.rook.io/v1alpha1/types.go
+++ b/pkg/apis/nfs.rook.io/v1alpha1/types.go
@@ -122,9 +122,6 @@ type ServerSpec struct {
 	// The clients allowed to access the NFS export
 	// +optional
 	AllowedClients []AllowedClientsSpec `json:"allowedClients,omitempty"`
-
-        // The image to use for the NFS server container.
-	Image string `json:"image,omitempty"`
 }
 
 // AllowedClientsSpec represents the client specs for accessing the NFS export


### PR DESCRIPTION
**Description of your changes:**
I want to add the ability to specify the Image that the NFS operator will use in the statefulset for the NFS server.

In this change I am adding Image the ServerSpec type, in a subsequent change I will use it in newStatefulSetForNFSServer with a default to the one it has right now. 
**Which issue is resolved by this Pull Request:**
Resolves #7174 