### PR TITLE
ceph: add ceph cluster fsid to LUKS header

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/security.go
+++ b/pkg/apis/ceph.rook.io/v1/security.go
@@ -16,6 +16,16 @@ limitations under the License.
 
 package v1
 
+import (
+	"strings"
+
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	VaultTLSConnectionDetails = []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey}
+)
+
 // IsEnabled return whether a KMS is configured
 func (kms *KeyManagementServiceSpec) IsEnabled() bool {
 	return len(kms.ConnectionDetails) != 0
@@ -24,4 +34,23 @@ func (kms *KeyManagementServiceSpec) IsEnabled() bool {
 // IsTokenAuthEnabled return whether KMS token auth is enabled
 func (kms *KeyManagementServiceSpec) IsTokenAuthEnabled() bool {
 	return kms.TokenSecretName != ""
+}
+
+// IsTLSEnabled return KMS TLS details are configured
+func (kms *KeyManagementServiceSpec) IsTLSEnabled() bool {
+	for _, tlsOption := range VaultTLSConnectionDetails {
+		tlsSecretName := getParam(kms.ConnectionDetails, tlsOption)
+		if tlsSecretName != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// getParam returns the value of the KMS config option
+func getParam(kmsConfig map[string]string, param string) string {
+	if val, ok := kmsConfig[param]; ok && val != "" {
+		return strings.TrimSpace(val)
+	}
+	return ""
 }

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -25,6 +25,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	luksDump = `LUKS header information
+Version:        2
+Epoch:          13
+Metadata area:  12288 bytes
+UUID:           a97525ee-7c30-4f70-89ac-e56d48907cc5
+Label:          pvc_name=set1-data-0lmdjp
+Subsystem:      ceph_fsid=811e7dc0-ea13-4951-b000-24a8565d0735
+Flags:          (no flags)
+
+Data segments:
+  0: crypt
+        offset: 2097152 [bytes]
+        length: (whole device)
+        cipher: aes-xts-plain64
+        sector: 512 [bytes]
+
+Keyslots:
+  0: luks2
+        Key:        256 bits
+        Priority:   normal
+        Cipher:     aes-xts-plain64
+        PBKDF:      pbkdf2
+        Hash:       sha256
+        Iterations: 583190
+        Salt:       4f 9d 0d 0b 83 41 2f 47 b4 1f 6b 35 df 89 e0 33
+                    c8 bd 27 60 22 a5 f5 02 62 94 a9 92 12 2a 4f c0
+        AF stripes: 4000
+        Area offset:32768 [bytes]
+        Area length:131072 [bytes]
+        Digest ID:  0
+Tokens:
+Digests:
+  0: pbkdf2
+        Hash:       sha256
+        Iterations: 36127
+        Salt:       db 98 33 3a d4 15 b6 6c 48 63 6d 7b 33 b0 7e cd
+                    ef 90 8d 81 46 37 78 b4 82 37 3b 84 e8 e7 d8 1b
+        Digest:     6d 86 96 05 99 4f a9 48 87 54
+                    5c ef 4b 99 3b 9d fa 0b 8f 8a`
+)
+
 func TestCloseEncryptedDevice(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
@@ -59,4 +101,26 @@ Driver version:    4.40.0
 	context := &clusterd.Context{Executor: executor}
 	err := dmsetupVersion(context)
 	assert.NoError(t, err)
+}
+
+func TestIsCephEncryptedBlock(t *testing.T) {
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("%s %v", command, args)
+		if command == cryptsetupBinary && args[0] == "luksDump" {
+			return luksDump, nil
+		}
+
+		return "", errors.Errorf("unknown command %s %s", command, args)
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	t.Run("different fsid", func(t *testing.T) {
+		isCephEncryptedBlock := isCephEncryptedBlock(context, "foo", "/dev/sda1")
+		assert.False(t, isCephEncryptedBlock)
+	})
+	t.Run("same cluster", func(t *testing.T) {
+		isCephEncryptedBlock := isCephEncryptedBlock(context, "811e7dc0-ea13-4951-b000-24a8565d0735", "/dev/sda1")
+		assert.True(t, isCephEncryptedBlock)
+	})
 }

--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -53,7 +53,7 @@ func vaultTokenEnvVarFromSecret(tokenSecretName string) v1.EnvVar {
 func vaultTLSEnvVarFromSecret(kmsConfig map[string]string) []v1.EnvVar {
 	vaultTLSEnvVar := []v1.EnvVar{}
 
-	for _, tlsOption := range vaultTLSConnectionDetails {
+	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
 		tlsSecretName := GetParam(kmsConfig, tlsOption)
 		if tlsSecretName != "" {
 			vaultTLSEnvVar = append(vaultTLSEnvVar, v1.EnvVar{Name: tlsOption, Value: path.Join(EtcVaultDir, tlsSecretPath(tlsOption))})
@@ -73,7 +73,7 @@ func VaultConfigToEnvVar(spec cephv1.ClusterSpec) []v1.EnvVar {
 	}
 	for k, v := range spec.Security.KeyManagementService.ConnectionDetails {
 		// Skip TLS and token env var to avoid env being set multiple times
-		toSkip := append(vaultTLSConnectionDetails, api.EnvVaultToken)
+		toSkip := append(cephv1.VaultTLSConnectionDetails, api.EnvVaultToken)
 		if client.StringInSlice(k, toSkip) {
 			continue
 		}

--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -25,6 +25,7 @@ import (
 	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/vault"
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,7 +43,6 @@ const (
 
 var (
 	vaultMandatoryConnectionDetails = []string{api.EnvVaultAddress}
-	vaultTLSConnectionDetails       = []string{api.EnvVaultCACert, api.EnvVaultClientCert, api.EnvVaultClientKey}
 )
 
 /* VAULT API INTERNAL VALUES
@@ -98,7 +98,7 @@ func InitVault(context *clusterd.Context, namespace string, config map[string]st
 
 func configTLS(clusterdContext *clusterd.Context, namespace string, config map[string]string) (map[string]string, error) {
 	ctx := context.TODO()
-	for _, tlsOption := range vaultTLSConnectionDetails {
+	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
 		tlsSecretName := GetParam(config, tlsOption)
 		if tlsSecretName == "" {
 			continue
@@ -209,7 +209,7 @@ func validateVaultConnectionDetails(clusterdContext *clusterd.Context, ns string
 	}
 
 	// Validate potential TLS configuration
-	for _, tlsOption := range vaultTLSConnectionDetails {
+	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
 		tlsSecretName := GetParam(kmsConfig, tlsOption)
 		if tlsSecretName != "" {
 			// Fetch the secret

--- a/pkg/daemon/ceph/osd/kms/volumes.go
+++ b/pkg/daemon/ceph/osd/kms/volumes.go
@@ -19,6 +19,7 @@ package kms
 import (
 	"github.com/hashicorp/vault/api"
 	"github.com/libopenstorage/secrets"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -45,7 +46,7 @@ func TLSSecretVolumeAndMount(config map[string]string) []v1.VolumeProjection {
 	mode := int32(0400)
 
 	// Vault TLS Secrets
-	for _, tlsOption := range vaultTLSConnectionDetails {
+	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
 		tlsSecretName := GetParam(config, tlsOption)
 		if tlsSecretName != "" {
 			projectionSecret := &v1.SecretProjection{Items: []v1.KeyToPath{{Key: tlsSecretKeyToCheck(tlsOption), Path: tlsSecretPath(tlsOption), Mode: &mode}}}

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -198,7 +198,7 @@ set -e
 KEK_NAME=%s
 KEY_PATH=%s
 CURL_PAYLOAD=$(mktemp)
-ARGS=(--silent --show-error --request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
+ARGS=(--silent --show-error --request GET --header "X-Vault-Token: ${VAULT_TOKEN//[$'\t\r\n']}")
 PYTHON_DATA_PARSE="['data']"
 
 # If a vault namespace is set

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -383,8 +383,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
 	cont = deployment.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, 7, len(cont.VolumeMounts), cont.VolumeMounts)
-	assert.Equal(t, 10, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes)                                     // One more than the encryption with k8s for the kek get init container
-	assert.Equal(t, 0, len(deployment.Spec.Template.Spec.Volumes[7].VolumeSource.Projected.Sources), deployment.Spec.Template.Spec.Volumes[0]) // 0 since we have no tls secrets
+	assert.Equal(t, 9, len(deployment.Spec.Template.Spec.Volumes), deployment.Spec.Template.Spec.Volumes) // One more than the encryption with k8s for the kek get init container
 
 	// Test with encrypted OSD on PVC with RAW with KMS with TLS
 	osdProp.encrypted = true

--- a/tests/manifests/test-cluster-on-pvc-encrypted.yaml
+++ b/tests/manifests/test-cluster-on-pvc-encrypted.yaml
@@ -14,7 +14,7 @@ spec:
           requests:
             storage: 5Gi
   cephVersion:
-    image: ceph/ceph:v14
+    image: ceph/ceph:v15
   dashboard:
     enabled: false
   network:

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -124,7 +124,7 @@ function deploy_cluster() {
 }
 
 function wait_for_prepare_pod() {
-    timeout 180 sh -c 'until kubectl -n rook-ceph logs -f $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'); do sleep 5; done' || true
+    timeout 180 sh -c 'until kubectl -n rook-ceph logs -f job/$(kubectl -n rook-ceph get job -l app=rook-ceph-osd-prepare -o jsonpath='{.items[0].metadata.name}'); do sleep 5; done' || true
     timeout 60 sh -c 'until kubectl -n rook-ceph logs $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd,ceph_daemon_id=0 -o jsonpath='{.items[*].metadata.name}') --all-containers; do echo "waiting for osd container" && sleep 1; done' || true
     kubectl -n rook-ceph describe job/$(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}') || true
     kubectl -n rook-ceph describe deploy/rook-ceph-osd-0 || true

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -105,10 +105,14 @@ function display_status {
   $EXEC_COMMAND osd dump > test/ceph-osd-dump.txt
   $EXEC_COMMAND report > test/ceph-report.txt
 
-  kubectl -n rook-ceph logs "$(kubectl -n rook-ceph -l app=rook-ceph-operator get pods -o jsonpath='{.items[*].metadata.name}')" > test/operator.txt
-  kubectl -n rook-ceph get pods > test/pods-list.txt
-  kubectl -n rook-ceph describe job/"$(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}')" > test/osd-prepare.txt
-  kubectl -n rook-ceph describe deploy/rook-ceph-osd-0 > test/osd-deploy.txt
+  kubectl -n rook-ceph logs deploy/rook-ceph-operator > test/operator-logs.txt
+  kubectl -n rook-ceph get pods -o wide > test/pods-list.txt
+  kubectl -n rook-ceph describe job/"$(kubectl -n rook-ceph get job -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}')" > test/osd-prepare-describe.txt
+  kubectl -n rook-ceph log job/"$(kubectl -n rook-ceph get job -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}')" > test/osd-prepare-logs.txt
+  kubectl -n rook-ceph describe deploy/rook-ceph-osd-0 > test/rook-ceph-osd-0-describe.txt
+  kubectl -n rook-ceph describe deploy/rook-ceph-osd-1 > test/rook-ceph-osd-1-describe.txt
+  kubectl -n rook-ceph logs deploy/rook-ceph-osd-0 --all-containers > test/rook-ceph-osd-0-logs.txt
+  kubectl -n rook-ceph logs deploy/rook-ceph-osd-1 --all-containers > test/rook-ceph-osd-1-logs.txt
   kubectl get all -n rook-ceph -o wide > test/cluster-wide.txt
   kubectl get all -n rook-ceph -o yaml > test/cluster-yaml.txt
   kubectl -n rook-ceph get cephcluster -o yaml > test/cephcluster.txt


### PR DESCRIPTION
When configuring encrypted on-pvc clusters we now set the cluster fsid
in the LUKS header. If needed we can then determine if the encrypted
block is part of our cluster or not. We also attach the pvc_name in case
it might become useful.

Closes: #7991
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
