### PR TITLE
rook: Add image pull secrets option on new helm cluster

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/serviceaccount.yaml
@@ -4,14 +4,17 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-osd
+{{ template "imagePullSecrets" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-mgr
+{{ template "imagePullSecrets" . }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rook-ceph-cmd-reporter
+{{ template "imagePullSecrets" . }}
 {{- end }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -29,6 +29,10 @@ monitoring:
   enabled: false
   rulesNamespaceOverride:
 
+# imagePullSecrets option allow to pull docker images from private docker registry. Option will be passed to all service accounts.
+# imagePullSecrets:
+# - name: my-registry-secret
+
 # All values below are taken from the CephCluster CRD
 # More information can be found at [Ceph Cluster CRD](/Documentation/ceph-cluster-crd.md)
 cephClusterSpec:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Allow to specify imagePullSecrets to pull operator/ceph images from private registry

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
