### PR TITLE
ceph: fix example of cluster on local pvc

### DIFF
--- a/cluster/examples/kubernetes/ceph/cluster-on-local-pvc.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster-on-local-pvc.yaml
@@ -193,6 +193,18 @@ spec:
         tuneDeviceClass: true
         tuneFastDeviceClass: false
         encrypted: false
+        placement:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - rook-ceph-osd
+                      - rook-ceph-osd-prepare
         preparePlacement:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -208,6 +220,7 @@ spec:
                         operator: In
                         values:
                           - rook-ceph-osd-prepare
+                  topologyKey: kubernetes.io/hostname
         resources:
         # These are the OSD daemon limits. For OSD prepare limits, see the separate section below for "prepareosd" resources
         #   limits:


### PR DESCRIPTION
**Description of your changes:**

`cluster-on-local-pvc.yaml` doesn't work due to missing topologyKey. In addition, it's better to add the example of `topologySpreadConstraints` for K8s >= 1.18 users.

**Which issue is resolved by this Pull Request:**
Resolves #8478 

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
