### PR TITLE
ceph: fix external cluster upgrade

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -479,8 +479,6 @@ spec:
                     image:
                       description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
                       type: string
-                  required:
-                    - image
                   type: object
                 cleanupPolicy:
                   description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster deletion is not imminent.
@@ -1142,8 +1140,6 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                  required:
-                    - count
                   type: object
                 monitoring:
                   description: Prometheus based Monitoring settings

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -479,8 +479,6 @@ spec:
                     image:
                       description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
                       type: string
-                  required:
-                    - image
                   type: object
                 cleanupPolicy:
                   description: Indicates user intent when deleting a cluster; blocks orchestration and should not be set if cluster deletion is not imminent.
@@ -1142,8 +1140,6 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                  required:
-                    - count
                   type: object
                 monitoring:
                   description: Prometheus based Monitoring settings

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -252,7 +252,8 @@ type KeyManagementServiceSpec struct {
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.
 type CephVersionSpec struct {
 	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.4
-	Image string `json:"image"`
+	// +optional
+	Image string `json:"image,omitempty"`
 
 	// Whether to allow unsupported versions (do not set to true in production)
 	// +optional
@@ -448,7 +449,8 @@ const (
 type MonSpec struct {
 	// Count is the number of Ceph monitors
 	// +kubebuilder:validation:Minimum=0
-	Count int `json:"count"`
+	// +optional
+	Count int `json:"count,omitempty"`
 	// AllowMultiplePerNode determines if we can run multiple monitors on the same node (not recommended)
 	// +optional
 	AllowMultiplePerNode bool `json:"allowMultiplePerNode,omitempty"`


### PR DESCRIPTION
Both MonSpec.Count and CephVersionSpec.Image should be optional for the
external cluster. So marking them as so.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
