### PR TITLE
ceph: Integration tests use master tag even in release branch

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -18,6 +18,7 @@ package installer
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -82,7 +83,11 @@ func (m *CephManifestsMaster) GetOperator() string {
 	} else {
 		manifest = m.settings.readManifest("operator.yaml")
 	}
-	return m.settings.replaceOperatorSettings(manifest)
+	manifest = m.settings.replaceOperatorSettings(manifest)
+
+	// In release branches replace the tag with a master build since the local build has the master tag
+	r, _ := regexp.Compile(`image: rook/ceph:v[a-z0-9.-]+`)
+	return r.ReplaceAllString(manifest, "image: rook/ceph:master")
 }
 
 func (m *CephManifestsMaster) GetCommonExternal() string {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests pick up the manifests directly from the examples folder, including with the release tag. In the release branch the Jenkins build still uses the master build when building locally before tagging it with the release tag. So the tests need to use the master tag.

Cherry-picked from release-1.6 since it needed to be tested there first.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
