### PR TITLE
ceph: Detect the osd topology affinity during upgrade

### DIFF
--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -421,7 +421,7 @@ func TestGetOSDInfo(t *testing.T) {
 
 	node := "n1"
 	location := "root=default host=myhost zone=myzone"
-	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location}
+	osd1 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "dev/logical-volume-path", CVMode: "raw", Location: location, TopologyAffinity: "topology.rook.io/rack=rack0"}
 	osd2 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "vg1/lv1", CVMode: "lvm", LVBackedPV: true}
 	osd3 := OSDInfo{ID: 3, UUID: "osd-uuid", BlockPath: "", CVMode: "raw"}
 	osdProp := osdProperties{
@@ -430,6 +430,7 @@ func TestGetOSDInfo(t *testing.T) {
 		selection:     rookv1.Selection{},
 		resources:     corev1.ResourceRequirements{},
 		storeConfig:   config.StoreConfig{},
+		portable:      true,
 	}
 	dataPathMap := &provisionConfig{
 		DataPathMap: opconfig.NewDatalessDaemonDataPathMap(c.clusterInfo.Namespace, c.spec.DataDirHostPath),
@@ -442,6 +443,8 @@ func TestGetOSDInfo(t *testing.T) {
 		assert.Equal(t, osd1.BlockPath, osdInfo1.BlockPath)
 		assert.Equal(t, osd1.CVMode, osdInfo1.CVMode)
 		assert.Equal(t, location, osdInfo1.Location)
+		assert.Equal(t, osd1.TopologyAffinity, osdInfo1.TopologyAffinity)
+		osdProp.portable = false
 
 		d2, _ := c.makeDeployment(osdProp, osd2, dataPathMap)
 		osdInfo2, _ := c.getOSDInfo(d2)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The nodeAffinity for portable OSDs is needed to ensure the OSDs are tied to the same zone or other failure domain where the OSD was prepared and where it is expected to run. During upgrade the topology affinity was not being detected since the osd prepare job is skipped in that case. Now the topology will be detected from the running OSD daemon pod's node.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
