### PR TITLE
ceph: update erasure coded profile command

### DIFF
--- a/pkg/daemon/ceph/client/erasure-code-profile.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile.go
@@ -89,7 +89,7 @@ func CreateErasureCodeProfile(context *clusterd.Context, clusterInfo *ClusterInf
 		profilePairs = append(profilePairs, fmt.Sprintf("crush-device-class=%s", pool.DeviceClass))
 	}
 
-	args := []string{"osd", "erasure-code-profile", "set", profileName}
+	args := []string{"osd", "erasure-code-profile", "set", profileName, "--force"}
 	args = append(args, profilePairs...)
 	_, err = NewCephCommand(context, clusterInfo, args).Run()
 	if err != nil {

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -61,11 +61,12 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 			}
 			if args[2] == "set" {
 				assert.Equal(t, "myapp", args[3])
-				assert.Equal(t, fmt.Sprintf("k=%d", spec.ErasureCoded.DataChunks), args[4])
-				assert.Equal(t, fmt.Sprintf("m=%d", spec.ErasureCoded.CodingChunks), args[5])
-				assert.Equal(t, "plugin=myplugin", args[6])
-				assert.Equal(t, "technique=t", args[7])
-				nextArg := 8
+				assert.Equal(t, "--force", args[4])
+				assert.Equal(t, fmt.Sprintf("k=%d", spec.ErasureCoded.DataChunks), args[5])
+				assert.Equal(t, fmt.Sprintf("m=%d", spec.ErasureCoded.CodingChunks), args[6])
+				assert.Equal(t, "plugin=myplugin", args[7])
+				assert.Equal(t, "technique=t", args[8])
+				nextArg := 9
 				if failureDomain != "" {
 					assert.Equal(t, fmt.Sprintf("crush-failure-domain=%s", failureDomain), args[nextArg])
 					nextArg++


### PR DESCRIPTION
currently, recreating erasure codedpPool with
different Settings show error and creation
failed.

**Description of your changes:**

Adding `--force` to the erasure coded profile
command works file with above condition.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves #2016 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
