### PR TITLE
ceph: update CRDs for healthcheck in crds.yaml

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -878,10 +878,18 @@ spec:
                       type: object
                       nullable: true
                       properties:
-                        enabled:
+                        disabled:
                           type: boolean
                         interval:
                           type: string
+                        timeout:
+                          type: string
+                    livenessProbe:
+                      type: object
+                      nullable: true
+                      properties:
+                        disabled:
+                          type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -924,10 +924,18 @@ spec:
                       type: object
                       nullable: true
                       properties:
-                        enabled:
+                        disabled:
                           type: boolean
                         interval:
                           type: string
+                        timeout:
+                          type: string
+                    livenessProbe:
+                      type: object
+                      nullable: true
+                      properties:
+                        disabled:
+                          type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -536,10 +536,17 @@ spec:
               properties:
                 bucket:
                   properties:
-                    enabled:
+                    disabled:
                       type: boolean
                     interval:
                       type: string
+                    timeout:
+                      type: string
+                livenessProbe:
+                  type: object
+                  properties:
+                    disabled:
+                      type: boolean
   subresources:
     status: {}
 

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1938,10 +1938,18 @@ spec:
               properties:
                 bucket:
                   properties:
-                    enabled:
+                    disabled:
                       type: boolean
                     interval:
                       type: string
+                    timeout:
+                      type: string
+                livenessProbe:
+                  type: object
+                  nullable: true
+                  properties:
+                    disabled:
+                      type: boolean
   subresources:
   subresources:
     status: {}


### PR DESCRIPTION
Even though CRs for bucket health check was added, CRDs were missing from
crds.yaml file. So the health check always enabled for RGW.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
