### PR TITLE
ceph: update references to v15.2.11 to v16.2.4

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -32,7 +32,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -59,7 +59,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -129,7 +129,7 @@ spec:
       - name: c
   cephVersion:
     # Stretch cluster is supported in Ceph Pacific or newer.
-    image: ceph/ceph:v16.2.2
+    image: ceph/ceph:v16.2.4
     allowUnsupported: true
   # Either storageClassDeviceSets or the storage section can be specified for creating OSDs.
   # This example uses all devices for simplicity.
@@ -167,7 +167,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 * `external`:
   * `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs if an image is provided and will refuse otherwise. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster). If `cephVersion.image` is left blank, Rook will refuse the creation of extra CRs like object, file and nfs.
 * `cephVersion`: The version information for launching the ceph daemons.
-  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v14.2.12` or `ceph/ceph:v15.2.11`. For more details read the [container images section](#ceph-container-images).
+  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v15.2.12` or `v16.2.4`. For more details read the [container images section](#ceph-container-images).
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
   To ensure a consistent version of the image is running across all nodes in the cluster, it is recommended to use a very specific image version.
   Tags also exist that would give the latest version, but they are only recommended for test environments. For example, the tag `v14` will be updated each time a new nautilus build is released.
@@ -651,8 +651,8 @@ kubectl -n rook-ceph get CephCluster -o yaml
       deviceClasses:
       - name: hdd
     version:
-      image: ceph/ceph:v15
-      version: 15.2.9-0
+      image: ceph/ceph:v16.2.4
+      version: 16.2.4-0
     conditions:
     - lastHeartbeatTime: "2021-03-02T21:22:11Z"
       lastTransitionTime: "2021-03-02T21:21:09Z"
@@ -713,7 +713,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -745,7 +745,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -785,7 +785,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -832,7 +832,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -938,7 +938,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -984,7 +984,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -1442,7 +1442,7 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v15.2.11 # Should match external cluster version
+    image: ceph/ceph:v16.2.4 # Should match external cluster version
 ```
 
 ### Cleanup policy

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -400,10 +400,10 @@ until all the daemons have been updated.
 Official Ceph container images can be found on [Docker Hub](https://hub.docker.com/r/ceph/ceph/tags/).
 These images are tagged in a few ways:
 
-* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v15.2.11-20210224`).
+* The most explicit form of tags are full-ceph-version-and-build tags (e.g., `v16.2.4-20210514`).
   These tags are recommended for production clusters, as there is no possibility for the cluster to
   be heterogeneous with respect to the version of Ceph running in containers.
-* Ceph major version tags (e.g., `v15`) are useful for development and test clusters so that the
+* Ceph major version tags (e.g., `v16`) are useful for development and test clusters so that the
   latest version of Ceph is always available.
 
 **Ceph containers other than the official images from the registry above will not be supported.**
@@ -416,7 +416,7 @@ The majority of the upgrade will be handled by the Rook operator. Begin the upgr
 Ceph image field in the cluster CRD (`spec.cephVersion.image`).
 
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v15.2.11-20210224'
+NEW_CEPH_IMAGE='ceph/ceph:v16.2.4-20210514'
 CLUSTER_NAME="$ROOK_CLUSTER_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_CLUSTER_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```
@@ -435,10 +435,10 @@ Determining when the Ceph has fully updated is rather simple.
 ```console
 kubectl -n $ROOK_CLUSTER_NAMESPACE get deployment -l rook_cluster=$ROOK_CLUSTER_NAMESPACE -o jsonpath='{range .items[*]}{"ceph-version="}{.metadata.labels.ceph-version}{"\n"}{end}' | sort | uniq
 This cluster is not yet finished:
-    ceph-version=14.2.7-0
-    ceph-version=15.2.9-0
+    ceph-version=15.2.12-0
+    ceph-version=16.2.4-0
 This cluster is finished:
-    ceph-version=15.2.9-0
+    ceph-version=16.2.4-0
 ```
 
 #### 3. Verify the updated cluster

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -477,7 +477,7 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.11
+                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
                       type: string
                   required:
                     - image

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -19,4 +19,4 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is required, if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v15.2.11 # Should match external cluster version
+    image: ceph/ceph:v16.2.4 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -33,7 +33,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -39,7 +39,7 @@ spec:
     count: 2
   cephVersion:
     # Stretch cluster support upstream is only available starting in Ceph Pacific
-    image: ceph/ceph:v16.2.2
+    image: ceph/ceph:v16.2.4
     allowUnsupported: true
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -19,9 +19,9 @@ spec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.11-20200419
+    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v16.2.4-20210514
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
     # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -477,7 +477,7 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.11
+                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
                       type: string
                   required:
                     - image

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -230,7 +230,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v15.2.11"
+              "image": "ceph/ceph:v16.2.4"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/design/ceph/ceph-cluster-cleanup.md
+++ b/design/ceph/ceph-cluster-cleanup.md
@@ -34,7 +34,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v15.2.11
+    image: ceph/ceph:v16.2.4
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -18,9 +18,9 @@ include ../image.mk
 # Image Build Options
 
 ifeq ($(GOARCH),amd64)
-CEPH_VERSION = v16.2.2-20210505
+CEPH_VERSION = v16.2.4-20210513
 else
-CEPH_VERSION = v16.2.2-20210505
+CEPH_VERSION = v16.2.4-20210514
 endif
 BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -251,7 +251,7 @@ type KeyManagementServiceSpec struct {
 
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.
 type CephVersionSpec struct {
-	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v15.2.11
+	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
 	Image string `json:"image"`
 
 	// Whether to allow unsupported versions (do not set to true in production)

--- a/tests/scripts/k8s-vagrant-multi-node.sh
+++ b/tests/scripts/k8s-vagrant-multi-node.sh
@@ -43,7 +43,6 @@ function copy_images() {
     if [[ "$1" == "" || "$1" == "ceph" ]]; then
       echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-      copy_image_to_cluster ceph/ceph:v15 ceph/ceph:v15
     fi
 
     if [[ "$1" == "" || "$1" == "cassandra" ]]; then

--- a/tests/scripts/minikube.sh
+++ b/tests/scripts/minikube.sh
@@ -31,8 +31,6 @@ function copy_images() {
     if [[ "$1" == "" || "$1" == "ceph" ]]; then
       echo "copying ceph images"
       copy_image_to_cluster "${BUILD_REGISTRY}/ceph-amd64" rook/ceph:master
-      # uncomment to push the nautilus image when needed
-      #copy_image_to_cluster ceph/ceph:v15 ceph/ceph:v15
     fi
 
     if [[ "$1" == "" || "$1" == "cassandra" ]]; then


### PR DESCRIPTION
Ceph v16 will be the default in Rook v1.7. Update references in the
master branch from v15 (currently v15.2.11) to v16 (currently v16.2.4).

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
