### PR TITLE
ceph: Tests are picking up release tag instead of local build

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -18,6 +18,7 @@ package installer
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -82,7 +83,11 @@ func (m *CephManifestsMaster) GetOperator() string {
 	} else {
 		manifest = m.settings.readManifest("operator.yaml")
 	}
-	return m.settings.replaceOperatorSettings(manifest)
+	manifest = m.settings.replaceOperatorSettings(manifest)
+
+	// In release branches replace the tag with a master build since the local build has the master tag
+	r, _ := regexp.Compile(`image: rook/ceph:v[a-z0-9.-]+`)
+	return r.ReplaceAllString(manifest, "image: rook/ceph:master")
 }
 
 func (m *CephManifestsMaster) GetCommonExternal() string {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests in the CI seem to be picking up the rook/ceph:master tag that is published instead of using the local build. This was observed in #7558 where the helm and upgrade suites failed to run in the backport PR because the rook-ceph-default service account was not created. However, the mon canary pod was still started by the operator as if it was running code from the published master tag. After the master tag was pushed from merging #7556 and the tests were rerun, then they did pass. Therefore, it appears the CI is not testing what is built locally.

This PR is only a draft while simulating a failure to investigate the issue...

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
