### PR TITLE
ci: Run integration tests on k8s 1.21

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.16.15','v1.18.15','v1.19.7','v1.20.2']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12', 'v1.20.2']
+        kubernetes-versions : ['v1.15.12', 'v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.16.15','v1.18.15','v1.19.7','v1.20.2']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.20.2']
+        kubernetes-versions : ['v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.20.2']
+        kubernetes-versions : ['v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.16.15','v1.18.15','v1.19.7','v1.20.2']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12', 'v1.20.2']
+        kubernetes-versions : ['v1.15.12', 'v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.16.15','v1.18.15','v1.19.7','v1.20.2']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.20.2']
+        kubernetes-versions : ['v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.16.15','v1.18.15','v1.19.7','v1.20.2']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -135,11 +135,11 @@ pull_request_rules:
       - 'check-success=encryption-pvc-db-wal'
       - 'check-success=encryption-pvc-kms-vault-token-auth'
       - 'check-success=TestCephSmokeSuite (v1.15.12)'
-      - 'check-success=TestCephSmokeSuite (v1.20.2)'
+      - 'check-success=TestCephSmokeSuite (v1.21.0)'
       - 'check-success=TestCephHelmSuite (v1.15.12)'
-      - 'check-success=TestCephHelmSuite (v1.20.2)'
-      - 'check-success=TestCephMultiClusterDeploySuite (v1.20.2)'
-      - 'check-success=TestCephUpgradeSuite (v1.20.2)'
+      - 'check-success=TestCephHelmSuite (v1.21.0)'
+      - 'check-success=TestCephMultiClusterDeploySuite (v1.21.0)'
+      - 'check-success=TestCephUpgradeSuite (v1.21.0)'
     actions:
       merge:
         method: merge

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,8 +156,8 @@ pipeline {
                         "aws_1.15.x": "v1.15.12",
                         "aws_1.16.x": "v1.16.15",
                         "aws_1.18.x": "v1.18.12",
-                        "aws_1.19.x": "v1.19.4",
-                        "aws_1.20.x": "v1.20.0"
+                        "aws_1.20.x": "v1.20.5",
+                        "aws_1.21.x": "v1.21.0"
                     ]
                     testruns = [:]
                     for (kv in mapToList(data)) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the release of K8s 1.21.0 we now run the integration tests on v1.21.0. To keep consistent with running master builds on five recent releases, we keep master builds back to v1.15 and skip other less changed versions such as v1.16 and 1.19.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
