### PR TITLE
ceph: Remove obsolete osd dirs config

### DIFF
--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -19,18 +19,7 @@ package config
 
 import (
 	"strconv"
-
-	"github.com/rook/rook/pkg/operator/k8sutil"
 )
-
-const (
-	OSDFSStoreNameFmt  = "rook-ceph-osd-%d-fs-backup"
-	configStoreNameFmt = "rook-ceph-osd-%s-config"
-)
-
-func GetConfigStoreName(nodeName string) string {
-	return k8sutil.TruncateNodeName(configStoreNameFmt, nodeName)
-}
 
 const (
 	WalSizeMBKey       = "walSizeMB"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
OSD directories were removed in v1.2, this is some more cleanup of dir configuration that is no longer needed.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
