### PR TITLE
nfs: Add Image to the NFSServerSpec

### DIFF
--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -236,7 +236,11 @@ func (r *NFSServerReconciler) reconcileNFSServer(ctx context.Context, cr *nfsv1a
 		r.Recorder.Eventf(cr, corev1.EventTypeNormal, nfsv1alpha1.EventUpdated, "%s nfs-server service: %s", strings.Title(string(svcop)), svc.Name)
 	}
 
-	sts := newStatefulSetForNFSServer(cr)
+	sts, err := newStatefulSetForNFSServer(cr, r.Context.Clientset, ctx)
+	if err != nil {
+		return fmt.Errorf("unable to generate the NFS StatefulSet spec: %v", err)
+	}
+
 	stsop, err := controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {
 		if sts.ObjectMeta.CreationTimestamp.IsZero() {
 			sts.Spec.Selector = &metav1.LabelSelector{


### PR DESCRIPTION
**Description of your changes:**
Give the user the ability to specify the image that the operator will use
to spin up new NFS server.

After this change, I am going to use it in the `newStatefulSetForNFSServer`
function and use the current image as the default value so the change will not affect current users.

**Which issue is resolved by this Pull Request:**
Resolves #7174 