### PR TITLE
ceph: always rehydrate the access and secret keys

### DIFF
--- a/pkg/operator/ceph/object/health.go
+++ b/pkg/operator/ceph/object/health.go
@@ -146,15 +146,15 @@ func (c *bucketChecker) checkObjectStoreHealth() error {
 	// Create checker user
 	logger.Debugf("creating s3 user object %q for object store %q health check", userConfig.ID, c.namespacedName.Name)
 	var user admin.User
-	user, err := c.objContext.AdminOpsClient.CreateUser(context.TODO(), userConfig)
+	user, err := c.objContext.AdminOpsClient.GetUser(context.TODO(), userConfig)
 	if err != nil {
-		if errors.Is(err, admin.ErrUserExists) {
-			user, err = c.objContext.AdminOpsClient.GetUser(context.TODO(), userConfig)
+		if errors.Is(err, admin.ErrNoSuchUser) {
+			user, err = c.objContext.AdminOpsClient.CreateUser(context.TODO(), userConfig)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get details from ceph object user %q", userConfig.ID)
+				return errors.Wrapf(err, "failed to create from ceph object user %v", userConfig.ID)
 			}
 		} else {
-			return errors.Wrapf(err, "failed to create ceph object user %q", userConfig.ID)
+			return errors.Wrapf(err, "failed to get details from ceph object user %q", userConfig.ID)
 		}
 	}
 

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -270,19 +270,19 @@ func (r *ReconcileObjectStoreUser) reconcileCephUser(cephObjectStoreUser *cephv1
 func (r *ReconcileObjectStoreUser) createorUpdateCephUser(u *cephv1.CephObjectStoreUser) error {
 	logger.Infof("creating ceph object user %q in namespace %q", u.Name, u.Namespace)
 
-	logCreateOrUpdate := fmt.Sprintf("created ceph object user %q", u.Name)
+	logCreateOrUpdate := fmt.Sprintf("retrieved existing ceph object user %q", u.Name)
 	var user admin.User
 	var err error
-	user, err = r.objContext.AdminOpsClient.CreateUser(context.TODO(), *r.userConfig)
+	user, err = r.objContext.AdminOpsClient.GetUser(context.TODO(), *r.userConfig)
 	if err != nil {
-		if errors.Is(err, admin.ErrUserExists) {
-			user, err = r.objContext.AdminOpsClient.GetUser(context.TODO(), *r.userConfig)
+		if errors.Is(err, admin.ErrNoSuchUser) {
+			user, err = r.objContext.AdminOpsClient.CreateUser(context.TODO(), *r.userConfig)
 			if err != nil {
-				return errors.Wrapf(err, "failed to get details from ceph object user %v", &r.userConfig.ID)
+				return errors.Wrapf(err, "failed to create ceph object user %v", &r.userConfig.ID)
 			}
-			logCreateOrUpdate = fmt.Sprintf("retrieved existing ceph object user %q", u.Name)
+			logCreateOrUpdate = fmt.Sprintf("created ceph object user %q", u.Name)
 		} else {
-			return errors.Wrapf(err, "failed to create ceph object user %q", u.Name)
+			return errors.Wrapf(err, "failed to get details from ceph object user %q", u.Name)
 		}
 	}
 

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -269,6 +269,8 @@ func (r *ReconcileObjectStoreUser) reconcileCephUser(cephObjectStoreUser *cephv1
 
 func (r *ReconcileObjectStoreUser) createorUpdateCephUser(u *cephv1.CephObjectStoreUser) error {
 	logger.Infof("creating ceph object user %q in namespace %q", u.Name, u.Namespace)
+
+	logCreateOrUpdate := fmt.Sprintf("created ceph object user %q", u.Name)
 	var user admin.User
 	var err error
 	user, err = r.objContext.AdminOpsClient.CreateUser(context.TODO(), *r.userConfig)
@@ -278,18 +280,17 @@ func (r *ReconcileObjectStoreUser) createorUpdateCephUser(u *cephv1.CephObjectSt
 			if err != nil {
 				return errors.Wrapf(err, "failed to get details from ceph object user %v", &r.userConfig.ID)
 			}
-
-			return nil
+			logCreateOrUpdate = fmt.Sprintf("retrieved existing ceph object user %q", u.Name)
+		} else {
+			return errors.Wrapf(err, "failed to create ceph object user %q", u.Name)
 		}
-
-		return errors.Wrapf(err, "failed to create ceph object user %q", u.Name)
 	}
 
 	// Set access and secret key
 	r.userConfig.Keys[0].AccessKey = user.Keys[0].AccessKey
 	r.userConfig.Keys[0].SecretKey = user.Keys[0].SecretKey
 
-	logger.Infof("created ceph object user %q", u.Name)
+	logger.Info(logCreateOrUpdate)
 	return nil
 }
 
@@ -384,7 +385,6 @@ func (r *ReconcileObjectStoreUser) reconcileCephUserSecret(cephObjectStoreUser *
 		return reconcile.Result{}, errors.Wrapf(err, "failed to create or update ceph object user %q secret", secret.Name)
 	}
 
-	logger.Infof("created ceph object user secret %q", secret.Name)
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
**Description of your changes:**

Prior to that the access and secret keys were left empty if the user
already existed, which led to updating the secret with empty values when
the operator restarts.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
