### PR TITLE
ceph: fix overwriting shared livenessProbe

### DIFF
--- a/pkg/operator/ceph/config/livenessprobe.go
+++ b/pkg/operator/ceph/config/livenessprobe.go
@@ -53,6 +53,8 @@ func ConfigureLivenessProbe(daemon rook.KeyType, container v1.Container, healthC
 }
 
 func GetLivenessProbeWithDefaults(desiredProbe, currentProbe *v1.Probe) *v1.Probe {
+	newProbe := *desiredProbe
+
 	// Do not replace the handler with the previous one!
 	// On the first iteration, the handler appears empty and is then replaced by whatever first daemon value comes in
 	// e.g: [env -i sh -c ceph --admin-daemon /run/ceph/ceph-mon.b.asok mon_status] - meaning mon b was the first picked in the list of mons
@@ -61,25 +63,25 @@ func GetLivenessProbeWithDefaults(desiredProbe, currentProbe *v1.Probe) *v1.Prob
 	//
 	// Let's always force the default handler, there is no reason to change it anyway since the underlying content is generated based on the daemon's name
 	// so we can not make it generic via the spec
-	desiredProbe.Handler = currentProbe.Handler
+	newProbe.Handler = currentProbe.Handler
 
 	// If the user has not specified thresholds and timeouts, set them to the same values as
 	// in the default liveness probe created by Rook.
-	if desiredProbe.FailureThreshold == 0 {
-		desiredProbe.FailureThreshold = currentProbe.FailureThreshold
+	if newProbe.FailureThreshold == 0 {
+		newProbe.FailureThreshold = currentProbe.FailureThreshold
 	}
-	if desiredProbe.PeriodSeconds == 0 {
-		desiredProbe.PeriodSeconds = currentProbe.PeriodSeconds
+	if newProbe.PeriodSeconds == 0 {
+		newProbe.PeriodSeconds = currentProbe.PeriodSeconds
 	}
-	if desiredProbe.SuccessThreshold == 0 {
-		desiredProbe.SuccessThreshold = currentProbe.SuccessThreshold
+	if newProbe.SuccessThreshold == 0 {
+		newProbe.SuccessThreshold = currentProbe.SuccessThreshold
 	}
-	if desiredProbe.TimeoutSeconds == 0 {
-		desiredProbe.TimeoutSeconds = currentProbe.TimeoutSeconds
+	if newProbe.TimeoutSeconds == 0 {
+		newProbe.TimeoutSeconds = currentProbe.TimeoutSeconds
 	}
-	if desiredProbe.InitialDelaySeconds == 0 {
-		desiredProbe.InitialDelaySeconds = currentProbe.InitialDelaySeconds
+	if newProbe.InitialDelaySeconds == 0 {
+		newProbe.InitialDelaySeconds = currentProbe.InitialDelaySeconds
 	}
 
-	return desiredProbe
+	return &newProbe
 }


### PR DESCRIPTION
When the Operator set the livenessProbe of the POD, it overwrote the contents of the shared desiredProbe.
Therefore, the wrongly configured livenessProbe was applied to other PODs, resulting in a CrashLoop.
In this PR, I created another instance to avoid overwriting the desiredProbe.

Closes: https://github.com/rook/rook/issues/8196
Signed-off-by: Yuji Ito <llamerada.jp@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #8196

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
