### PR TITLE
ceph: Preserve volume claim template metadata in schema

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -47,6 +47,7 @@ copy_ob_obc_crds() {
 generating_crds_v1() {
   echo "Generating v1 in crds.yaml"
   "$CONTROLLER_GEN_BIN_PATH" "$CRD_OPTIONS" paths="./pkg/apis/ceph.rook.io/v1" output:crd:artifacts:config="$OLM_CATALOG_DIR"
+  sed -i'' -e "s/\( *\)\(description: 'Standard object''s metadata. More info: https:\/\/git.k8s.io\/community\/contributors\/devel\/sig-architecture\/api-conventions.md#metadata'\)/\1\2\n\1x-kubernetes-preserve-unknown-fields: true/" cluster/olm/ceph/deploy/crds/ceph.rook.io_cephclusters.yaml
 }
 
 generating_crds_v1alpha2() {
@@ -75,13 +76,13 @@ build_helm_resources() {
     # add header
     echo "{{- if .Values.crds.enabled }}"
     echo "{{- if semverCompare \">=1.16.0\" .Capabilities.KubeVersion.GitVersion }}"
-    
+
     # Add helm annotations to all CRDS and skip the first 4 lines of crds.yaml
     "$YQ_BIN_PATH" w -d'*' "$CRDS_FILE_PATH" "metadata.annotations[helm.sh/resource-policy]" keep | tail -n +5
-    
+
     # add else
     echo "{{- else }}"
-    
+
     # add footer
     cat "$CRDS_BEFORE_1_16_FILE_PATH"
     # DO NOT REMOVE the empty line, it is necessary

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -817,6 +817,7 @@ spec:
                                     type: string
                                   metadata:
                                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                    x-kubernetes-preserve-unknown-fields: true
                                     type: object
                                   spec:
                                     description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -971,6 +972,7 @@ spec:
                           type: string
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          x-kubernetes-preserve-unknown-fields: true
                           type: object
                         spec:
                           description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -1792,6 +1794,7 @@ spec:
                                   type: string
                                 metadata:
                                   description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  x-kubernetes-preserve-unknown-fields: true
                                   type: object
                                 spec:
                                   description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -2838,6 +2841,7 @@ spec:
                                   type: string
                                 metadata:
                                   description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  x-kubernetes-preserve-unknown-fields: true
                                   type: object
                                 spec:
                                   description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -3003,6 +3007,7 @@ spec:
                             type: string
                           metadata:
                             description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            x-kubernetes-preserve-unknown-fields: true
                             type: object
                           spec:
                             description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -820,6 +820,7 @@ spec:
                                   type: string
                                 metadata:
                                   description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                  x-kubernetes-preserve-unknown-fields: true
                                   type: object
                                 spec:
                                   description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -974,6 +975,7 @@ spec:
                         type: string
                       metadata:
                         description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        x-kubernetes-preserve-unknown-fields: true
                         type: object
                       spec:
                         description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -1795,6 +1797,7 @@ spec:
                                 type: string
                               metadata:
                                 description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                x-kubernetes-preserve-unknown-fields: true
                                 type: object
                               spec:
                                 description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -2841,6 +2844,7 @@ spec:
                                 type: string
                               metadata:
                                 description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                x-kubernetes-preserve-unknown-fields: true
                                 type: object
                               spec:
                                 description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
@@ -3006,6 +3010,7 @@ spec:
                           type: string
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          x-kubernetes-preserve-unknown-fields: true
                           type: object
                         spec:
                           description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -96,11 +96,17 @@ func (c *Cluster) createDeviceSetPVCsForIndex(deviceSet rookv1.StorageClassDevic
 
 	var dataSize string
 	var crushDeviceClass string
+	typesFound := util.NewSet()
 	for _, pvcTemplate := range deviceSet.VolumeClaimTemplates {
 		if pvcTemplate.Name == "" {
 			// For backward compatibility a blank name must be treated as a data volume
 			pvcTemplate.Name = bluestorePVCData
 		}
+		if typesFound.Contains(pvcTemplate.Name) {
+			errs.addError("found duplicate volume claim template %q for device set %q", pvcTemplate.Name, deviceSet.Name)
+			continue
+		}
+		typesFound.Add(pvcTemplate.Name)
 
 		pvc, err := c.createDeviceSetPVC(existingPVCs, deviceSet.Name, pvcTemplate, setIndex)
 		if err != nil {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The schema generation was not generating the metadata properties under the VolumeClaimTemplate type, resulting in the properties being ignored by the api server. The preserve unknown fields tag was not working recursively on the volumeClaimTemplates since the subtypes were defined. Now we post-process the schema so we can preserve the unknown fields for the volume claim templates metadata.
 
Also we add check for the metadata to ensure we don't end up with duplicate crushDeviceClasses.

**Which issue is resolved by this Pull Request:**
Resolves #7629 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
