### PR TITLE
ci: mitigate flapping block device in ceph test suites

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -31,8 +31,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -35,8 +35,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -35,8 +35,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -35,8 +35,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -35,8 +35,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -35,8 +35,10 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
-        sudo lsblk
+        DISK=$(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        sudo wipefs --all --force "$DISK"
+        lsblk
+        tests/scripts/bypass-device-flapping-problem.sh $DISK
 
     - name: build rook
       run: |

--- a/tests/scripts/bypass-device-flapping-problem.sh
+++ b/tests/scripts/bypass-device-flapping-problem.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Rook Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+#############
+# VARIABLES #
+#############
+FSSIZE=1024M
+
+#############
+# FUNCTIONS #
+#############
+
+function wipe_disk {
+  sudo sgdisk --zap-all --clear --mbrtogpt -g -- "$DISK"
+  sudo dd if=/dev/zero of="$DISK" bs=1M count=10
+  sudo parted -s "$DISK" mklabel gpt
+  sudo partprobe "$DISK"
+  sudo udevadm settle
+  sudo parted "$DISK" -s print
+}
+
+########
+# MAIN #
+########
+if [ "$#" -ne 1 ]; then
+  exit 1
+fi
+
+DISK="$1"
+
+# First wipe the disk
+wipe_disk
+
+# Some github actions runners seem to delete and re-create block devices
+# if there is no mounted filesystem on it. It causes test failure.
+# So let's bypass this problem by mounting a fake filesystem.
+# For more details, see the following PR.
+# https://github.com/rook/rook/pull/7404
+sudo sgdisk --new=0:0:+"$FSSIZE" -- "$DISK"
+FAKEFSPART=${DISK}1
+sudo mkfs.ext4 ${FAKEFSPART}
+sudo mount ${FAKEFSPART} /mnt
+
+# Create a partition for OSD
+sudo sgdisk --largest-new=0 -- "$DISK"
+
+# Inform the kernel of partition table changes
+sudo partprobe "$DISK"
+
+# Wait the udev event queue, and exits if all current events are handled.
+sudo udevadm settle
+
+# Print drives
+sudo lsblk
+sudo parted "$DISK" -s print


### PR DESCRIPTION
**Description of your changes:**

`rbd ls -l device_health_metrics` causes timeout frequently.

```console
...
2021-03-15T01:49:44.7896081Z === RUN TestCephSmokeSuite/TestBlockStorage_SmokeTest
2021-03-15T01:49:44.7905141Z 2021-03-15 01:49:44.789998 I | integrationTest: Block Storage End to End Integration Test - create, mount, write to, read from, and unmount
2021-03-15T01:49:44.7906815Z 2021-03-15 01:49:44.790015 I | integrationTest: Running on Rook Cluster smoke-ns
2021-03-15T01:49:44.7907806Z 2021-03-15 01:49:44.790019 I | integrationTest: Step 0 : Get Initial List Block
2021-03-15T01:49:44.7909156Z 2021-03-15 01:49:44.790028 D | exec: Running command: kubectl exec -i rook-ceph-tools -n smoke-ns -- ceph osd lspools --connect-timeout=15 --format json
2021-03-15T01:49:46.0122492Z 2021-03-15 01:49:46.011781 D | exec: Running command: kubectl exec -i rook-ceph-tools -n smoke-ns -- rbd ls -l device_health_metrics --format json
2021-03-15T02:17:24.9291728Z panic: test timed out after 30m0s
...
```

It's because the block device file, that backs OSD, is attached/detached continuously in some github actions runners. This problem seem to happen if there is no mounted filesystem in this device. Let's bypass this problem by mounting a fake filesystem.

**Which issue is resolved by this Pull Request:**
Resolves #7405 

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
