### PR TITLE
ceph: webhook check if one of port or securePort are non-zero

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/object_test.go
+++ b/pkg/apis/ceph.rook.io/v1/object_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateObjectStoreSpec(t *testing.T) {
+	o := &CephObjectStore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-store",
+			Namespace: "rook-ceph",
+		},
+		Spec: ObjectStoreSpec{
+			Gateway: GatewaySpec{
+				Port:       1,
+				SecurePort: 0,
+			},
+		},
+	}
+	err := ValidateObjectSpec(o)
+	assert.NoError(t, err)
+
+	// when both port and securePort are o
+	o.Spec.Gateway.Port = 0
+	err = ValidateObjectSpec(o)
+	assert.Error(t, err)
+
+	// when securePort is greater than 65535
+	o.Spec.Gateway.SecurePort = 65536
+	err = ValidateObjectSpec(o)
+	assert.Error(t, err)
+
+	// when name is empty
+	o.ObjectMeta.Name = ""
+	err = ValidateObjectSpec(o)
+	assert.Error(t, err)
+
+	// when namespace is empty
+	o.ObjectMeta.Namespace = ""
+	err = ValidateObjectSpec(o)
+	assert.Error(t, err)
+}

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -280,15 +280,8 @@ func (c *clusterConfig) storeLabelSelector() string {
 
 // Validate the object store arguments
 func (r *ReconcileCephObjectStore) validateStore(s *cephv1.CephObjectStore) error {
-	if s.Name == "" {
-		return errors.New("missing name")
-	}
-	if s.Namespace == "" {
-		return errors.New("missing namespace")
-	}
-	securePort := s.Spec.Gateway.SecurePort
-	if securePort < 0 || securePort > 65535 {
-		return errors.Errorf("securePort value of %d must be between 0 and 65535", securePort)
+	if err := cephv1.ValidateObjectSpec(s); err != nil {
+		return err
 	}
 
 	// Validate the pool settings, but allow for empty pools specs in case they have already been created

--- a/pkg/operator/ceph/server.go
+++ b/pkg/operator/ceph/server.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	scheme    = runtime.NewScheme()
-	resources = []webhook.Validator{&cephv1.CephCluster{}, &cephv1.CephBlockPool{}}
+	resources = []webhook.Validator{&cephv1.CephCluster{}, &cephv1.CephBlockPool{}, &cephv1.CephObjectStore{}}
 )
 
 const (

--- a/tests/scripts/webhook-config.yaml
+++ b/tests/scripts/webhook-config.yaml
@@ -34,3 +34,18 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]  # API server will try to use first version in the list which it supports.
     sideEffects: None
     timeoutSeconds: 5
+  - name: cephobjectstore-wh-${SERVICE_NAME}-${NAMESPACE}.rook.io
+    rules:
+      - apiGroups:   ["ceph.rook.io"]
+        apiVersions: ["v1"]
+        operations:  ["CREATE","UPDATE","DELETE"]
+        resources:   ["cephobjectstores"]
+    clientConfig:
+      service:
+        name: ${SERVICE_NAME}
+        namespace: ${NAMESPACE}
+        path: /validate-ceph-rook-io-v1-cephobjectstore
+      caBundle: ${CA_BUNDLE}
+    admissionReviewVersions: ["v1", "v1beta1"]  # API server will try to use first version in the list which it supports.
+    sideEffects: None
+    timeoutSeconds: 5


### PR DESCRIPTION
this commit adds new crd to admission webhooks to check
if one of the port or securePort are set to non-zero
value in objectstore crd.

If both are set to 0 in crd we'll see error like
```
Error from server (invalid create: either of port or securePort
fields should be not be zero): error when creating "object-test.yaml":
admission webhook
"cephobjectstore-wh-rook-ceph-admission-controller-rook-ceph.rook.io"
denied the request: invalid create: either of port or securePort fields
should be not be zero.
```

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
