### PR TITLE
ceph: trim subsystems in set-ceph-debug script

### DIFF
--- a/images/ceph/set-ceph-debug-level
+++ b/images/ceph/set-ceph-debug-level
@@ -23,8 +23,6 @@ fi
 
 CEPH_DEBUG_LEVEL=$1
 CEPH_DEBUG_FLAG=(
-  lockdep
-  context
   crush
   mds
   mds_balancer
@@ -32,54 +30,33 @@ CEPH_DEBUG_FLAG=(
   mds_log
   mds_log_expire
   mds_migrator
-  buffer
-  timer
-  filer
-  striper
-  objecter
   rados
   rbd
   rbd_mirror
   rbd_replay
-  journaler
-  objectcacher
-  client
   osd
-  optracker
-  objclass
-  filestore
-  journal
   ms
   mon
   monc
   paxos
-  tp
   auth
-  crypto
-  finisher
-  reserver
-  heartbeatmap
-  perfcounter
   rgw
   rgw_sync
-  civetweb
-  javaclient
   asok
-  throttle
-  refs
-  compressor
   bluestore
   bluefs
   bdev
   kstore
   rocksdb
-  leveldb
-  memdb
-  fuse
   mgr
   mgrc
-  dpdk
-  eventtrace
+)
+
+DAEMONS=(
+  mon
+  mgr
+  osd
+  mds
 )
 
 #############
@@ -105,14 +82,15 @@ exec_ceph_command() {
   
   # exec command
   for flag in "${CEPH_DEBUG_FLAG[@]}"; do
-    ARGS=("$action" global debug_"$flag")
-    if [[ "$debug_level" != "default" ]]; then
-      ARGS+=("$debug_level")
-    fi
-    # put stdout in /dev/null since increase debug log will overflow the terminal
-    echo "ceph config ${ARGS[*]}"
-    ceph config "${ARGS[@]}" &> /dev/null & pids+=($!)
-    
+    for daemon in "${DAEMONS[@]}"; do
+      ARGS=("$action" "$daemon" debug_"$flag")
+      if [[ "$debug_level" != "default" ]]; then
+        ARGS+=("$debug_level")
+      fi
+      # put stdout in /dev/null since increase debug log will overflow the terminal
+      echo "ceph config ${ARGS[*]}"
+      ceph config "${ARGS[@]}" &> /dev/null & pids+=($!)
+    done
   done
   echo "waiting for all the new logging configuration to be applied, this can take a few seconds"
   wait "${pids[@]}"


### PR DESCRIPTION
We now apply the desired debug level on less subsystems and especially
not on clients.
Also, we isolate each subsystem into each daemon type, not using the
global section anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
