### PR TITLE
ceph: only prepare partitions if gpt

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -30,6 +30,7 @@ jobs:
           # te: udev persistent naming test in pkg/daemon/ceph/osd/daemon_test.go
           # parm: modinfo parameter
           # assigment: inherited from K8s TopologySpreadConstraints dependency
-          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment
+          # msdos: output for an MS-DOS partition label from 'parted' tool
+          ignore_words_list: aks,keyserver,atleast,ser,ist,ba,iam,te,parm,assigment,msdos
           check_filenames: true
           check_hidden: true

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -437,6 +437,10 @@ Below are the settings available, both at the cluster and individual node level,
   * `config`: Device-specific config settings. See the [config settings](#osd-configuration-settings) below
 * `storageClassDeviceSets`: Explained in [Storage Class Device Sets](#storage-class-device-sets)
 
+In all cases, Rook will skip deploying OSDs on devices if the disk has partitions, a filesystem,
+or is otherwise in use. Rook will skip deploying OSDs on partitions if the partition has a
+filesystem or is in use.
+
 ### Storage Class Device Sets
 
 The following are the settings for Storage Class Device Sets which can be configured to create OSDs that are backed by block mode PVs.

--- a/Documentation/ceph-quickstart.md
+++ b/Documentation/ceph-quickstart.md
@@ -24,7 +24,7 @@ To make sure you have a Kubernetes cluster that is ready for `Rook`, you can [fo
 
 In order to configure the Ceph storage cluster, at least one of these local storage options are required:
 - Raw devices (no partitions or formatted filesystems)
-- Raw partitions (no formatted filesystem)
+- Unused GPT partitions (no formatted filesystem)
 - PVs available from a storage class in `block` mode
 
 You can confirm whether your partitions or devices are formatted filesystems with the following command.

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -205,3 +205,12 @@ func PopulateDeviceUdevInfo(d string, executor exec.Executor, disk *sys.LocalDis
 
 	return disk, nil
 }
+
+func PopulateDevicePartitionType(d string, executor exec.Executor, disk *sys.LocalDisk) (*sys.LocalDisk, error) {
+	pType, err := sys.PartitionTableType(executor, d)
+	if err != nil {
+		return disk, err
+	}
+	disk.PartitionTableType = pType
+	return disk, nil
+}


### PR DESCRIPTION
Only prepare an OSD on a partition if the partition type is GPT. Any
other type (or un-typed) of partition will be ignored.

This is to avoid the kernel issue described in
https://github.com/rook/rook/issues/7940.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #7940 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
