### PR TITLE
ceph: update PodDisruptionBudget from v1beta1 to v1

### DIFF
--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -279,7 +279,7 @@ func (r *ReconcileNode) deleteCrashCollector(deployment appsv1.Deployment) error
 func (r *ReconcileNode) reconcileCrashRetention(namespace string, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) error {
 	k8sVersion, err := k8sutil.GetK8SVersion(r.context.Clientset)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch get k8s version")
+		return errors.Wrap(err, "failed to fetch k8s version")
 	}
 	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(minVersionForCronV1))
 

--- a/pkg/operator/ceph/disruption/clusterdisruption/add.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/add.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -87,6 +89,11 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 		return err
 	}
 
+	usePDBV1Beta1, err := k8sutil.UsePDBV1Beta1Version(reconcileClusterDisruption.context.ClusterdContext.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch pdb version")
+	}
+
 	// Only reconcile for PDB update event when allowed disruptions for the main OSD PDB is 0.
 	// This means that one of the OSD is down due to node drain or any other reason
 	pdbPredicate := predicate.Funcs{
@@ -95,7 +102,14 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			pdb, ok := e.ObjectNew.DeepCopyObject().(*policyv1beta1.PodDisruptionBudget)
+			if usePDBV1Beta1 {
+				pdb, ok := e.ObjectNew.DeepCopyObject().(*policyv1beta1.PodDisruptionBudget)
+				if !ok {
+					return false
+				}
+				return pdb.Name == osdPDBAppName && pdb.Status.DisruptionsAllowed == 0
+			}
+			pdb, ok := e.ObjectNew.DeepCopyObject().(*policyv1.PodDisruptionBudget)
 			if !ok {
 				return false
 			}
@@ -108,24 +122,46 @@ func Add(mgr manager.Manager, context *controllerconfig.Context) error {
 	}
 
 	// Watch for main PodDisruptionBudget and enqueue the CephCluster in the namespace
-	err = c.Watch(
-		&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}},
-		handler.EnqueueRequestsFromMapFunc(handler.MapFunc(func(obj client.Object) []reconcile.Request {
-			pdb, ok := obj.(*policyv1beta1.PodDisruptionBudget)
-			if !ok {
-				// Not a pdb, returning empty
-				logger.Errorf("PDB handler received non-PDB")
-				return []reconcile.Request{}
-			}
-			namespace := pdb.GetNamespace()
-			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
-			return []reconcile.Request{req}
-		}),
-		),
-		pdbPredicate,
-	)
-	if err != nil {
-		return err
+	if usePDBV1Beta1 {
+		err = c.Watch(
+			&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}},
+			handler.EnqueueRequestsFromMapFunc(handler.MapFunc(func(obj client.Object) []reconcile.Request {
+				pdb, ok := obj.(*policyv1beta1.PodDisruptionBudget)
+				if !ok {
+					// Not a pdb, returning empty
+					logger.Error("PDB handler received non-PDB")
+					return []reconcile.Request{}
+				}
+				namespace := pdb.GetNamespace()
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
+				return []reconcile.Request{req}
+			}),
+			),
+			pdbPredicate,
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = c.Watch(
+			&source.Kind{Type: &policyv1.PodDisruptionBudget{}},
+			handler.EnqueueRequestsFromMapFunc(handler.MapFunc(func(obj client.Object) []reconcile.Request {
+				pdb, ok := obj.(*policyv1.PodDisruptionBudget)
+				if !ok {
+					// Not a pdb, returning empty
+					logger.Error("PDB handler received non-PDB")
+					return []reconcile.Request{}
+				}
+				namespace := pdb.GetNamespace()
+				req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
+				return []reconcile.Request{req}
+			}),
+			),
+			pdbPredicate,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// enqueues with an empty name that is populated by the reconciler.

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd.go
@@ -34,11 +34,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	// cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 )
 
 const (
@@ -53,18 +53,18 @@ const (
 	nooutFlag                 = "noout"
 )
 
-func (r *ReconcileClusterDisruption) createPDB(pdb *policyv1beta1.PodDisruptionBudget) error {
+func (r *ReconcileClusterDisruption) createPDB(pdb client.Object) error {
 	err := r.client.Create(context.TODO(), pdb)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return errors.Wrapf(err, "failed to create pdb %q", pdb.Name)
+		return errors.Wrapf(err, "failed to create pdb %q", pdb.GetName())
 	}
 	return nil
 }
 
-func (r *ReconcileClusterDisruption) deletePDB(pdb *policyv1beta1.PodDisruptionBudget) error {
+func (r *ReconcileClusterDisruption) deletePDB(pdb client.Object) error {
 	err := r.client.Delete(context.TODO(), pdb)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to delete pdb %q", pdb.Name)
+		return errors.Wrapf(err, "failed to delete pdb %q", pdb.GetName())
 	}
 	return nil
 }
@@ -77,25 +77,56 @@ func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string) er
 		return errors.Errorf("failed to find the namespace %q in the clustermap", namespace)
 	}
 	pdbRequest := types.NamespacedName{Name: osdPDBAppName, Namespace: namespace}
-	pdb := &policyv1beta1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      osdPDBAppName,
-			Namespace: namespace,
-		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			MaxUnavailable: &intstr.IntOrString{IntVal: 1},
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{k8sutil.AppAttr: osdPDBAppName},
+	objectMeta := metav1.ObjectMeta{
+		Name:      osdPDBAppName,
+		Namespace: namespace,
+	}
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{k8sutil.AppAttr: osdPDBAppName},
+	}
+	usePDBV1Beta1, err := k8sutil.UsePDBV1Beta1Version(r.context.ClusterdContext.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch pdb version")
+	}
+	if usePDBV1Beta1 {
+		pdb := &policyv1beta1.PodDisruptionBudget{
+			ObjectMeta: objectMeta,
+			Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+				Selector:       selector,
 			},
+		}
+		ownerInfo := k8sutil.NewOwnerInfo(cephCluster, r.scheme)
+		err := ownerInfo.SetControllerReference(pdb)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set owner reference to pdb %v", pdb)
+		}
+
+		err = r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("all PGs are active+clean. Restoring default OSD pdb settings")
+				logger.Infof("creating the default pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
+				return r.createPDB(pdb)
+			}
+			return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
+		}
+		return nil
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: objectMeta,
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+			Selector:       selector,
 		},
 	}
 	ownerInfo := k8sutil.NewOwnerInfo(cephCluster, r.scheme)
-	err := ownerInfo.SetControllerReference(pdb)
+	err = ownerInfo.SetControllerReference(pdb)
 	if err != nil {
-		return errors.Wrapf(err, "failed to set owner reference to pdb %q", pdb)
+		return errors.Wrapf(err, "failed to set owner reference to pdb %v", pdb)
 	}
 
-	err = r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+	err = r.client.Get(context.TODO(), pdbRequest, &policyv1.PodDisruptionBudget{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("all PGs are active+clean. Restoring default OSD pdb settings")
@@ -109,13 +140,32 @@ func (r *ReconcileClusterDisruption) createDefaultPDBforOSD(namespace string) er
 
 func (r *ReconcileClusterDisruption) deleteDefaultPDBforOSD(namespace string) error {
 	pdbRequest := types.NamespacedName{Name: osdPDBAppName, Namespace: namespace}
-	pdb := &policyv1beta1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      osdPDBAppName,
-			Namespace: namespace,
-		},
+	objectMeta := metav1.ObjectMeta{
+		Name:      osdPDBAppName,
+		Namespace: namespace,
 	}
-	err := r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+	usePDBV1Beta1, err := k8sutil.UsePDBV1Beta1Version(r.context.ClusterdContext.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch pdb version")
+	}
+	if usePDBV1Beta1 {
+		pdb := &policyv1beta1.PodDisruptionBudget{
+			ObjectMeta: objectMeta,
+		}
+		err := r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
+		}
+		logger.Infof("deleting the default pdb %q with maxUnavailable=1 for all osd", osdPDBAppName)
+		return r.deletePDB(pdb)
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: objectMeta,
+	}
+	err = r.client.Get(context.TODO(), pdbRequest, &policyv1.PodDisruptionBudget{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -136,24 +186,53 @@ func (r *ReconcileClusterDisruption) createBlockingPDBForOSD(namespace, failureD
 
 	pdbName := getPDBName(failureDomainType, failureDomainName)
 	pdbRequest := types.NamespacedName{Name: pdbName, Namespace: namespace}
-	pdb := &policyv1beta1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pdbName,
-			Namespace: namespace,
-		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			MaxUnavailable: &intstr.IntOrString{IntVal: 0},
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{fmt.Sprintf(osd.TopologyLocationLabel, failureDomainType): failureDomainName},
+	objectMeta := metav1.ObjectMeta{
+		Name:      pdbName,
+		Namespace: namespace,
+	}
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{fmt.Sprintf(osd.TopologyLocationLabel, failureDomainType): failureDomainName},
+	}
+	usePDBV1Beta1, err := k8sutil.UsePDBV1Beta1Version(r.context.ClusterdContext.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch pdb version")
+	}
+	if usePDBV1Beta1 {
+		pdb := &policyv1beta1.PodDisruptionBudget{
+			ObjectMeta: objectMeta,
+			Spec: policyv1beta1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+				Selector:       selector,
 			},
+		}
+		ownerInfo := k8sutil.NewOwnerInfo(cephCluster, r.scheme)
+		err := ownerInfo.SetControllerReference(pdb)
+		if err != nil {
+			return errors.Wrapf(err, "failed to set owner reference to pdb %v", pdb)
+		}
+		err = r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Infof("creating temporary blocking pdb %q with maxUnavailable=0 for %q failure domain %q", pdbName, failureDomainType, failureDomainName)
+				return r.createPDB(pdb)
+			}
+			return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
+		}
+		return nil
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: objectMeta,
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+			Selector:       selector,
 		},
 	}
 	ownerInfo := k8sutil.NewOwnerInfo(cephCluster, r.scheme)
-	err := ownerInfo.SetControllerReference(pdb)
+	err = ownerInfo.SetControllerReference(pdb)
 	if err != nil {
-		return errors.Wrapf(err, "failed to set owner reference to pdb %q", pdb)
+		return errors.Wrapf(err, "failed to set owner reference to pdb %v", pdb)
 	}
-	err = r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+	err = r.client.Get(context.TODO(), pdbRequest, &policyv1.PodDisruptionBudget{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Infof("creating temporary blocking pdb %q with maxUnavailable=0 for %q failure domain %q", pdbName, failureDomainType, failureDomainName)
@@ -167,13 +246,32 @@ func (r *ReconcileClusterDisruption) createBlockingPDBForOSD(namespace, failureD
 func (r *ReconcileClusterDisruption) deleteBlockingPDBForOSD(namespace, failureDomainType, failureDomainName string) error {
 	pdbName := getPDBName(failureDomainType, failureDomainName)
 	pdbRequest := types.NamespacedName{Name: pdbName, Namespace: namespace}
-	pdb := &policyv1beta1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pdbName,
-			Namespace: namespace,
-		},
+	objectMeta := metav1.ObjectMeta{
+		Name:      pdbName,
+		Namespace: namespace,
 	}
-	err := r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+	usePDBV1Beta1, err := k8sutil.UsePDBV1Beta1Version(r.context.ClusterdContext.Clientset)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch pdb version")
+	}
+	if usePDBV1Beta1 {
+		pdb := &policyv1beta1.PodDisruptionBudget{
+			ObjectMeta: objectMeta,
+		}
+		err := r.client.Get(context.TODO(), pdbRequest, &policyv1beta1.PodDisruptionBudget{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return errors.Wrapf(err, "failed to get pdb %q", pdb.Name)
+		}
+		logger.Infof("deleting temporary blocking pdb with %q with maxUnavailable=0 for %q failure domain %q", pdbName, failureDomainType, failureDomainName)
+		return r.deletePDB(pdb)
+	}
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: objectMeta,
+	}
+	err = r.client.Get(context.TODO(), pdbRequest, &policyv1.PodDisruptionBudget{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
This commit update the PodDisruptionBudget policy to use version v1
Updated to policy/v1 as policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+

Closes: https://github.com/rook/rook/issues/7917
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
