### PR TITLE
build: Publish and promote with correct branch name

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
        # docker/setup-qemu action installs QEMU static binaries, which are used to run builders for architectures other than the host.
       - name: set up QEMU
@@ -56,8 +58,4 @@ jobs:
           AWS_PSW: ${{ secrets.AWS_PSW }}
           GITHUB_REF: $ {{ env.GITHUB_REF }}
         run: |
-          if [[ ${GITHUB_REF} =~ master|v ]]; then
-            tests/scripts/build-release.sh publish_and_promote
-          else
-            tests/scripts/build-release.sh publish
-          fi
+          tests/scripts/build-release.sh

--- a/tests/scripts/build-release.sh
+++ b/tests/scripts/build-release.sh
@@ -5,13 +5,6 @@ set -ex
 # FUNCTIONS #
 #############
 
-
-if [[ ${GITHUB_REF} =~ master ]]; then
-  CHANNEL=master
-else
-  CHANNEL=release
-fi
-
 function  build() {
     # set VERSION to a dummy value since Jenkins normally sets it for us. Do this to make Helm happy and not fail with "Error: Invalid Semantic Version"
     build/run make VERSION=0 build.all
@@ -19,28 +12,51 @@ function  build() {
     build/run make mod.check
 }
 
-function publish_and_promote() {
-    build
-    build/run make -C build/release build BRANCH_NAME=${BRANCH_NAME}  GIT_API_TOKEN=${GIT_API_TOKEN}
-    git status &
-    git diff &
-    build/run make -C build/release publish BRANCH_NAME=${BRANCH_NAME} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_API_TOKEN}
-    # automatically promote the master builds
-    build/run make -C build/release promote BRANCH_NAME=${BRANCH_NAME} CHANNEL=${CHANNEL} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}
-
-}
-
 function publish() {
     build
-    build/run make -C build/release build BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=true GIT_API_TOKEN=${GIT_API_TOKEN}
+    build/run make -C build/release build BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=${TAG_WITH_SUFFIX} GIT_API_TOKEN=${GIT_API_TOKEN}
     git status &
     git diff &
-    build/run make -C build/release publish BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=true AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_API_TOKEN}
+    build/run make -C build/release publish BRANCH_NAME=${BRANCH_NAME} TAG_WITH_SUFFIX=${TAG_WITH_SUFFIX} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW} GIT_API_TOKEN=${GIT_API_TOKEN}
 }
 
-selected_function="$1"
-if [ "$selected_function" = "publish_and_promote" ]; then
-    publish_and_promote
-elif [ "$selected_function" = "publish" ]; then
-    publish
+function promote() {
+    # automatically promote the master builds
+    echo "Promoting from branch ${BRANCH_NAME}"
+    build/run make -C build/release promote BRANCH_NAME=${BRANCH_NAME} CHANNEL=${CHANNEL} AWS_ACCESS_KEY_ID=${AWS_USR} AWS_SECRET_ACCESS_KEY=${AWS_PSW}
+}
+
+#############
+# MAIN      #
+#############
+
+SHOULD_PROMOTE=true
+if [[ ${GITHUB_REF} =~ master ]]; then
+    echo "Publishing from master"
+    CHANNEL=master
+else
+    echo "Tagging with suffix for release and tagged builds"
+    TAG_WITH_SUFFIX=true
+    CHANNEL=release
+
+    # If a tag, find the source release branch
+    if [[ $BRANCH_NAME = v* ]]; then
+        TAG_NAME=${BRANCH_NAME}
+        BRANCH_NAME=$(git branch -r --contain refs/tags/${BRANCH_NAME} | grep "origin/release-." | sed 's/origin\///' | xargs)
+        if [[ $BRANCH_NAME = "" ]]; then
+            echo "Branch name not found in tag $TAG_NAME"
+            exit 1
+        fi
+        echo "Publishing tag ${TAG_NAME} in branch ${BRANCH_NAME}"
+    else
+        echo "Publishing from release branch ${BRANCH_NAME}"
+        SHOULD_PROMOTE=false
+    fi
+fi
+
+
+publish
+
+if [[ "$SHOULD_PROMOTE" = true ]]; then
+  promote
 fi


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The tagged builds will run git checkout on the correct tag, though the publish and promote actions expect a branch name to be available due to internal build assumptions. Now the publish looks up the branch name from the tag and passes it to the publish command as expected.

**Which issue is resolved by this Pull Request:**
Resolves #8378 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
