### PR TITLE
ceph: Test upgrades from v1.6 to master

### DIFF
--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -203,11 +203,13 @@ func (c *bucketChecker) cleanupHealthCheck() {
 
 	thePurge := true
 	err := c.objContext.AdminOpsClient.RemoveBucket(context.TODO(), admin.Bucket{Bucket: bucketToDelete, PurgeObject: &thePurge})
-	if errors.Is(err, admin.ErrNoSuchBucket) {
-		// opinion: "not found" is not an error
-		logger.Debugf("bucket %q does not exist", bucketToDelete)
-	} else {
-		logger.Errorf("failed to delete bucket %q for object store %q. %v", bucketToDelete, c.namespacedName.Name, err)
+	if err != nil {
+		if errors.Is(err, admin.ErrNoSuchBucket) {
+			// opinion: "not found" is not an error
+			logger.Debugf("bucket %q does not exist", bucketToDelete)
+		} else {
+			logger.Errorf("failed to delete bucket %q for object store %q. %v", bucketToDelete, c.namespacedName.Name, err)
+		}
 	}
 
 	userToDelete := genUserCheckerConfig(c.objContext.UID)

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -59,8 +59,8 @@ func NewCephManifests(settings *TestCephSettings) CephManifests {
 	switch settings.RookVersion {
 	case VersionMaster:
 		return &CephManifestsMaster{settings}
-	case Version1_5:
-		return &CephManifestsV1_5{settings}
+	case Version1_6:
+		return &CephManifestsV1_6{settings}
 	}
 	panic(fmt.Errorf("unrecognized ceph manifest version: %s", settings.RookVersion))
 }

--- a/tests/framework/installer/ceph_manifests_v1.6.go
+++ b/tests/framework/installer/ceph_manifests_v1.6.go
@@ -25,19 +25,19 @@ import (
 
 const (
 	// The version from which the upgrade test will start
-	Version1_5 = "v1.5.8"
+	Version1_6 = "v1.6.7"
 )
 
-// CephManifestsV1_4 wraps rook yaml definitions
-type CephManifestsV1_5 struct {
+// CephManifestsV1_6 wraps rook yaml definitions
+type CephManifestsV1_6 struct {
 	settings *TestCephSettings
 }
 
-func (m *CephManifestsV1_5) Settings() *TestCephSettings {
+func (m *CephManifestsV1_6) Settings() *TestCephSettings {
 	return m.settings
 }
 
-func (m *CephManifestsV1_5) GetCRDs(k8shelper *utils.K8sHelper) string {
+func (m *CephManifestsV1_6) GetCRDs(k8shelper *utils.K8sHelper) string {
 	if k8shelper.VersionAtLeast("v1.16.0") {
 		return m.settings.readManifestFromGithub("crds.yaml")
 	}
@@ -45,7 +45,7 @@ func (m *CephManifestsV1_5) GetCRDs(k8shelper *utils.K8sHelper) string {
 }
 
 // GetRookOperator returns rook Operator manifest
-func (m *CephManifestsV1_5) GetOperator() string {
+func (m *CephManifestsV1_6) GetOperator() string {
 	var manifest string
 	if utils.IsPlatformOpenShift() {
 		manifest = m.settings.readManifestFromGithub("operator-openshift.yaml")
@@ -56,12 +56,12 @@ func (m *CephManifestsV1_5) GetOperator() string {
 }
 
 // GetCommon returns rook-cluster manifest
-func (m *CephManifestsV1_5) GetCommon() string {
+func (m *CephManifestsV1_6) GetCommon() string {
 	return m.settings.readManifestFromGithub("common.yaml")
 }
 
 // GetRookToolBox returns rook-toolbox manifest
-func (m *CephManifestsV1_5) GetToolbox() string {
+func (m *CephManifestsV1_6) GetToolbox() string {
 	if m.settings.DirectMountToolbox {
 		manifest := strings.ReplaceAll(m.settings.readManifestFromGithub("direct-mount.yaml"), "name: rook-direct-mount", "name: rook-ceph-tools")
 		return strings.ReplaceAll(manifest, "app: rook-direct-mount", "app: rook-ceph-tools")
@@ -69,7 +69,7 @@ func (m *CephManifestsV1_5) GetToolbox() string {
 	return m.settings.readManifestFromGithub("toolbox.yaml")
 }
 
-func (m *CephManifestsV1_5) GetCommonExternal() string {
+func (m *CephManifestsV1_6) GetCommonExternal() string {
 	return m.settings.readManifestFromGithub("common-external.yaml")
 }
 
@@ -82,7 +82,7 @@ func (m *CephManifestsV1_5) GetCommonExternal() string {
 //**********************************************************************************
 
 // GetRookCluster returns rook-cluster manifest
-func (m *CephManifestsV1_5) GetCephCluster() string {
+func (m *CephManifestsV1_6) GetCephCluster() string {
 	crushRoot := "# crushRoot not specified; Rook will use `default`"
 	if m.settings.Mons == 1 {
 		crushRoot = `crushRoot: "custom-root"`
@@ -188,7 +188,7 @@ spec:
         interval: 5s`
 }
 
-func (m *CephManifestsV1_5) GetBlockSnapshotClass(snapshotClassName, reclaimPolicy string) string {
+func (m *CephManifestsV1_6) GetBlockSnapshotClass(snapshotClassName, reclaimPolicy string) string {
 	// Create a CSI driver snapshotclass
 	return `
 apiVersion: snapshot.storage.k8s.io/v1beta1
@@ -204,7 +204,7 @@ parameters:
 `
 }
 
-func (m *CephManifestsV1_5) GetFileStorageSnapshotClass(snapshotClassName, reclaimPolicy string) string {
+func (m *CephManifestsV1_6) GetFileStorageSnapshotClass(snapshotClassName, reclaimPolicy string) string {
 	// Create a CSI driver snapshotclass
 	return `
 apiVersion: snapshot.storage.k8s.io/v1beta1
@@ -220,7 +220,7 @@ parameters:
 `
 }
 
-func (m *CephManifestsV1_5) GetBlockPool(poolName, replicaSize string) string {
+func (m *CephManifestsV1_6) GetBlockPool(poolName, replicaSize string) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
@@ -244,7 +244,7 @@ spec:
       interval: 10s`
 }
 
-func (m *CephManifestsV1_5) GetBlockStorageClass(poolName, storageClassName, reclaimPolicy string) string {
+func (m *CephManifestsV1_6) GetBlockStorageClass(poolName, storageClassName, reclaimPolicy string) string {
 	// Create a CSI driver storage class
 	if m.settings.UseCSI {
 		return `
@@ -278,7 +278,7 @@ parameters:
     clusterNamespace: ` + m.settings.Namespace
 }
 
-func (m *CephManifestsV1_5) GetFileStorageClass(fsName, storageClassName string) string {
+func (m *CephManifestsV1_6) GetFileStorageClass(fsName, storageClassName string) string {
 	// Create a CSI driver storage class
 	csiCephFSNodeSecret := "rook-csi-cephfs-node"               //nolint:gosec // We safely suppress gosec in tests file
 	csiCephFSProvisionerSecret := "rook-csi-cephfs-provisioner" //nolint:gosec // We safely suppress gosec in tests file
@@ -300,7 +300,7 @@ parameters:
 }
 
 // GetFilesystem returns the manifest to create a Rook filesystem resource with the given config.
-func (m *CephManifestsV1_5) GetFilesystem(name string, activeCount int) string {
+func (m *CephManifestsV1_6) GetFilesystem(name string, activeCount int) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
@@ -322,7 +322,7 @@ spec:
 }
 
 // GetFilesystem returns the manifest to create a Rook Ceph NFS resource with the given config.
-func (m *CephManifestsV1_5) GetNFS(name, pool string, count int) string {
+func (m *CephManifestsV1_6) GetNFS(name, pool string, count int) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephNFS
 metadata:
@@ -336,7 +336,7 @@ spec:
     active: ` + strconv.Itoa(count)
 }
 
-func (m *CephManifestsV1_5) GetObjectStore(name string, replicaCount, port int, tlsEnable bool) string {
+func (m *CephManifestsV1_6) GetObjectStore(name string, replicaCount, port int, tlsEnable bool) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
@@ -363,7 +363,7 @@ spec:
 `
 }
 
-func (m *CephManifestsV1_5) GetObjectStoreUser(name string, displayName string, store string) string {
+func (m *CephManifestsV1_6) GetObjectStoreUser(name string, displayName string, store string) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephObjectStoreUser
 metadata:
@@ -375,7 +375,7 @@ spec:
 }
 
 //GetBucketStorageClass returns the manifest to create object bucket
-func (m *CephManifestsV1_5) GetBucketStorageClass(storeName, storageClassName, reclaimPolicy, region string) string {
+func (m *CephManifestsV1_6) GetBucketStorageClass(storeName, storageClassName, reclaimPolicy, region string) string {
 	return `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -389,7 +389,7 @@ parameters:
 }
 
 //GetOBC returns the manifest to create object bucket claim
-func (m *CephManifestsV1_5) GetOBC(claimName, storageClassName, objectBucketName, maxObject string, varBucketName bool) string {
+func (m *CephManifestsV1_6) GetOBC(claimName, storageClassName, objectBucketName, maxObject string, varBucketName bool) string {
 	bucketParameter := "generateBucketName"
 	if varBucketName {
 		bucketParameter = "bucketName"
@@ -405,7 +405,7 @@ spec:
     maxObjects: "` + maxObject + `"`
 }
 
-func (m *CephManifestsV1_5) GetClient(claimName string, caps map[string]string) string {
+func (m *CephManifestsV1_6) GetClient(claimName string, caps map[string]string) string {
 	clientCaps := []string{}
 	for name, cap := range caps {
 		str := name + ": " + cap
@@ -421,7 +421,7 @@ spec:
     ` + strings.Join(clientCaps, "\n    ")
 }
 
-func (m *CephManifestsV1_5) GetExternalCephCluster() string {
+func (m *CephManifestsV1_6) GetExternalCephCluster() string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
@@ -434,7 +434,7 @@ spec:
 }
 
 // GetRBDMirror returns the manifest to create a Rook Ceph RBD Mirror resource with the given config.
-func (m *CephManifestsV1_5) GetRBDMirror(name string, count int) string {
+func (m *CephManifestsV1_6) GetRBDMirror(name string, count int) string {
 	return `apiVersion: ceph.rook.io/v1
 kind: CephRBDMirror
 metadata:

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -575,7 +575,7 @@ func waitForFilesystemActive(k8sh *utils.K8sHelper, clusterInfo *client.ClusterI
 
 	logger.Infof("waiting for filesystem %q to be active", filesystemName)
 	for i := 0; i < utils.RetryLoop; i++ {
-		// start the rgw admin command
+		// run the ceph fs status command
 		stat, err := k8sh.MakeContext().Executor.ExecuteCommandWithCombinedOutput(command, args...)
 		if err != nil {
 			logger.Warningf("failed to get filesystem %q status. %+v", filesystemName, err)
@@ -586,7 +586,7 @@ func waitForFilesystemActive(k8sh *utils.K8sHelper, clusterInfo *client.ClusterI
 			logger.Infof("done waiting for filesystem %q to be active", filesystemName)
 			return nil
 		}
-		logger.Infof("waiting for filesystem %q to be active", filesystemName)
+		logger.Infof("waiting for filesystem %q to be active. status=%s", filesystemName, stat)
 		time.Sleep(utils.RetryInterval * time.Second)
 	}
 	return fmt.Errorf("gave up waiting to get filesystem %q status [err: %+v] Status returned:\n%s", filesystemName, err, stat)

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -84,7 +84,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		Mons:              1,
 		UseCSI:            true,
 		SkipOSDCreation:   false,
-		RookVersion:       installer.Version1_5,
+		RookVersion:       installer.Version1_6,
 		CephVersion:       installer.NautilusPartitionVersion,
 	}
 
@@ -158,7 +158,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	require.True(s.T(), created)
 
 	// verify that we're actually running the right pre-upgrade image
-	s.verifyOperatorImage(installer.Version1_5)
+	s.verifyOperatorImage(installer.Version1_6)
 
 	message := "my simple message"
 	preFilename := "pre-upgrade-file"
@@ -177,30 +177,30 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	require.NotEqual(s.T(), 0, numOSDs)
 
 	//
-	// Upgrade Rook from v1.5 to master
+	// Upgrade Rook from v1.6 to master
 	//
-	logger.Infof("*** UPGRADING ROOK FROM %s to master ***", installer.Version1_5)
+	logger.Infof("*** UPGRADING ROOK FROM %s to master ***", installer.Version1_6)
 	s.gatherLogs(s.settings.OperatorNamespace, "_before_master_upgrade")
 	s.upgradeToMaster()
 
 	s.verifyOperatorImage(installer.VersionMaster)
+	s.verifyRookUpgrade(numOSDs)
 	err = s.installer.WaitForToolbox(s.namespace)
 	assert.NoError(s.T(), err)
 
-	s.verifyRookUpgrade(numOSDs)
-	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_5)
-	newFile := "post-upgrade-1_5-to-master-file"
+	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_6)
+	newFile := "post-upgrade-1_6-to-master-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
 
 	checkCephObjectUser(s.Suite, s.helper, s.k8sh, s.namespace, objectStoreName, objectUserID, true)
 
-	// should be Bound after upgrade to Rook v1.5+
+	// should be Bound after upgrade to Rook master
 	// do not need retry b/c the OBC controller runs parallel to Rook-Ceph orchestration
-	require.True(s.T(), s.helper.BucketClient.CheckOBC(obcName, "bound"))
+	assert.True(s.T(), s.helper.BucketClient.CheckOBC(obcName, "bound"))
 
-	logger.Infof("Verified upgrade from %s to master", installer.Version1_5)
+	logger.Infof("Verified upgrade from %s to master", installer.Version1_6)
 
 	//
 	// Upgrade from nautilus to octopus


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With v1.7 approaching, the upgrade integration test will now test from v1.6.x to the latest master, which will effectively become the v1.7 release soon.

Updating the upgrade test for the next release is so much simpler these days!

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
