### PR TITLE
ceph: implement CephCluster CRD Helm Chart

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -1,0 +1,104 @@
+---
+title: Ceph Cluster
+weight: 10200
+indent: true
+---
+
+{% include_relative branch.liquid %}
+
+# Ceph Cluster Helm Chart
+
+Installs a [Ceph](https://ceph.io/) cluster on Rook using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+* Kubernetes 1.13+
+* Helm 3.x
+* Preinstalled Rook Operator. See the [Helm Operator](https://rook.github.io/docs/rook/master/helm-operator.html) topic to install.
+
+## Installing
+
+The `helm install` command deploys rook on the Kubernetes cluster in the default configuration.
+The [configuration](#configuration) section lists the parameters that can be configured during installation. It is
+recommended that the rook operator be installed into the `rook-ceph` namespace (you will install your clusters into
+separate namespaces).
+
+If the operator was installed in a non-default location, the namespace of the *Rook Operator* installed
+must be set in the `operatorNamespace` variable.
+
+Rook currently publishes builds of this chart to the `release` and `master` channels.
+
+### Release
+
+The release channel is the most recent release of Rook that is considered stable for the community.
+
+```console
+helm repo add rook-release https://charts.rook.io/release
+helm install --create-namespace --namespace rook-ceph rook-ceph --set operatorNamespace=rook-ceph rook-release/rook-ceph-cluster
+```
+
+### Development Build
+
+To deploy from a local build from your development environment:
+
+1. Install the helm chart:
+
+```console
+cd cluster/charts/rook-ceph-cluster
+helm install --create-namespace --namespace rook-ceph rook-ceph-cluster .
+```
+
+## Uninstalling the Chart
+
+To see the currently installed Rook chart:
+
+```console
+helm ls --namespace rook-ceph
+```
+
+To uninstall/delete the `rook-ceph-cluster` chart:
+
+```console
+helm delete --namespace rook-ceph rook-ceph-cluster
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release. Removing the cluster
+chart does not remove the Rook operator. In addition, all data on hosts in the Rook data directory
+(`/var/lib/rook` by default) and on OSD raw devices is kept. To reuse disks, you will have to wipe them before recreating the cluster.
+
+See the [teardown documentation](ceph-teardown.md) for more information.
+
+## Configuration
+
+The following tables lists the configurable parameters of the rook-operator chart and their default values.
+
+| Parameter               | Description                                                          | Default                 |
+|-----------------------  |----------------------------------------------------------------------|-------------------------|
+| `operatorNamespace`     | Namespace of the Rook Operator                                       | `rook-ceph`             |
+| `configOverride`        | Cluster ceph.conf override                                           | <empty>                 |
+| `toolbox.enabled`       | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`                 |
+| `toolbox.tolerations`   | Toolbox tolerations                                                  | `[]`                    |
+| `toolbox.affinity`      | Toolbox affinity                                                     | `{}`                    |
+| `monitoring.enabled`    | Enable Prometheus integration, will also create necessary RBAC rules | `false`                 |
+| `cephClusterSpec.*`     | Cluster configuration, see below                                     | See below               |
+
+### Ceph Cluster Spec
+
+The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
+For the full list, see the [Cluster CRD](https://rook.github.io/docs/rook/master/ceph-cluster-crd.html).
+
+### Command Line
+
+You can pass the settings with helm command line parameters. Specify each parameter using the
+`--set key=value[,key=value]` argument to `helm install`.
+
+### Settings File
+
+Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while
+installing the chart.
+
+```console
+helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph-cluster -f values-override.yaml
+```
+
+For example settings, see [values.yaml](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)

--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # the helm charts to build
-HELM_CHARTS ?= rook-ceph
+HELM_CHARTS ?= rook-ceph rook-ceph-cluster
 HELM_BASE_URL ?= https://charts.rook.io
 HELM_S3_BUCKET ?= rook.chart
 HELM_CHARTS_DIR ?= $(ROOT_DIR)/cluster/charts

--- a/cluster/charts/rook-ceph-cluster/.helmignore
+++ b/cluster/charts/rook-ceph-cluster/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.tmpl

--- a/cluster/charts/rook-ceph-cluster/Chart.yaml
+++ b/cluster/charts/rook-ceph-cluster/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+description: Manages a single Ceph cluster namespace for Rook
+name: rook-ceph-cluster
+version: 0.0.1
+icon: https://rook.io/images/rook-logo.svg
+sources:
+  - https://github.com/rook/rook

--- a/cluster/charts/rook-ceph-cluster/README.md
+++ b/cluster/charts/rook-ceph-cluster/README.md
@@ -1,0 +1,1 @@
+See the [Helm Ceph Cluster](/Documentation/helm-ceph-cluster.md) documentation.

--- a/cluster/charts/rook-ceph-cluster/templates/NOTES.txt
+++ b/cluster/charts/rook-ceph-cluster/templates/NOTES.txt
@@ -1,0 +1,8 @@
+The Ceph Cluster has been installed. Check its status by running:
+  kubectl --namespace {{ .Release.Namespace }} get cephcluster
+
+Visit https://rook.github.io/docs/rook/master/ceph-cluster-crd.html for more information about the Ceph CRD.
+
+Important Notes:
+- You can only deploy a single cluster per namespace
+- If you wish to delete this cluster and start fresh, you will also have to wipe the OSD disks using `sfdisk`

--- a/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define imagePullSecrets option to pass to all service accounts
+*/}}
+{{- define "imagePullSecrets" }}
+{{- if .Values.imagePullSecrets -}}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets }}
+{{- end -}}
+{{- end -}}

--- a/cluster/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: {{ .Release.Namespace }}
+spec:
+  monitoring:
+    rulesNamespace: {{ default .Release.Namespace .Values.monitoring.rulesNamespaceOverride }}
+{{ toYaml .Values.monitoring | indent 4 }}
+
+{{ toYaml .Values.cephClusterSpec | indent 2 }}

--- a/cluster/charts/rook-ceph-cluster/templates/clusterrolebinding.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+{{- if ne .Release.Namespace .Values.operatorNamespace }}
+---
+# Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr-cluster-{{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-cluster
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }}
+---
+# Allow the ceph osd to access cluster-wide resources necessary for determining their topology location
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd-{{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-osd
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/configmap.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.configOverride }}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rook-config-override
+data:
+  config: |
+{{ .Values.configOverride | nindent 4 }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.toolbox.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rook-ceph-tools
+  labels:
+    app: rook-ceph-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rook-ceph-tools
+  template:
+    metadata:
+      labels:
+        app: rook-ceph-tools
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+{{- if default "" .Values.cephClusterSpec.network.provider | eq "host" }}
+      hostNetwork: true
+{{- end }}
+      containers:
+        - name: rook-ceph-tools
+          image: {{ .Values.toolbox.image }}
+          command: ["/tini"]
+          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ROOK_CEPH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-username
+            - name: ROOK_CEPH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-mon
+                  key: ceph-secret
+          volumeMounts:
+            - mountPath: /etc/ceph
+              name: ceph-config
+            - name: mon-endpoint-volume
+              mountPath: /etc/rook
+      volumes:
+        - name: mon-endpoint-volume
+          configMap:
+            name: rook-ceph-mon-endpoints
+            items:
+                - key: data
+                  path: mon-endpoints
+        - name: ceph-config
+          emptyDir: {}
+      tolerations:
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 5
+{{- if .Values.toolbox.tolerations }}
+{{ toYaml .Values.toolbox.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.toolbox.affinity }}
+      affinity:
+{{ toYaml .Values.toolbox.affinity | indent 8 }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/role.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/role.yaml
@@ -1,0 +1,89 @@
+{{- if ne .Release.Namespace .Values.operatorNamespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["ceph.rook.io"]
+    resources: ["cephclusters", "cephclusters/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cmd-reporter
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+
+{{- if .Values.monitoring.enabled }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/rolebinding.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/rolebinding.yaml
@@ -1,0 +1,87 @@
+{{- if ne .Release.Namespace .Values.operatorNamespace }}
+---
+# Allow the operator to create resources in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cluster-mgmt
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: {{ .Values.operatorNamespace }}
+---
+# Allow the osd pods in this namespace to work with configmaps
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-osd
+---
+# Allow the ceph mgr to access the cluster-specific resources necessary for the mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-mgr
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+---
+# Allow the ceph mgr to access the rook system resources necessary for the mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr-system-{{ .Release.Namespace }}
+  namespace: {{ .Values.operatorNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-system
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cmd-reporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-cmd-reporter
+    namespace: {{ .Release.Namespace }}
+
+{{- if .Values.monitoring.enabled }}
+---
+# Allow the operator to get ServiceMonitors in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: {{ .Values.operatorNamespace }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if ne .Release.Namespace .Values.operatorNamespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-osd
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-mgr
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -1,0 +1,274 @@
+# Default values for a single rook-ceph cluster
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Namespace of the main rook operator
+operatorNamespace: rook-ceph
+
+# Ability to override ceph.conf
+configOverride:
+#configOverride: |
+#  [global]
+#  mon_allow_pool_delete = true
+#
+#  osd_pool_default_size = 3
+#  osd_pool_default_min_size = 2
+
+# Installs a debugging toolbox deployment
+toolbox:
+  enabled: false
+  image: rook/ceph:VERSION
+  tolerations: []
+  affinity: {}
+
+monitoring:
+  # requires Prometheus to be pre-installed
+  # enabling will also create RBAC rules to allow Operator to create ServiceMonitors
+  enabled: false
+  rulesNamespaceOverride:
+
+# All values below are taken from the CephCluster CRD
+# More information can be found at [Ceph Cluster CRD](/Documentation/ceph-cluster-crd.md)
+cephClusterSpec:
+  cephVersion:
+    # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
+    # v13 is mimic, v14 is nautilus, and v15 is octopus.
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
+    # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
+    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.11-20200419
+    # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
+    image: ceph/ceph:v16.2.4
+    # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
+    # Future versions such as `pacific` would require this to be set to `true`.
+    # Do not set to true in production.
+    allowUnsupported: false
+
+  # The path on the host where configuration files will be persisted. Must be specified.
+  # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
+  # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
+  dataDirHostPath: /var/lib/rook
+  # Whether or not upgrade should continue even if a check fails
+  # This means Ceph's status could be degraded and we don't recommend upgrading but you might decide otherwise
+  # Use at your OWN risk
+  # To understand Rook's upgrade process of Ceph, read https://rook.io/docs/rook/master/ceph-upgrade.html#ceph-version-upgrades
+  skipUpgradeChecks: false
+  # Whether or not continue if PGs are not clean during an upgrade
+  continueUpgradeAfterChecksEvenIfNotHealthy: false
+  # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
+  # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
+  # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
+  # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
+  # The default wait timeout is 10 minutes.
+  waitTimeoutForHealthyOSDInMinutes: 10
+  mon:
+    # Set the number of mons to be started. Must be an odd number, and is generally recommended to be 3.
+    count: 3
+    # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
+    # Mons should only be allowed on the same node for test environments where data loss is acceptable.
+    allowMultiplePerNode: false
+  mgr:
+    # When higher availability of the mgr is needed, increase the count to 2.
+    # In that case, one mgr will be active and one in standby. When Ceph updates which
+    # mgr is active, Rook will update the mgr services to match the active mgr.
+    count: 1
+    modules:
+      # Several modules should not need to be included in this list. The "dashboard" and "monitoring" modules
+      # are already enabled by other settings in the cluster CR.
+      - name: pg_autoscaler
+        enabled: true
+  # enable the ceph dashboard for viewing cluster status
+  dashboard:
+    enabled: true
+    # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+    # urlPrefix: /ceph-dashboard
+    # serve the dashboard at the given port.
+    # port: 8443
+    # serve the dashboard using SSL
+    ssl: true
+  network:
+  # enable host networking
+  #provider: host
+  # EXPERIMENTAL: enable the Multus network provider
+  #provider: multus
+  #selectors:
+  # The selector keys are required to be `public` and `cluster`.
+  # Based on the configuration, the operator will do the following:
+  #   1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
+  #   2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
+  #
+  # In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
+  #
+  #public: public-conf --> NetworkAttachmentDefinition object name in Multus
+  #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+  # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
+  #ipFamily: "IPv6"
+  # Ceph daemons to listen on both IPv4 and Ipv6 networks
+  #dualStack: false
+  # enable the crash collector for ceph daemon crash collection
+  crashCollector:
+    disable: false
+    # Uncomment daysToRetain to prune ceph crash entries older than the
+    # specified number of days.
+    #daysToRetain: 30
+  # enable log collector, daemons will log on files and rotate
+  # logCollector:
+  #   enabled: true
+  #   periodicity: 24h # SUFFIX may be 'h' for hours or 'd' for days.
+  # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
+  cleanupPolicy:
+    # Since cluster cleanup is destructive to data, confirmation is required.
+    # To destroy all Rook data on hosts during uninstall, confirmation must be set to "yes-really-destroy-data".
+    # This value should only be set when the cluster is about to be deleted. After the confirmation is set,
+    # Rook will immediately stop configuring the cluster and only wait for the delete command.
+    # If the empty string is set, Rook will not destroy any data on hosts during uninstall.
+    confirmation: ""
+    # sanitizeDisks represents settings for sanitizing OSD disks on cluster deletion
+    sanitizeDisks:
+      # method indicates if the entire disk should be sanitized or simply ceph's metadata
+      # in both case, re-install is possible
+      # possible choices are 'complete' or 'quick' (default)
+      method: quick
+      # dataSource indicate where to get random bytes from to write on the disk
+      # possible choices are 'zero' (default) or 'random'
+      # using random sources will consume entropy from the system and will take much more time then the zero source
+      dataSource: zero
+      # iteration overwrite N times instead of the default (1)
+      # takes an integer value
+      iteration: 1
+    # allowUninstallWithVolumes defines how the uninstall should be performed
+    # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
+    allowUninstallWithVolumes: false
+  # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
+  # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
+  # tolerate taints with a key of 'storage-node'.
+  #  placement:
+  #    all:
+  #      nodeAffinity:
+  #        requiredDuringSchedulingIgnoredDuringExecution:
+  #          nodeSelectorTerms:
+  #          - matchExpressions:
+  #            - key: role
+  #              operator: In
+  #              values:
+  #              - storage-node
+  #      podAffinity:
+  #      podAntiAffinity:
+  #      topologySpreadConstraints:
+  #      tolerations:
+  #      - key: storage-node
+  #        operator: Exists
+  # The above placement information can also be specified for mon, osd, and mgr components
+  #    mon:
+  # Monitor deployments may contain an anti-affinity rule for avoiding monitor
+  # collocation on the same node. This is a required rule when host network is used
+  # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
+  # preferred rule with weight: 50.
+  #    osd:
+  #    mgr:
+  #    cleanup:
+  annotations:
+  #    all:
+  #    mon:
+  #    osd:
+  #    cleanup:
+  #    prepareosd:
+  # If no mgr annotations are set, prometheus scrape annotations will be set by default.
+  #    mgr:
+  labels:
+  #    all:
+  #    mon:
+  #    osd:
+  #    cleanup:
+  #    mgr:
+  #    prepareosd:
+  # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
+  # These labels can be passed as LabelSelector to Prometheus
+  #    monitoring:
+  resources:
+  # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+  #    mgr:
+  #      limits:
+  #        cpu: "500m"
+  #        memory: "1024Mi"
+  #      requests:
+  #        cpu: "500m"
+  #        memory: "1024Mi"
+  # The above example requests/limits can also be added to the other components
+  #    mon:
+  #    osd:
+  #    prepareosd:
+  #    mgr-sidecar:
+  #    crashcollector:
+  #    logcollector:
+  #    cleanup:
+  # The option to automatically remove OSDs that are out and are safe to destroy.
+  removeOSDsIfOutAndSafeToRemove: false
+  #  priorityClassNames:
+  #    all: rook-ceph-default-priority-class
+  #    mon: rook-ceph-mon-priority-class
+  #    osd: rook-ceph-osd-priority-class
+  #    mgr: rook-ceph-mgr-priority-class
+  storage: # cluster level storage configuration and selection
+    useAllNodes: true
+    useAllDevices: true
+    #deviceFilter:
+    config:
+    # crushRoot: "custom-root" # specify a non-default root label for the CRUSH map
+    # metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
+    # databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB
+    # journalSizeMB: "1024"  # uncomment if the disks are 20 GB or smaller
+    # osdsPerDevice: "1" # this value can be overridden at the node or device level
+    # encryptedDevice: "true" # the default value for this option is "false"
+  # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
+  # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
+  #    nodes:
+  #    - name: "172.17.4.201"
+  #      devices: # specific devices to use for storage can be specified for each node
+  #      - name: "sdb"
+  #      - name: "nvme01" # multiple osds can be created on high performance devices
+  #        config:
+  #          osdsPerDevice: "5"
+  #      - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # devices can be specified using full udev paths
+  #      config: # configuration can be specified at the node level which overrides the cluster level config
+  #    - name: "172.17.4.301"
+  #      deviceFilter: "^sd."
+  # The section for configuring management of daemon disruptions during upgrade or fencing.
+  disruptionManagement:
+    # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically
+    # via the strategy outlined in the [design](https://github.com/rook/rook/blob/master/design/ceph/ceph-managed-disruptionbudgets.md). The operator will
+    # block eviction of OSDs by default and unblock them safely when drains are detected.
+    managePodBudgets: true
+    # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
+    # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
+    osdMaintenanceTimeout: 30
+    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
+    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
+    # No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+    pgHealthCheckTimeout: 0
+    # If true, the operator will create and manage MachineDisruptionBudgets to ensure OSDs are only fenced when the cluster is healthy.
+    # Only available on OpenShift.
+    manageMachineDisruptionBudgets: false
+    # Namespace in which to watch for the MachineDisruptionBudgets.
+    machineDisruptionBudgetNamespace: openshift-machine-api
+
+  # healthChecks
+  # Valid values for daemons are 'mon', 'osd', 'status'
+  healthCheck:
+    daemonHealth:
+      mon:
+        disabled: false
+        interval: 45s
+      osd:
+        disabled: false
+        interval: 60s
+      status:
+        disabled: false
+        interval: 60s
+    # Change pod liveness probe, it works for all mon,mgr,osd daemons
+    livenessProbe:
+      mon:
+        disabled: false
+      mgr:
+        disabled: false
+      osd:
+        disabled: false

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/tevino/abool v1.2.0
 	github.com/yanniszark/go-nodetool v0.0.0-20191206125106-cd8f91fa16be
 	gopkg.in/ini.v1 v1.57.0
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.1
 	k8s.io/apiextensions-apiserver v0.20.1
 	k8s.io/apimachinery v0.20.1

--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installer
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	OperatorChartName    = "rook-ceph"
+	CephClusterChartName = "rook-ceph-cluster"
+)
+
+// CreateRookOperatorViaHelm creates rook operator via Helm chart named local/rook present in local repo
+func (h *CephInstaller) CreateRookOperatorViaHelm(values map[string]interface{}) error {
+	// create the operator namespace before the admission controller is created
+	if err := h.k8shelper.CreateNamespace(h.settings.OperatorNamespace); err != nil {
+		return errors.Errorf("failed to create namespace %s. %v", h.settings.Namespace, err)
+	}
+	if err := h.startAdmissionController(); err != nil {
+		return errors.Errorf("Failed to start admission controllers: %v", err)
+	}
+	if err := h.helmHelper.InstallLocalRookHelmChart(h.settings.OperatorNamespace, OperatorChartName, values); err != nil {
+		return errors.Errorf("failed to install rook operator via helm, err : %v", err)
+	}
+
+	return nil
+}
+
+// CreateRookCephClusterViaHelm creates rook cluster via Helm
+func (h *CephInstaller) CreateRookCephClusterViaHelm(values map[string]interface{}) error {
+	var err error
+	h.settings.DataDirHostPath, err = h.initTestDir(h.settings.Namespace)
+	if err != nil {
+		return err
+	}
+
+	var clusterCRD map[string]interface{}
+	if err := yaml.Unmarshal([]byte(h.Manifests.GetCephCluster()), &clusterCRD); err != nil {
+		return err
+	}
+
+	values["operatorNamespace"] = h.settings.OperatorNamespace
+	values["configOverride"] = clusterCustomSettings
+	values["toolbox"] = map[string]interface{}{
+		"enabled": true,
+		"image":   "rook/ceph:master",
+	}
+	values["cephClusterSpec"] = clusterCRD["spec"]
+
+	logger.Infof("Creating ceph cluster using Helm with values: %+v", values)
+	if err := h.helmHelper.InstallLocalRookHelmChart(h.settings.Namespace, CephClusterChartName, values); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This manages a CephCluster CRD, and is designed to be deployed into its own namespace to manage a single Ceph cluster independent of the main Rook operator.

Additional functions:
- Ability to setup ServiceMonitor for the Prometheus operator

Signed-off-by: Henry Zhang <me@henry.dev>

**Description of your changes:**

Implements a CephCluster chart that deploys the necessary roles, with the option of also deploying the toolbox
pod alongside the CRD.

I saw some progress on the issue regarding moving the charts out of the Rook repository. This is probably a good idea longer term, but as that ticket had stagnated, I went ahead and implemented this chart.

This is just a thin wrapper around the `CephCluster` CRD. The `values.yaml` is almost the `cluster.yaml` example.

Example template output: https://gist.github.com/henryzhangsta/026f471eda9a9f4c4c35dac4aebda926

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/2109

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
