### PR TITLE
ceph: fix healthcheck in case ssl enabled for rgw (backport #7331) 

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/object.go
+++ b/pkg/apis/ceph.rook.io/v1/object.go
@@ -20,6 +20,10 @@ func (s *ObjectStoreSpec) IsMultisite() bool {
 	return s.Zone.Name != ""
 }
 
+func (s *ObjectStoreSpec) IsTLSEnabled() bool {
+	return s.Gateway.SecurePort != 0 && s.Gateway.SSLCertificateRef != ""
+}
+
 func (s *ObjectStoreSpec) IsExternal() bool {
 	return len(s.Gateway.ExternalRgwEndpoints) != 0
 }

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -73,7 +73,7 @@ func (p Provisioner) Provision(options *apibkt.BucketOptions) (*bktv1alpha1.Obje
 		return nil, errors.Wrap(err, "Provision: can't create ceph user")
 	}
 
-	s3svc, err := cephObject.NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint(), true)
+	s3svc, err := cephObject.NewS3Agent(p.accessKeyID, p.secretAccessKey, p.getObjectStoreEndpoint(), true, nil)
 	if err != nil {
 		p.deleteOBCResourceLogError("")
 		return nil, err
@@ -147,7 +147,7 @@ func (p Provisioner) Grant(options *apibkt.BucketOptions) (*bktv1alpha1.ObjectBu
 		return nil, errors.Wrapf(err, "could not get user (user: %s)", stats.Owner)
 	}
 
-	s3svc, err := cephObject.NewS3Agent(*objectUser.AccessKey, *objectUser.SecretKey, p.getObjectStoreEndpoint(), true)
+	s3svc, err := cephObject.NewS3Agent(*objectUser.AccessKey, *objectUser.SecretKey, p.getObjectStoreEndpoint(), true, nil)
 	if err != nil {
 		p.deleteOBCResourceLogError("")
 		return nil, err
@@ -242,7 +242,7 @@ func (p Provisioner) Revoke(ob *bktv1alpha1.ObjectBucket) error {
 			return nil
 		}
 
-		s3svc, err := cephObject.NewS3Agent(*user.AccessKey, *user.SecretKey, p.getObjectStoreEndpoint(), true)
+		s3svc, err := cephObject.NewS3Agent(*user.AccessKey, *user.SecretKey, p.getObjectStoreEndpoint(), true, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -337,7 +337,6 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 	objContext := NewContext(r.context, r.clusterInfo, cephObjectStore.Name)
 	objContext.UID = string(cephObjectStore.UID)
 
-	var serviceIP string
 	var err error
 
 	if cephObjectStore.Spec.IsExternal() {
@@ -345,7 +344,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 		// RECONCILE SERVICE
 		logger.Info("reconciling object store service")
-		serviceIP, err = cfg.reconcileService(cephObjectStore)
+		_, err = cfg.reconcileService(cephObjectStore)
 		if err != nil {
 			return r.setFailedStatus(namespacedName, "failed to reconcile service", err)
 		}
@@ -382,7 +381,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 		// RECONCILE SERVICE
 		logger.Debug("reconciling object store service")
-		serviceIP, err = cfg.reconcileService(cephObjectStore)
+		serviceIP, err := cfg.reconcileService(cephObjectStore)
 		if err != nil {
 			return r.setFailedStatus(namespacedName, "failed to reconcile service", err)
 		}
@@ -412,7 +411,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 	// Start monitoring
 	if !cephObjectStore.Spec.HealthCheck.Bucket.Disabled {
-		r.startMonitoring(cephObjectStore, objContext, serviceIP, namespacedName)
+		r.startMonitoring(cephObjectStore, objContext, namespacedName)
 	}
 
 	return reconcile.Result{}, nil
@@ -500,7 +499,7 @@ func (r *ReconcileCephObjectStore) verifyObjectBucketCleanup(objectstore *cephv1
 	return opcontroller.WaitForRequeueIfFinalizerBlocked, false
 }
 
-func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjectStore, objContext *Context, serviceIP string, namespacedName types.NamespacedName) {
+func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjectStore, objContext *Context, namespacedName types.NamespacedName) {
 	// Start monitoring object store
 	if r.objectStoreChannels[objectstore.Name].monitoringRunning {
 		logger.Debug("external rgw endpoint monitoring go routine already running!")
@@ -521,7 +520,7 @@ func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjec
 		return
 	}
 
-	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec, r.clusterSpec.External.Enable)
+	rgwChecker := newBucketChecker(r.context, objContext, port, r.client, namespacedName, &objectstore.Spec, r.clusterSpec.External.Enable)
 	logger.Info("starting rgw healthcheck")
 	go rgwChecker.checkObjectStore(r.objectStoreChannels[objectstore.Name].stopChan)
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -511,18 +510,18 @@ func (r *ReconcileCephObjectStore) startMonitoring(objectstore *cephv1.CephObjec
 	// Set the monitoring flag so we don't start more than one go routine
 	r.objectStoreChannels[objectstore.Name].monitoringRunning = true
 
-	var port string
+	var port int32
 
-	if objectstore.Spec.Gateway.SecurePort != 0 && objectstore.Spec.Gateway.SSLCertificateRef != "" {
-		port = strconv.Itoa(int(objectstore.Spec.Gateway.SecurePort))
+	if objectstore.Spec.IsTLSEnabled() {
+		port = objectstore.Spec.Gateway.SecurePort
 	} else if objectstore.Spec.Gateway.Port != 0 {
-		port = strconv.Itoa(int(objectstore.Spec.Gateway.Port))
+		port = objectstore.Spec.Gateway.Port
 	} else {
 		logger.Error("At least one of Port or SecurePort should be non-zero")
 		return
 	}
 
-	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec.HealthCheck, r.clusterSpec.External.Enable)
+	rgwChecker := newBucketChecker(r.context, objContext, serviceIP, port, r.client, namespacedName, &objectstore.Spec, r.clusterSpec.External.Enable)
 	logger.Info("starting rgw healthcheck")
 	go rgwChecker.checkObjectStore(r.objectStoreChannels[objectstore.Name].stopChan)
 }

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -43,15 +45,15 @@ type bucketChecker struct {
 	objContext      *Context
 	interval        time.Duration
 	serviceIP       string
-	port            string
+	port            int32
 	client          client.Client
 	namespacedName  types.NamespacedName
-	healthCheckSpec *cephv1.BucketHealthCheckSpec
+	objectStoreSpec *cephv1.ObjectStoreSpec
 	isExternal      bool
 }
 
 // newbucketChecker creates a new HealthChecker object
-func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP, port string, client client.Client, namespacedName types.NamespacedName, healthCheckSpec *cephv1.BucketHealthCheckSpec, isExternal bool) *bucketChecker {
+func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP string, port int32, client client.Client, namespacedName types.NamespacedName, objectStoreSpec *cephv1.ObjectStoreSpec, isExternal bool) *bucketChecker {
 	c := &bucketChecker{
 		context:         context,
 		objContext:      objContext,
@@ -60,12 +62,12 @@ func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP,
 		port:            port,
 		namespacedName:  namespacedName,
 		client:          client,
-		healthCheckSpec: healthCheckSpec,
+		objectStoreSpec: objectStoreSpec,
 		isExternal:      isExternal,
 	}
 
 	// allow overriding the check interval
-	checkInterval := healthCheckSpec.Bucket.Interval
+	checkInterval := objectStoreSpec.HealthCheck.Bucket.Interval
 	if checkInterval != "" {
 		if duration, err := time.ParseDuration(checkInterval); err == nil {
 			logger.Infof("ceph rgw status check interval for object store %q is %q", namespacedName.Name, checkInterval)
@@ -122,10 +124,11 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 
 		Always keep the bucket and the user for the health check, just do PUT and GET because bucket creation is expensive
 	*/
-
+	ctx := context.TODO()
 	var s3AccessKey string
 	var s3SecretKey string
-	s3endpoint := fmt.Sprintf("%s:%s", BuildDomainName(c.objContext.Name, c.namespacedName.Namespace), c.port)
+	var sslCert []byte
+	s3endpoint := buildDNSEndpoint(BuildDomainName(c.objContext.Name, c.namespacedName.Namespace), c.port, c.objectStoreSpec.IsTLSEnabled())
 
 	// Generate unique user and bucket name
 	bucketName := genUniqueBucketName(c.objContext.UID)
@@ -148,9 +151,13 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	s3AccessKey = *user.AccessKey
 	s3SecretKey = *user.SecretKey
 
+	if c.objectStoreSpec.IsTLSEnabled() {
+		sslSecretCert, _ := c.context.Clientset.CoreV1().Secrets(c.namespacedName.Namespace).Get(ctx, c.objectStoreSpec.Gateway.SSLCertificateRef, metav1.GetOptions{})
+		sslCert = sslSecretCert.Data[certKeyName]
+	}
 	// Initiate s3 agent
 	logger.Debugf("initializing s3 connection for object store %q", c.namespacedName.Name)
-	s3client, err := NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, false)
+	s3client, err := NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, false, sslCert)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize s3 connection")
 	}

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -44,7 +44,6 @@ type bucketChecker struct {
 	context         *clusterd.Context
 	objContext      *Context
 	interval        time.Duration
-	serviceIP       string
 	port            int32
 	client          client.Client
 	namespacedName  types.NamespacedName
@@ -53,12 +52,11 @@ type bucketChecker struct {
 }
 
 // newbucketChecker creates a new HealthChecker object
-func newBucketChecker(context *clusterd.Context, objContext *Context, serviceIP string, port int32, client client.Client, namespacedName types.NamespacedName, objectStoreSpec *cephv1.ObjectStoreSpec, isExternal bool) *bucketChecker {
+func newBucketChecker(context *clusterd.Context, objContext *Context, port int32, client client.Client, namespacedName types.NamespacedName, objectStoreSpec *cephv1.ObjectStoreSpec, isExternal bool) *bucketChecker {
 	c := &bucketChecker{
 		context:         context,
 		objContext:      objContext,
 		interval:        defaultHealthCheckInterval,
-		serviceIP:       serviceIP,
 		port:            port,
 		namespacedName:  namespacedName,
 		client:          client,

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -160,7 +160,7 @@ func runObjectE2ETest(helper *clients.TestClient, k8sh *utils.K8sHelper, s suite
 	s3endpoint, _ := helper.ObjectClient.GetEndPointUrl(namespace, storeName)
 	s3AccessKey, _ := helper.BucketClient.GetAccessKey(obcName)
 	s3SecretKey, _ := helper.BucketClient.GetSecretKey(obcName)
-	s3client, err := rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, true)
+	s3client, err := rgw.NewS3Agent(s3AccessKey, s3SecretKey, s3endpoint, true, nil)
 	require.Nil(s.T(), err)
 	logger.Infof("endpoint (%s) Accesskey (%s) secret (%s)", s3endpoint, s3AccessKey, s3SecretKey)
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In case ssl enabled for RGW, bucket healthcheck won't work since access is denied from the server.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
