### PR TITLE
ceph: Remove old references to luminous and mimic versions

### DIFF
--- a/Documentation/ceph-advanced-configuration.md
+++ b/Documentation/ceph-advanced-configuration.md
@@ -78,14 +78,14 @@ When you create the second CephCluster CR, use the same `NAMESPACE` and the oper
 
 ## Use custom Ceph user and secret for mounting
 
-> **NOTE**: For extensive info about creating Ceph users, consult the Ceph documentation: http://docs.ceph.com/docs/mimic/rados/operations/user-management/#add-a-user.
+> **NOTE**: For extensive info about creating Ceph users, consult the Ceph documentation: https://docs.ceph.com/en/latest/rados/operations/user-management/#add-a-user.
 
 Using a custom Ceph user and secret can be done for filesystem and block storage.
 
-Create a custom user in Ceph with read-write access in the `/bar` directory on CephFS (For Ceph Mimic or newer, use `data=POOL_NAME` instead of `pool=POOL_NAME`):
+Create a custom user in Ceph with read-write access in the `/bar` directory on CephFS:
 
 ```console
-$ ceph auth get-or-create-key client.user1 mon 'allow r' osd 'allow rw tag cephfs pool=YOUR_FS_DATA_POOL' mds 'allow r, allow rw path=/bar'
+$ ceph auth get-or-create-key client.user1 mon 'allow r' osd 'allow rw tag cephfs data=YOUR_FS_DATA_POOL' mds 'allow r, allow rw path=/bar'
 ```
 
 The command will return a Ceph secret key, this key should be added as a secret in Kubernetes like this:
@@ -109,7 +109,7 @@ mountSecret: ceph-user1-secret
 
 If you want the Rook Ceph agent to require a `mountUser` and `mountSecret` to be set in StorageClasses using Rook, you must set the environment variable `AGENT_MOUNT_SECURITY_MODE` to `Restricted` on the Rook Ceph operator Deployment.
 
-For more information on using the Ceph feature to limit access to CephFS paths, see [Ceph Documentation - Path Restriction](http://docs.ceph.com/docs/mimic/cephfs/client-auth/#path-restriction).
+For more information on using the Ceph feature to limit access to CephFS paths, see [Ceph Documentation - Path Restriction](https://docs.ceph.com/en/latest/cephfs/client-auth/#path-restriction).
 
 ### ClusterRole
 

--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -487,14 +487,8 @@ The following storage selection settings are specific to Ceph and do not apply t
 * `initialWeight`: The initial OSD weight in TiB units. By default, this value is derived from OSD's capacity.
 * `primaryAffinity`: The [primary-affinity](https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity) value of an OSD, within range `[0, 1]` (default: `1`).
 * `osdsPerDevice`**: The number of OSDs to create on each device. High performance devices such as NVMe can handle running multiple OSDs. If desired, this can be overridden for each node and each device.
-* `encryptedDevice`**: Encrypt OSD volumes using dmcrypt ("true" or "false"). By default this option is disabled. See [encryption](http://docs.ceph.com/docs/nautilus/ceph-volume/lvm/encryption/) for more information on encryption in Ceph.
+* `encryptedDevice`**: Encrypt OSD volumes using dmcrypt ("true" or "false"). By default this option is disabled. See [encryption](http://docs.ceph.com/docs/master/ceph-volume/lvm/encryption/) for more information on encryption in Ceph.
 * `crushRoot`: The value of the `root` CRUSH map label. The default is `default`. Generally, you should not need to change this. However, if any of your topology labels may have the value `default`, you need to change `crushRoot` to avoid conflicts, since CRUSH map values need to be unique.
-
-**NOTE**: Depending on the Ceph image running in your cluster, OSDs will be configured differently. Newer images will configure OSDs with `ceph-volume`, which provides support for `osdsPerDevice`, `encryptedDevice`, as well as other features that will be exposed in future Rook releases. OSDs created prior to Rook v0.9 or with older images of Luminous and Mimic are not created with `ceph-volume` and thus would not support the same features. For `ceph-volume`, the following images are supported:
-
-* Luminous 12.2.10 or newer
-* Mimic 13.2.3 or newer
-* Nautilus
 
 ### Annotations and Labels
 

--- a/Documentation/ceph-common-issues.md
+++ b/Documentation/ceph-common-issues.md
@@ -25,12 +25,12 @@ If after trying the suggestions found on this page and the problem is not resolv
 * [Using multiple shared filesystem (CephFS) is attempted on a kernel version older than 4.7](#using-multiple-shared-filesystem-cephfs-is-attempted-on-a-kernel-version-older-than-47)
 * [Set debug log level for all Ceph daemons](#set-debug-log-level-for-all-ceph-daemons)
 * [Activate log to file for a particular Ceph daemon](#activate-log-to-file-for-a-particular-ceph-daemon)
-* [Flex storage class versus Ceph CSI storage class](#flex-storage-class-versus-ceph-csi-storage-class)
 * [A worker node using RBD devices hangs up](#a-worker-node-using-rbd-devices-hangs-up)
 * [Too few PGs per OSD warning is shown](#too-few-pgs-per-osd-warning-is-shown)
 * [LVM metadata can be corrupted with OSD on LV-backed PVC](#lvm-metadata-can-be-corrupted-with-osd-on-lv-backed-pvc)
 * [OSD prepare job fails due to low aio-max-nr setting](#osd-prepare-job-fails-due-to-low-aio-max-nr-setting)
 * [Failed to create CRDs](#failed-to-create-crds)
+* [Unexpected partitions created](#unexpected-partitions-created)
 
 See also the [CSI Troubleshooting Guide](ceph-csi-troubleshooting.md).
 
@@ -824,7 +824,6 @@ They are cases where looking at Kubernetes logs is not enough for diverse reason
 
 So for each daemon, `dataDirHostPath` is used to store logs, if logging is activated.
 Rook will bindmount `dataDirHostPath` for every pod.
-As of Ceph Nautilus 14.2.1, it is possible to enable logging for a particular daemon on the fly.
 Let's say you want to enable logging for `mon.a`, but only for this daemon.
 Using the toolbox or from inside the operator run:
 
@@ -836,24 +835,6 @@ This will activate logging on the filesystem, you will be able to find logs in `
 You don't need to restart the pod, the effect will be immediate.
 
 To disable the logging on file, simply set `log_to_file` to `false`.
-
-For Ceph Luminous/Mimic releases, `mon_cluster_log_file` and `cluster_log_file` can be set to
-`/var/log/ceph/XXXX` in the config override ConfigMap to enable logging. See the (Advanced
-Documentation)[Documentation/advanced-configuration.md#kubernetes] for information about how to use
-the config override ConfigMap.
-
-For Ceph Luminous/Mimic releases, `mon_cluster_log_file` and `cluster_log_file` can be set to `/var/log/ceph/XXXX` in the config override ConfigMap to enable logging. See the [Advanced Documentation](#custom-cephconf-settings) for information about how to use the config override ConfigMap.
-
-## Flex storage class versus Ceph CSI storage class
-
-Since Rook 1.1, Ceph CSI has become stable and moving forward is the ultimate replacement over the Flex driver.
-However, not all Flex storage classes are available through Ceph CSI since it's basically catching up on features.
-Ceph CSI in its 1.2 version (with Rook 1.1) does not support the Erasure coded pools storage class.
-
-So, if you are looking at using such storage class you should enable the Flex driver by setting `ROOK_ENABLE_FLEX_DRIVER: true` in your `operator.yaml`.
-Also, if you are in the need of specific features and wonder if CSI is capable of handling them, you should read [the ceph-csi support matrix](https://github.com/ceph/ceph-csi#support-matrix).
-
-See also the [CSI Troubleshooting Guide](ceph-csi-troubleshooting.md).
 
 ## A worker node using RBD devices hangs up
 

--- a/Documentation/ceph-configuration.md
+++ b/Documentation/ceph-configuration.md
@@ -29,11 +29,7 @@ of OSDs the user expects to have backing each pool. The Ceph [OSD and Pool confi
 docs](https://docs.ceph.com/docs/master/rados/operations/placement-groups/#a-preselection-of-pg-num)
 provide detailed information about how to tune these parameters: `osd_pool_default_pg_num` and `osd_pool_default_pgp_num`.
 
-Pools created prior to v1.1 will have a default PG count of 100. Pools created after v1.1
-will have Ceph's default PG count.
-
-An easier option exists for Rook-Ceph clusters running Ceph Nautilus (v14.2.x) or newer. Nautilus
-[introduced the PG auto-scaler mgr module](https://ceph.com/rados/new-in-nautilus-pg-merging-and-autotuning/)
+Nautilus [introduced the PG auto-scaler mgr module](https://ceph.com/rados/new-in-nautilus-pg-merging-and-autotuning/)
 capable of automatically managing PG and PGP values for pools. Please see
 [Ceph New in Nautilus: PG merging and autotuning](https://ceph.io/rados/new-in-nautilus-pg-merging-and-autotuning/)
 for more information about this module.
@@ -49,7 +45,7 @@ spec:
       enabled: true
 ```
 
-In Octopus (v15.2.x), this module is enabled by default without the above-mentioned setting.
+In Octopus (v15.2.x) and newer, this module is enabled by default without the above-mentioned setting.
 
 With that setting, the autoscaler will be enabled for all new pools. If you do not desire to have
 the autoscaler enabled for all new pools, you will need to use the Rook toolbox to enable the module

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -38,7 +38,7 @@ monitoring:
 cephClusterSpec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
-    # v13 is mimic, v14 is nautilus, and v15 is octopus.
+    # v14 is nautilus, v15 is octopus, and v16 is pacific.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such quay.io/ceph/ceph:v15.2.11-20200419

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -16,13 +16,13 @@ metadata:
 spec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
-    # v13 is mimic, v14 is nautilus, and v15 is octopus.
+    # v14 is nautilus, v15 is octopus, and v16 is pacific.
     # RECOMMENDATION: In production, use a specific version tag instead of the general v14 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such quay.io/ceph/ceph:v16.2.5-20210708
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
     image: quay.io/ceph/ceph:v16.2.5
-    # Whether to allow unsupported versions of Ceph. Currently `nautilus` and `octopus` are supported.
+    # Whether to allow unsupported versions of Ceph. Currently `nautilus`, `octopus`, and `pacific` are supported.
     # Future versions such as `pacific` would require this to be set to `true`.
     # Do not set to true in production.
     allowUnsupported: false

--- a/cluster/examples/kubernetes/ceph/filesystem.yaml
+++ b/cluster/examples/kubernetes/ceph/filesystem.yaml
@@ -17,7 +17,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode:
         none
         # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
@@ -33,7 +33,7 @@ spec:
         requireSafeReplicaSize: true
       parameters:
         # Inline compression mode for the data pool
-        # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+        # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
         compression_mode:
           none
           # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -20,7 +20,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
@@ -33,7 +33,7 @@ spec:
       codingChunks: 1
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -20,7 +20,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
@@ -35,7 +35,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -20,7 +20,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
@@ -35,7 +35,7 @@ spec:
       requireSafeReplicaSize: true
     parameters:
       # Inline compression mode for the data pool
-      # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+      # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
       compression_mode: none
       # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
       # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size

--- a/cluster/examples/kubernetes/ceph/pool.yaml
+++ b/cluster/examples/kubernetes/ceph/pool.yaml
@@ -26,10 +26,10 @@ spec:
     # The name of the failure domain to place further down replicas
     # subFailureDomain: host
   # Ceph CRUSH root location of the rule
-  # For reference: https://docs.ceph.com/docs/nautilus/rados/operations/crush-map/#types-and-buckets
+  # For reference: https://docs.ceph.com/docs/master/rados/operations/crush-map/#types-and-buckets
   #crushRoot: my-root
   # The Ceph CRUSH device class associated with the CRUSH replicated rule
-  # For reference: https://docs.ceph.com/docs/nautilus/rados/operations/crush-map/#device-classes
+  # For reference: https://docs.ceph.com/docs/master/rados/operations/crush-map/#device-classes
   #deviceClass: my-class
   # Enables collecting RBD per-image IO statistics by enabling dynamic OSD performance counters. Defaults to false.
   # For reference: https://docs.ceph.com/docs/master/mgr/prometheus/#rbd-io-statistics
@@ -38,7 +38,7 @@ spec:
   # see https://docs.ceph.com/docs/master/rados/operations/pools/#set-pool-values
   parameters:
     # Inline compression mode for the data pool
-    # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
+    # Further reference: https://docs.ceph.com/docs/master/rados/configuration/bluestore-config-ref/#inline-compression
     compression_mode: none
     # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
     # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size

--- a/pkg/daemon/ceph/client/filesystem.go
+++ b/pkg/daemon/ceph/client/filesystem.go
@@ -284,8 +284,7 @@ func FailMDS(context *clusterd.Context, clusterInfo *ClusterInfo, gid int) error
 }
 
 // FailFilesystem efficiently brings down the filesystem by marking the filesystem as down
-// and failing the MDSes using a single Ceph command. This works only from nautilus version
-// of Ceph onwards.
+// and failing the MDSes using a single Ceph command.
 func FailFilesystem(context *clusterd.Context, clusterInfo *ClusterInfo, fsName string) error {
 	args := []string{"fs", "fail", fsName}
 	_, err := NewCephCommand(context, clusterInfo, args).Run()

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -236,12 +236,12 @@ func StringInSlice(a string, list []string) bool {
 // Assume the following:
 //
 // "mon": {
-//     "ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
-//     "ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+//     "ceph version 16.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) pacific (stable)": 2,
+//     "ceph version 17.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) quincy (stable)": 1
 // }
 //
-// In the case we will pick: "ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
-// And eventually return 13.2.5
+// In the case we will pick: "ceph version 16.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) pacific (stable)": 2,
+// And eventually return 16.2.5
 func LeastUptodateDaemonVersion(context *clusterd.Context, clusterInfo *ClusterInfo, daemonType string) (cephver.CephVersion, error) {
 	var r map[string]int
 	var vv cephver.CephVersion

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -141,8 +141,8 @@ func TestDaemonMapEntry(t *testing.T) {
 	dummyVersionsRaw := []byte(`
 	{
 		"mon": {
-			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
-			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+			"ceph version 16.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) pacific (stable)": 1,
+			"ceph version 17.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) quincy (stable)": 2
 		}
 	}`)
 

--- a/pkg/operator/ceph/cluster/mgr/dashboard.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard.go
@@ -174,7 +174,7 @@ func (c *Cluster) initializeSecureDashboard() (bool, error) {
 }
 
 func (c *Cluster) createSelfSignedCert() (bool, error) {
-	// create a self-signed cert for the https connections required in mimic
+	// create a self-signed cert for the https connections
 	args := []string{"dashboard", "create-self-signed-cert"}
 
 	// retry a few times in the case that the mgr module is not ready to accept commands

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -35,8 +35,8 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	fakeRunningVersions := []byte(`
 	{
 		"mon": {
-			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
-			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+			"ceph version 16.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) pacific (stable)": 1,
+			"ceph version 17.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) quincy (stable)": 2
 		}
 	}`)
 	var dummyRunningVersions cephv1.CephDaemonsVersions
@@ -51,8 +51,8 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	fakeRunningVersions = []byte(`
 	{
 		"overall": {
-			"ceph version 13.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) mimic (stable)": 1,
-			"ceph version 14.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+			"ceph version 16.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) pacific (stable)": 1,
+			"ceph version 17.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) quincy (stable)": 2
 		}
 	}`)
 	var dummyRunningVersions2 cephv1.CephDaemonsVersions
@@ -79,11 +79,11 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.True(t, m)
 
 	// 4 test - spec version is higher than running cluster --> we upgrade
-	fakeImageVersion = cephver.Nautilus
+	fakeImageVersion = cephver.Pacific
 	fakeRunningVersions = []byte(`
 	{
 		"overall": {
-			"ceph version 13.2.0 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) mimic (stable)": 2
+			"ceph version 15.2.5 (cbff874f9007f1869bfd3821b7e33b2a6ffd4988) octopus (stable)": 2
 		}
 	}`)
 	var dummyRunningVersions4 cephv1.CephDaemonsVersions
@@ -95,12 +95,12 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.True(t, m)
 
 	// 5 test - spec version and running cluster versions are identical --> we upgrade
-	fakeImageVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 2,
+	fakeImageVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 2,
 		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc"}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {
-				"ceph version 14.2.2 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+				"ceph version 16.2.2 (3a54b2b6d167d4a2a19e003a705696d4fe619afc) pacific (stable)": 2
 			}
 		}`)
 	var dummyRunningVersions5 cephv1.CephDaemonsVersions
@@ -112,12 +112,12 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.False(t, m)
 
 	// 6 test - spec version and running cluster have different commit ID
-	fakeImageVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11, Build: 139,
+	fakeImageVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 11, Build: 139,
 		CommitID: "5c0dc966af809fd1d429ec7bac48962a746af243"}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {
-				"ceph version 14.2.11-139.el8cp (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+				"ceph version 16.2.11-139.el8cp (3a54b2b6d167d4a2a19e003a705696d4fe619afc) pacific (stable)": 2
 			}
 		}`)
 	var dummyRunningVersions6 cephv1.CephDaemonsVersions
@@ -129,12 +129,12 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	assert.True(t, m)
 
 	// 7 test - spec version and running cluster have same commit ID
-	fakeImageVersion = cephver.CephVersion{Major: 14, Minor: 2, Extra: 11, Build: 139,
+	fakeImageVersion = cephver.CephVersion{Major: 16, Minor: 2, Extra: 11, Build: 139,
 		CommitID: "3a54b2b6d167d4a2a19e003a705696d4fe619afc"}
 	fakeRunningVersions = []byte(`
 		{
 			"overall": {
-				"ceph version 14.2.11-139.el8cp (3a54b2b6d167d4a2a19e003a705696d4fe619afc) nautilus (stable)": 2
+				"ceph version 16.2.11-139.el8cp (3a54b2b6d167d4a2a19e003a705696d4fe619afc) pacific (stable)": 2
 			}
 		}`)
 	var dummyRunningVersions7 cephv1.CephDaemonsVersions

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -53,24 +53,24 @@ func extractVersionHelper(t *testing.T, text string, major, minor, extra, build 
 
 func TestExtractVersion(t *testing.T) {
 	// release build
-	v0c := "ceph version 13.2.6 (ae699615bac534ea496ee965ac6192cb7e0e07c1) mimic (stable)"
+	v0c := "ceph version 16.2.6 (ae699615bac534ea496ee965ac6192cb7e0e07c1) pacific (stable)"
 	v0d := `
 root@7a97f5a78bc6:/# ceph --version
-ceph version 13.2.6 (ae699615bac534ea496ee965ac6192cb7e0e07c1) mimic (stable)
+ceph version 16.2.6 (ae699615bac534ea496ee965ac6192cb7e0e07c1) pacific (stable)
 `
-	extractVersionHelper(t, v0c, 13, 2, 6, 0, "ae699615bac534ea496ee965ac6192cb7e0e07c1")
-	extractVersionHelper(t, v0d, 13, 2, 6, 0, "ae699615bac534ea496ee965ac6192cb7e0e07c1")
+	extractVersionHelper(t, v0c, 16, 2, 6, 0, "ae699615bac534ea496ee965ac6192cb7e0e07c1")
+	extractVersionHelper(t, v0d, 16, 2, 6, 0, "ae699615bac534ea496ee965ac6192cb7e0e07c1")
 
 	// development build
-	v1c := "ceph version 14.1.33-403-g7ba6bece41 (7ba6bece4187eda5d05a9b84211fe6ba8dd287bd) nautilus (rc)"
+	v1c := "ceph version 16.1.33-403-g7ba6bece41 (7ba6bece4187eda5d05a9b84211fe6ba8dd287bd) pacific (rc)"
 	v1d := `
 bin/ceph --version
 *** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
-ceph version 14.1.33-403-g7ba6bece41
+ceph version 16.1.33-403-g7ba6bece41
 (7ba6bece4187eda5d05a9b84211fe6ba8dd287bd) nautilus (rc)
 `
-	extractVersionHelper(t, v1c, 14, 1, 33, 403, "7ba6bece4187eda5d05a9b84211fe6ba8dd287bd")
-	extractVersionHelper(t, v1d, 14, 1, 33, 403, "7ba6bece4187eda5d05a9b84211fe6ba8dd287bd")
+	extractVersionHelper(t, v1c, 16, 1, 33, 403, "7ba6bece4187eda5d05a9b84211fe6ba8dd287bd")
+	extractVersionHelper(t, v1d, 16, 1, 33, 403, "7ba6bece4187eda5d05a9b84211fe6ba8dd287bd")
 
 	// build without git version info. it is possible to build the ceph tree
 	// without a version number, but none of the container builds do this.
@@ -78,7 +78,7 @@ ceph version 14.1.33-403-g7ba6bece41
 	// explicitly adding fine-grained versioning to avoid issues with
 	// release granularity. adding the reverse name-to-version is easy
 	// enough if this ever becomes a need.
-	v2c := "ceph version Development (no_version) nautilus (rc)"
+	v2c := "ceph version Development (no_version) pacific (rc)"
 	v2d := `
 bin/ceph --version
 *** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
References to luminous and mimic, and unnecessary references to nautilus were found in the docs that have been cleaned up and clarified. At the same time, the tests are updated to use more recent versions.

**Which issue is resolved by this Pull Request:**
Resolves #8409 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
