### PR TITLE
ceph: Tag default service account for CSV generation

### DIFF
--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -373,14 +373,14 @@ subjects:
 # namespace. If you want to create the cluster in a different namespace, you will need to modify these roles
 # and bindings accordingly.
 #################################################################################################################
-# OLM: BEGIN SERVICEACCOUNT DEFAULT
+# OLM: BEGIN SERVICE ACCOUNT DEFAULT
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-default
   namespace: rook-ceph # namespace:cluster
-# OLM: END SERVICEACCOUNT DEFAULT
+# OLM: END SERVICE ACCOUNT DEFAULT
 # OLM: BEGIN SERVICE ACCOUNT OSD
 ---
 # Service account for the Ceph OSDs. Must exist and cannot be renamed.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The csv was not generating the rook-ceph-default service account because the comment delimiting it had a typo.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
