### PR TITLE
ci: retry vgcreate on failure

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -140,7 +140,7 @@ function create_LV_on_disk() {
     VG=test-rook-vg
     LV=test-rook-lv
     sudo pvcreate "$BLOCK"
-    sudo vgcreate "$VG" "$BLOCK"
+    sudo vgcreate "$VG" "$BLOCK" || sudo vgcreate "$VG" "$BLOCK" || sudo vgcreate "$VG" "$BLOCK"
     sudo lvcreate -l 100%FREE -n "${LV}" "${VG}"
     tests/scripts/localPathPV.sh /dev/"${VG}"/${LV}
     kubectl create -f cluster/examples/kubernetes/ceph/crds.yaml


### PR DESCRIPTION
Try to mitigate the following error from the CI:

```
+ sudo vgcreate test-rook-vg /dev/sdb
  Can't open /dev/sdb exclusively.  Mounted filesystem?
Error: Process completed with exit code 5.
```

Now we retry up to 3 times to create the volume group.

Closes: https://github.com/rook/rook/issues/7487
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
