### PR TITLE
ci: ability to skip ci with a label

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   canary:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -121,6 +122,7 @@ jobs:
 
   pvc:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -221,6 +223,7 @@ jobs:
 
   pvc-db:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -313,6 +316,7 @@ jobs:
 
   pvc-db-wal:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -407,6 +411,7 @@ jobs:
 
   encryption-pvc:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -495,6 +500,7 @@ jobs:
 
   encryption-pvc-db:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -587,6 +593,7 @@ jobs:
 
   encryption-pvc-db-wal:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -681,6 +688,7 @@ jobs:
 
   encryption-pvc-kms-vault-token-auth:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -782,6 +790,7 @@ jobs:
 
   lvm-pvc:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   TestCephFlexSuite:
-    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
     steps:
     - name: checkout

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   TestCephHelmSuite:
-    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 jobs:
   TestCephMgrSuite:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   TestCephMultiClusterDeploySuite:
-    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   TestCephSmokeSuite:
-    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   TestCephUpgradeSuite:
-    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Description of your changes:**

Additionally to skip ci tag in the commit message from https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
We can now skip integration tests by applying the "skip-ci" label at the
**creation time** of the PR. Obviously adding later works but will still
trigger the test in the initial opening of the PR. Subsequent pushes
will skip integration tests.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
