### PR TITLE
ceph: suppress golanglint-ci complaints

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.38
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -179,9 +179,8 @@ func CreatePoolWithProfile(context *clusterd.Context, clusterInfo *ClusterInfo, 
 
 func checkForImagesInPool(context *clusterd.Context, clusterInfo *ClusterInfo, name string) error {
 	var err error
-	var stats = new(PoolStatistics)
 	logger.Debugf("checking any images/snapshosts present in pool %q", name)
-	stats, err = GetPoolStatistics(context, clusterInfo, name)
+	stats, err := GetPoolStatistics(context, clusterInfo, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "No such file or directory") {
 			return nil

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -31,11 +31,11 @@ func TestGetContainerInPod(t *testing.T) {
 	imageName := "myimage"
 
 	// no container fails
-	container, err := GetMatchingContainer([]v1.Container{}, expectedName)
+	_, err := GetMatchingContainer([]v1.Container{}, expectedName)
 	assert.NotNil(t, err)
 
 	// one container will allow any name
-	container, err = GetMatchingContainer([]v1.Container{{Name: "foo", Image: imageName}}, expectedName)
+	container, err := GetMatchingContainer([]v1.Container{{Name: "foo", Image: imageName}}, expectedName)
 	assert.Nil(t, err)
 	assert.Equal(t, imageName, container.Image)
 

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -241,6 +241,7 @@ func pickNode(clientset *fake.Clientset) string {
 	if len(nodes.Items) == 0 {
 		panic(fmt.Errorf("pickNode: no nodes are available in the fake clientset to pick from"))
 	}
+	// #nosec G404 It's harmless since it's a test code
 	randIdx := rand.Intn(len(nodes.Items))
 	return nodes.Items[randIdx].GetName()
 }

--- a/tests/framework/installer/ceph_manifests_v1.5.go
+++ b/tests/framework/installer/ceph_manifests_v1.5.go
@@ -40,8 +40,9 @@ type CephManifestsV1_5 struct {
 func readManifestFromGithub(filename string) string {
 	url := fmt.Sprintf("https://raw.githubusercontent.com/rook/rook/%s/cluster/examples/kubernetes/ceph/%s", Version1_5, filename)
 	logger.Infof("Retrieving manifest: %s", url)
-	// nolint:gosec G107 This is only test code and is expected to read from a url
+	// #nosec G107 This is only test code and is expected to read from a url
 	response, err := http.Get(url)
+
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to read manifest from %s", url))
 	}


### PR DESCRIPTION
**Description of your changes:**

Suppress the following complaints.

```
$ golangci-lint run -E gosec
pkg/operator/test/client.go:244:13: G404: Use of weak random number generator (math/rand instead of crypto/rand) (gosec)
        randIdx := rand.Intn(len(nodes.Items))
                   ^
tests/framework/installer/ceph_manifests_v1.5.go:44:19: G107: Potential HTTP request made with variable url (gosec)
        response, err := http.Get(url)
                         ^
pkg/daemon/ceph/client/pool.go:182:6: ineffectual assignment to stats (ineffassign)
        var stats = new(PoolStatistics)
            ^
pkg/operator/k8sutil/pod_test.go:34:2: ineffectual assignment to container (ineffassign)
        container, err := GetMatchingContainer([]v1.Container{}, expectedName)
        ^
```

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
