### PR TITLE
ceph: cancel on-going orchestration on any CR update

### DIFF
--- a/pkg/operator/ceph/cluster/predicate.go
+++ b/pkg/operator/ceph/cluster/predicate.go
@@ -132,23 +132,18 @@ func watchControllerPredicate(rookContext *clusterd.Context) predicate.Funcs {
 				}
 				diff := cmp.Diff(objOld.Spec, objNew.Spec, resourceQtyComparer)
 				if diff != "" {
-					logger.Infof("CR has changed for %q. diff=%s", objNew.Name, diff)
-
-					// If spec Images are different we cancel any on-going orchestration
-					if objOld.Spec.CephVersion.Image != objNew.Spec.CephVersion.Image {
-						// Set the cancellation flag to stop any ongoing orchestration
-						rookContext.RequestCancelOrchestration.Set()
-
-						logger.Info("upgrade requested, cancelling any ongoing orchestration")
-					}
-
+					// Set the cancellation flag to stop any ongoing orchestration
+					rookContext.RequestCancelOrchestration.Set()
+					logger.Infof("CR has changed for %q. cancelling any ongoing orchestration. diff=%s", objNew.Name, diff)
 					return true
-				} else if objOld.GetDeletionTimestamp() != objNew.GetDeletionTimestamp() {
+
+				} else if !objOld.GetDeletionTimestamp().Equal(objNew.GetDeletionTimestamp()) {
 					// Set the cancellation flag to stop any ongoing orchestration
 					rookContext.RequestCancelOrchestration.Set()
 
 					logger.Infof("CR %q is going be deleted, cancelling any ongoing orchestration", objNew.Name)
 					return true
+
 				} else if objOld.GetGeneration() != objNew.GetGeneration() {
 					logger.Debugf("skipping resource %q update with unchanged spec", objNew.Name)
 				}


### PR DESCRIPTION
# **RELEASE 1.5 PATCH**

If the CephCluster CR is updated let's cancel any on-going
orchestration. This will handle the situation where the spec is
misconfigured and OSD are crashlooping.
Prior to this patch, we would have to wait for the provisioning to
timeout, which will leave the cluster in a bad state for 10min or more.

Now the CR changes are picked up right away and the OSDs will deploy
normally.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
