### PR TITLE
ceph: do not overwrite the probe handler

### DIFF
--- a/pkg/operator/ceph/config/livenessprobe_test.go
+++ b/pkg/operator/ceph/config/livenessprobe_test.go
@@ -76,51 +76,70 @@ func configLivenessProbeHelper(t *testing.T, keyType rookv1.KeyType) {
 }
 
 func TestGetLivenessProbeWithDefaults(t *testing.T) {
-	defaultProbe := &v1.Probe{
-		Handler: v1.Handler{
-			Exec: &v1.ExecAction{
-				// Example:
-				Command: []string{
-					"env",
-					"-i",
-					"sh",
-					"-c",
-					"ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status",
+	t.Run("using default probe", func(t *testing.T) {
+		currentProb := &v1.Probe{
+			Handler: v1.Handler{
+				Exec: &v1.ExecAction{
+					// Example:
+					Command: []string{
+						"env",
+						"-i",
+						"sh",
+						"-c",
+						"ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status",
+					},
 				},
 			},
-		},
-		InitialDelaySeconds: 10,
-	}
-	// in case of default probe
-	desiredProbe := &v1.Probe{}
-	desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, defaultProbe)
-	assert.Equal(t, desiredProbe, defaultProbe)
+			InitialDelaySeconds: 10,
+		}
+		// in case of default probe
+		desiredProbe := &v1.Probe{}
+		desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, currentProb)
+		assert.Equal(t, desiredProbe, currentProb)
+	})
 
-	// in case of overriding probe
-	desiredProbe = &v1.Probe{
-		Handler: v1.Handler{
-			Exec: &v1.ExecAction{
-				// Example:
-				Command: []string{
-					"env",
-					"-i",
-					"sh",
-					"-c",
-					"ceph --admin-daemon /run/ceph/ceph-osd.0.asok status",
+	t.Run("overriding default probes", func(t *testing.T) {
+		currentProb := &v1.Probe{
+			Handler: v1.Handler{
+				Exec: &v1.ExecAction{
+					// Example:
+					Command: []string{
+						"env",
+						"-i",
+						"sh",
+						"-c",
+						"ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status",
+					},
 				},
 			},
-		},
-		InitialDelaySeconds: 1,
-		FailureThreshold:    2,
-		PeriodSeconds:       3,
-		SuccessThreshold:    4,
-		TimeoutSeconds:      5,
-	}
-	desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, defaultProbe)
-	assert.Equal(t, desiredProbe.Exec.Command, []string{"env", "-i", "sh", "-c", "ceph --admin-daemon /run/ceph/ceph-osd.0.asok status"})
-	assert.Equal(t, desiredProbe.InitialDelaySeconds, int32(1))
-	assert.Equal(t, desiredProbe.FailureThreshold, int32(2))
-	assert.Equal(t, desiredProbe.PeriodSeconds, int32(3))
-	assert.Equal(t, desiredProbe.SuccessThreshold, int32(4))
-	assert.Equal(t, desiredProbe.TimeoutSeconds, int32(5))
+			InitialDelaySeconds: 10,
+		}
+
+		desiredProbe := &v1.Probe{
+			Handler: v1.Handler{
+				Exec: &v1.ExecAction{
+					// Example:
+					Command: []string{
+						"env",
+						"-i",
+						"sh",
+						"-c",
+						"ceph --admin-daemon /run/ceph/ceph-mon.foo.asok mon_status",
+					},
+				},
+			},
+			InitialDelaySeconds: 1,
+			FailureThreshold:    2,
+			PeriodSeconds:       3,
+			SuccessThreshold:    4,
+			TimeoutSeconds:      5,
+		}
+		desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, currentProb)
+		assert.Equal(t, desiredProbe.Exec.Command, []string{"env", "-i", "sh", "-c", "ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status"})
+		assert.Equal(t, desiredProbe.InitialDelaySeconds, int32(1))
+		assert.Equal(t, desiredProbe.FailureThreshold, int32(2))
+		assert.Equal(t, desiredProbe.PeriodSeconds, int32(3))
+		assert.Equal(t, desiredProbe.SuccessThreshold, int32(4))
+		assert.Equal(t, desiredProbe.TimeoutSeconds, int32(5))
+	})
 }


### PR DESCRIPTION
Changing the livenessprobe handler is not possible anymore for the
simple reason that it does not make sense. Practicly speaking we just
cannot change its value since it is propapaged to all the daemons. The
exec handler contains the socket name of the daemon, because daemons
have different names we cannot possibly make it generic since it will
apply to all.

Closes: https://github.com/rook/rook/issues/7842
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
