### PR TITLE
ceph: update CSR from v1beta1 to v1

### DIFF
--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.21.0']
+        kubernetes-versions : ['v1.16.15', 'v1.22.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.21.0']
+        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.22.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/design/ceph/admission-controller.md
+++ b/design/ceph/admission-controller.md
@@ -61,7 +61,7 @@ openssl base64 -d -A -out ${PUBLIC_KEY_NAME}.pem
 
 **Sample : Certificate Signing Request (CSR) in Kubernetes**
 ```
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}

--- a/tests/scripts/deploy-validate-vault.sh
+++ b/tests/scripts/deploy-validate-vault.sh
@@ -30,53 +30,7 @@ if [[ "$(uname)" == "Linux" ]]; then
   install_helm
 fi
 
-function generate_vault_tls_config {
-  openssl genrsa -out "${TMPDIR}"/vault.key 2048
-  
-  cat <<EOF >"${TMPDIR}"/csr.conf
-[req]
-req_extensions = v3_req
-distinguished_name = req_distinguished_name
-[req_distinguished_name]
-[ v3_req ]
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
-[alt_names]
-DNS.1 = ${SERVICE}
-DNS.2 = ${SERVICE}.${NAMESPACE}
-DNS.3 = ${SERVICE}.${NAMESPACE}.svc
-DNS.4 = ${SERVICE}.${NAMESPACE}.svc.cluster.local
-IP.1 = 127.0.0.1
-EOF
-  
-  openssl req -new -key "${TMPDIR}"/vault.key -subj "/CN=${SERVICE}.${NAMESPACE}.svc" -out "${TMPDIR}"/server.csr -config "${TMPDIR}"/csr.conf
-  
-  export CSR_NAME=vault-csr
-  
-  cat <<EOF >"${TMPDIR}"/csr.yaml
-apiVersion: certificates.k8s.io/v1beta1
-kind: CertificateSigningRequest
-metadata:
-  name: ${CSR_NAME}
-spec:
-  groups:
-  - system:authenticated
-  request: $(cat ${TMPDIR}/server.csr | base64 | tr -d '\n')
-  usages:
-  - digital signature
-  - key encipherment
-  - server auth
-EOF
-  
-  kubectl create -f "${TMPDIR}/"csr.yaml
-  
-  kubectl certificate approve ${CSR_NAME}
-  
-  serverCert=$(kubectl get csr ${CSR_NAME} -o jsonpath='{.status.certificate}')
-  echo "${serverCert}" | openssl base64 -d -A -out "${TMPDIR}"/vault.crt
-  kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 -d > "${TMPDIR}"/vault.ca
+function create_secret_generic {
   kubectl create secret generic ${SECRET_NAME} \
   --namespace ${NAMESPACE} \
   --from-file=vault.key="${TMPDIR}"/vault.key \
@@ -124,7 +78,9 @@ EOF
 
 function deploy_vault {
   # TLS config
-  generate_vault_tls_config
+  scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  bash "${scriptdir}"/generate-tls-config.sh "${TMPDIR}" ${SERVICE} ${NAMESPACE}
+  create_secret_generic
   vault_helm_tls
   
   # Install Vault with Helm

--- a/tests/scripts/generate-tls-config.sh
+++ b/tests/scripts/generate-tls-config.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -xe
+
+DIR=$1
+SERVICE=$2
+NAMESPACE=$3
+IP=$4
+if [ -z "${IP}" ]; then
+    IP=127.0.0.1
+fi
+
+openssl genrsa -out "${DIR}"/"${SERVICE}".key 2048
+
+cat <<EOF >"${DIR}"/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${SERVICE}
+DNS.2 = ${SERVICE}.${NAMESPACE}
+DNS.3 = ${SERVICE}.${NAMESPACE}.svc
+DNS.4 = ${SERVICE}.${NAMESPACE}.svc.cluster.local
+IP.1  = ${IP}
+EOF
+
+openssl req -new -key "${DIR}"/"${SERVICE}".key -subj "/CN=system:node:${SERVICE};/O=system:nodes" -out "${DIR}"/server.csr -config "${DIR}"/csr.conf
+
+export CSR_NAME=${SERVICE}-csr
+
+# Minimum 1.19.0 kubernetes version is required for certificates.k8s.io/v1 version
+SERVER_VERSION=$(kubectl version --short | awk -F  "."  '/Server Version/ {print $2}')
+MINIMUM_VERSION=19
+if [ "${SERVER_VERSION}" -lt "${MINIMUM_VERSION}" ]
+then
+    cat <<EOF >"${DIR}"/csr.yaml
+  apiVersion: certificates.k8s.io/v1beta1
+  kind: CertificateSigningRequest
+  metadata:
+    name: ${CSR_NAME}
+  spec:
+    groups:
+    - system:authenticated
+    request: $(cat "${DIR}"/server.csr | base64 | tr -d '\n')
+    usages:
+    - digital signature
+    - key encipherment
+    - server auth
+EOF
+else
+    cat <<EOF >"${DIR}"/csr.yaml
+  apiVersion: certificates.k8s.io/v1
+  kind: CertificateSigningRequest
+  metadata:
+    name: ${CSR_NAME}
+  spec:
+    groups:
+    - system:authenticated
+    request: $(cat "${DIR}"/server.csr | base64 | tr -d '\n')
+    signerName: kubernetes.io/kubelet-serving
+    usages:
+    - digital signature
+    - key encipherment
+    - server auth
+EOF
+fi
+
+kubectl create -f "${DIR}/"csr.yaml
+
+kubectl certificate approve "${CSR_NAME}"
+
+serverCert=$(kubectl get csr "${CSR_NAME}" -o jsonpath='{.status.certificate}')
+echo "${serverCert}" | openssl base64 -d -A -out "${DIR}"/"${SERVICE}".crt
+kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 -d > "${DIR}"/"${SERVICE}".ca


### PR DESCRIPTION
This commit update the certificates.k8s.io to use version v1
Updated to v1 as v1beta1 certificates.k8s.io is deprecated in v1.19+

Closes: https://github.com/rook/rook/issues/8308
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
