### PR TITLE
build: stage CSV files into tmp while building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ csv-ceph: csv-clean crds ## Generate a CSV file for OLM.
 	$(MAKE) -C images/ceph csv
 
 csv-clean: ## Remove existing OLM files.
-	$(MAKE) -C images/ceph csv-clean
+	@$(MAKE) -C images/ceph csv-clean
 
 crds: $(CONTROLLER_GEN) $(YQ)
 	@echo Updating CRD manifests

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -64,10 +64,6 @@ CXX := $(CROSS_TRIPLE)-g++
 export CC CXX
 endif
 
-# sed -i'' -e works on both UNIX (MacOS) and GNU (Linux) versions of sed
-SED_CMD ?= sed -i'' -e
-export SED_CMD
-
 # set the version number. you should not need to do this
 # for the majority of scenarios.
 ifeq ($(origin VERSION), undefined)
@@ -105,6 +101,9 @@ endif
 ifeq ($(BUILD_REGISTRY),build-)
 $(error Failed to get unique ID for host+dir. Check that '$(SHA256CMD)' functions or override SHA256CMD)
 endif
+
+SED_IN_PLACE = $(ROOT_DIR)/build/sed-in-place
+export SED_IN_PLACE
 
 # This is a neat little target that prints any variable value from the Makefile
 # Usage: make echo.IMAGES echo.PLATFORM

--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -39,7 +39,7 @@ define helm.chart
 $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) $(shell find $(HELM_CHARTS_DIR)/$(1) -type f)
 	@echo === helm package $(1)
 	@cp -r $(HELM_CHARTS_DIR)/$(1) $(OUTPUT_DIR)
-	@$(SED_CMD) 's|VERSION|$(VERSION)|g' $(OUTPUT_DIR)/$(1)/values.yaml
+	@$(SED_IN_PLACE) 's|VERSION|$(VERSION)|g' $(OUTPUT_DIR)/$(1)/values.yaml
 	@$(HELM) lint $(abspath $(OUTPUT_DIR)/$(1)) --set image.tag=$(VERSION)
 	@$(HELM) package --version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(OUTPUT_DIR)/$(1))
 $(HELM_INDEX): $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz

--- a/build/sed-in-place
+++ b/build/sed-in-place
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eEuo pipefail
+
+# sed is NOT portable across OSes
+
+# sed -i '' does in-place on Mac, BSD, and other POSIX-compliant OSes
+# sed -i '' does not work with GNU sed, but sed -i (without small quotes) does
+
+# assume that sed is not GNU sed initially
+SED=(sed -i '')
+
+if sed --help &>/dev/null; then
+  # if sed doesn't have help text, it isn't GNU sed
+  if [[ $(sed --help 2>&1) == *GNU* ]]; then
+    SED=(sed -i)
+  fi
+fi
+
+# sed -e is required on Mac/BSD if the -i option is used
+# sed -e is not required but is supported by GNU sed
+# Therefore, this script supplies -e it unless the first argument to this script is a flag
+if [[ $1 != -* ]]; then
+  SED+=(-e)
+fi
+
+"${SED[@]}" "${@}"

--- a/cluster/olm/ceph/generate-rook-csv-templates.sh
+++ b/cluster/olm/ceph/generate-rook-csv-templates.sh
@@ -12,13 +12,13 @@ if [ -f "Dockerfile" ]; then
     cd ../../
 fi
 
-OLM_CATALOG_DIR=cluster/olm/ceph
+: "${OLM_CATALOG_DIR:=cluster/olm/ceph}"
 DEPLOY_DIR="$OLM_CATALOG_DIR/deploy"
 CRDS_DIR="$DEPLOY_DIR/crds"
 
 TEMPLATES_DIR="$OLM_CATALOG_DIR/templates"
 
-SED=${SED_CMD:-"sed -i'' -e"}
+: "${SED_IN_PLACE:="build/sed-in-place"}"
 
 function generate_template() {
     local provider=$1
@@ -32,7 +32,7 @@ function generate_template() {
     mv $tmp_csv_gen_file $csv_template_file
 
     # replace the placeholder with the templated value
-    $SED "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
+    $SED_IN_PLACE "s/9999.9999.9999/{{.RookOperatorCsvVersion}}/g" $csv_template_file
 
     echo "Template stored at $csv_template_file"
 }

--- a/cluster/olm/ceph/generate-rook-csv.sh
+++ b/cluster/olm/ceph/generate-rook-csv.sh
@@ -4,7 +4,7 @@ set -e
 ##################
 # INIT VARIABLES #
 ##################
-OLM_CATALOG_DIR=cluster/olm/ceph
+: "${OLM_CATALOG_DIR:=cluster/olm/ceph}"
 ASSEMBLE_FILE_COMMON="$OLM_CATALOG_DIR/assemble/metadata-common.yaml"
 ASSEMBLE_FILE_K8S="$OLM_CATALOG_DIR/assemble/metadata-k8s.yaml"
 ASSEMBLE_FILE_OCP="$OLM_CATALOG_DIR/assemble/metadata-ocp.yaml"
@@ -76,8 +76,7 @@ ROOK_OP_VERSION=$3
 #############
 # VARIABLES #
 #############
-SED_I=(sed -i'' -e)
-[ -n "$SED_CMD" ] || read -ra SED_CMD <<< "${SED_I[@]}"
+: "${SED_IN_PLACE:="build/sed-in-place"}"
 YQ_CMD_DELETE=($yq delete -i)
 YQ_CMD_MERGE_OVERWRITE=($yq merge --inplace --overwrite --prettyPrint)
 YQ_CMD_MERGE=($yq merge --inplace --append -P )
@@ -226,26 +225,26 @@ function hack_csv() {
     # rook-ceph-osd --> serviceAccountName
     #     rook-ceph-osd --> rule
 
-    "${SED_I[@]}" 's/rook-ceph-global/rook-ceph-system/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/rook-ceph-object-bucket/rook-ceph-system/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/rook-ceph-cluster-mgmt/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rook-ceph-global/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rook-ceph-object-bucket/rook-ceph-system/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rook-ceph-cluster-mgmt/rook-ceph-system/' "$CSV_FILE_NAME"
 
-    "${SED_I[@]}" 's/rook-ceph-mgr-cluster/rook-ceph-mgr/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/rook-ceph-mgr-system/rook-ceph-mgr/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rook-ceph-mgr-cluster/rook-ceph-mgr/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rook-ceph-mgr-system/rook-ceph-mgr/' "$CSV_FILE_NAME"
 
-    "${SED_I[@]}" 's/cephfs-csi-nodeplugin/rook-csi-cephfs-plugin-sa/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/cephfs-external-provisioner-runner/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/cephfs-csi-nodeplugin/rook-csi-cephfs-plugin-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/cephfs-external-provisioner-runner/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
 
-    "${SED_I[@]}" 's/rbd-csi-nodeplugin/rook-csi-rbd-plugin-sa/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/rbd-external-provisioner-runner/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rbd-csi-nodeplugin/rook-csi-rbd-plugin-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rbd-external-provisioner-runner/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
     # The operator-sdk also does not properly respect when
     # Roles differ from the Service Account name
     # The operator-sdk instead assumes the Role/ClusterRole is the ServiceAccount name
     #
     # To account for these mappings, we have to replace Role/ClusterRole names with
     # the corresponding ServiceAccount.
-    "${SED_I[@]}" 's/cephfs-external-provisioner-cfg/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
-    "${SED_I[@]}" 's/rbd-external-provisioner-cfg/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/cephfs-external-provisioner-cfg/rook-csi-cephfs-provisioner-sa/' "$CSV_FILE_NAME"
+    $SED_IN_PLACE 's/rbd-external-provisioner-cfg/rook-csi-rbd-provisioner-sa/' "$CSV_FILE_NAME"
 }
 
 function generate_package() {

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -53,7 +53,7 @@ export OPERATOR_SDK YQ
 # ====================================================================================
 # Build Rook
 
-do.build: generate-csv-ceph-templates
+do.build:
 	@echo === container build $(CEPH_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp toolbox.sh $(TEMP)
@@ -65,12 +65,13 @@ do.build: generate-csv-ceph-templates
 	@mkdir -p $(TEMP)/rook-external/test-data
 	@cp ../../cluster/examples/kubernetes/ceph/create-external-cluster-resources.* $(TEMP)/rook-external/
 	@cp ../../cluster/examples/kubernetes/ceph/test-data/ceph-status-out $(TEMP)/rook-external/test-data/
-	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
-		cp -r ../../cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates;\
-	else\
-		mkdir $(TEMP)/ceph-csv-templates;\
-	fi
-	@cd $(TEMP) && $(SED_CMD) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
+ifeq ($(INCLUDE_CSV_TEMPLATES),true)
+	@$(MAKE) CSV_TEMPLATE_DIR=$(TEMP) generate-csv-templates
+	@cp -r $(TEMP)/cluster/olm/ceph/templates $(TEMP)/ceph-csv-templates
+else
+	mkdir $(TEMP)/ceph-csv-templates
+endif
+	@cd $(TEMP) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@if [ -z "$(BUILD_CONTAINER_IMAGE)" ]; then\
 		$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
@@ -79,39 +80,41 @@ do.build: generate-csv-ceph-templates
 		$(TEMP);\
 	fi
 	@rm -fr $(TEMP)
-	@$(MAKE) -C ../.. crds # revert changes made to the crds.yaml file during the csv-gen sequence
 
-generate-csv-ceph-templates: $(OPERATOR_SDK) $(YQ)
-	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
-		if [ "$(GOARCH)" = amd64 ]; then\
-			BEFORE_GEN_CRD_SIZE=$$(wc -l < ../../cluster/examples/kubernetes/ceph/crds.yaml);\
-			$(MAKE) -C ../.. NO_OB_OBC_VOL_GEN=true MAX_DESC_LEN=0 crds;\
-			AFTER_GEN_CRD_SIZE=$$(wc -l < ../../cluster/examples/kubernetes/ceph/crds.yaml);\
-			if [ "$$BEFORE_GEN_CRD_SIZE" -le "$$AFTER_GEN_CRD_SIZE" ]; then\
-				echo "the new crd file must be smaller since the description fields were stripped!";\
-				echo "length before $$BEFORE_GEN_CRD_SIZE";\
-				echo "length after $$AFTER_GEN_CRD_SIZE";\
-				exit 1;\
-			fi;\
-		fi;\
-		../../cluster/olm/ceph/generate-rook-csv-templates.sh;\
+# generate CSV template files into the directory defined by the env var CSV_TEMPLATE_DIR
+# CSV_TEMPLATE_DIR will be created if it doesn't already exist
+generate-csv-templates: $(OPERATOR_SDK) $(YQ) ## Generate CSV templates for OLM into CSV_TEMPLATE_DIR
+	@if [[ -z "$(CSV_TEMPLATE_DIR)" ]]; then echo "CSV_TEMPLATE_DIR is not set"; exit 1; fi
+	@# first, copy the existing CRDs and OLM catalog directory to CSV_TEMPLATE_DIR
+	@# then, generate or copy all prerequisites into CSV_TEMPLATE_DIR (e.g., CRDs)
+	@# finally, generate the templates in-place using CSV_TEMPLATE_DIR as a staging dir
+	@mkdir -p $(CSV_TEMPLATE_DIR)
+	@cp -a ../../cluster $(CSV_TEMPLATE_DIR)/cluster
+	@set -eE;\
+	BEFORE_GEN_CRD_SIZE=$$(wc -l < ../../cluster/examples/kubernetes/ceph/crds.yaml);\
+	$(MAKE) -C ../.. NO_OB_OBC_VOL_GEN=true MAX_DESC_LEN=0 BUILD_CRDS_INTO_DIR=$(CSV_TEMPLATE_DIR) crds;\
+	AFTER_GEN_CRD_SIZE=$$(wc -l < $(CSV_TEMPLATE_DIR)/cluster/examples/kubernetes/ceph/crds.yaml);\
+	if [ "$$BEFORE_GEN_CRD_SIZE" -le "$$AFTER_GEN_CRD_SIZE" ]; then\
+		echo "the new crd file must be smaller since the description fields were stripped!";\
+		echo "length before $$BEFORE_GEN_CRD_SIZE";\
+		echo "length after $$AFTER_GEN_CRD_SIZE";\
+		exit 1;\
 	fi
+	@OLM_CATALOG_DIR=$(CSV_TEMPLATE_DIR)/cluster/olm/ceph ../../cluster/olm/ceph/generate-rook-csv-templates.sh
+	@echo " === Generated CSV templates can be found at $(CSV_TEMPLATE_DIR)/cluster/olm/ceph/templates"
 
 $(YQ):
-	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
-		echo === installing yq $(GOHOST);\
-		mkdir -p $(TOOLS_HOST_DIR);\
-		curl -JL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(HOST_PLATFORM) -o $(YQ);\
-		chmod +x $(YQ);\
-	fi
+	@echo === installing yq $(GOHOST)
+	@mkdir -p $(TOOLS_HOST_DIR)
+	@curl -JL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(HOST_PLATFORM) -o $(YQ)
+	@chmod +x $(YQ)
 
 $(OPERATOR_SDK):
-	@if [ ! "$(INCLUDE_CSV_TEMPLATES)" = "" ]; then\
-		echo === installing operator-sdk $(GOHOST);\
-		mkdir -p $(TOOLS_HOST_DIR);\
-		curl -JL https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM) -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION);\
-		chmod +x $(OPERATOR_SDK);\
-	fi
+	@echo === installing operator-sdk $(GOHOST)
+	@mkdir -p $(TOOLS_HOST_DIR)
+	@curl -JL -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) \
+		https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM)
+	@chmod +x $(OPERATOR_SDK)
 
 csv: $(OPERATOR_SDK) $(YQ) ## Generate a CSV file for OLM.
 	@echo Generating CSV manifests

--- a/images/nfs/Makefile
+++ b/images/nfs/Makefile
@@ -42,7 +42,7 @@ do.build:
 	@echo === container build $(NFS_IMAGE)
 	@cp Dockerfile $(TEMP)
 	@cp $(OUTPUT_DIR)/bin/linux_$(GOARCH)/rook $(TEMP)
-	@cd $(TEMP) && $(SED_CMD) 's|NFS_BASEIMAGE|$(NFS_BASEIMAGE)|g' Dockerfile
+	@cd $(TEMP) && $(SED_IN_PLACE) 's|NFS_BASEIMAGE|$(NFS_BASEIMAGE)|g' Dockerfile
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		-t $(NFS_IMAGE) \
 		$(TEMP)


### PR DESCRIPTION
If a user were to `make build` Rook, and after the Ceph CSV was
generated and before make had finished, the Rook repo would be left with
changes caused by the build modifying files temporarily in-place.

All CSV template generation in the Ceph makefile is now self-contained
and can be configured to operate outside of the main repo so that files
are not modified in-place.

In-place modification of files was also incorrect. On Mac some files
with `-e` trailing were left, and in-place backups were also present in
the form `<filename>''`. Therefore, also fix the generation to fix
in-place modifications.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
