### PR TITLE
ci: try to mitigate object user error

### DIFF
--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -57,11 +57,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Running on Rook Cluster %s", namespace)
 	clusterInfo := client.AdminClusterInfo(namespace)
 
-	logger.Infof("Step 0 : Create Object Store User")
-	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
-	assert.Nil(s.T(), cosuErr)
-
-	logger.Infof("Step 1 : Create Object Store")
+	logger.Infof("Step 0 : Create Object Store")
 	cobsErr := helper.ObjectClient.Create(namespace, storeName, 3)
 	assert.Nil(s.T(), cobsErr)
 
@@ -76,6 +72,9 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	logger.Infof("Object store created successfully")
 
 	// check that ObjectUser is created
+	logger.Infof("Step 1 : Create Object Store User")
+	cosuErr := helper.ObjectUserClient.Create(namespace, userid, userdisplayname, storeName)
+	assert.Nil(s.T(), cosuErr)
 	logger.Infof("Waiting 5 seconds for the object user to be created")
 	time.Sleep(5 * time.Second)
 	logger.Infof("Checking to see if the user secret has been created")


### PR DESCRIPTION
Sometimes the ci fails to find the object store user, this could be
because the user is created before the object store. So first it fails
since there is no object store and stay in a retry back-off.
Then the object store is created and always need a bit of time, at the
same time the object-user is still waiting and the next retry is longer.
Creating the object store first and then the user hopefully will help
resolve that so we don't have to increase the retry for the object-user
presence.

The error:

```
2021-03-26T08:39:34.7283769Z 2021-03-26 08:39:34.727946 I | testutil: All 2 pod(s) with label rook_object_store=teststore are running
2021-03-26T08:39:34.7284744Z 2021-03-26 08:39:34.727972 I | testutil: Running kubectl [apply -f -]
2021-03-26T08:39:35.1110681Z service/rgw-external-teststore created
2021-03-26T08:39:35.1142392Z 2021-03-26 08:39:35.112479 I | integrationTest: Check that RGW pods are Running
2021-03-26T08:39:35.1181683Z 2021-03-26 08:39:35.117763 I | testutil: 2 of 1 pods with label app=rook-ceph-rgw were found
2021-03-26T08:39:35.1251276Z 2021-03-26 08:39:35.124933 I | testutil: 2 of 1 pods with label app=rook-ceph-rgw were found
2021-03-26T08:39:35.1348603Z 2021-03-26 08:39:35.133276 I | integrationTest: RGW pods are running
2021-03-26T08:39:35.1350090Z 2021-03-26 08:39:35.133290 I | integrationTest: Object store created successfully
2021-03-26T08:39:35.1351373Z 2021-03-26 08:39:35.133295 I | integrationTest: Waiting 5 seconds for the object user to be created
2021-03-26T08:39:40.1340659Z 2021-03-26 08:39:40.133401 I | integrationTest: Checking to see if the user secret has been created
2021-03-26T08:39:40.1342715Z 2021-03-26 08:39:40.133440 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:39:40.2618726Z 2021-03-26 08:39:40.261412 I | clients: Unable to find user secret
2021-03-26T08:39:40.2619705Z 2021-03-26 08:39:40.261433 I | integrationTest: (0) secret check sleeping for 5 seconds ...
2021-03-26T08:39:45.2621870Z 2021-03-26 08:39:45.261641 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:39:45.3863424Z 2021-03-26 08:39:45.386048 I | clients: Unable to find user secret
2021-03-26T08:39:45.3864586Z 2021-03-26 08:39:45.386075 I | integrationTest: (1) secret check sleeping for 5 seconds ...
2021-03-26T08:39:50.3869496Z 2021-03-26 08:39:50.386292 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:39:50.4991166Z 2021-03-26 08:39:50.498862 I | clients: Unable to find user secret
2021-03-26T08:39:50.4991987Z 2021-03-26 08:39:50.498881 I | integrationTest: (2) secret check sleeping for 5 seconds ...
2021-03-26T08:39:55.4998176Z 2021-03-26 08:39:55.499038 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:39:55.6075640Z 2021-03-26 08:39:55.607337 I | clients: Unable to find user secret
2021-03-26T08:39:55.6076472Z 2021-03-26 08:39:55.607355 I | integrationTest: (3) secret check sleeping for 5 seconds ...
2021-03-26T08:40:00.6080687Z 2021-03-26 08:40:00.607466 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:40:00.8415649Z 2021-03-26 08:40:00.841309 I | clients: Unable to find user secret
2021-03-26T08:40:00.8417179Z 2021-03-26 08:40:00.841331 I | integrationTest: (4) secret check sleeping for 5 seconds ...
2021-03-26T08:40:05.8419407Z 2021-03-26 08:40:05.841385 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:40:05.9732221Z 2021-03-26 08:40:05.972910 I | clients: Unable to find user secret
2021-03-26T08:40:05.9733777Z 2021-03-26 08:40:05.972932 I | integrationTest: (5) secret check sleeping for 5 seconds ...
2021-03-26T08:40:10.9734134Z 2021-03-26 08:40:10.973067 D | exec: Running command: kubectl get -n smoke-ns secrets -l rook_object_store=teststore -l user=rook-user
2021-03-26T08:40:11.1686581Z 2021-03-26 08:40:11.168373 I | clients: Unable to find user secret
2021-03-26T08:40:11.1687925Z     ceph_base_object_test.go:87:
2021-03-26T08:40:11.1688924Z         	Error Trace:	ceph_base_object_test.go:87
2021-03-26T08:40:11.1689961Z         	            				ceph_smoke_test.go:132
2021-03-26T08:40:11.1691113Z         	Error:      	Should be true
2021-03-26T08:40:11.1692167Z         	Test:       	TestCephSmokeSuite/TestObjectStorage_SmokeTest
2021-03-26T08:40:11.1693751Z 2021-03-26 08:40:11.168502 D | ceph-object-controller: getting s3 user "rook-user"
2021-03-26T08:40:11.1695580Z 2021-03-26 08:40:11.168514 D | exec: Running command: kubectl exec -i rook-ceph-tools-78cdfd976c-2nbp2 -n smoke-ns -- timeout 15 radosgw-admin user info --uid rook-user --rgw-realm= --rgw-zonegroup= --rgw-zone=
2021-03-26T08:40:11.6090406Z     ceph_base_object_test.go:89:
2021-03-26T08:40:11.6093015Z         	Error Trace:	ceph_base_object_test.go:89
2021-03-26T08:40:11.6093968Z         	            				ceph_smoke_test.go:132
2021-03-26T08:40:11.6095116Z         	Error:      	Received unexpected error:
2021-03-26T08:40:11.6095798Z         	            	failed to get user info: warn: s3 user not found
2021-03-26T08:40:11.6096724Z         	            	github.com/rook/rook/pkg/operator/ceph/object.GetUser
2021-03-26T08:40:11.6097795Z         	            		/home/runner/work/rook/rook/pkg/operator/ceph/object/user.go:98
2021-03-26T08:40:11.6098764Z         	            	github.com/rook/rook/tests/framework/clients.(*ObjectUserOperation).GetUser
2021-03-26T08:40:11.6099814Z         	            		/home/runner/work/rook/rook/tests/framework/clients/object_user.go:45
2021-03-26T08:40:11.6100792Z         	            	github.com/rook/rook/tests/integration.runObjectE2ETest
2021-03-26T08:40:11.6101858Z         	            		/home/runner/work/rook/rook/tests/integration/ceph_base_object_test.go:88
2021-03-26T08:40:11.6103298Z         	            	github.com/rook/rook/tests/integration.(*SmokeSuite).TestObjectStorage_SmokeTest
2021-03-26T08:40:11.6104371Z         	            		/home/runner/work/rook/rook/tests/integration/ceph_smoke_test.go:132
2021-03-26T08:40:11.6105104Z         	            	reflect.Value.call
2021-03-26T08:40:11.6105856Z         	            		/opt/hostedtoolcache/go/1.15.10/x64/src/reflect/value.go:476
2021-03-26T08:40:11.6106662Z         	            	reflect.Value.Call
2021-03-26T08:40:11.6107412Z         	            		/opt/hostedtoolcache/go/1.15.10/x64/src/reflect/value.go:337
2021-03-26T08:40:11.6108217Z         	            	github.com/stretchr/testify/suite.Run.func1
2021-03-26T08:40:11.6109104Z         	            		/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.6.1/suite/suite.go:158
2021-03-26T08:40:11.6109844Z         	            	testing.tRunner
2021-03-26T08:40:11.6110578Z         	            		/opt/hostedtoolcache/go/1.15.10/x64/src/testing/testing.go:1123
2021-03-26T08:40:11.6111271Z         	            	runtime.goexit
2021-03-26T08:40:11.6112037Z         	            		/opt/hostedtoolcache/go/1.15.10/x64/src/runtime/asm_amd64.s:1374
2021-03-26T08:40:11.6112995Z         	Test:       	TestCephSmokeSuite/TestObjectStorage_SmokeTest
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]