### PR TITLE
ceph: Instructions for taking over management of the cluster CR with the cluster helm chart

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -23,18 +23,18 @@ The [configuration](#configuration) section lists the parameters that can be con
 recommended that the rook operator be installed into the `rook-ceph` namespace. The clusters can be installed
 into the same namespace as the operator or a separate namespace.
 
-If the operator was installed in a namespace other than `rook-ceph`, the namespace
-must be set in the `operatorNamespace` variable.
-
 Rook currently publishes builds of this chart to the `release` and `master` channels.
+
+**Before installing, review the values.yaml to confirm if the default settings need to be updated.**
+- If the operator was installed in a namespace other than `rook-ceph`, the namespace
+  must be set in the `operatorNamespace` variable.
+- Set the desired settings in the `cephClusterSpec`. The [defaults](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)
+  are only an example and not likely to apply to your cluster.
+- The `monitoring` section should be removed from the `cephClusterSpec`, as it is specified separately in the helm settings.
 
 ### Release
 
 The release channel is the most recent release of Rook that is considered stable for the community.
-
-**Before installing, review the values.yaml to confirm if the default settings need to be updated.
-The [defaults](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)
-are only an example and not likely to apply to your cluster.**
 
 The example install assumes you have created a values-override.yaml.
 

--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -14,16 +14,16 @@ Installs a [Ceph](https://ceph.io/) cluster on Rook using the [Helm](https://hel
 
 * Kubernetes 1.13+
 * Helm 3.x
-* Preinstalled Rook Operator. See the [Helm Operator](https://rook.github.io/docs/rook/master/helm-operator.html) topic to install.
+* Preinstalled Rook Operator. See the [Helm Operator](helm-operator.md) topic to install.
 
 ## Installing
 
 The `helm install` command deploys rook on the Kubernetes cluster in the default configuration.
 The [configuration](#configuration) section lists the parameters that can be configured during installation. It is
-recommended that the rook operator be installed into the `rook-ceph` namespace (you will install your clusters into
-separate namespaces).
+recommended that the rook operator be installed into the `rook-ceph` namespace. The clusters can be installed
+into the same namespace as the operator or a separate namespace.
 
-If the operator was installed in a non-default location, the namespace of the *Rook Operator* installed
+If the operator was installed in a namespace other than `rook-ceph`, the namespace
 must be set in the `operatorNamespace` variable.
 
 Rook currently publishes builds of this chart to the `release` and `master` channels.
@@ -32,20 +32,68 @@ Rook currently publishes builds of this chart to the `release` and `master` chan
 
 The release channel is the most recent release of Rook that is considered stable for the community.
 
+**Before installing, review the values.yaml to confirm if the default settings need to be updated.
+The [defaults](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)
+are only an example and not likely to apply to your cluster.**
+
+The example install assumes you have created a values-override.yaml.
+
 ```console
 helm repo add rook-release https://charts.rook.io/release
-helm install --create-namespace --namespace rook-ceph rook-ceph --set operatorNamespace=rook-ceph rook-release/rook-ceph-cluster
+helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \
+   --set operatorNamespace=rook-ceph rook-release/rook-ceph-cluster -f values-override.yaml
 ```
+
+## Configuration
+
+The following tables lists the configurable parameters of the rook-operator chart and their default values.
+
+| Parameter             | Description                                                          | Default     |
+| --------------------- | -------------------------------------------------------------------- | ----------- |
+| `operatorNamespace`   | Namespace of the Rook Operator                                       | `rook-ceph` |
+| `configOverride`      | Cluster ceph.conf override                                           | <empty>     |
+| `toolbox.enabled`     | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
+| `toolbox.tolerations` | Toolbox tolerations                                                  | `[]`        |
+| `toolbox.affinity`    | Toolbox affinity                                                     | `{}`        |
+| `monitoring.enabled`  | Enable Prometheus integration, will also create necessary RBAC rules | `false`     |
+| `cephClusterSpec.*`   | Cluster configuration, see below                                     | See below   |
+
+
+### Ceph Cluster Spec
+
+The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
+For the full list, see the [Cluster CRD](ceph-cluster-crd.md) topic.
+
+### Existing Clusters
+
+If you have an existing CephCluster CR that was created without the helm chart and you want the helm
+chart to start managing the cluster:
+
+1. Extract the `spec` section of your existing CephCluster CR and copy to the `cephClusterSpec`
+   section in `values-override.yaml`.
+
+2. Add the following annotations and label to your existing CephCluster CR:
+
+```
+  annotations:
+    meta.helm.sh/release-name: rook-ceph-cluster
+    meta.helm.sh/release-namespace: rook-ceph
+  labels:
+    app.kubernetes.io/managed-by: Helm
+```
+
+1. Run the `helm install` command in the [Installing section](#release) to create the chart.
+
+2. In the future when updates to the cluster are needed, ensure the values-override.yaml always
+   contains the desired CephCluster spec.
 
 ### Development Build
 
 To deploy from a local build from your development environment:
 
-1. Install the helm chart:
-
 ```console
 cd cluster/charts/rook-ceph-cluster
-helm install --create-namespace --namespace rook-ceph rook-ceph-cluster .
+helm install --create-namespace --namespace rook-ceph rook-ceph-cluster -f values-override.yaml .
 ```
 
 ## Uninstalling the Chart
@@ -67,38 +115,3 @@ chart does not remove the Rook operator. In addition, all data on hosts in the R
 (`/var/lib/rook` by default) and on OSD raw devices is kept. To reuse disks, you will have to wipe them before recreating the cluster.
 
 See the [teardown documentation](ceph-teardown.md) for more information.
-
-## Configuration
-
-The following tables lists the configurable parameters of the rook-operator chart and their default values.
-
-| Parameter               | Description                                                          | Default                 |
-|-----------------------  |----------------------------------------------------------------------|-------------------------|
-| `operatorNamespace`     | Namespace of the Rook Operator                                       | `rook-ceph`             |
-| `configOverride`        | Cluster ceph.conf override                                           | <empty>                 |
-| `toolbox.enabled`       | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`                 |
-| `toolbox.tolerations`   | Toolbox tolerations                                                  | `[]`                    |
-| `toolbox.affinity`      | Toolbox affinity                                                     | `{}`                    |
-| `monitoring.enabled`    | Enable Prometheus integration, will also create necessary RBAC rules | `false`                 |
-| `cephClusterSpec.*`     | Cluster configuration, see below                                     | See below               |
-
-### Ceph Cluster Spec
-
-The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
-For the full list, see the [Cluster CRD](https://rook.github.io/docs/rook/master/ceph-cluster-crd.html).
-
-### Command Line
-
-You can pass the settings with helm command line parameters. Specify each parameter using the
-`--set key=value[,key=value]` argument to `helm install`.
-
-### Settings File
-
-Alternatively, a yaml file that specifies the values for the above parameters (`values.yaml`) can be provided while
-installing the chart.
-
-```console
-helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph-cluster -f values-override.yaml
-```
-
-For example settings, see [values.yaml](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -37,8 +37,7 @@ The release channel is the most recent release of Rook that is considered stable
 
 ```console
 helm repo add rook-release https://charts.rook.io/release
-kubectl create namespace rook-ceph
-helm install --namespace rook-ceph rook-ceph rook-release/rook-ceph
+helm install --create-namespace --namespace rook-ceph rook-ceph rook-release/rook-ceph
 ```
 
 ### Development Build

--- a/Documentation/helm.md
+++ b/Documentation/helm.md
@@ -8,6 +8,7 @@ weight: 10000
 Rook has published a Helm chart for the [operator](helm-operator.md). Other Helm charts will also be potentially developed for each of the
 CRDs for all Rook storage backends.
 
-* [Rook Ceph Operator](helm-operator.md): Installs the Rook Operator and Agents necessary to run a Ceph cluster
+* [Rook Ceph Operator](helm-operator.md): Installs the Ceph Operator
+* [Rook Ceph Cluster](helm-ceph-cluster.md): Configures resources necessary to run a Ceph cluster
 
 Contributions are welcome to create our other Helm charts!

--- a/cluster/charts/rook-ceph-cluster/templates/cephcluster.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephcluster.yaml
@@ -2,7 +2,7 @@
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: {{ .Release.Namespace }}
+  name: {{ default .Release.Namespace .Values.clusterName }}
 spec:
   monitoring:
     rulesNamespace: {{ default .Release.Namespace .Values.monitoring.rulesNamespaceOverride }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -5,6 +5,9 @@
 # Namespace of the main rook operator
 operatorNamespace: rook-ceph
 
+# The metadata.name of the CephCluster CR. The default name is the same as the namespace.
+#clusterName: rook-ceph
+
 # Ability to override ceph.conf
 configOverride:
 #configOverride: |


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Document how the CephCluster CR for an existing cluster can be taken over by the new cluster helm chart if desired, for simpler management of the RBAC and related resources.
- The cluster CR name defaults to the namespace where the CR is created. This name may need to be overridden if the chart is taking over a cluster that had been previously created with a different name.

@henryzhangsta PTAL

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
