### PR TITLE
ceph: parse json correctly

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -60,7 +60,7 @@ func NewMultisiteContext(context *clusterd.Context, clusterInfo *client.ClusterI
 func extractJSON(output string) (string, error) {
 	// `radosgw-admin` sometimes leaves logs to stderr even if it succeeds.
 	// So we should skip them if parsing output as json.
-	pattern := regexp.MustCompile("(?ms)^{.*")
+	pattern := regexp.MustCompile(`(?ms)^{.*}$`)
 	match := pattern.Find([]byte(output))
 	if match == nil {
 		return "", errors.Errorf("didn't contain json. %s", output)

--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -45,4 +45,10 @@ func TestExtractJson(t *testing.T) {
 	match, err = extractJSON(s)
 	assert.NoError(t, err)
 	assert.True(t, json.Valid([]byte(match)))
+
+	s = `{"test": "test"}
+this line can't be parsed as json`
+	match, err = extractJSON(s)
+	assert.NoError(t, err)
+	assert.True(t, json.Valid([]byte(match)))
 }


### PR DESCRIPTION
**Description of your changes:**

radosgw-admin may output logs before and after JSON when this command succeeds. We should get rid of these logs before unmarshaling output. Although the logs before JSON were treated in  PR7354, the logs after JSON weren't.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
