### PR TITLE
docs: Clarify that helm charts are optional

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -8,7 +8,12 @@ indent: true
 
 # Ceph Cluster Helm Chart
 
-Installs a [Ceph](https://ceph.io/) cluster on Rook using the [Helm](https://helm.sh) package manager.
+Creates Rook resources to configure a [Ceph](https://ceph.io/) cluster using the [Helm](https://helm.sh) package manager.
+This chart is a simple packaging of templates that will optionally create Rook resources such as:
+- CephCluster, CephFilesystem, and CephObjectStore CRs
+- Storage classes to expose Ceph RBD volumes, CephFS volumes, and RGW buckets
+- Ingress for external access to the dashboard
+- Toolbox
 
 ## Prerequisites
 
@@ -72,42 +77,42 @@ For the full list, see the [Cluster CRD](ceph-cluster-crd.md) topic.
 
 The `cephBlockPools` array in the values file will define a list of CephBlockPool as described in the table below.
 
-| Parameter                           | Description                                                                                  | Default          |
-| ----------------------------------- | -------------------------------------------------------------------------------------------- | ---------------- |
-| `name`                              | The name of the CephBlockPool                                                                | `ceph-blockpool` |
-| `spec`                              | The CephBlockPool spec, see the [CephBlockPool](ceph-pool-crd.md#spec) documentation.        | `{}`             |
-| `storageClass.enabled`              | Whether a storage class is deployed alongside the CephBlockPool                              | `true`           |
-| `storageClass.isDefault`            | Whether the storage class will be the default storage class for PVCs. See the PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) documentation for details. | `true` |
-| `storageClass.name`                 | The name of the storage class                                                                | `ceph-block`     |
-| `storageClass.parameters`           | See [Block Storage](ceph-block.md) documentation or the helm values.yaml for suitable values | see values.yaml  |
-| `storageClass.reclaimPolicy`        | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
-| `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default. | `true` |
+| Parameter                           | Description                                                                                                                                                                                                             | Default          |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `name`                              | The name of the CephBlockPool                                                                                                                                                                                           | `ceph-blockpool` |
+| `spec`                              | The CephBlockPool spec, see the [CephBlockPool](ceph-pool-crd.md#spec) documentation.                                                                                                                                   | `{}`             |
+| `storageClass.enabled`              | Whether a storage class is deployed alongside the CephBlockPool                                                                                                                                                         | `true`           |
+| `storageClass.isDefault`            | Whether the storage class will be the default storage class for PVCs. See the PersistentVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) documentation for details. | `true`           |
+| `storageClass.name`                 | The name of the storage class                                                                                                                                                                                           | `ceph-block`     |
+| `storageClass.parameters`           | See [Block Storage](ceph-block.md) documentation or the helm values.yaml for suitable values                                                                                                                            | see values.yaml  |
+| `storageClass.reclaimPolicy`        | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class.                                                             | `Delete`         |
+| `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default.                                                                                  | `true`           |
 
 ### Ceph File Systems
 
 The `cephFileSystems` array in the values file will define a list of CephFileSystem as described in the table below.
 
-| Parameter                    | Description                                                                                           | Default           |
-| -----------------------------| ----------------------------------------------------------------------------------------------------- | ----------------- |
-| `name`                       | The name of the CephFileSystem                                                                        | `ceph-filesystem` |
-| `spec`                       | The CephFileSystem spec, see the [CephFilesystem CRD](ceph-filesystem-crd.md) documentation.          | see values.yaml   |
-| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephFileSystem                                      | `true`            |
-| `storageClass.name`          | The name of the storage class                                                                         | `ceph-filesystem` |
-| `storageClass.parameters`    | See [Shared Filesystem](ceph-filesystem.md) documentation or the helm values.yaml for suitable values | see values.yaml   |
-| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+| Parameter                    | Description                                                                                                                                                 | Default           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `name`                       | The name of the CephFileSystem                                                                                                                              | `ceph-filesystem` |
+| `spec`                       | The CephFileSystem spec, see the [CephFilesystem CRD](ceph-filesystem-crd.md) documentation.                                                                | see values.yaml   |
+| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephFileSystem                                                                                            | `true`            |
+| `storageClass.name`          | The name of the storage class                                                                                                                               | `ceph-filesystem` |
+| `storageClass.parameters`    | See [Shared Filesystem](ceph-filesystem.md) documentation or the helm values.yaml for suitable values                                                       | see values.yaml   |
+| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete`          |
 
 ### Ceph Object Stores
 
 The `cephObjectStores` array in the values file will define a list of CephObjectStore as described in the table below.
 
-| Parameter                    | Description                                                                                                             | Default             |
-| -----------------------------| ----------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `name`                       | The name of the CephObjectStore                                                                                         | `ceph-objectstore`  |
-| `spec`                       | The CephObjectStore spec, see the [CephObjectStore CRD](ceph-object-store-crd.md) documentation.                        | see values.yaml     |
-| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephObjectStore                                                       | `true`              |
-| `storageClass.name`          | The name of the storage class                                                                                           | `ceph-bucket`       |
-| `storageClass.parameters`    | See [Object Store storage class](ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values | see values.yaml     |
-| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete` |
+| Parameter                    | Description                                                                                                                                                 | Default            |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `name`                       | The name of the CephObjectStore                                                                                                                             | `ceph-objectstore` |
+| `spec`                       | The CephObjectStore spec, see the [CephObjectStore CRD](ceph-object-store-crd.md) documentation.                                                            | see values.yaml    |
+| `storageClass.enabled`       | Whether a storage class is deployed alongside the CephObjectStore                                                                                           | `true`             |
+| `storageClass.name`          | The name of the storage class                                                                                                                               | `ceph-bucket`      |
+| `storageClass.parameters`    | See [Object Store storage class](ceph-object-bucket-claim.md) documentation or the helm values.yaml for suitable values                                     | see values.yaml    |
+| `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete`           |
 
 ### Existing Clusters
 

--- a/Documentation/helm.md
+++ b/Documentation/helm.md
@@ -3,12 +3,16 @@ title: Helm Charts
 weight: 10000
 ---
 
+{% include_relative branch.liquid %}
+
 # Helm Charts
 
-Rook has published a Helm chart for the [operator](helm-operator.md). Other Helm charts will also be potentially developed for each of the
-CRDs for all Rook storage backends.
+Rook has published the following Helm charts for the Ceph storage provider:
 
-* [Rook Ceph Operator](helm-operator.md): Installs the Ceph Operator
-* [Rook Ceph Cluster](helm-ceph-cluster.md): Configures resources necessary to run a Ceph cluster
+* [Rook Ceph Operator](helm-operator.md): Starts the Ceph Operator, which will watch for Ceph CRs (custom resources)
+* [Rook Ceph Cluster](helm-ceph-cluster.md): Creates Ceph CRs that the operator will use to configure the cluster
 
-Contributions are welcome to create our other Helm charts!
+The Helm charts are intended to simplify deployment and upgrades.
+Configuring the Rook resources without Helm is also fully supported by creating the
+[manifests](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes)
+directly.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the v1.7 release and the Cluster helm chart, this clarifies that the helm charts are still completely optional, but are intended only to simplify deployment for those who choose to use them.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
