### PR TITLE
ceph: set pool quota with k8s quantity format

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -195,8 +195,8 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
     * `interval`: time interval to refresh the mirroring status (default 60s)
 
 * `quotas`: Set byte and object quotas. See the [ceph documentation](https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas) for more info.
-  * `maxBytes`: quota in bytes (default: 0)
-  * `maxObjects`: quota in objects (default: 0)
+  * `maxSize`: quota in bytes as a string with quantity suffixes (e.g. "10Gi")
+  * `maxObjects`: quota in objects as an integer
     > **NOTE**: A value of 0 disables the quota.
 
 ### Add specific pool properties

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -1219,6 +1219,9 @@ spec:
                     maxBytes:
                       type: integer
                       minimum: 0
+                    maxSize:
+                      pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE][i]?)?$
+                      type: string
                     maxObjects:
                       type: integer
                       minimum: 0

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -1267,6 +1267,9 @@ spec:
                     maxBytes:
                       type: integer
                       minimum: 0
+                    maxSize:
+                      pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE][i]?)?$
+                      type: string
                     maxObjects:
                       type: integer
                       minimum: 0

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -57,7 +57,7 @@ spec:
   # quota in bytes and/or objects, default value is 0 (unlimited)
   # see https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas
   # quotas:
-    # maxBytes: 10737418240 # 10GiB = 10 * 1024 * 1024 * 1024
+    # maxSize: "10Gi" # valid suffixes include K, M, G, T, P, Ki, Mi, Gi, Ti, Pi
     # maxObjects: 1000000000 # 1 billion objects
   # A key/value list of annotations
   annotations:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -469,7 +469,11 @@ type SnapshotScheduleSpec struct {
 // QuotaSpec represents the spec for quotas in a pool
 type QuotaSpec struct {
 	// MaxBytes represents the quota in bytes
+	// Deprecated in favor of MaxSize
 	MaxBytes *uint64 `json:"maxBytes,omitempty"`
+
+	// MaxSize represents the quota in bytes as a string
+	MaxSize *string `json:"maxSize,omitempty"`
 
 	// MaxObjects represents the quota in objects
 	MaxObjects *uint64 `json:"maxObjects,omitempty"`

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -1970,6 +1970,11 @@ func (in *QuotaSpec) DeepCopyInto(out *QuotaSpec) {
 		*out = new(uint64)
 		**out = **in
 	}
+	if in.MaxSize != nil {
+		in, out := &in.MaxSize, &out.MaxSize
+		*out = new(string)
+		**out = **in
+	}
 	if in.MaxObjects != nil {
 		in, out := &in.MaxObjects, &out.MaxObjects
 		*out = new(uint64)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -1569,7 +1569,7 @@ spec:
     enabled: true
     mode: image
   quotas:
-    maxBytes: 10737418240
+    maxSize: 10Gi
     maxObjects: 1000000
   statusCheck:
     mirror:


### PR DESCRIPTION
This is a follow up to:

https://github.com/rook/rook/pull/7264

which added pool quotas. It was stated that it would be nice to
be able to set pool max_bytes quotas using standard k8s quantity
formats rather than an integer representing the number of bytes.

I was too busy at the time to make the changes. This PR adds the
functionality.

Signed-off-by: Frank Ritchie <12985912+fritchie@users.noreply.github.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
