### PR TITLE
ceph: do not fail prepareOSD job if devices are not passed

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -290,6 +290,10 @@ func getLocation(clientset kubernetes.Interface) (string, string, error) {
 
 // Parse the devices, which are sent as a JSON-marshalled list of device IDs with a StorageConfig spec
 func parseDevices(devices string) ([]osddaemon.DesiredDevice, error) {
+	if devices == "" {
+		return []osddaemon.DesiredDevice{}, nil
+	}
+
 	configuredDevices := []osdcfg.ConfiguredDevice{}
 	err := json.Unmarshal([]byte(devices), &configuredDevices)
 	if err != nil {

--- a/cmd/rook/ceph/osd_test.go
+++ b/cmd/rook/ceph/osd_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	osddaemon "github.com/rook/rook/pkg/daemon/ceph/osd"
 	osdcfg "github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -167,4 +168,8 @@ func TestParseDesiredDevices(t *testing.T) {
 	assert.False(t, result[2].IsDevicePathFilter)
 	assert.False(t, result[3].IsDevicePathFilter)
 
+	// check empty devices list
+	result, err = parseDevices("")
+	assert.NoError(t, err)
+	assert.Equal(t, []osddaemon.DesiredDevice{}, result)
 }


### PR DESCRIPTION
If devices are not specified for node return empty desired devices
list and do not fail prepareOSD job.

Closes: #8097
Signed-off-by: Denis Egorenko degorenko@mirantis.com

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
