### PR TITLE
ceph: mark maxSize as optional

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -107,6 +107,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 quotas:
                   description: The quota settings
+                  nullable: true
                   properties:
                     maxBytes:
                       description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -118,6 +119,7 @@ spec:
                       type: integer
                     maxSize:
                       description: MaxSize represents the quota in bytes as a string
+                      pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                       type: string
                   type: object
                 replicated:
@@ -4727,6 +4729,7 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                       quotas:
                         description: The quota settings
+                        nullable: true
                         properties:
                           maxBytes:
                             description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -4738,6 +4741,7 @@ spec:
                             type: integer
                           maxSize:
                             description: MaxSize represents the quota in bytes as a string
+                            pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                             type: string
                         type: object
                       replicated:
@@ -4858,6 +4862,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -4869,6 +4874,7 @@ spec:
                           type: integer
                         maxSize:
                           description: MaxSize represents the quota in bytes as a string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
@@ -6138,6 +6144,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -6149,6 +6156,7 @@ spec:
                           type: integer
                         maxSize:
                           description: MaxSize represents the quota in bytes as a string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
@@ -6900,6 +6908,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -6911,6 +6920,7 @@ spec:
                           type: integer
                         maxSize:
                           description: MaxSize represents the quota in bytes as a string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
@@ -7245,6 +7255,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -7256,6 +7267,7 @@ spec:
                           type: integer
                         maxSize:
                           description: MaxSize represents the quota in bytes as a string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
@@ -7375,6 +7387,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated in favor of MaxSize
@@ -7386,6 +7399,7 @@ spec:
                           type: integer
                         maxSize:
                           description: MaxSize represents the quota in bytes as a string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -123,6 +123,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               quotas:
                 description: The quota settings
+                nullable: true
                 properties:
                   maxBytes:
                     description: MaxBytes represents the quota in bytes Deprecated
@@ -135,6 +136,7 @@ spec:
                     type: integer
                   maxSize:
                     description: MaxSize represents the quota in bytes as a string
+                    pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                     type: string
                 type: object
               replicated:
@@ -7599,6 +7601,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     quotas:
                       description: The quota settings
+                      nullable: true
                       properties:
                         maxBytes:
                           description: MaxBytes represents the quota in bytes Deprecated
@@ -7612,6 +7615,7 @@ spec:
                         maxSize:
                           description: MaxSize represents the quota in bytes as a
                             string
+                          pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                           type: string
                       type: object
                     replicated:
@@ -7750,6 +7754,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   quotas:
                     description: The quota settings
+                    nullable: true
                     properties:
                       maxBytes:
                         description: MaxBytes represents the quota in bytes Deprecated
@@ -7762,6 +7767,7 @@ spec:
                         type: integer
                       maxSize:
                         description: MaxSize represents the quota in bytes as a string
+                        pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                         type: string
                     type: object
                   replicated:
@@ -9788,6 +9794,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   quotas:
                     description: The quota settings
+                    nullable: true
                     properties:
                       maxBytes:
                         description: MaxBytes represents the quota in bytes Deprecated
@@ -9800,6 +9807,7 @@ spec:
                         type: integer
                       maxSize:
                         description: MaxSize represents the quota in bytes as a string
+                        pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                         type: string
                     type: object
                   replicated:
@@ -10986,6 +10994,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   quotas:
                     description: The quota settings
+                    nullable: true
                     properties:
                       maxBytes:
                         description: MaxBytes represents the quota in bytes Deprecated
@@ -10998,6 +11007,7 @@ spec:
                         type: integer
                       maxSize:
                         description: MaxSize represents the quota in bytes as a string
+                        pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                         type: string
                     type: object
                   replicated:
@@ -11365,6 +11375,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   quotas:
                     description: The quota settings
+                    nullable: true
                     properties:
                       maxBytes:
                         description: MaxBytes represents the quota in bytes Deprecated
@@ -11377,6 +11388,7 @@ spec:
                         type: integer
                       maxSize:
                         description: MaxSize represents the quota in bytes as a string
+                        pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                         type: string
                     type: object
                   replicated:
@@ -11514,6 +11526,7 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   quotas:
                     description: The quota settings
+                    nullable: true
                     properties:
                       maxBytes:
                         description: MaxBytes represents the quota in bytes Deprecated
@@ -11526,6 +11539,7 @@ spec:
                         type: integer
                       maxSize:
                         description: MaxSize represents the quota in bytes as a string
+                        pattern: ^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$
                         type: string
                     type: object
                   replicated:

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -57,7 +57,7 @@ spec:
   # quota in bytes and/or objects, default value is 0 (unlimited)
   # see https://docs.ceph.com/en/latest/rados/operations/pools/#set-pool-quotas
   # quotas:
-    # maxSize: "10Gi" # valid suffixes include K, M, G, T, P, Ki, Mi, Gi, Ti, Pi
+    # maxSize: "10Gi" # valid suffixes include k, M, G, T, P, E, Ki, Mi, Gi, Ti, Pi, Ei
     # maxObjects: 1000000000 # 1 billion objects
   # A key/value list of annotations
   annotations:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -564,6 +564,8 @@ type PoolSpec struct {
 	StatusCheck MirrorHealthCheckSpec `json:"statusCheck,omitempty"`
 
 	// The quota settings
+	// +optional
+	// +nullable
 	Quotas QuotaSpec `json:"quotas,omitempty"`
 }
 
@@ -806,6 +808,8 @@ type QuotaSpec struct {
 	MaxBytes *uint64 `json:"maxBytes,omitempty"`
 
 	// MaxSize represents the quota in bytes as a string
+	// +kubebuilder:validation:Pattern=`^[0-9]+[\.]?[0-9]*([KMGTPE]i|[kMGTPE])?$`
+	// +optional
 	MaxSize *string `json:"maxSize,omitempty"`
 
 	// MaxObjects represents the quota in objects

--- a/pkg/daemon/ceph/client/pool.go
+++ b/pkg/daemon/ceph/client/pool.go
@@ -289,7 +289,7 @@ func setCommonPoolProperties(context *clusterd.Context, clusterInfo *ClusterInfo
 		maxBytesQuota, err := resource.ParseQuantity(*pool.Quotas.MaxSize)
 		if err != nil {
 			if err == resource.ErrFormatWrong {
-				return errors.Wrapf(err, "maxSize quota incorrectly formatted for pool %q, valid units include K, M, G, T, P, Ki, Mi, Gi, Ti, Pi", poolName)
+				return errors.Wrapf(err, "maxSize quota incorrectly formatted for pool %q, valid units include k, M, G, T, P, E, Ki, Mi, Gi, Ti, Pi, Ei", poolName)
 			}
 			return errors.Wrapf(err, "failed setting quota for pool %q, maxSize quota parse error", poolName)
 		}


### PR DESCRIPTION
This is a follow up to:

https://github.com/rook/rook/pull/7397

Looks like I forgot to mark maxSize as optional.

Additionally, I updated an error message.

Signed-off-by: Frank Ritchie <12985912+fritchie@users.noreply.github.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
