### PR TITLE
ceph: expand PVC only if storageclass allow expansion

### DIFF
--- a/pkg/operator/k8sutil/pvc_test.go
+++ b/pkg/operator/k8sutil/pvc_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,24 +32,46 @@ import (
 func TestExpandPVCIfRequired(t *testing.T) {
 
 	testcases := []struct {
-		label          string
-		currentPVCSize string
-		desiredPVCSize string
+		label            string
+		currentPVCSize   string
+		desiredPVCSize   string
+		expansionAllowed bool
 	}{
 		{
-			label:          "case 1: size is equal",
-			currentPVCSize: "1Mi",
-			desiredPVCSize: "1Mi",
+			label:            "case 1: size is equal",
+			currentPVCSize:   "1Mi",
+			desiredPVCSize:   "1Mi",
+			expansionAllowed: true,
 		},
 		{
-			label:          "case 2: current size is less",
-			currentPVCSize: "1Mi",
-			desiredPVCSize: "2Mi",
+			label:            "case 2: current size is less",
+			currentPVCSize:   "1Mi",
+			desiredPVCSize:   "2Mi",
+			expansionAllowed: true,
 		},
 		{
-			label:          "case 3: current size is more",
-			currentPVCSize: "2Mi",
-			desiredPVCSize: "1Mi",
+			label:            "case 3: current size is more",
+			currentPVCSize:   "2Mi",
+			desiredPVCSize:   "1Mi",
+			expansionAllowed: true,
+		},
+		{
+			label:            "case 4: storage class allows expansion",
+			currentPVCSize:   "1Mi",
+			desiredPVCSize:   "2Mi",
+			expansionAllowed: true,
+		},
+		{
+			label:            "case 5: storage class does not allow expansion",
+			currentPVCSize:   "1Mi",
+			desiredPVCSize:   "2Mi",
+			expansionAllowed: false,
+		},
+	}
+
+	storageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
 		},
 	}
 
@@ -66,15 +89,17 @@ func TestExpandPVCIfRequired(t *testing.T) {
 					v1.ResourceName(v1.ResourceStorage): apiresource.MustParse("1Mi"),
 				},
 			},
+			StorageClassName: &storageClass.ObjectMeta.Name,
 		},
 	}
 
 	for _, tc := range testcases {
 
 		desiredPVC.Spec.Resources.Requests[v1.ResourceStorage] = apiresource.MustParse(tc.currentPVCSize)
+		storageClass.AllowVolumeExpansion = &tc.expansionAllowed
 
 		// create fake client with PVC
-		cl := fake.NewClientBuilder().WithRuntimeObjects(desiredPVC).Build()
+		cl := fake.NewClientBuilder().WithRuntimeObjects(desiredPVC, storageClass).Build()
 
 		// get existing PVC
 		existingPVC := &v1.PersistentVolumeClaim{}
@@ -90,7 +115,7 @@ func TestExpandPVCIfRequired(t *testing.T) {
 		assert.NoError(t, err)
 
 		// verify size
-		if tc.currentPVCSize <= tc.desiredPVCSize {
+		if tc.currentPVCSize <= tc.desiredPVCSize && tc.expansionAllowed {
 			assert.Equal(t, desiredPVC.Spec.Resources.Requests[v1.ResourceStorage], existingPVC.Spec.Resources.Requests[v1.ResourceStorage])
 		} else {
 			assert.Equal(t, apiresource.MustParse(tc.currentPVCSize), existingPVC.Spec.Resources.Requests[v1.ResourceStorage])


### PR DESCRIPTION
Expand the functionality of 'ExpandPVCIfRequired' to check if
storageclass does allow expansion then only expand the PVC.
otherwise skip the expansion.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

**Description of your changes:**
We have seen cases where expansion is not allowed by the storage class and PVC update with the new size fails because of the same reason. Handle this via checking the storage class's ability to expand PVC.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
