### PR TITLE
build: Min version for cassandra and nfs tests is k8s 1.16

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -275,7 +275,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
+        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -326,7 +326,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.15.12','v1.18.15','v1.20.5','v1.21.0']
+        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The minimum K8s version for v1 CRDs is 1.16. Since support for v1beta1 cassandra and nfs was removed and only v1 is supported, the CI will now only run back to 1.16 for those providers.

With the merge of #8326 the release notes were already updated with the new min version supported, the master/release CI update was just missed.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
