### PR TITLE
ceph: retry once before mon failover if mon pod is unscheduled

### DIFF
--- a/Documentation/ceph-mon-health.md
+++ b/Documentation/ceph-mon-health.md
@@ -78,6 +78,8 @@ If you want to force a mon to failover for testing or other purposes, you can sc
 for the timeout. Note that the operator may scale up the mon again automatically if the operator is restarted or if a full
 reconcile is triggered, such as when the CephCluster CR is updated.
 
+If the mon pod is in pending state and couldn't be assigned to a node (say, due to node drain), then the operator will wait for the timeout again before the mon failover. So the timeout waiting for the mon failover will be doubled in this case.
+
 To disable monitor automatic failover, the `timeout` can be set to `0`, if the monitor goes out of quorum Rook will never fail it over onto another node.
 This is especially useful for planned maintenance.
 

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -397,3 +397,21 @@ func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
 	}
 	container.Env = vars
 }
+
+func IsPodScheduled(clientSet kubernetes.Interface, namespace, selector string) (bool, error) {
+	listOpts := metav1.ListOptions{LabelSelector: selector}
+	podList, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to list pods with label selector %q in namespace %q", selector, namespace)
+	}
+
+	if len(podList.Items) == 0 {
+		return false, errors.Errorf("no pods found with label selector %q in namespace %q", selector, namespace)
+	}
+
+	if podList.Items[0].Spec.NodeName == "" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -16,10 +16,13 @@ limitations under the License.
 package k8sutil
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"testing"
 
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
+	"github.com/rook/rook/pkg/operator/test"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -219,4 +222,47 @@ func TestPodSpecPlacement(t *testing.T) {
 	testPodSpecPlacement(t, true, 2, 1, &p)
 	p = makePlacement()
 	testPodSpecPlacement(t, false, 1, 2, &p)
+}
+
+func TestIsMonScheduled(t *testing.T) {
+	ctx := context.TODO()
+	clientset := test.New(t, 1)
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mon-pod",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"app":            "rook-ceph-mon",
+				"ceph_daemon_id": "a",
+			},
+		},
+	}
+
+	// no pods running
+	isScheduled, err := IsPodScheduled(clientset, "ns", "a")
+	assert.Error(t, err)
+	assert.False(t, isScheduled)
+
+	selector := fmt.Sprintf("%s=%s,%s=%s", AppAttr, "rook-ceph-mon", "ceph_daemon_id", "a")
+
+	// unscheduled pod
+	_, err = clientset.CoreV1().Pods("ns").Create(ctx, &pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	isScheduled, err = IsPodScheduled(clientset, "ns", selector)
+	assert.NoError(t, err)
+	assert.False(t, isScheduled)
+
+	// scheduled pod
+	pod.Spec.NodeName = "node0"
+	_, err = clientset.CoreV1().Pods("ns").Update(ctx, &pod, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	isScheduled, err = IsPodScheduled(clientset, "ns", selector)
+	assert.NoError(t, err)
+	assert.True(t, isScheduled)
+
+	// no pods found
+	assert.NoError(t, err)
+	isScheduled, err = IsPodScheduled(clientset, "ns", "b")
+	assert.Error(t, err)
+	assert.False(t, isScheduled)
 }


### PR DESCRIPTION
Events like node drain can take more than 10-15 minutes. If the node is not up before the default monTimeOut of 10 minutes, then rook will attempt to fail over the mon. This failover won't work as the node is still down.
This PR retries once before the mon failover if the mon pod is not scheduled

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7776

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
