### PR TITLE
ceph: fix csi blocker owner deletion

### DIFF
--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -99,9 +99,14 @@ func (info *OwnerInfo) SetControllerReference(object metav1.Object) error {
 	if err != nil {
 		return err
 	}
-	blockOwnerDeletion := true
+
+	// Do not override the BlockOwnerDeletion is already set
+	if info.ownerRef.BlockOwnerDeletion == nil {
+		blockOwnerDeletion := true
+		info.ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
+	}
+
 	controller := true
-	info.ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 	info.ownerRef.Controller = &controller
 	SetOwnerRef(object, info.ownerRef)
 	return nil


### PR DESCRIPTION
**Description of your changes:**

Small regression introduced in https://github.com/rook/rook/commit/26c8fd9bd14178d74dcc28f009e5c2f658224436
which was overriding the BlockOwnerDeletion from the ownerref.
Now, if set we don't modify it.
This fixes deployments on OCP.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
