### PR TITLE
ceph: strip crd description for csv generation

### DIFF
--- a/.github/workflows/crds-gen.yml
+++ b/.github/workflows/crds-gen.yml
@@ -1,8 +1,6 @@
 name: CRDs gen
 on:
   pull_request:
-    paths:
-    - '**.go'
 
 jobs:
   crds-gen:

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ distclean: clean ## Remove all files that are created by building or configuring
 prune: ## Prune cached artifacts.
 	@$(MAKE) -C images prune
 
+csv-ceph: export MAX_DESC_LEN=0 # sets the description length to 0 since CSV cannot be bigger than 1MB
 csv-ceph: crds ## Generate a CSV file for OLM.
 	@echo Generating CSV manifests
 	@cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)

--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -21,8 +21,9 @@ set -o pipefail
 SCRIPT_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd -P)
 CONTROLLER_GEN_BIN_PATH=$1
 YQ_BIN_PATH=$2
+: "${MAX_DESC_LEN:=-1}"
 # allowDangerousTypes is used to accept float64
-CRD_OPTIONS="crd:trivialVersions=true,allowDangerousTypes=true"
+CRD_OPTIONS="crd:maxDescLen=$MAX_DESC_LEN,trivialVersions=true,allowDangerousTypes=true"
 OLM_CATALOG_DIR="${SCRIPT_ROOT}/cluster/olm/ceph/deploy/crds"
 CRDS_FILE_PATH="${SCRIPT_ROOT}/cluster/examples/kubernetes/ceph/crds.yaml"
 HELM_CRDS_FILE_PATH="${SCRIPT_ROOT}/cluster/charts/rook-ceph/templates/resources.yaml"
@@ -72,13 +73,13 @@ build_helm_resources() {
     # add header
     echo "{{- if .Values.crds.enabled }}"
     echo "{{- if semverCompare \">=1.16.0\" .Capabilities.KubeVersion.GitVersion }}"
-
+    
     # Add helm annotations to all CRDS and skip the first 4 lines of crds.yaml
     "$YQ_BIN_PATH" w -d'*' "$CRDS_FILE_PATH" "metadata.annotations[helm.sh/resource-policy]" keep | tail -n +5
-
+    
     # add else
     echo "{{- else }}"
-
+    
     # add footer
     cat "$CRDS_BEFORE_1_16_FILE_PATH"
     # DO NOT REMOVE the empty line, it is necessary

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -67,7 +67,15 @@ do.build: generate-csv-ceph-templates
 
 generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
 	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
-		$(MAKE) -C ../.. crds;\
+		BEFORE_GEN_CRD_SIZE=$$(wc -l < ../../cluster/examples/kubernetes/ceph/crds.yaml);\
+		$(MAKE) -C ../.. MAX_DESC_LEN=0 crds;\
+		AFTER_GEN_CRD_SIZE=$$(wc -l < ../../cluster/examples/kubernetes/ceph/crds.yaml);\
+		if [ "$$BEFORE_GEN_CRD_SIZE" -le "$$AFTER_GEN_CRD_SIZE" ]; then\
+			echo "the new crd file must be smaller since the description fields were stripped!";\
+			echo "length before $$BEFORE_GEN_CRD_SIZE";\
+			echo "length after $$AFTER_GEN_CRD_SIZE";\
+			exit 1;\
+		fi;\
 		OPERATOR_SDK=$(OPERATOR_SDK) YQ_TOOL=$(YQ) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
 	fi
 


### PR DESCRIPTION
**Description of your changes:**

The CSV file size cannot be bigger than 1MB so let's remove all the
description fields make it lighter.

With that change the CRDs size went from 692K to 372K so the size was
reduced by almost 50%.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
