### PR TITLE
ci: add arm64 runner

### DIFF
--- a/.github/workflows/canary-integration-test-arm64.yml
+++ b/.github/workflows/canary-integration-test-arm64.yml
@@ -1,0 +1,74 @@
+name: Canary integration tests ARM64
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
+
+jobs:
+  canary-arm64:
+    runs-on: [self-hosted, ubuntu-20.04, ARM64]
+    env:
+      BLOCK: /dev/sdb
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: teardown minikube and docker
+      run: |
+        uptime
+        minikube delete
+        docker system prune -a
+
+    - name: setup minikube
+      run: |
+        # sudo apt-get install build-essential -y
+        # curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-arm64
+        # sudo install minikube-linux-arm64 /usr/local/bin/minikube
+        # sudo rm -f minikube-linux-arm64
+        # curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+        # sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        minikube start --memory 28g --cpus=12 --driver=docker
+
+    - name: print k8s cluster status
+      run: tests/scripts/github-action-helper.sh print_k8s_cluster_status
+
+    - name: use local disk and create partitions for osds
+      run: |
+        tests/scripts/github-action-helper.sh use_local_disk
+        tests/scripts/create-bluestore-partitions.sh --disk "$BLOCK" --osd-count 1
+
+    - name: validate-yaml
+      run: tests/scripts/github-action-helper.sh validate_yaml
+
+    - name: deploy cluster
+      run: |
+        # removing liveness probes since the env is slow and the probe is killing the daemons
+        yq write -d1 -i cluster/examples/kubernetes/ceph/cluster-test.yaml "spec.healthCheck.livenessProbe.mon.disabled" true
+        yq write -d1 -i cluster/examples/kubernetes/ceph/cluster-test.yaml "spec.healthCheck.livenessProbe.mgr.disabled" true
+        yq write -d1 -i cluster/examples/kubernetes/ceph/cluster-test.yaml "spec.healthCheck.livenessProbe.osd.disabled" true
+        tests/scripts/github-action-helper.sh deploy_cluster
+        # there are no package for arm64 nfs-ganesha
+        kubectl delete -f cluster/examples/kubernetes/ceph/nfs-test.yaml
+
+    - name: wait for prepare pod
+      run: timeout 900 sh -c 'until kubectl -n rook-ceph logs -f $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'); do sleep 5; done' || kubectl -n rook-ceph get all && kubectl logs -n rook-ceph deploy/rook-ceph-operator
+
+    - name: wait for ceph to be ready
+      run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 1
+
+    - name: teardown minikube and docker
+      run: |
+        minikube delete
+        docker system prune -a
+
+    - name: upload canary test result
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: canary-arm64
+        path: test


### PR DESCRIPTION
Thanks to @xin3liang we now have 2 hosted runners on ARM64. So let's add
a small integration test for it.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.

[skip ci]