### PR TITLE
ceph: prevent creating hang if directories not created

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -135,15 +135,15 @@ spec:
         - name: csi-plugins-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins"
-            type: Directory
+            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins_registry/"
-            type: Directory
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/pods"
-            type: Directory
+            type: DirectoryOrCreate
         - name: host-sys
           hostPath:
             path: /sys

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -135,15 +135,15 @@ spec:
         - name: plugin-mount-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins"
-            type: Directory
+            type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/plugins_registry/"
-            type: Directory
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: "{{ .KubeletDirPath }}/pods"
-            type: Directory
+            type: DirectoryOrCreate
         - name: host-dev
           hostPath:
             path: /dev


### PR DESCRIPTION
**Description of your changes:**
This patch tend to prevent creating hangs if the directories(such as /var/lib/kubelet/plugins_registry/) were not created
