### PR TITLE
ceph: add static IPAM support for CNI

### DIFF
--- a/pkg/operator/ceph/config/network_test.go
+++ b/pkg/operator/ceph/config/network_test.go
@@ -144,14 +144,15 @@ func TestGenerateNetworkSettings(t *testing.T) {
 }
 
 func TestGetNetworkRange(t *testing.T) {
-	ns := "rook-ceph"
-	nad := &networkv1.NetworkAttachmentDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "public-network-attach-def",
-			Namespace: ns,
-		},
-		Spec: networkv1.NetworkAttachmentDefinitionSpec{
-			Config: `{
+	t.Run("simple host-local IPAM test", func(t *testing.T) {
+		ns := "rook-ceph"
+		nad := &networkv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-network-attach-def",
+				Namespace: ns,
+			},
+			Spec: networkv1.NetworkAttachmentDefinitionSpec{
+				Config: `{
 				"cniVersion": "0.3.0",
 				"type": "macvlan",
 				"master": "eth2",
@@ -162,41 +163,146 @@ func TestGetNetworkRange(t *testing.T) {
 				  "gateway": "172.18.8.1"
 				}
 			  }`,
-		},
+			},
+		}
+
+		netConfig, err := k8sutil.GetNetworkAttachmentConfig(*nad)
+		assert.NoError(t, err)
+
+		//
+		// TEST 1: subnet/range is empty
+		//
+		networkRange := getNetworkRange(netConfig)
+		assert.Empty(t, networkRange)
+
+		//
+		// TEST 2: subnet is not empty
+		//
+		netConfig.Ipam.Type = "host-local"
+		netConfig.Ipam.Subnet = "192.168.0.0/24"
+		networkRange = getNetworkRange(netConfig)
+		assert.Equal(t, "192.168.0.0/24", networkRange)
+	})
+
+	t.Run("advanced host-local IPAM test", func(t *testing.T) {
+		ns := "rook-ceph"
+		nad := &networkv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-network-attach-def",
+				Namespace: ns,
+			},
+			Spec: networkv1.NetworkAttachmentDefinitionSpec{
+				Config: `{
+	"ipam": {
+		"type": "host-local",
+		"ranges": [
+			[
+				{
+					"subnet": "10.10.0.0/16",
+					"rangeStart": "10.10.1.20",
+					"rangeEnd": "10.10.3.50",
+					"gateway": "10.10.0.254"
+				},
+				{
+					"subnet": "172.16.5.0/24"
+				}
+			],
+			[
+				{
+					"subnet": "3ffe:ffff:0:01ff::/64",
+					"rangeStart": "3ffe:ffff:0:01ff::0010",
+					"rangeEnd": "3ffe:ffff:0:01ff::0020"
+				}
+			]
+		],
+		"routes": [
+			{ "dst": "0.0.0.0/0" },
+			{ "dst": "192.168.0.0/16", "gw": "10.10.5.1" },
+			{ "dst": "3ffe:ffff:0:01ff::1/64" }
+		],
+		"dataDir": "/run/my-orchestrator/container-ipam-state"
 	}
+}`,
+			},
+		}
 
-	netConfig, err := k8sutil.GetNetworkAttachmentConfig(*nad)
-	assert.NoError(t, err)
+		netConfig, err := k8sutil.GetNetworkAttachmentConfig(*nad)
+		assert.NoError(t, err)
+		networkRange := getNetworkRange(netConfig)
+		assert.Equal(t, "10.10.0.0/16,172.16.5.0/24,3ffe:ffff:0:01ff::/64", networkRange)
+	})
 
-	//
-	// TEST 1: subnet/range is empty
-	//
-	networkRange := getNetworkRange(netConfig)
-	assert.Empty(t, networkRange)
+	t.Run("advanced static IPAM test", func(t *testing.T) {
+		ns := "rook-ceph"
+		nad := &networkv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-network-attach-def",
+				Namespace: ns,
+			},
+			Spec: networkv1.NetworkAttachmentDefinitionSpec{
+				Config: `{
+	"ipam": {
+		"type": "static",
+		"addresses": [
+			{
+				"address": "10.10.0.1/24",
+				"gateway": "10.10.0.254"
+			},
+			{
+				"address": "3ffe:ffff:0:01ff::1/64",
+				"gateway": "3ffe:ffff:0::1"
+			}
+		],
+		"routes": [
+			{ "dst": "0.0.0.0/0" },
+			{ "dst": "192.168.0.0/16", "gw": "10.10.5.1" },
+			{ "dst": "3ffe:ffff:0:01ff::1/64" }
+		],
+		"dns": {
+			"nameservers" : ["8.8.8.8"],
+			"domain": "example.com",
+			"search": [ "example.com" ]
+		}
+	}
+}`,
+			},
+		}
+		netConfig, err := k8sutil.GetNetworkAttachmentConfig(*nad)
+		assert.NoError(t, err)
+		networkRange := getNetworkRange(netConfig)
+		assert.Equal(t, "10.10.0.1/24,3ffe:ffff:0:01ff::1/64", networkRange)
+	})
 
-	//
-	// TEST 2: subnet is not empty
-	//
-	netConfig.Ipam.Type = "host-local"
-	netConfig.Ipam.Subnet = "192.168.0.0/24"
-	networkRange = getNetworkRange(netConfig)
-	assert.Equal(t, "192.168.0.0/24", networkRange)
-
-	//
-	// TEST 3: range is empty and ipam type is whereabouts
-	//
-	netConfig.Ipam.Type = "whereabouts"
-	netConfig.Ipam.Subnet = ""
-	networkRange = getNetworkRange(netConfig)
-	assert.Empty(t, networkRange)
-
-	//
-	// TEST 4: range is not empty and ipam type is whereabouts
-	//
-	netConfig.Ipam.Type = "whereabouts"
-	netConfig.Ipam.Range = "192.168.0.0/24"
-	networkRange = getNetworkRange(netConfig)
-	assert.Equal(t, "192.168.0.0/24", networkRange)
+	t.Run("advanced whereabouts IPAM test", func(t *testing.T) {
+		ns := "rook-ceph"
+		nad := &networkv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-network-attach-def",
+				Namespace: ns,
+			},
+			Spec: networkv1.NetworkAttachmentDefinitionSpec{
+				Config: `{
+      "cniVersion": "0.3.0",
+      "name": "whereaboutsexample",
+      "type": "macvlan",
+      "master": "eth0",
+      "mode": "bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.2.225/28",
+        "exclude": [
+           "192.168.2.229/30",
+           "192.168.2.236/32"
+        ]
+      }
+}`,
+			},
+		}
+		netConfig, err := k8sutil.GetNetworkAttachmentConfig(*nad)
+		assert.NoError(t, err)
+		networkRange := getNetworkRange(netConfig)
+		assert.Equal(t, "192.168.2.225/28", networkRange)
+	})
 }
 
 func TestGetMultusNamespace(t *testing.T) {

--- a/pkg/operator/k8sutil/network.go
+++ b/pkg/operator/k8sutil/network.go
@@ -33,21 +33,31 @@ const (
 
 // NetworkAttachmentConfig represents the configuration of the NetworkAttachmentDefinitions object
 type NetworkAttachmentConfig struct {
-	CniVersion string `json:"cniVersion"`
-	Type       string `json:"type"`
-	Master     string `json:"master"`
-	Mode       string `json:"mode"`
+	CniVersion string `json:"cniVersion,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Master     string `json:"master,omitempty"`
+	Mode       string `json:"mode,omitempty"`
 	Ipam       struct {
-		Type       string `json:"type"`
-		Subnet     string `json:"subnet"`
-		Range      string `json:"range"`
-		RangeStart string `json:"rangeStart"`
-		RangeEnd   string `json:"rangeEnd"`
+		Type      string `json:"type,omitempty"`
+		Subnet    string `json:"subnet,omitempty"`
+		Addresses []struct {
+			Address string `json:"address,omitempty"`
+			Gateway string `json:"gateway,omitempty"`
+		} `json:"addresses,omitempty"`
+		Ranges [][]struct {
+			Subnet     string `json:"subnet,omitempty"`
+			RangeStart string `json:"rangeStart,omitempty"`
+			RangeEnd   string `json:"rangeEnd,omitempty"`
+			Gateway    string `json:"gateway,omitempty"`
+		} `json:"ranges,omitempty"`
+		Range      string `json:"range,omitempty"`
+		RangeStart string `json:"rangeStart,omitempty"`
+		RangeEnd   string `json:"rangeEnd,omitempty"`
 		Routes     []struct {
-			Dst string `json:"dst"`
-		} `json:"routes"`
-		Gateway string `json:"gateway"`
-	} `json:"ipam"`
+			Dst string `json:"dst,omitempty"`
+		} `json:"routes,omitempty"`
+		Gateway string `json:"gateway,omitempty"`
+	} `json:"ipam,omitempty"`
 }
 
 // ApplyMultus apply multus selector to Pods


### PR DESCRIPTION
**Description of your changes:**

We now support reading Network Attachment Definitions with a "static"
IPAM.
Also added more unit tests.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
