### PR TITLE
Ceph: Fix consistency in crds

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -107,7 +107,7 @@ spec:
                     operator: In
                     values:
                       - rook-ceph-osd-prepare
-        resources:
+        #resources:
         # These are the OSD daemon limits. For OSD prepare limits, see the separate section below for "prepareosd" resources
         #   limits:
         #     cpu: "500m"
@@ -158,7 +158,7 @@ spec:
         #       - ReadWriteOnce
         # Scheduler name for OSD pod placement
         # schedulerName: osd-scheduler
-  resources:
+  #resources:
   #  prepareosd:
   #    limits:
   #      cpu: "200m"

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -177,7 +177,7 @@ spec:
 # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
 # These labels can be passed as LabelSelector to Prometheus
 #    monitoring:
-  resources:
+  #resources:
 # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
 #    mgr:
 #      limits:


### PR DESCRIPTION
https://github.com/rook/rook-client-python/pull/4 found two inconsistencies in the Ceph CR(D)s:

---
    Ceph CRs: `resources` is not marked as `nullable`
    
    Thus I removed it from the examples. Otherwise the example
    is inconsistent.
    
---
    Ceph CRDs: Marked `preference` as optional.
    
    Cause it is not set in a lot of places, like
    
    `object.yaml/.spec.gateway.placement.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0]`
    

