### PR TITLE
ceph: proxy rbd commands when multus is enabled

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -45,6 +45,10 @@ const (
 	CrushTool = "crushtool"
 	// DefaultPGCount will cause Ceph to use the internal default PG count
 	DefaultPGCount = "0"
+	// CommandProxyInitContainerName is the name of the init container for proxying ceph command when multus is used
+	CommandProxyInitContainerName = "cmd-proxy"
+	// ProxyAppLabel is the label used to identify the proxy container
+	ProxyAppLabel = "rook-ceph-mgr"
 )
 
 // CephConfFilePath returns the location to the cluster's config file in the operator container.
@@ -86,13 +90,14 @@ func FinalizeCephCommandArgs(command string, clusterInfo *ClusterInfo, args []st
 }
 
 type CephToolCommand struct {
-	context     *clusterd.Context
-	clusterInfo *ClusterInfo
-	tool        string
-	args        []string
-	timeout     time.Duration
-	JsonOutput  bool
-	OutputFile  bool
+	context         *clusterd.Context
+	clusterInfo     *ClusterInfo
+	tool            string
+	args            []string
+	timeout         time.Duration
+	JsonOutput      bool
+	OutputFile      bool
+	RemoteExecution bool
 }
 
 func newCephToolCommand(tool string, context *clusterd.Context, clusterInfo *ClusterInfo, args []string) *CephToolCommand {
@@ -114,6 +119,12 @@ func NewRBDCommand(context *clusterd.Context, clusterInfo *ClusterInfo, args []s
 	cmd := newCephToolCommand(RBDTool, context, clusterInfo, args)
 	cmd.JsonOutput = false
 	cmd.OutputFile = false
+
+	// When Multus is enabled, the RBD tool should run inside the proxy container
+	if clusterInfo.NetworkSpec.IsMultus() {
+		cmd.RemoteExecution = true
+	}
+
 	return cmd
 }
 
@@ -128,7 +139,7 @@ func (c *CephToolCommand) run() ([]byte, error) {
 		}
 	}
 
-	var output string
+	var output, stderr string
 	var err error
 
 	if c.OutputFile {
@@ -149,7 +160,18 @@ func (c *CephToolCommand) run() ([]byte, error) {
 			}
 		}
 	} else {
-		if c.timeout == 0 {
+		// NewRBDCommand does not use the --out-file option so we only check for remote execution here
+		// Still forcing the check for the command if the behavior changes in the future
+		if command == RBDTool {
+			if c.RemoteExecution {
+				output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
+				output = fmt.Sprintf("%s.%s", output, stderr)
+			} else if c.timeout == 0 {
+				output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
+			} else {
+				output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)
+			}
+		} else if c.timeout == 0 {
 			output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
 		} else {
 			output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)

--- a/pkg/daemon/ceph/client/info.go
+++ b/pkg/daemon/ceph/client/info.go
@@ -45,6 +45,7 @@ type ClusterInfo struct {
 	// If the CR name is needed, access it through the NamespacedName() method.
 	name              string
 	OsdUpgradeTimeout time.Duration
+	NetworkSpec       cephv1.NetworkSpec
 }
 
 // MonInfo is a collection of information about a Ceph mon.

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -105,6 +105,7 @@ func (c *cluster) doOrchestration(rookImage string, cephVersion cephver.CephVers
 	clusterInfo.OwnerInfo = c.ownerInfo
 	clusterInfo.SetName(c.namespacedName.Name)
 	c.ClusterInfo = clusterInfo
+	c.ClusterInfo.NetworkSpec = spec.Network
 
 	// The cluster Identity must be established at this point
 	if !c.ClusterInfo.IsInitialized(true) {

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/apis/rook.io"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/config/keyring"
@@ -36,9 +37,8 @@ import (
 )
 
 const (
-	podIPEnvVar                   = "ROOK_POD_IP"
-	serviceMetricName             = "http-metrics"
-	CommandProxyInitContainerName = "cmd-proxy"
+	podIPEnvVar       = "ROOK_POD_IP"
+	serviceMetricName = "http-metrics"
 )
 
 func (c *Cluster) makeDeployment(mgrConfig *mgrConfig) (*apps.Deployment, error) {
@@ -241,7 +241,7 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 func (c *Cluster) makeCmdProxySidecarContainer(mgrConfig *mgrConfig) v1.Container {
 	_, adminKeyringVolMount := keyring.Volume().Admin(), keyring.VolumeMount().Admin()
 	container := v1.Container{
-		Name:            CommandProxyInitContainerName,
+		Name:            client.CommandProxyInitContainerName,
 		Command:         []string{"sleep"},
 		Args:            []string{"infinity"},
 		Image:           c.spec.CephVersion.Image,

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -22,6 +22,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/apis/rook.io"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/config"
 	"github.com/rook/rook/pkg/operator/ceph/controller"
@@ -88,7 +89,7 @@ func TestPodSpec(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(d.Spec.Template.Annotations))                                                                                                                              // Multus annotations
 		assert.Equal(t, 2, len(d.Spec.Template.Spec.Containers))                                                                                                                          // mgr pod + sidecar
-		assert.Equal(t, CommandProxyInitContainerName, d.Spec.Template.Spec.Containers[1].Name)                                                                                           // sidecar pod
+		assert.Equal(t, client.CommandProxyInitContainerName, d.Spec.Template.Spec.Containers[1].Name)                                                                                    // sidecar pod
 		assert.Equal(t, 6, len(d.Spec.Template.Spec.Containers[1].VolumeMounts))                                                                                                          // + admin keyring
 		assert.Equal(t, "CEPH_ARGS", d.Spec.Template.Spec.Containers[1].Env[len(d.Spec.Template.Spec.Containers[1].Env)-1].Name)                                                          // connection info to the cluster
 		assert.Equal(t, "-m $(ROOK_CEPH_MON_HOST) -k /etc/ceph/admin-keyring-store/keyring", d.Spec.Template.Spec.Containers[1].Env[len(d.Spec.Template.Spec.Containers[1].Env)-1].Value) // connection info to the cluster

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -27,7 +27,6 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
-	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	"github.com/rook/rook/pkg/util/exec"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -170,7 +169,7 @@ func RunAdminCommandNoMultisite(c *Context, expectJSON bool, args ...string) (st
 
 	// If Multus is enabled we proxy all the command to the mgr sidecar
 	if c.CephClusterSpec.Network.IsMultus() {
-		output, stderr, err = c.Context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(mgr.AppName, mgr.CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{"radosgw-admin"}, args...)...)
+		output, stderr, err = c.Context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(cephclient.ProxyAppLabel, cephclient.CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{"radosgw-admin"}, args...)...)
 	} else {
 		command, args := cephclient.FinalizeCephCommandArgs("radosgw-admin", c.clusterInfo, args, c.Context.ConfigDir)
 		output, err = c.Context.Executor.ExecuteCommandWithTimeout(exec.CephCommandTimeout, command, args...)


### PR DESCRIPTION
**Description of your changes:**

We now pass the networking spec to the clusterInfo so that the executor
can make the right decision on how to execute a command.
This is a small change that allows us to remove the CephBlockPool CR
since it's checking for rbd images. On a Multus deployment, the operator
does not have the network annotations, thus has no access to the OSD
network then rbd commands are hanging forever.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
