### PR TITLE
ceph: remove an missing field in crd

### DIFF
--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -36,7 +36,6 @@ spec:
       codingChunks: 1
   preservePoolsOnDelete: true
   gateway:
-    type: s3
     # sslCertificateRef:
     port: 80
     # securePort: 443

--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -47,7 +47,6 @@ spec:
       codingChunks: 1
   preservePoolsOnDelete: true
   gateway:
-    type: s3
     sslCertificateRef:
     port: 80
     # securePort: 443

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -42,8 +42,6 @@ spec:
   preservePoolsOnDelete: true
   # The gateway service configuration
   gateway:
-    # type of the gateway (s3)
-    type: s3
     # A reference to the secret in the rook namespace where the ssl certificate is stored
     sslCertificateRef:
     # The port that RGW pods will listen on (http)

--- a/cluster/examples/kubernetes/ceph/object-multisite-pull-realm.yaml
+++ b/cluster/examples/kubernetes/ceph/object-multisite-pull-realm.yaml
@@ -56,7 +56,6 @@ metadata:
   namespace: new-rook-ceph-namespace
 spec:
   gateway:
-    type: s3
     port: 80
     # securePort: 443
     instances: 1

--- a/cluster/examples/kubernetes/ceph/object-multisite.yaml
+++ b/cluster/examples/kubernetes/ceph/object-multisite.yaml
@@ -43,7 +43,6 @@ metadata:
   namespace: rook-ceph # namespace:cluster
 spec:
   gateway:
-    type: s3
     port: 80
     # securePort: 443
     instances: 1

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -44,8 +44,6 @@ spec:
   preservePoolsOnDelete: true
   # The gateway service configuration
   gateway:
-    # type of the gateway (s3)
-    type: s3
     # A reference to the secret in the rook namespace where the ssl certificate is stored
     # sslCertificateRef:
     # The port that RGW pods will listen on (http)

--- a/cluster/examples/kubernetes/ceph/object-test.yaml
+++ b/cluster/examples/kubernetes/ceph/object-test.yaml
@@ -17,7 +17,6 @@ spec:
       size: 1
   preservePoolsOnDelete: false
   gateway:
-    type: s3
     port: 80
     # securePort: 443
     instances: 1

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -44,8 +44,6 @@ spec:
   preservePoolsOnDelete: false
   # The gateway service configuration
   gateway:
-    # type of the gateway (s3)
-    type: s3
     # A reference to the secret in the rook namespace where the ssl certificate is stored
     # sslCertificateRef:
     # The port that RGW pods will listen on (http)

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -30,7 +30,6 @@ spec:
       dataChunks: 6
       codingChunks: 2
   gateway:
-    type: s3
     port: 80
     securePort: 443
     instances: 3
@@ -90,9 +89,7 @@ The RGW service can be configured to listen on both http and https by specifying
 
 ```yaml
  gateway:
-    type: s3
     sslCertificateRef: my-ssl-cert-secret
-    port: 80
     securePort: 443
     instances: 1
 ```

--- a/design/common/object-bucket.md
+++ b/design/common/object-bucket.md
@@ -50,7 +50,6 @@ spec:
       dataChunks: 6
       codingChunks: 2
   gateway:
-    type: s3
     port: 80
     securePort: 443
     instances: 3
@@ -109,7 +108,6 @@ The RGW service can be configured to listen on both http and https by specifying
 
 ```yaml
  gateway:
-    type: s3
     sslCertificateRef: my-ssl-cert-secret
     port: 80
     securePort: 443

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -401,7 +401,6 @@ spec:
       size: 1
       requireSafeReplicaSize: false
   gateway:
-    type: s3
     port: ` + strconv.Itoa(port) + `
     instances: ` + strconv.Itoa(replicaCount) + `
   healthCheck:

--- a/tests/framework/installer/ceph_manifests_v1.5.go
+++ b/tests/framework/installer/ceph_manifests_v1.5.go
@@ -353,7 +353,6 @@ spec:
       size: 1
       requireSafeReplicaSize: false
   gateway:
-    type: s3
     sslCertificateRef:
     port: ` + strconv.Itoa(port) + `
     instances: ` + strconv.Itoa(replicaCount) + `

--- a/tests/manifests/test-object.yaml
+++ b/tests/manifests/test-object.yaml
@@ -17,7 +17,6 @@ spec:
       size: 1
   preservePoolsOnDelete: false
   gateway:
-    type: s3
     port: 80
     # securePort: 443
     instances: 1


### PR DESCRIPTION
**Description of your changes:**

`CephObjectStore->gateway->type` is not used. Rook has only supported s3-like interface and hasn't had no code which handles `type` field.

In addition, this field was removed from CRD in the following commit.

ceph: auto-gen crds
31db03fece6d11c3054a6488b96d1c6ad3722b84

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
