### PR TITLE
ceph: add mirroring peer specification to CephBlockPool CRD (backport #8380)

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -779,7 +779,7 @@ jobs:
 
     - name: add block mirror peer secret to the other cluster
       run: |
-        kubectl -n rook-ceph-secondary patch cephrbdmirror my-rbd-mirror --type merge -p '{"spec":{"peers": {"secretNames": ["pool-peer-token-replicapool-config"]}}}'
+        kubectl -n rook-ceph-secondary patch cephblockpool replicapool --type merge -p '{"spec":{"mirroring":{"peers": {"secretNames": ["pool-peer-token-replicapool-config"]}}}}'
 
     - name: verify image has been mirrored
       run: |

--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -208,6 +208,8 @@ stretched) then you will have 2 replicas per datacenter where each replica ends 
   * `snapshotSchedules`: schedule(s) snapshot at the **pool** level. **Only** supported as of Ceph Octopus release. One or more schedules are supported.
     * `interval`: frequency of the snapshots. The interval can be specified in days, hours, or minutes using d, h, m suffix respectively.
     * `startTime`: optional, determines at what time the snapshot process starts, specified using the ISO 8601 time format.
+  * `peers`: to configure mirroring peers
+    * `secretNames`:  a list of peers to connect to. Currently (Ceph Octopus release) **only a single** peer is supported where a peer represents a Ceph cluster.
 
 * `statusCheck`: Sets up pool mirroring status
   * `mirror`: displays the mirroring status

--- a/Documentation/ceph-rbd-mirror-crd.md
+++ b/Documentation/ceph-rbd-mirror-crd.md
@@ -41,9 +41,6 @@ If any setting is unspecified, a suitable default will be used automatically.
 ### RBDMirror Settings
 
 * `count`: The number of rbd mirror instance to run.
-* `peers`: to configure mirroring peers
-  * `secretNames`:  a list of peers to connect to. Currently (Ceph Octopus release) **only a single** peer is supported where a peer represents a Ceph cluster.
-  However, if you want to enable mirroring of multiple pools, you would have to have **one Secret per pool**, but the token (the peer identity) must be the same.
 * `placement`: The rbd mirror pods can be given standard Kubernetes placement restrictions with `nodeAffinity`, `tolerations`, `podAffinity`, and `podAntiAffinity` similar to placement defined for daemons configured by the [cluster CRD](https://github.com/rook/rook/blob/{{ branchName }}/cluster/examples/kubernetes/ceph/cluster.yaml).
 * `annotations`: Key value pair list of annotations to add.
 * `labels`: Key value pair list of labels to add.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -40,6 +40,7 @@ So the CephCLuster spec field `image` must be updated to point to quay, like `im
 - Add support for Kubernetes TLS secret for referring TLS certs needed for ceph RGW server.
 - Stretch clusters are considered stable
   - Ceph v16.2.5 or greater is required for stretch clusters
+- The use of peer secret names in CephRBDMirror is deprecated. Please use CephBlockPool CR to configure peer secret names and import peers. Checkout the `mirroring` section in the CephBlockPool [spec](Documentation/ceph-pool-crd.md#spec) for more details.
 
 ### Cassandra
 

--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -87,6 +87,16 @@ spec:
                     mode:
                       description: 'Mode is the mirroring mode: either pool or image'
                       type: string
+                    peers:
+                      description: Peers represents the peers spec
+                      nullable: true
+                      properties:
+                        secretNames:
+                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                          items:
+                            type: string
+                          type: array
+                      type: object
                     snapshotSchedules:
                       description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                       items:
@@ -4497,6 +4507,16 @@ spec:
                           mode:
                             description: 'Mode is the mirroring mode: either pool or image'
                             type: string
+                          peers:
+                            description: Peers represents the peers spec
+                            nullable: true
+                            properties:
+                              secretNames:
+                                description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                                items:
+                                  type: string
+                                type: array
+                            type: object
                           snapshotSchedules:
                             description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                             items:
@@ -4655,6 +4675,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -6406,6 +6436,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7331,6 +7371,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7750,6 +7800,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7906,6 +7966,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -9777,6 +9847,10 @@ spec:
                   enum:
                   - image
                   - pool
+                peers:
+                  properties:
+                    secretNames:
+                      type: array
                 snapshotSchedules:
                   type: object
                   properties:

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -89,6 +89,16 @@ spec:
                     mode:
                       description: 'Mode is the mirroring mode: either pool or image'
                       type: string
+                    peers:
+                      description: Peers represents the peers spec
+                      nullable: true
+                      properties:
+                        secretNames:
+                          description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                          items:
+                            type: string
+                          type: array
+                      type: object
                     snapshotSchedules:
                       description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                       items:
@@ -4495,6 +4505,16 @@ spec:
                           mode:
                             description: 'Mode is the mirroring mode: either pool or image'
                             type: string
+                          peers:
+                            description: Peers represents the peers spec
+                            nullable: true
+                            properties:
+                              secretNames:
+                                description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                                items:
+                                  type: string
+                                type: array
+                            type: object
                           snapshotSchedules:
                             description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                             items:
@@ -4653,6 +4673,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -6401,6 +6431,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7326,6 +7366,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7742,6 +7792,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:
@@ -7898,6 +7958,16 @@ spec:
                         mode:
                           description: 'Mode is the mirroring mode: either pool or image'
                           type: string
+                        peers:
+                          description: Peers represents the peers spec
+                          nullable: true
+                          properties:
+                            secretNames:
+                              description: SecretNames represents the Kubernetes Secret names to add rbd-mirror or cephfs-mirror peers
+                              items:
+                                type: string
+                              type: array
+                          type: object
                         snapshotSchedules:
                           description: SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
                           items:

--- a/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/pre-k8s-1.16/crds.yaml
@@ -684,6 +684,10 @@ spec:
                   enum:
                   - image
                   - pool
+                peers:
+                  properties:
+                    secretNames:
+                      type: array
                 snapshotSchedules:
                   type: object
                   properties:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -873,6 +873,11 @@ type MirroringSpec struct {
 	// SnapshotSchedules is the scheduling of snapshot for mirrored images/pools
 	// +optional
 	SnapshotSchedules []SnapshotScheduleSpec `json:"snapshotSchedules,omitempty"`
+
+	// Peers represents the peers spec
+	// +nullable
+	// +optional
+	Peers *MirroringPeerSpec `json:"peers,omitempty"`
 }
 
 // SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -2067,6 +2067,11 @@ func (in *MirroringSpec) DeepCopyInto(out *MirroringSpec) {
 		*out = make([]SnapshotScheduleSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.Peers != nil {
+		in, out := &in.Peers, &out.Peers
+		*out = new(MirroringPeerSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/daemon/ceph/client/mirror.go
+++ b/pkg/daemon/ceph/client/mirror.go
@@ -59,6 +59,7 @@ func ImportRBDMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluste
 		return errors.Wrapf(err, "failed to add rbd-mirror peer token for pool %q. %s", poolName, output)
 	}
 
+	logger.Infof("successfully added rbd-mirror peer token for pool %q", poolName)
 	return nil
 }
 

--- a/pkg/operator/ceph/cluster/rbd/config.go
+++ b/pkg/operator/ceph/cluster/rbd/config.go
@@ -83,6 +83,8 @@ func (r *ReconcileCephRBDMirror) reconcileAddBoostrapPeer(cephRBDMirror *cephv1.
 	ctx := context.TODO()
 	// List all the peers secret, we can have more than one peer we might want to configure
 	// For each, get the Kubernetes Secret and import the "peer token" so that we can configure the mirroring
+
+	logger.Warning("(DEPRECATED) use of peer secret names in CephRBDMirror is deprecated. Please use CephBlockPool CR to configure peer secret names and import peers.")
 	for _, peerSecret := range cephRBDMirror.Spec.Peers.SecretNames {
 		logger.Debugf("fetching bootstrap peer kubernetes secret %q", peerSecret)
 		s, err := r.context.Clientset.CoreV1().Secrets(r.clusterInfo.Namespace).Get(ctx, peerSecret, metav1.GetOptions{})

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -301,6 +301,13 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 			}
 		}
 
+		// Add bootstrap peer if any
+		logger.Debug("reconciling ceph bootstrap peers import")
+		reconcileResponse, err = r.reconcileAddBoostrapPeer(cephBlockPool, request.NamespacedName)
+		if err != nil {
+			return reconcileResponse, errors.Wrap(err, "failed to add ceph rbd mirror peer")
+		}
+
 		// Set Ready status, we are done reconciling
 		updateStatus(r.client, request.NamespacedName, cephv1.ConditionReady, opcontroller.GenerateStatusInfo(cephBlockPool))
 

--- a/pkg/operator/ceph/pool/peers.go
+++ b/pkg/operator/ceph/pool/peers.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *ReconcileCephBlockPool) reconcileAddBoostrapPeer(pool *cephv1.CephBlockPool,
+	namespacedName types.NamespacedName) (reconcile.Result, error) {
+
+	if pool.Spec.Mirroring.Peers == nil {
+		return reconcile.Result{}, nil
+	}
+
+	// List all the peers secret, we can have more than one peer we might want to configure
+	// For each, get the Kubernetes Secret and import the "peer token" so that we can configure the mirroring
+	for _, peerSecret := range pool.Spec.Mirroring.Peers.SecretNames {
+		logger.Debugf("fetching bootstrap peer kubernetes secret %q", peerSecret)
+		s, err := r.context.Clientset.CoreV1().Secrets(r.clusterInfo.Namespace).Get(context.TODO(), peerSecret, metav1.GetOptions{})
+		// We don't care about IsNotFound here, we still need to fail
+		if err != nil {
+			return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to fetch kubernetes secret %q bootstrap peer", peerSecret)
+		}
+
+		// Validate peer secret content
+		err = opcontroller.ValidatePeerToken(pool, s.Data)
+		if err != nil {
+			return opcontroller.ImmediateRetryResult, errors.Wrapf(err, "failed to validate rbd-mirror bootstrap peer secret %q data", peerSecret)
+		}
+
+		// Import bootstrap peer
+		err = client.ImportRBDMirrorBootstrapPeer(r.context, r.clusterInfo, string(s.Data["pool"]), string(s.Data["direction"]), s.Data["token"])
+		if err != nil {
+			return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to import bootstrap peer token")
+		}
+	}
+
+	return reconcile.Result{}, nil
+}


### PR DESCRIPTION
Instead of having the RBDMirroringPeerSpec in the RBDMirror CRD we want
to move it on the CephBlockPool CRD so that each pool can have its own peer.
This enables pool to re-use an existing peer secret if it points to the
same cluster peer.So we don't need to duplicate secret peer anymore.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 3b50f5fd007157941ab8508655269e3634ce04da)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
