### PR TITLE
ceph: Consolidate the calls to set mon config

### DIFF
--- a/pkg/daemon/ceph/client/config.go
+++ b/pkg/daemon/ceph/client/config.go
@@ -300,31 +300,3 @@ func WriteCephConfig(context *clusterd.Context, clusterInfo *ClusterInfo) error 
 	}
 	return nil
 }
-
-// SetConfig applies a setting for a single mgr daemon
-func SetConfig(context *clusterd.Context, clusterInfo *ClusterInfo, daemonID string, key, val string, force bool) (bool, error) {
-	var getArgs, setArgs []string
-	getArgs = append(getArgs, "config", "get", daemonID, key)
-	if val == "" {
-		setArgs = append(setArgs, "config", "rm", daemonID, key)
-	} else {
-		setArgs = append(setArgs, "config", "set", daemonID, key, val)
-	}
-	if force {
-		setArgs = append(setArgs, "--force")
-	}
-
-	// Retrieve previous value to monitor changes
-	var prevVal string
-	buf, err := NewCephCommand(context, clusterInfo, getArgs).Run()
-	if err == nil {
-		prevVal = strings.TrimSpace(string(buf))
-	}
-
-	if _, err := NewCephCommand(context, clusterInfo, setArgs).Run(); err != nil {
-		return false, errors.Wrapf(err, "failed to set config key %s to %q", key, val)
-	}
-
-	hasChanged := prevVal != val
-	return hasChanged, nil
-}

--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -28,6 +28,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/config"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -158,7 +159,8 @@ func (c *cephStatusChecker) configureHealthSettings(status cephclient.CephStatus
 	if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM_ALLOWED"]; ok {
 		if _, ok := status.Health.Checks["AUTH_INSECURE_GLOBAL_ID_RECLAIM"]; !ok {
 			logger.Info("Disabling the insecure global ID as no legacy clients are currently connected. If you still require the insecure connections, see the CVE to suppress the health warning and re-enable the insecure connections. https://docs.ceph.com/en/latest/security/CVE-2021-20288/")
-			if _, err := cephclient.SetConfig(c.context, c.clusterInfo, "mon", "auth_allow_insecure_global_id_reclaim", "false", false); err != nil {
+			monStore := config.GetMonStore(c.context, c.clusterInfo)
+			if err := monStore.Set("mon", "auth_allow_insecure_global_id_reclaim", "false"); err != nil {
 				logger.Warningf("failed to disable the insecure global ID. %v", err)
 			} else {
 				logger.Info("insecure global ID is now disabled")

--- a/pkg/operator/ceph/config/monstore.go
+++ b/pkg/operator/ceph/config/monstore.go
@@ -52,6 +52,22 @@ type Option struct {
 	Value string
 }
 
+func (m *MonStore) SetIfChanged(who, option, value string) (bool, error) {
+	currentVal, err := m.Get(who, option)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get value %q", option)
+	}
+	if currentVal == value {
+		// no need to update the setting
+		return false, nil
+	}
+
+	if err := m.Set(who, option, value); err != nil {
+		return false, errors.Wrapf(err, "failed to set value %s=%s", option, value)
+	}
+	return true, nil
+}
+
 // Set sets a config in the centralized mon configuration database.
 // https://docs.ceph.com/docs/master/rados/configuration/ceph-conf/#monitor-configuration-database
 func (m *MonStore) Set(who, option, value string) error {

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -445,13 +445,16 @@ func TestConfigureRBDStats(t *testing.T) {
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
-			switch {
-			case args[0] == "config" && args[1] == "set" && args[2] == "mgr." && args[3] == "mgr/prometheus/rbd_stats_pools" && args[4] != "":
-				return "", nil
-			case args[0] == "config" && args[1] == "get" && args[2] == "mgr." && args[3] == "mgr/prometheus/rbd_stats_pools":
-				return "", nil
-			case args[0] == "config" && args[1] == "rm" && args[2] == "mgr." && args[3] == "mgr/prometheus/rbd_stats_pools":
-				return "", nil
+			if args[0] == "config" && args[2] == "mgr." && args[3] == "mgr/prometheus/rbd_stats_pools" {
+				if args[1] == "set" && args[4] != "" {
+					return "", nil
+				}
+				if args[1] == "get" {
+					return "", nil
+				}
+				if args[1] == "rm" {
+					return "", nil
+				}
 			}
 			return "", errors.Errorf("unexpected arguments %q", args)
 		},
@@ -509,7 +512,7 @@ func TestConfigureRBDStats(t *testing.T) {
 	context.Executor = &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
-			return "", errors.New("mock error to simulate failure of SetConfig() function")
+			return "", errors.New("mock error to simulate failure of mon store Set() function")
 		},
 	}
 	err = configureRBDStats(context, clusterInfo)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The mon config had two different implementations that have evolved over the lifetime of the project. This is a simple refactor to remove the SetConfig() option and stick with the MonStore as a single implementation for updating the mon store.

**Which issue is resolved by this Pull Request:**
Resolves #8107 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
