### PR TITLE
ceph: Expand Mon Pvc's

### DIFF
--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -49,8 +50,11 @@ func (c *Cluster) getLabels(monConfig *monConfig, canary, includeNewLabels bool)
 		labels["mon_canary"] = "true"
 	}
 	if includeNewLabels {
-		if c.monVolumeClaimTemplate(monConfig) != nil {
+		monVolumeClaimTemplate := c.monVolumeClaimTemplate(monConfig)
+		if monVolumeClaimTemplate != nil {
+			size := monVolumeClaimTemplate.Spec.Resources.Requests[v1.ResourceStorage]
 			labels["pvc_name"] = monConfig.ResourceName
+			labels["pvc_size"] = size.String()
 		}
 		if monConfig.Zone != "" {
 			labels["stretch-zone"] = monConfig.Zone

--- a/pkg/operator/ceph/cluster/osd/deviceset_test.go
+++ b/pkg/operator/ceph/cluster/osd/deviceset_test.go
@@ -27,7 +27,6 @@ import (
 	testexec "github.com/rook/rook/pkg/operator/test"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -232,42 +231,6 @@ func testVolumeClaim(name string) corev1.PersistentVolumeClaim {
 	}}
 	claim.Name = name
 	return claim
-}
-
-func TestUpdatePVCSize(t *testing.T) {
-	clientset := testexec.New(t, 1)
-	context := &clusterd.Context{
-		Clientset: clientset,
-	}
-	cluster := &Cluster{
-		context:     context,
-		clusterInfo: client.AdminClusterInfo("testns"),
-	}
-	current := &corev1.PersistentVolumeClaim{}
-	desired := &corev1.PersistentVolumeClaim{}
-	current.Spec.Resources.Requests = corev1.ResourceList{}
-	desired.Spec.Resources.Requests = corev1.ResourceList{}
-	current.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("5Gi")
-
-	// Nothing happens if no size is set on the new PVC
-	cluster.updatePVCIfChanged(desired, current)
-	result, ok := current.Spec.Resources.Requests[corev1.ResourceStorage]
-	assert.True(t, ok)
-	assert.Equal(t, "5Gi", result.String())
-
-	// Nothing happens if the size shrinks
-	desired.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("4Gi")
-	cluster.updatePVCIfChanged(desired, current)
-	result, ok = current.Spec.Resources.Requests[corev1.ResourceStorage]
-	assert.True(t, ok)
-	assert.Equal(t, "5Gi", result.String())
-
-	// The size is updated when it increases
-	desired.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("6Gi")
-	cluster.updatePVCIfChanged(desired, current)
-	result, ok = current.Spec.Resources.Requests[corev1.ResourceStorage]
-	assert.True(t, ok)
-	assert.Equal(t, "6Gi", result.String())
 }
 
 func TestPrepareDeviceSetsWithCrushParams(t *testing.T) {

--- a/pkg/operator/k8sutil/pvc.go
+++ b/pkg/operator/k8sutil/pvc.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ExpandPVCIfRequired will expand the PVC if requested size is greater than the actual size of existing PVC
+func ExpandPVCIfRequired(client client.Client, desiredPVC *v1.PersistentVolumeClaim, currentPVC *v1.PersistentVolumeClaim) {
+	desiredSize, desiredOK := desiredPVC.Spec.Resources.Requests[v1.ResourceStorage]
+	currentSize, currentOK := currentPVC.Spec.Resources.Requests[v1.ResourceStorage]
+	if !desiredOK || !currentOK {
+		logger.Debugf("desired or current size are not specified for PVC %q", currentPVC.Name)
+		return
+	}
+	if desiredSize.Value() > currentSize.Value() {
+		currentPVC.Spec.Resources.Requests[v1.ResourceStorage] = desiredSize
+		logger.Infof("updating PVC %q size from %s to %s", currentPVC.Name, currentSize.String(), desiredSize.String())
+		if err := client.Update(context.TODO(), currentPVC); err != nil {
+			// log the error, but don't fail the reconcile
+			logger.Errorf("failed to update PVC size. %v", err)
+			return
+		}
+		logger.Infof("successfully updated PVC %q size", currentPVC.Name)
+	} else if desiredSize.Value() < currentSize.Value() {
+		logger.Warningf("ignoring request to shrink PVC %q size from %s to %s, only expansion is allowed", currentPVC.Name, currentSize.String(), desiredSize.String())
+	}
+}

--- a/pkg/operator/k8sutil/pvc_test.go
+++ b/pkg/operator/k8sutil/pvc_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestExpandPVCIfRequired(t *testing.T) {
+
+	testcases := []struct {
+		label          string
+		currentPVCSize string
+		desiredPVCSize string
+	}{
+		{
+			label:          "case 1: size is equal",
+			currentPVCSize: "1Mi",
+			desiredPVCSize: "1Mi",
+		},
+		{
+			label:          "case 2: current size is less",
+			currentPVCSize: "1Mi",
+			desiredPVCSize: "2Mi",
+		},
+		{
+			label:          "case 3: current size is more",
+			currentPVCSize: "2Mi",
+			desiredPVCSize: "1Mi",
+		},
+	}
+
+	desiredPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "rook-ceph",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): apiresource.MustParse("1Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+
+		desiredPVC.Spec.Resources.Requests[v1.ResourceStorage] = apiresource.MustParse(tc.currentPVCSize)
+
+		// create fake client with PVC
+		cl := fake.NewClientBuilder().WithRuntimeObjects(desiredPVC).Build()
+
+		// get existing PVC
+		existingPVC := &v1.PersistentVolumeClaim{}
+		err := cl.Get(context.TODO(), client.ObjectKey{Name: "test", Namespace: "rook-ceph"}, existingPVC)
+		assert.NoError(t, err)
+
+		desiredPVC.Spec.Resources.Requests[v1.ResourceStorage] = apiresource.MustParse(tc.desiredPVCSize)
+
+		ExpandPVCIfRequired(cl, desiredPVC, existingPVC)
+
+		// get existing PVC
+		err = cl.Get(context.TODO(), client.ObjectKey{Name: "test", Namespace: "rook-ceph"}, existingPVC)
+		assert.NoError(t, err)
+
+		// verify size
+		if tc.currentPVCSize <= tc.desiredPVCSize {
+			assert.Equal(t, desiredPVC.Spec.Resources.Requests[v1.ResourceStorage], existingPVC.Spec.Resources.Requests[v1.ResourceStorage])
+		} else {
+			assert.Equal(t, apiresource.MustParse(tc.currentPVCSize), existingPVC.Spec.Resources.Requests[v1.ResourceStorage])
+		}
+	}
+}


### PR DESCRIPTION
Expand Mon Pvc's if storage request has increased for the Mons in the
cephcluster crd.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

**Description of your changes:**
rook will now expand the mon PVC's if the size of mon storage has changed/increased in the cephcluster CRD
rook will do nothing if size in the cephcluster CRD is less than actual size of PVC or equal to the actual size of PVC.


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
