### PR TITLE
cassandra: Tests should just use master tag instead of version tag

### DIFF
--- a/.github/workflows/integration-test-cassandra-suite.yaml
+++ b/.github/workflows/integration-test-cassandra-suite.yaml
@@ -43,7 +43,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='cassandra' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:v1.7.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:master
 
     - name: TestCassandraSuite
       run: |

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -295,7 +295,7 @@ jobs:
         # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='cassandra' VERSION=0 build
         docker images
-        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:v1.7.0-beta.0
+        docker tag $(docker images|awk '/build-/ {print $1}') rook/cassandra:master
 
     - name: TestCassandraSuite
       run: |


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The cassandra integration tests expect a tag of `rook/cassandra:master` instead of the version tag from the release builds.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
****