### PR TITLE
ceph: Debug log the k8s version instead of info

### DIFF
--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -73,7 +73,7 @@ func GetK8SVersion(clientset kubernetes.Interface) (*version.Version, error) {
 	index := strings.Index(serverVersion.GitVersion, "+")
 	if index != -1 {
 		newVersion := serverVersion.GitVersion[:index]
-		logger.Infof("returning version %s instead of %s", newVersion, serverVersion.GitVersion)
+		logger.Debugf("returning version %s instead of %s", newVersion, serverVersion.GitVersion)
 		serverVersion.GitVersion = newVersion
 	}
 	return version.MustParseSemantic(serverVersion.GitVersion), nil


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The info log is rather verbose with all the filtering of the K8s version
like the following:
```
2021-07-01 21:54:36.383925 I | op-k8sutil: returning version v1.19.0 instead of v1.19.0+43983cd
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
