### PR TITLE
ceph: Run helm tests without admission controller

### DIFF
--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -71,7 +71,7 @@ func (h *HelmSuite) SetupSuite() {
 		Mons:                      1,
 		UseCSI:                    true,
 		SkipOSDCreation:           false,
-		EnableAdmissionController: true,
+		EnableAdmissionController: false,
 		EnableDiscovery:           true,
 		RookVersion:               installer.VersionMaster,
 		CephVersion:               installer.OctopusVersion,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The helm tests frequently hit an issue with the admission controller. The admission controller is also enabled in other test suites, so it seems safe enough to disable for the helm test suite.

For example in [this test](https://github.com/rook/rook/runs/2974651548?check_suite_focus=true), the helm test failed here:
```
Error: Internal error occurred: failed calling webhook "cephcluster-wh-rook-ceph-admission-controller-helm-ns.rook.io": Post "https://rook-ceph-admission-controller.helm-ns.svc:443/validate-ceph-rook-io-v1-cephcluster?timeout=5s": dial tcp 10.109.33.128:443: connect: connection refused: exit status 1
2021-07-02 18:07:29.220846 E | testutil: could not install helm chart with name : rook-ceph-cluster, namespace: helm-ns  - . coalesce.go:199: warning: destination for network is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for config is a table. Ignoring non-table value <nil>
```

The error about the non-table value may also need to be fixed separately, but let's just eliminate the admission controller factor for now.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
