### PR TITLE
ceph: Set the location on the mon daemon for stretch clusters

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -94,8 +94,6 @@ For a more advanced scenario, such as adding a dedicated device you can refer to
 
 ## Stretch Cluster
 
-**Experimental Mode**
-
 For environments that only have two failure domains available where data can be replicated, consider
 the case where one failure domain is down and the data is still fully available in the
 remaining failure domain. To support this scenario, Ceph has recently integrated support for "stretch" clusters.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -31,4 +31,6 @@ v1.7...
   - Checkout the [ceph docs](https://docs.ceph.com/en/latest/rados/operations/crush-map/#custom-crush-rules)
     for detailed information.
 - Add support cephfs mirroring peer configuration, refer to the [configuration](Documentation/ceph-filesystem-crd.md#mirroring) for more details
-- Add support for Kubernetes TLS secret for referring TLS certs needed for ceph RGW server. 
+- Add support for Kubernetes TLS secret for referring TLS certs needed for ceph RGW server.
+- Stretch clusters are considered stable
+  - Ceph v16.2.5 or greater is required for stretch clusters

--- a/cluster/examples/kubernetes/ceph/cluster-stretched-aws.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched-aws.yaml
@@ -1,0 +1,136 @@
+#################################################################################################################
+# Define the settings for the rook-ceph cluster with common settings for a production cluster.
+# All nodes with available raw devices will be used for the Ceph cluster. At least three nodes are required
+# in this example. See the documentation for more details on storage settings available.
+
+# For example, to create the cluster:
+#   kubectl create -f crds.yaml -f common.yaml -f operator.yaml
+#   kubectl create -f cluster-stretched.yaml
+#################################################################################################################
+
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph # namespace:cluster
+spec:
+  dataDirHostPath: /var/lib/rook
+  mon:
+    # Five mons must be created for stretch mode
+    count: 5
+    allowMultiplePerNode: false
+    stretchCluster:
+      # The ceph failure domain will be extracted from the label, which by default is the zone. The nodes running OSDs must have
+      # this label in order for the OSDs to be configured in the correct topology. For topology labels, see
+      # https://rook.github.io/docs/rook/master/ceph-cluster-crd.html#osd-topology.
+      failureDomainLabel: topology.kubernetes.io/zone
+      # The sub failure domain is the secondary level at which the data will be placed to maintain data durability and availability.
+      # The default is "host", which means that each OSD must be on a different node and you would need at least two nodes per zone.
+      # If the subFailureDomain is set to "osd", the OSDs would be allowed anywhere in the same zone including on the same node.
+      # If set to "rack" or some other intermediate failure domain, those labels would also need to be set on the nodes where
+      # the osds are started.
+      subFailureDomain: host
+      zones:
+        - name: us-east-2a
+          arbiter: true
+        - name: us-east-2b
+        - name: us-east-2c
+    volumeClaimTemplate:
+      spec:
+        storageClassName: gp2
+        resources:
+          requests:
+            storage: 10Gi
+  mgr:
+    count: 2
+  cephVersion:
+    # Stretch cluster support upstream is only available starting in Ceph Pacific
+    image: ceph/ceph:v16.2.2
+    allowUnsupported: true
+  skipUpgradeChecks: false
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  dashboard:
+    enabled: true
+    ssl: true
+  storage:
+    useAllNodes: false
+    useAllDevices: false
+    deviceFilter: ""
+    storageClassDeviceSets:
+      - name: set1
+        # The number of OSDs to create from this device set
+        count: 2
+        portable: true
+        placement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - us-east-2b
+        preparePlacement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - us-east-2b
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              resources:
+                requests:
+                  storage: 10Gi
+              storageClassName: gp2
+              volumeMode: Block
+              accessModes:
+                - ReadWriteOnce
+      - name: set2
+        # The number of OSDs to create from this device set
+        count: 2
+        portable: true
+        placement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - us-east-2c
+        preparePlacement:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: topology.kubernetes.io/zone
+                      operator: In
+                      values:
+                        - us-east-2c
+        volumeClaimTemplates:
+          - metadata:
+              name: data
+            spec:
+              resources:
+                requests:
+                  storage: 10Gi
+              storageClassName: gp2
+              volumeMode: Block
+              accessModes:
+                - ReadWriteOnce
+  placement:
+    # The arbiter mon can have its own placement settings that will be different from the mons.
+    # If the arbiter section is not included in the placement, the arbiter will use the same placement
+    # settings as other mons. In this example, the arbiter has a toleration to run on a master node.
+    arbiter:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+  disruptionManagement:
+    managePodBudgets: true

--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -17,7 +17,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"syscall"
 
@@ -130,19 +129,6 @@ func CreateDefaultStretchCrushRule(context *clusterd.Context, clusterInfo *Clust
 		return errors.Wrap(err, "failed to create default stretch crush rule")
 	}
 	logger.Info("successfully created the default stretch crush rule")
-	return nil
-}
-
-// SetMonStretchZone sets the location of a mon in the stretch cluster
-func SetMonStretchZone(context *clusterd.Context, clusterInfo *ClusterInfo, monName, failureDomain, zone string) error {
-	args := []string{"mon", "set_location", monName, fmt.Sprintf("%s=%s", failureDomain, zone)}
-	buf, err := NewCephCommand(context, clusterInfo, args).Run()
-	if err != nil {
-		return errors.Wrap(err, "failed to set mon stretch zone")
-	}
-	output := string(buf)
-	logger.Debug(output)
-	logger.Infof("successfully set mon %q stretch zone to %q", monName, zone)
 	return nil
 }
 

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -82,28 +82,6 @@ func TestStretchElectionStrategy(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestStretchClusterSettings(t *testing.T) {
-	monName := "a"
-	failureDomain := "rack"
-	zone := "rack-x"
-	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
-		logger.Infof("Command: %s %v", command, args)
-		switch {
-		case args[0] == "mon" && args[1] == "set_location":
-			assert.Equal(t, monName, args[2])
-			assert.Equal(t, fmt.Sprintf("%s=%s", failureDomain, zone), args[3])
-			return "", nil
-		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-	context := &clusterd.Context{Executor: executor}
-	clusterInfo := AdminClusterInfo("mycluster")
-
-	err := SetMonStretchZone(context, clusterInfo, monName, failureDomain, zone)
-	assert.NoError(t, err)
-}
-
 func TestStretchClusterMonTiebreaker(t *testing.T) {
 	monName := "a"
 	failureDomain := "rack"

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -240,6 +240,12 @@ func (c *ClusterController) configureLocalCephCluster(cluster *cluster) error {
 		return errors.Wrap(err, "failed the ceph version check")
 	}
 
+	if cluster.Spec.IsStretchCluster() {
+		if !cephVersion.IsAtLeast(cephver.CephVersion{Major: 16, Minor: 2, Build: 5}) {
+			return errors.Errorf("stretch clusters minimum ceph version is v16.2.5, but is running %s", cephVersion.String())
+		}
+	}
+
 	// Set the value of isUpgrade based on the image discovery done by detectAndValidateCephVersion()
 	cluster.isUpgrade = isUpgrade
 	controller.UpdateCondition(c.context, c.namespacedName, cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, "Configuring the Ceph cluster")

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -426,14 +426,7 @@ func (c *Cluster) failoverMon(name string) error {
 
 	// Assign to a zone if a stretch cluster
 	if c.spec.IsStretchCluster() {
-		updateArbiter := false
 		if name == c.arbiterMon {
-			updateArbiter = true
-		}
-		if err := c.assignStretchMonsToZones([]*monConfig{m}); err != nil {
-			return errors.Wrap(err, "failed to assign mons to zones")
-		}
-		if updateArbiter {
 			// Update the arbiter mon for the stretch cluster if it changed
 			if err := c.ConfigureArbiter(); err != nil {
 				return errors.Wrap(err, "failed to configure stretch arbiter")

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -317,6 +317,15 @@ func (c *Cluster) makeMonDaemonContainer(monConfig *monConfig) corev1.Container 
 		WorkingDir:    config.VarLogCephDir,
 	}
 
+	if monConfig.Zone != "" {
+		desiredLocation := fmt.Sprintf("%s=%s", c.stretchFailureDomainName(), monConfig.Zone)
+		container.Args = append(container.Args, []string{"--set-crush-location", desiredLocation}...)
+		if monConfig.Zone == c.getArbiterZone() {
+			// remember the arbiter mon to be set later in the reconcile after the OSDs are configured
+			c.arbiterMon = monConfig.DaemonName
+		}
+	}
+
 	// If the liveness probe is enabled
 	container = config.ConfigureLivenessProbe(cephv1.KeyMon, container, c.spec.HealthCheck)
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon daemon in a stretch cluster now can have its location set as a CLI param instead of setting it with a separate command. This enables mon failover to set the location of a mon immediately when it is joining quorum instead of having a delayed command to set the location.

**The mon is not yet joining quorum with these changes, still testing**

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
