### PR TITLE
ceph: add missing spec to the object context

### DIFF
--- a/pkg/operator/ceph/object/admin_test.go
+++ b/pkg/operator/ceph/object/admin_test.go
@@ -19,7 +19,14 @@ package object
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
+	v1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/rook/rook/pkg/util/exec"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,4 +121,40 @@ this line can't be parsed as json
 		"four": 4
 	}
 ]`, match)
+}
+
+func TestRunAdminCommandNoMultisite(t *testing.T) {
+	objContext := &Context{
+		Context:     &clusterd.Context{RemoteExecutor: exec.RemotePodCommandExecutor{ClientSet: test.New(t, 3)}},
+		clusterInfo: client.AdminClusterInfo("mycluster"),
+	}
+
+	t.Run("no network provider - we run the radosgw-admin command from the operator", func(t *testing.T) {
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if args[0] == "zone" {
+					return `{
+		"id": "237e6250-5f7d-4b85-9359-8cb2b1848507",
+		"name": "realm-a",
+		"current_period": "df665ecb-1762-47a9-9c66-f938d251c02a",
+		"epoch": 2
+	}`, nil
+				}
+				return "", nil
+			},
+		}
+
+		objContext.Context.Executor = executor
+		_, err := RunAdminCommandNoMultisite(objContext, true, []string{"zone", "get"}...)
+		assert.NoError(t, err)
+	})
+
+	t.Run("with multus - we use the remote executor", func(t *testing.T) {
+		objContext.CephClusterSpec = v1.ClusterSpec{Network: v1.NetworkSpec{Provider: "multus"}}
+		_, err := RunAdminCommandNoMultisite(objContext, true, []string{"zone", "get"}...)
+		assert.Error(t, err)
+
+		// This is not the best but it shows we go through the right codepath
+		assert.EqualError(t, err, "no pods found with selector \"rook-ceph-mgr\"")
+	})
 }

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -309,6 +309,11 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 	if err != nil {
 		return errors.Wrapf(err, "Multisite failed to set on object context for object store user")
 	}
+
+	// The object store context needs the CephCluster spec to read networkinfo
+	// Otherwise GetAdminOPSUserCredentials() will fail detecting the network provider when running RunAdminCommandNoMultisite()
+	objContext.CephClusterSpec = *r.cephClusterSpec
+
 	opsContext, err := object.NewMultisiteAdminOpsContext(objContext, &store.Spec)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialized rgw admin ops client api")


### PR DESCRIPTION
**Description of your changes:**

The CephClusterSpec was missing from the object context, so the check
for the network provider in RunAdminCommandNoMultisite() was not
discovering the network property correctly.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
