### PR TITLE
WIP: ceph: set orchestration cancel only when ceph version is updated

### DIFF
--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -131,8 +131,11 @@ func watchControllerPredicate(rookContext *clusterd.Context) predicate.Funcs {
 				}
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
-					// Set the cancellation flag to stop any ongoing orchestration
-					rookContext.RequestCancelOrchestration.Set()
+					// Set the cancellation flag to stop any ongoing orchestration only if ceph version is updated
+					if objOld.Spec.CephVersion.Image != objNew.Spec.CephVersion.Image {
+						logger.Infof("ceph image is updated in the CR %q, cancelling any ongoing orchestration", objNew.Name)
+						rookContext.RequestCancelOrchestration.Set()
+					}
 
 					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
 					return true


### PR DESCRIPTION
Orchestration Cancel flag is set whenever the cephCluster is updated. This causes ceph cluster CR edits to be ignored sometimes. This PR adds orchestration cancel flag only if ceph version is updated.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7872

```
2021-05-19 11:13:45.015084 I | ceph-cluster-controller: clusterInfo not yet found, must be a new cluster
2021-05-19 11:13:45.043528 E | ceph-cluster-controller: failed to reconcile. failed to reconcile cluster "rook-ceph": failed to configure local ceph cluster: failed to perform validation before cluster creation: cannot start 3 mons on 1 node(s) when allowMultiplePerNode is false
2021-05-19 11:14:13.061994 I | ceph-cluster-controller: CR has changed for "rook-ceph". diff=  v1.ClusterSpec{
  	... // 11 identical fields
  	WaitTimeoutForHealthyOSDInMinutes: s"10ns",
  	DisruptionManagement:              {ManagePodBudgets: true, OSDMaintenanceTimeout: s"30ns", MachineDisruptionBudgetNamespace: "openshift-machine-api"},
  	Mon: v1.MonSpec{
  		Count:                3,
- 		AllowMultiplePerNode: false,
+ 		AllowMultiplePerNode: true,
  		StretchCluster:       nil,
  		VolumeClaimTemplate:  nil,
  	},
  	CrashCollector: {},
  	Dashboard:      {Enabled: true, SSL: true},
  	... // 8 identical fields
  }
2021-05-19 11:14:13.062051 I | ceph-cluster-controller: reconciling ceph cluster in namespace "rook-ceph"
2021-05-19 11:14:13.067174 I | ceph-cluster-controller: clusterInfo not yet found, must be a new cluster
2021-05-19 11:14:13.085272 I | ceph-cluster-controller: detecting the ceph image version for image ceph/ceph:v15.2.11...
2021-05-19 11:14:14.561484 I | ceph-cluster-controller: detected ceph image version: "15.2.11-0 octopus"
2021-05-19 11:14:14.561853 I | ceph-cluster-controller: validating ceph version from provided image
2021-05-19 11:14:14.564386 I | ceph-cluster-controller: cluster "rook-ceph": version "15.2.11-0 octopus" detected for image "ceph/ceph:v15.2.11"
2021-05-19 11:14:14.608706 I | op-mon: start running mons
2021-05-19 11:14:14.679180 I | op-mon: creating mon secrets for a new cluster
2021-05-19 11:14:14.689374 I | op-mon: existing maxMonID not found or failed to load. configmaps "rook-ceph-mon-endpoints" not found
2021-05-19 11:14:14.694700 I | op-mon: saved mon endpoints to config map map[csi-cluster-config-json:[{"clusterID":"rook-ceph","monitors":[]}] data: mapping:{"node":{}} maxMonId:-1]
2021-05-19 11:14:15.172075 I | cephclient: writing config file /var/lib/rook/rook-ceph/rook-ceph.config
2021-05-19 11:14:15.172257 I | cephclient: generated admin config in /var/lib/rook/rook-ceph
2021-05-19 11:14:16.351419 I | op-mon: targeting the mon count 3
2021-05-19 11:14:16.359041 I | op-mon: sched-mon: created canary deployment rook-ceph-mon-a-canary
2021-05-19 11:14:16.375811 I | op-mon: sched-mon: created canary deployment rook-ceph-mon-b-canary
2021-05-19 11:14:16.402726 I | op-mon: sched-mon: created canary deployment rook-ceph-mon-c-canary
2021-05-19 11:14:17.150222 I | op-mon: sched-mon: canary monitor deployment rook-ceph-mon-a-canary scheduled to minikube
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
