### PR TITLE
ceph: add ability to disable mirroring

### DIFF
--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -97,6 +97,39 @@ func enablePoolMirroring(context *clusterd.Context, clusterInfo *ClusterInfo, po
 	return nil
 }
 
+// disablePoolMirroring turns off mirroring on a pool
+func disablePoolMirroring(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string) error {
+	logger.Infof("disabling mirroring for pool %q", poolName)
+
+	// Build command
+	args := []string{"mirror", "pool", "disable", poolName}
+	cmd := NewRBDCommand(context, clusterInfo, args)
+
+	// Run command
+	output, err := cmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to disable mirroring for pool %q. %s", poolName, output)
+	}
+
+	return nil
+}
+
+func removeClusterPeer(context *clusterd.Context, clusterInfo *ClusterInfo, poolName, peerUUID string) error {
+	logger.Infof("removing cluster peer with UUID %q for the pool %q", peerUUID, poolName)
+
+	// Build command
+	args := []string{"mirror", "pool", "peer", "remove", poolName, peerUUID}
+	cmd := NewRBDCommand(context, clusterInfo, args)
+
+	// Run command
+	output, err := cmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove cluster peer with UUID %q for the pool %q. %s", peerUUID, poolName, output)
+	}
+
+	return nil
+}
+
 // GetPoolMirroringStatus prints the pool mirroring status
 func GetPoolMirroringStatus(context *clusterd.Context, clusterInfo *ClusterInfo, poolName string) (*cephv1.PoolMirroringStatus, error) {
 	logger.Debugf("retrieving mirroring pool %q status", poolName)

--- a/pkg/daemon/ceph/client/mirror_test.go
+++ b/pkg/daemon/ceph/client/mirror_test.go
@@ -303,3 +303,42 @@ func TestRemoveSnapshotSchedules(t *testing.T) {
 	err := removeSnapshotSchedules(context, AdminClusterInfo("mycluster"), *poolSpec, pool)
 	assert.NoError(t, err)
 }
+
+func TestDisableMirroring(t *testing.T) {
+	pool := "pool-test"
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if args[0] == "mirror" {
+			assert.Equal(t, "pool", args[1])
+			assert.Equal(t, "disable", args[2])
+			assert.Equal(t, pool, args[3])
+			return "", nil
+		}
+		return "", errors.New("unknown command")
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	err := disablePoolMirroring(context, AdminClusterInfo("mycluster"), pool)
+	assert.NoError(t, err)
+}
+
+func TestRemoveClusterPeer(t *testing.T) {
+	pool := "pool-test"
+	peerUUID := "39ae33fb-1dd6-4f9b-8ed7-0e4517068900"
+	executor := &exectest.MockExecutor{}
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		if args[0] == "mirror" {
+			assert.Equal(t, "pool", args[1])
+			assert.Equal(t, "peer", args[2])
+			assert.Equal(t, "remove", args[3])
+			assert.Equal(t, pool, args[4])
+			assert.Equal(t, peerUUID, args[5])
+			return "", nil
+		}
+		return "", errors.New("unknown command")
+	}
+	context := &clusterd.Context{Executor: executor}
+
+	err := removeClusterPeer(context, AdminClusterInfo("mycluster"), pool, peerUUID)
+	assert.NoError(t, err)
+}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -375,6 +375,27 @@ func TestCephBlockPoolController(t *testing.T) {
 		assert.NotEmpty(t, myPeerSecret.Data["token"], myPeerSecret.Data)
 		assert.NotEmpty(t, myPeerSecret.Data["pool"])
 	}
+
+	//
+	// TEST 6: Mirroring disabled
+	r = &ReconcileCephBlockPool{
+		client:            cl,
+		scheme:            s,
+		context:           c,
+		blockPoolChannels: make(map[string]*blockPoolHealth),
+	}
+	pool.Spec.Mirroring.Enabled = false
+	pool.Spec.Mirroring.Mode = "image"
+	err = r.client.Update(context.TODO(), pool)
+	assert.NoError(t, err)
+	res, err = r.Reconcile(ctx, req)
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue)
+	err = r.client.Get(context.TODO(), req.NamespacedName, pool)
+	assert.NoError(t, err)
+	assert.Equal(t, cephv1.ConditionReady, pool.Status.Phase)
+
+	assert.Nil(t, pool.Status.MirroringStatus)
 }
 
 func TestConfigureRBDStats(t *testing.T) {

--- a/pkg/operator/ceph/pool/validate.go
+++ b/pkg/operator/ceph/pool/validate.go
@@ -158,7 +158,7 @@ func ValidatePoolSpec(context *clusterd.Context, clusterInfo *cephclient.Cluster
 	}
 
 	if !p.Mirroring.Enabled && p.Mirroring.SnapshotSchedulesEnabled() {
-		return errors.New("mirroring must be enabled to configure snapshot scheduling")
+		logger.Warning("mirroring must be enabled to configure snapshot scheduling")
 	}
 
 	return nil

--- a/pkg/operator/ceph/pool/validate_test.go
+++ b/pkg/operator/ceph/pool/validate_test.go
@@ -164,12 +164,6 @@ func TestValidatePool(t *testing.T) {
 		p.Spec.Mirroring.SnapshotSchedules = []cephv1.SnapshotScheduleSpec{{Interval: "24h"}}
 		err = ValidatePool(context, clusterInfo, clusterSpec, &p)
 		assert.NoError(t, err)
-
-		// Error mirror is disabled but snap schedule is enabled
-		p.Spec.Mirroring.Enabled = false
-		err = ValidatePool(context, clusterInfo, clusterSpec, &p)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "mirroring must be enabled to configure snapshot scheduling")
 	}
 
 	// Failure and subfailure domains


### PR DESCRIPTION
This PR is for backporting 8215 to release-1.6

The PR disables mirroring on a pool when PoolSpec.Mirroring.Enabled
is set to false
- disable mirroring on the pool for `Mirroring.Mode == pool`
- Add warning for the user to disable mirroring manually for `Mirroring.Mode == image`
- Stop the mirroring health checker goroutine
- Reset the mirroring health check status in the CR.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 05b0ae09bbb449e1e7594998649d1ca474109280)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
