### PR TITLE
docs: reset the pending release notes

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,6 +1,6 @@
 # Major Themes
 
-v1.6...
+v1.7...
 
 ## K8s Version Support
 
@@ -9,31 +9,9 @@ v1.6...
 ## Breaking Changes
 
 ### Ceph
-* Support for adding OSDs via Drive Groups was removed. Please refer to the
-  [Ceph upgrade guide](Documentation/ceph-upgrade.md#migrate-the-drive-group-spec) for migration
-  instructions.
-  See https://github.com/rook/rook/issues/7275 for more information.
 
 ## Features
 
 ### Core
 
 ### Ceph
-
-* Ceph Pacific support and along with it:
-  * Multiple Ceph Filesystems
-  * Networking dualstack
-* CephClient CRD has been converted to use the controller-runtime library
-* Extending the support of vault KMS configuration for Ceph RGW
-* Enable disruption budgets (PDBs) by default for Mon, RGW, MDS, and OSD daemons
-* Add CephFilesystemMirror CRD to deploy cephfs-mirror daemon
-* Multiple Ceph mgr daemons are supported for stretch clusters and other clusters where HA of the mgr is more critical
-* OSDs:
-  * as of Nautilus 14.2.14 and Octopus 15.2.9 if the OSD scenario is simple (one OSD per disk) we won't use LVM to prepare the disk anymore
-  * for Pacific (16.2.x), Rook is able to update multiple OSD Deployments at the same time to speed
-    up updates and upgrades for larger Ceph clusters
-* Disable CSI GRPC metrics by default
-* Update CephCSI to v3.3.0
-* Monitors failover can be [disabled](Documentation/ceph-mon-health.md#failing-over-a-monitor), this is useful for monitor going under planned maintenance where automatic failover is not desired
-* RGW: Rook has started using deployment's replicatset functionality instead of deploying multiple deployments for each rgw
-* Support running Volume Replication Controller on the RBD provisioner pod. Depends on Cephcsi v3.3.0


### PR DESCRIPTION
Since the v1.6 release is completed, reset the pending release notes
for v1.7.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]