### PR TITLE
ceph: sslCertificateRef can't be null

### DIFF
--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -47,7 +47,7 @@ spec:
     # type of the gateway (s3)
     type: s3
     # A reference to the secret in the rook namespace where the ssl certificate is stored
-    sslCertificateRef:
+    # sslCertificateRef:
     # The port that RGW pods will listen on (http)
     port: 8080
     # The port that RGW pods will listen on (https). An ssl certificate is required.


### PR DESCRIPTION
**Description of your changes:**

comment` sslCertificateRef` as it can't be
null.

closes #7578 
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Which issue is resolved by this Pull Request:**
Resolves #7578 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
