### PR TITLE
ceph: Reconcile mgr services with every reconcile

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -46,6 +46,10 @@ func TestStartMgr(t *testing.T) {
 
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+			logger.Infof("Execute: %s %v", command, args)
+			if args[0] == "mgr" && args[1] == "stat" {
+				return `{"active_name": "a"}`, nil
+			}
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
@@ -63,7 +67,7 @@ func TestStartMgr(t *testing.T) {
 		Clientset:                  clientset,
 		RequestCancelOrchestration: abool.New()}
 	ownerInfo := cephclient.NewMinimumOwnerInfo(t)
-	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo}
+	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo, CephVersion: cephver.CephVersion{Major: 16, Minor: 2, Build: 5}}
 	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
 		Annotations:        map[rook.KeyType]rook.Annotations{cephv1.KeyMgr: {"my": "annotation"}},
@@ -99,13 +103,8 @@ func TestStartMgr(t *testing.T) {
 	assert.Nil(t, err)
 	err = c.Start()
 	assert.Nil(t, err)
-	// trigger the sidecar reconcile since the operator didn't do it so we can perform the full validation
-	err = c.reconcileService("a")
-	assert.Nil(t, err)
 	validateStart(t, c)
 
-	// the dashboard service is only deleted by the operator reconcile if the replicas are 1,
-	// otherwise the sidecar has the responsibility
 	c.spec.Mgr.Count = 1
 	c.spec.Dashboard.Enabled = false
 	// clean the previous deployments
@@ -201,7 +200,8 @@ func TestMgrSidecarReconcile(t *testing.T) {
 	c := &Cluster{spec: spec, context: ctx, clusterInfo: clusterInfo}
 
 	// Update services according to the active mgr
-	err := c.ReconcileMultipleServices(activeMgr, false)
+	clusterInfo.CephVersion = cephver.CephVersion{Major: 15, Minor: 2, Build: 0}
+	err := c.ReconcileActiveMgrServices(activeMgr)
 	assert.NoError(t, err)
 	assert.False(t, calledMgrStat)
 	assert.True(t, calledMgrDump)
@@ -210,7 +210,8 @@ func TestMgrSidecarReconcile(t *testing.T) {
 
 	// nothing is created or updated when the requested mgr is not the active mgr
 	calledMgrDump = false
-	err = c.ReconcileMultipleServices("b", true)
+	clusterInfo.CephVersion = cephver.CephVersion{Major: 16, Minor: 2, Build: 5}
+	err = c.ReconcileActiveMgrServices("b")
 	assert.NoError(t, err)
 	assert.True(t, calledMgrStat)
 	assert.False(t, calledMgrDump)
@@ -219,7 +220,7 @@ func TestMgrSidecarReconcile(t *testing.T) {
 
 	// nothing is updated when the requested mgr is not the active mgr
 	activeMgr = "b"
-	err = c.ReconcileMultipleServices("b", true)
+	err = c.ReconcileActiveMgrServices("b")
 	assert.NoError(t, err)
 	validateServices(t, c)
 	validateServiceMatches(t, c, "b")

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -226,7 +226,7 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 		{Name: "ROOK_MONITORING_ENABLED", Value: strconv.FormatBool(c.spec.Monitoring.Enabled)},
 		{Name: "ROOK_UPDATE_INTERVAL", Value: "15s"},
 		{Name: "ROOK_DAEMON_NAME", Value: mgrConfig.DaemonID},
-		{Name: "ROOK_MGR_STAT_SUPPORTED", Value: strconv.FormatBool(c.clusterInfo.CephVersion.IsAtLeastPacific())},
+		{Name: "ROOK_CEPH_VERSION", Value: "ceph version " + c.clusterInfo.CephVersion.String()},
 	}
 
 	return v1.Container{

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -44,9 +44,7 @@ func TestReleaseName(t *testing.T) {
 	assert.Equal(t, unknownVersionString, ver.ReleaseName())
 }
 
-func extractVersionHelper(t *testing.T, text string,
-	major, minor, extra, build int,
-	commitID string) {
+func extractVersionHelper(t *testing.T, text string, major, minor, extra, build int, commitID string) {
 	v, err := ExtractCephVersion(text)
 	if assert.NoError(t, err) {
 		assert.Equal(t, *v, CephVersion{major, minor, extra, build, commitID})
@@ -93,6 +91,13 @@ ceph version Development (no_version) nautilus (rc)
 	v, err = ExtractCephVersion(v2d)
 	assert.Error(t, err)
 	assert.Nil(t, v)
+
+	// Test the round trip for serializing and deserializing the version
+	v3c := "ceph version 16.2.5-1 pacific"
+	v, err = ExtractCephVersion(v3c)
+	assert.NoError(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, "16.2.5-1 pacific", v.String())
 }
 
 func TestSupported(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When there are multiple mgr daemons, the mgr sidecar owns reconciling the services for the active mgr. However, for efficiency the sidecar only reconciles the services if the active mgr changes. Now the operator will also reconcile the mgr services to ensure that services are re-created after being deleted, or otherwise in an incorrect state.

**Which issue is resolved by this Pull Request:**
Resolves #8321 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
