### PR TITLE
ceph: append additional info in the rbd-mirror bootstrap peer token

### DIFF
--- a/pkg/operator/ceph/cluster/rbd/config.go
+++ b/pkg/operator/ceph/cluster/rbd/config.go
@@ -50,14 +50,6 @@ type daemonConfig struct {
 	ownerInfo    *k8sutil.OwnerInfo
 }
 
-// PeerToken is the content of the peer token
-type PeerToken struct {
-	ClusterFSID string `json:"fsid"`
-	ClientID    string `json:"client_id"`
-	Key         string `json:"key"`
-	MonHost     string `json:"mon_host"`
-}
-
 func (r *ReconcileCephRBDMirror) generateKeyring(clusterInfo *client.ClusterInfo, daemonConfig *daemonConfig) (string, error) {
 	ctx := context.TODO()
 	user := fullDaemonName(daemonConfig.DaemonID)

--- a/pkg/operator/ceph/controller/mirror_peer.go
+++ b/pkg/operator/ceph/controller/mirror_peer.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller provides Kubernetes controller/pod/container spec items used for many Ceph daemons
+package controller
+
+// PeerToken is the content of the peer token
+type PeerToken struct {
+	ClusterFSID string `json:"fsid"`
+	ClientID    string `json:"client_id"`
+	Key         string `json:"key"`
+	MonHost     string `json:"mon_host"`
+	// These fields are added by Rook and NOT part of the output of client.CreateRBDMirrorBootstrapPeer()
+	PoolID    int    `json:"pool_id"`
+	Namespace string `json:"namespace"`
+}

--- a/pkg/operator/ceph/file/mirror/config.go
+++ b/pkg/operator/ceph/file/mirror/config.go
@@ -46,14 +46,6 @@ type daemonConfig struct {
 	ownerInfo    *k8sutil.OwnerInfo
 }
 
-// PeerToken is the content of the peer token
-type PeerToken struct {
-	ClusterFSID string `json:"fsid"`
-	ClientID    string `json:"client_id"`
-	Key         string `json:"key"`
-	MonHost     string `json:"mon_host"`
-}
-
 func (r *ReconcileFilesystemMirror) generateKeyring(clusterInfo *client.ClusterInfo, daemonConfig *daemonConfig) (string, error) {
 	access := []string{
 		"mon", "allow r",

--- a/pkg/operator/ceph/pool/config_test.go
+++ b/pkg/operator/ceph/pool/config_test.go
@@ -18,11 +18,21 @@ limitations under the License.
 package pool
 
 import (
+	"encoding/base64"
+	"reflect"
 	"testing"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	testop "github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/tevino/abool"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGenerateStatusInfo(t *testing.T) {
@@ -37,4 +47,35 @@ func TestGenerateStatusInfo(t *testing.T) {
 	secretName := info["rbdMirrorBootstrapPeerSecretName"]
 	assert.NotEmpty(t, secretName)
 	assert.Equal(t, "pool-peer-token-foo", secretName)
+}
+
+func TestExpandBootstrapPeerToken(t *testing.T) {
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			if reflect.DeepEqual(args[0:5], []string{"osd", "pool", "get", "pool", "all"}) {
+				return `{"pool_id":13}`, nil
+			}
+
+			return "", errors.Errorf("unknown command args: %s", args[0:5])
+		},
+	}
+	c := &clusterd.Context{
+		Executor:                   executor,
+		Clientset:                  testop.New(t, 1),
+		RookClientset:              rookclient.NewSimpleClientset(),
+		RequestCancelOrchestration: abool.New(),
+	}
+
+	// Create a ReconcileCephBlockPool object with the scheme and fake client.
+	r := &ReconcileCephBlockPool{
+		context:     c,
+		clusterInfo: &cephclient.ClusterInfo{Namespace: "rook-ceph"},
+	}
+
+	newToken, err := r.expandBootstrapPeerToken(&cephv1.CephBlockPool{ObjectMeta: v1.ObjectMeta{Name: "pool", Namespace: "rook-ceph"}}, types.NamespacedName{Namespace: "rook-ceph"}, []byte(`eyJmc2lkIjoiYzZiMDg3ZjItNzgyOS00ZGJiLWJjZmMtNTNkYzM0ZTBiMzVkIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFBV1lsWmZVQ1Q2RGhBQVBtVnAwbGtubDA5YVZWS3lyRVV1NEE9PSIsIm1vbl9ob3N0IjoiW3YyOjE5Mi4xNjguMTExLjEwOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTA6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjEyOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTI6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjExOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTE6Njc4OV0ifQ==`))
+	assert.NoError(t, err)
+	newTokenDecoded, err := base64.StdEncoding.DecodeString(string(newToken))
+	assert.NoError(t, err)
+	assert.Contains(t, string(newTokenDecoded), "pool_id")
+	assert.Contains(t, string(newTokenDecoded), "namespace")
 }


### PR DESCRIPTION
We know append additional information to the rbd-mirror bootstrap peer
token. It is useful for disaster recovery scenario where the other
cluster is reading the peer token and needs to know the pool_id as well
as the namespace.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
