### PR TITLE
Making script backward compatible with python2

### DIFF
--- a/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+++ b/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
@@ -604,22 +604,22 @@ class RadosJSON:
         try:
             output = subprocess.check_output(cmd,
                                              stderr=subprocess.PIPE)
-        except subprocess.CalledProcessError as exec:
+        except subprocess.CalledProcessError as execErr:
             # if the user already exists, we just query it
-            if exec.returncode == errno.EEXIST:
+            if execErr.returncode == errno.EEXIST:
                 cmd = ['radosgw-admin', 'user', 'info',
                        '--uid', self.EXTERNAL_RGW_ADMIN_OPS_USER_NAME
                        ]
                 try:
                     output = subprocess.check_output(cmd,
                                                      stderr=subprocess.PIPE)
-                except subprocess.CalledProcessError as exec:
+                except subprocess.CalledProcessError as execErr:
                     err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
-                        cmd, exec.output, exec.returncode, exec.stderr)
+                        cmd, execErr.output, execErr.returncode, execErr.stderr)
                     raise Exception(err_msg)
             else:
                 err_msg = "failed to execute command %s. Output: %s. Code: %s. Error: %s" % (
-                    cmd, exec.output, exec.returncode, exec.stderr)
+                    cmd, execErr.output, execErr.returncode, execErr.stderr)
                 raise Exception(err_msg)
 
         jsonoutput = json.loads(output)


### PR DESCRIPTION
Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
As `exec` is an internal builtin function for python2 there were some errors thrown while running the script with python2.
Changed the variable name to `execErr`.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
