### PR TITLE
build: run 'go mod vendor' on each build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'build/run make -j\$(nproc) test'
+                sh 'build/run make test'
             }
         }
 

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -128,7 +128,7 @@ go.install:
 	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=0 $(GO) install -v $(GO_STATIC_FLAGS) $(p)${\n})
 
 .PHONY: go.test.unit
-go.test.unit: $(GOJUNIT)
+go.test.unit: $(GOJUNIT) go.mod.vendor
 	@echo === go test unit-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
 	CGO_ENABLED=0 $(GOHOST) test -v -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES)
@@ -164,6 +164,11 @@ go.mod.update:
 	@echo === updating modules
 	@$(GOHOST) get -u ./...
 
+.PHONY: go.mod.vendor
+go.mod.vendor:
+	@echo === ensuring vendor modules are installed
+	@$(GOHOST) mod vendor
+
 .PHONY: go.mod.check
 go.mod.check:
 	@echo === ensuring modules are tidied
@@ -198,7 +203,7 @@ export CONTROLLER_GEN=$(TOOLS_HOST_DIR)/controller-gen-$(CONTROLLER_GEN_VERSION)
 export YQ=$(TOOLS_HOST_DIR)/yq-v3
 $(CONTROLLER_GEN) $(YQ):
 	{ \
-		set -ex ;\
+		set -e ;\
 		mkdir -p $(TOOLS_HOST_DIR) ;\
 		CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 		cd $$CONTROLLER_GEN_TMP_DIR ;\


### PR DESCRIPTION
CI fails on builds of release branches when Jenkins runs unit tests with the warning below:

    [2021-04-15T14:15:28.461Z] go: inconsistent vendoring in /home/rook/go/src/github.com/rook/rook:
    [2021-04-15T14:15:28.461Z] 	github.com/jstemmer/go-junit-report@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt

Fix this by running `go mod vendor` before each build.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]