### PR TITLE
WIP: ceph: subresources block cephcluster deletion

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -144,7 +144,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephClient)
+	err = opcontroller.AddSelfFinalizerIfNotPresent(r.client, cephClient)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
 	}
@@ -155,7 +155,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	_, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deletePool() function since everything is gone already
@@ -165,7 +165,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
 		if !cephClient.GetDeletionTimestamp().IsZero() && !cephClusterExists {
 			// Remove finalizer
-			err = opcontroller.RemoveFinalizer(r.client, cephClient)
+			err = opcontroller.RemoveSelfFinalizer(r.client, cephClient)
 			if err != nil {
 				return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -191,7 +191,7 @@ func (r *ReconcileCephClient) reconcile(request reconcile.Request) (reconcile.Re
 		}
 
 		// Remove finalizer
-		err = opcontroller.RemoveFinalizer(r.client, cephClient)
+		err = opcontroller.RemoveSelfFinalizer(r.client, cephClient)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 		}

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -127,7 +127,7 @@ func watchControllerPredicate(rookContext *clusterd.Context) predicate.Funcs {
 				// If the labels "do_not_reconcile" is set on the object, let's not reconcile that request
 				isDoNotReconcile := controller.IsDoNotReconcile(objNew.GetLabels())
 				if isDoNotReconcile {
-					logger.Debugf("object %q matched on update but %q label is set, doing nothing", controller.DoNotReconcileLabelName, objNew.Name)
+					logger.Debugf("CephCluster %q matched on update but %q label is set, doing nothing", controller.DoNotReconcileLabelName, objNew.Name)
 					return false
 				}
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
@@ -135,18 +135,15 @@ func watchControllerPredicate(rookContext *clusterd.Context) predicate.Funcs {
 					// Set the cancellation flag to stop any ongoing orchestration
 					rookContext.RequestCancelOrchestration.Set()
 
-					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					logger.Infof("CephCluster %q has changed. diff=%s", objNew.Name, diff)
 					return true
 
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					// Set the cancellation flag to stop any ongoing orchestration
-					rookContext.RequestCancelOrchestration.Set()
-
-					logger.Infof("CR %q is going be deleted, cancelling any ongoing orchestration", objNew.Name)
+					logger.Infof("CephCluster %q is going to be deleted", objNew.Name)
 					return true
 
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
-					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
+					logger.Debugf("skipping CephCluster %q update with unchanged spec", objNew.Name)
 				}
 			}
 

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileCephRBDMirror) reconcile(request reconcile.Request) (reconcile
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, _, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		logger.Debugf("CephCluster resource not ready in namespace %q, retrying in %q.", request.NamespacedName.Namespace, reconcileResponse.RequeueAfter.String())
 		return reconcileResponse, nil

--- a/pkg/operator/ceph/controller/finalizer_test.go
+++ b/pkg/operator/ceph/controller/finalizer_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestAddFinalizerIfNotPresent(t *testing.T) {
+func TestAddSelfFinalizerIfNotPresent(t *testing.T) {
 	fakeObject := &cephv1.CephBlockPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test",
@@ -45,12 +45,12 @@ func TestAddFinalizerIfNotPresent(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	assert.Empty(t, fakeObject.Finalizers)
-	err := AddFinalizerIfNotPresent(cl, fakeObject)
+	err := AddSelfFinalizerIfNotPresent(cl, fakeObject)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fakeObject.Finalizers)
 }
 
-func TestRemoveFinalizer(t *testing.T) {
+func TestRemoveSelfFinalizer(t *testing.T) {
 	fakeObject := &cephv1.CephBlockPool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -72,7 +72,7 @@ func TestRemoveFinalizer(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	assert.NotEmpty(t, fakeObject.Finalizers)
-	err := RemoveFinalizer(cl, fakeObject)
+	err := RemoveSelfFinalizer(cl, fakeObject)
 	assert.NoError(t, err)
 	assert.Empty(t, fakeObject.Finalizers)
 }

--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -75,7 +75,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -100,7 +100,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -120,7 +120,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -140,7 +140,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -160,7 +160,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -180,7 +180,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -200,7 +200,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -225,7 +225,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -250,7 +250,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -275,7 +275,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
@@ -300,7 +300,7 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					logger.Debugf("CR %q is going be deleted", objNew.Name)
+					logger.Debugf("CR %q is going to be deleted", objNew.Name)
 					return true
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -177,7 +177,7 @@ func (r *ReconcileFilesystemMirror) reconcile(request reconcile.Request) (reconc
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, _, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		logger.Debugf("CephCluster resource not ready in namespace %q, retrying in %q.", request.NamespacedName.Namespace, reconcileResponse.RequeueAfter.String())
 		return reconcileResponse, nil

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -152,7 +152,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephNFS)
+	err = opcontroller.AddSelfFinalizerIfNotPresent(r.client, cephNFS)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
 	}
@@ -163,7 +163,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deleteStore() function since everything is gone already
@@ -173,7 +173,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
 		if !cephNFS.GetDeletionTimestamp().IsZero() && !cephClusterExists {
 			// Remove finalizer
-			err := opcontroller.RemoveFinalizer(r.client, cephNFS)
+			err := opcontroller.RemoveSelfFinalizer(r.client, cephNFS)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -212,7 +212,7 @@ func (r *ReconcileCephNFS) reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		// Remove finalizer
-		err = opcontroller.RemoveFinalizer(r.client, cephNFS)
+		err = opcontroller.RemoveSelfFinalizer(r.client, cephNFS)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 		}

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephObjectStore)
+	err = opcontroller.AddSelfFinalizerIfNotPresent(r.client, cephObjectStore)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
 	}
@@ -198,7 +198,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deleteStore() function since everything is gone already
@@ -208,7 +208,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
 		if !cephObjectStore.GetDeletionTimestamp().IsZero() && !cephClusterExists {
 			// Remove finalizer
-			err := opcontroller.RemoveFinalizer(r.client, cephObjectStore)
+			err := opcontroller.RemoveSelfFinalizer(r.client, cephObjectStore)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -283,7 +283,7 @@ func (r *ReconcileCephObjectStore) reconcile(request reconcile.Request) (reconci
 		}
 
 		// Remove finalizer
-		err = opcontroller.RemoveFinalizer(r.client, cephObjectStore)
+		err = opcontroller.RemoveSelfFinalizer(r.client, cephObjectStore)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 		}

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -148,7 +148,7 @@ func (r *ReconcileObjectRealm) reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	_, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectRealm.GetDeletionTimestamp().IsZero() && !cephClusterExists {

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephObjectStoreUser)
+	err = opcontroller.AddSelfFinalizerIfNotPresent(r.client, cephObjectStoreUser)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to add finalizer")
 	}
@@ -158,7 +158,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deleteUser() function since everything is gone already
@@ -168,7 +168,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
 		if !cephObjectStoreUser.GetDeletionTimestamp().IsZero() && !cephClusterExists {
 			// Remove finalizer
-			err = opcontroller.RemoveFinalizer(r.client, cephObjectStoreUser)
+			err = opcontroller.RemoveSelfFinalizer(r.client, cephObjectStoreUser)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -191,7 +191,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 	if err != nil {
 		if !cephObjectStoreUser.GetDeletionTimestamp().IsZero() {
 			// Remove finalizer
-			err = opcontroller.RemoveFinalizer(r.client, cephObjectStoreUser)
+			err = opcontroller.RemoveSelfFinalizer(r.client, cephObjectStoreUser)
 			if err != nil {
 				return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -218,7 +218,7 @@ func (r *ReconcileObjectStoreUser) reconcile(request reconcile.Request) (reconci
 		}
 
 		// Remove finalizer
-		err = opcontroller.RemoveFinalizer(r.client, cephObjectStoreUser)
+		err = opcontroller.RemoveSelfFinalizer(r.client, cephObjectStoreUser)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to remove finalizer")
 		}

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -143,7 +143,7 @@ func (r *ReconcileObjectZone) reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		//

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -141,7 +141,7 @@ func (r *ReconcileObjectZoneGroup) reconcile(request reconcile.Request) (reconci
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	_, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	_, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		if !cephObjectZoneGroup.GetDeletionTimestamp().IsZero() && !cephClusterExists {

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -140,7 +140,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	}
 
 	// Set a finalizer so we can do cleanup before the object goes away
-	err = opcontroller.AddFinalizerIfNotPresent(r.client, cephBlockPool)
+	err = opcontroller.AddSelfFinalizerIfNotPresent(r.client, cephBlockPool)
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to add finalizer")
 	}
@@ -151,7 +151,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 	}
 
 	// Make sure a CephCluster is present otherwise do nothing
-	cephCluster, isReadyToReconcile, cephClusterExists, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
+	cephCluster, isReadyToReconcile, cephClusterExists, _, reconcileResponse := opcontroller.IsReadyToReconcile(r.client, r.context, request.NamespacedName, controllerName)
 	if !isReadyToReconcile {
 		// This handles the case where the Ceph Cluster is gone and we want to delete that CR
 		// We skip the deletePool() function since everything is gone already
@@ -161,7 +161,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		// This handles the case where the operator is not ready to accept Ceph command but the cluster exists
 		if !cephBlockPool.GetDeletionTimestamp().IsZero() && !cephClusterExists {
 			// Remove finalizer
-			err = opcontroller.RemoveFinalizer(r.client, cephBlockPool)
+			err = opcontroller.RemoveSelfFinalizer(r.client, cephBlockPool)
 			if err != nil {
 				return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to remove finalizer")
 			}
@@ -213,7 +213,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		}
 
 		// Remove finalizer
-		err = opcontroller.RemoveFinalizer(r.client, cephBlockPool)
+		err = opcontroller.RemoveSelfFinalizer(r.client, cephBlockPool)
 		if err != nil {
 			return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to remove finalizer")
 		}


### PR DESCRIPTION
We have a report from a user that expects that if an OBC exists for a Rook-Ceph object, the Rook-Ceph cluster will not be deleted until the OBC is deleted.

I think this user's expectation that existence of an OBC, since it is dependent on the Rook-Ceph cluster to function properly, should block deletion of the Ceph cluster is a reasonable one. This is a pattern that I've seen in other Kubernetes applications as well, and finalizers are the tool given to enable this functionality.

In the COSI spec, for example, if there is an ObjectBucket, multiple users can request Access to the bucket, and each Access is added as a finalizer on the ObjectBucket so that deletion of the OB cannot happen until all Accesses have been removed (unless the OB is forcicbly deleted).

I think this model makes sense for Ceph and our subresources also, even those beyond OBC. If a CephFilesystem, CephBlockPool, CephObjectStore, CephObjectUser, or another subresource exists, it means the CephCluster should not delete until those resources are no longer in use.

If we enable this in Rook, a real-world example might look like this. If an admin wants to delete the Ceph cluster and finds that there are users still using the cluster, they have some options:
- request that users migrate their data and delete their resources and wait for the Ceph cluster to delete (the nicest option for users and for data safety overall)
- forcibly delete user resources, and then the Ceph cluster will then delete (hard on users but sometimes maybe necessary, users will know their resources are no longer usable because they don't exist)
- forcibly delete the Ceph cluster and leave user resources dangling (what we do today, and is very rude for users given they might think things should be working when they aren't)

My proposal would be to have a finalizer added to the CephCluster for all Rook-Ceph sub-resources, and CephCluster deletion will wait until all those finalizers are removed before deleting.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
