### PR TITLE
ceph: use serviceAccountName as the key in ceph csi templates

### DIFF
--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin-provisioner-dep.yaml
@@ -17,7 +17,7 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
-      serviceAccount: rook-csi-cephfs-provisioner-sa
+      serviceAccountName: rook-csi-cephfs-provisioner-sa
       {{ if .ProvisionerPriorityClassName }}
       priorityClassName: {{ .ProvisionerPriorityClassName }}
       {{ end }}

--- a/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/cephfs/csi-cephfsplugin.yaml
@@ -18,7 +18,7 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
-      serviceAccount: rook-csi-cephfs-plugin-sa
+      serviceAccountName: rook-csi-cephfs-plugin-sa
       hostNetwork: {{ .EnableCSIHostNetwork }}
       {{ if .PluginPriorityClassName }}
       priorityClassName: {{ .PluginPriorityClassName }}

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin-provisioner-dep.yaml
@@ -17,7 +17,7 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
-      serviceAccount: rook-csi-rbd-provisioner-sa
+      serviceAccountName: rook-csi-rbd-provisioner-sa
       {{ if .ProvisionerPriorityClassName }}
       priorityClassName: {{ .ProvisionerPriorityClassName }}
       {{ end }}

--- a/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/template/rbd/csi-rbdplugin.yaml
@@ -18,7 +18,7 @@ spec:
         {{ $key }}: "{{ $value }}"
         {{ end }}
     spec:
-      serviceAccount: rook-csi-rbd-plugin-sa
+      serviceAccountName: rook-csi-rbd-plugin-sa
       {{ if .PluginPriorityClassName }}
       priorityClassName: {{ .PluginPriorityClassName }}
       {{ end }}


### PR DESCRIPTION

Since core->v1 (https://pkg.go.dev/k8s.io/api/core/v1),  serviceAccountName is the correct key in the pod spec. 
Ref# https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
https://docs.openshift.com/container-platform/3.11/rest_api/core/podtemplate-core-v1.html

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>



**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
