### PR TITLE
docs: add design for overriding mon_data_size_warn

### DIFF
--- a/design/ceph/ceph-mon-pv.md
+++ b/design/ceph/ceph-mon-pv.md
@@ -1,7 +1,5 @@
 # Ceph monitor PV storage
 
-**Target version**: Rook 1.1
-
 ## Overview
 
 Currently all of the storage for Ceph monitors (data, logs, etc..) is provided
@@ -25,6 +23,7 @@ type MonSpec struct {
 	Count                int  `json:"count"`
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode"`
 	VolumeClaimTemplate  *v1.PersistentVolumeClaim
+	DataSizeWarn *resource.Quantity `json:"dataSizeWarn,omitempty"`
 }
 ```
 
@@ -36,6 +35,19 @@ template. If the storage resource requirements are not specified in the claim
 template, then Rook will use a default value. This is possible because unlike
 the storage requirements of OSDs (xf: StorageClassDeviceSets), reasonable
 defaults (e.g. 5-10 GB) exist for monitor daemon storage needs.
+
+`MON_DISK_BIG` alert is triggered if the size of the monitor’s database is larger
+than `mon_data_size_warn` (default: 15 GiB) config. `DataSizeWarn` can be used to
+override the default `mon_data_size_warn`. `DataSizeWarn` should be used only in
+case of monitors on PV. Its value should be less than storage requirement provided
+in the VolumeClaimTemplate.
+
+For example: If the storage requirement for monitor PV is 15Gi then `DataSizeWarn`
+could be set to 10Gi. This will set the `mon_data_size_warn` config to 10Gi and
+`MON_DISK_BIG` alert will be triggered when this threshold of 10Gi is exceeded.
+
+If `DataSizeWarn` is not provided then rook will set the `mon_data_size_warn` to
+90% of the storage requirement mentioned in the `VolumelClaimTemplate`
 
 *Logs and crash data*. The current implementation continues the use of a
 HostPath volume based on `dataDirHostPath` for storing daemon log and crash


### PR DESCRIPTION
`mon_data_size_warn health` config for monitors has default value of 15Gi. For monitors on PV with size of 10Gi, this alert never gets triggered. Added design to override the default mon_data_size_warn threshold.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.


[skip ci]