### PR TITLE
ci: run gh action on multiple k8s version

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   TestCephFlexSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
     steps:
     - name: checkout
@@ -17,7 +18,7 @@ jobs:
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
         minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        kubernetes version: 'v1.15.12'
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -3,7 +3,12 @@ on: [pull_request]
 
 jobs:
   TestCephHelmSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.15.12', 'v1.20.2']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -16,8 +21,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.16.0'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -3,7 +3,12 @@ on: [pull_request]
 
 jobs:
   TestCephMgrSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.20.2']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -16,8 +21,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.16.0'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -3,7 +3,12 @@ on: [pull_request]
 
 jobs:
   TestCephMultiClusterDeploySuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.20.2']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -16,8 +21,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.16.0'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -3,7 +3,12 @@ on: [pull_request]
 
 jobs:
   TestCephSmokeSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.15.12', 'v1.20.2']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -16,8 +21,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.16.0'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -3,7 +3,12 @@ on: [pull_request]
 
 jobs:
   TestCephUpgradeSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.20.2']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -16,8 +21,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.3.1
       with:
-        minikube version: 'v1.13.1'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.16.0'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
 
     - name: check k8s cluster status


### PR DESCRIPTION
**Description of your changes:**

this commit enables gh action to run

Flex test on only 'v1.15.12',
Smoke and Helm tests on both 'v1.15.12','v1.20.2',
Mgr, Multicluster and upgrade tests on only 'v1.20.2'

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
