### PR TITLE
test: do not allow go.test parallel dependencies (bp #7664)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
     - '**.go'
+    - build/makelib/golang.mk
+    - Makefile
 
 jobs:
   unittests:

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -127,8 +127,11 @@ go.install:
 	@echo === go install $(PLATFORM)
 	$(foreach p,$(GO_STATIC_PACKAGES),@CGO_ENABLED=0 $(GO) install -v $(GO_STATIC_FLAGS) $(p)${\n})
 
+# GOJUNIT and go.mod.vendor need to happen in order and NOT in parallel, so call them explicitly
 .PHONY: go.test.unit
-go.test.unit: $(GOJUNIT) go.mod.vendor
+go.test.unit: 
+	@$(MAKE) $(GOJUNIT) 
+	@$(MAKE) go.mod.vendor
 	@echo === go test unit-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
 	CGO_ENABLED=0 $(GOHOST) test -v -cover $(GO_STATIC_FLAGS) $(GO_PACKAGES)


### PR DESCRIPTION
Dependencies for `make go.test` have to run in order, so call them
explicitly from the target rather than allowing them to be done in
parallel if `make -j` flag is used.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>
(cherry picked from commit a818a01a13c04cff5dc89c3ce92fa2cbc4217ce3)

// skip jenkins
[skip ci]

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
