### PR TITLE
ceph: handle ssl cases for RGW's livenessprobe

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -302,13 +302,12 @@ func (c *clusterConfig) generateLiveProbePort() intstr.IntOrString {
 
 	// If Host Networking is enabled, the port from the spec must be reflected
 	if c.clusterSpec.Network.IsHost() {
-		if c.store.Spec.Gateway.Port == 0 && c.store.Spec.Gateway.SecurePort != 0 && c.store.Spec.Gateway.SSLCertificateRef != "" {
-			port = intstr.FromInt(int(c.store.Spec.Gateway.SecurePort))
-		} else {
-			port = intstr.FromInt(int(c.store.Spec.Gateway.Port))
-		}
+		port = intstr.FromInt(int(c.store.Spec.Gateway.Port))
 	}
 
+	if c.store.Spec.Gateway.Port == 0 && c.store.Spec.Gateway.SecurePort != 0 && c.store.Spec.Gateway.SSLCertificateRef != "" {
+		port = intstr.FromInt(int(c.store.Spec.Gateway.SecurePort))
+	}
 	return port
 }
 

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -215,14 +215,6 @@ func TestGenerateLiveProbe(t *testing.T) {
 	assert.Equal(t, int32(8080), p.Handler.HTTPGet.Port.IntVal)
 	assert.Equal(t, v1.URISchemeHTTP, p.Handler.HTTPGet.Scheme)
 
-	// SSL - HostNetwork is disabled - using internal port
-	c.store.Spec.Gateway.Port = 0
-	c.store.Spec.Gateway.SecurePort = 321
-	c.store.Spec.Gateway.SSLCertificateRef = "foo"
-	p = c.generateLiveProbe()
-	assert.Equal(t, int32(8080), p.Handler.HTTPGet.Port.IntVal)
-	assert.Equal(t, v1.URISchemeHTTPS, p.Handler.HTTPGet.Scheme)
-
 	// No SSL - HostNetwork is enabled
 	c.store.Spec.Gateway.Port = 123
 	c.store.Spec.Gateway.SecurePort = 0


### PR DESCRIPTION
The livenessprobe for swift/health always check with RGW internal port if host network disabled,
but won't work if only secure port is configured

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
