### PR TITLE
ceph: avoid restarting all encrypted osd on cluster growth

### DIFF
--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -19,6 +19,7 @@ package kms
 import (
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/vault/api"
@@ -87,7 +88,8 @@ func VaultConfigToEnvVar(spec cephv1.ClusterSpec) []v1.EnvVar {
 
 	logger.Debugf("kms envs are %v", envs)
 
-	return envs
+	// Sort env vars since the input is a map which by nature is unsorted...
+	return sortV1EnvVar(envs)
 }
 
 // ConfigEnvsToMapString returns all the env variables in map from a known KMS
@@ -101,6 +103,15 @@ func ConfigEnvsToMapString() map[string]string {
 			}
 		}
 	}
+
+	return envs
+}
+
+// sortV1EnvVar sorts a list of v1.EnvVar
+func sortV1EnvVar(envs []v1.EnvVar) []v1.EnvVar {
+	sort.SliceStable(envs, func(i, j int) bool {
+		return envs[i].Name < envs[j].Name
+	})
 
 	return envs
 }

--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -18,6 +18,7 @@ package kms
 
 import (
 	"os"
+	"sort"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -29,6 +30,10 @@ func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 	// No TLS
 	spec := cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200"}}}}
 	envVars := VaultConfigToEnvVar(spec)
+	areEnvVarsSorted := sort.SliceIsSorted(envVars, func(i, j int) bool {
+		return envVars[i].Name < envVars[j].Name
+	})
+	assert.True(t, areEnvVarsSorted)
 	assert.Equal(t, 4, len(envVars))
 	assert.Contains(t, envVars, v1.EnvVar{Name: "KMS_PROVIDER", Value: "vault"})
 	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"})
@@ -38,6 +43,10 @@ func TestVaultTLSEnvVarFromSecret(t *testing.T) {
 	// TLS
 	spec = cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{TokenSecretName: "vault-token", ConnectionDetails: map[string]string{"KMS_PROVIDER": "vault", "VAULT_ADDR": "http://1.1.1.1:8200", "VAULT_CACERT": "vault-ca-cert-secret"}}}}
 	envVars = VaultConfigToEnvVar(spec)
+	areEnvVarsSorted = sort.SliceIsSorted(envVars, func(i, j int) bool {
+		return envVars[i].Name < envVars[j].Name
+	})
+	assert.True(t, areEnvVarsSorted)
 	assert.Equal(t, 5, len(envVars))
 	assert.Contains(t, envVars, v1.EnvVar{Name: "KMS_PROVIDER", Value: "vault"})
 	assert.Contains(t, envVars, v1.EnvVar{Name: "VAULT_ADDR", Value: "http://1.1.1.1:8200"})


### PR DESCRIPTION
When the cluster is growing, the operator always processes all OSDs and
re-generate their Deployment spec. The generated environment variables
for encryption are coming from a map, which by design is unordered. So
once generated the deployment will see their spec change since the
environment variable position will change.

See from the following diff:

```
        env:							        env:
        - name: KMS_SERVICE_NAME			      <
          value: vault					      <
        - name: VAULT_NAMESPACE				      <
          value: ocsns					      <
        - name: VAULT_TLS_SERVER_NAME			      <
        - name: VAULT_BACKEND_PATH			      <
          value: n_ocs					      <
        - name: VAULT_ADDR					        - name: VAULT_ADDR
          value: https://vault.qe.rh-ocs.com:8200		          value: https://vault.qe.rh-ocs.com:8200
							      >	        - name: VAULT_BACKEND_PATH
							      >	          value: n_ocs
							      >	        - name: VAULT_TLS_SERVER_NAME
        - name: KMS_PROVIDER					        - name: KMS_PROVIDER
          value: vault						          value: vault
							      >	        - name: KMS_SERVICE_NAME
							      >	          value: vault
							      >	        - name: VAULT_NAMESPACE
							      >	          value: ocsns
        - name: VAULT_TOKEN					        - name: VAULT_TOKEN
          valueFrom:						          valueFrom:
            secretKeyRef:					            secretKeyRef:
              key: token					              key: token
              name: ocs-kms-token				              name: ocs-kms-token
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
