### PR TITLE
ceph: add dualstack support on pacific

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -293,6 +293,8 @@ Configure the network that will be enabled for the cluster and services.
 
 * `provider`: Specifies the network provider that will be used to connect the network interface. You can choose between `host`, and `multus`.
 * `selectors`: List the network selector(s) that will be used associated by a key.
+* `ipFamily`: Specifies the network stack Ceph daemons should listen on.
+* `dualStack`: Specifies that Ceph daemon should listen on both IPv4 and IPv6 network stacks.
 
 > **NOTE:** Changing networking configuration after a Ceph cluster has been deployed is NOT
 > supported and will result in a non-functioning cluster.
@@ -366,7 +368,8 @@ This is required in order to use the NAD across namespaces.
 
 #### IPFamily
 
-Provide single-stack IPv4 or IPv6 protocol to assign corresponding addresses to pods and services. This field is optional. Possible inputs are IPv6 and IPv4. Empty value will be treated as IPv4. Kubernetes version should be at least v1.13 to run IPv6. Dual-stack is not supported by ceph.
+Provide single-stack IPv4 or IPv6 protocol to assign corresponding addresses to pods and services. This field is optional. Possible inputs are IPv6 and IPv4. Empty value will be treated as IPv4. Kubernetes version should be at least v1.13 to run IPv6. Dual-stack is supported as of ceph Pacific.
+To turn on dual stack see the [network configuration section](#network-configuration-settings).
 
 ### Node Settings
 
@@ -1267,7 +1270,7 @@ export ROOK_EXTERNAL_ADMIN_SECRET=AQC6Ylxdja+NDBAAB7qy9MEAr4VLLq4dCIvxtg==
 If the Ceph admin key is not provided, the following script needs to be executed on a machine that can connect to the Ceph cluster using the Ceph admin key.
 On that machine, run `cluster/examples/kubernetes/ceph/create-external-cluster-resources.sh`.
 
-> **WARNING**: Since only Ceph admin key can create CRs in the external cluster, please make sure that rgw pools have been prepared. You can get existing pools by running `ceph osd pool ls`. 
+> **WARNING**: Since only Ceph admin key can create CRs in the external cluster, please make sure that rgw pools have been prepared. You can get existing pools by running `ceph osd pool ls`.
 
 **Example**:
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -20,17 +20,17 @@ v1.6...
 
 ### Ceph
 
-* Ceph Pacific support
-* Multiple Ceph Filesystems (with Pacific only)
+* Ceph Pacific support and along with it:
+  * Multiple Ceph Filesystems
+  * Networking dualstack
 * CephClient CRD has been converted to use the controller-runtime library
 * Extending the support of vault KMS configuration for Ceph RGW
 * Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons
 * Add CephFilesystemMirror CRD to deploy cephfs-mirror daemon
 * Multiple Ceph mgr daemons are supported for stretch clusters and other clusters where HA of the mgr is more critical
-* OSDs: 
+* OSDs:
   * as of Nautilus 14.2.14 and Octopus 15.2.9 if the OSD scenario is simple (one OSD per disk) we won't use LVM to prepare the disk anymore
   * for Pacific (16.2.x), Rook is able to update multiple OSD Deployments at the same time to speed
     up updates and upgrades for larger Ceph clusters
 * Disable CSI GRPC metrics by default
 * Ceph daemon pods using the `default` service account now use a new `rook-ceph-default` service account.
-

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -1172,11 +1172,18 @@ spec:
                   description: Network related configuration
                   nullable: true
                   properties:
+                    dualStack:
+                      description: DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
+                      type: boolean
                     hostNetwork:
                       description: HostNetwork to enable host network
                       type: boolean
                     ipFamily:
+                      default: IPv4
                       description: IPFamily is the single stack IPv6 or IPv4 protocol
+                      enum:
+                        - IPv4
+                        - IPv6
                       nullable: true
                       type: string
                     provider:

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -95,6 +95,8 @@ spec:
       #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
     # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
     #ipFamily: "IPv6"
+    # Ceph daemons to listen on both IPv4 and Ipv6 networks
+    #dualStack: false
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -1462,11 +1462,19 @@ spec:
                 description: Network related configuration
                 nullable: true
                 properties:
+                  dualStack:
+                    description: DualStack determines whether Ceph daemons should
+                      listen on both IPv4 and IPv6
+                    type: boolean
                   hostNetwork:
                     description: HostNetwork to enable host network
                     type: boolean
                   ipFamily:
+                    default: IPv4
                     description: IPFamily is the single stack IPv6 or IPv4 protocol
+                    enum:
+                    - IPv4
+                    - IPv6
                     nullable: true
                     type: string
                   provider:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1353,9 +1353,15 @@ type NetworkSpec struct {
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 
 	// IPFamily is the single stack IPv6 or IPv4 protocol
+	// +kubebuilder:validation:Enum=IPv4;IPv6
+	// +kubebuilder:default=IPv4
 	// +nullable
 	// +optional
 	IPFamily IPFamilyType `json:"ipFamily,omitempty"`
+
+	// DualStack determines whether Ceph daemons should listen on both IPv4 and IPv6
+	// +optional
+	DualStack bool `json:"dualStack,omitempty"`
 }
 
 // DisruptionManagementSpec configures management of daemon disruptions

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -452,10 +452,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 
 	args = append(args, opconfig.LoggingFlags()...)
 	args = append(args, osdOnSDNFlag(c.spec.Network)...)
-
-	if c.spec.Network.IPFamily == cephv1.IPv6 {
-		args = append(args, opconfig.NewFlag("ms-bind-ipv6", "true"))
-	}
+	args = append(args, controller.NetworkBindingFlags(c.clusterInfo, &c.spec)...)
 
 	osdDataDirPath := activateOSDMountPath + osdID
 	if osdProps.onPVC() && osd.CVMode == "lvm" {


### PR DESCRIPTION
**Description of your changes:**

With Pacific comes the support for dualstack where ceph daemons can
listen on both ipv4 and ipv6 stacks.
A new field in the network spec has been added: `dualStack`

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
