### PR TITLE
ceph: remove operator config `ROOK_ALLOW_MULTIPLE_FILESYSTEMS`

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -10,6 +10,10 @@ v1.7...
 
 ### Ceph
 
+- The Operator configuration option `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` has been removed in favor of simply verifying the Ceph version is at least Pacific.
+Multiple filesystems are stable since Ceph Pacific.
+So users who had `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` enabled will need to update their Ceph version to Pacific.
+
 ## Features
 
 ### Core

--- a/cluster/charts/rook-ceph/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph/templates/deployment.yaml
@@ -320,10 +320,6 @@ spec:
         - name: ROOK_UNREACHABLE_NODE_TOLERATION_SECONDS
           value: {{ .Values.unreachableNodeTolerationSeconds | quote }}
 {{- end }}
-{{- if .Values.allowMultipleFilesystems }}
-        - name: ROOK_ALLOW_MULTIPLE_FILESYSTEMS
-          value: {{ .Values.allowMultipleFilesystems | quote }}
-{{- end }}
 {{- if .Values.resources }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -19,19 +19,12 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
 	"k8s.io/apimachinery/pkg/util/wait"
-)
-
-const (
-	// MultiFsEnv defines the name of the Rook environment variable which controls if Rook is
-	// allowed to create multiple Ceph filesystems.
-	MultiFsEnv = "ROOK_ALLOW_MULTIPLE_FILESYSTEMS"
 )
 
 type MDSDump struct {
@@ -141,7 +134,7 @@ func CreateFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, name,
 	var err error
 
 	// Always enable multiple fs when running on Pacific
-	if IsMultiFSEnabled() || clusterInfo.CephVersion.IsAtLeastPacific() {
+	if clusterInfo.CephVersion.IsAtLeastPacific() {
 		// enable multiple file systems in case this is not the first
 		args := []string{"fs", "flag", "set", "enable_multiple", "true", confirmFlag}
 		_, err = NewCephCommand(context, clusterInfo, args).Run()
@@ -177,13 +170,6 @@ func AddDataPoolToFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo
 		return errors.Wrapf(err, "failed to add pool %q to file system %q. (%v)", poolName, name, err)
 	}
 	return nil
-}
-
-// IsMultiFSEnabled returns true if ROOK_ALLOW_MULTIPLE_FILESYSTEMS is set to "true", allowing
-// Rook to create multiple Ceph filesystems. False if Rook is not allowed to do so.
-func IsMultiFSEnabled() bool {
-	t := os.Getenv(MultiFsEnv)
-	return t == "true"
 }
 
 // SetNumMDSRanks sets the number of mds ranks (max_mds) for a Ceph filesystem.

--- a/pkg/operator/ceph/file/filesystem.go
+++ b/pkg/operator/ceph/file/filesystem.go
@@ -230,7 +230,7 @@ func (f *Filesystem) doFilesystemCreate(context *clusterd.Context, clusterInfo *
 	}
 	// This check prevents from concurrent CephFilesystem CRD trying to create a filesystem
 	// Whoever gets to create the Filesystem first wins the race, then we fail if that cluster is not Ceph Pacific and one Filesystem is present
-	if len(fslist) > 0 && !clusterInfo.CephVersion.IsAtLeastPacific() && !cephclient.IsMultiFSEnabled() {
+	if len(fslist) > 0 && !clusterInfo.CephVersion.IsAtLeastPacific() {
 		return errors.New("multiple filesystems are only supported as of ceph pacific")
 	}
 

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -376,21 +376,6 @@ func TestCreateFilesystem(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, fmt.Sprintf("failed to create filesystem %q: multiple filesystems are only supported as of ceph pacific", fsName), err.Error())
 
-	// It works since the op env var is specified even if we don't run on pacific
-	os.Setenv(cephclient.MultiFsEnv, "true")
-	fsName = "myfs2"
-	fs = fsTest(fsName)
-	executor = fsExecutor(t, fsName, configDir, true)
-	clusterInfo.CephVersion = version.Pacific
-	context = &clusterd.Context{
-		Executor:  executor,
-		ConfigDir: configDir,
-		Clientset: clientset,
-	}
-	err = createFilesystem(context, clusterInfo, fs, &cephv1.ClusterSpec{}, ownerInfo, "/var/lib/rook/")
-	assert.NoError(t, err)
-	os.Unsetenv(cephclient.MultiFsEnv)
-
 	// It works since the Ceph version is Pacific
 	fsName = "myfs3"
 	fs = fsTest(fsName)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Multiple filesystems are supported as of the Ceph Pacific release. So we
remove the flag from the operator configuration and just have a ceph
version check instead.

The Operator configuration option `ROOK_ALLOW_MULTIPLE_FILESYSTEMS`
has been removed in favor of simply verifying the Ceph version is
at least Pacific.
Multiple filesystems are stable since Ceph Pacific.
So users who had `ROOK_ALLOW_MULTIPLE_FILESYSTEMS` enabled will
need to update their Ceph version to Pacific.

Closes: #7183
Signed-off-by: Sébastien Han <seb@redhat.com>


**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
