### PR TITLE
ceph: allow empty compressionMode in CRD pools

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -41,6 +41,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                   type: string
                 crushRoot:
                   description: The root of the crush hierarchy utilized by the pool
@@ -4769,6 +4770,7 @@ spec:
                           - passive
                           - aggressive
                           - force
+                          - ""
                         type: string
                       crushRoot:
                         description: The root of the crush hierarchy utilized by the pool
@@ -4907,6 +4909,7 @@ spec:
                         - passive
                         - aggressive
                         - force
+                        - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool
@@ -6196,6 +6199,7 @@ spec:
                         - passive
                         - aggressive
                         - force
+                        - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool
@@ -6968,6 +6972,7 @@ spec:
                         - passive
                         - aggressive
                         - force
+                        - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool
@@ -7320,6 +7325,7 @@ spec:
                         - passive
                         - aggressive
                         - force
+                        - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool
@@ -7457,6 +7463,7 @@ spec:
                         - passive
                         - aggressive
                         - force
+                        - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -44,6 +44,7 @@ spec:
                 - passive
                 - aggressive
                 - force
+                - ""
                 type: string
               crushRoot:
                 description: The root of the crush hierarchy utilized by the pool
@@ -4772,6 +4773,7 @@ spec:
                       - passive
                       - aggressive
                       - force
+                      - ""
                       type: string
                     crushRoot:
                       description: The root of the crush hierarchy utilized by the pool
@@ -4910,6 +4912,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                     type: string
                   crushRoot:
                     description: The root of the crush hierarchy utilized by the pool
@@ -6199,6 +6202,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                     type: string
                   crushRoot:
                     description: The root of the crush hierarchy utilized by the pool
@@ -6971,6 +6975,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                     type: string
                   crushRoot:
                     description: The root of the crush hierarchy utilized by the pool
@@ -7323,6 +7328,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                     type: string
                   crushRoot:
                     description: The root of the crush hierarchy utilized by the pool
@@ -7460,6 +7466,7 @@ spec:
                     - passive
                     - aggressive
                     - force
+                    - ""
                     type: string
                   crushRoot:
                     description: The root of the crush hierarchy utilized by the pool

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -578,7 +578,7 @@ type PoolSpec struct {
 	DeviceClass string `json:"deviceClass,omitempty"`
 
 	// The inline compression mode in Bluestore OSD to set to (options are: none, passive, aggressive, force)
-	// +kubebuilder:validation:Enum=none;passive;aggressive;force
+	// +kubebuilder:validation:Enum=none;passive;aggressive;force;""
 	// +kubebuilder:default=none
 	// +optional
 	CompressionMode string `json:"compressionMode,omitempty"`


### PR DESCRIPTION
Allow empty ("") compressionMode in CRDs' 'pool' spec.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
