### PR TITLE
ceph: use vault binary when available

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -197,68 +197,72 @@ set -e
 
 KEK_NAME=%s
 KEY_PATH=%s
-CURL_PAYLOAD=$(mktemp)
-ARGS=(--silent --show-error --request GET --header "X-Vault-Token: ${VAULT_TOKEN//[$'\t\r\n']}")
-PYTHON_DATA_PARSE="['data']"
+export VAULT_TOKEN=${VAULT_TOKEN//[$'\t\r\n']}
 
-# If a vault namespace is set
-if [ -n "$VAULT_NAMESPACE" ]; then
-  ARGS+=(--header "X-Vault-Namespace: ${VAULT_NAMESPACE}")
-fi
+if command -v vault; then
+  vault kv get -field="$KEK_NAME" "$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$KEY_PATH"
+else
+  CURL_PAYLOAD=$(mktemp)
+  ARGS=(--silent --show-error --request GET --header "X-Vault-Token: ${VAULT_TOKEN}")
+  PYTHON_DATA_PARSE="['data']"
 
-# If SSL is configured but self-signed CA is used
-if [ -n "$VAULT_SKIP_VERIFY" ] && [[ "$VAULT_SKIP_VERIFY" == "true" ]]; then
-  ARGS+=(--insecure)
-fi
+  # If a vault namespace is set
+  if [ -n "$VAULT_NAMESPACE" ]; then
+    ARGS+=(--header "X-Vault-Namespace: ${VAULT_NAMESPACE}")
+  fi
 
-# TLS args
-if [ -n "$VAULT_CACERT" ]; then
-  ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
-fi
-if [ -n "$VAULT_CLIENT_CERT" ]; then
-  ARGS+=(--cert "${VAULT_CLIENT_CERT}")
-fi
-if [ -n "$VAULT_CLIENT_KEY" ]; then
-  ARGS+=(--key "${VAULT_CLIENT_KEY}")
-fi
+  # If SSL is configured but self-signed CA is used
+  if [ -n "$VAULT_SKIP_VERIFY" ] && [[ "$VAULT_SKIP_VERIFY" == "true" ]]; then
+    ARGS+=(--insecure)
+  fi
 
-# For a request to any host/port, connect to VAULT_TLS_SERVER_NAME:requests original port instead
-# Used for SNI validation and correct certificate matching
-if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
-  ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
-fi
+  # TLS args
+  if [ -n "$VAULT_CACERT" ]; then
+    ARGS+=(--capath $(dirname "${VAULT_CACERT}"))
+  fi
+  if [ -n "$VAULT_CLIENT_CERT" ]; then
+    ARGS+=(--cert "${VAULT_CLIENT_CERT}")
+  fi
+  if [ -n "$VAULT_CLIENT_KEY" ]; then
+    ARGS+=(--key "${VAULT_CLIENT_KEY}")
+  fi
 
-# trim VAULT_BACKEND_PATH for last character '/' to avoid a redirect response from the server
-VAULT_BACKEND_PATH="${VAULT_BACKEND_PATH%%/}"
+  # For a request to any host/port, connect to VAULT_TLS_SERVER_NAME:requests original port instead
+  # Used for SNI validation and correct certificate matching
+  if [ -n "$VAULT_TLS_SERVER_NAME" ]; then
+    ARGS+=(--connect-to ::"${VAULT_TLS_SERVER_NAME}":)
+  fi
 
-# Check KV engine version
-if [[ "$VAULT_BACKEND" == "v2" ]]; then
-  PYTHON_DATA_PARSE="['data']['data']"
-  VAULT_BACKEND_PATH="$VAULT_BACKEND_PATH/data"
-fi
+  # trim VAULT_BACKEND_PATH for last character '/' to avoid a redirect response from the server
+  VAULT_BACKEND_PATH="${VAULT_BACKEND_PATH%%/}"
+
+  # Check KV engine version
+  if [[ "$VAULT_BACKEND" == "v2" ]]; then
+    PYTHON_DATA_PARSE="['data']['data']"
+    VAULT_BACKEND_PATH="$VAULT_BACKEND_PATH/data"
+  fi
 
 
-# Get the Key Encryption Key
-curl "${ARGS[@]}" "$VAULT_ADDR"/v1/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
+  # Get the Key Encryption Key
+  curl "${ARGS[@]}" "$VAULT_ADDR"/v1/"$VAULT_BACKEND_PATH"/"$KEK_NAME" > "$CURL_PAYLOAD"
 
-# Check for warnings in the payload
-if python3 -c "import sys, json; print(json.load(sys.stdin)[\"warnings\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
-  # We could get a warning but it is not necessary an issue, so if there is no key we exit
-  if ! python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
+  # Check for warnings in the payload
+  if python3 -c "import sys, json; print(json.load(sys.stdin)[\"warnings\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
+    # We could get a warning but it is not necessary an issue, so if there is no key we exit
+    if ! python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
+      exit 1
+    fi
+  fi
+
+  # Check for errors in the payload
+  if python3 -c "import sys, json; print(json.load(sys.stdin)[\"errors\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
     exit 1
   fi
+
+  # Put the KEK in a file for cryptsetup to read
+  python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
 fi
 
-# Check for errors in the payload
-if python3 -c "import sys, json; print(json.load(sys.stdin)[\"errors\"], end='')" 2> /dev/null < "$CURL_PAYLOAD"; then
-  exit 1
-fi
-
-# Put the KEK in a file for cryptsetup to read
-python3 -c "import sys, json; print(json.load(sys.stdin)${PYTHON_DATA_PARSE}[\"$KEK_NAME\"], end='')" < "$CURL_PAYLOAD" > "$KEY_PATH"
-
-# purge payload file
-rm -f "$CURL_PAYLOAD"
 `
 
 	// If the disk identifier changes (different major and minor) we must force copy


### PR DESCRIPTION
The cURL code has become really complex and using the vault binary if
available in the container image is preferred.
I'm keeping the cURL code for backward compatibility.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Depends on https://github.com/ceph/ceph-container/pull/1905.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
