### PR TITLE
ceph: move scheme initialization to the same place

### DIFF
--- a/pkg/operator/ceph/client/controller.go
+++ b/pkg/operator/ceph/client/controller.go
@@ -78,15 +78,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	return &ReconcileCephClient{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/cluster/controller.go
+++ b/pkg/operator/ceph/cluster/controller.go
@@ -113,12 +113,6 @@ func Add(mgr manager.Manager, ctx *clusterd.Context, clusterController *ClusterC
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, ctx *clusterd.Context, clusterController *ClusterController) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	// add "rook-" prefix to the controller name to make sure it is clear to all reading the events
 	// that they are coming from Rook. The controller name already has context that it is for Ceph
 	// and from the cluster controller.
@@ -126,7 +120,7 @@ func newReconciler(mgr manager.Manager, ctx *clusterd.Context, clusterController
 
 	return &ReconcileCephCluster{
 		client:            mgr.GetClient(),
-		scheme:            mgrScheme,
+		scheme:            mgr.GetScheme(),
 		context:           ctx,
 		clusterController: clusterController,
 	}

--- a/pkg/operator/ceph/cluster/rbd/controller.go
+++ b/pkg/operator/ceph/cluster/rbd/controller.go
@@ -92,14 +92,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileCephRBDMirror{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 		peers:   make(map[string]*peerSpec),
 	}

--- a/pkg/operator/ceph/cr_manager.go
+++ b/pkg/operator/ceph/cr_manager.go
@@ -20,18 +20,46 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
+	"k8s.io/apimachinery/pkg/runtime"
 
+	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	healthchecking "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+var (
+	resourcesSchemeFuncs = []func(*runtime.Scheme) error{
+		clientgoscheme.AddToScheme,
+		mapiv1.AddToScheme,
+		healthchecking.AddToScheme,
+		cephv1.AddToScheme,
+		v1alpha2.AddToScheme,
+	}
+)
+
 func (o *Operator) startManager(namespaceToWatch string, context context.Context, mgrErrorCh chan error) {
+	logger.Info("setting up schemes")
+	// Setup Scheme for all resources
+	scheme := runtime.NewScheme()
+	for _, f := range resourcesSchemeFuncs {
+		err := f(scheme)
+		if err != nil {
+			mgrErrorCh <- errors.Wrap(err, "failed to add to scheme")
+			return
+		}
+	}
+
 	// Set up a manager
 	mgrOpts := manager.Options{
 		LeaderElection: false,
 		Namespace:      namespaceToWatch,
+		Scheme:         scheme,
 	}
 
 	logger.Info("setting up the controller-runtime manager")

--- a/pkg/operator/ceph/disruption/clusterdisruption/add.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/add.go
@@ -42,19 +42,12 @@ import (
 // Read more about how Managers, Controllers, and their Watches, Handlers, Predicates, etc work here:
 // https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg
 func Add(mgr manager.Manager, context *controllerconfig.Context) error {
-
-	// Add the cephv1 scheme to the manager scheme
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		return errors.Wrap(err, "failed to add ceph scheme to manager scheme")
-	}
-
 	// This will be used to associate namespaces and cephclusters.
 	sharedClusterMap := &ClusterMap{}
 
 	reconcileClusterDisruption := &ReconcileClusterDisruption{
 		client:     mgr.GetClient(),
-		scheme:     mgrScheme,
+		scheme:     mgr.GetScheme(),
 		context:    context,
 		clusterMap: sharedClusterMap,
 	}

--- a/pkg/operator/ceph/disruption/machinedisruption/add.go
+++ b/pkg/operator/ceph/disruption/machinedisruption/add.go
@@ -18,7 +18,6 @@ package machinedisruption
 
 import (
 	healthchecking "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
-	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -32,17 +31,9 @@ import (
 // Read more about how Managers, Controllers, and their Watches, Handlers, Predicates, etc work here:
 // https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg
 func Add(mgr manager.Manager, ctx *controllerconfig.Context) error {
-	mgrScheme := mgr.GetScheme()
-	if err := healthchecking.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrap(err, "failed to add to healthchecking scheme")
-	}
-	if err := cephv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrap(err, "failed to add to ceph scheme")
-	}
-
 	reconcileMachineDisruption := &MachineDisruptionReconciler{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: ctx,
 	}
 

--- a/pkg/operator/ceph/disruption/machinelabel/add.go
+++ b/pkg/operator/ceph/disruption/machinelabel/add.go
@@ -19,7 +19,6 @@ package machinelabel
 import (
 	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	"github.com/pkg/errors"
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/disruption/controllerconfig"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,17 +40,9 @@ const (
 // Read more about how Managers, Controllers, and their Watches, Handlers, Predicates, etc work here:
 // https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg
 func Add(mgr manager.Manager, context *controllerconfig.Context) error {
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrap(err, "failed to add scheme to ceph")
-	}
-	if err := mapiv1.AddToScheme(mgrScheme); err != nil {
-		return errors.Wrap(err, "failed to add scheme to map")
-	}
-
 	reconcileMachineLabel := &ReconcileMachineLabel{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		options: context,
 	}
 

--- a/pkg/operator/ceph/file/controller.go
+++ b/pkg/operator/ceph/file/controller.go
@@ -90,14 +90,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileCephFilesystem{
 		client:     mgr.GetClient(),
-		scheme:     mgrScheme,
+		scheme:     mgr.GetScheme(),
 		context:    context,
 		fsChannels: make(map[string]*fsHealth),
 	}

--- a/pkg/operator/ceph/file/mirror/controller.go
+++ b/pkg/operator/ceph/file/mirror/controller.go
@@ -84,14 +84,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileFilesystemMirror{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/nfs/controller.go
+++ b/pkg/operator/ceph/nfs/controller.go
@@ -84,15 +84,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	return &ReconcileCephNFS{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -99,16 +99,10 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	context.Client = mgr.GetClient()
 	return &ReconcileCephObjectStore{
 		client:              mgr.GetClient(),
-		scheme:              mgrScheme,
+		scheme:              mgr.GetScheme(),
 		context:             context,
 		bktclient:           bktclient.NewForConfigOrDie(context.KubeConfig),
 		objectStoreChannels: make(map[string]*objectStoreHealth),

--- a/pkg/operator/ceph/object/realm/controller.go
+++ b/pkg/operator/ceph/object/realm/controller.go
@@ -86,15 +86,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	return &ReconcileObjectRealm{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/object/user/controller.go
+++ b/pkg/operator/ceph/object/user/controller.go
@@ -85,15 +85,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
-
 	return &ReconcileObjectStoreUser{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/object/zone/controller.go
+++ b/pkg/operator/ceph/object/zone/controller.go
@@ -82,14 +82,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileObjectZone{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/object/zonegroup/controller.go
+++ b/pkg/operator/ceph/object/zonegroup/controller.go
@@ -80,14 +80,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileObjectZoneGroup{
 		client:  mgr.GetClient(),
-		scheme:  mgrScheme,
+		scheme:  mgr.GetScheme(),
 		context: context,
 	}
 }

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -84,14 +84,9 @@ func Add(mgr manager.Manager, context *clusterd.Context) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, context *clusterd.Context) reconcile.Reconciler {
-	// Add the cephv1 scheme to the manager scheme so that the controller knows about it
-	mgrScheme := mgr.GetScheme()
-	if err := cephv1.AddToScheme(mgr.GetScheme()); err != nil {
-		panic(err)
-	}
 	return &ReconcileCephBlockPool{
 		client:            mgr.GetClient(),
-		scheme:            mgrScheme,
+		scheme:            mgr.GetScheme(),
 		context:           context,
 		blockPoolChannels: make(map[string]*blockPoolHealth),
 	}


### PR DESCRIPTION
**Description of your changes:**

Let's initialize the schemes in a single place instead of doing it
when each controller initializes.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
