### PR TITLE
ci: missing exports for import-external-cluster.sh

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # this script creates all the users/keys on the external cluster
 # those keys will be injected via the import-external-cluster.sh once this one is done running
-# so you can run import-external-cluster.sh right after this script
+# so you can run import-external-cluster.sh right after this script 
 set -Eeuo pipefail
 
 #############


### PR DESCRIPTION
Add funktion for the missing export environment variable that needed for the import-external-cluster.sh script
