### PR TITLE
ceph: remove unnecessary exec helpers

### DIFF
--- a/pkg/daemon/ceph/client/auth.go
+++ b/pkg/daemon/ceph/client/auth.go
@@ -29,7 +29,6 @@ func AuthGetOrCreate(context *clusterd.Context, clusterInfo *ClusterInfo, name, 
 	args := append([]string{"auth", "get-or-create", name, "-o", keyringPath}, caps...)
 	cmd := NewCephCommand(context, clusterInfo, args)
 	cmd.JsonOutput = false
-	cmd.OutputFile = false
 	_, err := cmd.Run()
 	if err != nil {
 		return errors.Wrapf(err, "failed to auth get-or-create for %s", name)

--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -162,6 +162,12 @@ func mergeDefaultConfigWithRookConfigOverride(clusterdContext *clusterd.Context,
 		return errors.Wrapf(err, "failed to load config data from %q", k8sutil.ConfigOverrideName)
 	}
 
+	// Remove any debug message setting from the config file
+	// Debug messages will be printed on stdout, rendering the output of each command unreadable, especially json output
+	// This call is idempotent and will not fail if the debug message is not present
+	configFile.Section("global").DeleteKey("debug_ms")
+	configFile.Section("global").DeleteKey("debug ms")
+
 	return nil
 }
 

--- a/pkg/daemon/ceph/client/crash_test.go
+++ b/pkg/daemon/ceph/client/crash_test.go
@@ -39,7 +39,7 @@ var (
 func TestCephCrash(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 		if args[0] == "crash" && args[1] == "ls" {
 			return fakecrash, nil

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -115,7 +115,6 @@ func GetCompiledCrushMap(context *clusterd.Context, clusterInfo *ClusterInfo) (s
 
 	args := []string{"osd", "getcrushmap", "--out-file", compiledCrushMapFile.Name()}
 	exec := NewCephCommand(context, clusterInfo, args)
-	exec.OutputFile = false
 	exec.JsonOutput = false
 	buf, err := exec.Run()
 	if err != nil {
@@ -234,7 +233,6 @@ func decompileCRUSHMap(context *clusterd.Context, crushMapPath string) error {
 func injectCRUSHMap(context *clusterd.Context, clusterInfo *ClusterInfo, crushMapPath string) error {
 	args := []string{"osd", "setcrushmap", "--in-file", crushMapPath}
 	exec := NewCephCommand(context, clusterInfo, args)
-	exec.OutputFile = false
 	exec.JsonOutput = false
 	buf, err := exec.Run()
 	if err != nil {
@@ -247,7 +245,6 @@ func injectCRUSHMap(context *clusterd.Context, clusterInfo *ClusterInfo, crushMa
 func setCRUSHMap(context *clusterd.Context, clusterInfo *ClusterInfo, crushMapPath string) error {
 	args := []string{"osd", "crush", "set", crushMapPath}
 	exec := NewCephCommand(context, clusterInfo, args)
-	exec.OutputFile = false
 	exec.JsonOutput = false
 	buf, err := exec.Run()
 	if err != nil {

--- a/pkg/daemon/ceph/client/crush_test.go
+++ b/pkg/daemon/ceph/client/crush_test.go
@@ -265,7 +265,7 @@ const testCrushMap = `{
 
 func TestGetCrushMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return testCrushMap, nil
@@ -283,7 +283,7 @@ func TestGetCrushMap(t *testing.T) {
 
 func TestGetOSDOnHost(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "ls" {
 			return "[\"osd.2\",\"osd.0\",\"osd.1\"]", nil

--- a/pkg/daemon/ceph/client/deviceclass_test.go
+++ b/pkg/daemon/ceph/client/deviceclass_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestGetDeviceClassOSDs(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "class" && args[3] == "ls-osd" && args[4] == "ssd" {
 			// Mock executor for `ceph osd crush class ls-osd ssd`

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -52,7 +52,7 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "erasure-code-profile" {
 			if args[2] == "get" {

--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -57,7 +57,6 @@ func EnableFilesystemSnapshotMirror(context *clusterd.Context, clusterInfo *Clus
 	// Build command
 	args := []string{"fs", "snapshot", "mirror", "enable", filesystem}
 	cmd := NewCephCommand(context, clusterInfo, args)
-	cmd.OutputFile = false
 
 	// Run command
 	output, err := cmd.Run()
@@ -76,7 +75,6 @@ func DisableFilesystemSnapshotMirror(context *clusterd.Context, clusterInfo *Clu
 	// Build command
 	args := []string{"fs", "snapshot", "mirror", "disable", filesystem}
 	cmd := NewCephCommand(context, clusterInfo, args)
-	cmd.OutputFile = false
 
 	// Run command
 	output, err := cmd.Run()
@@ -213,7 +211,6 @@ func GetFSMirrorDaemonStatus(context *clusterd.Context, clusterInfo *ClusterInfo
 	// Build command
 	args := []string{"fs", "snapshot", "mirror", "daemon", "status", fsName}
 	cmd := NewCephCommand(context, clusterInfo, args)
-	cmd.OutputFile = false
 
 	// Run command
 	output, err := cmd.Run()

--- a/pkg/daemon/ceph/client/filesystem_mirror_test.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror_test.go
@@ -78,7 +78,7 @@ func TestImportFilesystemMirrorPeer(t *testing.T) {
 	fs := "myfs"
 	token := "my-token"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command string, outfileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -99,7 +99,7 @@ func TestImportFilesystemMirrorPeer(t *testing.T) {
 func TestCreateFSMirrorBootstrapPeer(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command string, outfileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -123,10 +123,12 @@ func TestRemoveFilesystemMirrorPeer(t *testing.T) {
 	peerUUID := "peer-uuid"
 	executor := &exectest.MockExecutor{}
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
-			assert.Equal(t, "mirror", args[1])
-			assert.Equal(t, "peer_remove", args[2])
-			assert.Equal(t, peerUUID, args[3])
+			assert.Equal(t, "snapshot", args[1])
+			assert.Equal(t, "mirror", args[2])
+			assert.Equal(t, "peer_remove", args[3])
+			assert.Equal(t, peerUUID, args[4])
 			return "", nil
 		}
 		return "", errors.New("unknown command")

--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -105,7 +105,7 @@ func TestFilesystemRemove(t *testing.T) {
 			DataPools:      []int{1},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -149,17 +149,13 @@ func TestFilesystemRemove(t *testing.T) {
 				return "", nil
 			}
 		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
-
 		if args[0] == "pool" {
 			if args[1] == "stats" {
 				return emptyPool, nil
 			}
 		}
-		return "", errors.Errorf("unexpected rbd command %q", args)
+		return "", errors.Errorf("unexpected ceph command %q", args)
 	}
 
 	err := RemoveFilesystem(context, AdminClusterInfo("mycluster"), fs.MDSMap.FilesystemName, false)
@@ -196,7 +192,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -244,7 +240,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -289,7 +285,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -339,7 +335,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -364,7 +360,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test errors
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -411,7 +407,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 		},
 	}
 	// test get mds by id failed error
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -459,7 +455,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -488,7 +484,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 func TestGetMDSDump(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -511,7 +507,7 @@ func TestGetMDSDump(t *testing.T) {
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, mdsDump.Standbys, []MDSStandBy{{Name: "rook-ceph-filesystem-b", Rank: -1}})
 
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -528,7 +524,7 @@ func TestGetMDSDump(t *testing.T) {
 func TestWaitForNoStandbys(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -550,7 +546,7 @@ func TestWaitForNoStandbys(t *testing.T) {
 	err := WaitForNoStandbys(context, AdminClusterInfo("mycluster"), 6*time.Second)
 	assert.Error(t, err)
 
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -564,7 +560,7 @@ func TestWaitForNoStandbys(t *testing.T) {
 	assert.Error(t, err)
 
 	firstCall := true
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {

--- a/pkg/daemon/ceph/client/mgr_test.go
+++ b/pkg/daemon/ceph/client/mgr_test.go
@@ -30,7 +30,7 @@ func TestEnableModuleRetries(t *testing.T) {
 	moduleEnableRetries := 0
 	moduleEnableWaitTime = 0
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "balancer" && args[1] == "on":
@@ -74,7 +74,7 @@ func TestEnableModuleRetries(t *testing.T) {
 
 func TestEnableModule(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mgr" && args[1] == "module" && args[2] == "enable":
@@ -107,7 +107,7 @@ func TestEnableModule(t *testing.T) {
 
 func TestEnableDisableBalancerModule(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "balancer" && args[1] == "on":
@@ -131,7 +131,7 @@ func TestEnableDisableBalancerModule(t *testing.T) {
 
 func TestSetBalancerMode(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "balancer" && args[1] == "mode" && args[2] == "upmap" {
 			return "", nil

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -67,7 +67,7 @@ func TestCephArgs(t *testing.T) {
 
 func TestStretchElectionStrategy(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "mon" && args[1] == "set" && args[2] == "election_strategy" {
 			assert.Equal(t, "connectivity", args[3])
@@ -86,7 +86,7 @@ func TestStretchClusterMonTiebreaker(t *testing.T) {
 	monName := "a"
 	failureDomain := "rack"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mon" && args[1] == "enable_stretch_mode":
@@ -106,7 +106,7 @@ func TestStretchClusterMonTiebreaker(t *testing.T) {
 
 func TestMonDump(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mon" && args[1] == "dump":

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -64,7 +64,7 @@ var (
 func TestHostTree(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyTreeResult := false
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "tree":
@@ -92,7 +92,7 @@ func TestHostTree(t *testing.T) {
 func TestOsdListNum(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyOsdListNumResult := false
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "ls":
@@ -116,7 +116,7 @@ func TestOsdListNum(t *testing.T) {
 
 func TestOSDDeviceClasses(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "crush" && args[2] == "get-device-class" && len(args) > 3:
@@ -147,7 +147,7 @@ func TestOSDOkToStop(t *testing.T) {
 	seenArgs := []string{}
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "ok-to-stop":

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -53,7 +53,7 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 	}
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
@@ -112,7 +112,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 	compressionModeCreated := false
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
@@ -232,7 +232,7 @@ func TestSetPoolReplicatedSizeProperty(t *testing.T) {
 	poolName := "mypool"
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 
 		if args[2] == "set" {
@@ -249,7 +249,7 @@ func TestSetPoolReplicatedSizeProperty(t *testing.T) {
 	assert.NoError(t, err)
 
 	// TEST POOL SIZE 1 AND RequireSafeReplicaSize True
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 
 		if args[2] == "set" {
@@ -297,10 +297,6 @@ func testCreateStretchCrushRule(t *testing.T, alreadyExists bool) {
 				return "", nil
 			}
 		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
-		logger.Infof("Command (file): %s %v", command, args)
 		if args[0] == "osd" && args[1] == "crush" && args[2] == "dump" {
 			return testCrushMap, nil
 		}
@@ -343,7 +339,7 @@ func testCreatePoolWithReplicasPerFailureDomain(t *testing.T, failureDomain, cru
 	}
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		assert.Equal(t, command, "ceph")
 		assert.Equal(t, args[0], "osd")
@@ -425,10 +421,6 @@ func testCreateHybridCrushRule(t *testing.T, alreadyExists bool) {
 				return "", nil
 			}
 		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
-		logger.Infof("Command (file): %s %v", command, args)
 		if args[0] == "osd" && args[1] == "crush" && args[2] == "dump" {
 			return testCrushMap, nil
 		}

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -71,7 +71,6 @@ func TestEnableReleaseOSDFunctionality(t *testing.T) {
 	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		assert.Equal(t, "osd", args[0])
 		assert.Equal(t, "require-osd-release", args[1])
-		assert.Equal(t, 3, len(args))
 		return "", nil
 	}
 	context := &clusterd.Context{Executor: executor}
@@ -306,7 +305,7 @@ func TestOSDUpdateShouldCheckOkToStop(t *testing.T) {
 	treeOutput := ""
 	context := &clusterd.Context{
 		Executor: &exectest.MockExecutor{
-			MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				t.Logf("command: %s %v", command, args)
 				if command != "ceph" || args[0] != "osd" {
 					panic("not a 'ceph osd' call")

--- a/pkg/daemon/ceph/osd/device_test.go
+++ b/pkg/daemon/ceph/osd/device_test.go
@@ -33,7 +33,7 @@ func TestOSDBootstrap(t *testing.T) {
 	defer os.RemoveAll(configDir)
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -343,9 +343,6 @@ func TestConfigureCVDevices(t *testing.T) {
 	{
 		t.Log("Test case for creating new raw mode OSD on LV-backed PVC")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutputFile = func(command string, outFileArg string, args ...string) (string, error) {
-			return "{\"key\":\"mysecurekey\"}", nil
-		}
 		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
 			if command == "lsblk" && args[0] == mountedDev {
@@ -356,6 +353,9 @@ func TestConfigureCVDevices(t *testing.T) {
 			}
 			if contains(args, "lvm") && contains(args, "list") {
 				return `{}`, nil
+			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\"}", nil
 			}
 			if contains(args, "raw") && contains(args, "list") {
 				return fmt.Sprintf(`{

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -146,7 +146,7 @@ func TestCephClientController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -241,7 +241,7 @@ func TestCephClientController(t *testing.T) {
 	c.Client = cl
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -164,7 +164,7 @@ func TestConfigureHealthSettings(t *testing.T) {
 	getGlobalIDReclaim := false
 	setGlobalIDReclaim := false
 	c.context.Executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[0] == "config" && args[3] == "auth_allow_insecure_global_id_reclaim" {
 				if args[1] == "get" {

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -83,30 +83,31 @@ func TestStartSecureDashboard(t *testing.T) {
 	moduleRetries := 0
 	exitCodeResponse := 0
 	clientset := test.New(t, 3)
-	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
-			logger.Infof("command: %s %v", command, args)
-			exitCodeResponse = 0
-			if args[1] == "module" {
-				if args[2] == "enable" {
-					enables++
-				} else if args[2] == "disable" {
-					disables++
-				}
+	mockFN := func(command string, args ...string) (string, error) {
+		logger.Infof("command: %s %v", command, args)
+		exitCodeResponse = 0
+		if args[1] == "module" {
+			if args[2] == "enable" {
+				enables++
+			} else if args[2] == "disable" {
+				disables++
 			}
-			if args[0] == "dashboard" && args[1] == "create-self-signed-cert" {
-				if moduleRetries < 2 {
-					logger.Infof("simulating retry...")
-					exitCodeResponse = invalidArgErrorCode
-					moduleRetries++
-					return "", errors.New("test failure")
-				}
+		}
+		if args[0] == "dashboard" && args[1] == "create-self-signed-cert" {
+			if moduleRetries < 2 {
+				logger.Infof("simulating retry...")
+				exitCodeResponse = invalidArgErrorCode
+				moduleRetries++
+				return "", errors.New("test failure")
 			}
-			return "", nil
-		},
+		}
+		return "", nil
 	}
-	executor.MockExecuteCommandWithOutputFileTimeout = func(timeout time.Duration, command, outfileArg string, arg ...string) (string, error) {
-		return executor.MockExecuteCommandWithOutputFile(command, outfileArg, arg...)
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutput: mockFN,
+		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, arg ...string) (string, error) {
+			return mockFN(command, arg...)
+		},
 	}
 
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -45,7 +45,7 @@ func TestStartMgr(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Execute: %s %v", command, args)
 			if args[0] == "mgr" && args[1] == "stat" {
 				return `{"active_name": "a"}`, nil
@@ -176,7 +176,7 @@ func TestMgrSidecarReconcile(t *testing.T) {
 		},
 	}
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[1] == "dump" {
 				calledMgrDump = true
@@ -245,7 +245,7 @@ func TestConfigureModules(t *testing.T) {
 	configSettings := map[string]string{}
 	lastModuleConfigured := ""
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if command == "ceph" && len(args) > 3 {
 				if args[0] == "mgr" && args[1] == "module" {

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -33,7 +33,7 @@ func TestOrchestratorModules(t *testing.T) {
 	rookModuleEnabled := false
 	rookBackendSet := false
 	backendErrorCount := 0
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "mgr" && args[1] == "module" && args[2] == "enable" {
 			if args[3] == "rook" {
@@ -43,7 +43,7 @@ func TestOrchestratorModules(t *testing.T) {
 		}
 		return "", errors.Errorf("unexpected ceph command '%v'", args)
 	}
-	executor.MockExecuteCommandWithOutputFileTimeout = func(timeout time.Duration, command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "orchestrator" && args[1] == "set" && args[2] == "backend" && args[3] == "rook" {
 			if backendErrorCount < 5 {
@@ -86,7 +86,7 @@ func TestOrchestratorModules(t *testing.T) {
 	c.clusterInfo.CephVersion = cephver.Octopus
 	err = c.setRookOrchestratorBackend()
 	assert.Error(t, err)
-	executor.MockExecuteCommandWithOutputFileTimeout = func(timeout time.Duration, command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithTimeout = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "orch" && args[1] == "set" && args[2] == "backend" && args[3] == "rook" {
 			if backendErrorCount < 5 {

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -49,7 +49,7 @@ func TestCheckHealth(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return clienttest.MonInQuorumResponse(), nil
 		},
 	}
@@ -245,7 +245,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return clienttest.MonInQuorumResponse(), nil
 		},
 	}
@@ -304,7 +304,7 @@ func TestAddRemoveMons(t *testing.T) {
 
 	monQuorumResponse := clienttest.MonInQuorumResponse()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return monQuorumResponse, nil
 		},
 	}

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -88,12 +88,9 @@ func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monRe
 			if strings.Contains(command, "ceph-authtool") {
 				err := clienttest.CreateConfigDir(path.Join(configDir, namespace))
 				return "", errors.Wrap(err, "failed testing of start cluster without quorum response")
+			} else {
+				return monResponse()
 			}
-			return "", nil
-		},
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
-			// mock quorum health check because a second `Start()` triggers a health check
-			return monResponse()
 		},
 	}
 	return &clusterd.Context{
@@ -654,9 +651,6 @@ func TestCheckIfArbiterReady(t *testing.T) {
 	balanced := true
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
-			return "", fmt.Errorf("unrecognized output command: %s %v", command, args)
-		},
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
 			switch {
 			case args[0] == "osd" && args[1] == "crush" && args[2] == "dump":
 				crushBuckets := `

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -43,26 +43,20 @@ func TestOSDHealthCheck(t *testing.T) {
 
 	var execCount = 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
-			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
+			execCount++
+			if args[1] == "dump" {
+				// Mock executor for OSD Dump command, returning an osd in Down state
+				return `{"OSDs": [{"OSD": 0, "Up": 0, "In": 0}]}`, nil
+			} else if args[1] == "safe-to-destroy" {
+				// Mock executor for OSD Dump command, returning an osd in Down state
+				return `{"safe_to_destroy":[0],"active":[],"missing_stats":[],"stored_pgs":[]}`, nil
+			} else if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
+			}
+			return "", nil
 		},
-	}
-	executor.MockExecuteCommandWithOutputFile = func(command string, outFileArg string, args ...string) (string, error) {
-		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
-		execCount++
-		if args[1] == "dump" {
-			// Mock executor for OSD Dump command, returning an osd in Down state
-			return `{"OSDs": [{"OSD": 0, "Up": 0, "In": 0}]}`, nil
-		} else if args[1] == "safe-to-destroy" {
-			// Mock executor for OSD Dump command, returning an osd in Down state
-			return `{"safe_to_destroy":[0],"active":[],"missing_stats":[],"stored_pgs":[]}`, nil
-		}
-		return "", nil
-	}
-
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
-		logger.Infof("ExecuteCommandWithOutput: %s %v", command, args)
-		return "", nil
 	}
 
 	// Setting up objects needed to create OSD
@@ -146,11 +140,11 @@ func TestDeviceClasses(t *testing.T) {
 
 	var execCount = 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
 		},
 	}
-	executor.MockExecuteCommandWithOutputFile = func(command string, outFileArg string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 		execCount++
 		if args[1] == "crush" && args[2] == "class" && args[3] == "ls" {

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -524,7 +524,7 @@ func testOSDIntegration(t *testing.T) {
 
 func osdIntegrationTestExecutor(t *testing.T, clientset *fake.Clientset, namespace string) *exectest.MockExecutor {
 	return &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			t.Logf("command: %s %v", command, args)
 			if command != "ceph" {
 				return "", errors.Errorf("unexpected command %q with args %v", command, args)

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -156,7 +156,7 @@ func TestAddRemoveNode(t *testing.T) {
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	generateKey := "expected key"
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return "{\"key\": \"" + generateKey + "\"}", nil
 		},
 	}
@@ -209,7 +209,7 @@ func TestAddRemoveNode(t *testing.T) {
 
 	// mock the ceph calls that will be called during remove node
 	context.Executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[0] == "status" {
 				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -142,7 +142,7 @@ func Test_updateExistingOSDs(t *testing.T) {
 		}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			t.Logf("command: %s %v", command, args)
 			if args[0] == "osd" {
 				if args[1] == "ok-to-stop" {

--- a/pkg/operator/ceph/cluster/rbd/controller_test.go
+++ b/pkg/operator/ceph/cluster/rbd/controller_test.go
@@ -82,7 +82,7 @@ func TestCephRBDMirrorController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -92,15 +92,6 @@ func TestCephRBDMirrorController(t *testing.T) {
 			if args[0] == "versions" {
 				return dummyVersionsRaw, nil
 			}
-			if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
-				return `{"mode":"image","site_name":"39074576-5884-4ef3-8a4d-8a0c5ed33031","peers":[{"uuid":"4a6983c0-3c9d-40f5-b2a9-2334a4659827","direction":"rx-tx","site_name":"ocs","mirror_uuid":"","client_name":"client.rbd-mirror-peer"}]}`, nil
-			}
-			if args[0] == "mirror" && args[1] == "pool" && args[2] == "status" {
-				return `{"summary":{"health":"WARNING","daemon_health":"OK","image_health":"WARNING","states":{"unknown":1}}}`, nil
-			}
-			return "", nil
-		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "mirror" && args[1] == "pool" && args[2] == "info" {
 				return `{"mode":"image","site_name":"39074576-5884-4ef3-8a4d-8a0c5ed33031","peers":[{"uuid":"4a6983c0-3c9d-40f5-b2a9-2334a4659827","direction":"rx-tx","site_name":"ocs","mirror_uuid":"","client_name":"client.rbd-mirror-peer"}]}`, nil
 			}

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -95,7 +95,7 @@ func TestOnK8sNode(t *testing.T) {
 	client := getFakeClient(objects...)
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		return "", errors.New("failed to get osd list on host")
 	}
 	clientCluster := newClientCluster(client, ns, &clusterd.Context{

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -37,7 +37,7 @@ func TestGenerateKey(t *testing.T) {
 	var generateKey = ""
 	var failGenerateKey = false
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if failGenerateKey {
 				return "", errors.New("test error")
 			}

--- a/pkg/operator/ceph/config/monstore_test.go
+++ b/pkg/operator/ceph/config/monstore_test.go
@@ -41,8 +41,8 @@ func TestMonStore_Set(t *testing.T) {
 	// us to cause it to return an error when it detects a keyword.
 	execedCmd := ""
 	execInjectErr := false
-	executor.MockExecuteCommandWithOutputFile =
-		func(command string, outfile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput =
+		func(command string, args ...string) (string, error) {
 			execedCmd = command + " " + strings.Join(args, " ")
 			if execInjectErr {
 				return "output from cmd with error", errors.New("mocked error")
@@ -86,8 +86,8 @@ func TestMonStore_Delete(t *testing.T) {
 	// us to cause it to return an error when it detects a keyword.
 	execedCmd := ""
 	execInjectErr := false
-	executor.MockExecuteCommandWithOutputFile =
-		func(command string, outfile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput =
+		func(command string, args ...string) (string, error) {
 			execedCmd = command + " " + strings.Join(args, " ")
 			if execInjectErr {
 				return "output from cmd with error", errors.New("mocked error")
@@ -125,8 +125,8 @@ func TestMonStore_GetDaemon(t *testing.T) {
 		"\"rgw_enable_usage_log\":{\"value\":\"true\",\"section\":\"client.rgw.test.a\",\"mask\":{}," +
 		"\"can_update_at_runtime\":true}}"
 	execInjectErr := false
-	executor.MockExecuteCommandWithOutputFile =
-		func(command string, outfile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput =
+		func(command string, args ...string) (string, error) {
 			execedCmd = command + " " + strings.Join(args, " ")
 			if execInjectErr {
 				return "output from cmd with error", errors.New("mocked error")
@@ -171,8 +171,8 @@ func TestMonStore_DeleteDaemon(t *testing.T) {
 		"\"can_update_at_runtime\":true}," +
 		"\"rgw_enable_usage_log\":{\"value\":\"true\",\"section\":\"client.rgw.test.a\",\"mask\":{}," +
 		"\"can_update_at_runtime\":true}}"
-	executor.MockExecuteCommandWithOutputFile =
-		func(command string, outfile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput =
+		func(command string, args ...string) (string, error) {
 			execedCmd = command + " " + strings.Join(args, " ")
 			return execReturn, nil
 		}
@@ -197,8 +197,8 @@ func TestMonStore_SetAll(t *testing.T) {
 	// us to cause it to return an error when it detects a keyword.
 	execedCmds := []string{}
 	execInjectErrOnKeyword := "donotinjectanerror"
-	executor.MockExecuteCommandWithOutputFile =
-		func(command string, outfile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput =
+		func(command string, args ...string) (string, error) {
 			execedCmd := command + " " + strings.Join(args, " ")
 			execedCmds = append(execedCmds, execedCmd)
 			k := execInjectErrOnKeyword

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -260,7 +260,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			Namespace: "rook-ceph",
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "192.168.0.1:6801/2535462469"), nil
@@ -268,6 +268,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 				return "", errors.New("unknown command")
 			},
 		}
+
 		ctx := &clusterd.Context{
 			Clientset:     test.New(t, 3),
 			RookClientset: rookclient.NewSimpleClientset(),
@@ -293,7 +294,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			Namespace: "rook-ceph",
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "172.17.0.12:6801/2535462469"), nil
@@ -326,7 +327,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			Namespace: "rook-ceph",
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "172.17.0.12:6801/2535462469"), nil
@@ -364,7 +365,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			Namespace: "rook-ceph",
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutputFile: func(command, outFile string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "192.168.0.1:6801/2535462469"), nil

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -346,7 +346,7 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			clusterInfo := getFakeClusterInfo()
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
 			executor := &exectest.MockExecutor{}
-			executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "status" {
 					return tc.fakeCephStatus, nil
@@ -402,7 +402,7 @@ func TestPGHealthcheckTimeout(t *testing.T) {
 	clusterInfo := getFakeClusterInfo()
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "status" {
 			return unHealthyCephStatus, nil

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -177,7 +177,7 @@ func TestCephFilesystemController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -278,7 +278,7 @@ func TestCephFilesystemController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/file/mirror/controller_test.go
+++ b/pkg/operator/ceph/file/mirror/controller_test.go
@@ -86,7 +86,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -205,7 +205,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 	// SUCCESS! The CephCluster is ready and running Ceph Pacific!
 	//
 	r.context.Executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -107,7 +107,7 @@ func TestCephNFSController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -207,7 +207,7 @@ func TestCephNFSController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -303,7 +303,7 @@ func TestCephObjectStoreController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -416,7 +416,7 @@ func TestCephObjectStoreController(t *testing.T) {
 
 	// Override executor with the new ceph status and more content
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -585,7 +585,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -106,8 +106,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 	executor := &exectest.MockExecutor{}
 	deletedRootPool := false
 	deletedErasureCodeProfile := false
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
-		//logger.Infof("command: %s %v", command, args)
+	mockExecutorFuncOutput := func(command string, args ...string) (string, error) {
 		if args[0] == "osd" {
 			if args[1] == "pool" {
 				if args[2] == "get" {
@@ -141,10 +140,6 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 				}
 			}
 		}
-		return "", errors.Errorf("unexpected ceph command %q", args)
-	}
-
-	mockExecutorFuncOutput := func(command string, args ...string) (string, error) {
 		if args[0] == "realm" {
 			if args[1] == "delete" {
 				realmDeleted = true
@@ -249,7 +244,7 @@ func TestGetObjectBucketProvisioner(t *testing.T) {
 func TestDashboard(t *testing.T) {
 	storeName := "myobject"
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			return "", nil
 		},
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
@@ -269,7 +264,7 @@ func TestDashboard(t *testing.T) {
 	err = enableRGWDashboard(objContext)
 	assert.Nil(t, err)
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "dashboard" && args[1] == "get-rgw-api-access-key" {
 				return access_key, nil
 			}
@@ -289,7 +284,7 @@ func TestDashboard(t *testing.T) {
 	err = enableRGWDashboard(objContext)
 	assert.Nil(t, err)
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "dashboard" && args[1] == "get-rgw-api-access-key" {
 				return access_key, nil
 			}

--- a/pkg/operator/ceph/object/realm/controller_test.go
+++ b/pkg/operator/ceph/object/realm/controller_test.go
@@ -134,13 +134,10 @@ func TestCephObjectRealmController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(r.scheme).WithRuntimeObjects(object...).Build()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
-			return "", nil
-		},
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "realm" && args[1] == "get" {
 				return realmGetJSON, nil
 			}
@@ -230,7 +227,7 @@ func getObjectRealmAndReconcileObjectRealm(t *testing.T) (*ReconcileObjectRealm,
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -43,10 +43,10 @@ func TestStartRGW(t *testing.T) {
 	ctx := context.TODO()
 	clientset := testop.New(t, 3)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command string, outFileArg string, args ...string) (string, error) {
-			return `{"key":"mysecurekey"}`, nil
-		},
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return `{"key":"mysecurekey"}`, nil
+			}
 			return `{"id":"test-id"}`, nil
 		},
 	}
@@ -83,23 +83,22 @@ func validateStart(ctx context.Context, t *testing.T, c *clusterConfig, clientse
 
 func TestCreateObjectStore(t *testing.T) {
 	commandWithOutputFunc := func(command string, args ...string) (string, error) {
-		return `{"realms": []}`, nil
+		logger.Infof("Command: %s %v", command, args)
+		if command == "ceph" {
+			if args[1] == "erasure-code-profile" {
+				return `{"k":"2","m":"1","plugin":"jerasure","technique":"reed_sol_van"}`, nil
+			}
+			if args[0] == "auth" && args[1] == "get-or-create-key" {
+				return `{"key":"mykey"}`, nil
+			}
+		} else {
+			return `{"realms": []}`, nil
+		}
+		return "", nil
 	}
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithCombinedOutput: commandWithOutputFunc,
 		MockExecuteCommandWithOutput:         commandWithOutputFunc,
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
-			logger.Infof("Command: %s %v", command, args)
-			if command == "ceph" {
-				if args[1] == "erasure-code-profile" {
-					return `{"k":"2","m":"1","plugin":"jerasure","technique":"reed_sol_van"}`, nil
-				}
-				if args[0] == "auth" && args[1] == "get-or-create-key" {
-					return `{"key":"mykey"}`, nil
-				}
-			}
-			return "", nil
-		},
 	}
 
 	store := simpleStore()

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -203,7 +203,7 @@ func TestSSLPodSpec(t *testing.T) {
 
 func TestValidateSpec(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return `{"types":[{"type_id": 0,"name": "osd"}, {"type_id": 1,"name": "host"}],"buckets":[{"id": -1,"name":"default"},{"id": -2,"name":"good"}, {"id": -3,"name":"host"}]}`, nil

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -119,7 +119,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -215,7 +215,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -159,7 +159,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -262,7 +262,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -308,7 +308,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/zonegroup/controller_test.go
+++ b/pkg/operator/ceph/object/zonegroup/controller_test.go
@@ -153,7 +153,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -256,7 +256,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -310,7 +310,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutputFile: func(command, outfile string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/pool/validate_test.go
+++ b/pkg/operator/ceph/pool/validate_test.go
@@ -182,7 +182,7 @@ func TestValidateCrushProperties(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "myns"}
-	executor.MockExecuteCommandWithOutputFile = func(command, outputFile string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return `{"types":[{"type_id": 0,"name": "osd"}],"buckets":[{"id": -1,"name":"default"},{"id": -2,"name":"good"}, {"id": -3,"name":"host"}]}`, nil
@@ -270,7 +270,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 			clusterInfo := &cephclient.ClusterInfo{Namespace: "myns"}
 			executor := &exectest.MockExecutor{}
 			context := &clusterd.Context{Executor: executor}
-			executor.MockExecuteCommandWithOutputFile = func(command string, outFileArg string, args ...string) (string, error) {
+			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 				logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 				if args[1] == "crush" && args[2] == "class" && args[3] == "ls-osd" && args[4] == "ssd" {
 					// Mock executor for `ceph osd crush class ls-osd ssd`

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -46,8 +46,6 @@ type Executor interface {
 	ExecuteCommandWithEnv(env []string, command string, arg ...string) error
 	ExecuteCommandWithOutput(command string, arg ...string) (string, error)
 	ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error)
-	ExecuteCommandWithOutputFile(command, outfileArg string, arg ...string) (string, error)
-	ExecuteCommandWithOutputFileTimeout(timeout time.Duration, command, outfileArg string, arg ...string) (string, error)
 	ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error)
 }
 

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -23,14 +23,12 @@ import (
 
 // MockExecutor mocks all the exec commands
 type MockExecutor struct {
-	MockExecuteCommand                      func(command string, arg ...string) error
-	MockExecuteCommandWithEnv               func(env []string, command string, arg ...string) error
-	MockStartExecuteCommand                 func(command string, arg ...string) (*exec.Cmd, error)
-	MockExecuteCommandWithOutput            func(command string, arg ...string) (string, error)
-	MockExecuteCommandWithCombinedOutput    func(command string, arg ...string) (string, error)
-	MockExecuteCommandWithOutputFile        func(command, outfileArg string, arg ...string) (string, error)
-	MockExecuteCommandWithOutputFileTimeout func(timeout time.Duration, command, outfileArg string, arg ...string) (string, error)
-	MockExecuteCommandWithTimeout           func(timeout time.Duration, command string, arg ...string) (string, error)
+	MockExecuteCommand                   func(command string, arg ...string) error
+	MockExecuteCommandWithEnv            func(env []string, command string, arg ...string) error
+	MockStartExecuteCommand              func(command string, arg ...string) (*exec.Cmd, error)
+	MockExecuteCommandWithOutput         func(command string, arg ...string) (string, error)
+	MockExecuteCommandWithCombinedOutput func(command string, arg ...string) (string, error)
+	MockExecuteCommandWithTimeout        func(timeout time.Duration, command string, arg ...string) (string, error)
 }
 
 // ExecuteCommand mocks ExecuteCommand
@@ -74,24 +72,6 @@ func (e *MockExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command 
 func (e *MockExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithCombinedOutput != nil {
 		return e.MockExecuteCommandWithCombinedOutput(command, arg...)
-	}
-
-	return "", nil
-}
-
-// ExecuteCommandWithOutputFile mocks ExecuteCommandWithOutputFile
-func (e *MockExecutor) ExecuteCommandWithOutputFile(command, outfileArg string, arg ...string) (string, error) {
-	if e.MockExecuteCommandWithOutputFile != nil {
-		return e.MockExecuteCommandWithOutputFile(command, outfileArg, arg...)
-	}
-
-	return "", nil
-}
-
-// ExecuteCommandWithOutputFileTimeout mocks ExecuteCommandWithOutputFileTimeout
-func (e *MockExecutor) ExecuteCommandWithOutputFileTimeout(timeout time.Duration, command, outfileArg string, arg ...string) (string, error) {
-	if e.MockExecuteCommandWithOutputFileTimeout != nil {
-		return e.MockExecuteCommandWithOutputFileTimeout(timeout, command, outfileArg, arg...)
 	}
 
 	return "", nil

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -56,20 +56,6 @@ func (e *TranslateCommandExecutor) ExecuteCommandWithCombinedOutput(command stri
 	return e.Executor.ExecuteCommandWithCombinedOutput(transCommand, transArgs...)
 }
 
-// ExecuteCommandWithOutputFile starts a process and saves output to file
-func (e *TranslateCommandExecutor) ExecuteCommandWithOutputFile(command, outfileArg string, arg ...string) (string, error) {
-	transCommand, transArgs := e.Translator(command, arg...)
-	return e.Executor.ExecuteCommandWithOutputFile(transCommand, outfileArg, transArgs...)
-}
-
-// ExecuteCommandWithOutputFileTimeout is the same as ExecuteCommandWithOutputFile but with a timeout limit.
-func (e *TranslateCommandExecutor) ExecuteCommandWithOutputFileTimeout(
-	timeout time.Duration,
-	command, outfileArg string, arg ...string) (string, error) {
-	transCommand, transArgs := e.Translator(command, arg...)
-	return e.Executor.ExecuteCommandWithOutputFileTimeout(timeout, transCommand, outfileArg, transArgs...)
-}
-
 // ExecuteCommandWithTimeout starts a process and wait for its completion with timeout.
 func (e *TranslateCommandExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command string, arg ...string) (string, error) {
 	transCommand, transArgs := e.Translator(command, arg...)


### PR DESCRIPTION
**Description of your changes:**

Both `ExecuteCommandWithOutputFileTimeout()` and
`ExecuteCommandWithOutputFile()` generate unnecessary system calls by
creating/reading/removing files where the stream output of the command
can simply be used. So sticking with `ExecuteCommandWithOutput()` and
`ExecuteCommandWithCombinedOutput()` for reading outputs is sufficient.

Closes: https://github.com/rook/rook/issues/8343
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
