### PR TITLE
ceph: set device class for already present osd deployments

### DIFF
--- a/pkg/daemon/ceph/client/fake/osd.go
+++ b/pkg/daemon/ceph/client/fake/osd.go
@@ -128,3 +128,13 @@ func OsdOkToStopOutput(queriedID int, returnOsdIds []int, useCephPacificPlusOutp
 	}
 	return fmt.Sprintf(okTemplate, strings.Join(osdIdsStr, ","))
 }
+
+// OSDDeviceClassOutput returns JSON output from 'ceph osd crush get-device-class' that can be used for unit tests.
+// osdId is a osd ID to get from crush map. If ID is empty raise a fake error.
+func OSDDeviceClassOutput(osdId string) string {
+	if osdId == "" {
+		return "ERR: fake error from ceph cli"
+	}
+	okTemplate := `[{"osd":%s,"device_class":"hdd"}]`
+	return fmt.Sprintf(okTemplate, osdId)
+}

--- a/pkg/daemon/ceph/client/osd.go
+++ b/pkg/daemon/ceph/client/osd.go
@@ -307,6 +307,31 @@ func OsdListNum(context *clusterd.Context, clusterInfo *ClusterInfo) (OsdList, e
 	return output, nil
 }
 
+// OSDDeviceClass report device class for osd
+type OSDDeviceClass struct {
+	ID          int    `json:"osd"`
+	DeviceClass string `json:"device_class"`
+}
+
+// OSDDeviceClasses returns the device classes for particular OsdIDs
+func OSDDeviceClasses(context *clusterd.Context, clusterInfo *ClusterInfo, osdIds []string) ([]OSDDeviceClass, error) {
+	var deviceClasses []OSDDeviceClass
+
+	args := []string{"osd", "crush", "get-device-class"}
+	args = append(args, osdIds...)
+	buf, err := NewCephCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return deviceClasses, errors.Wrap(err, "failed to get device-class info")
+	}
+
+	err = json.Unmarshal(buf, &deviceClasses)
+	if err != nil {
+		return deviceClasses, errors.Wrap(err, "failed to unmarshal 'osd crush get-device-class' response")
+	}
+
+	return deviceClasses, nil
+}
+
 // OSDOkToStopStats report detailed information about which OSDs are okay to stop
 type OSDOkToStopStats struct {
 	OkToStop          bool     `json:"ok_to_stop"`

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -557,6 +557,11 @@ func osdIntegrationTestExecutor(t *testing.T, clientset *fake.Clientset, namespa
 				if args[1] == "tree" {
 					return cephclientfake.OsdTreeOutput(3, 3), nil // fake output for cluster with 3 nodes having 3 OSDs
 				}
+				if args[1] == "crush" {
+					if args[2] == "get-device-class" {
+						return cephclientfake.OSDDeviceClassOutput(args[3]), nil
+					}
+				}
 			}
 			if args[0] == "versions" {
 				// the update deploy code only cares about the mons from the ceph version command results

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -238,6 +238,9 @@ func TestAddRemoveNode(t *testing.T) {
 					if args[2] == "rm" {
 						return "", nil
 					}
+					if args[2] == "get-device-class" {
+						return cephclientfake.OSDDeviceClassOutput(args[3]), nil
+					}
 				}
 				if args[1] == "out" {
 					return "", nil

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -128,6 +128,16 @@ func (c *updateConfig) updateExistingOSDs(errs *provisionErrors) {
 			continue
 		}
 
+		// backward compatibility for old deployments
+		if osdInfo.DeviceClass == "" {
+			deviceClassInfo, err := cephclient.OSDDeviceClasses(c.cluster.context, c.cluster.clusterInfo, []string{strconv.Itoa(osdID)})
+			if err != nil {
+				logger.Errorf("failed to get device class for existing deployment %q. %v", depName, err)
+			} else {
+				osdInfo.DeviceClass = deviceClassInfo[0].DeviceClass
+			}
+		}
+
 		nodeOrPVCName, err := getNodeOrPVCName(dep)
 		if err != nil {
 			errs.addError("%v", errors.Wrapf(err, "failed to update OSD %d", osdID))


### PR DESCRIPTION
Add ability to set device class for existing osd deployments,
based on its crush map device class.

Related-Issue: rook#8028
Signed-off-by: Denis Egorenko <degorenko@mirantis.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
