### PR TITLE
ci: fix disk issue with crashing osd

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -31,8 +31,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -56,7 +61,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-flex-suite')
       uses: mxschmitt/action-tmate@v3
-  
+
   TestCephFlexSuite-Master:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
     runs-on: ubuntu-18.04

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -35,8 +35,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -62,7 +67,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-helm-suite')
       uses: mxschmitt/action-tmate@v3
-  
+
   TestCephHelmSuite-Master:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
     runs-on: ubuntu-18.04

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -35,8 +35,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -35,8 +35,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -61,7 +66,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-multi-cluster-suite')
       uses: mxschmitt/action-tmate@v3
-  
+
   TestCephMultiClusterDeploySuite-Master:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
     runs-on: ubuntu-18.04

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -35,8 +35,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -35,8 +35,13 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -119,4 +124,3 @@ jobs:
     - name: setup tmate session for debugging
       if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-upgrade-suite')
       uses: mxschmitt/action-tmate@v3
-  

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -68,7 +68,7 @@ func FinalizeCephCommandArgs(command string, clusterInfo *ClusterInfo, args []st
 
 	// If the command should be run inside the toolbox pod, include the kubectl args to call the toolbox
 	if RunAllCephCommandsInToolboxPod != "" {
-		toolArgs := []string{"exec", "-i", RunAllCephCommandsInToolboxPod, "-n", clusterInfo.Namespace, "--", command}
+		toolArgs := []string{"exec", "-i", RunAllCephCommandsInToolboxPod, "-n", clusterInfo.Namespace, "--", "timeout", "15", command}
 		return Kubectl, append(toolArgs, args...)
 	}
 

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -84,6 +84,8 @@ func TestFinalizeCephCommandArgsToolBox(t *testing.T) {
 		"-n",
 		"rook",
 		"--",
+		"timeout",
+		"15",
 		"ceph",
 		"health",
 		"--connect-timeout=15",

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -42,15 +42,15 @@ func TestCephArgs(t *testing.T) {
 	args = []string{}
 	command, args = FinalizeCephCommandArgs(CephTool, clusterInfo, args, "/etc")
 	assert.Equal(t, Kubectl, command)
-	assert.Equal(t, 8, len(args), fmt.Sprintf("%+v", args))
+	assert.Equal(t, 10, len(args), fmt.Sprintf("%+v", args))
 	assert.Equal(t, "exec", args[0])
 	assert.Equal(t, "-i", args[1])
 	assert.Equal(t, "rook-ceph-tools", args[2])
 	assert.Equal(t, "-n", args[3])
 	assert.Equal(t, clusterInfo.Namespace, args[4])
 	assert.Equal(t, "--", args[5])
-	assert.Equal(t, CephTool, args[6])
-	assert.Equal(t, "--connect-timeout=15", args[7])
+	assert.Equal(t, CephTool, args[8])
+	assert.Equal(t, "--connect-timeout=15", args[9])
 	RunAllCephCommandsInToolboxPod = ""
 
 	// cluster under /var/lib/rook

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -1129,6 +1129,14 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 	   Command successful.
 	*/
 
+	// Add /dev/mapper in the volume mount list
+	// This will fix issues when running on multi-path, where cryptsetup complains that the underlying device does not exist
+	// Essentially, the device cannot be found because it was not mounted in the container
+	// Typically, the device is mapped to the OSD data dir so it is mounted
+	volMount := []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)}
+	_, volMountMapper := getDeviceMapperVolume()
+	volMount = append(volMount, volMountMapper)
+
 	return v1.Container{
 		Name:  expandEncryptedPVCOSDInitContainer,
 		Image: c.spec.CephVersion.Image,
@@ -1136,7 +1144,7 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 			"cryptsetup",
 		},
 		Args:            []string{"--verbose", "resize", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
-		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)},
+		VolumeMounts:    volMount,
 		SecurityContext: PrivilegedContext(),
 		Resources:       osdProps.resources,
 	}

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -232,6 +232,8 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, "blkdevmapper-encryption", deployment.Spec.Template.Spec.InitContainers[2].Name)
 	assert.Equal(t, "encrypted-block-status", deployment.Spec.Template.Spec.InitContainers[3].Name)
 	assert.Equal(t, "expand-encrypted-bluefs", deployment.Spec.Template.Spec.InitContainers[4].Name)
+	assert.Equal(t, 2, len(deployment.Spec.Template.Spec.InitContainers[4].VolumeMounts), deployment.Spec.Template.Spec.InitContainers[4].VolumeMounts)
+	assert.Equal(t, "dev-mapper", deployment.Spec.Template.Spec.InitContainers[4].VolumeMounts[1].Name, deployment.Spec.Template.Spec.InitContainers[4].VolumeMounts)
 	assert.Equal(t, "activate", deployment.Spec.Template.Spec.InitContainers[5].Name)
 	assert.Equal(t, "expand-bluefs", deployment.Spec.Template.Spec.InitContainers[6].Name)
 	assert.Equal(t, "chown-container-data-dir", deployment.Spec.Template.Spec.InitContainers[7].Name)

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -509,6 +509,12 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 	// Gather logs after status checks
 	h.GatherAllRookLogs(h.T().Name(), append([]string{h.settings.OperatorNamespace}, clusterNamespaces...)...)
 
+	// If test failed do not teardown and leave the cluster in the state it is
+	if h.T().Failed() {
+		logger.Info("one of the tests failed, leaving the cluster in its bad shape for investigation")
+		return
+	}
+
 	logger.Infof("Uninstalling Rook")
 	var err error
 	skipOperatorCleanup := false


### PR DESCRIPTION
**Description of your changes:**

Let's try to create a 'ceph' user with the uid 167 and add it to the
'disk' group so that if the permissions on the disk change then the OSD
should be able to access the disk.

Closes: https://github.com/rook/rook/issues/7405
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/7405

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
