### PR TITLE
ceph: remove auth in osd-purge job

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -140,6 +140,13 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 	// call archiveCrash to silence crash warning in ceph health if any
 	archiveCrash(clusterdContext, clusterInfo, osdID)
 
+	// remove the auth for the osd. should be done by 'osd purge', but doesn't always seem to happen
+	err = client.AuthDelete(clusterdContext, clusterInfo, fmt.Sprintf("osd.%d", osdID))
+	if err != nil {
+		// 'ceph auth del' returns error code 0 (success) if auth doesn't exist
+		logger.Errorf("failed to delete auth for osd.%d. user may need to use 'ceph auth del' or 'ceph auth rm' manually. %v", osdID, err)
+	}
+
 	logger.Infof("completed removal of OSD %d", osdID)
 }
 


### PR DESCRIPTION
`ceph osd purge` should remove the OSD auth, but many users have issues
where they are unable to create new OSDs after removing old ones due to
the old OSD auth still being present. Therefore, run `ceph auth del` for
the OSD after purging to fix this.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
