### PR TITLE
build: allow CSV gen on mac

### DIFF
--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -64,7 +64,9 @@ CXX := $(CROSS_TRIPLE)-g++
 export CC CXX
 endif
 
-SED_CMD?=sed -i -e
+# sed -i'' -e works on both UNIX (MacOS) and GNU (Linux) versions of sed
+SED_CMD ?= sed -i'' -e
+export SED_CMD
 
 # set the version number. you should not need to do this
 # for the majority of scenarios.

--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -18,6 +18,8 @@ CRDS_DIR="$DEPLOY_DIR/crds"
 
 TEMPLATES_DIR="$OLM_CATALOG_DIR/templates"
 
+SED=${SED_CMD:-"sed -i'' -e"}
+
 function generate_template() {
     local provider=$1
     local csv_manifest_path="$DEPLOY_DIR/olm-catalog/${provider}/9999.9999.9999/manifests"
@@ -30,7 +32,7 @@ function generate_template() {
     mv $tmp_csv_gen_file $csv_template_file
 
     # replace the placeholder with the templated value
-    sed -i "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
+    $SED "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
 
     echo "Template stored at $csv_template_file"
 }

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -13,7 +13,7 @@ PACKAGE_FILE="$OLM_CATALOG_DIR/assemble/rook-ceph.package.yaml"
 SUPPORTED_PLATFORMS='k8s|ocp|okd'
 
 operator_sdk="${OPERATOR_SDK:-operator-sdk}"
-yq="${YQ_TOOL:-yq}"
+yq="${YQ:-yq}"
 
 # Default CSI to true
 : "${OLM_INCLUDE_CEPHFS_CSI:=true}"
@@ -76,6 +76,7 @@ ROOK_OP_VERSION=$3
 #############
 # VARIABLES #
 #############
+SED_I=${SED_CMD:-"sed -i'' -e"}
 YQ_CMD_DELETE=($yq delete -i)
 YQ_CMD_MERGE_OVERWRITE=($yq merge --inplace --overwrite --prettyPrint)
 YQ_CMD_MERGE=($yq merge --inplace --append -P )
@@ -222,26 +223,26 @@ function hack_csv() {
     # rook-ceph-osd --> serviceAccountName
     #     rook-ceph-osd --> rule
 
-    sed -i 's/rook-ceph-global/rook-ceph-system/' "$CSV_FILE_NAME"
-    sed -i 's/rook-ceph-object-bucket/rook-ceph-system/' "$CSV_FILE_NAME"
-    sed -i 's/rook-ceph-cluster-mgmt/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_I 's/rook-ceph-global/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_I 's/rook-ceph-object-bucket/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_I 's/rook-ceph-cluster-mgmt/rook-ceph-system/' "$CSV_FILE_NAME"
 
-    sed -i 's/rook-ceph-mgr-cluster/rook-ceph-mgr/' "$CSV_FILE_NAME"
-    sed -i 's/rook-ceph-mgr-system/rook-ceph-mgr/' "$CSV_FILE_NAME"
+    $SED_I 's/rook-ceph-mgr-cluster/rook-ceph-mgr/' "$CSV_FILE_NAME"
+    $SED_I 's/rook-ceph-mgr-system/rook-ceph-mgr/' "$CSV_FILE_NAME"
 
-    sed -i 's/cephfs-csi-nodeplugin/rook-csi-cephfs-plugin-sa/' "$CSV_FILE_NAME"
-    sed -i 's/cephfs-external-provisioner-runner/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/cephfs-csi-nodeplugin/rook-csi-cephfs-plugin-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/cephfs-external-provisioner-runner/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
 
-    sed -i 's/rbd-csi-nodeplugin/rook-csi-rbd-plugin-sa/' "$CSV_FILE_NAME"
-    sed -i 's/rbd-external-provisioner-runner/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/rbd-csi-nodeplugin/rook-csi-rbd-plugin-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/rbd-external-provisioner-runner/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
     # The operator-sdk also does not properly respect when
     # Roles differ from the Service Account name
     # The operator-sdk instead assumes the Role/ClusterRole is the ServiceAccount name
     #
     # To account for these mappings, we have to replace Role/ClusterRole names with
     # the corresponding ServiceAccount.
-    sed -i 's/cephfs-external-provisioner-cfg/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
-    sed -i 's/rbd-external-provisioner-cfg/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/cephfs-external-provisioner-cfg/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_I 's/rbd-external-provisioner-cfg/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
 }
 
 function generate_package() {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -25,6 +25,8 @@ endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 OPERATOR_SDK_VERSION = v0.17.1
+# TODO: update to yq v4 - v3 end of life in Aug 2021 ; v4 removes the 'yq delete' cmd and changes syntax
+YQ_VERSION = 3.3.0
 GOHOST := GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) go
 
 TEMP := $(shell mktemp -d)
@@ -33,9 +35,19 @@ ifeq ($(HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
 endif
+ifeq ($(HOST_PLATFORM),darwin_amd64)
+OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
+INCLUDE_CSV_TEMPLATES = true
+endif
+ifneq ($(INCLUDE_CSV_TEMPLATES),true)
+$(info )
+$(info NOT INCLUDING OLM/CSV TEMPLATES!)
+$(info )
+endif
 
 OPERATOR_SDK := $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION)
-YQ := $(TOOLS_HOST_DIR)/yq
+YQ := $(TOOLS_HOST_DIR)/yq-$(YQ_VERSION)
+export OPERATOR_SDK YQ
 
 # ====================================================================================
 # Build Rook
@@ -77,18 +89,28 @@ generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
 			echo "length after $$AFTER_GEN_CRD_SIZE";\
 			exit 1;\
 		fi;\
-		OPERATOR_SDK=$(OPERATOR_SDK) YQ_TOOL=$(YQ) ../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
+		../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
 	fi
 
 $(YQ):
 	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
 		echo === installing yq $(GOHOST);\
-		curl -JL https://github.com/mikefarah/yq/releases/download/3.3.0/yq_$(HOST_PLATFORM) -o $(YQ);\
+		mkdir -p $(TOOLS_HOST_DIR);\
+		curl -JL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(HOST_PLATFORM) -o $(YQ);\
 		chmod +x $(YQ);\
 	fi
 
 $(OPERATOR_SDK):
 	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
+		echo === installing operator-sdk $(GOHOST);\
+		mkdir -p $(TOOLS_HOST_DIR);\
 		curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM) -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION);\
 		chmod +x $(OPERATOR_SDK);\
-        fi
+	fi
+
+csv: $(OPERATOR_SDK) $(YQ) ## Generate a CSV file for OLM.
+	@echo Generating CSV manifests
+	@cd ../.. && cluster/olm/ceph/generate-rook-csv.sh $(CSV_VERSION) $(CSV_PLATFORM) $(ROOK_OP_VERSION)
+
+csv-clean: $(OPERATOR_SDK) $(YQ) ## Remove existing OLM files.
+	@rm -fr ../../cluster/olm/ceph/deploy/* ../../cluster/olm/ceph/templates/*


### PR DESCRIPTION
CSV generation now requires versions of yq and operator-sdk that are
downloaded by the makefiles. Previously Ceph image creation used
makefile versions but `make csv-ceph` used versions present on the
system.

`sed -i 's///g' $FILE` doesn't work on Unix/Mac.
`sed -i'' -e 's///g' $FILE` is portable.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

// skip jenkins; all tests should fail if build is failing
[skip ci]

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
