### PR TITLE
ceph: remove one extra mon per health check

### DIFF
--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -166,14 +166,15 @@ func (c *Cluster) checkHealth() error {
 				if err := c.removeMon(mon.Name); err != nil {
 					logger.Warningf("failed to remove mon %q. %v", mon.Name, err)
 				}
-			} else {
-				logger.Warningf(
-					"mon %q not in source of truth and not in quorum, not enough mons to remove now (wanted: %d, current: %d)",
-					mon.Name,
-					desiredMonCount,
-					len(quorumStatus.MonMap.Mons),
-				)
+				// only remove one extra mon per health check
+				return nil
 			}
+			logger.Warningf(
+				"mon %q not in source of truth and not in quorum, not enough mons to remove now (wanted: %d, current: %d)",
+				mon.Name,
+				desiredMonCount,
+				len(quorumStatus.MonMap.Mons),
+			)
 		}
 
 		if inQuorum {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
If the number of desired mons is reduced, for example from 5 down to 3, the extra mons will be removed by the next health check. Only a single mon can be removed per health check to ensure that other mons do not become unhealthy at the same time as removing an extra mon, and so the list of healthy mons can be refreshed. If multiple mons are removed in a single health check, we risk removing too many mons and losing quorum.

This also enables specific mons to be removed as described in #7999.

**Which issue is resolved by this Pull Request:**
Resolves #7999

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
