### PR TITLE
docs: add release note for GPT-only support

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -15,6 +15,10 @@ v1.7...
   - See [the design](https://github.com/rook/rook/blob/master/design/ceph/resource-dependencies.md)
     for detailed information.
 
+- OSDs
+  - Only GPT partitions can be used for OSDs. Partitions without a type or with any other type will
+    be ignored.
+
 ## Features
 
 ### Core

--- a/pkg/clusterd/disk.go
+++ b/pkg/clusterd/disk.go
@@ -203,5 +203,9 @@ func PopulateDeviceUdevInfo(d string, executor exec.Executor, disk *sys.LocalDis
 		disk.WWN = val
 	}
 
+	if val, ok := udevInfo["ID_PART_TABLE_TYPE"]; ok {
+		disk.PartitionTableType = val
+	}
+
 	return disk, nil
 }

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -328,6 +328,14 @@ func getAvailableDevices(context *clusterd.Context, agent *OsdAgent) (*DeviceOsd
 				logger.Errorf("failed to get udev info of partition %q. %v", device.Name, err)
 				continue
 			}
+			if device.PartitionTableType != sys.GPTType {
+				pType := "unknown or untyped (possibly atari)"
+				if device.PartitionTableType != "" {
+					pType = device.PartitionTableType
+				}
+				logger.Infof("skipping partition %q because it is not a gpt partition. detected: %q", device.Name, pType)
+				continue
+			}
 		}
 
 		// Check if the desired device is available

--- a/pkg/util/sys/device.go
+++ b/pkg/util/sys/device.go
@@ -43,11 +43,17 @@ const (
 	MultiPath = "mpath"
 	// LinearType is a linear type
 	LinearType = "linear"
-	sgdiskCmd  = "sgdisk"
+	// GPTType is a gpt partition type
+	GPTType = "gpt"
+
 	// CephLVPrefix is the prefix of a LV owned by ceph-volume
 	CephLVPrefix = "ceph--"
 	// DeviceMapperPrefix is the prefix of a LV from the device mapper interface
 	DeviceMapperPrefix = "dm-"
+)
+
+const (
+	sgdiskCmd = "sgdisk"
 )
 
 // CephVolumeInventory represents the output of the ceph-volume inventory command
@@ -114,6 +120,8 @@ type LocalDisk struct {
 	KernelName string `json:"kernel-name,omitempty"`
 	// Whether this device should be encrypted
 	Encrypted bool `json:"encrypted,omitempty"`
+	// PartitionTableType is the partition table type of the device (e.g., dos, gpt, )
+	PartitionTableType string
 }
 
 // ListDevices list all devices available on a machine


### PR DESCRIPTION
Only prepare an OSD on a partition if the partition type is GPT. Any
other type (or un-typed) of partition will be ignored.

This is to avoid the kernel issue described in
https://github.com/rook/rook/issues/7940.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
