### PR TITLE
Disable the Jenkins build in master by default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,15 +1,15 @@
 # Building Rook
 
-Rook is composed of golang project and can be built directly with standard `golang` tools,
+Rook is composed of a golang project and can be built directly with standard `golang` tools,
 and storage software (like Ceph) that are built inside containers. We currently support
-three different platforms for building:
+these platforms for building:
 
 * Linux: most modern distributions should work although most testing has been done on Ubuntu
 * Mac: macOS 10.6+ is supported
 
 ## Build Requirements
 
-An Intel-based machine (recommend 2+ cores, 8+ GB of memory and 128GB of SSD). Inside your build environment (Docker for Mac or a VM), 6+ GB memory is also recommended.
+An Intel-based machine (recommend 2+ cores, 8+ GB of memory and 128GB of SSD). Inside your build environment (Docker for Mac or a VM), 2+ GB memory is also recommended.
 
 The following tools are need on the host:
 
@@ -39,25 +39,14 @@ make -j4 IMAGES='ceph' build
 
 Run `make help` for more options.
 
-## Building inside the cross container
+## CI Workflow
 
-Official Rook builds are done inside a build container. This ensures that we get a consistent build, test and release environment. To run the build inside the cross container run:
+Every PR and every merge to master triggers the CI process in Github actions.
+On every commit to PR and master the CI will build, run unit tests, and run integration tests.
+If the build is for master or a release, the build will also be published to
+[dockerhub.com](https://cloud.docker.com/u/rook/repository/list).
 
-```console
-> build/run make -j4
-```
-
-The first run of `build/run` will build the container itself and could take a few
-minutes to complete.
-
-### Resetting the build container
-
-If you're running the build container on the Mac using Docker for Mac, the build
-container will rely on rsync to copy source to and from the host. To reset the build container and it's persistent volumes, you can run the below command. You shouldn't have to do this often unless something is broken or stale with your build container:
-
-```console
-build/reset
-```
+> Note that if the pull request title follows Rook's [contribution guidelines](https://rook.io/docs/rook/master/development-flow.html#commit-structure), the CI will automatically run the appropriate test scenario. For example if a pull request title is "ceph: add a feature", then the tests for the Ceph storage provider will run. Similarly, tests will only run for a single provider with the "cassandra:" and "nfs:" prefixes.
 
 ## Building for other platforms
 
@@ -128,74 +117,3 @@ EOF
 
 systemctl enable update-binfmt.service
 ```
-
-# Improving Build Speed
-
-## Image Caching and Pruning
-
-Doing a complete build of Rook and the dependent packages can take a long time (more than an hour on a standard laptop). To speed things up we rely heavily on image caching in docker. Docker support content-addressable images by default and we use that effectively when building images. Images are factored to increase reusability across builds. We also tag and timestamp images that should remain in the cache to help future builds.
-
-### Pruning the cache
-
-To prune the number of cached images run `make prune`. There are two options that control the level of pruning performed:
-
-* `PRUNE_HOURS` - the number of hours from when an image was last used (a cache hit) for it to be considered for pruning. The default is 48 hrs.
-* `PRUNE_KEEP` - the minimum number of cached images to keep in the cache. Default is 24 images.
-
-## CI workflow and options
-
-Every PR and every merge to master triggers the CI process in [Jenkins](http://jenkins.rook.io).
-On every commit to PR and master the Jenkins CI will build, run unit tests, and run integration tests.
-If the build is for master or a release, the build will also be published.
-If any of the CI stages fail, then the process is aborted and no artifacts are published.
-On every successful build Artifacts are pushed to an [s3 bucket](https://release.rook.io/). On every successful master build,
-images are pushed to [dockerhub.com](https://cloud.docker.com/u/rook/repository/list).
-
-During the integration tests phase, all tests under [/tests/integration](/tests/integration) are run.
-It may take a while to run all Integration tests. Based on the changes in the PR, it may not be required to run the full CI.
-For faster CI options, add the following tags somewhere in the body of the main PR message.
-
-### [skip ci]
-
-Jenkins will skip the build process completely if `[skip ci]` is found in the PR message.
-This option **should** be used when updating documentation, yaml, or other files that
-do not change runtime code. If your PR is marked as WIP and will not be ready for some time to run integration tests,
-this tag should also be added, then removed later when the CI should be triggered.
-
-This option should **not** be used if there are any changes to `.go` files, CI scripts, etc.
-
-In case there are known CI failures that are blocking a merge, project maintainers can add this flag
-to unblock the CI and merge the PR. This should be used with extreme care so regressions are not introduced.
-
-### [test storage-provider]
-
-Jenkins will only run the tests for an individual storage provider if specified. There is a keyword for each
-storage provider that has integration tests:
-
-* `[test cassandra]`
-* `[test ceph]`
-* `[test nfs]`
-
-Since the majority of effort for a PR generally focuses on a single storage provider it will save time
-in the CI if you only trigger the tests for your provider. If this key phrase is not found in the PR,
-all tests will be executed.
-
-These options should **not** be used if there are any changes to code which is shared with other
-storage providers. If there is any risk of affecting another storage provider, all tests should
-be executed in the CI.
-
-> Note that if the pull request title follows Rook's [contribution guidelines](https://rook.io/docs/rook/master/development-flow.html#commit-structure), the CI will automatically run the appropriate test scenario. For example if a pull request title is "ceph: add a feature", then the tests for the Ceph storage provider will run.
-
-### [test full]
-
-In master and release builds, all test suites will run on all supported versions of K8s.
-In PR builds, all the test suites will run on some version of K8s. For bigger changes,
-it is recommended to run all test suites on all versions of K8s by using the tag:
-
-```text
-[test full]
-```
-
-### [test]
-
-If specified, the `[test]` flag will instruct the CI to run all storage providers integration tests.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ these platforms for building:
 
 ## Build Requirements
 
-An Intel-based machine (recommend 2+ cores, 8+ GB of memory and 128GB of SSD). Inside your build environment (Docker for Mac or a VM), 2+ GB memory is also recommended.
+Recommend 2+ cores, 8+ GB of memory and 128GB of SSD. Inside your build environment (Docker for Mac or a VM), 2+ GB memory is also recommended.
 
 The following tools are need on the host:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,73 +18,16 @@ pipeline {
             when { branch "PR-*" }
             steps {
                 script {
-                    def json = sh (script: "curl -s https://api.github.com/repos/rook/rook/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
-                    def draft = evaluateJson(json,'${json.draft}')
-                    if (draft.contains("true")) {
-                        echo ("This is a draft PR. Aborting")
-                        env.shouldBuild = "false"
-                    }
-                    def body = evaluateJson(json,'${json.body}')
-                    if (body.contains("[skip ci]")) {
-                        echo ("'[skip ci]' spotted in PR body text. Aborting.")
-                        env.shouldBuild = "false"
-                    }
-                    if (body.contains("[skip tests]")) {
-                        env.shouldTest = "false"
-                    }
-                    if (body.contains("[all logs]")) {
-                        env.getLogs = "all"
-                    }
-
                     // When running in a PR we assuming it's not an official build
                     env.isOfficialBuild = "false"
 
-                    if (!body.contains("[test full]")) {
-                        // By default run the min test matrix (all tests run, but will be distributed on different versions of K8s).
-                        // This only affects the PR builds. The master and release builds will always run the full matrix.
-                        env.testArgs = "min-test-matrix"
-                    }
-
-                    // Get changed files
-                    def json_changed_files = sh (script: "curl -s https://api.github.com/repos/rook/rook/pulls/${env.CHANGE_ID}/files", returnStdout: true).trim()
-                    def list = new groovy.json.JsonSlurper().parseText(json_changed_files)
-                    def changed_files = list.filename.join(",")
-                     echo ("changed files are: ${changed_files}")
-
-                    // Get PR title
-                    def title = evaluateJson(json,'${json.title}')
-
-                    // extract which specific storage provider to test
-                    if (body.contains("[test cassandra]") || title.contains("cassandra:")) {
-                        env.testProvider = "cassandra"
-                    } else if (body.contains("[test ceph]")) {
-                        // Run the Ceph tests in Jenkins if specifically requested
-                        env.testProvider = "ceph"
-                    } else if (title.contains("ceph:")) {
-                        // Don't run Jenkins for ceph PRs by default since they are covered by github actions
-                        env.shouldBuild = "false"
-                    } else if (body.contains("[test nfs]") || title.contains("nfs:")) {
-                        env.testProvider = "nfs"
-                    } else if (body.contains("[test]")) {
+                    // Only build and test if [test full]
+                    def json = sh (script: "curl -s https://api.github.com/repos/rook/rook/pulls/${env.CHANGE_ID}", returnStdout: true).trim()
+                    def body = evaluateJson(json,'${json.body}')
+                    env.shouldBuild = "false"
+                    if (body.contains("[test full]")) {
                         env.shouldBuild = "true"
-                    } else if (!changed_files.contains(".go")) {
-                        echo ("No golang changes detected! Looking for .md, .yaml and .txt now.")
-                        if (changed_files.contains(".md")) {
-                            echo ("Documentation changes detected! Aborting.")
-                            env.shouldBuild = "false"
-                        } else if (changed_files.contains(".yaml")) {
-                            echo ("YAML changes detected! Aborting.")
-                            env.shouldBuild = "false"
-                        } else if (changed_files.contains(".txt")) {
-                            echo ("Text changes detected! Aborting.")
-                            env.shouldBuild = "false"
-                        }
-                    } else if (!changed_files.contains(".go")) {
-                        echo ("No code changes detected! Just building.")
-                        env.shouldTest = "false"
                     }
-
-                    echo ("integration test provider: ${env.testProvider}")
                 }
             }
         }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- The github actions are fully covering the build needs in master so we can go ahead and disable Jenkins by default. In case there is still a desired to run Jenkins for a particular PR, the `test full` text can still trigger it.
- Given the improvements with github actions and other improvements, we now clean up the build instructions for developers joining the rook project. There is no need to understand about Jenkins pipelines since we will soon be fully on github actions.

@subhamkrai @leseb Nothing left before we disable Jenkins in master, right?

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
