### PR TITLE
fix gpt table after dd [skip-ci]

### DIFF
--- a/Documentation/ceph-teardown.md
+++ b/Documentation/ceph-teardown.md
@@ -86,6 +86,9 @@ dd if=/dev/zero of="$DISK" bs=1M count=100 oflag=direct,dsync
 # Clean disks such as ssd with blkdiscard instead of dd
 blkdiscard $DISK
 
+# Recreate GPT table
+parted $DISK -s mklabel gpt
+
 # These steps only have to be run once on each node
 # If rook sets up osds using ceph-volume, teardown leaves some devices mapped that lock the disks.
 ls /dev/mapper/ceph-* | xargs -I% -- dmsetup remove %


### PR DESCRIPTION
When tearing down the cluster I also had to recreate the gpt tables on the disks. 