### PR TITLE
ceph: Add additional helm chart functionality for ingresses and defining the ceph storage crds

### DIFF
--- a/Documentation/ceph-block.md
+++ b/Documentation/ceph-block.md
@@ -83,6 +83,10 @@ parameters:
 
 # Delete the rbd volume when a PVC is deleted
 reclaimPolicy: Delete
+
+# Optional, if you want to add dynamic resize for PVC. Works for Kubernetes 1.14+
+# For now only ext3, ext4, xfs resize support provided, like in Kubernetes itself.
+allowVolumeExpansion: true
 ```
 
 If you've deployed the Rook operator in a namespace other than "rook-ceph",

--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -26,11 +26,12 @@ into the same namespace as the operator or a separate namespace.
 Rook currently publishes builds of this chart to the `release` and `master` channels.
 
 **Before installing, review the values.yaml to confirm if the default settings need to be updated.**
-- If the operator was installed in a namespace other than `rook-ceph`, the namespace
+* If the operator was installed in a namespace other than `rook-ceph`, the namespace
   must be set in the `operatorNamespace` variable.
-- Set the desired settings in the `cephClusterSpec`. The [defaults](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)
+* Set the desired settings in the `cephClusterSpec`. The [defaults](https://github.com/rook/rook/tree/{{ branchName }}/cluster/charts/rook-ceph-cluster/values.yaml)
   are only an example and not likely to apply to your cluster.
-- The `monitoring` section should be removed from the `cephClusterSpec`, as it is specified separately in the helm settings.
+* The `monitoring` section should be removed from the `cephClusterSpec`, as it is specified separately in the helm settings.
+* The default values for `cephBlockPools`, `cephFileSystems`, and `CephObjectStores` will create one of each, and their corresponding storage classes.
 
 ### Release
 
@@ -48,21 +49,65 @@ helm install --create-namespace --namespace rook-ceph rook-ceph-cluster \
 
 The following tables lists the configurable parameters of the rook-operator chart and their default values.
 
-| Parameter             | Description                                                          | Default     |
-| --------------------- | -------------------------------------------------------------------- | ----------- |
-| `operatorNamespace`   | Namespace of the Rook Operator                                       | `rook-ceph` |
-| `configOverride`      | Cluster ceph.conf override                                           | <empty>     |
-| `toolbox.enabled`     | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
-| `toolbox.tolerations` | Toolbox tolerations                                                  | `[]`        |
-| `toolbox.affinity`    | Toolbox affinity                                                     | `{}`        |
-| `monitoring.enabled`  | Enable Prometheus integration, will also create necessary RBAC rules | `false`     |
-| `cephClusterSpec.*`   | Cluster configuration, see below                                     | See below   |
-
+| Parameter              | Description                                                          | Default     |
+| ---------------------- | -------------------------------------------------------------------- | ----------- |
+| `operatorNamespace`    | Namespace of the Rook Operator                                       | `rook-ceph` |
+| `configOverride`       | Cluster ceph.conf override                                           | <empty>     |
+| `toolbox.enabled`      | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
+| `toolbox.tolerations`  | Toolbox tolerations                                                  | `[]`        |
+| `toolbox.affinity`     | Toolbox affinity                                                     | `{}`        |
+| `monitoring.enabled`   | Enable Prometheus integration, will also create necessary RBAC rules | `false`     |
+| `cephClusterSpec.*`    | Cluster configuration, see below                                     | See below   |
+| `ingress.dashboard`    | Enable an ingress for the ceph-dashboard                             | `{}`        |
+| `cephBlockPools.[*]`   | A list of CephBlockPool configurations to deploy                     | See below   |
+| `cephFileSystems.[*]`  | A list of CephFileSystem configurations to deploy                    | See below   |
+| `cephObjectStores.[*]` | A list of CephObjectStore configurations to deploy                   | See below   |
 
 ### Ceph Cluster Spec
 
 The `CephCluster` CRD takes its spec from `cephClusterSpec.*`. This is not an exhaustive list of parameters.
 For the full list, see the [Cluster CRD](ceph-cluster-crd.md) topic.
+
+### Ceph Block Pools
+
+The `cephBlockPools` array in the values file will define a list of CephBlockPool as described in the table below.
+
+| Parameter                           | Description                                                                                  | Default          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
+| `name`                              | The name of the CephBlockPool                                                                | `ceph-blockpool` |
+| `spec`                              | The CephBlockPool spec, see the [CephBlockPool](ceph-pool-crd.md#spec) documentation.        | `{}`             |
+| `storageClass.enabled`              | Whether a storage class is deployed alongside the CephBlockPool                              | `true`           |
+| `storageClass.isDefault`            | Whether the storage class will be the default storage class for PVCs. See the PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) documentation for details. | `true` |
+| `storageClass.name`                 | The name of the storage class                                                                | `ceph-block`     |
+| `storageClass.parameters`           | See [Block Storage](ceph-block.md) documentation or the helm values.yaml for suitable values | see values.yaml  |
+| `storageClass.reclaimPolicy`        | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+| `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
+
+### Ceph File Systems
+
+The `cephFileSystems` array in the values file will define a list of CephFileSystem as described in the table below.
+
+| Parameter                    | Description                                                                                           | Default           |
+| -----------------------------| ----------------------------------------------------------------------------------------------------- | ----------------- |
+| `name`                       | The name of the CephFileSystem                                                                        | `ceph-filesystem` |
+| `spec`                       | The CephFileSystem spec, see the [CephFilesystem CRD](ceph-filesystem-crd.md) documentation.          | see values.yaml   |
+| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephFileSystem                                      | `true`            |
+| `storageClass.name`          | The name of the storage class                                                                         | `ceph-filesystem` |
+| `storageClass.parameters`    | See [Shared Filesystem](ceph-filesystem.md) documentation or the helm values.yaml for suitable values | see values.yaml   |
+| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+
+### Ceph Object Stores
+
+The `cephObjectStores` array in the values file will define a list of CephObjectStore as described in the table below.
+
+| Parameter                    | Description                                                                                                             | Default             |
+| -----------------------------| ----------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `name`                       | The name of the CephObjectStore                                                                                         | `ceph-objectstore`  |
+| `spec`                       | The CephObjectStore spec, see the [CephObjectStore CRD](ceph-object-store-crd.md) documentation.                        | see values.yaml     |
+| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephObjectStore                                                       | `true`              |
+| `storageClass.name`          | The name of the storage class                                                                                           | `ceph-bucket`       |
+| `storageClass.parameters`    | See [Object Store storage class](ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml     |
+| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
 
 ### Existing Clusters
 

--- a/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -24,3 +24,10 @@ imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define the clusterName as defaulting to the release namespace
+*/}}
+{{- define "clusterName" -}}
+{{ .Values.clusterName | default .Release.Namespace }}
+{{- end -}}

--- a/cluster/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -1,0 +1,26 @@
+{{- $root := . -}}
+{{- range $blockpool := .Values.cephBlockPools -}}
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: {{ $blockpool.name }}
+spec:
+{{ toYaml $blockpool.spec | indent 2 }}
+---
+{{- if default false $blockpool.storageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $blockpool.storageClass.name }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "{{ if default false $blockpool.storageClass.isDefault }}true{{ else }}false{{ end }}"
+provisioner: {{ $root.Values.operatorNamespace }}.rbd.csi.ceph.com
+parameters:
+  pool: {{ $blockpool.name }}
+  clusterID: {{ $root.Release.Namespace }}
+{{ toYaml $blockpool.storageClass.parameters | indent 2 }}
+reclaimPolicy: {{ default "Delete" $blockpool.storageClass.reclaimPolicy }}
+allowVolumeExpansion: {{ default "true" $blockpool.storageClass.allowVolumeExpansion }}
+{{ end }}
+{{ end }}

--- a/cluster/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -1,0 +1,24 @@
+{{- $root := . -}}
+{{- range $filesystem := .Values.cephFileSystems -}}
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: {{ $filesystem.name }}
+spec:
+{{ toYaml $filesystem.spec | indent 2 }}
+---
+{{- if default false $filesystem.storageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $filesystem.storageClass.name }}
+provisioner: {{ $root.Values.operatorNamespace }}.cephfs.csi.ceph.com
+parameters:
+  fsName: {{ $filesystem.name }}
+  pool: {{ $filesystem.name }}-data0
+  clusterID: {{ $root.Release.Namespace }}
+{{ toYaml $filesystem.storageClass.parameters | indent 2 }}
+reclaimPolicy: {{ default "Delete" $filesystem.storageClass.reclaimPolicy }}
+{{ end }}
+{{ end }}

--- a/cluster/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -1,0 +1,23 @@
+{{- $root := . -}}
+{{- range $objectstore := .Values.cephObjectStores -}}
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: {{ $objectstore.name }}
+spec:
+{{ toYaml $objectstore.spec | indent 2 }}
+---
+{{- if default false $objectstore.storageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $objectstore.storageClass.name }}
+provisioner: {{ $root.Release.Namespace }}.ceph.rook.io/bucket
+reclaimPolicy: {{ default "Delete" $objectstore.storageClass.reclaimPolicy }}
+parameters:
+  objectStoreName: {{ $objectstore.name }}
+  objectStoreNamespace: {{ $root.Release.Namespace }}
+{{ toYaml $objectstore.storageClass.parameters | indent 2 }}
+{{ end }}
+{{ end }}

--- a/cluster/charts/rook-ceph-cluster/templates/configmap.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.configOverride }}
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.toolbox.enabled }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingress.dashboard.host }}
+---
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: Ingress
+metadata:
+  name: {{ template "clusterName" . }}-dashboard
+  {{- if .Values.ingress.dashboard.annotations }}
+  annotations: {{- toYaml .Values.ingress.dashboard.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.dashboard.host.name }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.dashboard.host.path }}
+            backend:
+              serviceName: rook-ceph-mgr-dashboard
+              servicePort: http-dashboard
+  {{- if .Values.ingress.dashboard.tls }}
+  tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -6,15 +6,14 @@
 operatorNamespace: rook-ceph
 
 # The metadata.name of the CephCluster CR. The default name is the same as the namespace.
-#clusterName: rook-ceph
+# clusterName: rook-ceph
 
 # Ability to override ceph.conf
-#configOverride: |
-#  [global]
-#  mon_allow_pool_delete = true
-#
-#  osd_pool_default_size = 3
-#  osd_pool_default_min_size = 2
+# configOverride: |
+#   [global]
+#   mon_allow_pool_delete = true
+#   osd_pool_default_size = 3
+#   osd_pool_default_min_size = 2
 
 # Installs a debugging toolbox deployment
 toolbox:
@@ -53,25 +52,30 @@ cephClusterSpec:
   # Important: if you reinstall the cluster, make sure you delete this directory from each host or else the mons will fail to start on the new cluster.
   # In Minikube, the '/data' directory is configured to persist across reboots. Use "/data/rook" in Minikube environment.
   dataDirHostPath: /var/lib/rook
+
   # Whether or not upgrade should continue even if a check fails
   # This means Ceph's status could be degraded and we don't recommend upgrading but you might decide otherwise
   # Use at your OWN risk
   # To understand Rook's upgrade process of Ceph, read https://rook.io/docs/rook/master/ceph-upgrade.html#ceph-version-upgrades
   skipUpgradeChecks: false
+
   # Whether or not continue if PGs are not clean during an upgrade
   continueUpgradeAfterChecksEvenIfNotHealthy: false
+
   # WaitTimeoutForHealthyOSDInMinutes defines the time (in minutes) the operator would wait before an OSD can be stopped for upgrade or restart.
   # If the timeout exceeds and OSD is not ok to stop, then the operator would skip upgrade for the current OSD and proceed with the next one
   # if `continueUpgradeAfterChecksEvenIfNotHealthy` is `false`. If `continueUpgradeAfterChecksEvenIfNotHealthy` is `true`, then opertor would
   # continue with the upgrade of an OSD even if its not ok to stop after the timeout. This timeout won't be applied if `skipUpgradeChecks` is `true`.
   # The default wait timeout is 10 minutes.
   waitTimeoutForHealthyOSDInMinutes: 10
+
   mon:
     # Set the number of mons to be started. Must be an odd number, and is generally recommended to be 3.
     count: 3
     # The mons should be on unique nodes. For production, at least 3 nodes are recommended for this reason.
     # Mons should only be allowed on the same node for test environments where data loss is acceptable.
     allowMultiplePerNode: false
+
   mgr:
     # When higher availability of the mgr is needed, increase the count to 2.
     # In that case, one mgr will be active and one in standby. When Ceph updates which
@@ -82,6 +86,7 @@ cephClusterSpec:
       # are already enabled by other settings in the cluster CR.
       - name: pg_autoscaler
         enabled: true
+
   # enable the ceph dashboard for viewing cluster status
   dashboard:
     enabled: true
@@ -89,37 +94,40 @@ cephClusterSpec:
     # urlPrefix: /ceph-dashboard
     # serve the dashboard at the given port.
     # port: 8443
-    # serve the dashboard using SSL
-    ssl: true
-  #network:
-  # enable host networking
-  #provider: host
-  # EXPERIMENTAL: enable the Multus network provider
-  #provider: multus
-  #selectors:
-  # The selector keys are required to be `public` and `cluster`.
-  # Based on the configuration, the operator will do the following:
-  #   1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
-  #   2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
-  #
-  # In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
-  #
-  #public: public-conf --> NetworkAttachmentDefinition object name in Multus
-  #cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
-  # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
-  #ipFamily: "IPv6"
-  # Ceph daemons to listen on both IPv4 and Ipv6 networks
-  #dualStack: false
+
+  # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/ceph-cluster-crd.md#network-configuration-settings
+  # network:
+  #   # enable host networking
+  #   provider: host
+  #   # EXPERIMENTAL: enable the Multus network provider
+  #   provider: multus
+  #   selectors:
+  #     # The selector keys are required to be `public` and `cluster`.
+  #     # Based on the configuration, the operator will do the following:
+  #     #   1. if only the `public` selector key is specified both public_network and cluster_network Ceph settings will listen on that interface
+  #     #   2. if both `public` and `cluster` selector keys are specified the first one will point to 'public_network' flag and the second one to 'cluster_network'
+  #     #
+  #     # In order to work, each selector value must match a NetworkAttachmentDefinition object in Multus
+  #     #
+  #     # public: public-conf --> NetworkAttachmentDefinition object name in Multus
+  #     # cluster: cluster-conf --> NetworkAttachmentDefinition object name in Multus
+  #   # Provide internet protocol version. IPv6, IPv4 or empty string are valid options. Empty string would mean IPv4
+  #   ipFamily: "IPv6"
+  #   # Ceph daemons to listen on both IPv4 and Ipv6 networks
+  #   dualStack: false
+
   # enable the crash collector for ceph daemon crash collection
   crashCollector:
     disable: false
     # Uncomment daysToRetain to prune ceph crash entries older than the
     # specified number of days.
-    #daysToRetain: 30
+    # daysToRetain: 30
+
   # enable log collector, daemons will log on files and rotate
   # logCollector:
   #   enabled: true
   #   periodicity: 24h # SUFFIX may be 'h' for hours or 'd' for days.
+
   # automate [data cleanup process](https://github.com/rook/rook/blob/master/Documentation/ceph-teardown.md#delete-the-data-on-hosts) in cluster destruction.
   cleanupPolicy:
     # Since cluster cleanup is destructive to data, confirmation is required.
@@ -144,100 +152,109 @@ cephClusterSpec:
     # allowUninstallWithVolumes defines how the uninstall should be performed
     # If set to true, cephCluster deletion does not wait for the PVs to be deleted.
     allowUninstallWithVolumes: false
+
   # To control where various services will be scheduled by kubernetes, use the placement configuration sections below.
   # The example under 'all' would have all services scheduled on kubernetes nodes labeled with 'role=storage-node' and
   # tolerate taints with a key of 'storage-node'.
-  #  placement:
-  #    all:
-  #      nodeAffinity:
-  #        requiredDuringSchedulingIgnoredDuringExecution:
-  #          nodeSelectorTerms:
-  #          - matchExpressions:
-  #            - key: role
-  #              operator: In
-  #              values:
-  #              - storage-node
-  #      podAffinity:
-  #      podAntiAffinity:
-  #      topologySpreadConstraints:
-  #      tolerations:
-  #      - key: storage-node
-  #        operator: Exists
-  # The above placement information can also be specified for mon, osd, and mgr components
-  #    mon:
-  # Monitor deployments may contain an anti-affinity rule for avoiding monitor
-  # collocation on the same node. This is a required rule when host network is used
-  # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
-  # preferred rule with weight: 50.
-  #    osd:
-  #    mgr:
-  #    cleanup:
-  #annotations:
-  #    all:
-  #    mon:
-  #    osd:
-  #    cleanup:
-  #    prepareosd:
-  # If no mgr annotations are set, prometheus scrape annotations will be set by default.
-  #    mgr:
-  #labels:
-  #    all:
-  #    mon:
-  #    osd:
-  #    cleanup:
-  #    mgr:
-  #    prepareosd:
-  # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
-  # These labels can be passed as LabelSelector to Prometheus
-  #    monitoring:
-  #resources:
-  # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
-  #    mgr:
-  #      limits:
-  #        cpu: "500m"
-  #        memory: "1024Mi"
-  #      requests:
-  #        cpu: "500m"
-  #        memory: "1024Mi"
-  # The above example requests/limits can also be added to the other components
-  #    mon:
-  #    osd:
-  #    prepareosd:
-  #    mgr-sidecar:
-  #    crashcollector:
-  #    logcollector:
-  #    cleanup:
+  # placement:
+  #   all:
+  #     nodeAffinity:
+  #       requiredDuringSchedulingIgnoredDuringExecution:
+  #         nodeSelectorTerms:
+  #           - matchExpressions:
+  #             - key: role
+  #               operator: In
+  #             values:
+  #             - storage-node
+  #     podAffinity:
+  #     podAntiAffinity:
+  #     topologySpreadConstraints:
+  #     tolerations:
+  #     - key: storage-node
+  #       operator: Exists
+  #   # The above placement information can also be specified for mon, osd, and mgr components
+  #   mon:
+  #   # Monitor deployments may contain an anti-affinity rule for avoiding monitor
+  #   # collocation on the same node. This is a required rule when host network is used
+  #   # or when AllowMultiplePerNode is false. Otherwise this anti-affinity rule is a
+  #   # preferred rule with weight: 50.
+  #   osd:
+  #   mgr:
+  #   cleanup:
+
+  # annotations:
+  #   all:
+  #   mon:
+  #   osd:
+  #   cleanup:
+  #   prepareosd:
+  #   # If no mgr annotations are set, prometheus scrape annotations will be set by default.
+  #   mgr:
+
+  # labels:
+  #   all:
+  #   mon:
+  #   osd:
+  #   cleanup:
+  #   mgr:
+  #   prepareosd:
+  #   # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
+  #   # These labels can be passed as LabelSelector to Prometheus
+  #   monitoring:
+
+  # resources:
+  #   # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
+  #   mgr:
+  #     limits:
+  #       cpu: "500m"
+  #       memory: "1024Mi"
+  #     requests:
+  #       cpu: "500m"
+  #       memory: "1024Mi"
+  #   # The above example requests/limits can also be added to the other components
+  #   mon:
+  #   osd:
+  #   prepareosd:
+  #   mgr-sidecar:
+  #   crashcollector:
+  #   logcollector:
+  #   cleanup:
+
   # The option to automatically remove OSDs that are out and are safe to destroy.
   removeOSDsIfOutAndSafeToRemove: false
-  #  priorityClassNames:
-  #    all: rook-ceph-default-priority-class
-  #    mon: rook-ceph-mon-priority-class
-  #    osd: rook-ceph-osd-priority-class
-  #    mgr: rook-ceph-mgr-priority-class
+
+  # priority classes to apply to ceph resources
+  # priorityClassNames:
+  #   all: rook-ceph-default-priority-class
+  #   mon: rook-ceph-mon-priority-class
+  #   osd: rook-ceph-osd-priority-class
+  #   mgr: rook-ceph-mgr-priority-class
+
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true
-    #deviceFilter:
-    #config:
-    # crushRoot: "custom-root" # specify a non-default root label for the CRUSH map
-    # metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
-    # databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB
-    # journalSizeMB: "1024"  # uncomment if the disks are 20 GB or smaller
-    # osdsPerDevice: "1" # this value can be overridden at the node or device level
-    # encryptedDevice: "true" # the default value for this option is "false"
-  # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
-  # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
-  #    nodes:
-  #    - name: "172.17.4.201"
-  #      devices: # specific devices to use for storage can be specified for each node
-  #      - name: "sdb"
-  #      - name: "nvme01" # multiple osds can be created on high performance devices
-  #        config:
-  #          osdsPerDevice: "5"
-  #      - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # devices can be specified using full udev paths
-  #      config: # configuration can be specified at the node level which overrides the cluster level config
-  #    - name: "172.17.4.301"
-  #      deviceFilter: "^sd."
+    # deviceFilter:
+    # config:
+    #   crushRoot: "custom-root" # specify a non-default root label for the CRUSH map
+    #   metadataDevice: "md0" # specify a non-rotational storage so ceph-volume will use it as block db device of bluestore.
+    #   databaseSizeMB: "1024" # uncomment if the disks are smaller than 100 GB
+    #   journalSizeMB: "1024"  # uncomment if the disks are 20 GB or smaller
+    #   osdsPerDevice: "1" # this value can be overridden at the node or device level
+    #   encryptedDevice: "true" # the default value for this option is "false"
+    # # Individual nodes and their config can be specified as well, but 'useAllNodes' above must be set to false. Then, only the named
+    # # nodes below will be used as storage resources.  Each node's 'name' field should match their 'kubernetes.io/hostname' label.
+    # nodes:
+    #   - name: "172.17.4.201"
+    #     devices: # specific devices to use for storage can be specified for each node
+    #       - name: "sdb"
+    #       - name: "nvme01" # multiple osds can be created on high performance devices
+    #     config:
+    #       osdsPerDevice: "5"
+    #   - name: "/dev/disk/by-id/ata-ST4000DM004-XXXX" # devices can be specified using full udev paths
+    #     config: # configuration can be specified at the node level which overrides the cluster level config
+    #   - name: "172.17.4.301"
+    #     deviceFilter: "^sd."
+
   # The section for configuring management of daemon disruptions during upgrade or fencing.
   disruptionManagement:
     # If true, the operator will create and manage PodDisruptionBudgets for OSD, Mon, RGW, and MDS daemons. OSD PDBs are managed dynamically
@@ -257,7 +274,7 @@ cephClusterSpec:
     # Namespace in which to watch for the MachineDisruptionBudgets.
     machineDisruptionBudgetNamespace: openshift-machine-api
 
-  # healthChecks
+  # Configure the healthcheck and liveness probes for ceph pods.
   # Valid values for daemons are 'mon', 'osd', 'status'
   healthCheck:
     daemonHealth:
@@ -270,7 +287,7 @@ cephClusterSpec:
       status:
         disabled: false
         interval: 60s
-    # Change pod liveness probe, it works for all mon,mgr,osd daemons
+    # Change pod liveness probe, it works for all mon, mgr, and osd pods.
     livenessProbe:
       mon:
         disabled: false
@@ -278,3 +295,122 @@ cephClusterSpec:
         disabled: false
       osd:
         disabled: false
+
+ingress:
+  dashboard: {}
+    # annotations:
+    #   kubernetes.io/ingress.class: nginx
+    #   external-dns.alpha.kubernetes.io/hostname: example.com
+    #   nginx.ingress.kubernetes.io/rewrite-target: /ceph-dashboard/$2
+    # host:
+    #   name: example.com
+    #   path: "/ceph-dashboard(/|$)(.*)"
+    # tls:
+
+cephBlockPools:
+  - name: ceph-blockpool
+    # see https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md#spec for available configuration
+    spec:
+      failureDomain: host
+      replicated:
+        size: 3
+    storageClass:
+      enabled: true
+      name: ceph-block
+      isDefault: true
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      # see https://github.com/rook/rook/blob/master/Documentation/ceph-block.md#provision-storage for available configuration
+      parameters:
+        # (optional) mapOptions is a comma-separated list of map options.
+        # For krbd options refer
+        # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+        # For nbd options refer
+        # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+        # mapOptions: lock_on_read,queue_depth=1024
+  
+        # (optional) unmapOptions is a comma-separated list of unmap options.
+        # For krbd options refer
+        # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+        # For nbd options refer
+        # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+        # unmapOptions: force
+  
+        # RBD image format. Defaults to "2".
+        imageFormat: "2"
+        # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
+        imageFeatures: layering
+        # The secrets contain Ceph admin credentials.
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+        # Specify the filesystem type of the volume. If not specified, csi-provisioner
+        # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+        # in hyperconverged settings where the volume is mounted on the same node as the osds.
+        csi.storage.k8s.io/fstype: ext4
+
+cephFileSystems:
+  - name: ceph-filesystem
+    # see https://github.com/rook/rook/blob/master/Documentation/ceph-filesystem-crd.md#filesystem-settings for available configuration
+    spec:
+      metadataPool:
+        replicated:
+          size: 3
+      dataPools:
+        - failureDomain: host
+          replicated:
+            size: 3
+      metadataServer:
+        activeCount: 1
+        activeStandby: true
+    storageClass:
+      enabled: true
+      name: ceph-filesystem
+      reclaimPolicy: Delete
+      # see https://github.com/rook/rook/blob/master/Documentation/ceph-filesystem.md#provision-storage for available configuration
+      parameters:
+        # The secrets contain Ceph admin credentials.
+        csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+        csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+        csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+        # Specify the filesystem type of the volume. If not specified, csi-provisioner
+        # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+        # in hyperconverged settings where the volume is mounted on the same node as the osds.
+        csi.storage.k8s.io/fstype: ext4
+
+cephObjectStores:
+  - name: ceph-objectstore
+    # see https://github.com/rook/rook/blob/master/Documentation/ceph-object-store-crd.md#object-store-settings for available configuration
+    spec:
+      metadataPool:
+        failureDomain: host
+        replicated:
+          size: 3
+      dataPool:
+        failureDomain: host
+        erasureCoded:
+          dataChunks: 2
+          codingChunks: 1
+      preservePoolsOnDelete: true
+      gateway:
+        port: 80
+        # securePort: 443
+        # sslCertificateRef:
+        instances: 1
+      healthCheck:
+        bucket:
+          interval: 60s
+    storageClass:
+      enabled: true
+      name: ceph-bucket
+      reclaimPolicy: Delete
+      # see https://github.com/rook/rook/blob/master/Documentation/ceph-object-bucket-claim.md#storageclass for available configuration
+      parameters:
+        # note: objectStoreNamespace and objectStoreName are configured by the chart
+        region: us-east-1

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -26,27 +26,28 @@ import (
 
 // TestCephSettings struct for handling panic and test suite tear down
 type TestCephSettings struct {
-	DataDirHostPath           string
-	ClusterName               string
-	Namespace                 string
-	OperatorNamespace         string
-	StorageClassName          string
-	UseHelm                   bool
-	UsePVC                    bool
-	Mons                      int
-	UseCrashPruner            bool
-	MultipleMgrs              bool
-	SkipOSDCreation           bool
-	UseCSI                    bool
-	EnableDiscovery           bool
-	EnableAdmissionController bool
-	IsExternal                bool
-	SkipClusterCleanup        bool
-	SkipCleanupPolicy         bool
-	DirectMountToolbox        bool
-	EnableVolumeReplication   bool
-	RookVersion               string
-	CephVersion               cephv1.CephVersionSpec
+	DataDirHostPath             string
+	ClusterName                 string
+	Namespace                   string
+	OperatorNamespace           string
+	StorageClassName            string
+	UseHelm                     bool
+	RetainHelmDefaultStorageCRs bool
+	UsePVC                      bool
+	Mons                        int
+	UseCrashPruner              bool
+	MultipleMgrs                bool
+	SkipOSDCreation             bool
+	UseCSI                      bool
+	EnableDiscovery             bool
+	EnableAdmissionController   bool
+	IsExternal                  bool
+	SkipClusterCleanup          bool
+	SkipCleanupPolicy           bool
+	DirectMountToolbox          bool
+	EnableVolumeReplication     bool
+	RookVersion                 string
+	CephVersion                 cephv1.CephVersionSpec
 }
 
 func (s *TestCephSettings) ApplyEnvVars() {


### PR DESCRIPTION
…

Signed-off-by: Tom Hellier <me@tomhellier.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This commit adds an ingress resource to the rook-ceph-cluster helm chart, allowing ingress to the ceph-dashboard service. It also adds the ability to define the various storage types that
you can run on ceph inside kubernetes.

**Which issue is resolved by this Pull Request:**
Resolves #8384 

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
