### PR TITLE
ceph: Set default service account in the SCC 

### DIFF
--- a/Documentation/ceph-openshift.md
+++ b/Documentation/ceph-openshift.md
@@ -80,7 +80,7 @@ users:
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
   - system:serviceaccount:rook-ceph:rook-ceph-system
-  - system:serviceaccount:rook-ceph:default
+  - system:serviceaccount:rook-ceph:rook-ceph-default
   - system:serviceaccount:rook-ceph:rook-ceph-mgr
   - system:serviceaccount:rook-ceph:rook-ceph-osd
 ```

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -46,7 +46,7 @@ users:
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
   - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
-  - system:serviceaccount:rook-ceph:default # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-default # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster
 ---

--- a/cluster/examples/kubernetes/ceph/scc.yaml
+++ b/cluster/examples/kubernetes/ceph/scc.yaml
@@ -39,7 +39,7 @@ users:
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
   - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
-  - system:serviceaccount:rook-ceph:default # serviceaccount:namespace:cluster
+  - system:serviceaccount:rook-ceph:rook-ceph-default # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster
 ---


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The security context constraints need to grant access to the new default service account that is applied to the mons previous using the built-in default service account. This is related to #7406. If only we had CI on openshift to catch issues like this...

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
