### PR TITLE
ci: build and run various make commands on MacOS

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -889,6 +889,7 @@ jobs:
 
   multi-cluster-mirroring:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,49 @@
+name: MacOS build
+on:
+  pull_request:
+
+jobs:
+  macos-build:
+    runs-on: macos-10.15
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: copy working directory to GOPATH
+      run: sudo mkdir -p /Users/runner/go/src/github.com && sudo cp -a /Users/runner/work/rook /Users/runner/go/src/github.com/
+
+    - name: build rook
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: |
+        # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
+        GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' VERSION=0 BUILD_CONTAINER_IMAGE=false build
+
+    - name: run codegen
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: GOPATH=$(go env GOPATH) make codegen
+
+    - name: validate codegen
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: tests/scripts/validate_modified_files.sh codegen
+
+    - name: run mod check
+      run: GOPATH=$(go env GOPATH) make -j $(nproc) mod.check
+
+    - name: validate modcheck
+      run: tests/scripts/validate_modified_files.sh modcheck
+
+    - name: run crds-gen
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: make csv-clean && GOPATH=$(go env GOPATH) make crds
+
+    - name: validate crds-gen
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: tests/scripts/validate_modified_files.sh crd
+
+    - name: setup tmate session for debugging
+      if: failure()
+      uses: mxschmitt/action-tmate@v3

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ do.build.platform.%:
 
 do.build.parallel: $(foreach p,$(PLATFORMS), do.build.platform.$(p))
 
-build: build.common ## Build source code for host platform.
+build: csv-clean build.common ## Build source code for host platform.
 	@$(MAKE) go.build
 # if building on non-linux platforms, also build the linux container
 ifneq ($(GOOS),linux)

--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -52,7 +52,9 @@ generating_crds_v1() {
   $YQ_BIN_PATH w -i cluster/olm/ceph/deploy/crds/ceph.rook.io_cephclusters.yaml spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.storage.properties.nodes.items.properties.volumeClaimTemplates.items.properties.metadata.x-kubernetes-preserve-unknown-fields true
   $YQ_BIN_PATH w -i cluster/olm/ceph/deploy/crds/ceph.rook.io_cephclusters.yaml spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.storage.properties.storageClassDeviceSets.items.properties.volumeClaimTemplates.items.properties.metadata.x-kubernetes-preserve-unknown-fields true
   # fixes a bug in yq: https://github.com/mikefarah/yq/issues/351 where the '---' gets removed
-  sed -i '1i ---' cluster/olm/ceph/deploy/crds/ceph.rook.io_cephclusters.yaml
+  sed -i'' -e '1i\
+---
+' cluster/olm/ceph/deploy/crds/ceph.rook.io_cephclusters.yaml
 }
 
 generating_crds_v1alpha2() {

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -129,8 +129,8 @@ go.install:
 
 # GOJUNIT and go.mod.vendor need to happen in order and NOT in parallel, so call them explicitly
 .PHONY: go.test.unit
-go.test.unit: 
-	@$(MAKE) $(GOJUNIT) 
+go.test.unit:
+	@$(MAKE) $(GOJUNIT)
 	@$(MAKE) go.mod.vendor
 	@echo === go test unit-tests
 	@mkdir -p $(GO_TEST_OUTPUT)
@@ -211,9 +211,9 @@ $(CONTROLLER_GEN) $(YQ):
 		CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 		cd $$CONTROLLER_GEN_TMP_DIR ;\
 		go mod init tmp;\
-		unset GOOS GOARCH  # avoid error: "cannot install cross-compiled binaries when GOBIN is set" ;\
-		export CGO_ENABLED=0  # do not need gcc nor the errors that come with not having it ;\
-		export GOBIN=$$CONTROLLER_GEN_TMP_DIR  # go get dependencies into the temp dir ;\
+		unset GOOS GOARCH ;\
+		export CGO_ENABLED=0 ;\
+		export GOBIN=$$CONTROLLER_GEN_TMP_DIR ;\
 		echo === installing controller-gen ;\
 		go get sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_GEN_VERSION);\
 		mv $$CONTROLLER_GEN_TMP_DIR/controller-gen $(CONTROLLER_GEN) ;\

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -70,11 +70,13 @@ do.build: generate-csv-ceph-templates
 		mkdir $(TEMP)/ceph-csv-templates;\
 	fi
 	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
-	@$(DOCKERCMD) build $(BUILD_ARGS) \
+	@if [ -z "$(BUILD_CONTAINER_IMAGE)" ]; then\
+		$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
 		-t $(CEPH_IMAGE) \
-		$(TEMP)
+		$(TEMP);\
+	fi
 	@rm -fr $(TEMP)
 	@$(MAKE) -C ../.. crds # revert changes made to the crds.yaml file during the csv-gen sequence
 


### PR DESCRIPTION
**Description of your changes:**

Introducing a small action on MacOS to help us catch errors with various
'make' command on OSX, most notably 'sed' versus 'gnu-sed'.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]