### PR TITLE
ceph: `pkg/operator/ceph/file`: multiple imports

### DIFF
--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -29,7 +29,6 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	clienttest "github.com/rook/rook/pkg/daemon/ceph/client/test"
 	"github.com/rook/rook/pkg/operator/ceph/file/mds"
@@ -47,7 +46,7 @@ import (
 
 func TestValidateSpec(t *testing.T) {
 	context := &clusterd.Context{Executor: &exectest.MockExecutor{}}
-	clusterInfo := &client.ClusterInfo{Namespace: "ns"}
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns"}
 	fs := &cephv1.CephFilesystem{}
 	clusterSpec := &cephv1.ClusterSpec{}
 
@@ -216,7 +215,7 @@ func TestCreateFilesystem(t *testing.T) {
 		ConfigDir: configDir,
 		Clientset: clientset}
 	fs := fsTest(fsName)
-	clusterInfo := &client.ClusterInfo{FSID: "myfsid", CephVersion: version.Octopus}
+	clusterInfo := &cephclient.ClusterInfo{FSID: "myfsid", CephVersion: version.Octopus}
 
 	// start a basic cluster
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
@@ -299,7 +298,7 @@ func TestCreateFilesystem(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("failed to create filesystem %q: multiple filesystems are only supported as of ceph pacific", fsName), err.Error())
 
 	// It works since the op env var is specified even if we don't run on pacific
-	os.Setenv(client.MultiFsEnv, "true")
+	os.Setenv(cephclient.MultiFsEnv, "true")
 	fsName = "myfs2"
 	fs = fsTest(fsName)
 	executor = fsExecutor(t, fsName, configDir, true)
@@ -311,7 +310,7 @@ func TestCreateFilesystem(t *testing.T) {
 	}
 	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, ownerInfo, "/var/lib/rook/")
 	assert.NoError(t, err)
-	os.Unsetenv(client.MultiFsEnv)
+	os.Unsetenv(cephclient.MultiFsEnv)
 
 	// It works since the Ceph version is Pacific
 	fsName = "myfs3"
@@ -357,7 +356,7 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 			},
 		},
 	}
-	clusterInfo := &client.ClusterInfo{FSID: "myfsid"}
+	clusterInfo := &cephclient.ClusterInfo{FSID: "myfsid"}
 
 	// start a basic cluster
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -26,7 +26,6 @@ import (
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
-	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 
@@ -73,7 +72,7 @@ func testDeploymentObject(t *testing.T, network cephv1.NetworkSpec) (*apps.Deplo
 			Network:     network,
 		},
 		fs,
-		&client.CephFilesystemDetails{ID: 15},
+		&cephclient.CephFilesystemDetails{ID: 15},
 		&k8sutil.OwnerInfo{},
 		"/var/lib/rook/",
 	)


### PR DESCRIPTION
**Description of your changes:**
This fixes code and tests in `pkg/operator/ceph/file` and its subpackages that were importing the same libraries multiple times.

**Checklist:**

- [ X ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ X ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
