### PR TITLE
ceph: Enable Ceph Pacific as a supported version

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -38,8 +38,8 @@ spec:
   mgr:
     count: 2
   cephVersion:
-    # Stretch cluster support upstream is only planned starting in Ceph Pacific
-    image: ceph/daemon-base:latest-master
+    # Stretch cluster support upstream is only available starting in Ceph Pacific
+    image: ceph/ceph:v16.2.0
     allowUnsupported: true
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v15
+    image: ceph/ceph:v16
     allowUnsupported: true
   mon:
     count: 1

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v15.2.9-20210224
+CEPH_VERSION = v16.2.0-20210401
 else
-CEPH_VERSION = v15.2.9-20210224
+CEPH_VERSION = v16.2.0-20210401
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -134,11 +134,19 @@ func TestSupportedVersion(t *testing.T) {
 	c := testSpec(t)
 
 	// Supported versions are valid
-	v := &cephver.CephVersion{Major: 14, Minor: 2, Extra: 5}
+	v := &cephver.CephVersion{Major: 14, Minor: 2, Extra: 12}
+	assert.NoError(t, c.validateCephVersion(v))
+
+	// Supported versions are valid
+	v = &cephver.CephVersion{Major: 15, Minor: 2, Extra: 5}
+	assert.NoError(t, c.validateCephVersion(v))
+
+	// Supported versions are valid
+	v = &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
 	assert.NoError(t, c.validateCephVersion(v))
 
 	// Unsupported versions are not valid
-	v = &cephver.CephVersion{Major: 16, Minor: 2, Extra: 0}
+	v = &cephver.CephVersion{Major: 17, Minor: 2, Extra: 0}
 	assert.Error(t, c.validateCephVersion(v))
 
 	// Unsupported versions are now valid

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -53,7 +53,7 @@ var (
 	cephVolumeLVMDiskSortingCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 13}
 
 	// supportedVersions are production-ready versions that rook supports
-	supportedVersions = []CephVersion{Nautilus, Octopus}
+	supportedVersions = []CephVersion{Nautilus, Octopus, Pacific}
 
 	// unsupportedVersions are possibly Ceph pin-point release that introduced breaking changes and not recommended
 	unsupportedVersions = []CephVersion{cephVolumeLVMDiskSortingCephVersion}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -46,6 +46,8 @@ const (
 	nautilusTestImage = "ceph/ceph:v14.2.12"
 	// test with the latest octopus build
 	octopusTestImage = "ceph/ceph:v15"
+	// test with the latest pacific build
+	pacificTestImage = "ceph/ceph:v16"
 	// test with the latest master image
 	masterTestImage    = "ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"
@@ -55,6 +57,7 @@ const (
 var (
 	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage}
 	OctopusVersion  = cephv1.CephVersionSpec{Image: octopusTestImage}
+	PacificVersion  = cephv1.CephVersionSpec{Image: pacificTestImage}
 	MasterVersion   = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
 )
 

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -100,7 +100,7 @@ func (s *SmokeSuite) SetupSuite() {
 		EnableAdmissionController: true,
 		UseCrashPruner:            true,
 		RookVersion:               installer.VersionMaster,
-		CephVersion:               installer.OctopusVersion,
+		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()
 

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -202,6 +202,17 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	newFile = "post-octopus-upgrade-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
 	logger.Infof("Verified upgrade from nautilus to octopus")
+
+	//
+	// Upgrade from octopus to pacific
+	//
+	logger.Infof("*** UPGRADING CEPH FROM OCTOPUS TO PACIFIC ***")
+	s.gatherLogs(s.settings.OperatorNamespace, "_before_pacific_upgrade")
+	s.upgradeCephVersion(installer.PacificVersion.Image, numOSDs)
+	// Verify reading and writing to the test clients
+	newFile = "post-pacific-upgrade-file"
+	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
+	logger.Infof("Verified upgrade from octopus to pacific")
 }
 
 func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -69,7 +69,7 @@ function test_demo_mds {
   # so we first check if the pools exit, from that we assume that
   # the process will start. We stop waiting after 10 seconds.
   # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND osd dump | grep -sq cephfs && $EXEC_COMMAND -s | grep -sq 'up:active'")
+  return $(wait_for_daemon "$EXEC_COMMAND osd dump | grep -sq cephfs && $EXEC_COMMAND -s | grep -sq up")
 }
 
 function test_demo_rbd_mirror {

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -72,11 +72,6 @@ function test_demo_mds {
   return $(wait_for_daemon "$EXEC_COMMAND osd dump | grep -sq cephfs && $EXEC_COMMAND -s | grep -sq 'up:active'")
 }
 
-function test_demo_rgw {
-  # shellcheck disable=SC2046
-  return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'rgw:'")
-}
-
 function test_demo_rbd_mirror {
   # shellcheck disable=SC2046
   return $(wait_for_daemon "$EXEC_COMMAND -s | grep -sq 'rbd-mirror:'")


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the Ceph Pacific release coming this week we add support in Rook for Pacific with the Rook v1.6 release coming soon. The integration tests will now run across nautilus, octopus, and pacific to cover all supported Ceph versions. The default examples still specify Octopus until there is more bake time for Pacific.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
