### PR TITLE
ceph: set secret type on external cluster script

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh
@@ -24,11 +24,11 @@ function checkEnv() {
     echo "'ceph' binary is expected'"
     exit 1
   fi
-
+  
   if ! ceph -s 1>/dev/null; then
     echo "cannot connect to the ceph cluster"
     exit 1
-fi
+  fi
 }
 
 function createCheckerKey() {
@@ -39,7 +39,7 @@ function createCheckerKey() {
 
 function createCephCSIKeyringRBDNode() {
   cephCSIKeyringRBDNodeKey=$(ceph auth get-or-create client.csi-rbd-node mon 'profile rbd' osd 'profile rbd'|awk '/key =/ { print $3}')
-  echo "export CSI_RBD_NODE_SECRET_SECRET=$cephCSIKeyringRBDNodeKey"
+  echo "export CSI_RBD_NODE_SECRET=$cephCSIKeyringRBDNodeKey"
 }
 
 function createCephCSIKeyringRBDProvisioner() {

--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -48,8 +48,8 @@ function checkEnvVars() {
       echo "Please populate the environment variable ROOK_EXTERNAL_USERNAME"
       exit 1
     fi
-    if [ -z "$CSI_RBD_NODE_SECRET_SECRET" ]; then
-      echo "Please populate the environment variable CSI_RBD_NODE_SECRET_SECRET"
+    if [ -z "$CSI_RBD_NODE_SECRET" ]; then
+      echo "Please populate the environment variable CSI_RBD_NODE_SECRET"
       exit 1
     fi
     if [ -z "$CSI_RBD_PROVISIONER_SECRET" ]; then
@@ -104,7 +104,7 @@ function importCsiRBDNodeSecret() {
   --type="kubernetes.io/rook" \
   "$CSI_RBD_NODE_SECRET_NAME" \
   --from-literal=userID=csi-rbd-node \
-  --from-literal=userKey="$CSI_RBD_NODE_SECRET_SECRET"
+  --from-literal=userKey="$CSI_RBD_NODE_SECRET"
 }
 
 function importCsiRBDProvisionerSecret() {

--- a/cluster/examples/kubernetes/ceph/import-external-cluster.sh
+++ b/cluster/examples/kubernetes/ceph/import-external-cluster.sh
@@ -27,112 +27,117 @@ ROOK_EXTERNAL_MONITOR_SECRET=mon-secret
 #############
 
 function checkEnvVars() {
-    if [ -z "$NAMESPACE" ]; then
-        echo "Please populate the environment variable NAMESPACE"
-        exit 1
+  if [ -z "$NAMESPACE" ]; then
+    echo "Please populate the environment variable NAMESPACE"
+    exit 1
+  fi
+  if [ -z "$ROOK_EXTERNAL_FSID" ]; then
+    echo "Please populate the environment variable ROOK_EXTERNAL_FSID"
+    exit 1
+  fi
+  if [ -z "$ROOK_EXTERNAL_CEPH_MON_DATA" ]; then
+    echo "Please populate the environment variable ROOK_EXTERNAL_CEPH_MON_DATA"
+    exit 1
+  fi
+  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" == "admin-secret" ]]; then
+    if [ -z "$ROOK_EXTERNAL_USER_SECRET" ]; then
+      echo "Please populate the environment variable ROOK_EXTERNAL_USER_SECRET"
+      exit 1
     fi
-    if [ -z "$ROOK_EXTERNAL_FSID" ]; then
-        echo "Please populate the environment variable ROOK_EXTERNAL_FSID"
-        exit 1
+    if [ -z "$ROOK_EXTERNAL_USERNAME" ]; then
+      echo "Please populate the environment variable ROOK_EXTERNAL_USERNAME"
+      exit 1
     fi
-    if [ -z "$ROOK_EXTERNAL_CEPH_MON_DATA" ]; then
-        echo "Please populate the environment variable ROOK_EXTERNAL_CEPH_MON_DATA"
-        exit 1
+    if [ -z "$CSI_RBD_NODE_SECRET_SECRET" ]; then
+      echo "Please populate the environment variable CSI_RBD_NODE_SECRET_SECRET"
+      exit 1
     fi
-    if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" == "admin-secret" ]]; then
-        if [ -z "$ROOK_EXTERNAL_USER_SECRET" ]; then
-            echo "Please populate the environment variable ROOK_EXTERNAL_USER_SECRET"
-            exit 1
-        fi
-        if [ -z "$ROOK_EXTERNAL_USERNAME" ]; then
-            echo "Please populate the environment variable ROOK_EXTERNAL_USERNAME"
-            exit 1
-        fi
-        if [ -z "$CSI_RBD_NODE_SECRET_SECRET" ]; then
-            echo "Please populate the environment variable CSI_RBD_NODE_SECRET_SECRET"
-            exit 1
-        fi
-        if [ -z "$CSI_RBD_PROVISIONER_SECRET" ]; then
-            echo "Please populate the environment variable CSI_RBD_PROVISIONER_SECRET"
-            exit 1
-        fi
-        if [ -z "$CSI_CEPHFS_NODE_SECRET" ]; then
-            echo "Please populate the environment variable CSI_CEPHFS_NODE_SECRET"
-            exit 1
-        fi
-        if [ -z "$CSI_CEPHFS_PROVISIONER_SECRET" ]; then
-            echo "Please populate the environment variable CSI_CEPHFS_PROVISIONER_SECRET"
-            exit 1
-        fi
+    if [ -z "$CSI_RBD_PROVISIONER_SECRET" ]; then
+      echo "Please populate the environment variable CSI_RBD_PROVISIONER_SECRET"
+      exit 1
     fi
-    if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ] ; then
-        echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
-        exit 1
+    if [ -z "$CSI_CEPHFS_NODE_SECRET" ]; then
+      echo "Please populate the environment variable CSI_CEPHFS_NODE_SECRET"
+      exit 1
     fi
+    if [ -z "$CSI_CEPHFS_PROVISIONER_SECRET" ]; then
+      echo "Please populate the environment variable CSI_CEPHFS_PROVISIONER_SECRET"
+      exit 1
+    fi
+  fi
+  if [[ "$ROOK_EXTERNAL_ADMIN_SECRET" != "admin-secret" ]] && [ -n "$ROOK_EXTERNAL_USER_SECRET" ] ; then
+    echo "Providing both ROOK_EXTERNAL_ADMIN_SECRET and ROOK_EXTERNAL_USER_SECRET is not supported, choose one only."
+    exit 1
+  fi
 }
 
 function importSecret() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    "$MON_SECRET_NAME" \
-    --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
-    --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
-    --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
-    --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
-    --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
-    --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
+  kubectl -n "$NAMESPACE" \
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$MON_SECRET_NAME" \
+  --from-literal="$MON_SECRET_CLUSTER_NAME_KEYNAME"="$ROOK_EXTERNAL_CLUSTER_NAME" \
+  --from-literal="$MON_SECRET_FSID_KEYNAME"="$ROOK_EXTERNAL_FSID" \
+  --from-literal="$MON_SECRET_ADMIN_KEYRING_KEYNAME"="$ROOK_EXTERNAL_ADMIN_SECRET" \
+  --from-literal="$MON_SECRET_MON_KEYRING_KEYNAME"="$ROOK_EXTERNAL_MONITOR_SECRET" \
+  --from-literal="$MON_SECRET_CEPH_USERNAME_KEYNAME"="$ROOK_EXTERNAL_USERNAME" \
+  --from-literal="$MON_SECRET_CEPH_SECRET_KEYNAME"="$ROOK_EXTERNAL_USER_SECRET"
 }
 
 function importConfigMap() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    configmap \
-    "$MON_ENDPOINT_CONFIGMAP_NAME" \
-    --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
-    --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
-    --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
+  kubectl -n "$NAMESPACE" \
+  create \
+  configmap \
+  "$MON_ENDPOINT_CONFIGMAP_NAME" \
+  --from-literal=data="$ROOK_EXTERNAL_CEPH_MON_DATA" \
+  --from-literal=mapping="$ROOK_EXTERNAL_MAPPING" \
+  --from-literal=maxMonId="$ROOK_EXTERNAL_MAX_MON_ID"
 }
 
 function importCsiRBDNodeSecret() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    "$CSI_RBD_NODE_SECRET_NAME" \
-    --from-literal=userID=csi-rbd-node \
-    --from-literal=userKey="$CSI_RBD_NODE_SECRET_SECRET"
+  kubectl -n "$NAMESPACE" \
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$CSI_RBD_NODE_SECRET_NAME" \
+  --from-literal=userID=csi-rbd-node \
+  --from-literal=userKey="$CSI_RBD_NODE_SECRET_SECRET"
 }
 
 function importCsiRBDProvisionerSecret() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    "$CSI_RBD_PROVISIONER_SECRET_NAME" \
-    --from-literal=userID=csi-rbd-provisioner \
-    --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
+  kubectl -n "$NAMESPACE" \
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$CSI_RBD_PROVISIONER_SECRET_NAME" \
+  --from-literal=userID=csi-rbd-provisioner \
+  --from-literal=userKey="$CSI_RBD_PROVISIONER_SECRET"
 }
 
 function importCsiCephFSNodeSecret() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    "$CSI_CEPHFS_NODE_SECRET_NAME" \
-    --from-literal=adminID=csi-cephfs-node \
-    --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
+  kubectl -n "$NAMESPACE" \
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$CSI_CEPHFS_NODE_SECRET_NAME" \
+  --from-literal=adminID=csi-cephfs-node \
+  --from-literal=adminKey="$CSI_CEPHFS_NODE_SECRET"
 }
 
 function importCsiCephFSProvisionerSecret() {
-    kubectl -n "$NAMESPACE" \
-    create \
-    secret \
-    generic \
-    "$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
-    --from-literal=adminID=csi-cephfs-provisioner \
-    --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
+  kubectl -n "$NAMESPACE" \
+  create \
+  secret \
+  generic \
+  --type="kubernetes.io/rook" \
+  "$CSI_CEPHFS_PROVISIONER_SECRET_NAME" \
+  --from-literal=adminID=csi-cephfs-provisioner \
+  --from-literal=adminKey="$CSI_CEPHFS_PROVISIONER_SECRET"
 }
 
 ########


### PR DESCRIPTION
**Description of your changes:**

The secret type was missing earlier and must be set
to "kubernetes.io/rook" so that the operator does not complain.

Closes: https://github.com/rook/rook/issues/5732
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
