### PR TITLE
docs: add a warning before running create-external-cluster-resources.sh

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -1266,6 +1266,29 @@ export ROOK_EXTERNAL_ADMIN_SECRET=AQC6Ylxdja+NDBAAB7qy9MEAr4VLLq4dCIvxtg==
 
 If the Ceph admin key is not provided, the following script needs to be executed on a machine that can connect to the Ceph cluster using the Ceph admin key.
 On that machine, run `cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh`.
+
+> **WARNING**: Since only Ceph admin key can create CRs in the external cluster, please make sure that rgw pools have been prepared. You can get existing pools by running `ceph osd pool ls`. 
+
+**Example**:
+
+```console
+ceph osd pool ls
+```
+>```
+>my-store.rgw.control
+>my-store.rgw.meta
+>my-store.rgw.log
+>my-store.rgw.buckets.index
+>my-store.rgw.buckets.non-ec
+>my-store.rgw.buckets.data
+>```
+
+In this example, you can simply export RGW_POOL_PREFIX before executing the script like this:
+
+```console
+export RGW_POOL_PREFIX=my-store
+```
+
 The script will automatically create users and keys with the lowest possible privileges and populate the necessary environment variables for `cluster/examples/kubernetes/ceph/import-external-cluster.sh` to work correctly.
 
 Finally, you can simply execute the script like this from a machine that has access to your Kubernetes cluster:


### PR DESCRIPTION
Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If we don't export RGW_POOL_PREFIX firstly, RGW_POOL_PREFIX will be set to default value, which is "default". Add a warning in document to give user instructions.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]