### PR TITLE
ceph: Update test to watch for v1 cronjob instead of v1beta1

### DIFF
--- a/pkg/operator/ceph/cluster/crash/reconcile.go
+++ b/pkg/operator/ceph/cluster/crash/reconcile.go
@@ -60,7 +60,10 @@ var (
 
 	// wait for secret "rook-ceph-crash-collector-keyring" to be created
 	waitForRequeueIfSecretNotCreated = reconcile.Result{Requeue: true, RequeueAfter: 30 * time.Second}
-	minVersionForCronV1              = "1.21.0"
+)
+
+const (
+	MinVersionForCronV1 = "1.21.0"
 )
 
 // ReconcileNode reconciles ReplicaSets
@@ -279,9 +282,9 @@ func (r *ReconcileNode) deleteCrashCollector(deployment appsv1.Deployment) error
 func (r *ReconcileNode) reconcileCrashRetention(namespace string, cephCluster cephv1.CephCluster, cephVersion *cephver.CephVersion) error {
 	k8sVersion, err := k8sutil.GetK8SVersion(r.context.Clientset)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch k8s version")
+		return errors.Wrap(err, "failed to get k8s version")
 	}
-	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(minVersionForCronV1))
+	useCronJobV1 := k8sVersion.AtLeast(version.MustParseSemantic(MinVersionForCronV1))
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      prunerName,


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The v1beta1 cronjob is deprecated and needs to use v1 for K8s 1.16 and newer. This is just one remaining place in the integration tests to fix since #8114. 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
