### PR TITLE
ceph: fix error message in UpdateNodeStatus

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -238,7 +238,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 			Message:      err.Error(),
 			PvcBackedOSD: cfg.pvcBacked,
 		}
-		oposd.UpdateNodeStatus(kv, cfg.nodeName, status)
+		oposd.UpdateNodeOrPVCStatus(kv, cfg.nodeName, status)
 
 		rook.TerminateFatal(err)
 	}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -180,7 +180,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating}
-	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
 
 	if err := client.WriteCephConfig(context, agent.clusterInfo); err != nil {
 		return errors.Wrap(err, "failed to generate ceph config")
@@ -221,7 +221,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// orchestration is about to start, update the status
 	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating, PvcBackedOSD: agent.pvcBacked}
-	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
 
 	// start the desired OSDs on devices
 	logger.Infof("configuring osd devices: %+v", devices)
@@ -238,7 +238,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 	if len(deviceOSDs) == 0 {
 		logger.Warningf("skipping OSD configuration as no devices matched the storage settings for this node %q", agent.nodeName)
 		status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
-		oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
+		oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
 		return nil
 	}
 
@@ -278,7 +278,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// orchestration is completed, update the status
 	status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
-	oposd.UpdateNodeStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
 
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -56,7 +56,7 @@ func TestOrchestrationStatus(t *testing.T) {
 
 	// update the status map with some status
 	status := OrchestrationStatus{Status: OrchestrationStatusOrchestrating, Message: "doing work"}
-	UpdateNodeStatus(kv, nodeName, status)
+	UpdateNodeOrPVCStatus(kv, nodeName, status)
 
 	// retrieve the status and verify it
 	statusMap, err := c.context.Clientset.CoreV1().ConfigMaps(c.clusterInfo.Namespace).Get(ctx, cmName, metav1.GetOptions{})
@@ -94,7 +94,7 @@ func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatch
 					},
 					Status: OrchestrationStatusCompleted,
 				}
-				UpdateNodeStatus(c.kv, nodeName, *status)
+				UpdateNodeOrPVCStatus(c.kv, nodeName, *status)
 
 				// 2) call modify on the fake watcher so a watch event will get triggered
 				s, _ := json.Marshal(status)


### PR DESCRIPTION
**Description of your changes:**
The error message in UpdateNodeStatus regards the second argument
as node name. However, it is a PVC name in OSD on PVC.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
