### PR TITLE
ceph: change osd on pvc unit test to use t.Log()

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_pvc_test.go
@@ -49,11 +49,6 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// make infof function for helping identify logs from unit test helpers versus from runtime code.
-func infof(t *testing.T, format string, args ...interface{}) {
-	logger.Infof(t.Name()+": "+format, args...)
-}
-
 // The definition for this test is a wrapper for the test function that adds a timeout
 func TestOSDsOnPVC(t *testing.T) {
 	oldLogger := *logger
@@ -112,7 +107,7 @@ func testOSDsOnPVC(t *testing.T) {
 		// can't use mockNodeOrchestrationCompleted here b/c it uses a context.CoreV1() method that
 		// is mutex locked when a reactor is processing
 		status := parseOrchestrationStatus(cm.Data)
-		infof(t, "configmap reactor: updating configmap %q status to completed", cm.Name)
+		t.Logf("configmap reactor: updating configmap %q status to completed", cm.Name)
 		// configmap names are deterministic can be mapped indirectly to an OSD ID, and since the
 		// configmaps are used to report completion status of OSD provisioning, we use this property in
 		// thse unit tests
@@ -165,11 +160,11 @@ func testOSDsOnPVC(t *testing.T) {
 
 			status := parseOrchestrationStatus(cm.Data)
 			if status.Status == OrchestrationStatusAlreadyExists {
-				infof(t, "configmap reactor: delete: OSD for configmap %q was updated", cm.Name)
+				t.Logf("configmap reactor: delete: OSD for configmap %q was updated", cm.Name)
 				// allow tests to specify a custom callback for this case
 				deleteConfigMapWithStatusAlreadyExistsCallback(cm, action)
 			} else if status.Status == OrchestrationStatusCompleted {
-				infof(t, "configmap reactor: delete: OSD for configmap %q was created", cm.Name)
+				t.Logf("configmap reactor: delete: OSD for configmap %q was created", cm.Name)
 			}
 		}
 
@@ -197,7 +192,7 @@ func testOSDsOnPVC(t *testing.T) {
 			// deployment already exists, so this isn't be a valid create
 			return false, nil, nil
 		}
-		infof(t, "creating deployment %q", d.Name)
+		t.Logf("creating deployment %q", d.Name)
 		deploymentOps.Add(d.Name, "create")
 		return false, nil, nil
 	}
@@ -210,7 +205,7 @@ func testOSDsOnPVC(t *testing.T) {
 		updateDeploymentAndWait = oldUDAW
 	}()
 	updateDeploymentAndWait = func(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, deployment *appsv1.Deployment, daemonType string, daemonName string, skipUpgradeChecks bool, continueUpgradeAfterChecksEvenIfNotHealthy bool) error {
-		infof(t, "updating deployment %q", deployment.Name)
+		t.Logf("updating deployment %q", deployment.Name)
 		deploymentOps.Add(deployment.Name, "update")
 		return nil
 	}
@@ -269,7 +264,7 @@ func testOSDsOnPVC(t *testing.T) {
 	}
 
 	// =============================================================================================
-	infof(t, "Step 1: create new PVCs")
+	t.Log("Step 1: create new PVCs")
 
 	// when creating new configmaps with status "starting", simulate them becoming "completed"
 	// before any opportunistic updates can happen by changing the status to "completed" before
@@ -286,10 +281,10 @@ func testOSDsOnPVC(t *testing.T) {
 	waitForDone := func() {
 		for {
 			if provisionDone {
-				infof(t, "provisioning done")
+				t.Log("provisioning done")
 				break
 			}
-			infof(t, "provisioning not done. waiting...")
+			t.Log("provisioning not done. waiting...")
 			time.Sleep(time.Millisecond)
 		}
 	}
@@ -318,12 +313,12 @@ func testOSDsOnPVC(t *testing.T) {
 	assert.Equal(t, 5, deploymentOps.Len())
 	// all 5 should be create operations
 	assert.Len(t, deploymentOps.ResourcesWithOperation("create"), 5)
-	infof(t, "deployments successfully created for new PVCs")
+	t.Log("deployments successfully created for new PVCs")
 
 	waitForDone()
 
 	// =============================================================================================
-	infof(t, "Step 2: verify deployments are updated when run again")
+	t.Log("Step 2: verify deployments are updated when run again")
 	// clean the create times maps
 	reset := func() {
 		deploymentOps = newResourceOperationList()
@@ -348,7 +343,7 @@ func testOSDsOnPVC(t *testing.T) {
 	waitForDone()
 
 	// =============================================================================================
-	infof(t, "Step 3: verify new deployments are created before existing ones are updated")
+	t.Log("Step 3: verify new deployments are created before existing ones are updated")
 	reset()
 
 	spec.Storage.StorageClassDeviceSets[0].Count = 8
@@ -383,7 +378,7 @@ func testOSDsOnPVC(t *testing.T) {
 	waitForDone()
 
 	// =============================================================================================
-	infof(t, "Step 4: verify updates can happen opportunistically")
+	t.Log("Step 4: verify updates can happen opportunistically")
 	reset()
 
 	spec.Storage.StorageClassDeviceSets[0].Count = 10
@@ -397,7 +392,7 @@ func testOSDsOnPVC(t *testing.T) {
 	// in update-then-create fashion until all creates are done, followed by all updates.
 	configMapsThatNeedUpdatedToCompleted := []string{}
 	createConfigMapWithStatusStartingCallback = func(cm *corev1.ConfigMap) {
-		infof(t, "configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
+		t.Logf("configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
 		configMapsThatNeedUpdatedToCompleted = append(configMapsThatNeedUpdatedToCompleted, cm.Name)
 	}
 	deleteConfigMapWithStatusAlreadyExistsCallback = func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
@@ -453,7 +448,7 @@ func testOSDsOnPVC(t *testing.T) {
 	waitForDone()
 
 	// =============================================================================================
-	infof(t, "Step 5: verify opportunistic updates can all happen before creates")
+	t.Log("Step 5: verify opportunistic updates can all happen before creates")
 	reset()
 
 	spec.Storage.StorageClassDeviceSets[0].Count = 12
@@ -465,7 +460,7 @@ func testOSDsOnPVC(t *testing.T) {
 	configMapsThatNeedUpdatedToCompleted = []string{}
 	createConfigMapWithStatusStartingCallback = func(cm *corev1.ConfigMap) {
 		// re-define this behavior as a reminder for readers of the test
-		infof(t, "configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
+		t.Logf("configmap reactor: create: marking that configmap %q needs to be completed later", cm.Name)
 		configMapsThatNeedUpdatedToCompleted = append(configMapsThatNeedUpdatedToCompleted, cm.Name)
 	}
 	deleteConfigMapWithStatusAlreadyExistsCallback = func(cm *corev1.ConfigMap, action k8stesting.DeleteActionImpl) {
@@ -509,7 +504,7 @@ func testOSDsOnPVC(t *testing.T) {
 	}
 
 	waitForDone()
-	infof(t, "success")
+	t.Log("success")
 }
 
 /*
@@ -519,7 +514,7 @@ func testOSDsOnPVC(t *testing.T) {
 func osdPVCTestExecutor(t *testing.T, clientset *fake.Clientset, namespace string) *exectest.MockExecutor {
 	return &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
-			infof(t, "command: %s %v", command, args)
+			t.Logf("command: %s %v", command, args)
 			if command != "ceph" {
 				return "", errors.Errorf("unexpected command %q with args %v", command, args)
 			}
@@ -571,7 +566,7 @@ func waitForNumPVCs(t *testing.T, clientset *fake.Clientset, namespace string, c
 		l, err := clientset.CoreV1().PersistentVolumeClaims(namespace).List(context.TODO(), metav1.ListOptions{})
 		assert.NoError(t, err)
 		if len(l.Items) >= count {
-			infof(t, "PVCs for OSDs on PVC all exist")
+			t.Log("PVCs for OSDs on PVC all exist")
 			break
 		}
 		<-time.After(1 * time.Millisecond)
@@ -583,7 +578,7 @@ func waitForNumDeployments(t *testing.T, clientset *fake.Clientset, namespace st
 		l, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
 		assert.NoError(t, err)
 		if len(l.Items) >= count {
-			infof(t, "Deployments for OSDs on PVC all exist")
+			t.Log("Deployments for OSDs on PVC all exist")
 			break
 		}
 		<-time.After(1 * time.Millisecond)
@@ -608,13 +603,13 @@ func newOSDIDGenerator() osdIDGenerator {
 
 func (g *osdIDGenerator) osdID(t *testing.T, namedResource string) int {
 	if id, ok := g.osdIDMap[namedResource]; ok {
-		infof(t, "resource %q has existing OSD ID %d", namedResource, id)
+		t.Logf("resource %q has existing OSD ID %d", namedResource, id)
 		return id
 	}
 	id := g.nextOSDID
 	g.osdIDMap[namedResource] = id
 	g.nextOSDID++
-	infof(t, "generated new OSD ID %d for resource %q", id, namedResource)
+	t.Logf("generated new OSD ID %d for resource %q", id, namedResource)
 	return id
 }
 


### PR DESCRIPTION
Change the TestOSDsOnPVC unit test to use t.Log()/t.Logf() to avoid
having a special infof() function that was unnecessary since our unit
tests run with `go test -v` where the `-v` flag interleaves t.Log()
output.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
