### PR TITLE
build: Add release-1.7 mergify backport rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,14 @@ pull_request_rules:
       label:
         add:
           - cassandra
+  - name: auto nfs label pr storage backend
+    conditions:
+      - title~=^nfs
+      - base=master
+    actions:
+      label:
+        add:
+          - nfs
 
   # if there is a conflict in a backport PR, ping the author to send a proper backport PR
   - name: ping author on conflicts

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -77,21 +77,6 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
-  # automerge backports if CI successfully ran
-  # release-1.3 branch
-  - name: automerge backport release-1.3
-    conditions:
-      - author=mergify[bot]
-      - base=release-1.3
-      - label!=do-not-merge
-      - 'status-success=DCO'
-      - 'status-success=continuous-integration/jenkins/pr-head'
-    actions:
-      merge:
-        method: merge
-        strict: false
-      dismiss_reviews: {}
-      delete_head_branch: {}
   # release-1.4 branch
   - name: automerge backport release-1.4
     conditions:
@@ -106,6 +91,7 @@ pull_request_rules:
         strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
+
   # release-1.5 branch
   - name: automerge backport release-1.5
     conditions:
@@ -120,6 +106,7 @@ pull_request_rules:
         strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
+
   # release-1.6 branch
   - name: automerge backport release-1.6
     conditions:
@@ -153,15 +140,38 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
-  # Trigger backport PRs based on label
-  # release-1.3 branch
-  - actions:
-      backport:
-        branches:
-          - release-1.3
+  # release-1.7 branch
+  - name: automerge backport release-1.7
     conditions:
-      - label=backport-release-1.3
-    name: backport release-1.3
+      - author=mergify[bot]
+      - base=release-1.7
+      - label!=do-not-merge
+      - 'status-success=DCO'
+      - 'check-success=canary'
+      - 'check-success=unittests'
+      - 'check-success=golangci-lint'
+      - 'check-success=codegen'
+      - 'check-success=lint'
+      - 'check-success=modcheck'
+      - 'check-success=pvc'
+      - 'check-success=pvc-db'
+      - 'check-success=pvc-db-wal'
+      - 'check-success=encryption-pvc'
+      - 'check-success=encryption-pvc-db'
+      - 'check-success=encryption-pvc-db-wal'
+      - 'check-success=encryption-pvc-kms-vault-token-auth'
+      - 'check-success=TestCephSmokeSuite (v1.15.12)'
+      - 'check-success=TestCephSmokeSuite (v1.21.0)'
+      - 'check-success=TestCephHelmSuite (v1.15.12)'
+      - 'check-success=TestCephHelmSuite (v1.21.0)'
+      - 'check-success=TestCephMultiClusterDeploySuite (v1.21.0)'
+      - 'check-success=TestCephUpgradeSuite (v1.21.0)'
+    actions:
+      merge:
+        method: merge
+        strict: false
+      dismiss_reviews: {}
+      delete_head_branch: {}
 
   # release-1.4 branch
   - actions:
@@ -189,3 +199,12 @@ pull_request_rules:
     conditions:
       - label=backport-release-1.6
     name: backport release-1.6
+
+  # release-1.7 branch
+  - actions:
+      backport:
+        branches:
+          - release-1.7
+    conditions:
+      - label=backport-release-1.7
+    name: backport release-1.7


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mergify bot now has rules for backporting to the release-1.7 branch. Backporting to 1.3 is no longer needed, so we can remove that backport rule.

While we're at it, the cassandra and ceph PRs already had the label added automatically, now the nfs PRs will also have a label added.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
