### PR TITLE
cassandra: Get working Cassandra test in a github action (bp #7601)

### DIFF
--- a/.github/workflows/integration-test-cassandra-suite.yaml
+++ b/.github/workflows/integration-test-cassandra-suite.yaml
@@ -1,0 +1,113 @@
+name: Integration test CassandraSuite
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - release-*
+  pull_request:
+
+jobs:
+  TestCassandraSuite:
+    if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.15.12', 'v1.21.0']
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.3.1
+      with:
+        minikube version: 'v1.18.1'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
+        start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: check k8s cluster status
+      run: |
+        kubectl cluster-info
+        kubectl get pods -n kube-system
+
+    - name: build rook
+      run: |
+        # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
+        GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='cassandra' VERSION=0 build
+        docker images
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:master
+
+    - name: TestCassandraSuite
+      run: |
+        go test -v -timeout 1800s -run CassandraSuite github.com/rook/rook/tests/integration
+
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cassandra-suite-artifact
+        path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
+    - name: setup tmate session for debugging
+      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-cassandra-suite')
+      uses: mxschmitt/action-tmate@v3
+
+  TestCassandraSuite-Master:
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.3.1
+      with:
+        minikube version: 'v1.18.1'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
+        start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: check k8s cluster status
+      run: |
+        kubectl cluster-info
+        kubectl get pods -n kube-system
+
+    - name: build rook
+      run: |
+        # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
+        GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='cassandra' VERSION=0 build
+        docker images
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:master
+
+    - name: TestCassandraSuite
+      run: |
+       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CassandraSuite github.com/rook/rook/tests/integration
+
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cassandra-suite-artifact
+        path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
+    - name: setup tmate session for debugging
+      if: failure() && contains(github.event.pull_request.labels.*.name, 'cassandra-suite')
+      uses: mxschmitt/action-tmate@v3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -234,6 +234,7 @@ def RunIntegrationTest(k, v) {
                         sh '''#!/bin/bash
                               set -o pipefail
                               export KUBECONFIG=$HOME/admin.conf \
+                                  SKIP_CASSANDRA_TESTS=true \
                                   TEST_ENV_NAME='''+"${k}"+''' \
                                   TEST_BASE_DIR="WORKING_DIR" \
                                   TEST_LOG_COLLECTION_LEVEL='''+"${env.getLogs}"+''' \

--- a/tests/framework/installer/cassandra_manifests.go
+++ b/tests/framework/installer/cassandra_manifests.go
@@ -209,6 +209,8 @@ rules:
     verbs:
       - get
       - list
+      - patch
+      - watch
   - apiGroups:
       - cassandra.rook.io
     resources:

--- a/tests/integration/z_cassandra_test.go
+++ b/tests/integration/z_cassandra_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -30,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ************************************************
@@ -132,14 +132,58 @@ func (s *CassandraSuite) Teardown() {
 // and CQL is working.
 func (s *CassandraSuite) CheckClusterHealth() {
 	// Verify that cassandra-operator is running
-	logger.Infof("Verifying that all expected pods in cassandra cluster %s are running", s.namespace)
-	assert.True(s.T(), s.k8sHelper.CheckPodCountAndState("rook-cassandra-operator", s.systemNamespace, 1, "Running"), "rook-cassandra-operator must be in Running state")
+	operatorName := "rook-cassandra-operator"
+	logger.Infof("Verifying that all expected pods of cassandra operator are ready")
+	ready := utils.Retry(10, 30*time.Second,
+		"Waiting for Cassandra operator to be ready", func() bool {
+			sts, err := s.k8sHelper.Clientset.AppsV1().StatefulSets(s.systemNamespace).Get(context.TODO(), operatorName, v1.GetOptions{})
+			if err != nil {
+				logger.Errorf("Error getting Cassandra operator `%s`", operatorName)
+				return false
+			}
+			if sts.Generation != sts.Status.ObservedGeneration {
+				logger.Infof("Operator Statefulset has not converged yet")
+				return false
+			}
+			if sts.Status.UpdatedReplicas != *sts.Spec.Replicas {
+				logger.Error("Operator StatefulSet is rolling updating")
+				return false
+			}
+			if sts.Status.ReadyReplicas != *sts.Spec.Replicas {
+				logger.Infof("Statefulset not ready. Got: %v, Want: %v",
+					sts.Status.ReadyReplicas, sts.Spec.Replicas)
+				return false
+			}
+			return true
+		})
+	assert.True(s.T(), ready, "Timed out waiting for Cassandra operator to become ready")
 
-	// Give the StatefulSet a head start
-	// CheckPodCountAndState timeout might be too fast and the test may fail
-	time.Sleep(30 * time.Second)
 	// Verify cassandra cluster instances are running OK
-	assert.True(s.T(), s.k8sHelper.CheckPodCountAndState("rook-cassandra", s.namespace, s.instanceCount, "Running"), fmt.Sprintf("%d rook-cassandra pods must be in running state", s.instanceCount))
+	clusterName := "cassandra-ns"
+	clusterNamespace := "cassandra-ns"
+	ready = utils.Retry(10, 30*time.Second,
+		"Waiting for Cassandra cluster to be ready", func() bool {
+			c, err := s.k8sHelper.RookClientset.CassandraV1alpha1().Clusters(clusterNamespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+			if err != nil {
+				logger.Errorf("Error getting Cassandra cluster `%s`", clusterName)
+				return false
+			}
+			for rackName, rack := range c.Status.Racks {
+				var desiredMembers int32
+				for _, r := range c.Spec.Datacenter.Racks {
+					if r.Name == rackName {
+						desiredMembers = r.Members
+						break
+					}
+				}
+				if !(desiredMembers == rack.Members && rack.Members == rack.ReadyMembers) {
+					logger.Infof("Rack `%s` is not ready yet", rackName)
+					return false
+				}
+			}
+			return true
+		})
+	assert.True(s.T(), ready, "Timed out waiting for Cassandra cluster to become ready")
 
 	// Determine a pod name for the cluster
 	podName := "cassandra-ns-us-east-1-us-east-1a-0"

--- a/tests/integration/z_cassandra_test.go
+++ b/tests/integration/z_cassandra_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -52,6 +54,9 @@ type CassandraSuite struct {
 // TestCassandraSuite initiates the CassandraSuite
 func TestCassandraSuite(t *testing.T) {
 	if installer.SkipTestSuite(installer.CassandraTestSuite) {
+		t.Skip()
+	}
+	if os.Getenv("SKIP_CASSANDRA_TESTS") == "true" {
 		t.Skip()
 	}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Create a github action to run the Cassandra test since the Jenkins test machine is constantly failing on the newer ubuntu release.

**Which issue is resolved by this Pull Request:**
Resolves #7569 in release-1.5 branch

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
