### PR TITLE
ceph: Test against release version in the branch

### DIFF
--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -18,7 +18,6 @@ package installer
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -83,11 +82,7 @@ func (m *CephManifestsMaster) GetOperator() string {
 	} else {
 		manifest = m.settings.readManifest("operator.yaml")
 	}
-	manifest = m.settings.replaceOperatorSettings(manifest)
-
-	// In release branches replace the tag with a master build since the local build has the master tag
-	r, _ := regexp.Compile(`image: rook/ceph:v[a-z0-9.-]+`)
-	return r.ReplaceAllString(manifest, "image: rook/ceph:master")
+	return m.settings.replaceOperatorSettings(manifest)
 }
 
 func (m *CephManifestsMaster) GetCommonExternal() string {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The release version needs to be the same in the example/test manifests as it is in the local build image. The github actions are different in this regard than the Jenkins builds were. The Jenkins builds always locally used the master tag instead of a release-specific tag. Now that the github actions use the release-specific tag, the test framework no longer should be using the master tag in release branches.

This just became apparent with integration tests failing in 1.6 and 1.7 release branches with the merge of #8493 to master only. The tests in 1.6 and 1.7 were actually running against master builds with those changes, but failing wherever the admission controller was enabled.

This will fix the builds in 1.6 and 1.7 branches, but master tests will continue to be successful as before.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
