### PR TITLE
ci: in helm chart field should not be empty

### DIFF
--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -9,7 +9,6 @@ operatorNamespace: rook-ceph
 #clusterName: rook-ceph
 
 # Ability to override ceph.conf
-configOverride:
 #configOverride: |
 #  [global]
 #  mon_allow_pool_delete = true
@@ -88,7 +87,7 @@ cephClusterSpec:
     # port: 8443
     # serve the dashboard using SSL
     ssl: true
-  network:
+  #network:
   # enable host networking
   #provider: host
   # EXPERIMENTAL: enable the Multus network provider
@@ -169,7 +168,7 @@ cephClusterSpec:
   #    osd:
   #    mgr:
   #    cleanup:
-  annotations:
+  #annotations:
   #    all:
   #    mon:
   #    osd:
@@ -177,7 +176,7 @@ cephClusterSpec:
   #    prepareosd:
   # If no mgr annotations are set, prometheus scrape annotations will be set by default.
   #    mgr:
-  labels:
+  #labels:
   #    all:
   #    mon:
   #    osd:
@@ -187,7 +186,7 @@ cephClusterSpec:
   # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
   # These labels can be passed as LabelSelector to Prometheus
   #    monitoring:
-  resources:
+  #resources:
   # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
   #    mgr:
   #      limits:
@@ -215,7 +214,7 @@ cephClusterSpec:
     useAllNodes: true
     useAllDevices: true
     #deviceFilter:
-    config:
+    #config:
     # crushRoot: "custom-root" # specify a non-default root label for the CRUSH map
     # metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
     # databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB


### PR DESCRIPTION
ci is complaining due to empty field in
values.yaml with error
```
coalesce.go:199: warning: destination for config is a table. Ignoring non-table value <nil>
```
this commit make those field empty map/list.

Closes: https://github.com/rook/rook/issues/8239
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #8239 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
