### PR TITLE
ceph: rework multiple filesystem support

### DIFF
--- a/Documentation/ceph-filesystem.md
+++ b/Documentation/ceph-filesystem.md
@@ -15,11 +15,9 @@ This example runs a shared filesystem for the [kube-registry](https://github.com
 
 This guide assumes you have created a Rook cluster as explained in the main [Kubernetes guide](ceph-quickstart.md)
 
-### Multiple Filesystems Not Supported
+### Multiple Filesystems Support
 
-By default only one shared filesystem can be created with Rook. Multiple filesystem support in Ceph is still considered experimental and can be enabled with the environment variable `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` defined in `operator.yaml`.
-
-Please refer to [cephfs experimental features](http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster) page for more information.
+Multiple filesystems are supported as of the Ceph Pacific release.
 
 ## Create the Filesystem
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,6 +20,8 @@ v1.6...
 
 ### Ceph
 
+* Ceph Pacific support
+* Multiple Ceph Filesystems (with Pacific only)
 * CephClient CRD has been converted to use the controller-runtime library
 * Extending the support of vault KMS configuration for Ceph RGW
 * Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -280,12 +280,14 @@ spec:
         - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
           value: {{ .Values.unreachableNodeTolerationSeconds | quote }}
 {{- end }}
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
 {{- if .Values.allowMultipleFilesystems }}
         - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
           value: {{ .Values.allowMultipleFilesystems | quote }}
 {{- end }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.useOperatorHostNetwork }}
       hostNetwork: true
 {{- end }}

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -443,12 +443,7 @@ spec:
         # (Optional) Discover Agent Pod Labels.
         # - name: DISCOVER_AGENT_POD_LABELS
         #   value: "key1=value1,key2=value2"
-        # Allow rook to create multiple file systems. Note: This is considered
-        # an experimental feature in Ceph as described at
-        # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster
-        # which might cause mons to crash as seen in https://github.com/rook/rook/issues/1027
-        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
-          value: "false"
+
         # The logging level for the operator: INFO | DEBUG
         - name: ROOK_LOG_LEVEL
           value: "INFO"

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -386,12 +386,6 @@ spec:
         # (Optional) Discover Agent Pod Labels.
         # - name: DISCOVER_AGENT_POD_LABELS
         #   value: "key1=value1,key2=value2"
-        # Allow rook to create multiple file systems. Note: This is considered
-        # an experimental feature in Ceph as described at
-        # http://docs.ceph.com/docs/master/cephfs/experimental-features/#multiple-filesystems-within-a-ceph-cluster
-        # which might cause mons to crash as seen in https://github.com/rook/rook/issues/1027
-        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
-          value: "false"
 
         # The logging level for the operator: INFO | DEBUG
         - name: ROOK_LOG_LEVEL

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -130,13 +130,13 @@ func CreateFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, name,
 	logger.Infof("creating filesystem %q with metadata pool %q and data pools %v", name, metadataPool, dataPools)
 	var err error
 
-	if IsMultiFSEnabled() {
+	// Always enable multiple fs when running on Pacific
+	if IsMultiFSEnabled() || clusterInfo.CephVersion.IsAtLeastPacific() {
 		// enable multiple file systems in case this is not the first
 		args := []string{"fs", "flag", "set", "enable_multiple", "true", confirmFlag}
 		_, err = NewCephCommand(context, clusterInfo, args).Run()
 		if err != nil {
-			// continue if this fails
-			logger.Warning("failed enabling multiple file systems. %v", err)
+			return errors.Wrap(err, "failed to enable multiple file systems")
 		}
 	}
 


### PR DESCRIPTION
**Description of your changes:**

The upcoming Rook release 1.6 will support Ceph Pacific which introduces
stable support for multiple Ceph Filesystems in the same cluster. So we
now allow the creation of multiple Filesystem if the release is Pacific.

Also, we remove the Operator config flag which was not necessary.

Here I have 2 filesystems:

```
[root@rook-ceph-tools-6b4889fdfd-vncck /]# ceph fs ls
name: myfs, metadata pool: myfs-metadata, data pools: [myfs-data0 ]
name: myfs2, metadata pool: myfs2-metadata, data pools: [myfs2-data0 ]
```

```
  cluster:
    id:     cc747950-589a-4862-bad2-ff7de1217b1a
    health: HEALTH_WARN
            mons a,b,c are low on available space
            6 pool(s) have no replicas configured

  services:
    mon: 3 daemons, quorum a,b,c (age 2d)
    mgr: a(active, since 2d)
    mds: myfs:1 myfs2:1 {myfs2:0=myfs2-b=up:active,myfs:0=myfs-b=up:active} 2 up:standby-replay
    osd: 3 osds: 3 up (since 2m), 3 in (since 6d)

  data:
    pools:   6 pools, 717 pgs
    objects: 44 objects, 4.2 KiB
    usage:   46 MiB used, 90 GiB / 90 GiB avail
    pgs:     717 active+clean

  io:
    client:   1.8 KiB/s rd, 4 op/s rd, 0 op/s wr

  progress:
    Global Recovery Event (45s)
      [===========================.]
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
