### PR TITLE
ceph: bump operator chart version

### DIFF
--- a/cluster/charts/rook-ceph/Chart.yaml
+++ b/cluster/charts/rook-ceph/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: File, Block, and Object Storage Services for your Cloud-Native Environment
 name: rook-ceph
-version: 0.0.1
+version: 0.1.0
 icon: https://rook.io/images/rook-logo.svg
 sources:
   - https://github.com/rook/rook


### PR DESCRIPTION
**Description of your changes:**

In MR #6556 the dependency on helm version was updated.
Helm charts use semver to indicate changes. This should at least be a minor change.
Also, future commits that change the chart should have a bump in chart version, following semver.

Chart versions are used for consistent experience and reproducability. 
Whenever chart version 0.0.1 is installed, it should point to exactly one version and one deployment method / options of the operator. 

[skip ci]

**Which issue is resolved by this Pull Request:**

None

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.