### PR TITLE
ceph: ensure object store endpoint is initialized for user

### DIFF
--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -310,12 +310,18 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 	}
 
 	r.objContext = objContext
-	r.objContext.Endpoint = store.Status.Info["endpoint"]
-	if store.Status != nil && store.Status.Info["secureEndpoint"] != "" {
-		r.objContext.Endpoint = store.Status.Info["secureEndpoint"]
+	if store.Status == nil {
+		return errors.New("failed to initialize ceph object user because unknown object store status")
 	}
-	if r.objContext.Endpoint == "" {
+
+	if _, ok := store.Status.Info["endpoint"]; ok {
+		r.objContext.Endpoint = store.Status.Info["endpoint"]
+	} else {
 		return errors.Errorf("endpoint is missing in the status Info")
+	}
+
+	if _, ok := store.Status.Info["secureEndpoint"]; ok {
+		r.objContext.Endpoint = store.Status.Info["secureEndpoint"]
 	}
 
 	return nil


### PR DESCRIPTION
when store.Status was not initialized it caused
crashes when assigning store.Status.Info["endpoint"]
to objContext.Endpoint.

This commits makes sure store.Status is not Nil
before setting objContext.Endpoint and
objContext.SecureEndpoint in the ObjectStoreUser
controller.

Closes: https://github.com/rook/rook/issues/6916
Signed-off-by: Ali Maredia <amaredia@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #6916

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
