### PR TITLE
ceph: do not duplicate osd info

### DIFF
--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -187,7 +187,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 		if err != nil {
 			logger.Infof("failed to get device already provisioned by ceph-volume raw. %v", err)
 		}
-		osds = append(osds, rawOsds...)
+		osds = appendOSDInfo(osds, rawOsds)
 
 		return osds, nil
 	}
@@ -248,6 +248,12 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	}
 
 	// List OSD configured with ceph-volume lvm mode
+	lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, false, lvBackedPV)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume lvm")
+	}
+	osds = append(osds, lvmOsds...)
+
 	// List THE configured OSD with ceph-volume raw mode
 	// When the block is encrypted we need to list against the encrypted device mapper
 	if !isEncrypted {
@@ -261,13 +267,7 @@ func (a *OsdAgent) configureCVDevices(context *clusterd.Context, devices *Device
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume raw")
 	}
-	osds = append(osds, rawOsds...)
-
-	lvmOsds, err = GetCephVolumeLVMOSDs(context, a.clusterInfo, a.clusterInfo.FSID, block, false, lvBackedPV)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get devices already provisioned by ceph-volume lvm")
-	}
-	osds = append(osds, lvmOsds...)
+	osds = appendOSDInfo(osds, rawOsds)
 
 	return osds, err
 }
@@ -1064,4 +1064,23 @@ func callCephVolume(context *clusterd.Context, requiresCombinedOutput bool, args
 	logger.Debugf("%v", co)
 
 	return co, nil
+}
+
+func appendOSDInfo(currentOSDs, osdsToAppend []oposd.OSDInfo) []oposd.OSDInfo {
+	for _, osdToAppend := range osdsToAppend {
+		if !isInOSDInfoList(osdToAppend.UUID, currentOSDs) {
+			currentOSDs = append(currentOSDs, osdToAppend)
+		}
+	}
+	return currentOSDs
+}
+
+func isInOSDInfoList(uuid string, osds []oposd.OSDInfo) bool {
+	for _, osd := range osds {
+		if osd.UUID == uuid {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
**Description of your changes:**

When c-v runs after the end of the prepare sequence, it will look for
lvm and raw-based OSDs. The raw mode detects LVM OSDs so we must trim
the list of OSD, only to report the LVM ones if their ID exists.

Closes: https://github.com/rook/rook/issues/7359
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/7359

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
