### PR TITLE
ceph: redact secret info from reconcile diffs

### DIFF
--- a/pkg/operator/ceph/controller/predicate_test.go
+++ b/pkg/operator/ceph/controller/predicate_test.go
@@ -122,18 +122,18 @@ func TestIsValidEvent(t *testing.T) {
 		}
 	  }`)
 
-	b := isValidEvent(valid, obj)
+	b := isValidEvent(valid, obj, false)
 	assert.True(t, b)
 
 	valid = []byte(`{"foo": "bar"}`)
-	b = isValidEvent(valid, obj)
+	b = isValidEvent(valid, obj, false)
 	assert.True(t, b)
 
 	invalid := []byte(`{
 		"metadata": {},
 		"status": {},
 	  }`)
-	b = isValidEvent(invalid, obj)
+	b = isValidEvent(invalid, obj, false)
 	assert.False(t, b)
 }
 


### PR DESCRIPTION
To avoid logging sensitive information, do not output diffs from secrets
when reconciling resources.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7624 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
