### PR TITLE
ceph: support specifying only public network or only cluster network or both

### DIFF
--- a/pkg/operator/ceph/config/network.go
+++ b/pkg/operator/ceph/config/network.go
@@ -50,10 +50,8 @@ func generateNetworkSettings(clusterdContext *clusterd.Context, namespace string
 	cephNetworks := []Option{}
 
 	for _, selectorKey := range NetworkSelectors {
-		// This means only "public" was specified and thus we use the same subnet for cluster too
+		// skip if selector is not specified
 		if _, ok := networkSelectors[selectorKey]; !ok {
-			cephNetworks = append(cephNetworks, cephNetworks[0])
-			cephNetworks[1].Option = fmt.Sprintf("%s_network", selectorKey)
 			continue
 		}
 


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With this change, the Rook ceph cluster can have only a public network or
only a cluster network or both can be specified. Prior to this commit if
only a public network was specified, it was copied to the cluster network.

Also, cluster network will only be applied to Osd pods.

**Which issue is resolved by this Pull Request:**
Resolves #7436

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
