### PR TITLE
ceph: work around object user create/update incompatibilities between Rook v1.6 and Ceph pre-Pacific

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -313,3 +313,12 @@ func assertErrorType(err error) string {
 
 	return ""
 }
+
+// ExtractExitCode attempts to get the exit code from the error returned by an Executor function.
+// This should also work for any errors returned by the golang os/exec package.
+func ExtractExitCode(err error) (int, error) {
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode(), nil
+	}
+	return 0, errors.Errorf("error %#v is not an ExitError", err)
+}


### PR DESCRIPTION
Work around issue https://github.com/rook/rook/issues/7573
and make sure integration tests check for regressions.

Eventually we should use the RADOS Gateway admin REST API, but for now
we need to work around an issue where the built version of
'radosgw-admin' has incompatibilities with the RADOS Gateway version
running in the Ceph cluster.

Of note, Rook built on the Ceph Pacific image will not support
some 'radosgw-admin' commands to Ceph Nautilus (v14) or Octopus (v15)
clusters.

Further complicating matters, the flag used for the workaround changes
between Ceph v16.2.0 and v16.2.1 (both Pacific).

This bug needs to be treated a little differently than most of the ways
Rook handles different commands for different Ceph versions because this
is based on the Ceph version that is installed in the container with the
Rook operator primarily and not the version of Ceph running in the
cluster.

Resolves #7573 

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

Also note, this does not just affect `radosgw-admin` commands for `user create` and `user modify`. My testing shows that it also gets activated for `user info` and `period update` commands.

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
