### PR TITLE
docs: workaround preserveUnknownFields upgrade

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -298,6 +298,18 @@ Then apply the latest changes from v1.6.
 kubectl apply -f common.yaml -f crds.yaml
 ```
 
+> **NOTE:** If your Rook-Ceph cluster was initially installed with rook v1.4 or lower, the above
+> command will return errors due to updates from Kubernetes' v1beta1 Custom Resource Definitions.
+> The error will contain text similar to `... spec.preserveUnknownFields: Invalid value...`.
+
+If you experience this error applying the latest changes to CRDs, use `kubectl`'s `replace` command
+to replace the resources followed by `apply` to verify that the resources are updated without other 
+errors.
+```sh
+kubectl replace -f crds.yaml
+kubectl apply -f crds.yaml
+```
+
 ## 2. Update Ceph CSI versions
 
 > Automatically updated if you are upgrading via the helm chart


### PR DESCRIPTION
When upgrading Rook clusters created before v1.5,
`kubectl apply -f crds.yaml` fails due to the existence of
the usupported `spec.preserveUnknownFields`. Add text documenting how to
work around this issue in the Ceph upgrade docs.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7659 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
