### PR TITLE
ceph: avoid duplicate ownerReferences

### DIFF
--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -85,9 +86,30 @@ func (info *OwnerInfo) SetOwnerReference(object metav1.Object) error {
 	if err != nil {
 		return err
 	}
-	ownerRefs := append(object.GetOwnerReferences(), *info.ownerRef)
+	ownerRefs := object.GetOwnerReferences()
+	for _, v := range ownerRefs {
+		if referSameObject(v, *info.ownerRef) {
+			return nil
+		}
+	}
+	ownerRefs = append(ownerRefs, *info.ownerRef)
 	object.SetOwnerReferences(ownerRefs)
 	return nil
+}
+
+// The original code is in https://github.com/kubernetes-sigs/controller-runtime/blob/a905949b9040084f0c6d2a27ec70e77c3c5c0931/pkg/controller/controllerutil/controllerutil.go#L160
+func referSameObject(a, b metav1.OwnerReference) bool {
+	groupVersionA, err := schema.ParseGroupVersion(a.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	groupVersionB, err := schema.ParseGroupVersion(b.APIVersion)
+	if err != nil {
+		return false
+	}
+
+	return groupVersionA.Group == groupVersionB.Group && a.Kind == b.Kind && a.Name == b.Name
 }
 
 // SetControllerReference set the controller reference of object

--- a/pkg/operator/k8sutil/resources_test.go
+++ b/pkg/operator/k8sutil/resources_test.go
@@ -142,3 +142,24 @@ func TestValidateController(t *testing.T) {
 	err = newOwnerInfo.validateController(object)
 	assert.Error(t, err)
 }
+
+func TestSetOwnerReference(t *testing.T) {
+	info := OwnerInfo{
+		ownerRef: &metav1.OwnerReference{Name: "test-id"},
+	}
+	object := v1.ConfigMap{}
+	err := info.SetOwnerReference(&object)
+	assert.NoError(t, err)
+	assert.Equal(t, object.GetOwnerReferences(), []metav1.OwnerReference{*info.ownerRef})
+
+	err = info.SetOwnerReference(&object)
+	assert.NoError(t, err)
+	assert.Equal(t, object.GetOwnerReferences(), []metav1.OwnerReference{*info.ownerRef})
+
+	info2 := OwnerInfo{
+		ownerRef: &metav1.OwnerReference{Name: "test-id-2"},
+	}
+	err = info2.SetOwnerReference(&object)
+	assert.NoError(t, err)
+	assert.Equal(t, object.GetOwnerReferences(), []metav1.OwnerReference{*info.ownerRef, *info2.ownerRef})
+}


### PR DESCRIPTION
**Description of your changes:**
If we call OwnerInfo.SetOwnerReference for an object multiple times, it results in OwnerReference duplication.


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
