### PR TITLE
ceph: placement in case of both PVC and non-PVC's 

### DIFF
--- a/pkg/apis/rook.io/v1/placement_test.go
+++ b/pkg/apis/rook.io/v1/placement_test.go
@@ -94,34 +94,29 @@ topologySpreadConstraints:
 func TestMergeNodeAffinity(t *testing.T) {
 	// affinity is nil
 	p := Placement{}
-	result := p.mergeNodeAffinity(nil, true)
+	result := p.mergeNodeAffinity(nil)
 	assert.Nil(t, result)
 
 	// node affinity is only set on the placement and should remain unchanged
 	p.NodeAffinity = placementTestGenerateNodeAffinity()
-	result = p.mergeNodeAffinity(nil, true)
+	result = p.mergeNodeAffinity(nil)
 	assert.Equal(t, p.NodeAffinity, result)
 
 	// preferred set, but required not set
 	affinityToMerge := placementTestGenerateNodeAffinity()
 	affinityToMerge.RequiredDuringSchedulingIgnoredDuringExecution = nil
-	result = p.mergeNodeAffinity(affinityToMerge, true)
+	result = p.mergeNodeAffinity(affinityToMerge)
 	assert.Equal(t, 2, len(result.PreferredDuringSchedulingIgnoredDuringExecution))
 	assert.Equal(t, p.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution, result.RequiredDuringSchedulingIgnoredDuringExecution)
 
 	// preferred and required expressions set
 	affinityToMerge = placementTestGenerateNodeAffinity()
 	affinityToMerge.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key = "baz"
-	result = p.mergeNodeAffinity(affinityToMerge, true)
+	result = p.mergeNodeAffinity(affinityToMerge)
 	assert.Equal(t, 2, len(result.PreferredDuringSchedulingIgnoredDuringExecution))
 	assert.Equal(t, 2, len(result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions))
 	assert.Equal(t, "baz", result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key)
 	assert.Equal(t, "foo", result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[1].Key)
-
-	result = p.mergeNodeAffinity(affinityToMerge, false)
-	assert.Equal(t, 1, len(result.PreferredDuringSchedulingIgnoredDuringExecution))
-	assert.Equal(t, 1, len(result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions))
-	assert.Equal(t, "foo", result.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key)
 }
 
 func TestPlacementApplyToPodSpec(t *testing.T) {
@@ -145,7 +140,7 @@ func TestPlacementApplyToPodSpec(t *testing.T) {
 		TopologySpreadConstraints: tc,
 	}
 	ps = &v1.PodSpec{}
-	p.ApplyToPodSpec(ps, true)
+	p.ApplyToPodSpec(ps)
 	assert.Equal(t, expected, ps)
 	assert.Equal(t, 1, len(ps.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
 
@@ -159,7 +154,7 @@ func TestPlacementApplyToPodSpec(t *testing.T) {
 	// partial update
 	p = Placement{NodeAffinity: na, PodAntiAffinity: antiaffinity}
 	ps = &v1.PodSpec{Tolerations: to, TopologySpreadConstraints: tc}
-	p.ApplyToPodSpec(ps, true)
+	p.ApplyToPodSpec(ps)
 	assert.Equal(t, expected, ps)
 
 	// overridden attributes
@@ -173,7 +168,7 @@ func TestPlacementApplyToPodSpec(t *testing.T) {
 		Tolerations:               placementTestGetTolerations("bar", "baz"),
 		TopologySpreadConstraints: placementTestGetTopologySpreadConstraints("rack"),
 	}
-	p.ApplyToPodSpec(ps, true)
+	p.ApplyToPodSpec(ps)
 	assert.Equal(t, expected, ps)
 
 	// The preferred affinity is merged from both sources to result in two node affinities
@@ -185,11 +180,8 @@ func TestPlacementApplyToPodSpec(t *testing.T) {
 		Tolerations:               to,
 		TopologySpreadConstraints: tc,
 	}
-	p.ApplyToPodSpec(ps, true)
+	p.ApplyToPodSpec(ps)
 	assert.Equal(t, 2, len(ps.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
-
-	p.ApplyToPodSpec(ps, false)
-	assert.Equal(t, 1, len(ps.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
 }
 
 func TestPlacementMerge(t *testing.T) {

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -158,7 +158,7 @@ func (c *ClusterController) cleanUpJobTemplateSpec(cluster *cephv1.CephCluster, 
 	cephv1.GetCleanupLabels(cluster.Spec.Labels).ApplyToObjectMeta(&podSpec.ObjectMeta)
 
 	// Apply placement
-	getCleanupPlacement(cluster.Spec).ApplyToPodSpec(&podSpec.Spec, true)
+	getCleanupPlacement(cluster.Spec).ApplyToPodSpec(&podSpec.Spec)
 
 	return podSpec
 }

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -64,7 +64,7 @@ func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error)
 			PriorityClassName:  cephv1.GetMgrPriorityClassName(c.spec.PriorityClassNames),
 		},
 	}
-	cephv1.GetMgrPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec.Spec, true)
+	cephv1.GetMgrPlacement(c.spec.Placement).ApplyToPodSpec(&podSpec.Spec)
 
 	// Run the sidecar and require anti affinity only if there are multiple mgrs
 	if c.spec.Mgr.Count > 1 {

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -661,7 +661,7 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 
 	// setup affinity settings for pod scheduling
 	p := c.getMonPlacement(mon.Zone)
-	p.ApplyToPodSpec(&d.Spec.Template.Spec, true)
+	p.ApplyToPodSpec(&d.Spec.Template.Spec)
 	k8sutil.SetNodeAntiAffinityForPod(&d.Spec.Template.Spec, requiredDuringScheduling(&c.spec), v1.LabelHostname,
 		map[string]string{k8sutil.AppAttr: AppName}, nil)
 
@@ -1260,7 +1260,7 @@ func (c *Cluster) startMon(m *monConfig, schedule *MonScheduleInfo) error {
 	}
 	p := c.getMonPlacement(zone)
 
-	p.ApplyToPodSpec(&d.Spec.Template.Spec, true)
+	p.ApplyToPodSpec(&d.Spec.Template.Spec)
 	if deploymentExists {
 		// the existing deployment may have a node selector. if the cluster
 		// isn't using host networking and the deployment is using pvc storage,

--- a/pkg/operator/ceph/cluster/rbd/spec.go
+++ b/pkg/operator/ceph/cluster/rbd/spec.go
@@ -67,7 +67,7 @@ func (r *ReconcileCephRBDMirror) makeDeployment(daemonConfig *daemonConfig, rbdM
 			return nil, err
 		}
 	}
-	rbdMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec, true)
+	rbdMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec)
 
 	// If the rbd mirror has a peer we must add the relevant ceph config file and key to connect to it
 	// Both cm and secret have been created already, so it's fine to just reference them

--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -131,7 +131,7 @@ func (c *cluster) detectCephVersion(rookImage, cephImage string, timeout time.Du
 	job.Spec.Template.Spec.ServiceAccountName = "rook-ceph-cmd-reporter"
 
 	// Apply the same placement for the ceph version detection as the mon daemons except for PodAntiAffinity
-	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec, true)
+	cephv1.GetMonPlacement(c.Spec.Placement).ApplyToPodSpec(&job.Spec.Template.Spec)
 	job.Spec.Template.Spec.Affinity.PodAntiAffinity = nil
 
 	stdout, stderr, retcode, err := versionReporter.Run(timeout)

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -76,7 +76,7 @@ func (c *Cluster) makeDeployment(mdsConfig *mdsConfig, namespace string) (*apps.
 
 	c.fs.Spec.MetadataServer.Annotations.ApplyToObjectMeta(&podSpec.ObjectMeta)
 	c.fs.Spec.MetadataServer.Labels.ApplyToObjectMeta(&podSpec.ObjectMeta)
-	c.fs.Spec.MetadataServer.Placement.ApplyToPodSpec(&podSpec.Spec, true)
+	c.fs.Spec.MetadataServer.Placement.ApplyToPodSpec(&podSpec.Spec)
 
 	replicas := int32(1)
 	d := &apps.Deployment{

--- a/pkg/operator/ceph/file/mirror/spec.go
+++ b/pkg/operator/ceph/file/mirror/spec.go
@@ -68,7 +68,7 @@ func (r *ReconcileFilesystemMirror) makeDeployment(daemonConfig *daemonConfig, f
 			return nil, err
 		}
 	}
-	fsMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec, true)
+	fsMirror.Spec.Placement.ApplyToPodSpec(&podSpec.Spec)
 
 	replicas := int32(1)
 	d := &apps.Deployment{

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -138,7 +138,7 @@ func (r *ReconcileCephNFS) makeDeployment(nfs *cephv1.CephNFS, cfg daemonConfig)
 	if r.cephClusterSpec.Network.IsHost() {
 		podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 	}
-	nfs.Spec.Server.Placement.ApplyToPodSpec(&podSpec, true)
+	nfs.Spec.Server.Placement.ApplyToPodSpec(&podSpec)
 
 	podTemplateSpec := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -133,7 +133,7 @@ func (c *clusterConfig) makeRGWPodSpec(rgwConfig *rgwConfig) (v1.PodTemplateSpec
 				c.vaultTokenInitContainer(rgwConfig))
 		}
 	}
-	c.store.Spec.Gateway.Placement.ApplyToPodSpec(&podSpec, true)
+	c.store.Spec.Gateway.Placement.ApplyToPodSpec(&podSpec)
 
 	// If host networking is not enabled, preferred pod anti-affinity is added to the rgw daemons
 	labels := getLabels(c.store.Name, c.store.Namespace, false)

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -179,7 +179,7 @@ func testPodSpecPlacement(t *testing.T, requiredDuringScheduling bool, req, pref
 		RestartPolicy:  v1.RestartPolicyAlways,
 	}
 
-	placement.ApplyToPodSpec(&spec, true)
+	placement.ApplyToPodSpec(&spec)
 	SetNodeAntiAffinityForPod(&spec, requiredDuringScheduling, v1.LabelHostname, map[string]string{"app": "mon"}, nil)
 
 	// should have a required anti-affinity and no preferred anti-affinity


### PR DESCRIPTION
**Description of your changes:**

In the case of PVC,
We'll first apply `placement.All()` and then we'll
apply `devicSet Placement`. If both are specified 
`placement.All` and `devicSet Placement` then we merging
both at least the `nodeAffinity`.

In case of non-PVC,
we apply `spec.placement`.

Signed-off-by: subhamkrai <srai@redhat.com>
co-authored-by: Travis Nielsen <tnielsen@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #7176 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
