### PR TITLE
ceph: Set active mgr label on mgr services

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/service-monitor.yaml
@@ -13,6 +13,7 @@ spec:
     matchLabels:
       app: rook-ceph-mgr
       rook_cluster: rook-ceph
+      ceph_daemon_id: a
   endpoints:
   - port: http-metrics
     path: /metrics

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -246,7 +246,7 @@ func getDefaultMgrLivenessProbe() *v1.Probe {
 
 // MakeMetricsService generates the Kubernetes service object for the monitoring service
 func (c *Cluster) MakeMetricsService(name, activeDaemon, servicePortMetricName string) (*v1.Service, error) {
-	labels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
+	labels := c.selectorLabels(activeDaemon)
 
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -268,7 +268,7 @@ func (c *Cluster) MakeMetricsService(name, activeDaemon, servicePortMetricName s
 
 	// If the cluster is external we don't need to add the selector
 	if name != ExternalMgrAppName {
-		svc.Spec.Selector = c.selectorLabels(activeDaemon)
+		svc.Spec.Selector = labels
 	}
 
 	err := c.clusterInfo.OwnerInfo.SetControllerReference(svc)
@@ -279,9 +279,7 @@ func (c *Cluster) MakeMetricsService(name, activeDaemon, servicePortMetricName s
 }
 
 func (c *Cluster) makeDashboardService(name, activeDaemon string) (*v1.Service, error) {
-	labels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
-	selectorLabels := controller.AppLabels(AppName, c.clusterInfo.Namespace)
-	selectorLabels[controller.DaemonIDLabel] = activeDaemon
+	labels := c.selectorLabels(activeDaemon)
 
 	portName := "https-dashboard"
 	if !c.spec.Dashboard.SSL {
@@ -294,7 +292,7 @@ func (c *Cluster) makeDashboardService(name, activeDaemon string) (*v1.Service, 
 			Labels:    labels,
 		},
 		Spec: v1.ServiceSpec{
-			Selector: selectorLabels,
+			Selector: labels,
 			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -91,7 +91,7 @@ func TestServiceSpec(t *testing.T) {
 	assert.NotNil(t, s)
 	assert.Equal(t, "rook-mgr", s.Name)
 	assert.Equal(t, 1, len(s.Spec.Ports))
-	assert.Equal(t, 2, len(s.Labels))
+	assert.Equal(t, 3, len(s.Labels))
 	assert.Equal(t, 3, len(s.Spec.Selector))
 	assert.Equal(t, "foo", s.Spec.Selector[controller.DaemonIDLabel])
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Other resources such as the service monitor need to match the labels on the services to the active mgr, thus the active mgr name is now set on the labels for the metrics service and dashboard service. This only affects master since adding support for multiple mgrs.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
