### PR TITLE
ceph: moved multus support out of experimental

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -302,10 +302,9 @@ Configure the network that will be enabled for the cluster and services.
 
 To use host networking, set `provider: host`.
 
-#### Multus (EXPERIMENTAL)
+#### Multus
 
-Rook has experimental support for Multus.
-Currently there is an [open issue](https://github.com/ceph/ceph-csi/issues/1323) in ceph-csi which explains the csi-rbdPlugin issue while using multus network.
+Rook supports addition of public and cluster network for ceph using Multus
 
 The selector keys are required to be `public` and `cluster` where each represent:
 
@@ -356,6 +355,7 @@ spec:
 * Ensure that `master` matches the network interface of the host that you want to use.
 * The NAD should be referenced along with the namespace in which it is present like `public: <namespace>/<name of NAD>`.
   e.g., the network attachment definition are in `rook-multus` namespace:
+* Ipam type `whereabouts` is required because it makes sure that all the pods get a unique IP address from the multus network.
 
 ```yaml
   public: rook-multus/rook-public-nw


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
moved multus support out of experimental.

**Which issue is resolved by this Pull Request:**
Resolves #6748

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]