### PR TITLE
ceph: allow resource dependents to stop deletion

### DIFF
--- a/pkg/operator/ceph/file/subresource.go
+++ b/pkg/operator/ceph/file/subresource.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Define CephFilesystem as a subresource of CephCluster
+
+package file
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/subresource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func init() {
+	err := subresource.CephClusterRegistry.Register(&fileSubresource{})
+	if err != nil {
+		// Safe to panic because this should only ever happen during initialization, which will be
+		// caught in development.
+		panic(fmt.Sprintf("failed to register CephFilesystem as a subresource of CephCluster. %v", err))
+	}
+}
+
+type fileSubresource struct{}
+
+func (s *fileSubresource) Kind() string {
+	return cephFilesystemKind
+}
+
+func (s *fileSubresource) DependentsOf(clusterdCtx *clusterd.Context, obj client.Object) ([]string, error) {
+	cephCluster, ok := obj.(*cephv1.CephCluster)
+	if !ok {
+		return []string{}, errors.Errorf("failed to find CephFilesystem dependents. given object could not be converted to a CephCluster: %+v", obj)
+	}
+	ns := cephCluster.Namespace
+	ctx := context.TODO()
+
+	// all and only CephFilesystems in the CephCluster namespace are dependents of the cluster
+	fsList, err := clusterdCtx.RookClientset.CephV1().CephFilesystems(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return []string{}, errors.Wrapf(err, "failed to list CephFilesystem dependents of CephCluster in namespace %q", ns)
+	}
+
+	fsNames := make([]string, 0, len(fsList.Items))
+	for _, fs := range fsList.Items {
+		fsNames = append(fsNames, fs.Name)
+	}
+	return fsNames, nil
+}

--- a/pkg/operator/ceph/file/subresource/registry.go
+++ b/pkg/operator/ceph/file/subresource/registry.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// subresource allows dependent subresources of CephFilesystem to register themselves
+package subresource
+
+import "github.com/rook/rook/pkg/operator/ceph/subresource"
+
+var CephFilesystemRegistry = subresource.NewRegistry()

--- a/pkg/operator/ceph/subresource/registry.go
+++ b/pkg/operator/ceph/subresource/registry.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subresource
+
+import "github.com/pkg/errors"
+
+var (
+	// CephClusterRegistry is the subresource registry for all resources which can be dependents of
+	// a CephCluster.
+	CephClusterRegistry = NewRegistry()
+)
+
+type Registry struct {
+	registry map[string]Subresource
+}
+
+// NewRegistry creates a new, empty Registry for a namespace/cluster.
+func NewRegistry() Registry {
+	return Registry{
+		registry: make(map[string]Subresource),
+	}
+}
+
+func (r *Registry) Register(s Subresource) error {
+	kind := s.Kind()
+	if _, ok := r.registry[kind]; ok {
+		return errors.Errorf("subresource %q is already registered", kind)
+	}
+	r.registry[kind] = s
+	return nil
+}
+
+func (r *Registry) List() []Subresource {
+	srs := make([]Subresource, 0, len(r.registry))
+	for _, v := range r.registry {
+		srs = append(srs, v)
+	}
+	return srs // not in any particular order
+}
+
+func (r *Registry) Get(kind string) (Subresource, error) {
+	sr, ok := r.registry[kind]
+	if !ok {
+		return nil, errors.Errorf("subresource %q has not been registered", kind)
+	}
+	return sr, nil
+}

--- a/pkg/operator/ceph/subresource/subresource.go
+++ b/pkg/operator/ceph/subresource/subresource.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subresource
+
+import (
+	"github.com/rook/rook/pkg/clusterd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Subresource interface {
+	// Kind is the Kubernetes Kind of the dependent subresource. e.g. "CephFilesystem" or "CephNFS"
+	Kind() string
+
+	// DependentsOf returns the name of each instance of the subresource that has been created that
+	// depends on the given object. The Object should be a fully-filled Kubernetes object so that
+	// the dependent subresource can check whether it is a dependent of the object.
+	DependentsOf(context *clusterd.Context, obj client.Object) ([]string, error)
+}


### PR DESCRIPTION
Allow resources to have dependent resources which can stop them from
being deleted.

CephCluster has dependents:
  CephBlockPool
  CephFilesystem
  CephObjectStore
  CephClient

CephFilesystem has dependents:
  CephNFS

CephObjectStore has dependents:
  ObjectBucketClaim

Dependencies that are unimplemented:
  CephObjectRealm
  CephObjectZoneGroup
  CephObjectZone
  CephRBDMirror (probably a dependent of CephCluster)
  CephFilesystemMirror

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
