### PR TITLE
ceph: mock object store user create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.35.24
 	github.com/banzaicloud/k8s-objectmatcher v1.1.0
-	github.com/ceph/go-ceph v0.9.1-0.20210607162346-8179bd4437f9
+	github.com/ceph/go-ceph v0.10.1-0.20210722102457-1a18c0719372
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/csi-addons/volume-replication-operator v0.1.1-0.20210525040814-ab575a2879fb
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywR
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20190214225812-119110094d0f/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
-github.com/ceph/go-ceph v0.9.1-0.20210607162346-8179bd4437f9 h1:M2eYrt7HSr7WImn5eGbonTcVwl2JddiKjnUNZ+LTs0s=
-github.com/ceph/go-ceph v0.9.1-0.20210607162346-8179bd4437f9/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
+github.com/ceph/go-ceph v0.10.1-0.20210722102457-1a18c0719372 h1:DZN/4RR6Yok0VJ3xaP8xxv8Le8bxJfX6XXE6Kxkvj2Y=
+github.com/ceph/go-ceph v0.10.1-0.20210722102457-1a18c0719372/go.mod h1:mafFpf5Vg8Ai8Bd+FAMvKBHLmtdpTXdRP/TNq8XWegY=
 github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/pkg/operator/ceph/object/admin_mock.go
+++ b/pkg/operator/ceph/object/admin_mock.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import "net/http"
+
+// MockClient is the mock of the HTTP Client
+// It can be used to mock HTTP request/response from the rgw admin ops API
+type MockClient struct {
+	// MockDo is a type that mock the Do method from the HTTP package
+	MockDo MockDoType
+}
+
+// MockDoType is a custom type that allows setting the function that our Mock Do func will run instead
+type MockDoType func(req *http.Request) (*http.Response, error)
+
+// Do is the mock client's `Do` func
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) { return m.MockDo(req) }

--- a/pkg/operator/ceph/object/dependents_test.go
+++ b/pkg/operator/ceph/object/dependents_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/util/exec"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestCephObjectStoreDependents(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, cephv1.AddToScheme(scheme))
+	ns := "test-ceph-object-store-dependents"
+	var c *clusterd.Context
+	executor := &exectest.MockExecutor{
+		MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+			logger.Infof("Command: %s %v", command, args)
+			if args[0] == "osd" {
+				if args[1] == "lspools" {
+					pools := []*client.CephStoragePoolSummary{}
+					output, err := json.Marshal(pools)
+					assert.Nil(t, err)
+					return string(output), nil
+				}
+			}
+			return "", errors.Errorf("unexpected ceph command %q", args)
+		},
+	}
+
+	newClusterdCtx := func(executor exec.Executor, objects ...runtime.Object) *clusterd.Context {
+		return &clusterd.Context{
+			DynamicClientset: dynamicfake.NewSimpleDynamicClient(scheme, objects...),
+			RookClientset:    rookclient.NewSimpleClientset(),
+			Executor:         executor,
+		}
+	}
+
+	pools := []*client.CephStoragePoolSummary{
+		{Name: "my-store.rgw.control"},
+		{Name: "my-store.rgw.meta"},
+		{Name: "my-store.rgw.log"},
+		{Name: "my-store.rgw.buckets.non-ec"},
+		{Name: "my-store.rgw.buckets.data"},
+		{Name: ".rgw.root"},
+		{Name: "my-store.rgw.buckets.index"},
+	}
+
+	// Mock HTTP call
+	mockClient := func(bucket string) *MockClient {
+		return &MockClient{
+			MockDo: func(req *http.Request) (*http.Response, error) {
+				if req.Method == http.MethodGet && req.URL.Path == "rook-ceph-rgw-my-store.mycluster.svc/admin/bucket" {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte(bucket))),
+					}, nil
+				}
+				return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)
+			},
+		}
+	}
+
+	clusterInfo := client.AdminClusterInfo(ns)
+	// Create objectmeta with the given name in our test namespace
+	meta := func(name string) v1.ObjectMeta {
+		return v1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		}
+	}
+
+	store := &cephv1.CephObjectStore{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "my-store",
+			Namespace: ns,
+		},
+		TypeMeta: v1.TypeMeta{
+			Kind: "CephObjectStore",
+		},
+		Spec: cephv1.ObjectStoreSpec{
+			Gateway: cephv1.GatewaySpec{Port: 80},
+		},
+	}
+
+	t.Run("missing pools so skipping", func(t *testing.T) {
+		c = newClusterdCtx(executor)
+		deps, err := CephObjectStoreDependents(c, clusterInfo, store, NewContext(c, clusterInfo, store.Name), &AdminOpsContext{})
+		assert.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("no objectstore users and no buckets", func(t *testing.T) {
+		executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" {
+					if args[1] == "lspools" {
+						output, err := json.Marshal(pools)
+						assert.Nil(t, err)
+						return string(output), nil
+					}
+				}
+				return "", errors.Errorf("unexpected ceph command %q", args)
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if command == "radosgw-admin" && args[0] == "user" {
+					return userCreateJSON, nil
+				}
+				return "", errors.Errorf("no such command %v %v", command, args)
+			},
+		}
+		c = newClusterdCtx(executor)
+		client, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(`[]`))
+		assert.NoError(t, err)
+		deps, err := CephObjectStoreDependents(c, clusterInfo, store, NewContext(c, clusterInfo, store.Name), &AdminOpsContext{AdminOpsClient: client})
+		assert.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("one objectstore users but wrong store and no buckets", func(t *testing.T) {
+		executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" {
+					if args[1] == "lspools" {
+						output, err := json.Marshal(pools)
+						assert.Nil(t, err)
+						return string(output), nil
+					}
+				}
+				return "", errors.Errorf("unexpected ceph command %q", args)
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if command == "radosgw-admin" && args[0] == "user" {
+					return userCreateJSON, nil
+				}
+				return "", errors.Errorf("no such command %v %v", command, args)
+			},
+		}
+		c = newClusterdCtx(executor, &cephv1.CephObjectStoreUser{ObjectMeta: meta("u1")})
+		_, err := c.RookClientset.CephV1().CephObjectStoreUsers(clusterInfo.Namespace).Create(context.TODO(), &cephv1.CephObjectStoreUser{ObjectMeta: meta("u1")}, v1.CreateOptions{})
+		assert.NoError(t, err)
+		client, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(`[]`))
+		assert.NoError(t, err)
+		deps, err := CephObjectStoreDependents(c, clusterInfo, store, NewContext(c, clusterInfo, store.Name), &AdminOpsContext{AdminOpsClient: client})
+		assert.NoError(t, err)
+		assert.True(t, deps.Empty())
+	})
+
+	t.Run("one objectstore users and no buckets", func(t *testing.T) {
+		executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" {
+					if args[1] == "lspools" {
+						output, err := json.Marshal(pools)
+						assert.Nil(t, err)
+						return string(output), nil
+					}
+				}
+				return "", errors.Errorf("unexpected ceph command %q", args)
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if command == "radosgw-admin" && args[0] == "user" {
+					return userCreateJSON, nil
+				}
+				return "", errors.Errorf("no such command %v %v", command, args)
+			},
+		}
+		c = newClusterdCtx(executor, &cephv1.CephObjectStoreUser{ObjectMeta: meta("u1")})
+		_, err := c.RookClientset.CephV1().CephObjectStoreUsers(clusterInfo.Namespace).Create(context.TODO(), &cephv1.CephObjectStoreUser{ObjectMeta: meta("u1"), Spec: cephv1.ObjectStoreUserSpec{Store: "my-store"}}, v1.CreateOptions{})
+		assert.NoError(t, err)
+		client, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(`[]`))
+		assert.NoError(t, err)
+		deps, err := CephObjectStoreDependents(c, clusterInfo, store, NewContext(c, clusterInfo, store.Name), &AdminOpsContext{AdminOpsClient: client})
+		assert.NoError(t, err)
+		assert.False(t, deps.Empty())
+		assert.ElementsMatch(t, []string{"u1"}, deps.OfPluralKind("CephObjectStoreUsers"))
+	})
+
+	t.Run("no objectstore users and buckets", func(t *testing.T) {
+		executor = &exectest.MockExecutor{
+			MockExecuteCommandWithOutputFile: func(command, outputFile string, args ...string) (string, error) {
+				logger.Infof("Command: %s %v", command, args)
+				if args[0] == "osd" {
+					if args[1] == "lspools" {
+						output, err := json.Marshal(pools)
+						assert.Nil(t, err)
+						return string(output), nil
+					}
+				}
+				return "", errors.Errorf("unexpected ceph command %q", args)
+			},
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if command == "radosgw-admin" && args[0] == "user" {
+					return userCreateJSON, nil
+				}
+				return "", errors.Errorf("no such command %v %v", command, args)
+			},
+		}
+		c = newClusterdCtx(executor)
+		client, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient(`["my-bucket"]`))
+		assert.NoError(t, err)
+		deps, err := CephObjectStoreDependents(c, clusterInfo, store, NewContext(c, clusterInfo, store.Name), &AdminOpsContext{AdminOpsClient: client})
+		assert.NoError(t, err)
+		assert.False(t, deps.Empty())
+		assert.ElementsMatch(t, []string{"my-bucket"}, deps.OfPluralKind("buckets in the object store (could be from ObjectBucketClaims or COSI Buckets)"), deps)
+	})
+}

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -53,6 +53,9 @@ const (
 	controllerName = "ceph-object-store-user-controller"
 )
 
+// newMultisiteAdminOpsCtxFunc help us mocking the admin ops API client in unit test
+var newMultisiteAdminOpsCtxFunc = object.NewMultisiteAdminOpsContext
+
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", controllerName)
 
 var cephObjectStoreUserKind = reflect.TypeOf(cephv1.CephObjectStoreUser{}).Name()
@@ -314,7 +317,7 @@ func (r *ReconcileObjectStoreUser) initializeObjectStoreContext(u *cephv1.CephOb
 	// Otherwise GetAdminOPSUserCredentials() will fail detecting the network provider when running RunAdminCommandNoMultisite()
 	objContext.CephClusterSpec = *r.cephClusterSpec
 
-	opsContext, err := object.NewMultisiteAdminOpsContext(objContext, &store.Spec)
+	opsContext, err := newMultisiteAdminOpsCtxFunc(objContext, &store.Spec)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialized rgw admin ops client api")
 	}


### PR DESCRIPTION
**Description of your changes:**

Since the mock client was added to the rgw/admin package from the
go-ceph project in https://github.com/ceph/go-ceph/pull/532 we can now
mock the HTTP client and validate the entire reconcile.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
