### PR TITLE
ceph: read and validate CSI params in Go routine

### DIFF
--- a/pkg/operator/ceph/csi/csi.go
+++ b/pkg/operator/ceph/csi/csi.go
@@ -34,6 +34,17 @@ func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage
 		v   *CephCSIVersion
 		err error
 	)
+
+	if err = setParams(context.Clientset); err != nil {
+		logger.Errorf("failed to configure CSI parameters. %v", err)
+		return
+	}
+
+	if err = validateCSIParam(); err != nil {
+		logger.Errorf("failed to validate CSI parameters. %v", err)
+		return
+	}
+
 	if !AllowUnsupported && CSIEnabled() {
 		if v, err = validateCSIVersion(context.Clientset, namespace, rookImage, securityAccount, ownerInfo); err != nil {
 			logger.Errorf("invalid csi version. %+v", err)
@@ -57,7 +68,7 @@ func ValidateAndConfigureDrivers(context *clusterd.Context, namespace, rookImage
 	stopDrivers(context.Clientset, namespace, serverVersion)
 }
 
-func SetParams(clientset kubernetes.Interface) error {
+func setParams(clientset kubernetes.Interface) error {
 	var err error
 
 	csiEnableRBD, err := k8sutil.GetOperatorSetting(clientset, controllerutil.OperatorSettingConfigMapName, "ROOK_CSI_ENABLE_RBD", "true")

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -189,7 +189,7 @@ func CSIEnabled() bool {
 	return EnableRBD || EnableCephFS
 }
 
-func ValidateCSIParam() error {
+func validateCSIParam() error {
 
 	if len(CSIParam.CSIPluginImage) == 0 {
 		return errors.New("missing csi rbd plugin image")

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -240,10 +240,6 @@ func (o *Operator) updateDrivers() error {
 		return errors.Wrap(err, "error getting server version")
 	}
 
-	if err = csi.SetParams(o.context.Clientset); err != nil {
-		return errors.Wrap(err, "failed to configure CSI parameters")
-	}
-
 	if serverVersion.Major < csi.KubeMinMajor || serverVersion.Major == csi.KubeMinMajor && serverVersion.Minor < csi.ProvDeploymentSuppVersion {
 		logger.Infof("CSI drivers only supported in K8s 1.14 or newer. version=%s", serverVersion.String())
 		// disable csi control variables to disable other csi functions
@@ -267,10 +263,6 @@ func (o *Operator) updateDrivers() error {
 	err = csi.CreateCsiConfigMap(o.operatorNamespace, o.context.Clientset, ownerInfo)
 	if err != nil {
 		return errors.Wrap(err, "failed creating csi config map")
-	}
-
-	if err = csi.ValidateCSIParam(); err != nil {
-		return errors.Wrap(err, "invalid csi params")
 	}
 
 	go csi.ValidateAndConfigureDrivers(o.context, o.operatorNamespace, o.rookImage, o.securityAccount, serverVersion, ownerInfo)


### PR DESCRIPTION
This commit moves SetParams and ValidateCSIParam func
into go routine/lock, since it modifies/reads global CSIParam
variable.

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
