### PR TITLE
ceph: network configuration should be optional in Helm chart

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -16,7 +16,8 @@ spec:
         app: rook-ceph-tools
     spec:
       dnsPolicy: ClusterFirstWithHostNet
-{{- if default "" .Values.cephClusterSpec.network.provider | eq "host" }}
+{{- $network := .Values.cephClusterSpec.network | default dict -}}
+{{- if ($network.provider | default "") | eq "host" }}
       hostNetwork: true
 {{- end }}
       containers:


### PR DESCRIPTION
**Description of your changes:**

adds a default empty dict for the network when deciding whether toolbox
should also be on the host network to catch the case when the entire
`network` block is empty

**Which issue is resolved by this Pull Request:**
Resolves #8251

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
