### PR TITLE
ceph: ignore errors when mirroring is not enabled on the filesystem

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -727,7 +727,6 @@ jobs:
         yq w -i -d1 cluster-test.yaml spec.dashboard.enabled false
         yq w -i -d1 cluster-test.yaml spec.storage.useAllDevices false
         yq w -i -d1 cluster-test.yaml spec.storage.deviceFilter ${BLOCK}1
-        yq w -i -d1 cluster-test.yaml spec.cephVersion.image ceph/daemon-base:latest-pacific-devel
         kubectl create -f cluster-test.yaml -f rbdmirror.yaml -f filesystem-mirror.yaml -f toolbox.yaml
 
     # cephfs-mirroring is a push operation

--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -79,6 +79,10 @@ func DisableFilesystemSnapshotMirror(context *clusterd.Context, clusterInfo *Clu
 	// Run command
 	output, err := cmd.Run()
 	if err != nil {
+		if code, err := exec.ExtractExitCode(err); err == nil && code == int(syscall.ENOTSUP) {
+			logger.Debug("filesystem mirroring is not enabled, nothing to disable")
+			return nil
+		}
 		return errors.Wrapf(err, "failed to disable ceph filesystem snapshot mirror for filesystem %q. %s", filesystem, output)
 	}
 

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mon"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
+	"github.com/rook/rook/pkg/operator/ceph/file/mirror"
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -289,9 +290,7 @@ func (r *ReconcileCephFilesystem) reconcile(request reconcile.Request) (reconcil
 	}
 
 	// Enable mirroring if needed
-	// TODO: change me to 16.2.5 once it's out, in the mean this allows us to run the CI and validate the code
-	// if r.clusterInfo.CephVersion.IsAtLeast(mirror.PeerAdditionMinVersion) {
-	if r.clusterInfo.CephVersion.IsAtLeastPacific() {
+	if r.clusterInfo.CephVersion.IsAtLeast(mirror.PeerAdditionMinVersion) {
 		// Disable mirroring on that filesystem if needed
 		if cephFilesystem.Spec.Mirroring != nil {
 			if !cephFilesystem.Spec.Mirroring.Enabled {

--- a/pkg/operator/ceph/file/mirror/config.go
+++ b/pkg/operator/ceph/file/mirror/config.go
@@ -41,8 +41,7 @@ const (
 
 var (
 	// PeerAdditionMinVersion This version includes a number of fixes for snapshots and mirror status
-	// TODO change me to 16.2.5
-	PeerAdditionMinVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 2}
+	PeerAdditionMinVersion = version.CephVersion{Major: 16, Minor: 2, Extra: 5}
 )
 
 // daemonConfig for a single rbd-mirror

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -36,7 +36,7 @@ func Retry(maxRetries int, delay time.Duration, f func() error) error {
 
 		tries++
 		if tries > maxRetries {
-			return fmt.Errorf("max retries exceeded, last err: %+v", err)
+			return fmt.Errorf("max retries exceeded, last err: %v", err)
 		}
 
 		logger.Infof("retrying after %v, last error: %v", delay, err)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Trying to disable mirroring on a cluster where mirroring is not enabled
results in an error during upgrades. Let's catch this error and ignore
it.

Funny enough the exec error resembles to:

```
Error ENOTSUP: Module 'mirroring' is not enabled (required by command 'fs snapshot mirror disable'): use `ceph mgr module enable mirroring` to enable it: exit status 95
```

So we get ENOTSUP which is 45 but exit status 95...

Closes: #8438
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #8438

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
