### PR TITLE
ceph: Add nullable to object gateway settings

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -6031,6 +6031,7 @@ spec:
                       format: int32
                       maximum: 65535
                       minimum: 0
+                      nullable: true
                       type: integer
                     service:
                       description: The configuration related to add/set on each rgw service.
@@ -6044,6 +6045,7 @@ spec:
                       type: object
                     sslCertificateRef:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections
+                      nullable: true
                       type: string
                   required:
                     - instances

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -6026,6 +6026,7 @@ spec:
                       format: int32
                       maximum: 65535
                       minimum: 0
+                      nullable: true
                       type: integer
                     service:
                       description: The configuration related to add/set on each rgw service.
@@ -6039,6 +6040,7 @@ spec:
                       type: object
                     sslCertificateRef:
                       description: The name of the secret that stores the ssl certificate for secure rgw connections
+                      nullable: true
                       type: string
                   required:
                     - instances

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1071,6 +1071,7 @@ type GatewaySpec struct {
 	// The port the rgw service will be listening on (https)
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
+	// +nullable
 	// +optional
 	SecurePort int32 `json:"securePort,omitempty"`
 
@@ -1079,6 +1080,7 @@ type GatewaySpec struct {
 	Instances int32 `json:"instances"`
 
 	// The name of the secret that stores the ssl certificate for secure rgw connections
+	// +nullable
 	// +optional
 	SSLCertificateRef string `json:"sslCertificateRef,omitempty"`
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In some clusters, the schema validation is failing for the default object.yaml example that the value must be of a type string null. While the null value shouldnt be strictly needed, we need working examples by default.

```
The CephObjectStore XXX is invalid:
* spec.gateway.sslCertificateRef: Invalid value: "null": spec.gateway.sslCertificateRef in body must be of type string: "null"
* spec.gateway.securePort: Invalid value: "null": spec.gateway.securePort in body must be of type integer: "null"
```

**Which issue is resolved by this Pull Request:**
Resolves #7803 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
