### PR TITLE
bot: auto merge backports to release-1.6

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,10 @@ pull_request_rules:
       - 'check-success=encryption-pvc-db'
       - 'check-success=encryption-pvc-db-wal'
       - 'check-success=encryption-pvc-kms-vault-token-auth'
+      - 'check-success=TestCephSmokeSuite'
+      - 'check-success=TestCephHelmSuite'
+      - 'check-success=TestCephMultiClusterDeploySuite'
+      - 'check-success=TestCephUpgradeSuite'
     actions:
       merge:
         method: merge
@@ -104,6 +108,36 @@ pull_request_rules:
       - label!=do-not-merge
       - 'status-success=DCO'
       - 'status-success=continuous-integration/jenkins/pr-head'
+    actions:
+      merge:
+        method: merge
+        strict: false
+      dismiss_reviews: {}
+      delete_head_branch: {}
+  # release-1.6 branch
+  - name: automerge backport release-1.6
+    conditions:
+      - author=mergify[bot]
+      - base=release-1.6
+      - label!=do-not-merge
+      - 'status-success=DCO'
+      - 'check-success=canary'
+      - 'check-success=unittests'
+      - 'check-success=golangci-lint'
+      - 'check-success=codegen'
+      - 'check-success=lint'
+      - 'check-success=modcheck'
+      - 'check-success=pvc'
+      - 'check-success=pvc-db'
+      - 'check-success=pvc-db-wal'
+      - 'check-success=encryption-pvc'
+      - 'check-success=encryption-pvc-db'
+      - 'check-success=encryption-pvc-db-wal'
+      - 'check-success=encryption-pvc-kms-vault-token-auth'
+      - 'check-success=TestCephSmokeSuite'
+      - 'check-success=TestCephHelmSuite'
+      - 'check-success=TestCephMultiClusterDeploySuite'
+      - 'check-success=TestCephUpgradeSuite'
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Previously forgot to add mergify rule to auto merge backports to
release-1.6. Backport PRs would still be created but not merged.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

// skip jenkins
[skip ci]

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
