### PR TITLE
ceph: run CLI output with Info logging

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -247,11 +247,16 @@ func startCommand(env []string, command string, arg ...string) (*exec.Cmd, io.Re
 
 // read from reader line by line and write it to the log
 func logFromReader(logger *capnslog.PackageLogger, reader io.ReadCloser) {
+	l := logger.Debug
+	// If we are an OSD we must log using Info to print out stdout/stderr
+	if os.Getenv("ROOK_OSD_ID") != "" {
+		l = logger.Info
+	}
 	in := bufio.NewScanner(reader)
 	lastLine := ""
 	for in.Scan() {
 		lastLine = in.Text()
-		logger.Debug(lastLine)
+		l(lastLine)
 	}
 }
 


### PR DESCRIPTION
In e8f9cfcb714685d93017be279d9ffdfc3847acca, the logging was replaced by
Debug which is probably a mistake given the intent of the commit to
enable debug logging on the prepare job.
However, this code is only triggered when running a ceph-osd with the
rook binary, so we must run Info and run Debug since Debug is not
activated.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
