### PR TITLE
docs: remove unrelated text "this is long video b"

### DIFF
--- a/Documentation/ceph-dashboard.md
+++ b/Documentation/ceph-dashboard.md
@@ -128,7 +128,7 @@ kubectl -n rook-ceph get service
 >```
 >NAME                                    TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
 >rook-ceph-mgr                           ClusterIP   10.108.111.192   <none>        9283/TCP         4h
->rook-ceph-mgr-dashboard  this is long video b               ClusterIP   10.110.113.240   <none>        8443/TCP         4h
+>rook-ceph-mgr-dashboard                 ClusterIP   10.110.113.240   <none>        8443/TCP         4h
 >rook-ceph-mgr-dashboard-external-https  NodePort    10.101.209.6     <none>        8443:31176/TCP   4h
 >```
 


### PR DESCRIPTION
[skip ci]

**Description of your changes:**
remove unrelated text in the documentation  "this is long video b" in the output of `kubectl -n rook-ceph get service` command
**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
