### PR TITLE
ceph: fix external cluster mode

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -782,7 +782,7 @@ spec:
                       type: boolean
                     count:
                       description: Count is the number of Ceph monitors
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     stretchCluster:
                       description: StretchCluster is the stretch cluster specification

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -782,7 +782,7 @@ spec:
                       type: boolean
                     count:
                       description: Count is the number of Ceph monitors
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     stretchCluster:
                       description: StretchCluster is the stretch cluster specification

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -447,7 +447,7 @@ const (
 // MonSpec represents the specification of the monitor
 type MonSpec struct {
 	// Count is the number of Ceph monitors
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Count int `json:"count"`
 	// AllowMultiplePerNode determines if we can run multiple monitors on the same node (not recommended)
 	// +optional

--- a/pkg/operator/ceph/cluster/cluster_external.go
+++ b/pkg/operator/ceph/cluster/cluster_external.go
@@ -143,6 +143,7 @@ func (c *ClusterController) configureExternalCephCluster(cluster *cluster) error
 		}
 	}
 
+	// We don't update the connection status since it is done by the health go routine
 	return nil
 }
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -323,8 +323,29 @@ func (h *CephInstaller) CreateRookExternalCluster(externalManifests CephManifest
 		return errors.Wrap(err, "failed to start toolbox on external cluster")
 	}
 
-	logger.Info("Rook external cluster started")
-	return err
+	var clusterStatus cephv1.ClusterStatus
+	for i := 0; i < 8; i++ {
+		ctx := context.TODO()
+		clusterResource, err := h.k8shelper.RookClientset.CephV1().CephClusters(externalSettings.Namespace).Get(ctx, externalSettings.ClusterName, metav1.GetOptions{})
+		if err != nil {
+			logger.Warningf("failed to get external cluster CR, retrying. %v", err)
+			time.Sleep(time.Second * 5)
+			continue
+		}
+
+		clusterStatus = clusterResource.Status
+		clusterPhase := string(clusterResource.Status.Phase)
+		if clusterPhase != "Connected" {
+			logger.Warningf("failed to start external cluster, retrying, state: %v", clusterResource.Status)
+			time.Sleep(time.Second * 5)
+		} else if clusterPhase == "Connected" {
+			logger.Info("Rook external cluster connected")
+			return nil
+		}
+
+	}
+
+	return errors.Errorf("failed to start external cluster, state: %v", clusterStatus)
 }
 
 // InjectRookExternalClusterInfo inject connection information for an external cluster

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -478,7 +478,11 @@ metadata:
 spec:
   external:
     enable: true
-  dataDirHostPath: ` + m.settings.DataDirHostPath + ``
+  dataDirHostPath: ` + m.settings.DataDirHostPath + `
+  healthCheck:
+    daemonHealth:
+      status:
+        interval: 5s`
 }
 
 // GetRBDMirror returns the manifest to create a Rook Ceph RBD Mirror resource with the given config.


### PR DESCRIPTION
 Because of the recent CRD changes made, the mon count had a minimum of
1, making the configuration of the external cluster impossible. The
operator would fail to add the finalizer:
    
```
2021-04-29 16:57:38.429451 E | ceph-cluster-controller: failed to reconcile. failed to add finalizer: failed to add finalizer "cephcluster.ceph.rook.io" on "test-external": CephCluster.ceph.rook.io "test-external" is invalid: spec.mon.count: Invalid value: 0: spec.mon.count in body should be greater than or equal to 1
```
    
We now fixed the CRD as well as adding the CR status.
   
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
