### PR TITLE
bot: set the correct k8s version for mergify auto-merge on 1.6

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -143,11 +143,11 @@ pull_request_rules:
       - 'check-success=encryption-pvc-db-wal'
       - 'check-success=encryption-pvc-kms-vault-token-auth'
       - 'check-success=TestCephSmokeSuite (v1.15.12)'
-      - 'check-success=TestCephSmokeSuite (v1.21.0)'
+      - 'check-success=TestCephSmokeSuite (v1.20.2)'
       - 'check-success=TestCephHelmSuite (v1.15.12)'
-      - 'check-success=TestCephHelmSuite (v1.21.0)'
-      - 'check-success=TestCephMultiClusterDeploySuite (v1.21.0)'
-      - 'check-success=TestCephUpgradeSuite (v1.21.0)'
+      - 'check-success=TestCephHelmSuite (v1.20.2)'
+      - 'check-success=TestCephMultiClusterDeploySuite (v1.20.2)'
+      - 'check-success=TestCephUpgradeSuite (v1.20.2)'
     actions:
       merge:
         method: merge


### PR DESCRIPTION
In the release-1.6 branch, the k8s versions are different, we run
v1.20.2 where the master branch runs v1.21.0

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]