### PR TITLE
core: sort multus annotation strings when applying

### DIFF
--- a/pkg/operator/k8sutil/network.go
+++ b/pkg/operator/k8sutil/network.go
@@ -19,6 +19,7 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	netapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -96,6 +97,9 @@ func ApplyMultus(net cephv1.NetworkSpec, objectMeta *metav1.ObjectMeta) error {
 	if shortSyntax && jsonSyntax {
 		return fmt.Errorf("ApplyMultus: Can't mix short and JSON form")
 	}
+
+	// Sort network strings so that pods/deployments won't need updated in a loop if nothing changes
+	sort.Strings(v)
 
 	networks := strings.Join(v, ", ")
 	if jsonSyntax {


### PR DESCRIPTION
In pkg/operator/k8sutil/network.go:ApplyMultus(), sort the string
annotations before applying them so that Rook will avoid the situation
where a Deployment or Pod will need updated repeatedly even when no
Multus network configuration has changed.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
