### PR TITLE
docs: remove left overs in /dev/mapper/ceph--*

### DIFF
--- a/Documentation/ceph-disaster-recovery.md
+++ b/Documentation/ceph-disaster-recovery.md
@@ -97,7 +97,7 @@ ceph-mon \
 Patch the `rook-ceph-mon-b` Deployment to stop this mon working without deleting the mon pod:
 
 ```console
-kubectl -n rook-ceph patch deployment rook-ceph-mon-b -p '[{"op":"remove", "path":"/spec/template/spec/containers/0/livenessProbe"}]'
+kubectl -n rook-ceph patch deployment rook-ceph-mon-b -p '{"op":"remove", "path":"/spec/template/spec/containers/0/livenessProbe"}'
 
 kubectl -n rook-ceph patch deployment rook-ceph-mon-b -p '{"spec": {"template": {"spec": {"containers": [{"name": "mon", "command": ["sleep", "infinity"], "args": []}]}}}}'
 ```

--- a/Documentation/ceph-teardown.md
+++ b/Documentation/ceph-teardown.md
@@ -90,8 +90,9 @@ blkdiscard $DISK
 # If rook sets up osds using ceph-volume, teardown leaves some devices mapped that lock the disks.
 ls /dev/mapper/ceph-* | xargs -I% -- dmsetup remove %
 
-# ceph-volume setup can leave ceph-<UUID> directories in /dev (unnecessary clutter)
+# ceph-volume setup can leave ceph-<UUID> directories in /dev and /dev/mapper (unnecessary clutter)
 rm -rf /dev/ceph-*
+rm -rf /dev/mapper/ceph--*
 ```
 
 ## Troubleshooting
@@ -132,12 +133,12 @@ done
 
 This command will patch the following CRDs on v1.3:
 >```
->cephblockpools.ceph.rook.io
->cephclients.ceph.rook.io
->cephfilesystems.ceph.rook.io
->cephnfses.ceph.rook.io
->cephobjectstores.ceph.rook.io
->cephobjectstoreusers.ceph.rook.io
+> cephblockpools.ceph.rook.io
+> cephclients.ceph.rook.io
+> cephfilesystems.ceph.rook.io
+> cephnfses.ceph.rook.io
+> cephobjectstores.ceph.rook.io
+> cephobjectstoreusers.ceph.rook.io
 >```
 
 Within a few seconds you should see that the cluster CRD has been deleted and will no longer block other cleanup such as deleting the `rook-ceph` namespace.


### PR DESCRIPTION
[skip ci]

**Description of your changes:**

Two commits to improve the documentation.

* During Ceph teradown these files also need to be removed as well.
  This is a continuation of the closed PR #7395.
* docs: fix disaster recovery mon patch command

    This removes the curly brackets from the json patch used to remove the
    livenessProbe of the mon pod. At least in 1.18+ otherwise the patch
    fails with a "cryptic" error.

    Resolves #7460

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.