### PR TITLE
ceph: create new keyring for osd

### DIFF
--- a/pkg/operator/ceph/cluster/osd/volumes.go
+++ b/pkg/operator/ceph/cluster/osd/volumes.go
@@ -87,6 +87,24 @@ func getDeviceMapperVolume() (v1.Volume, v1.VolumeMount) {
 	return volume, volumeMounts
 }
 
+func getOSDKeyring() (v1.Volume, v1.VolumeMount) {
+	volume := v1.Volume{
+		Name: "keyring",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: "/var/lib/ceph/bootstrap-osd/keyring",
+			},
+		},
+	}
+
+	volumeMounts := v1.VolumeMount{
+		Name:      "keyring",
+		MountPath: "/var/lib/ceph/bootstrap-osd/keyring",
+	}
+
+	return volume, volumeMounts
+}
+
 func getDataBridgeVolumeSource(claimName, configDir, namespace string, inProvisioning bool) v1.VolumeSource {
 	var source v1.VolumeSource
 	if inProvisioning {


### PR DESCRIPTION
when osd pods removed, they are not able
to add back due to missing `ceph auth`
or different `ceph auth`.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
this commit creates `ceph auth` in the osd
initcontainer.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
