### PR TITLE
nfs: fix `stale file handle error` issue

### DIFF
--- a/pkg/operator/nfs/controller.go
+++ b/pkg/operator/nfs/controller.go
@@ -176,7 +176,7 @@ EXPORT {
 
 	nfsGaneshaAdditionalConfig := `
 NFS_Core_Param {
-	fsid_device = true;
+	fsid_device = false;
 }
 `
 


### PR DESCRIPTION
Signed-off-by: Oleksii Kravchenko <kamikaze.ua@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

The fsid_device parameter if true indicates that only the device number is used, so when NFS pod is moved to another node device number could be changed (/dev/sdb -> /dev/sdc). In this case, NFS client gets an error `stale file handle error` bcz could not find the necessary device id. To bypass this problem fsid_device must be false (BTW, by default it is false), so NFS server could use other options to find an appropriate file system.

More info:
https://github.com/nfs-ganesha/nfs-ganesha/issues/538
https://github.com/kubernetes-retired/external-storage/issues/1274
https://github.com/nfs-ganesha/nfs-ganesha/commit/c583534b166be198755d905c82a7687d83b458d8

I do not see any options when fsid_device parameter should be true in the kubenretes environment. But maybe we have to make it configurable for backward compatibility

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
