### PR TITLE
ceph: check for kv engine version for SSE RGW

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -546,7 +546,10 @@ jobs:
         yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].count" 2
         yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].volumeClaimTemplates[0].spec.resources.requests.storage" 6Gi
         kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
-        kubectl create -f cluster/examples/kubernetes/ceph/object-test.yaml
+        yq merge --inplace --arrays append tests/manifests/test-object.yaml tests/manifests/test-kms-vault-spec.yaml
+        sed -i 's/ver1/ver2/g' tests/manifests/test-object.yaml
+        sed -i 's/VAULT_BACKEND: v1/VAULT_BACKEND: v2/g' tests/manifests/test-object.yaml
+        kubectl create -f tests/manifests/test-object.yaml
         kubectl create -f cluster/examples/kubernetes/ceph/toolbox.yaml
 
     - name: wait for prepare pod
@@ -559,10 +562,14 @@ jobs:
         kubectl -n rook-ceph get pods
         kubectl -n rook-ceph get secrets
 
-    - name: validate vault
+    - name: validate osd vault
       run: |
-        tests/scripts/deploy-validate-vault.sh validate
+        tests/scripts/deploy-validate-vault.sh validate_osd
         sudo lsblk
+
+    - name: validate rgw vault
+      run: |
+        tests/scripts/deploy-validate-vault.sh validate_rgw
 
     - name: Upload encryption-pvc-kms-vault-token-auth test result
       uses: actions/upload-artifact@v2

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -1468,10 +1468,6 @@ By default, the Key Encryption Keys (also known as Data Encryption Keys) are sto
 However, if a Key Management System exists Rook is capable of using it. HashiCorp Vault is the only KMS currently supported by Rook.
 Please refer to the next section.
 
-Ceph RGW supports encryption via KMS using HashiCorp Vault. If the below settings are defined, then RGW establish a connection between Vault
-and whenever S3 client sends a request with Server Side Encryption, it encrypts that using the key specified by the client.
-For more details w.r.t RGW, please refer [Ceph Vault documentation](https://docs.ceph.com/en/latest/radosgw/vault/)
-
 The `security` section contains settings related to encryption of the cluster.
 
 * `security`:
@@ -1588,16 +1584,3 @@ data:
 
 Note: if you are using self-signed certificates (not known/approved by a proper CA) you must pass `VAULT_SKIP_VERIFY: true`.
 Communications will remain encrypted but the validity of the certificate will not be verified.
-
-For RGW, please note the following:
-
-* `VAULT_SECRET_ENGINE` option is specifically for RGW to mention about the secret engine which can be used, currently supports two: [kv](https://www.vaultproject.io/docs/secrets/kv) and [transit](https://www.vaultproject.io/docs/secrets/transit).
-* The Storage administrator needs to create a secret in the Vault server so that S3 clients use that key for encryption
-```console
-# kv engine
-vault kv put rook/mybucketkey key=$(openssl rand -base64 32)
-
-# transit engine
-vault write -f transit/keys/mybucketkey exportable=true
-```
-* TLS authentication with custom certs between Vault and RGW are yet to support.

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -7187,6 +7187,26 @@ spec:
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
                   type: boolean
+                security:
+                  description: Security represents security settings
+                  nullable: true
+                  properties:
+                    kms:
+                      description: KeyManagementService is the main Key Management option
+                      nullable: true
+                      properties:
+                        connectionDetails:
+                          additionalProperties:
+                            type: string
+                          description: ConnectionDetails contains the KMS connection details (address, port etc)
+                          nullable: true
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        tokenSecretName:
+                          description: TokenSecretName is the kubernetes secret containing the KMS token
+                          type: string
+                      type: object
+                  type: object
                 zone:
                   description: The multisite info
                   nullable: true

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -7182,6 +7182,26 @@ spec:
                 preservePoolsOnDelete:
                   description: Preserve pools on object store deletion
                   type: boolean
+                security:
+                  description: Security represents security settings
+                  nullable: true
+                  properties:
+                    kms:
+                      description: KeyManagementService is the main Key Management option
+                      nullable: true
+                      properties:
+                        connectionDetails:
+                          additionalProperties:
+                            type: string
+                          description: ConnectionDetails contains the KMS connection details (address, port etc)
+                          nullable: true
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        tokenSecretName:
+                          description: TokenSecretName is the kubernetes secret containing the KMS token
+                          type: string
+                      type: object
+                  type: object
                 zone:
                   description: The multisite info
                   nullable: true

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -106,7 +106,31 @@ spec:
     # Configure the pod liveness probe for the rgw daemon
     livenessProbe:
       disabled: false
-
+  # security oriented settings
+  # security:
+  # To enable the KMS configuration properly don't forget to uncomment the Secret at the end of the file
+  #   kms:
+  #     # name of the config map containing all the kms connection details
+  #     connectionDetails:
+  #        KMS_PROVIDER: "vault"
+  #        VAULT_ADDR: VAULT_ADDR_CHANGE_ME # e,g: http://vault.my-domain.com:8200
+  #        VAULT_BACKEND_PATH: "rook"
+  #        VAULT_SECRET_ENGINE: "kv"
+  #        VAULT_BACKEND: v2
+  #     # name of the secret containing the kms authentication token
+  #     tokenSecretName: rook-vault-token
+# # UNCOMMENT THIS TO ENABLE A KMS CONNECTION
+# # Also, do not forget to replace both:
+# #  * ROOK_TOKEN_CHANGE_ME: with a base64 encoded value of the token to use
+# #  * VAULT_ADDR_CHANGE_ME: with the Vault address
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: rook-vault-token
+#   namespace: rook-ceph # namespace:cluster
+# data:
+#   token: ROOK_TOKEN_CHANGE_ME
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -110,3 +110,28 @@ spec:
     # Configure the pod liveness probe for the rgw daemon
     livenessProbe:
       disabled: false
+  # security oriented settings
+  # security:
+  # To enable the KMS configuration properly don't forget to uncomment the Secret at the end of the file
+  #   kms:
+  #     # name of the config map containing all the kms connection details
+  #     connectionDetails:
+  #        KMS_PROVIDER: "vault"
+  #        VAULT_ADDR: VAULT_ADDR_CHANGE_ME # e,g: http://vault.my-domain.com:8200
+  #        VAULT_BACKEND_PATH: "rook"
+  #        VAULT_SECRET_ENGINE: "kv"
+  #        VAULT_BACKEND: v2
+  #     # name of the secret containing the kms authentication token
+  #     tokenSecretName: rook-vault-token
+# # UNCOMMENT THIS TO ENABLE A KMS CONNECTION
+# # Also, do not forget to replace both:
+# #  * ROOK_TOKEN_CHANGE_ME: with a base64 encoded value of the token to use
+# #  * VAULT_ADDR_CHANGE_ME: with the Vault address
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: rook-vault-token
+#   namespace: rook-ceph # namespace:cluster
+# data:
+#   token: ROOK_TOKEN_CHANGE_ME

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1028,6 +1028,11 @@ type ObjectStoreSpec struct {
 	// +optional
 	// +nullable
 	HealthCheck BucketHealthCheckSpec `json:"healthCheck,omitempty"`
+
+	// Security represents security settings
+	// +optional
+	// +nullable
+	Security *SecuritySpec `json:"security,omitempty"`
 }
 
 // BucketHealthCheckSpec represents the health check of an object store

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -1896,6 +1896,11 @@ func (in *ObjectStoreSpec) DeepCopyInto(out *ObjectStoreSpec) {
 	in.Gateway.DeepCopyInto(&out.Gateway)
 	out.Zone = in.Zone
 	in.HealthCheck.DeepCopyInto(&out.HealthCheck)
+	if in.Security != nil {
+		in, out := &in.Security, &out.Security
+		*out = new(SecuritySpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -396,7 +396,7 @@ func (c *ClusterController) preClusterStartValidation(cluster *cluster) error {
 	// Validate on-PVC cluster encryption KMS settings
 	if cluster.Spec.Storage.IsOnPVCEncrypted() && cluster.Spec.Security.KeyManagementService.IsEnabled() {
 		// Validate the KMS details
-		err := kms.ValidateConnectionDetails(c.context, cluster.Spec, cluster.Namespace)
+		err := kms.ValidateConnectionDetails(c.context, cluster.Spec.Security, cluster.Namespace)
 		if err != nil {
 			return errors.Wrap(err, "failed to validate kms connection details")
 		}

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,12 +28,14 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	"github.com/rook/rook/pkg/operator/ceph/test"
+	cephtest "github.com/rook/rook/pkg/operator/ceph/test"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
+	"github.com/rook/rook/pkg/operator/test"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPodSpecs(t *testing.T) {
@@ -81,7 +84,7 @@ func TestPodSpecs(t *testing.T) {
 		getLabels(c.store.Name, c.store.Namespace, false),
 		s.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels)
 
-	podTemplate := test.NewPodTemplateSpecTester(t, &s)
+	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
@@ -132,7 +135,7 @@ func TestSSLPodSpec(t *testing.T) {
 	assert.Equal(t, secretVolSrc.SecretName, "mycert")
 	s, err := c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
-	podTemplate := test.NewPodTemplateSpecTester(t, &s)
+	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
@@ -144,7 +147,7 @@ func TestSSLPodSpec(t *testing.T) {
 	assert.Equal(t, secretVolSrc.SecretName, "rgw-cert")
 	s, err = c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
-	podTemplate = test.NewPodTemplateSpecTester(t, &s)
+	podTemplate = cephtest.NewPodTemplateSpecTester(t, &s)
 	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
@@ -256,4 +259,61 @@ func TestGenerateLiveProbe(t *testing.T) {
 	p = c.generateLiveProbe()
 	assert.Equal(t, v1.URISchemeHTTP, p.Handler.HTTPGet.Scheme)
 	assert.Equal(t, int32(123), p.Handler.HTTPGet.Port.IntVal)
+}
+
+func TestCheckRGWKMS(t *testing.T) {
+	ctx := context.TODO()
+	// Placeholder
+	context := &clusterd.Context{Clientset: test.New(t, 3)}
+	store := simpleStore()
+	store.Spec.Security = &cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{ConnectionDetails: map[string]string{}}}
+	c := &clusterConfig{
+		context: context,
+		store:   store,
+	}
+
+	// without KMS
+	b, err := c.CheckRGWKMS()
+	assert.False(t, b)
+	assert.NoError(t, err)
+
+	// setting KMS configurations
+	c.store.Spec.Security.KeyManagementService.TokenSecretName = "vault-token"
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["KMS_PROVIDER"] = "vault"
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["VAULT_ADDR"] = "https://1.1.1.1:8200"
+	s := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      store.Spec.Security.KeyManagementService.TokenSecretName,
+			Namespace: store.Namespace,
+		},
+		Data: map[string][]byte{
+			"token": []byte("myt-otkenbenvqrev"),
+		},
+	}
+	_, err = context.Clientset.CoreV1().Secrets(store.Namespace).Create(ctx, s, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// no secret engine set, will fail
+	b, err = c.CheckRGWKMS()
+	assert.False(t, b)
+	assert.Error(t, err)
+
+	// kv engine version v1, will fail
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["VAULT_SECRET_ENGINE"] = "kv"
+	b, err = c.CheckRGWKMS()
+	assert.False(t, b)
+	assert.Error(t, err)
+
+	// kv engine version v2, will pass
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["VAULT_BACKEND"] = "v2"
+	b, err = c.CheckRGWKMS()
+	assert.True(t, b)
+	assert.NoError(t, err)
+
+	// transit engine, will pass
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["VAULT_SECRET_ENGINE"] = "transit"
+	c.store.Spec.Security.KeyManagementService.ConnectionDetails["VAULT_BACKEND"] = ""
+	b, err = c.CheckRGWKMS()
+	assert.True(t, b)
+	assert.NoError(t, err)
 }

--- a/tests/manifests/test-kms-vault-spec.yaml
+++ b/tests/manifests/test-kms-vault-spec.yaml
@@ -4,7 +4,8 @@ spec:
       connectionDetails:
         KMS_PROVIDER: vault
         VAULT_ADDR: https://vault.default.svc.cluster.local:8200
-        VAULT_BACKEND_PATH: rook
+        VAULT_BACKEND_PATH: rook/ver1
         VAULT_SECRET_ENGINE: kv
+        VAULT_BACKEND: v1
         VAULT_SKIP_VERIFY: "true"
       tokenSecretName: rook-vault-token

--- a/tests/manifests/test-object.yaml
+++ b/tests/manifests/test-object.yaml
@@ -1,0 +1,23 @@
+#################################################################################################################
+# Create an object store with settings for a test environment. Only a single OSD is required in this example.
+#  kubectl create -f object-test.yaml
+#################################################################################################################
+
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: my-store
+  namespace: rook-ceph # namespace:cluster
+spec:
+  metadataPool:
+    replicated:
+      size: 1
+  dataPool:
+    replicated:
+      size: 1
+  preservePoolsOnDelete: false
+  gateway:
+    type: s3
+    port: 80
+    # securePort: 443
+    instances: 1


### PR DESCRIPTION
The "https://docs.ceph.com/en/latest/radosgw/vault/" says RGW supports only version v2 of
kv engine, so disable encryption if the admin didn't provide "VAULT_BACKEND" in security.kms.ConnectionDetails

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
