### PR TITLE
ci: Enable flex integration suite on K8s 1.11

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -26,12 +26,10 @@ jobs:
         go-version: 1.16
 
     - name: setup minikube
-      uses: manusa/actions-setup-minikube@v2.4.2
-      with:
-        minikube version: 'v1.21.0'
-        kubernetes version: 'v1.15.12'
-        start args: --memory 6g --cpus=2
-        github token: ${{ secrets.GITHUB_TOKEN }}
+      working-directory:
+      run: |
+        tests/scripts/github-action-helper.sh minikube_deps
+        minikube start --kubernetes-version=1.11.10 --driver=docker
 
     - name: print k8s cluster status
       run: tests/scripts/github-action-helper.sh print_k8s_cluster_status

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.11.10','v1.15.12','v1.18.15','v1.21.0']
+        kubernetes-versions : ['v1.15.12','v1.18.15','v1.21.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -36,6 +36,57 @@ jobs:
         minikube version: 'v1.21.0'
         kubernetes version: ${{ matrix.kubernetes-versions }}
         start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: print k8s cluster status
+      run: tests/scripts/github-action-helper.sh print_k8s_cluster_status
+
+    - name: use local disk
+      run: tests/scripts/github-action-helper.sh use_local_disk_for_integration_test
+
+    - name: build rook
+      run: tests/scripts/github-action-helper.sh build_rook
+
+    - name: TestCephFlexSuite
+      run: |
+       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+       go test -v -timeout 1800s -run CephFlexSuite github.com/rook/rook/tests/integration
+
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ceph-flex-suite-artifact
+        path: /home/runner/work/rook/rook/tests/integration/_output/tests/
+
+    - name: setup tmate session for debugging
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120
+
+  TestCephFlexSuite-on-older-K8s-version:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-versions : ['v1.11.10']
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.4.2
+      with:
+        minikube version: 'v1.6.1'
+        kubernetes version: ${{ matrix.kubernetes-versions }}
+        start args: --memory 6g --cpus=2 --force
         github token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: print k8s cluster status

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -28,6 +28,17 @@ INTERNAL_ERROR="INTERNAL_ERROR"
 # FUNCTIONS #
 #############
 
+function minikube_deps() {
+  cd
+  curl -LO https://storage.googleapis.com/minikube/releases/v1.9.0/minikube-linux-amd64
+  sudo install minikube-linux-amd64 /usr/local/bin/minikube
+  cp /usr/local/bin/minikube /home/runner/work/_temp/
+  curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+  curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+  echo "$(<kubectl.sha256) kubectl" | sha256sum --check
+  sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+}
+
 function install_deps() {
   sudo wget https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -O /usr/local/bin/yq
   sudo chmod +x /usr/local/bin/yq


### PR DESCRIPTION
since this #8422 pr merged in branch 1.7,
ci(master/release integration test) is
failing for flex suite because it is not
able to set up minikube with error
```
Specified Kubernetes version 1.11.10 is less than the oldest
supported version: v1.14.0

! You can force an unsupported Kubernetes version via the --force flag
```
https://github.com/rook/rook/runs/3186798720?check_suite_focus=true

because in that pr we added new k8s version
v1.11.10 for flex suite test.

we are now trying with macos hyperkit for k8s v1.11.10.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
