### PR TITLE
ceph: move all of our docker.io reference to quay.io

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -32,7 +32,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -59,7 +59,7 @@ metadata:
 spec:
   cephVersion:
     # see the "Cluster Settings" section below for more details on which image of ceph to run
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -127,7 +127,7 @@ spec:
       - name: c
   cephVersion:
     # Stretch cluster is supported in Ceph Pacific or newer.
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     allowUnsupported: true
   # Either storageClassDeviceSets or the storage section can be specified for creating OSDs.
   # This example uses all devices for simplicity.
@@ -165,7 +165,7 @@ Settings can be specified at the global level to apply to the cluster as a whole
 * `external`:
   * `enable`: if `true`, the cluster will not be managed by Rook but via an external entity. This mode is intended to connect to an existing cluster. In this case, Rook will only consume the external cluster. However, Rook will be able to deploy various daemons in Kubernetes such as object gateways, mds and nfs if an image is provided and will refuse otherwise. If this setting is enabled **all** the other options will be ignored except `cephVersion.image` and `dataDirHostPath`. See [external cluster configuration](#external-cluster). If `cephVersion.image` is left blank, Rook will refuse the creation of extra CRs like object, file and nfs.
 * `cephVersion`: The version information for launching the ceph daemons.
-  * `image`: The image used for running the ceph daemons. For example, `ceph/ceph:v15.2.12` or `v16.2.5`. For more details read the [container images section](#ceph-container-images).
+  * `image`: The image used for running the ceph daemons. For example, `quay.io/ceph/ceph:v15.2.12` or `v16.2.5`. For more details read the [container images section](#ceph-container-images).
   For the latest ceph images, see the [Ceph DockerHub](https://hub.docker.com/r/ceph/ceph/tags/).
   To ensure a consistent version of the image is running across all nodes in the cluster, it is recommended to use a very specific image version.
   Tags also exist that would give the latest version, but they are only recommended for test environments. For example, the tag `v14` will be updated each time a new nautilus build is released.
@@ -674,7 +674,7 @@ kubectl -n rook-ceph get CephCluster -o yaml
       deviceClasses:
       - name: hdd
     version:
-      image: ceph/ceph:v16.2.5
+      image: quay.io/ceph/ceph:v16.2.5
       version: 16.2.5-0
     conditions:
     - lastHeartbeatTime: "2021-03-02T21:22:11Z"
@@ -736,7 +736,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -768,7 +768,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -808,7 +808,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -855,7 +855,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -961,7 +961,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3
@@ -1007,7 +1007,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     allowUnsupported: false
   dashboard:
     enabled: true
@@ -1465,7 +1465,7 @@ spec:
     enable: true
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v16.2.5 # Should match external cluster version
+    image: quay.io/ceph/ceph:v16.2.5 # Should match external cluster version
 ```
 
 ### Security

--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -416,7 +416,7 @@ The majority of the upgrade will be handled by the Rook operator. Begin the upgr
 Ceph image field in the cluster CRD (`spec.cephVersion.image`).
 
 ```sh
-NEW_CEPH_IMAGE='ceph/ceph:v16.2.5-20210708'
+NEW_CEPH_IMAGE='quay.io/ceph/ceph:v16.2.5-20210708'
 CLUSTER_NAME="$ROOK_CLUSTER_NAMESPACE"  # change if your cluster name is not the Rook namespace
 kubectl -n $ROOK_CLUSTER_NAMESPACE patch CephCluster $CLUSTER_NAME --type=merge -p "{\"spec\": {\"cephVersion\": {\"image\": \"$NEW_CEPH_IMAGE\"}}}"
 ```

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -16,6 +16,8 @@ v1.7...
 
 ### Ceph
 
+- Official Ceph images have moved from docker.io to quay.io. Users running tags like `v14.2`, `v15.2`, `v16.2` must change the registry URL.
+So the CephCLuster spec field `image` must be updated to point to quay, like `image: quay.io/ceph/ceph:v16.2`.
 - Add user data protection when deleting Rook-Ceph Custom Resources
   - A CephCluster will not be deleted if there are any other Rook-Ceph Custom resources referencing
     it with the assumption that they are using the underlying Ceph cluster.

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -41,9 +41,9 @@ cephClusterSpec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v15.2.11-20200419
+    # If you want to be more precise, you can always use a timestamp tag such quay.io/ceph/ceph:v15.2.11-20200419
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -495,7 +495,7 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.5
+                      description: Image is the container image used to launch the ceph daemons, such as quay.io/ceph/ceph:<tag> The full list of images can be found at https://quay.io/repository/ceph/ceph?tab=tags
                       type: string
                   type: object
                 cleanupPolicy:

--- a/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-external-management.yaml
@@ -19,4 +19,4 @@ spec:
   dataDirHostPath: /var/lib/rook
   # providing an image is required, if you want to create other CRs (rgw, mds, nfs)
   cephVersion:
-    image: ceph/ceph:v16.2.5 # Should match external cluster version
+    image: quay.io/ceph/ceph:v16.2.5 # Should match external cluster version

--- a/cluster/examples/kubernetes/ceph/cluster-on-local-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-local-pvc.yaml
@@ -171,7 +171,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-pvc.yaml
@@ -32,7 +32,7 @@ spec:
           requests:
             storage: 10Gi
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     allowUnsupported: false
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-stretched-aws.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched-aws.yaml
@@ -45,7 +45,7 @@ spec:
     count: 2
   cephVersion:
     # Stretch cluster support upstream is only available starting in Ceph Pacific
-    image: ceph/ceph:v16.2.2
+    image: quay.io/ceph/ceph:v16.2.2
     allowUnsupported: true
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-stretched.yaml
@@ -39,7 +39,7 @@ spec:
     count: 2
   cephVersion:
     # Stretch cluster support upstream is only available starting in Ceph Pacific
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     allowUnsupported: true
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false

--- a/cluster/examples/kubernetes/ceph/cluster-test.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-test.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v16
+    image: quay.io/ceph/ceph:v16
     allowUnsupported: true
   mon:
     count: 1

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -19,9 +19,9 @@ spec:
     # v13 is mimic, v14 is nautilus, and v15 is octopus.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such ceph/ceph:v16.2.5-20210708
+    # If you want to be more precise, you can always use a timestamp tag such quay.io/ceph/ceph:v16.2.5-20210708
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
     # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -495,7 +495,7 @@ spec:
                       description: Whether to allow unsupported versions (do not set to true in production)
                       type: boolean
                     image:
-                      description: Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.5
+                      description: Image is the container image used to launch the ceph daemons, such as quay.io/ceph/ceph:<tag> The full list of images can be found at https://quay.io/repository/ceph/ceph?tab=tags
                       type: string
                   type: object
                 cleanupPolicy:

--- a/cluster/olm/ceph/assemble/metadata-common.yaml
+++ b/cluster/olm/ceph/assemble/metadata-common.yaml
@@ -230,7 +230,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v16.2.5"
+              "image": "quay.io/ceph/ceph:v16.2.5"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/design/ceph/ceph-cluster-cleanup.md
+++ b/design/ceph/ceph-cluster-cleanup.md
@@ -34,7 +34,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: ceph/ceph:v16.2.5
+    image: quay.io/ceph/ceph:v16.2.5
   dataDirHostPath: /var/lib/rook
   mon:
     count: 3

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -22,7 +22,8 @@ CEPH_VERSION = v16.2.5-20210708
 else
 CEPH_VERSION = v16.2.5-20210708
 endif
-BASEIMAGE = ceph/ceph-$(GOARCH):$(CEPH_VERSION)
+REGISTRY_NAME = quay.io
+BASEIMAGE = $(REGISTRY_NAME)/ceph/ceph-$(GOARCH):$(CEPH_VERSION)
 CEPH_IMAGE = $(BUILD_REGISTRY)/ceph-$(GOARCH)
 OPERATOR_SDK_VERSION = v0.17.1
 # TODO: update to yq v4 - v3 end of life in Aug 2021 ; v4 removes the 'yq delete' cmd and changes syntax

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -251,7 +251,8 @@ type KeyManagementServiceSpec struct {
 
 // CephVersionSpec represents the settings for the Ceph version that Rook is orchestrating.
 type CephVersionSpec struct {
-	// Image is the container image used to launch the ceph daemons, such as ceph/ceph:v16.2.5
+	// Image is the container image used to launch the ceph daemons, such as quay.io/ceph/ceph:<tag>
+	// The full list of images can be found at https://quay.io/repository/ceph/ceph?tab=tags
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/pkg/operator/ceph/cluster/cluster_external_test.go
+++ b/pkg/operator/ceph/cluster/cluster_external_test.go
@@ -29,7 +29,7 @@ func TestValidateExternalClusterSpec(t *testing.T) {
 	err := validateExternalClusterSpec(c)
 	assert.NoError(t, err)
 
-	c.Spec.CephVersion.Image = "ceph/ceph:v15"
+	c.Spec.CephVersion.Image = "quay.io/ceph/ceph:v15"
 	err = validateExternalClusterSpec(c)
 	assert.Error(t, err)
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -118,7 +118,7 @@ func TestStartSecureDashboard(t *testing.T) {
 	c := &Cluster{clusterInfo: clusterInfo, context: &clusterd.Context{Clientset: clientset, Executor: executor},
 		spec: cephv1.ClusterSpec{
 			Dashboard:   cephv1.DashboardSpec{Port: dashboardPortHTTP, Enabled: true, SSL: true},
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
+			CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v15"},
 		},
 	}
 	c.exitCode = func(err error) (int, bool) {

--- a/pkg/operator/ceph/cluster/mgr/spec_test.go
+++ b/pkg/operator/ceph/cluster/mgr/spec_test.go
@@ -39,7 +39,7 @@ func TestPodSpec(t *testing.T) {
 	clusterInfo := &cephclient.ClusterInfo{Namespace: "ns", FSID: "myfsid", OwnerInfo: ownerInfo}
 	clusterInfo.SetName("test")
 	clusterSpec := cephv1.ClusterSpec{
-		CephVersion:        cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"},
+		CephVersion:        cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:myceph"},
 		Dashboard:          cephv1.DashboardSpec{Port: 1234},
 		PriorityClassNames: map[rook.KeyType]string{cephv1.KeyMgr: "my-priority-class"},
 		DataDirHostPath:    "/var/lib/rook/",
@@ -75,7 +75,7 @@ func TestPodSpec(t *testing.T) {
 		podTemplate.Spec().Containers().RequireAdditionalEnvVars(
 			"ROOK_OPERATOR_NAMESPACE", "ROOK_CEPH_CLUSTER_CRD_VERSION",
 			"ROOK_CEPH_CLUSTER_CRD_NAME")
-		podTemplate.RunFullSuite(config.MgrType, "a", AppName, "ns", "ceph/ceph:myceph",
+		podTemplate.RunFullSuite(config.MgrType, "a", AppName, "ns", "quay.io/ceph/ceph:myceph",
 			"200", "100", "500", "250", /* resources */
 			"my-priority-class")
 		assert.Equal(t, 2, len(d.Spec.Template.Annotations))

--- a/pkg/operator/ceph/cluster/mon/spec_test.go
+++ b/pkg/operator/ceph/cluster/mon/spec_test.go
@@ -52,7 +52,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 		&sync.Mutex{},
 	)
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
-	c.spec.CephVersion = cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"}
+	c.spec.CephVersion = cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:myceph"}
 	c.spec.Resources = map[string]v1.ResourceRequirements{}
 	c.spec.Resources["mon"] = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -86,7 +86,7 @@ func testPodSpec(t *testing.T, monID string, pvc bool) {
 		config.MonType, monID, AppName, "ns")
 
 	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
-	podTemplate.RunFullSuite(config.MonType, monID, AppName, "ns", "ceph/ceph:myceph",
+	podTemplate.RunFullSuite(config.MonType, monID, AppName, "ns", "quay.io/ceph/ceph:myceph",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
 }
@@ -102,7 +102,7 @@ func TestDeploymentPVCSpec(t *testing.T) {
 		&sync.Mutex{},
 	)
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "rook/rook:myversion")
-	c.spec.CephVersion = cephv1.CephVersionSpec{Image: "ceph/ceph:myceph"}
+	c.spec.CephVersion = cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:myceph"}
 	c.spec.Resources = map[string]v1.ResourceRequirements{}
 	c.spec.Resources["mon"] = v1.ResourceRequirements{
 		Limits: v1.ResourceList{

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -201,7 +201,7 @@ func testOSDIntegration(t *testing.T) {
 	}
 	spec := cephv1.ClusterSpec{
 		CephVersion: cephv1.CephVersionSpec{
-			Image: "ceph/ceph:v16.2.0",
+			Image: "quay.io/ceph/ceph:v16.2.0",
 		},
 		DataDirHostPath: context.ConfigDir,
 		// This storage spec should... (see inline)

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -94,7 +94,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	context := &clusterd.Context{Clientset: clientset, ConfigDir: "/var/lib/rook", Executor: &exectest.MockExecutor{}}
 	spec := cephv1.ClusterSpec{
-		CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
+		CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v15"},
 		Storage: cephv1.StorageScopeSpec{
 			Selection: cephv1.Selection{UseAllDevices: &allDevices, DeviceFilter: deviceName},
 			Nodes:     []cephv1.Node{{Name: "node1"}},
@@ -164,7 +164,7 @@ func testPodDevices(t *testing.T, dataDir, deviceName string, allDevices bool) {
 
 	assert.Equal(t, 2, len(deployment.Spec.Template.Spec.InitContainers))
 	initCont := deployment.Spec.Template.Spec.InitContainers[0]
-	assert.Equal(t, "ceph/ceph:v15", initCont.Image)
+	assert.Equal(t, "quay.io/ceph/ceph:v15", initCont.Image)
 	assert.Equal(t, "activate", initCont.Name)
 	assert.Equal(t, 4, len(initCont.VolumeMounts))
 

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -482,7 +482,7 @@ func Test_updateExistingOSDs(t *testing.T) {
 
 func Test_getOSDUpdateInfo(t *testing.T) {
 	namespace := "rook-ceph"
-	cephImage := "ceph/ceph:v15"
+	cephImage := "quay.io/ceph/ceph:v15"
 
 	// NOTE: all tests share the same clientset
 	clientset := fake.NewSimpleClientset()

--- a/pkg/operator/ceph/cluster/rbd/spec_test.go
+++ b/pkg/operator/ceph/cluster/rbd/spec_test.go
@@ -48,7 +48,7 @@ func TestPodSpec(t *testing.T) {
 		},
 		Spec: cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{
-				Image: "ceph/ceph:v15",
+				Image: "quay.io/ceph/ceph:v15",
 			},
 		},
 	}
@@ -96,7 +96,7 @@ func TestPodSpec(t *testing.T) {
 		config.RbdMirrorType, "a", AppName, "ns")
 
 	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
-	podTemplate.RunFullSuite(config.RbdMirrorType, "a", AppName, "ns", "ceph/ceph:myceph",
+	podTemplate.RunFullSuite(config.RbdMirrorType, "a", AppName, "ns", "quay.io/ceph/ceph:myceph",
 		"200", "100", "600", "300", /* resources */
 		"my-priority-class")
 }

--- a/pkg/operator/ceph/file/mds/spec_test.go
+++ b/pkg/operator/ceph/file/mds/spec_test.go
@@ -68,7 +68,7 @@ func testDeploymentObject(t *testing.T, network cephv1.NetworkSpec) (*apps.Deplo
 		clusterInfo,
 		&clusterd.Context{Clientset: clientset},
 		&cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:testversion"},
+			CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:testversion"},
 			Network:     network,
 		},
 		fs,
@@ -96,7 +96,7 @@ func TestPodSpecs(t *testing.T) {
 		config.MdsType, "myfs-a", "rook-ceph-mds", "ns")
 
 	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
-	podTemplate.RunFullSuite(config.MdsType, "myfs-a", "rook-ceph-mds", "ns", "ceph/ceph:testversion",
+	podTemplate.RunFullSuite(config.MdsType, "myfs-a", "rook-ceph-mds", "ns", "quay.io/ceph/ceph:testversion",
 		"500", "250", "4337", "2169", /* resources */
 		"my-priority-class")
 

--- a/pkg/operator/ceph/file/mirror/spec_test.go
+++ b/pkg/operator/ceph/file/mirror/spec_test.go
@@ -46,7 +46,7 @@ func TestPodSpec(t *testing.T) {
 		},
 		Spec: cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{
-				Image: "ceph/ceph:v16",
+				Image: "quay.io/ceph/ceph:v16",
 			},
 		},
 	}
@@ -93,7 +93,7 @@ func TestPodSpec(t *testing.T) {
 		config.FilesystemMirrorType, userID, AppName, "ns")
 
 	podTemplate := test.NewPodTemplateSpecTester(t, &d.Spec.Template)
-	podTemplate.RunFullSuite(config.FilesystemMirrorType, userID, AppName, "ns", "ceph/ceph:v16",
+	podTemplate.RunFullSuite(config.FilesystemMirrorType, userID, AppName, "ns", "quay.io/ceph/ceph:v16",
 		"200", "100", "600", "300", /* resources */
 		"my-priority-class")
 }

--- a/pkg/operator/ceph/nfs/spec_test.go
+++ b/pkg/operator/ceph/nfs/spec_test.go
@@ -101,7 +101,7 @@ func TestDeploymentSpec(t *testing.T) {
 		},
 		cephClusterSpec: &cephv1.ClusterSpec{
 			CephVersion: cephv1.CephVersionSpec{
-				Image: "ceph/ceph:v15",
+				Image: "quay.io/ceph/ceph:v15",
 			},
 		},
 	}

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -60,7 +60,7 @@ func TestPodSpecs(t *testing.T) {
 		store:       store,
 		rookVersion: "rook/rook:myversion",
 		clusterSpec: &cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
+			CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v15"},
 			Network: cephv1.NetworkSpec{
 				HostNetwork: true,
 			},
@@ -85,7 +85,7 @@ func TestPodSpecs(t *testing.T) {
 		s.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels)
 
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
-	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
+	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "quay.io/ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
 }
@@ -119,7 +119,7 @@ func TestSSLPodSpec(t *testing.T) {
 		context:     context,
 		rookVersion: "rook/rook:myversion",
 		clusterSpec: &cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{Image: "ceph/ceph:v15"},
+			CephVersion: cephv1.CephVersionSpec{Image: "quay.io/ceph/ceph:v15"},
 			Network: cephv1.NetworkSpec{
 				HostNetwork: true,
 			},
@@ -156,7 +156,7 @@ func TestSSLPodSpec(t *testing.T) {
 	s, err := c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
 	podTemplate := cephtest.NewPodTemplateSpecTester(t, &s)
-	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
+	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "quay.io/ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
 	// TLS Secret
@@ -180,7 +180,7 @@ func TestSSLPodSpec(t *testing.T) {
 	s, err = c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
 	podTemplate = cephtest.NewPodTemplateSpecTester(t, &s)
-	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
+	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "quay.io/ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
 	// Using service serving cert
@@ -192,7 +192,7 @@ func TestSSLPodSpec(t *testing.T) {
 	s, err = c.makeRGWPodSpec(rgwConfig)
 	assert.NoError(t, err)
 	podTemplate = cephtest.NewPodTemplateSpecTester(t, &s)
-	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "ceph/ceph:myversion",
+	podTemplate.RunFullSuite(cephconfig.RgwType, "default", "rook-ceph-rgw", "mycluster", "quay.io/ceph/ceph:myversion",
 		"200", "100", "1337", "500", /* resources */
 		"my-priority-class")
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -43,14 +43,14 @@ import (
 
 const (
 	// test with the latest nautilus build
-	nautilusTestImage = "ceph/ceph:v14"
+	nautilusTestImage = "quay.io/ceph/ceph:v14"
 	// nautilusTestImagePartition is the image that contains working ceph-volume code to deploy OSDs on partitions
 	// currently only used for the upgrade test from 1.5 to 1.6, this cannot be changed to v14 since ceph-volume will fail to deploy OSD on partition on Rook 1.5
-	nautilusTestImagePartition = "ceph/ceph:v14.2.12"
+	nautilusTestImagePartition = "quay.io/ceph/ceph:v14.2.12"
 	// test with the latest octopus build
-	octopusTestImage = "ceph/ceph:v15"
+	octopusTestImage = "quay.io/ceph/ceph:v15"
 	// test with the latest pacific build
-	pacificTestImage = "ceph/ceph:v16"
+	pacificTestImage = "quay.io/ceph/ceph:v16"
 	// test with the latest master image
 	masterTestImage    = "ceph/daemon-base:latest-master-devel"
 	cephOperatorLabel  = "app=rook-ceph-operator"

--- a/tests/manifests/test-cluster-on-pvc-encrypted.yaml
+++ b/tests/manifests/test-cluster-on-pvc-encrypted.yaml
@@ -14,7 +14,7 @@ spec:
           requests:
             storage: 5Gi
   cephVersion:
-    image: ceph/ceph:v15
+    image: quay.io/ceph/ceph:v15
   dashboard:
     enabled: false
   network:


### PR DESCRIPTION
**Description of your changes:**

Recently, the builds of `ceph/ceph` image moved to quay.io, see
https://github.com/ceph/ceph-build/pull/1883 for more details.
Current images will remain but new builds will happen on quay.io only.

This means that tags such as `v14.2`, `v15.2`,`v16.2` will need to
switch to quay.io to get updates.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
