### PR TITLE
ceph: update osd purge docs

### DIFF
--- a/Documentation/ceph-osd-mgmt.md
+++ b/Documentation/ceph-osd-mgmt.md
@@ -66,6 +66,19 @@ and it is safe to proceed. If an OSD is failing, the PGs will not be perfectly c
 Update your CephCluster CR. Depending on your CR settings, you may need to remove the device from the list or update the device filter.
 If you are using `useAllDevices: true`, no change to the CR is necessary.
 
+**IMPORTANT: On host-based clusters, you may need to stop the Rook Operator while performing OSD
+removal steps in order to prevent Rook from detecting the old OSD and trying to re-create it before
+the disk is wiped or removed.**
+
+To stop the Rook Operator, run 
+`kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=0`.
+
+You must perform steps below to (1) purge the OSD and either (2.a) delete the underlying data or 
+(2.b)replace the disk before starting the Rook Operator again.
+
+Once you have done that, you can start the Rook operator again with
+`kubectl -n rook-ceph scale deployment rook-ceph-operator --replicas=1`.
+
 ### PVC-based cluster
 
 To reduce the storage in your cluster or remove a failed OSD on a PVC:

--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -140,13 +140,6 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 	// call archiveCrash to silence crash warning in ceph health if any
 	archiveCrash(clusterdContext, clusterInfo, osdID)
 
-	// remove the auth for the osd. should be done by 'osd purge', but doesn't always seem to happen
-	err = client.AuthDelete(clusterdContext, clusterInfo, fmt.Sprintf("osd.%d", osdID))
-	if err != nil {
-		// 'ceph auth del' returns error code 0 (success) if auth doesn't exist
-		logger.Errorf("failed to delete auth for osd.%d. user may need to use 'ceph auth del' or 'ceph auth rm' manually. %v", osdID, err)
-	}
-
 	logger.Infof("completed removal of OSD %d", osdID)
 }
 


### PR DESCRIPTION
Revert "ceph: remove auth in osd-purge job" and replace with doc update.

Upate osd purge docs to inform users they need to stop the operator before purging OSDs when using node-based OSDs.

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
