### PR TITLE
ceph: Allow pool replica min size 0 for EC pools

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -139,7 +139,7 @@ spec:
                       type: boolean
                     size:
                       description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     subFailureDomain:
                       description: SubFailureDomain the name of the sub-failure domain
@@ -4880,7 +4880,7 @@ spec:
                             type: boolean
                           size:
                             description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           subFailureDomain:
                             description: SubFailureDomain the name of the sub-failure domain
@@ -5019,7 +5019,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
@@ -6314,7 +6314,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
@@ -7087,7 +7087,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
@@ -7446,7 +7446,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
@@ -7584,7 +7584,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -142,7 +142,7 @@ spec:
                     type: boolean
                   size:
                     description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   subFailureDomain:
                     description: SubFailureDomain the name of the sub-failure domain
@@ -4883,7 +4883,7 @@ spec:
                           type: boolean
                         size:
                           description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                          minimum: 1
+                          minimum: 0
                           type: integer
                         subFailureDomain:
                           description: SubFailureDomain the name of the sub-failure domain
@@ -5022,7 +5022,7 @@ spec:
                         type: boolean
                       size:
                         description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       subFailureDomain:
                         description: SubFailureDomain the name of the sub-failure domain
@@ -6317,7 +6317,7 @@ spec:
                         type: boolean
                       size:
                         description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       subFailureDomain:
                         description: SubFailureDomain the name of the sub-failure domain
@@ -7090,7 +7090,7 @@ spec:
                         type: boolean
                       size:
                         description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       subFailureDomain:
                         description: SubFailureDomain the name of the sub-failure domain
@@ -7449,7 +7449,7 @@ spec:
                         type: boolean
                       size:
                         description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       subFailureDomain:
                         description: SubFailureDomain the name of the sub-failure domain
@@ -7587,7 +7587,7 @@ spec:
                         type: boolean
                       size:
                         description: Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       subFailureDomain:
                         description: SubFailureDomain the name of the sub-failure domain

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -799,7 +799,7 @@ type Status struct {
 // ReplicatedSpec represents the spec for replication in a pool
 type ReplicatedSpec struct {
 	// Size - Number of copies per object in a replicated storage pool, including the object itself (required for replicated pool type)
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Size uint `json:"size"`
 
 	// TargetSizeRatio gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In v1.6 EC pools are being disallowed by the schema since the minimum is set to 1 on the replicated.size. We expect the replicated.size to be 0 if an EC pool is being created.

**Which issue is resolved by this Pull Request:**
Resolves #7661 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
