### PR TITLE
ceph: Mons in stretch cluster should be assigned to a node when using dataDirHostPath

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -142,6 +142,42 @@ func TestResourceName(t *testing.T) {
 	assert.Equal(t, "rook-ceph-mon-b", resourceName("b"))
 }
 
+func TestStartMonDeployment(t *testing.T) {
+	ctx := context.TODO()
+	namespace := "ns"
+	context, err := newTestStartCluster(t, namespace)
+	assert.NoError(t, err)
+	c := newCluster(context, namespace, true, v1.ResourceRequirements{})
+	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)
+
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: EndpointConfigMapName},
+		Data:       map[string]string{"maxMonId": "1"},
+	}
+	_, err = c.context.Clientset.CoreV1().ConfigMaps(c.Namespace).Create(ctx, cm, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Start mon a on a specific node since there is no volumeClaimTemplate
+	m := &monConfig{ResourceName: "rook-ceph-mon-a", DaemonName: "a", Port: 3300, PublicIP: "1.2.3.4", DataPathMap: &config.DataPathMap{}}
+	schedule := &MonScheduleInfo{Hostname: "host-a", Zone: "zonea"}
+	err = c.startMon(m, schedule)
+	assert.NoError(t, err)
+	deployment, err := c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(ctx, m.ResourceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, schedule.Hostname, deployment.Spec.Template.Spec.NodeSelector["kubernetes.io/hostname"])
+
+	// Start mon b on any node in a zone since there is a volumeClaimTemplate
+	m = &monConfig{ResourceName: "rook-ceph-mon-b", DaemonName: "b", Port: 3300, PublicIP: "1.2.3.5", DataPathMap: &config.DataPathMap{}}
+	schedule = &MonScheduleInfo{Hostname: "host-b", Zone: "zoneb"}
+	c.spec.Mon.VolumeClaimTemplate = &v1.PersistentVolumeClaim{}
+	err = c.startMon(m, schedule)
+	assert.NoError(t, err)
+	deployment, err = c.context.Clientset.AppsV1().Deployments(c.Namespace).Get(ctx, m.ResourceName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	// no node selector when there is a volumeClaimTemplate and the mon is assigned to a zone
+	assert.Equal(t, 0, len(deployment.Spec.Template.Spec.NodeSelector))
+}
+
 func TestStartMonPods(t *testing.T) {
 	ctx := context.TODO()
 	namespace := "ns"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the mons are using the dataDirHostPath and not a volumeClaimTemplate, they need to be permanently assigned to a node. The node assignment was missing in stretch clusters when the dataDirHostPath was being used. This resulted in mons that were moving to other nodes for example during a node drain, which would cause the mon to lose its backing store.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
