### PR TITLE
ceph: remove redundant csi statefulset template path vars

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -90,11 +90,9 @@ var (
 
 	// template paths
 	RBDPluginTemplatePath         string
-	RBDProvisionerSTSTemplatePath string
 	RBDProvisionerDepTemplatePath string
 
 	CephFSPluginTemplatePath         string
-	CephFSProvisionerSTSTemplatePath string
 	CephFSProvisionerDepTemplatePath string
 
 	// configuration map for csi
@@ -195,7 +193,7 @@ func ValidateCSIParam() error {
 		if len(RBDPluginTemplatePath) == 0 {
 			return errors.New("missing rbd plugin template path")
 		}
-		if len(RBDProvisionerSTSTemplatePath) == 0 && len(RBDProvisionerDepTemplatePath) == 0 {
+		if len(RBDProvisionerDepTemplatePath) == 0 {
 			return errors.New("missing rbd provisioner template path")
 		}
 	}
@@ -204,7 +202,7 @@ func ValidateCSIParam() error {
 		if len(CephFSPluginTemplatePath) == 0 {
 			return errors.New("missing cephfs plugin template path")
 		}
-		if len(CephFSProvisionerSTSTemplatePath) == 0 && len(CephFSProvisionerDepTemplatePath) == 0 {
+		if len(CephFSProvisionerDepTemplatePath) == 0 {
 			return errors.New("missing ceph provisioner template path")
 		}
 	}


### PR DESCRIPTION
**Description of your changes:**

This commit removes redundant `RBDProvisionerSTSTemplatePath` and
`CephFSProvisionerSTSTemplatePath` variables which were forgetten to
be removed in https://github.com/rook/rook/pull/5982 when csi support
for k8s 1.13 was removed.

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->



**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
