### PR TITLE
ceph: prevent disk flapping problem in master

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -44,6 +44,10 @@ jobs:
         # search for the device since it keeps changing between sda and sdb
         sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -104,6 +108,10 @@ jobs:
         # search for the device since it keeps changing between sda and sdb
         sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -166,6 +174,10 @@ jobs:
         # search for the device since it keeps changing between sda and sdb
         sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -227,6 +239,10 @@ jobs:
         # search for the device since it keeps changing between sda and sdb
         sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |
@@ -287,6 +303,10 @@ jobs:
         # search for the device since it keeps changing between sda and sdb
         sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
         sudo lsblk
+        # add a udev rule to force the disk partitions to ceph
+        # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
+        # for more details see: https://github.com/rook/rook/issues/7405
+        echo "SUBSYSTEM==\"block\", ATTR{size}==\"29356032\", ACTION==\"add\", RUN+=\"/bin/chown 167:167 $PARTITION\"" | sudo tee -a /etc/udev/rules.d/01-rook.rules
 
     - name: build rook
       run: |


### PR DESCRIPTION
**Description of your changes:**

We resolved disk flapping problem (#7405) with #7467. However, this fix was not applied to integration test in master.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
