### PR TITLE
ceph: initialise httpclient for bucketchecker and objectstoreuser

### DIFF
--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/ceph/go-ceph/rgw/admin"
@@ -622,7 +621,7 @@ func (p *Provisioner) setTlsCaCert() error {
 func (p *Provisioner) setAdminOpsAPIClient() error {
 	// Build TLS transport for the HTTP client if needed
 	httpClient := &http.Client{
-		Timeout: time.Second * 15,
+		Timeout: cephObject.HttpTimeOut,
 	}
 	if p.tlsCert != nil {
 		httpClient.Transport = cephObject.BuildTransportTLS(p.tlsCert)

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	cephconfig "github.com/rook/rook/pkg/operator/ceph/config"
@@ -42,6 +43,7 @@ caps osd = "allow rwx"
 	certKeyFileName                = "rgw-key.pem"
 	rgwPortInternalPort      int32 = 8080
 	ServiceServingCertCAFile       = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+	HttpTimeOut                    = time.Second * 15
 )
 
 var (

--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -131,13 +131,15 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	// Generate unique user and bucket name
 	bucketName := genUniqueBucketName(c.objContext.UID)
 	userConfig := c.genUserConfig()
-
-	var httpClient *http.Client
+	httpClient := &http.Client{
+		Timeout: HttpTimeOut,
+	}
 	if c.objectStoreSpec.IsTLSEnabled() {
 		tlsCert, err = GetTlsCaCert(c.objContext, c.objectStoreSpec)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch CA cert for the user %q to establish TLS connection with the object store %q", userConfig.ID, c.namespacedName.Name)
 		}
+
 		httpClient.Transport = BuildTransportTLS(tlsCert)
 	}
 

--- a/pkg/operator/ceph/object/s3-handlers.go
+++ b/pkg/operator/ceph/object/s3-handlers.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -45,7 +44,7 @@ func NewS3Agent(accessKey, secretKey, endpoint string, debug bool, tlsCert []byt
 		logLevel = aws.LogDebug
 	}
 	client := http.Client{
-		Timeout: time.Second * 15,
+		Timeout: HttpTimeOut,
 	}
 	tlsEnabled := false
 	if len(tlsCert) > 0 {

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -333,7 +333,9 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 	}
 
 	// Build TLS client if needed
-	var httpClient *http.Client
+	httpClient := &http.Client{
+		Timeout: object.HttpTimeOut,
+	}
 	if store.Spec.IsTLSEnabled() {
 		tlsCert, err := object.GetTlsCaCert(objContext, &store.Spec)
 		if err != nil {


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
For the TLS communication in AdminOps Api, httpclient is required and
filled with TLS certs. But it is set to nil pointer in `buckethealthchecker` and 
`cephobjectstoreuser`.

Thanks @Krast76 finding the issue even proposing the fix.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #8132

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
