### PR TITLE
ci: set tmate for 120min in case of ci failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   linux-build-all:
     runs-on: ubuntu-18.04
@@ -75,3 +76,4 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -89,8 +89,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-canary')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   pvc:
     runs-on: ubuntu-18.04
@@ -166,8 +167,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-canary-pvc')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   pvc-db:
     runs-on: ubuntu-18.04
@@ -230,8 +232,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-canary-pvc-db')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   pvc-db-wal:
     runs-on: ubuntu-18.04
@@ -298,8 +301,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-canary-pvc-db-wal')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   encryption-pvc:
     runs-on: ubuntu-18.04
@@ -365,8 +369,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-encryption-pvc')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   encryption-pvc-db:
     runs-on: ubuntu-18.04
@@ -432,8 +437,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-encryption-pvc-db')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   encryption-pvc-db-wal:
     runs-on: ubuntu-18.04
@@ -500,8 +506,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-encryption-pvc-db-wal')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
 
   encryption-pvc-kms-vault-token-auth:
@@ -587,8 +594,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-encryption-pvc-kms-vault-token-auth')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   lvm-pvc:
     runs-on: ubuntu-18.04
@@ -649,8 +657,9 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-lvm-pvc')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   multi-cluster-mirroring:
     runs-on: ubuntu-18.04
@@ -768,5 +777,6 @@ jobs:
         path: test
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-multi-cluster-mirroring')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-cassandra-suite.yaml
+++ b/.github/workflows/integration-test-cassandra-suite.yaml
@@ -57,5 +57,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-cassandra-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -53,5 +53,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-flex-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -59,5 +59,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-helm-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -54,5 +54,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-mgr-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -58,5 +58,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-multi-cluster-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-nfs-suite.yaml
+++ b/.github/workflows/integration-test-nfs-suite.yaml
@@ -61,5 +61,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-nfs-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -57,5 +57,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-smoke-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -57,5 +57,6 @@ jobs:
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging
-      if: failure() && contains(github.event.pull_request.labels.*.name, 'debug-upgrade-suite')
+      if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -61,6 +61,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestCephHelmSuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -112,6 +113,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestCephMultiClusterDeploySuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -162,6 +164,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestCephSmokeSuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -211,6 +214,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestCephUpgradeSuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -260,6 +264,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestCassandraSuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -310,6 +315,7 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
 
   TestNFSSuite:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/tags/release-*'
@@ -363,3 +369,4 @@ jobs:
     - name: setup tmate session for debugging
       if: failure()
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120


### PR DESCRIPTION
this commit enable tmate session for every ci failure
with 120min timeout.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
