### PR TITLE
ceph: use v14 image again for integration tests

### DIFF
--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -43,7 +43,10 @@ import (
 
 const (
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14.2.12"
+	nautilusTestImage = "ceph/ceph:v14"
+	// nautilusTestImagePartition is the image that contains working ceph-volume code to deploy OSDs on partitions
+	// currently only used for the upgrade test from 1.5 to 1.6, this cannot be changed to v14 since ceph-volume will fail to deploy OSD on partition on Rook 1.5
+	nautilusTestImagePartition = "ceph/ceph:v14.2.12"
 	// test with the latest octopus build
 	octopusTestImage = "ceph/ceph:v15"
 	// test with the latest pacific build
@@ -55,10 +58,11 @@ const (
 )
 
 var (
-	NautilusVersion = cephv1.CephVersionSpec{Image: nautilusTestImage}
-	OctopusVersion  = cephv1.CephVersionSpec{Image: octopusTestImage}
-	PacificVersion  = cephv1.CephVersionSpec{Image: pacificTestImage}
-	MasterVersion   = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
+	NautilusVersion          = cephv1.CephVersionSpec{Image: nautilusTestImage}
+	NautilusPartitionVersion = cephv1.CephVersionSpec{Image: nautilusTestImagePartition}
+	OctopusVersion           = cephv1.CephVersionSpec{Image: octopusTestImage}
+	PacificVersion           = cephv1.CephVersionSpec{Image: pacificTestImage}
+	MasterVersion            = cephv1.CephVersionSpec{Image: masterTestImage, AllowUnsupported: true}
 )
 
 // CephInstaller wraps installing and uninstalling rook on a platform

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -85,7 +85,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		UseCSI:            true,
 		SkipOSDCreation:   false,
 		RookVersion:       installer.Version1_5,
-		CephVersion:       installer.NautilusVersion,
+		CephVersion:       installer.NautilusPartitionVersion,
 	}
 
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, upgradeMinimalTestVersion)


### PR DESCRIPTION
**Description of your changes:**

Since Rook 1.6 is using raw mode for simple OSD scenarios we can use v14
again without having issue with ceph-volume.

Closes: https://github.com/rook/rook/issues/7669
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
