### PR TITLE
WIP: ceph: allow some resources to block cluster delete

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1484,6 +1484,7 @@ type CleanupPolicySpec struct {
 	// AllowUninstallWithVolumes defines whether we can proceed with the uninstall if they are RBD images still present
 	// +optional
 	AllowUninstallWithVolumes bool `json:"allowUninstallWithVolumes,omitempty"`
+	// TODO: add uninstall option AllowUninstallWithDependentResources
 }
 
 // CleanupConfirmationProperty represents the cleanup confirmation

--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -134,18 +134,19 @@ func watchControllerPredicate(rookContext *clusterd.Context) predicate.Funcs {
 					// Set the cancellation flag to stop any ongoing orchestration
 					rookContext.RequestCancelOrchestration.Set()
 
-					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
+					logger.Infof("CephCluster has changed for %q. diff=%s", objNew.Name, diff)
 					return true
 
 				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
-					// Set the cancellation flag to stop any ongoing orchestration
-					rookContext.RequestCancelOrchestration.Set()
-
-					logger.Infof("CR %q is going be deleted, cancelling any ongoing orchestration", objNew.Name)
+					// Do not cancel orchestration here! Some custom resources can block CephCluster
+					// deletion if they exist. Rook should still reconcile the CephCluster to keep
+					// Ceph healthy so other custom resource controllers can delete their
+					// resources properly.
+					logger.Infof("CephCluster %q is going be deleted", objNew.Name)
 					return true
 
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
-					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
+					logger.Debugf("skipping CephCluster %q update with unchanged spec", objNew.Name)
 				}
 			}
 

--- a/pkg/operator/ceph/cluster/register_controllers.go
+++ b/pkg/operator/ceph/cluster/register_controllers.go
@@ -35,7 +35,6 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/object/zone"
 	"github.com/rook/rook/pkg/operator/ceph/object/zonegroup"
 	"github.com/rook/rook/pkg/operator/ceph/pool"
-
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 


### PR DESCRIPTION
Allow some Ceph Custom Resources to block CephCluster deletion when they
exist. This will provide a measure of safety for user data if an
administrator deletes a Rook-Ceph cluster while Resources that use data
in the Ceph cluster still exist.

The administrator can still force-delete the CephCluster using the
cluster 'cleanupPolicy'.

Most blocking resources create data pools in the Ceph cluster. Some
resources reference pools that exist in the Ceph cluster which may be
pools created by Rook custom resources or may be user-created pools. To
allow for protection of user-created pools, also block deletion when
these resources exist.

Blocking resource kinds:
 - CephBlockPool
 - CephFilesystem
 - CephObjectStore
 - CephNFS (can use user-created Ceph pools)
 - CephClient (can use user-created Ceph pools)

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
