### PR TITLE
ceph: revert kms VAULT_KV_VERS to VAULT_BACKEND

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -1414,7 +1414,7 @@ security:
       KMS_PROVIDER: vault
       VAULT_ADDR: https://vault.default.svc.cluster.local:8200
       VAULT_BACKEND_PATH: rook
-      VAULT_BACKEND: kv
+      VAULT_SECRET_ENGINE: kv
     # name of the k8s secret containing the kms authentication token
     tokenSecretName: rook-vault-token
 ```
@@ -1512,7 +1512,7 @@ Communications will remain encrypted but the validity of the certificate will no
 
 For RGW, please note the following:
 
-* `VAULT_BACKEND` option is specifically for RGW to mention about the secret engine which can be used, currently supports two: [kv](https://www.vaultproject.io/docs/secrets/kv) and [transit](https://www.vaultproject.io/docs/secrets/transit).
+* `VAULT_SECRET_ENGINE` option is specifically for RGW to mention about the secret engine which can be used, currently supports two: [kv](https://www.vaultproject.io/docs/secrets/kv) and [transit](https://www.vaultproject.io/docs/secrets/transit).
 * The Storage administrator needs to create a secret in the Vault server so that S3 clients use that key for encryption
 ```console
 # kv engine

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -180,7 +180,7 @@ spec:
          #KMS_PROVIDER: "vault"
          #VAULT_ADDR: VAULT_ADDR_CHANGE_ME # e,g: https://vault.my-domain.com:8200
          #VAULT_BACKEND_PATH: "rook"
-         #VAULT_BACKEND: "kv"
+         #VAULT_SECRET_ENGINE: "kv"
   #     # name of the secret containing the kms authentication token
   #     tokenSecretName: rook-vault-token
 # UNCOMMENT THIS TO ENABLE A KMS CONNECTION

--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -32,6 +32,12 @@ import (
 const (
 	// EtcVaultDir is vault config dir
 	EtcVaultDir = "/etc/vault"
+	// VaultSecretEngineKey is the type of secret engine used (kv, transit)
+	VaultSecretEngineKey = "VAULT_SECRET_ENGINE"
+	// VaultKVSecretEngineKey is a kv secret engine type
+	VaultKVSecretEngineKey = "kv"
+	// VaultTransitSecretEngineKey is a transit secret engine type
+	VaultTransitSecretEngineKey = "transit"
 )
 
 var (

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -191,12 +191,13 @@ if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
 fi
 
 # Check KV engine version
-if [ -z "$VAULT_KV_VERS" ]; then
-	VAULT_KV_VERS=$VAULT_DEFAULT_KV_VERS
+if [ -z "$VAULT_BACKEND" ]; then
+	VAULT_BACKEND=$VAULT_DEFAULT_KV_VERS
 fi
 
 # Get the Key Encryption Key
-curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_KV_VERS"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
+curl "${ARGS[@]}" "$VAULT_ADDR"/"$VAULT_BACKEND"/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
+
 
 # Check for errors in the payload
 if python3 -c "import sys, json; print(json.load(sys.stdin)[\"errors\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -246,7 +246,7 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 					path.Join(c.DataPathMap.ContainerDataDir, kms.VaultFileName)),
 				cephconfig.NewFlag("rgw crypt vault prefix", c.vaultPrefixRGW()),
 				cephconfig.NewFlag("rgw crypt vault secret engine",
-					c.clusterSpec.Security.KeyManagementService.ConnectionDetails[vault.VaultBackendKey]),
+					c.clusterSpec.Security.KeyManagementService.ConnectionDetails[kms.VaultSecretEngineKey]),
 			)
 		}
 	}
@@ -401,14 +401,14 @@ func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore
 }
 
 func (c *clusterConfig) vaultPrefixRGW() string {
-	secretEngine := c.clusterSpec.Security.KeyManagementService.ConnectionDetails[vault.VaultBackendKey]
+	secretEngine := c.clusterSpec.Security.KeyManagementService.ConnectionDetails[kms.VaultSecretEngineKey]
 	vaultPrefixPath := "/v1/"
 
 	switch secretEngine {
-	case "kv":
+	case kms.VaultKVSecretEngineKey:
 		vaultPrefixPath = path.Join(vaultPrefixPath,
 			c.clusterSpec.Security.KeyManagementService.ConnectionDetails[vault.VaultBackendPathKey])
-	case "transit":
+	case kms.VaultTransitSecretEngineKey:
 		vaultPrefixPath = path.Join(vaultPrefixPath, secretEngine, "/export/encryption-key")
 	}
 

--- a/tests/manifests/test-kms-vault-spec.yaml
+++ b/tests/manifests/test-kms-vault-spec.yaml
@@ -5,6 +5,6 @@ spec:
         KMS_PROVIDER: vault
         VAULT_ADDR: https://vault.default.svc.cluster.local:8200
         VAULT_BACKEND_PATH: rook
-        VAULT_BACKEND: kv
+        VAULT_SECRET_ENGINE: kv
         VAULT_SKIP_VERIFY: "true"
       tokenSecretName: rook-vault-token


### PR DESCRIPTION
**Description of your changes:**

The vault env variable VAULT_BACKEND is read by the secret library so we
must not change it. This is reverting
ee6a03dfb85cd17d608773ca22abaedbe55868c2 with a few extra fixes for the
rgw code.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
