### PR TITLE
ceph: ignore atari partitions when provisioning OSDs

### DIFF
--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -316,13 +316,29 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 			}
 		}
 
-		// If we detect a partition we have to make sure that ceph-volume will be able to consume it
-		// ceph-volume version 14.2.8 has the right code to support partitions
 		if device.Type == sys.PartType {
+			// If we detect a partition we have to make sure that ceph-volume will be able to consume it
+			// ceph-volume version 14.2.8 has the right code to support partitions
 			if !agent.clusterInfo.CephVersion.IsAtLeast(cephVolumeRawModeMinCephVersion) {
 				logger.Infof("skipping device %q because it is a partition and ceph version is too old, you need at least ceph %q", device.Name, cephVolumeRawModeMinCephVersion.String())
 				continue
 			}
+
+			// raw disks or partitions provisioned with bluestore can sometimes appear to have
+			// Atari (AHDI) partitions created on them. These are phantom partitions that weren't
+			// actually created but appear because the Atari partition spec is too broad. If we
+			// detect an Atari partition, we ignore it because it is likely there is already an OSD
+			// provisioned and running on the disk. If we provision another, we will corrupt the
+			// already-running OSD.
+			isAtari, err := sys.PartitionIsAtari(context.Executor, device.Name)
+			if err != nil {
+				logger.Errorf("failed to determine if partition %q is Atari; skipping it to be safe. %v", device.Name, err)
+				continue
+			} else if isAtari {
+				logger.Infof("skipping Atari partition %q to avoid corrupting an already-running OSD", device.Name)
+				continue
+			}
+
 			device, err := clusterd.PopulateDeviceUdevInfo(device.Name, context.Executor, device)
 			if err != nil {
 				logger.Errorf("failed to get udev info of partition %q. %v", device.Name, err)

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -170,6 +170,12 @@ USEC_INITIALIZED=1128667
 		]
 	 }
 	 `
+
+	partedAtariOutput = `BYT;
+/dev/sdb1:1509kB:unknown:512:512:atari:Unknown:;`
+
+	partedUnknownOutput = `BYT;
+/dev/sdc1:10.7GB:unknown:512:512:unknown:Unknown:;`
 )
 
 func TestAvailableDevices(t *testing.T) {
@@ -242,7 +248,16 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 					}
 				}
 				return "{}", nil
+
+			} else if command == "parted" {
+				if strings.Contains(args[2], "sdu1") {
+					return partedAtariOutput, nil
+				} else if strings.Contains(args[2], "sdt1") {
+					// parted returns an error if the partition type is unknown
+					return partedUnknownOutput, errors.New("fake unknown part type err")
+				}
 			}
+
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		},
 	}
@@ -258,6 +273,8 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 		{Name: "rda", RealPath: "/dev/rda"},
 		{Name: "rdb", RealPath: "/dev/rdb"},
 		{Name: "sdt1", RealPath: "/dev/sdt1", Type: sys.PartType},
+		{Name: "sdu1", RealPath: "/dev/sdu1", Type: sys.PartType},                     // is atari
+		{Name: "sdv1", RealPath: "/dev/sdv1", Type: sys.PartType, Filesystem: "ext2"}, // has filesystem
 	}
 
 	version := cephver.Octopus
@@ -276,11 +293,17 @@ NAME="sdb1" SIZE="30" TYPE="part" PKNAME="sdb"`, nil
 	assert.Equal(t, 7, len(mapping.Entries))
 	assert.Equal(t, -1, mapping.Entries["sda"].Data)
 	assert.Equal(t, -1, mapping.Entries["sdd"].Data)
+	assert.Equal(t, -1, mapping.Entries["sde"].Data)
 	assert.Equal(t, -1, mapping.Entries["rda"].Data)
 	assert.Equal(t, -1, mapping.Entries["rdb"].Data)
 	assert.Equal(t, -1, mapping.Entries["nvme01"].Data)
 	assert.NotNil(t, mapping.Entries["nvme01"].Metadata)
 	assert.Equal(t, 0, len(mapping.Entries["nvme01"].Metadata))
+	assert.Equal(t, -1, mapping.Entries["sdt1"].Data)
+	assert.NotContains(t, mapping.Entries, "sdb")  // sdb is in use (has a partition)
+	assert.NotContains(t, mapping.Entries, "sdc")  // sdc is too small
+	assert.NotContains(t, mapping.Entries, "sdu1") // sdu1 is atari
+	assert.NotContains(t, mapping.Entries, "sdv1") // sdv1 has a filesystem
 
 	// Partition is skipped
 	agent.clusterInfo.CephVersion = cephver.Nautilus

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -472,3 +472,38 @@ func ListDevicesChild(executor exec.Executor, device string) ([]string, error) {
 
 	return strings.Split(childListRaw, "\n"), nil
 }
+
+// PartitionIsAtari returns true if the device partition is an Atari type.
+// Ceph bluestore raw disks can sometimes appear as though they have ATARI (AHDI)
+// partitions created on them when they don't in reality.
+// See: https://github.com/rook/rook/issues/7940
+func PartitionIsAtari(executor exec.Executor, device string) (bool, error) {
+	// the command error is not processed the same way as most Go errors. parted returns an error
+	// when the partition table type is unknown, so always process the raw output, even in the case
+	// of a command error
+	raw, cmdErr := executor.ExecuteCommandWithOutput("parted", "--machine", "--script", path.Join("/dev", device), "print")
+	// --machine gives machine-parseable output: https://alioth-lists.debian.net/pipermail/parted-devel/2006-December/000573.html
+	// HEADER-TYPE;
+	// DISK-FULL-PATH:...:PART-TABLE-TYPE:PART-TABLE-NAME:FLAGS-SET;
+	// FS INFO;
+	// always 6 fields or more and on the second line, but we only care about the 3rd to last field
+	raw = strings.TrimSpace(raw) // trim begin/end newlines if exist
+	lines := strings.Split(raw, "\n")
+	if len(lines) < 2 {
+		return true, fmt.Errorf("failed to get 'parted' info for device %q. expect at least two lines of output: %q. %v", device, raw, cmdErr)
+	}
+	rawInfo := lines[1]
+	if rawInfo[len(rawInfo)-1] != ';' {
+		// the last char should be a semicolon
+		return true, fmt.Errorf("failed to get 'parted' info for device %q. expect a semicolon at end: %q. %v", device, rawInfo, cmdErr)
+	}
+	rawInfo = strings.TrimRight(rawInfo, ";") // trim the right semicolon
+	items := strings.Split(rawInfo, ":")
+	if len(items) < 6 {
+		// expect at least 6 fields
+		return true, fmt.Errorf("failed to get 'parted' info for device %q. expect at least 6 fields: %q. %v", device, rawInfo, cmdErr)
+	}
+	pType := items[len(items)-3] // 3rd to last field
+
+	return pType == "atari", nil
+}


### PR DESCRIPTION
Ceph bluestore raw disks can sometimes appear as though they have Atari
(AHDI) partitions on them. If a disk has Atari partitions, we just
ignore them as though they don't exist. This should be a safe assumption
since the hardware was last manufactured in 1992 and likely can't run
Kubernetes.

If we don't ignore the Atari partitions, Rook can create a new OSD on a
disk that is already running an OSD, corrupting the first and possibly
also the latest OSD. This can happen an arbitrary number of times per
disk.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7940 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
