### PR TITLE
ceph: retry starting CSI drivers on failure

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -28,110 +28,110 @@ import (
 )
 
 func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage, securityAccount string, serverVersion *version.Info, ownerInfo *k8sutil.OwnerInfo) {
-	var v *CephCSIVersion
-	var err error
-	if !AllowUnsupported && CSIEnabled() {
-		if v, err = validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerInfo); err != nil {
-			logger.Errorf("invalid csi version. %+v", err)
-			return
-		}
-	} else {
-		logger.Info("Skipping csi version check, since unsupported versions are allowed or csi is disabled")
-	}
+	csiLock.Lock()
+	defer csiLock.Unlock()
 
 	if CSIEnabled() {
-		if err := startDrivers(context.Clientset, context.RookClientset, namespace, serverVersion, ownerInfo, v); err != nil {
-			logger.Errorf("failed to start Ceph csi drivers. %v", err)
-			return
+		for i := maxRetries - 1; i >= 0; i-- {
+			if err := startDrivers(context.Clientset, context.RookClientset, namespace, rookImage, securityAccount, serverVersion, ownerInfo); err != nil {
+				if i == 0 {
+					logger.Error("failed to start Ceph csi drivers. %v. Will not retry starting csi drivers.", err)
+				}
+				logger.Errorf("failed to start Ceph csi drivers. %v. Will retry starting csi drivers %d more times.", err, i)
+			} else {
+				break
+			}
 		}
 	}
 
 	stopDrivers(context.Clientset, namespace, serverVersion)
 }
 
-func SetParams(clientset kubernetes.Interface) error {
-	var err error
-
+func SetParams(clientset kubernetes.Interface) (Param, error) {
+	var (
+		err      error
+		CSIParam Param
+	)
 	csiEnableRBD, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ENABLE_RBD", "true")
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if CSI driver for RBD is enabled")
+		return CSIParam, errors.Wrap(err, "unable to determine if CSI driver for RBD is enabled")
 	}
 	if EnableRBD, err = strconv.ParseBool(csiEnableRBD); err != nil {
-		return errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_RBD'")
+		return CSIParam, errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_RBD'")
 	}
 
 	csiEnableCephFS, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ENABLE_CEPHFS", "true")
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if CSI driver for CephFS is enabled")
+		return CSIParam, errors.Wrap(err, "unable to determine if CSI driver for CephFS is enabled")
 	}
 	if EnableCephFS, err = strconv.ParseBool(csiEnableCephFS); err != nil {
-		return errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_CEPHFS'")
+		return CSIParam, errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_CEPHFS'")
 	}
 
 	csiAllowUnsupported, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ALLOW_UNSUPPORTED_VERSION", "false")
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if unsupported version is allowed")
+		return CSIParam, errors.Wrap(err, "unable to determine if unsupported version is allowed")
 	}
 	if AllowUnsupported, err = strconv.ParseBool(csiAllowUnsupported); err != nil {
-		return errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ALLOW_UNSUPPORTED_VERSION'")
+		return CSIParam, errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ALLOW_UNSUPPORTED_VERSION'")
 	}
 
 	csiEnableCSIGRPCMetrics, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ENABLE_GRPC_METRICS", "false")
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if CSI GRPC metrics is enabled")
+		return CSIParam, errors.Wrap(err, "unable to determine if CSI GRPC metrics is enabled")
 	}
 	if EnableCSIGRPCMetrics, err = strconv.ParseBool(csiEnableCSIGRPCMetrics); err != nil {
-		return errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_GRPC_METRICS'")
+		return CSIParam, errors.Wrap(err, "unable to parse value for 'ROOK_CSI_ENABLE_GRPC_METRICS'")
 	}
 
 	csiEnableCSIHostNetwork, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "CSI_ENABLE_HOST_NETWORK", "false")
 	if err != nil {
-		return errors.Wrap(err, "failed to determine if CSI Host Network is enabled")
+		return CSIParam, errors.Wrap(err, "failed to determine if CSI Host Network is enabled")
 	}
 	if CSIParam.EnableCSIHostNetwork, err = strconv.ParseBool(csiEnableCSIHostNetwork); err != nil {
-		return errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_HOST_NETWORK'")
+		return CSIParam, errors.Wrap(err, "failed to parse value for 'CSI_ENABLE_HOST_NETWORK'")
 	}
 
 	CSIParam.CSIPluginImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_CEPH_IMAGE", DefaultCSIPluginImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI plugin image")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI plugin image")
 	}
 	CSIParam.RegistrarImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_REGISTRAR_IMAGE", DefaultRegistrarImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI registrar image")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI registrar image")
 	}
 	CSIParam.ProvisionerImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_PROVISIONER_IMAGE", DefaultProvisionerImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI provisioner image")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI provisioner image")
 	}
 	CSIParam.AttacherImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ATTACHER_IMAGE", DefaultAttacherImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI attacher image")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI attacher image")
 	}
 	CSIParam.SnapshotterImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_SNAPSHOTTER_IMAGE", DefaultSnapshotterImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI snapshotter image")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI snapshotter image")
 	}
 	CSIParam.KubeletDirPath, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_KUBELET_DIR_PATH", DefaultKubeletDirPath)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI kubelet directory path")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI kubelet directory path")
 	}
 	CSIParam.VolumeReplicationImage, err = k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "CSI_VOLUME_REPLICATION_IMAGE", DefaultVolumeReplicationImage)
 	if err != nil {
-		return errors.Wrap(err, "unable to configure Volume replication controller image")
+		return CSIParam, errors.Wrap(err, "unable to configure Volume replication controller image")
 	}
 
 	csiCephFSPodLabels, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_CEPHFS_POD_LABELS", "")
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI CephFS pod labels")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI CephFS pod labels")
 	}
 	CSIParam.CSICephFSPodLabels = k8sutil.ParseStringToLabels(csiCephFSPodLabels)
 
 	csiRBDPodLabels, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_RBD_POD_LABELS", "")
 	if err != nil {
-		return errors.Wrap(err, "unable to configure CSI RBD pod labels")
+		return CSIParam, errors.Wrap(err, "unable to configure CSI RBD pod labels")
 	}
 	CSIParam.CSIRBDPodLabels = k8sutil.ParseStringToLabels(csiRBDPodLabels)
 
-	return nil
+	return CSIParam, nil
 }

--- a/pkg/operator/ceph/csi/spec_test.go
+++ b/pkg/operator/ceph/csi/spec_test.go
@@ -32,13 +32,6 @@ func TestStartCSI(t *testing.T) {
 	CephFSPluginTemplatePath = "csi-cephfsplugin.yaml"
 	CephFSProvisionerDepTemplatePath = "csi-cephfsplugin-provisioner-dep.yaml"
 
-	CSIParam = Param{
-		CSIPluginImage:   "image",
-		RegistrarImage:   "image",
-		ProvisionerImage: "image",
-		AttacherImage:    "image",
-		SnapshotterImage: "image",
-	}
 	clientset := test.New(t, 3)
 	context := &clusterd.Context{
 		Clientset:     clientset,
@@ -49,6 +42,6 @@ func TestStartCSI(t *testing.T) {
 		assert.Nil(t, err)
 	}
 	AllowUnsupported = true
-	err = startDrivers(context.Clientset, context.RookClientset, "ns", serverVersion, nil, nil)
+	err = startDrivers(context.Clientset, context.RookClientset, "ns", "", "", serverVersion, nil)
 	assert.Nil(t, err)
 }

--- a/pkg/operator/ceph/csi/util_test.go
+++ b/pkg/operator/ceph/csi/util_test.go
@@ -90,7 +90,7 @@ func TestDaemonSetTemplate(t *testing.T) {
 	assert.Nil(t, err)
 
 	tp := templateParam{
-		Param:     CSIParam,
+		Param:     Param{},
 		Namespace: "foo",
 	}
 	_, err = templateToDaemonSet("test-ds", tmp.Name(), tp)
@@ -109,7 +109,7 @@ func TestStatefulSetTemplate(t *testing.T) {
 	assert.Nil(t, err)
 
 	tp := templateParam{
-		Param:     CSIParam,
+		Param:     Param{},
 		Namespace: "foo",
 	}
 	_, err = templateToStatefulSet("test-ss", tmp.Name(), tp)

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -117,10 +117,10 @@ func (v *CephCSIVersion) isAtLeast(version *CephCSIVersion) bool {
 }
 
 // extractCephCSIVersion extracts the major, minor and extra digit of a Ceph CSI release
-func extractCephCSIVersion(src string) (*CephCSIVersion, error) {
+func extractCephCSIVersion(src, CSIPluginImage string) (*CephCSIVersion, error) {
 	m := versionCSIPattern.FindStringSubmatch(src)
 	if m == nil || len(m) < 3 {
-		return nil, errors.Errorf("failed to parse version from: %q", CSIParam.CSIPluginImage)
+		return nil, errors.Errorf("failed to parse version from: %q", CSIPluginImage)
 	}
 
 	major, err := strconv.Atoi(m[1])

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -134,7 +134,7 @@ func Test_extractCephCSIVersion(t *testing.T) {
 		Compiler: gc
 		Platform: linux/amd64
 		`)
-	version, err := extractCephCSIVersion(string(csiString))
+	version, err := extractCephCSIVersion(string(csiString), "quay.io/cephcsi/cephcsi:v3.0.0")
 
 	assert.Equal(t, &expectedVersion, version)
 	assert.Nil(t, err)
@@ -145,7 +145,7 @@ func Test_extractCephCSIVersion(t *testing.T) {
 	Compiler: gc
 	Platform: linux/amd64
 	`)
-	version, err = extractCephCSIVersion(string(csiString))
+	version, err = extractCephCSIVersion(string(csiString), "quay.io/cephcsi/cephcsi:v3.0.0")
 
 	assert.Nil(t, version)
 	assert.Contains(t, err.Error(), "failed to parse version from")

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -239,15 +239,8 @@ func (o *Operator) updateDrivers() error {
 		return errors.Wrap(err, "error getting server version")
 	}
 
-	if err = csi.SetParams(o.context.Clientset); err != nil {
-		return errors.Wrap(err, "failed to configure CSI parameters")
-	}
-
 	if serverVersion.Major < csi.KubeMinMajor || serverVersion.Major == csi.KubeMinMajor && serverVersion.Minor < csi.ProvDeploymentSuppVersion {
 		logger.Infof("CSI drivers only supported in K8s 1.14 or newer. version=%s", serverVersion.String())
-		// disable csi control variables to disable other csi functions
-		csi.EnableRBD = false
-		csi.EnableCephFS = false
 		return nil
 	}
 
@@ -266,10 +259,6 @@ func (o *Operator) updateDrivers() error {
 	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed creating csi config map")
-	}
-
-	if err = csi.ValidateCSIParam(); err != nil {
-		return errors.Wrap(err, "invalid csi params")
 	}
 
 	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerInfo)


### PR DESCRIPTION
CSI drivers failed to start if rook encountered any error
during starting it with no retry.
This commit introduces retry for starting CSI driver
if there is a failure upto 3 times.

Fixes: #7950

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
