### PR TITLE
build: rook-ceph Operator deployment for OKD should be the same as OCP for it to work

### DIFF
--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -152,6 +152,9 @@ function generate_operator_yaml() {
     if [[ "$platform" == "ocp" ]]; then
         operator_file=$OPERATOR_YAML_FILE_OCP
     fi
+    if [[ "$platform" == "okd" ]]; then
+        operator_file=$OPERATOR_YAML_FILE_OCP
+    fi
 
     sed -n '/^# OLM: BEGIN OPERATOR DEPLOYMENT$/,/# OLM: END OPERATOR DEPLOYMENT$/p' "$operator_file" > "$OLM_OPERATOR_YAML_FILE"
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

This commit makes it so the bundle created for OKD will actually create a operator deployment that works on OpenShift. Previously it did not set the variables in the Operator Deployment thus the operator was not working as expected after deployment by OLM.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
