### PR TITLE
ceph: correct mirroring typo

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -3778,7 +3778,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: FilesystemMirroringSpec is the filesystem mirorring specification
+              description: FilesystemMirroringSpec is the filesystem mirroring specification
               properties:
                 annotations:
                   additionalProperties:

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -3777,7 +3777,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: FilesystemMirroringSpec is the filesystem mirorring specification
+              description: FilesystemMirroringSpec is the filesystem mirroring specification
               properties:
                 annotations:
                   additionalProperties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1625,7 +1625,7 @@ type CephFilesystemMirrorList struct {
 	Items           []CephFilesystemMirror `json:"items"`
 }
 
-// FilesystemMirroringSpec is the filesystem mirorring specification
+// FilesystemMirroringSpec is the filesystem mirroring specification
 type FilesystemMirroringSpec struct {
 	// The affinity to place the rgw pods (default is to place on any available node)
 	// +nullable


### PR DESCRIPTION
codespell ci was failing due to mirroring typo.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
