### PR TITLE
ceph: Multicluster test cleanup of external cluster first

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,13 +57,12 @@ pipeline {
                     // extract which specific storage provider to test
                     if (body.contains("[test cassandra]") || title.contains("cassandra:")) {
                         env.testProvider = "cassandra"
-                    } else if (body.contains("[test ceph]") || title.contains("ceph:")) {
-                        // For Ceph storage provider we are using GitHub actions to run test
-                        if (body.contains("[test full]")) {
-                          env.testProvider = "ceph"
-                        } else {
-                          env.shouldBuild = "false"
-                        }
+                    } else if (body.contains("[test ceph]")) {
+                        // Run the Ceph tests in Jenkins if specifically requested
+                        env.testProvider = "ceph"
+                    } else if (title.contains("ceph:")) {
+                        // Don't run Jenkins for ceph PRs by default since they are covered by github actions
+                        env.shouldBuild = "false"
                     } else if (body.contains("[test nfs]") || title.contains("nfs:")) {
                         env.testProvider = "nfs"
                     } else if (body.contains("[test]")) {

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -559,7 +559,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 		testCleanupPolicy := !manifest.Settings().IsExternal && !manifest.Settings().SkipCleanupPolicy
 		if testCleanupPolicy {
 			// Add cleanup policy to the core ceph cluster
-			err = h.addCleanupPolicy(namespace)
+			err = h.addCleanupPolicy(namespace, clusterName)
 			if err != nil {
 				assert.NoError(h.T(), err)
 				// no need to check for cleanup policy later if it already failed
@@ -593,7 +593,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 			clusterDeleteRetries++
 			if clusterDeleteRetries > 10 {
 				// If the operator really isn't going to remove the finalizer, just force remove it
-				h.removeClusterFinalizers(namespace)
+				h.removeClusterFinalizers(namespace, clusterName)
 			}
 			return err
 		}
@@ -629,7 +629,7 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 		// non-helm cleanup
 		if manifest.Settings().IsExternal {
 			logger.Infof("Deleting all the resources in the common external manifest")
-			_, err = h.k8shelper.KubectlWithStdin(h.Manifests.GetCommonExternal(), deleteFromStdinArgs...)
+			_, err = h.k8shelper.KubectlWithStdin(manifest.GetCommonExternal(), deleteFromStdinArgs...)
 			if err != nil {
 				logger.Errorf("failed to remove common external resources. %v", err)
 			} else {
@@ -722,10 +722,10 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 	}
 }
 
-func (h *CephInstaller) removeClusterFinalizers(namespace string) {
+func (h *CephInstaller) removeClusterFinalizers(namespace, clusterName string) {
 	ctx := context.TODO()
 	// Get the latest cluster instead of using the same instance in case it has been changed
-	cluster, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Get(ctx, h.settings.ClusterName, metav1.GetOptions{})
+	cluster, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Get(ctx, clusterName, metav1.GetOptions{})
 	if err != nil {
 		logger.Errorf("failed to remove finalizer. failed to get cluster. %+v", err)
 		return
@@ -900,12 +900,12 @@ spec:
                    path:  ` + hostPathDir
 }
 
-func (h *CephInstaller) addCleanupPolicy(namespace string) error {
+func (h *CephInstaller) addCleanupPolicy(namespace, clusterName string) error {
 	// Retry updating the CR a few times in case of random failure
 	var returnErr error
 	for i := 0; i < 3; i++ {
 		ctx := context.TODO()
-		cluster, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Get(ctx, h.settings.ClusterName, metav1.GetOptions{})
+		cluster, err := h.k8shelper.RookClientset.CephV1().CephClusters(namespace).Get(ctx, clusterName, metav1.GetOptions{})
 		if err != nil {
 			return errors.Errorf("failed to get ceph cluster. %+v", err)
 		}

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -142,7 +142,7 @@ func (s *MultiClusterDeploySuite) deletePools() {
 
 func (s *MultiClusterDeploySuite) TearDownSuite() {
 	s.deletePools()
-	s.installer.UninstallRookFromMultipleNS(s.installer.Manifests, s.externalManifests)
+	s.installer.UninstallRookFromMultipleNS(s.externalManifests, s.installer.Manifests)
 }
 
 // Test to make sure all rook components are installed and Running


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The multicluster test was never removing the finalizer of the external cluster since the core cluster was being removed first. Now we remove the external cluster first to ensure the finalizer will be removed properly instead of forcefully by the test.

This is needed for the 1.6 patch release since the github tests are not currently being triggered for the release branch.

**Which issue is resolved by this Pull Request:**
Resolves #7824 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
