### PR TITLE
ceph: allow passing 'osd-crush-initial-weight'

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -3160,6 +3160,10 @@ spec:
                           crushDeviceClass:
                             description: CrushDeviceClass represents the crush device class for an OSD
                             type: string
+                          crushInitialWeight:
+                            description: CrushInitialWeight represents initial OSD weight in TiB units
+                            pattern: ^([0-9]*[.])?[0-9]$
+                            type: string
                           encrypted:
                             description: Whether to encrypt the deviceSet
                             type: boolean

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -3162,6 +3162,10 @@ spec:
                           crushDeviceClass:
                             description: CrushDeviceClass represents the crush device class for an OSD
                             type: string
+                          crushInitialWeight:
+                            description: CrushInitialWeight represents initial OSD weight in TiB units
+                            pattern: ^([0-9]*[.])?[0-9]$
+                            type: string
                           encrypted:
                             description: Whether to encrypt the deviceSet
                             type: boolean

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -118,6 +118,7 @@ func addOSDConfigFlags(command *cobra.Command) {
 	command.Flags().IntVar(&cfg.storeConfig.OSDsPerDevice, "osds-per-device", 1, "the number of OSDs per device")
 	command.Flags().BoolVar(&cfg.storeConfig.EncryptedDevice, "encrypted-device", false, "whether to encrypt the OSD with dmcrypt")
 	command.Flags().StringVar(&cfg.storeConfig.DeviceClass, "osd-crush-device-class", "", "The device class for all OSDs configured on this node")
+	command.Flags().StringVar(&cfg.storeConfig.InitialWeight, "osd-crush-initial-weight", "", "The initial weight of OSD in TiB units")
 }
 
 func init() {
@@ -303,6 +304,7 @@ func parseDevices(devices string) ([]osddaemon.DesiredDevice, error) {
 		d.OSDsPerDevice = cd.StoreConfig.OSDsPerDevice
 		d.DatabaseSizeMB = cd.StoreConfig.DatabaseSizeMB
 		d.DeviceClass = cd.StoreConfig.DeviceClass
+		d.InitialWeight = cd.StoreConfig.InitialWeight
 		d.MetadataDevice = cd.StoreConfig.MetadataDevice
 
 		if d.OSDsPerDevice < 1 {

--- a/pkg/apis/rook.io/v1/types.go
+++ b/pkg/apis/rook.io/v1/types.go
@@ -217,6 +217,10 @@ type VolumeSource struct {
 	// CrushDeviceClass represents the crush device class for an OSD
 	// +optional
 	CrushDeviceClass string `json:"crushDeviceClass,omitempty"`
+	// CrushInitialWeight represents initial OSD weight in TiB units
+	// +kubebuilder:validation:Pattern=`^([0-9]*[.])?[0-9]$`
+	// +optional
+	CrushInitialWeight string `json:"crushInitialWeight,omitempty"`
 	// Size represents the size requested for the PVC
 	Size string `json:"size"`
 	// Resources requests/limits for the devices

--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -42,6 +42,7 @@ type DesiredDevice struct {
 	MetadataDevice     string
 	DatabaseSizeMB     int
 	DeviceClass        string
+	InitialWeight      string
 	IsFilter           bool
 	IsDevicePathFilter bool
 }

--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -29,6 +29,7 @@ const (
 	EncryptedDeviceKey = "encryptedDevice"
 	MetadataDeviceKey  = "metadataDevice"
 	DeviceClassKey     = "deviceClass"
+	InitialWeightKey   = "initialWeight"
 )
 
 // StoreConfig represents the configuration of an OSD on a device.
@@ -39,6 +40,7 @@ type StoreConfig struct {
 	EncryptedDevice bool   `json:"encryptedDevice,omitempty"`
 	MetadataDevice  string `json:"metadataDevice,omitempty"`
 	DeviceClass     string `json:"deviceClass,omitempty"`
+	InitialWeight   string `json:"initialWeight,omitempty"`
 }
 
 // NewStoreConfig returns a StoreConfig with proper defaults set.
@@ -68,6 +70,8 @@ func ToStoreConfig(config map[string]string) StoreConfig {
 			storeConfig.MetadataDevice = v
 		case DeviceClassKey:
 			storeConfig.DeviceClass = v
+		case InitialWeightKey:
+			storeConfig.InitialWeight = v
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -96,6 +96,7 @@ func (c *Cluster) createDeviceSetPVCsForIndex(deviceSet rookv1.StorageClassDevic
 
 	var dataSize string
 	var crushDeviceClass string
+	var crushInitialWeight string
 	typesFound := util.NewSet()
 	for _, pvcTemplate := range deviceSet.VolumeClaimTemplates {
 		if pvcTemplate.Name == "" {
@@ -126,6 +127,8 @@ func (c *Cluster) createDeviceSetPVCsForIndex(deviceSet rookv1.StorageClassDevic
 			dataSize = pvcSize.String()
 			crushDeviceClass = pvcTemplate.Annotations["crushDeviceClass"]
 		}
+		crushInitialWeight = pvcTemplate.Annotations["crushInitialWeight"]
+
 		pvcSources[pvcType] = v1.PersistentVolumeClaimVolumeSource{
 			ClaimName: pvc.GetName(),
 			ReadOnly:  false,
@@ -145,6 +148,7 @@ func (c *Cluster) createDeviceSetPVCsForIndex(deviceSet rookv1.StorageClassDevic
 		TuneFastDeviceClass: deviceSet.TuneFastDeviceClass,
 		SchedulerName:       deviceSet.SchedulerName,
 		CrushDeviceClass:    crushDeviceClass,
+		CrushInitialWeight:  crushInitialWeight,
 		Encrypted:           deviceSet.Encrypted,
 	}
 }

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -45,6 +45,7 @@ const (
 	cvModeVarName                       = "ROOK_CV_MODE"
 	lvBackedPVVarName                   = "ROOK_LV_BACKED_PV"
 	CrushDeviceClassVarName             = "ROOK_OSD_CRUSH_DEVICE_CLASS"
+	CrushInitialWeightVarName           = "ROOK_OSD_CRUSH_INITIAL_WEIGHT"
 	CrushRootVarName                    = "ROOK_CRUSHMAP_ROOT"
 	tcmallocMaxTotalThreadCacheBytesEnv = "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 )
@@ -157,6 +158,10 @@ func lvBackedPVEnvVar(lvBackedPV string) v1.EnvVar {
 
 func crushDeviceClassEnvVar(crushDeviceClass string) v1.EnvVar {
 	return v1.EnvVar{Name: CrushDeviceClassVarName, Value: crushDeviceClass}
+}
+
+func crushInitialWeightEnvVar(crushInitialWeight string) v1.EnvVar {
+	return v1.EnvVar{Name: CrushInitialWeightVarName, Value: crushInitialWeight}
 }
 
 func encryptedDeviceEnvVar(encryptedDevice bool) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/osd.go
+++ b/pkg/operator/ceph/cluster/osd/osd.go
@@ -363,6 +363,8 @@ func (c *Cluster) getOSDPropsForPVC(pvcName string) (osdProperties, error) {
 				encrypted:           volumeSource.Encrypted,
 				deviceSetName:       volumeSource.Name,
 			}
+			osdProps.storeConfig.InitialWeight = volumeSource.CrushInitialWeight
+
 			// If OSD isn't portable, we're getting the host name either from the osd deployment that was already initialized
 			// or from the osd prepare job from initial creation.
 			if !volumeSource.Portable {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -229,6 +229,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 	}
 	envVars = append(envVars, v1.EnvVar{Name: "ROOK_CEPH_VERSION", Value: c.clusterInfo.CephVersion.CephVersionFormatted()})
 	envVars = append(envVars, crushDeviceClassEnvVar(osdProps.storeConfig.DeviceClass))
+	envVars = append(envVars, crushInitialWeightEnvVar(osdProps.storeConfig.InitialWeight))
 
 	if osdProps.metadataDevice != "" {
 		envVars = append(envVars, metadataDeviceEnvVar(osdProps.metadataDevice))

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -404,6 +404,11 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 		}
 	}
 
+	// Ceph expects initial weight as float value in tera-bytes units
+	if osdProps.storeConfig.InitialWeight != "" {
+		args = append(args, fmt.Sprintf("--osd-crush-initial-weight=%s", osdProps.storeConfig.InitialWeight))
+	}
+
 	// If the OSD runs on PVC
 	if osdProps.onPVC() {
 		// add the PVC size to the pod spec so that if the size changes the OSD will be restarted and pick up the change


### PR DESCRIPTION
Ceph support the option '--osd-crush-initial-weight' upon OSD start,
which sets an explicit weight (in TiB units) to specific OSD. Allow
passing this option all the way from the user (similar to
'DeviceClass'), for the special case where end users wants it cluster
to have non-even balance over specific OSDs (e.g., one of the OSDs is
placed over a partition alongside OS-partition).

ROOK issue: https://github.com/rook/rook/issues/7448

Signed-off-by: Shachar Sharon <ssharon@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Allow set OSD initial-weight, similar to device-class.

**Which issue is resolved by this Pull Request:**
Resolves #7448

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
