### PR TITLE
build: Run flex suite only on K8s 1.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,159 @@
+// Rook build for Jenkins Pipelines
+
+pipeline {
+   parameters {
+         booleanParam(defaultValue: false, description: 'Skip Integration Tests?', name: 'skipIntegrationTests')
+      }
+    agent { label 'ec2-stateful' }
+
+    options {
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr: '200'))
+        timeout(time: 2, unit: 'HOURS')
+        timestamps()
+    }
+
+    stages {
+        stage('Pre Build check'){
+            when { branch "PR-*" }
+            steps {
+                script {
+                    // When running in a PR we assuming it's not an official build
+                    env.isOfficialBuild = "false"
+                    env.shouldBuild = "true"
+                    env.testProvider = "ceph"
+                    env.testArgs = "min-test-matrix"
+                }
+            }
+        }
+        stage('Build') {
+            when {
+                expression {
+                    return env.shouldBuild != "false"
+                }
+            }
+            steps {
+                // run the build
+                script {
+                    if (env.isOfficialBuild == "false") {
+                        sh (script: "build/run make -j\$(nproc) build", returnStdout: true)
+                    } else {
+                        sh (script: "build/run make -j\$(nproc) build.all", returnStdout: true)
+                    }
+                }
+                sh 'git status'
+            }
+        }
+
+        stage('Integration Tests') {
+            when {
+                expression {
+                    return env.shouldBuild != "false" && !params.skipIntegrationTests
+                }
+            }
+            steps {
+                sh 'cat _output/version | xargs tests/scripts/makeTestImages.sh  save amd64'
+                stash name: 'repo-amd64',includes: 'ceph-amd64.tar,cassandra-amd64.tar,nfs-amd64.tar,build/common.sh,_output/tests/linux_amd64/,_output/charts/,tests/scripts/,cluster/'
+                script {
+                    def data = [
+                        "aws_1.11.x": "v1.11.10"
+                    ]
+                    testruns = [:]
+                    for (kv in mapToList(data)) {
+                        testruns[kv[0]] = RunIntegrationTest(kv[0], kv[1])
+                    }
+                    try{
+                        parallel testruns
+                    }
+
+                    finally{
+                        sh "build/run go get -u -f  github.com/jstemmer/go-junit-report"
+                        for (kv in mapToList(data)) {
+                            unstash "${kv[1]}_result"
+                            sh "cat _output/tests/${kv[1]}_integrationTests.log | _output/go-junit-report > _output/tests/${kv[1]}_integrationTests.xml"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archive '_output/tests/*'
+            junit allowEmptyResults: true, keepLongStdio: true, testResults: '_output/tests/*.xml'
+            sh 'make -j\$(nproc) clean'
+            sh 'make -j\$(nproc) prune PRUNE_HOURS=48 PRUNE_KEEP=48'
+            sh 'make -j\$(nproc) -C build/release clean'
+            deleteDir()
+        }
+    }
+}
+def RunIntegrationTest(k, v) {
+  return {
+      node("${k}") {
+        script{
+            try{
+                withEnv(["KUBE_VERSION=${v}"]){
+                    echo "running tests on k8s version ${v}"
+                    unstash 'repo-amd64'
+                    sh "tests/scripts/kubeadm.sh clean || 1"
+                    sh 'tests/scripts/makeTestImages.sh load amd64'
+                    sh "tests/scripts/kubeadm.sh up"
+                    sh '''#!/bin/bash
+                          export KUBECONFIG=$HOME/admin.conf
+                          tests/scripts/helm.sh up'''
+                    try{
+                        echo "Running full regression"
+                        sh '''#!/bin/bash
+                              set -o pipefail
+                              export KUBECONFIG=$HOME/admin.conf \
+                                  SKIP_TEST_CLEANUP=false \
+                                  SKIP_CLEANUP_POLICY=false \
+                                  SKIP_CASSANDRA_TESTS=true \
+                                  TEST_ENV_NAME='''+"${k}"+''' \
+                                  TEST_BASE_DIR="WORKING_DIR" \
+                                  TEST_LOG_COLLECTION_LEVEL='''+"${env.getLogs}"+''' \
+                                  STORAGE_PROVIDER_TESTS='''+"${env.testProvider}"+''' \
+                                  TEST_ARGUMENTS='''+"${env.testArgs}"+''' \
+                                  TEST_IS_OFFICIAL_BUILD='''+"${env.isOfficialBuild}"+''' \
+                                  TEST_SCRATCH_DEVICE=/dev/nvme0n1
+                              kubectl config view
+                              _output/tests/linux_amd64/integration -test.v -test.timeout 7200s 2>&1 | tee _output/tests/integrationTests.log'''
+                    }
+                    finally{
+                        sh "journalctl -u kubelet > _output/tests/kubelet_${v}.log"
+                        sh "journalctl > _output/tests/system_journalctl_${v}.log"
+                        sh "dmesg > _output/tests/system_dmesg_${v}.log"
+                        sh '''#!/bin/bash
+                              export KUBECONFIG=$HOME/admin.conf
+                              tests/scripts/helm.sh clean || true'''
+                        sh "mv _output/tests/integrationTests.log _output/tests/${v}_integrationTests.log"
+                        stash name: "${v}_result",includes : "_output/tests/${v}_integrationTests.log"
+                    }
+                }
+            }
+            finally{
+                archive '_output/tests/*.log'
+                sh 'sudo rm -rf ${PWD}/rook-test'
+                sh 'sudo ls -l ${PWD}'
+                deleteDir()
+            }
+        }
+      }
+  }
+}
+
+// Required due to JENKINS-27421
+@NonCPS
+List<List<?>> mapToList(Map map) {
+  return map.collect { it ->[it.key, it.value]}
+}
+
+@NonCPS
+def evaluateJson(String json, String gpath){
+    //parse json
+    def ojson = new groovy.json.JsonSlurper().parseText(json)
+    //evaluate gpath as a gstring template where $json is a parsed json parameter
+    return new groovy.text.GStringTemplateEngine().createTemplate(gpath).make(json:ojson).toString()
+}

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -39,7 +39,7 @@ const (
 	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
 	// instead of running all suites on all versions
 	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion      = "1.15.0"
+	flexDriverMinimalTestVersion      = "1.11.0"
 	cephMasterSuiteMinimalTestVersion = "1.16.0"
 	multiClusterMinimalTestVersion    = "1.16.0"
 	helmMinimalTestVersion            = "1.17.0"


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Temporarily continue running the flex suite on K8s 1.11 until the github action is working in this version or until the flex driver is removed in rook v1.8.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
