### PR TITLE
ceph: stick with ubuntu-18.04 on the CI (bp 7328)

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   canary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
         # execute the test file
 
   pvc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
         kubectl -n rook-ceph get pods
 
   pvc-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
         kubectl -n rook-ceph get pods
 
   pvc-db-wal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -312,7 +312,7 @@ jobs:
         kubectl -n rook-ceph get pods
 
   encryption-pvc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -381,7 +381,7 @@ jobs:
         sudo lsblk
 
   encryption-pvc-db:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -462,7 +462,7 @@ jobs:
         kubectl -n rook-ceph get secrets
 
   encryption-pvc-db-wal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -541,7 +541,7 @@ jobs:
         kubectl -n rook-ceph get secrets
 
   encryption-pvc-kms-vault-token-auth:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   codegen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint

--- a/.github/workflows/mod-check.yml
+++ b/.github/workflows/mod-check.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   modcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   unittests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
Github just switched to use Ubuntu 20.04 for the ubuntu-latest and it is
breaking some of our scenarios so far. Especially scenario creating
partitions.

Closes: https://github.com/rook/rook/issues/7327
Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit 0adf7624d95c5aab4a1dcb9fc9a732c31880f8a6)

**Backport of #7328**

[skip ci]