### PR TITLE
ci: mitigate block locking issues and flapping mirroring test

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1001,7 +1001,7 @@ jobs:
     - name: verify image has been mirrored
       run: |
         # let's wait a bit for the image to be present
-        timeout 30 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored" && sleep 1; done'
+        timeout 120 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored" && sleep 1; done'
 
     - name: display cephblockpool and image status
       run: |

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -42,7 +42,8 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
         # add a udev rule to force the disk partitions to ceph
         # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
@@ -106,7 +107,8 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
         # add a udev rule to force the disk partitions to ceph
         # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
@@ -172,7 +174,8 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
         # add a udev rule to force the disk partitions to ceph
         # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
@@ -237,7 +240,8 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
         # add a udev rule to force the disk partitions to ceph
         # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk
@@ -301,7 +305,8 @@ jobs:
         sudo swapoff --all --verbose
         sudo umount /mnt
         # search for the device since it keeps changing between sda and sdb
-        sudo wipefs --all --force /dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1
+        PARTITION="/dev/$(lsblk|awk '/14G/ {print $1}'| head -1)1"
+        sudo wipefs --all --force "$PARTITION"
         sudo lsblk
         # add a udev rule to force the disk partitions to ceph
         # we have observed that some runners keep detaching/re-attaching the additional disk overriding the permissions to the default root:disk

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -17,6 +17,7 @@ data:
     [global]
     osd_pool_default_size = 1
     mon_warn_on_pool_no_redundancy = false
+    bdev_flock_retry = 20
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephCluster

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -570,7 +570,7 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 				}
 
 				// Return failure
-				return errors.Wrap(err, "failed to run ceph-volume raw command") // fail return here as validation provided by ceph-volume
+				return errors.Wrapf(err, "failed to run ceph-volume raw command. %s", op) // fail return here as validation provided by ceph-volume
 			}
 			logger.Infof("%v", op)
 		} else {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -229,6 +229,7 @@ func (h *CephInstaller) CreateCephCluster() error {
 		"config": `
 [global]
 osd_pool_default_size = 1
+bdev_flock_retry = 20
 `}
 	customCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
ci: increase the number of lock retries

We have seen new cases where retrying to lock the device 3 times is not
enough. It's the same race we had experienced where Ceph tries to
acquire a lock on the device but systemd-udevd does the same too.
Retrying 20 times every 0.1sec seems to mitigate that issue in the CI.

ci: wait a bit longer for the mirroring to happen

30sec was not enough see:

```
  # let's wait a bit for the image to be present
  timeout 30 sh -c 'until [ "$(kubectl exec -n rook-ceph-secondary deploy/rook-ceph-tools -t -- rbd -p replicapool ls|grep -c test)" -eq 1 ]; do echo "waiting for image to be mirrored" && sleep 1; done'
  shell: /bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.16.3/x64
    MINIKUBE_HOME: /home/runner/work/_temp
unable to get monitor info from DNS SRV with service name: ceph-mon
rbd: couldn't connect to the cluster!
rbd: listing images failed: (2) No such file or directory
2021-04-22T08:17:47.053+0000 7f824b13e2c0 -1 failed for service _ceph-mon._tcp
2021-04-22T08:17:47.053+0000 7f824b13e2c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
command terminated with exit code 2
waiting for image to be mirrored
unable to get monitor info from DNS SRV with service name: ceph-mon
rbd: couldn't connect to the cluster!
rbd: listing images failed: (2) No such file or directory
2021-04-22T08:17:48.317+0000 7f31f6d372c0 -1 failed for service _ceph-mon._tcp
2021-04-22T08:17:48.317+0000 7f31f6d372c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
command terminated with exit code 2
waiting for image to be mirrored
unable to get monitor info from DNS SRV with service name: ceph-mon
rbd: couldn't connect to the cluster!
rbd: listing images failed: (2) No such file or directory
2021-04-22T08:17:49.597+0000 7fa3a2ac52c0 -1 failed for service _ceph-mon._tcp
2021-04-22T08:17:49.597+0000 7fa3a2ac52c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
command terminated with exit code 2
waiting for image to be mirrored
unable to get monitor info from DNS SRV with service name: ceph-mon
rbd: couldn't connect to the cluster!
rbd: listing images failed: (2) No such file or directory
2021-04-22T08:17:50.873+0000 7fab17fb12c0 -1 failed for service _ceph-mon._tcp
2021-04-22T08:17:50.873+0000 7fab17fb12c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
command terminated with exit code 2
waiting for image to be mirrored
unable to get monitor info from DNS SRV with service name: ceph-mon
rbd: couldn't connect to the cluster!
rbd: listing images failed: (2) No such file or directory
2021-04-22T08:17:52.169+0000 7f944f52f2c0 -1 failed for service _ceph-mon._tcp
2021-04-22T08:17:52.169+0000 7f944f52f2c0 -1 monclient: get_monmap_and_config cannot identify monitors to contact
command terminated with exit code 2
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
waiting for image to be mirrored
Error: Process completed with exit code 124.
```

However, when logging into the runner, the image was replicated.

[skip ci]