### PR TITLE
ceph: Disable insecure global id if no insecure clients

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -302,3 +302,31 @@ func WriteCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) error 
 	}
 	return nil
 }
+
+// SetConfig applies a setting for a single mgr daemon
+func SetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, daemonID string, key, val string, force bool) (bool, error) {
+	var getArgs, setArgs []string
+	getArgs = append(getArgs, "config", "get", daemonID, key)
+	if val == "" {
+		setArgs = append(setArgs, "config", "rm", daemonID, key)
+	} else {
+		setArgs = append(setArgs, "config", "set", daemonID, key, val)
+	}
+	if force {
+		setArgs = append(setArgs, "--force")
+	}
+
+	// Retrieve previous value to monitor changes
+	var prevVal string
+	buf, err := NewCephCommand(context, clusterInfo, getArgs).Run()
+	if err == nil {
+		prevVal = strings.TrimSpace(string(buf))
+	}
+
+	if _, err := NewCephCommand(context, clusterInfo, setArgs).Run(); err != nil {
+		return false, errors.Wrapf(err, "failed to set config key %s to %q", key, val)
+	}
+
+	hasChanged := prevVal != val
+	return hasChanged, nil
+}

--- a/pkg/daemon/ceph/client/mgr.go
+++ b/pkg/daemon/ceph/client/mgr.go
@@ -18,8 +18,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -102,35 +100,6 @@ func MgrDisableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name 
 		return enableDisableBalancerModule(context, clusterInfo, "off")
 	}
 	return enableModule(context, clusterInfo, name, false, "disable")
-}
-
-// MgrSetConfig applies a setting for a single mgr daemon
-func MgrSetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, mgrName string, key, val string, force bool) (bool, error) {
-	var getArgs, setArgs []string
-	mgrID := fmt.Sprintf("mgr.%s", mgrName)
-	getArgs = append(getArgs, "config", "get", mgrID, key)
-	if val == "" {
-		setArgs = append(setArgs, "config", "rm", mgrID, key)
-	} else {
-		setArgs = append(setArgs, "config", "set", mgrID, key, val)
-	}
-	if force {
-		setArgs = append(setArgs, "--force")
-	}
-
-	// Retrieve previous value to monitor changes
-	var prevVal string
-	buf, err := NewCephCommand(context, clusterInfo, getArgs).Run()
-	if err == nil {
-		prevVal = strings.TrimSpace(string(buf))
-	}
-
-	if _, err := NewCephCommand(context, clusterInfo, setArgs).Run(); err != nil {
-		return false, errors.Wrapf(err, "failed to set mgr config key %s to \"%s\"", key, val)
-	}
-
-	hasChanged := prevVal != val
-	return hasChanged, nil
 }
 
 func enableModule(context *clusterd.Context, clusterInfo *ClusterInfo, name string, force bool, action string) error {

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -25,10 +25,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	optest "github.com/rook/rook/pkg/operator/test"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -150,6 +152,97 @@ func TestNewCephStatusChecker(t *testing.T) {
 			if got := newCephStatusChecker(tt.args.context, tt.args.clusterInfo, tt.args.clusterSpec); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newCephStatusChecker() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestConfigureHealthSettings(t *testing.T) {
+	c := &cephStatusChecker{
+		context:     &clusterd.Context{},
+		clusterInfo: cephclient.AdminClusterInfo("ns"),
+	}
+	getGlobalIDReclaim := false
+	setGlobalIDReclaim := false
+	c.context.Executor = &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			if args[0] == "config" && args[3] == "auth_allow_insecure_global_id_reclaim" {
+				if args[1] == "get" {
+					getGlobalIDReclaim = true
+					return "", nil
+				}
+				if args[1] == "set" {
+					setGlobalIDReclaim = true
+					return "", nil
+				}
+			}
+			return "", errors.New("mock error to simulate failure of SetConfig() function")
+		},
+	}
+	noActionOneWarningStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"MDS_ALL_DOWN": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "MDS_ALL_DOWN",
+					},
+				},
+			},
+		},
+	}
+	disableInsecureGlobalIDStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "foo",
+					},
+				},
+			},
+		},
+	}
+	noDisableInsecureGlobalIDStatus := cephclient.CephStatus{
+		Health: cephclient.HealthStatus{
+			Checks: map[string]cephclient.CheckMessage{
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "foo",
+					},
+				},
+				"AUTH_INSECURE_GLOBAL_ID_RECLAIM": {
+					Severity: "HEALTH_WARN",
+					Summary: cephclient.Summary{
+						Message: "bar",
+					},
+				},
+			},
+		},
+	}
+
+	type args struct {
+		status                     cephclient.CephStatus
+		expectedGetGlobalIDSetting bool
+		expectedSetGlobalIDSetting bool
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"no-warnings", args{cephclient.CephStatus{}, false, false}},
+		{"no-action-one-warning", args{noActionOneWarningStatus, false, false}},
+		{"disable-insecure-global-id", args{disableInsecureGlobalIDStatus, true, true}},
+		{"no-disable-insecure-global-id", args{noDisableInsecureGlobalIDStatus, false, false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getGlobalIDReclaim = false
+			setGlobalIDReclaim = false
+			c.configureHealthSettings(tt.args.status)
+			assert.Equal(t, tt.args.expectedGetGlobalIDSetting, getGlobalIDReclaim)
+			assert.Equal(t, tt.args.expectedSetGlobalIDSetting, setGlobalIDReclaim)
 		})
 	}
 }

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -20,6 +20,7 @@ package mgr
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -109,15 +110,17 @@ func (c *Cluster) configureDashboardModules() error {
 }
 
 func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error) {
+	daemonID = fmt.Sprintf("mgr.%s", daemonID)
+
 	// url prefix
-	hasChanged, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/url_prefix", c.spec.Dashboard.URLPrefix, false)
+	hasChanged, err := client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/url_prefix", c.spec.Dashboard.URLPrefix, false)
 	if err != nil {
 		return false, err
 	}
 
 	// ssl support
 	ssl := strconv.FormatBool(c.spec.Dashboard.SSL)
-	changed, err := client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl", ssl, false)
+	changed, err := client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl", ssl, false)
 	if err != nil {
 		return false, err
 	}
@@ -125,7 +128,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// server port
 	port := strconv.Itoa(c.dashboardPort())
-	changed, err = client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/server_port", port, false)
+	changed, err = client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/server_port", port, false)
 	if err != nil {
 		return false, err
 	}
@@ -133,7 +136,7 @@ func (c *Cluster) configureDashboardModuleSettings(daemonID string) (bool, error
 
 	// SSL enabled. Needed to set specifically the ssl port setting
 	if c.spec.Dashboard.SSL {
-		changed, err = client.MgrSetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl_server_port", port, false)
+		changed, err = client.SetConfig(c.context, c.clusterInfo, daemonID, "mgr/dashboard/ssl_server_port", port, false)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -370,7 +370,7 @@ func configureRBDStats(clusterContext *clusterd.Context, clusterInfo *cephclient
 		}
 	}
 	logger.Debugf("RBD per-image IO statistics will be collected for pools: %v", enableStatsForPools)
-	_, err = cephclient.MgrSetConfig(clusterContext, clusterInfo, "", "mgr/prometheus/rbd_stats_pools", strings.Join(enableStatsForPools, ","), false)
+	_, err = cephclient.SetConfig(clusterContext, clusterInfo, "mgr.", "mgr/prometheus/rbd_stats_pools", strings.Join(enableStatsForPools, ","), false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to enable rbd_stats_pools")
 	}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -446,11 +446,11 @@ func TestConfigureRBDStats(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Case 5: Two CephBlockPools with EnableRBDStats:false & EnableRBDStats:true.
-	// MgrSetConfig returns an error
+	// SetConfig returns an error
 	context.Executor = &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
-			return "", errors.Errorf("mock error to simulate failure of MgrSetConfig() function")
+			return "", errors.New("mock error to simulate failure of SetConfig() function")
 		},
 	}
 	err = configureRBDStats(context, clusterInfo)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -101,6 +101,7 @@ func (m *CephManifestsMaster) GetCommon() string {
 func (m *CephManifestsMaster) GetToolbox() string {
 	if m.settings.DirectMountToolbox {
 		manifest := strings.ReplaceAll(m.settings.readManifest("direct-mount.yaml"), "name: rook-direct-mount", "name: rook-ceph-tools")
+		manifest = strings.ReplaceAll(manifest, "name: rook-direct-mount", "name: rook-ceph-tools")
 		return strings.ReplaceAll(manifest, "app: rook-direct-mount", "app: rook-ceph-tools")
 	}
 	return m.settings.readManifest("toolbox.yaml")

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -184,6 +184,9 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	s.upgradeToMaster()
 
 	s.verifyOperatorImage(installer.VersionMaster)
+	err = s.installer.WaitForToolbox(s.namespace)
+	assert.NoError(s.T(), err)
+
 	s.verifyRookUpgrade(numOSDs)
 	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_5)
 	newFile := "post-upgrade-1_5-to-master-file"
@@ -364,4 +367,7 @@ func (s *UpgradeSuite) upgradeToMaster() {
 
 	require.NoError(s.T(),
 		s.k8sh.SetDeploymentVersion(s.settings.OperatorNamespace, operatorContainer, operatorContainer, installer.VersionMaster))
+
+	require.NoError(s.T(),
+		s.k8sh.SetDeploymentVersion(s.settings.Namespace, "rook-ceph-tools", "rook-ceph-tools", installer.VersionMaster))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In the latest Ceph releases starting with v16.2.1, all clients are recommended to be updated so they will have a security fix to connect with a secure global ID. A health warning will be raised if any insecure clients are connected and another health warning is raised if insecure clients are still allowed. Rook will now disable allowing the insecure clients if the health warning is not being raised to indicate that there are insecure clients still connected. This means that upgraded clusters will not have this disabled until all the daemons are updated.

If there are any clients connecting insecurely, they will be denied the next time they come online after the operator disables this setting. Therefore, perhaps we need to consider an option in the operator so it won't force reconcile this setting every time it sees the corresponding health warnings.

**Which issue is resolved by this Pull Request:**
Resolves #7746 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
