### PR TITLE
ceph: fix hostpath of osd to avoid data corruption

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/libopenstorage/secrets"
 	"github.com/pkg/errors"
@@ -738,7 +737,7 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 			Path: filepath.Join(
 				configDir,
 				namespace,
-				strings.ReplaceAll(osdInfo.BlockPath, "/", "_"),
+				c.clusterInfo.FSID+"_"+osdInfo.UUID,
 			),
 			Type: &hostPathType,
 		},


### PR DESCRIPTION
**Description of your changes:**

A directory is created under dataDirHostPath for each OSD. In host-based cluster, its name is constructed from kernel device name like _dev_sdb though user specifies udev persistent device name. We should use unique name among all OSDs.

**Which issue is resolved by this Pull Request:**

Resolves #7878 

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
