### PR TITLE
ceph: update nodePort port to 9283 for rook-prometheus service

### DIFF
--- a/cluster/examples/kubernetes/ceph/monitoring/prometheus-service.yaml
+++ b/cluster/examples/kubernetes/ceph/monitoring/prometheus-service.yaml
@@ -8,7 +8,7 @@ spec:
   ports:
   - name: web
     nodePort: 30900
-    port: 9090
+    port: 9283
     protocol: TCP
     targetPort: web
   selector:


### PR DESCRIPTION
By default the `rook-ceph-mgr` is created at 9283/TCP
Updating the rook-prometheus service nodePort port to 9283 so it can become accessibe by default config

Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
