### PR TITLE
ceph: stick with ubuntu-18.04 on the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   canary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
 
 
   pvc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -195,7 +195,7 @@ jobs:
         path: test
 
   pvc-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -282,7 +282,7 @@ jobs:
         path: test
 
   pvc-db-wal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -371,7 +371,7 @@ jobs:
         path: test
 
   encryption-pvc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -448,7 +448,7 @@ jobs:
         path: test
 
   encryption-pvc-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -537,7 +537,7 @@ jobs:
         path: test
 
   encryption-pvc-db-wal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -624,7 +624,7 @@ jobs:
         path: test
 
   encryption-pvc-kms-vault-token-auth:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -714,7 +714,7 @@ jobs:
         path: test
 
   lvm-pvc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   codegen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   codespell:
     name: codespell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: codespell

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephFlexSuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephHelmSuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephMgrSuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephMultiClusterDeploySuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephSmokeSuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephUpgradeSuite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/mod-check.yml
+++ b/.github/workflows/mod-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   modcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/stale@v3
       with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unittests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
**Description of your changes:**

Github just switched to use Ubuntu 20.04 for the ubuntu-latest and it is
breaking some of our scenarios so far. Especially scenario creating
partitions.

Closes: https://github.com/rook/rook/issues/7327
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/7327

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
