### PR TITLE
nfs: MIGRATE common crd from v1beta1 to v1

### DIFF
--- a/cluster/examples/kubernetes/nfs/common.yaml
+++ b/cluster/examples/kubernetes/nfs/common.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: rook-nfs-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -11,14 +11,6 @@ metadata:
   creationTimestamp: null
   name: nfsservers.nfs.rook.io
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .metadata.creationTimestamp
-      name: AGE
-      type: date
-    - JSONPath: .status.state
-      description: NFS Server instance state
-      name: State
-      type: string
   group: nfs.rook.io
   names:
     kind: NFSServer
@@ -26,149 +18,156 @@ spec:
     plural: nfsservers
     singular: nfsserver
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: NFSServer is the Schema for the nfsservers API
-      properties:
-        apiVersion:
-          description:
-            "APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-          type: string
-        kind:
-          description:
-            "Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: NFSServerSpec represents the spec of NFS daemon
-          properties:
-            annotations:
-              additionalProperties:
-                type: string
-              description:
-                The annotations-related configuration to add/set on each
-                Pod related object.
-              type: object
-            exports:
-              description: The parameters to configure the NFS export
-              items:
-                description: ExportsSpec represents the spec of NFS exports
-                properties:
-                  name:
-                    description: Name of the export
-                    type: string
-                  persistentVolumeClaim:
-                    description: PVC from which the NFS daemon gets storage for sharing
-                    properties:
-                      claimName:
-                        description:
-                          "ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
-                        type: string
-                      readOnly:
-                        description:
-                          Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                      - claimName
-                    type: object
-                  server:
-                    description: The NFS server configuration
-                    properties:
-                      accessMode:
-                        description:
-                          Reading and Writing permissions on the export
-                          Valid values are "ReadOnly", "ReadWrite" and "none"
-                        enum:
-                          - ReadOnly
-                          - ReadWrite
-                          - none
-                        type: string
-                      allowedClients:
-                        description: The clients allowed to access the NFS export
-                        items:
-                          description:
-                            AllowedClientsSpec represents the client specs
-                            for accessing the NFS export
-                          properties:
-                            accessMode:
-                              description:
-                                Reading and Writing permissions for the
-                                client to access the NFS export Valid values are "ReadOnly",
-                                "ReadWrite" and "none" Gets overridden when ServerSpec.accessMode
-                                is specified
-                              enum:
-                                - ReadOnly
-                                - ReadWrite
-                                - none
-                              type: string
-                            clients:
-                              description:
-                                The clients that can access the share Values
-                                can be hostname, ip address, netgroup, CIDR network
-                                address, or all
-                              items:
-                                type: string
-                              type: array
-                            name:
-                              description: Name of the clients group
-                              type: string
-                            squash:
-                              description:
-                                Squash options for clients Valid values
-                                are "none", "rootid", "root", and "all" Gets overridden
-                                when ServerSpec.squash is specified
-                              enum:
-                                - none
-                                - rootid
-                                - root
-                                - all
-                              type: string
-                          type: object
-                        type: array
-                      squash:
-                        description:
-                          This prevents the root users connected remotely
-                          from having root privileges Valid values are "none", "rootid",
-                          "root", and "all"
-                        enum:
-                          - none
-                          - rootid
-                          - root
-                          - all
-                        type: string
-                    type: object
-                type: object
-              type: array
-            replicas:
-              description: Replicas of the NFS daemon
-              type: integer
-          type: object
-        status:
-          description: NFSServerStatus defines the observed state of NFSServer
-          properties:
-            message:
-              type: string
-            reason:
-              type: string
-            state:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true
       storage: true
+      additionalPrinterColumns:
+      - jsonPath: .metadata.creationTimestamp
+        name: AGE
+        type: date
+      - jsonPath: .status.state
+        description: NFS Server instance state
+        name: State
+        type: string
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: NFSServer is the Schema for the nfsservers API
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NFSServerSpec represents the spec of NFS daemon
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description:
+                    The annotations-related configuration to add/set on each
+                    Pod related object.
+                  type: object
+                exports:
+                  description: The parameters to configure the NFS export
+                  items:
+                    description: ExportsSpec represents the spec of NFS exports
+                    properties:
+                      name:
+                        description: Name of the export
+                        type: string
+                      persistentVolumeClaim:
+                        description: PVC from which the NFS daemon gets storage for sharing
+                        properties:
+                          claimName:
+                            description:
+                              "ClaimName is the name of a PersistentVolumeClaim
+                              in the same namespace as the pod using this volume. More
+                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                            type: string
+                          readOnly:
+                            description:
+                              Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
+                            type: boolean
+                        required:
+                          - claimName
+                        type: object
+                      server:
+                        description: The NFS server configuration
+                        properties:
+                          accessMode:
+                            description:
+                              Reading and Writing permissions on the export
+                              Valid values are "ReadOnly", "ReadWrite" and "none"
+                            enum:
+                              - ReadOnly
+                              - ReadWrite
+                              - none
+                            type: string
+                          allowedClients:
+                            description: The clients allowed to access the NFS export
+                            items:
+                              description:
+                                AllowedClientsSpec represents the client specs
+                                for accessing the NFS export
+                              properties:
+                                accessMode:
+                                  description:
+                                    Reading and Writing permissions for the
+                                    client to access the NFS export Valid values are "ReadOnly",
+                                    "ReadWrite" and "none" Gets overridden when ServerSpec.accessMode
+                                    is specified
+                                  enum:
+                                    - ReadOnly
+                                    - ReadWrite
+                                    - none
+                                  type: string
+                                clients:
+                                  description:
+                                    The clients that can access the share Values
+                                    can be hostname, ip address, netgroup, CIDR network
+                                    address, or all
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: Name of the clients group
+                                  type: string
+                                squash:
+                                  description:
+                                    Squash options for clients Valid values
+                                    are "none", "rootid", "root", and "all" Gets overridden
+                                    when ServerSpec.squash is specified
+                                  enum:
+                                    - none
+                                    - rootid
+                                    - root
+                                    - all
+                                  type: string
+                              type: object
+                            type: array
+                          squash:
+                            description:
+                              This prevents the root users connected remotely
+                              from having root privileges Valid values are "none", "rootid",
+                              "root", and "all"
+                            enum:
+                              - none
+                              - rootid
+                              - root
+                              - all
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                replicas:
+                  description: Replicas of the NFS daemon
+                  type: integer
+              type: object
+            status:
+              description: NFSServerStatus defines the observed state of NFSServer
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+              type: object
+          type: object
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
**Description of your changes:**

When I tried the "Getting Started" with NFS, on K8s v1.21 I got the warning,

```
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/nfsservers.nfs.rook.io created
...
```

From the `rook/cluster/examples/kubernetes/nfs/common.yaml`
```
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  ...
  name: nfsservers.nfs.rook.io
```

So I googled around, made changes to the CRD and now I'm curious to see what the tests do.

**Which issue is resolved by this Pull Request:**
I couldn't find a matching issue and didn't create one.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
