### PR TITLE
ceph: allow monitor maintenance mode

### DIFF
--- a/Documentation/ceph-mon-health.md
+++ b/Documentation/ceph-mon-health.md
@@ -78,6 +78,9 @@ If you want to force a mon to failover for testing or other purposes, you can sc
 for the timeout. Note that the operator may scale up the mon again automatically if the operator is restarted or if a full
 reconcile is triggered, such as when the CephCluster CR is updated.
 
+To disable monitor automatic failover, the `timeout` can be set to `0`, if the monitor goes out of quorum Rook will never fail it over onto another node.
+This is especially useful for planned maintenance.
+
 ### Example Failover
 
 Rook will create mons with pod names such as mon-a, mon-b, and mon-c. Let's say mon-b had an issue and the pod failed.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -34,3 +34,4 @@ v1.6...
     up updates and upgrades for larger Ceph clusters
 * Disable CSI GRPC metrics by default
 * Ceph daemon pods using the `default` service account now use a new `rook-ceph-default` service account.
+* Monitors failover can be [disabled](Documentation/ceph-mon-health.md#failing-over-a-monitor), this is useful for monitor going under planned maintenance where automatic failover is not desired

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -37,7 +37,7 @@ var (
 	// HealthCheckInterval is the interval to check if the mons are in quorum
 	HealthCheckInterval = 45 * time.Second
 	// MonOutTimeout is the duration to wait before removing/failover to a new mon pod
-	MonOutTimeout = 600 * time.Second
+	MonOutTimeout = 10 * time.Minute
 )
 
 // HealthChecker aggregates the mon/cluster info needed to check the health of the monitors


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

If the health spec of the CephCluster CRD has a timeout set to 0 like
so:

```
  healthCheck:
    daemonHealth:
      mon:
        disabled: false
        interval: 45s
        timeout: 0
```

And the mon goes out of quorum then Rook will not fail over the mon.
This is interesting when doing maintenance on a monitor and we don't
want to create a new one.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
