### PR TITLE
ci: use authenticated requests for minikube action on suite

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -27,6 +27,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: 'v1.15.12'
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |
@@ -91,6 +92,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -31,6 +31,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |
@@ -97,6 +98,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -23,6 +23,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -31,6 +31,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |
@@ -96,6 +97,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -31,6 +31,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |
@@ -95,6 +96,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -31,6 +31,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |
@@ -95,6 +96,7 @@ jobs:
         minikube version: 'v1.18.1'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: check k8s cluster status
       run: |


### PR DESCRIPTION
**Description of your changes:**

We have seen the CI failing to run the minikube action, reaching the API
limit. By using authenticated requests, we can overcome this limitation.
Follow-up of https://github.com/rook/rook/pull/7503/commits/1504fb869b5ed5b8f7df362bc9df3b45dd8ac9ea

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
