### PR TITLE
ceph: add support in RGW to communicate vault with TLS

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -422,7 +422,7 @@ jobs:
         yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].volumeClaimTemplates[0].spec.resources.requests.storage" 6Gi
         kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
         yq merge --inplace --arrays append tests/manifests/test-object.yaml tests/manifests/test-kms-vault-spec-token-auth.yaml
-        sed -i 's/ver1/ver2/g' tests/manifests/test-object.yaml
+        yq write -i tests/manifests/test-object.yaml "spec.security.kms.connectionDetails.VAULT_BACKEND_PATH" rook/ver2
         kubectl create -f tests/manifests/test-object.yaml
         tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/toolbox.yaml
 

--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -212,7 +212,7 @@ For RGW, please note the following:
 $ vault kv put rook/<mybucketkey> key=$(openssl rand -base64 32) # kv engine
 $ vault write -f transit/keys/<mybucketkey> exportable=true # transit engine
 
-* TLS authentication with custom certs between Vault and RGW are yet to be supported.
+* TLS authentication with custom certificates between Vault and CephObjectStore RGWs are supported from ceph v16.2.6 onwards
 
 ## Deleting a CephObjectStore
 

--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -49,7 +49,7 @@ func vaultTokenEnvVarFromSecret(tokenSecretName string) v1.EnvVar {
 }
 
 // vaultTLSEnvVarFromSecret translates TLS env var which are set to k8s secret name to their actual path on the fs once mounted as volume
-// See: TLSSecretVolumeAndMount() for more details
+// See: VaultSecretVolumeAndMount() for more details
 func vaultTLSEnvVarFromSecret(kmsConfig map[string]string) []v1.EnvVar {
 	vaultTLSEnvVar := []v1.EnvVar{}
 

--- a/pkg/daemon/ceph/osd/kms/volumes.go
+++ b/pkg/daemon/ceph/osd/kms/volumes.go
@@ -29,16 +29,16 @@ const (
 	vaultKeySecretKeyName    = "key"
 
 	// File names of the Secret value when mapping on the filesystem
-	vaultCAFileName   = "vault.ca"
-	vaultCertFileName = "vault.crt"
-	vaultKeyFileName  = "vault.key"
+	VaultCAFileName   = "vault.ca"
+	VaultCertFileName = "vault.crt"
+	VaultKeyFileName  = "vault.key"
 
 	// File name for token file
 	VaultFileName = "vault.token"
 )
 
-// TLSSecretVolumeAndMount return the volume and matching volume mount for mounting the secrets into /etc/vault
-func TLSSecretVolumeAndMount(config map[string]string) []v1.VolumeProjection {
+// VaultSecretVolumeAndMount return the volume and matching volume mount for mounting the vault secrets into /etc/vault
+func VaultSecretVolumeAndMount(kmsVaultConfigFiles map[string]string, tokenSecretName string) []v1.VolumeProjection {
 	// Projection list
 	secretVolumeProjections := []v1.VolumeProjection{}
 
@@ -49,7 +49,7 @@ func TLSSecretVolumeAndMount(config map[string]string) []v1.VolumeProjection {
 
 	// Vault TLS Secrets
 	for _, tlsOption := range cephv1.VaultTLSConnectionDetails {
-		tlsSecretName := GetParam(config, tlsOption)
+		tlsSecretName := GetParam(kmsVaultConfigFiles, tlsOption)
 		if tlsSecretName != "" {
 			projectionSecret := &v1.SecretProjection{Items: []v1.KeyToPath{{Key: tlsSecretKeyToCheck(tlsOption), Path: tlsSecretPath(tlsOption), Mode: &mode}}}
 			projectionSecret.Name = tlsSecretName
@@ -57,17 +57,22 @@ func TLSSecretVolumeAndMount(config map[string]string) []v1.VolumeProjection {
 			secretVolumeProjections = append(secretVolumeProjections, secretProjection)
 		}
 	}
-
+	if tokenSecretName != "" {
+		projectionSecret := &v1.SecretProjection{Items: []v1.KeyToPath{{Key: KMSTokenSecretNameKey, Path: VaultFileName, Mode: &mode}}}
+		projectionSecret.Name = tokenSecretName
+		secretProjection := v1.VolumeProjection{Secret: projectionSecret}
+		secretVolumeProjections = append(secretVolumeProjections, secretProjection)
+	}
 	return secretVolumeProjections
 }
 
 // VaultVolumeAndMount returns Vault volume and volume mount
-func VaultVolumeAndMount(config map[string]string) (v1.Volume, v1.VolumeMount) {
+func VaultVolumeAndMount(kmsVaultConfigFiles map[string]string, tokenSecretName string) (v1.Volume, v1.VolumeMount) {
 	v := v1.Volume{
 		Name: secrets.TypeVault,
 		VolumeSource: v1.VolumeSource{
 			Projected: &v1.ProjectedVolumeSource{
-				Sources: TLSSecretVolumeAndMount(config),
+				Sources: VaultSecretVolumeAndMount(kmsVaultConfigFiles, tokenSecretName),
 			},
 		},
 	}
@@ -84,25 +89,13 @@ func VaultVolumeAndMount(config map[string]string) (v1.Volume, v1.VolumeMount) {
 func tlsSecretPath(tlsOption string) string {
 	switch tlsOption {
 	case api.EnvVaultCACert:
-		return vaultCAFileName
+		return VaultCAFileName
 	case api.EnvVaultClientCert:
-		return vaultCertFileName
+		return VaultCertFileName
 	case api.EnvVaultClientKey:
-		return vaultKeyFileName
+		return VaultKeyFileName
 
 	}
 
 	return ""
-}
-
-// VaultTokenFileVolume save token from secret as volume mount
-func VaultTokenFileVolume(tokenSecretName string) v1.Volume {
-	return v1.Volume{
-		Name: secrets.TypeVault,
-		VolumeSource: v1.VolumeSource{
-			Secret: &v1.SecretVolumeSource{
-				SecretName: tokenSecretName,
-				Items: []v1.KeyToPath{
-					{Key: KMSTokenSecretNameKey, Path: VaultFileName},
-				}}}}
 }

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -123,7 +123,7 @@ func (c *Cluster) provisionPodTemplateSpec(osdProps osdProperties, restart v1.Re
 			if c.spec.Security.KeyManagementService.IsEnabled() {
 				kmsProvider := kms.GetParam(c.spec.Security.KeyManagementService.ConnectionDetails, kms.Provider)
 				if kmsProvider == secrets.TypeVault {
-					volumeTLS, _ := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails)
+					volumeTLS, _ := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails, "")
 					volumes = append(volumes, volumeTLS)
 				}
 			}
@@ -282,7 +282,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 			if c.spec.Security.KeyManagementService.IsEnabled() {
 				kmsProvider := kms.GetParam(c.spec.Security.KeyManagementService.ConnectionDetails, kms.Provider)
 				if kmsProvider == secrets.TypeVault {
-					_, volumeMountsTLS := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails)
+					_, volumeMountsTLS := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails, "")
 					volumeMounts = append(volumeMounts, volumeMountsTLS)
 					envVars = append(envVars, kms.VaultConfigToEnvVar(c.spec)...)
 				}

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -297,7 +297,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 			// Somehow when this happens and we try to update a deployment spec it fails with:
 			//  ValidationError(Pod.spec.volumes[7].projected): missing required field "sources"
 			if c.spec.Security.KeyManagementService.IsEnabled() && c.spec.Security.KeyManagementService.IsTLSEnabled() {
-				encryptedVol, _ := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails)
+				encryptedVol, _ := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails, "")
 				volumes = append(volumes, encryptedVol)
 			}
 		}
@@ -896,7 +896,7 @@ func (c *Cluster) getPVCEncryptionOpenInitContainerActivate(mountPath string, os
 
 			// Now let's see if there is a TLS config we need to mount as well
 			if c.spec.Security.KeyManagementService.IsTLSEnabled() {
-				_, vaultVolMount := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails)
+				_, vaultVolMount := kms.VaultVolumeAndMount(c.spec.Security.KeyManagementService.ConnectionDetails, "")
 				getKEKFromKMSContainer.VolumeMounts = append(getKEKFromKMSContainer.VolumeMounts, vaultVolMount)
 			}
 

--- a/pkg/operator/ceph/object/config.go
+++ b/pkg/operator/ceph/object/config.go
@@ -52,6 +52,8 @@ caps osd = "allow rwx"
 	rgwPortInternalPort       int32 = 8080
 	ServiceServingCertCAFile        = "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
 	HttpTimeOut                     = time.Second * 15
+	rgwVaultVolumeName              = "rgw-vault-volume"
+	rgwVaultDirName                 = "/etc/vault/rgw/"
 )
 
 var (


### PR DESCRIPTION
**Description of your changes:**

From ceph v16.2.6 onwards the vault TLS suppport in RGW was added,
include similar changes for RGW.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
