### PR TITLE
ceph: operator pod killed due to resource limit

### DIFF
--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -77,6 +77,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		rook.TerminateFatal(err)
 	}
 
+	rook.CheckOperatorResources(context.Clientset)
 	rookImage := rook.GetOperatorImage(context.Clientset, containerName)
 	rookBaseImageCephVersion, err := rook.GetOperatorBaseImageCephVersion(context)
 	if err != nil {

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -19,6 +19,7 @@ package rook
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/coreos/pkg/capnslog"
@@ -33,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/tevino/abool"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
@@ -201,6 +203,17 @@ func GetOperatorServiceAccount(clientset kubernetes.Interface) string {
 	TerminateOnError(err, "failed to get pod")
 
 	return pod.Spec.ServiceAccountName
+}
+
+func CheckOperatorResources(clientset kubernetes.Interface) {
+	// Getting the info of the operator pod
+	pod, err := k8sutil.GetRunningPod(clientset)
+	TerminateOnError(err, "failed to get pod")
+	resource := pod.Spec.Containers[0].Resources
+	// set env var if operator pod resources are set
+	if !reflect.DeepEqual(resource, (v1.ResourceRequirements{})) {
+		os.Setenv("OPERATOR_RESOURCES_SPECIFIED", "true")
+	}
 }
 
 // TerminateOnError terminates if err is not nil

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -580,7 +579,7 @@ func getObjectStores(context *Context) ([]string, error) {
 	return r.Realms, nil
 }
 
-func deletePools(context *Context, spec cephv1.ObjectStoreSpec, lastStore bool) error {
+func deletePools(ctx *Context, spec cephv1.ObjectStoreSpec, lastStore bool) error {
 	if emptyPool(spec.DataPool) && emptyPool(spec.MetadataPool) {
 		logger.Info("skipping removal of pools since not specified in the object store")
 		return nil
@@ -591,33 +590,44 @@ func deletePools(context *Context, spec cephv1.ObjectStoreSpec, lastStore bool) 
 		pools = append(pools, rootPool)
 	}
 
-	var wg sync.WaitGroup
-	for _, pool := range pools {
-		wg.Add(1)
-		name := poolName(context.Name, pool)
-		go func() {
-			defer wg.Done()
-			if err := cephclient.DeletePool(context.Context, context.clusterInfo, name); err != nil {
-				logger.Warningf("failed to delete pool %q. %v", name, err)
-				return
-			}
-		}()
-	}
+	if configurePoolsConcurrently() {
+		waitGroup, _ := errgroup.WithContext(context.TODO())
+		for _, pool := range pools {
+			name := poolName(ctx.Name, pool)
+			waitGroup.Go(func() error {
+				if err := cephclient.DeletePool(ctx.Context, ctx.clusterInfo, name); err != nil {
+					return errors.Wrapf(err, "failed to delete pool %q. ", name)
+				}
+				return nil
+			},
+			)
+		}
 
-	// Wait for all the pools to be deleted
-	wg.Wait()
+		// Wait for all the pools to be deleted
+		if err := waitGroup.Wait(); err != nil {
+			logger.Warning(err)
+		}
+
+	} else {
+		for _, pool := range pools {
+			name := poolName(ctx.Name, pool)
+			if err := cephclient.DeletePool(ctx.Context, ctx.clusterInfo, name); err != nil {
+				logger.Warningf("failed to delete pool %q. %v", name, err)
+			}
+		}
+	}
 
 	// Delete erasure code profile if any
-	erasureCodes, err := cephclient.ListErasureCodeProfiles(context.Context, context.clusterInfo)
+	erasureCodes, err := cephclient.ListErasureCodeProfiles(ctx.Context, ctx.clusterInfo)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list erasure code profiles for cluster %s", context.clusterInfo.Namespace)
+		return errors.Wrapf(err, "failed to list erasure code profiles for cluster %s", ctx.clusterInfo.Namespace)
 	}
 	// cleans up the EC profile for the data pool only. Metadata pools don't support EC (only replication is supported).
-	ecProfileName := cephclient.GetErasureCodeProfileForPool(context.Name)
+	ecProfileName := cephclient.GetErasureCodeProfileForPool(ctx.Name)
 	for i := range erasureCodes {
 		if erasureCodes[i] == ecProfileName {
-			if err := cephclient.DeleteErasureCodeProfile(context.Context, context.clusterInfo, ecProfileName); err != nil {
-				return errors.Wrapf(err, "failed to delete erasure code profile %s for object store %s", ecProfileName, context.Name)
+			if err := cephclient.DeleteErasureCodeProfile(ctx.Context, ctx.clusterInfo, ecProfileName); err != nil {
+				return errors.Wrapf(err, "failed to delete erasure code profile %s for object store %s", ecProfileName, ctx.Name)
 			}
 			break
 		}
@@ -699,52 +709,77 @@ func CreatePools(context *Context, clusterSpec *cephv1.ClusterSpec, metadataPool
 	return nil
 }
 
-func createSimilarPools(ctx *Context, pools []string, clusterSpec *cephv1.ClusterSpec, poolSpec cephv1.PoolSpec, pgCount, ecProfileName string) error {
-	waitGroup, _ := errgroup.WithContext(context.TODO())
-
-	for _, pool := range pools {
-		// Avoid the loop re-using the same value with a closure
-		pool := pool
-		waitGroup.Go(func() error {
-			// create the pool if it doesn't exist yet
-			name := poolName(ctx.Name, pool)
-			if poolDetails, err := cephclient.GetPoolDetails(ctx.Context, ctx.clusterInfo, name); err != nil {
-				// If the ceph config has an EC profile, an EC pool must be created. Otherwise, it's necessary
-				// to create a replicated pool.
-				var err error
-				if poolSpec.IsErasureCoded() {
-					// An EC pool backing an object store does not need to enable EC overwrites, so the pool is
-					// created with that property disabled to avoid unnecessary performance impact.
-					err = cephclient.CreateECPoolForApp(ctx.Context, ctx.clusterInfo, name, ecProfileName, poolSpec, pgCount, AppName, false /* enableECOverwrite */)
-				} else {
-					err = cephclient.CreateReplicatedPoolForApp(ctx.Context, ctx.clusterInfo, clusterSpec, name, poolSpec, pgCount, AppName)
-				}
-				if err != nil {
-					return errors.Wrapf(err, "failed to create pool %s for object store %s.", name, ctx.Name)
-				}
-			} else {
-				// pools already exist
-				if poolSpec.IsReplicated() {
-					// detect if the replication is different from the pool details
-					if poolDetails.Size != poolSpec.Replicated.Size {
-						logger.Infof("pool size is changed from %d to %d", poolDetails.Size, poolSpec.Replicated.Size)
-						if err := cephclient.SetPoolReplicatedSizeProperty(ctx.Context, ctx.clusterInfo, poolDetails.Name, strconv.FormatUint(uint64(poolSpec.Replicated.Size), 10)); err != nil {
-							return errors.Wrapf(err, "failed to set size property to replicated pool %q to %d", poolDetails.Name, poolSpec.Replicated.Size)
-						}
-					}
-				}
-			}
-			// Set the pg_num_min if not the default so the autoscaler won't immediately increase the pg count
-			if pgCount != cephclient.DefaultPGCount {
-				if err := cephclient.SetPoolProperty(ctx.Context, ctx.clusterInfo, name, "pg_num_min", pgCount); err != nil {
-					return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
-				}
-			}
-
-			return nil
-		})
+// configurePoolsConcurrently checks if operator pod resources are set or not
+func configurePoolsConcurrently() bool {
+	// if operator resources are specified return false as it will lead to operator pod killed due to resource limit
+	// nolint #S1008, we can safely suppress this
+	if os.Getenv("OPERATOR_RESOURCES_SPECIFIED") == "true" {
+		return false
 	}
-	return waitGroup.Wait()
+	return true
+}
+
+func createSimilarPools(ctx *Context, pools []string, clusterSpec *cephv1.ClusterSpec, poolSpec cephv1.PoolSpec, pgCount, ecProfileName string) error {
+	// We have concurrency
+	if configurePoolsConcurrently() {
+		waitGroup, _ := errgroup.WithContext(context.TODO())
+		for _, pool := range pools {
+			// Avoid the loop re-using the same value with a closure
+			pool := pool
+
+			waitGroup.Go(func() error { return createRGWPool(ctx, clusterSpec, poolSpec, pgCount, ecProfileName, pool) })
+		}
+		return waitGroup.Wait()
+	}
+
+	// No concurrency!
+	for _, pool := range pools {
+		err := createRGWPool(ctx, clusterSpec, poolSpec, pgCount, ecProfileName, pool)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createRGWPool(ctx *Context, clusterSpec *cephv1.ClusterSpec, poolSpec cephv1.PoolSpec, pgCount, ecProfileName, pool string) error {
+	// create the pool if it doesn't exist yet
+	name := poolName(ctx.Name, pool)
+	if poolDetails, err := cephclient.GetPoolDetails(ctx.Context, ctx.clusterInfo, name); err != nil {
+		// If the ceph config has an EC profile, an EC pool must be created. Otherwise, it's necessary
+		// to create a replicated pool.
+		var err error
+		if poolSpec.IsErasureCoded() {
+			// An EC pool backing an object store does not need to enable EC overwrites, so the pool is
+			// created with that property disabled to avoid unnecessary performance impact.
+			err = cephclient.CreateECPoolForApp(ctx.Context, ctx.clusterInfo, name, ecProfileName, poolSpec, pgCount, AppName, false /* enableECOverwrite */)
+		} else {
+			err = cephclient.CreateReplicatedPoolForApp(ctx.Context, ctx.clusterInfo, clusterSpec, name, poolSpec, pgCount, AppName)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "failed to create pool %s for object store %s.", name, ctx.Name)
+		}
+	} else {
+		// pools already exist
+		if poolSpec.IsReplicated() {
+			// detect if the replication is different from the pool details
+			if poolDetails.Size != poolSpec.Replicated.Size {
+				logger.Infof("pool size is changed from %d to %d", poolDetails.Size, poolSpec.Replicated.Size)
+				if err := cephclient.SetPoolReplicatedSizeProperty(ctx.Context, ctx.clusterInfo, poolDetails.Name, strconv.FormatUint(uint64(poolSpec.Replicated.Size), 10)); err != nil {
+					return errors.Wrapf(err, "failed to set size property to replicated pool %q to %d", poolDetails.Name, poolSpec.Replicated.Size)
+				}
+			}
+		}
+	}
+	// Set the pg_num_min if not the default so the autoscaler won't immediately increase the pg count
+	if pgCount != cephclient.DefaultPGCount {
+		if err := cephclient.SetPoolProperty(ctx.Context, ctx.clusterInfo, name, "pg_num_min", pgCount); err != nil {
+			return errors.Wrapf(err, "failed to set pg_num_min on pool %q to %q", name, pgCount)
+		}
+	}
+
+	return nil
 }
 
 func poolName(storeName, poolName string) string {


### PR DESCRIPTION
when operator pod resources are set(which are
default in case of helm), operator pod are
killed due to using concurrency while creating
object store.



Co-authored-by: Sébastien Han <seb@redhat.com>
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
this commit checks if operator resources are set
or not. if set then we'll *not* create object store
in concurrency or if not set then we'll create in
concurrency.

**Which issue is resolved by this Pull Request:**
Resolves #8149 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
