### PR TITLE
ci: only run ceph-csi volume replication on k8s >= 1.16

### DIFF
--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -99,13 +99,14 @@ func (s *SmokeSuite) SetupSuite() {
 		UseCSI:                    true,
 		EnableAdmissionController: true,
 		UseCrashPruner:            true,
-		EnableVolumeReplication:   true,
 		RookVersion:               installer.VersionMaster,
 		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()
-
 	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, smokeSuiteMinimalTestVersion)
+	if s.k8sh.VersionAtLeast("v1.16.0") {
+		s.settings.EnableVolumeReplication = true
+	}
 	s.helper = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
 }
 


### PR DESCRIPTION
Prior to 1.16 we do not injec the volumereplication CRDs so the
csi-rbdplugin-provisioner will fail to fetch the CRD.

Closes: https://github.com/rook/rook/issues/8039
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.


[skip ci]