### PR TITLE
ceph: pin volume replication to release-v0.1 branch

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -7501,10 +7501,16 @@ spec:
     kind: VolumeReplicationClass
     listKind: VolumeReplicationClassList
     plural: volumereplicationclasses
+    shortNames:
+      - vrc
     singular: volumereplicationclass
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .spec.provisioner
+          name: provisioner
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: VolumeReplicationClass is the Schema for the volumereplicationclasses API
@@ -7560,10 +7566,28 @@ spec:
     kind: VolumeReplication
     listKind: VolumeReplicationList
     plural: volumereplications
+    shortNames:
+      - vr
     singular: volumereplication
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.volumeReplicationClass
+          name: volumeReplicationClass
+          type: string
+        - jsonPath: .spec.dataSource.name
+          name: pvcName
+          type: string
+        - jsonPath: .spec.replicationState
+          name: desiredState
+          type: string
+        - jsonPath: .status.state
+          name: currentState
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: VolumeReplication is the Schema for the volumereplications API
@@ -7597,6 +7621,10 @@ spec:
                   type: object
                 replicationState:
                   description: ReplicationState represents the replication operation to be performed on the volume. Supported operations are "primary", "secondary" and "resync"
+                  enum:
+                    - primary
+                    - secondary
+                    - resync
                   type: string
                 volumeReplicationClass:
                   description: VolumeReplicationClass is the VolumeReplicationClass name for this VolumeReplication resource

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -7487,10 +7487,16 @@ spec:
     kind: VolumeReplicationClass
     listKind: VolumeReplicationClassList
     plural: volumereplicationclasses
+    shortNames:
+      - vrc
     singular: volumereplicationclass
   scope: Cluster
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .spec.provisioner
+          name: provisioner
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: VolumeReplicationClass is the Schema for the volumereplicationclasses API
@@ -7545,10 +7551,28 @@ spec:
     kind: VolumeReplication
     listKind: VolumeReplicationList
     plural: volumereplications
+    shortNames:
+      - vr
     singular: volumereplication
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.volumeReplicationClass
+          name: volumeReplicationClass
+          type: string
+        - jsonPath: .spec.dataSource.name
+          name: pvcName
+          type: string
+        - jsonPath: .spec.replicationState
+          name: desiredState
+          type: string
+        - jsonPath: .status.state
+          name: currentState
+          type: string
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: VolumeReplication is the Schema for the volumereplications API
@@ -7582,6 +7606,10 @@ spec:
                   type: object
                 replicationState:
                   description: ReplicationState represents the replication operation to be performed on the volume. Supported operations are "primary", "secondary" and "resync"
+                  enum:
+                    - primary
+                    - secondary
+                    - resync
                   type: string
                 volumeReplicationClass:
                   description: VolumeReplicationClass is the VolumeReplicationClass name for this VolumeReplication resource

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/banzaicloud/k8s-objectmatcher v1.1.0
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/corpix/uarand v0.1.1 // indirect
-	github.com/csi-addons/volume-replication-operator v0.1.0
+	github.com/csi-addons/volume-replication-operator v0.1.1-0.20210525040814-ab575a2879fb
 	github.com/davecgh/go-spew v1.1.1
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-ini/ini v1.51.1

--- a/go.sum
+++ b/go.sum
@@ -350,10 +350,10 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/csi-addons/spec v0.0.0-20210302071931-ad3b1446aba1 h1:iecYPYpGJEiTaxdl5sNeiJPMx8O+5fnRIE7B5bWxYuQ=
-github.com/csi-addons/spec v0.0.0-20210302071931-ad3b1446aba1/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
-github.com/csi-addons/volume-replication-operator v0.1.0 h1:kZal9GG4WnNZX2Sz/lm3shiGzQcKa8dLfCoElZ0F4Xo=
-github.com/csi-addons/volume-replication-operator v0.1.0/go.mod h1:BnUtthSLJf4POTRRwWn9WyovogYuXhdEilueIIb2fh4=
+github.com/csi-addons/spec v0.1.0 h1:y3TOd7qtnwBQPikGa1VvaL7ObyddAZehYW8DNGBlOyc=
+github.com/csi-addons/spec v0.1.0/go.mod h1:Mwq4iLiUV4s+K1bszcWU6aMsR5KPsbIYzzszJ6+56vI=
+github.com/csi-addons/volume-replication-operator v0.1.1-0.20210525040814-ab575a2879fb h1:SAD+o8nvVErQkOIa31u1BblVHAXXEPQl7mRc+U5GBp8=
+github.com/csi-addons/volume-replication-operator v0.1.1-0.20210525040814-ab575a2879fb/go.mod h1:cQvrR2fRQ7Z9jbbt3+PGZzFmByNfAH3KW8OuH3bkMbY=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/cznic/b v0.0.0-20180115125044-35e9bbe41f07/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/cznic/fileutil v0.0.0-20180108211300-6a051e75936f/go.mod h1:8S58EK26zhXSxzv7NQFpnliaOQsmDUxvoQO3rt154Vg=


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

added volume replication operator release-v0.1 branch to the go.mod as we are doing enhancements to the volume replication CRDS. Once we have a release will change this to the release-v0.1 branch.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
