### PR TITLE
ceph: remove '--site-name' arg when creating bootstrap peer token

### DIFF
--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -67,7 +67,7 @@ func CreateRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 	logger.Infof("create rbd-mirror bootstrap peer token for pool %q", poolName)
 
 	// Build command
-	args := []string{"mirror", "pool", "peer", "bootstrap", "create", poolName, "--site-name", clusterInfo.FSID}
+	args := []string{"mirror", "pool", "peer", "bootstrap", "create", poolName}
 	cmd := NewRBDCommand(context, clusterInfo, args)
 
 	// Run command

--- a/pkg/daemon/ceph/client/mirror_test.go
+++ b/pkg/daemon/ceph/client/mirror_test.go
@@ -45,8 +45,6 @@ func TestCreateRBDMirrorBootstrapPeer(t *testing.T) {
 			assert.Equal(t, "bootstrap", args[3])
 			assert.Equal(t, "create", args[4])
 			assert.Equal(t, pool, args[5])
-			assert.Equal(t, "--site-name", args[6])
-			assert.Equal(t, "4fe04ebb-ec0c-46c2-ac55-9eb52ebbfb82", args[7])
 			return bootstrapPeerToken, nil
 		}
 		return "", errors.New("unknown command")


### PR DESCRIPTION
`rbd mirror pool peer bootstrap create` will use cluster fsid by default, so specifying --site-name shouldn't be needed at all.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
