### PR TITLE
ceph: merge toleration for osd/prepareOSD pod if specified both places

### DIFF
--- a/pkg/apis/rook.io/v1/placement.go
+++ b/pkg/apis/rook.io/v1/placement.go
@@ -38,7 +38,7 @@ func (p Placement) ApplyToPodSpec(t *v1.PodSpec) {
 		t.Affinity.PodAntiAffinity = p.PodAntiAffinity.DeepCopy()
 	}
 	if p.Tolerations != nil {
-		t.Tolerations = p.Tolerations
+		t.Tolerations = p.mergeTolerations(t.Tolerations)
 	}
 	if p.TopologySpreadConstraints != nil {
 		t.TopologySpreadConstraints = p.TopologySpreadConstraints
@@ -92,6 +92,15 @@ func (p Placement) mergeNodeAffinity(nodeAffinity *v1.NodeAffinity) *v1.NodeAffi
 	return result
 }
 
+func (p Placement) mergeTolerations(tolerations []v1.Toleration) []v1.Toleration {
+	// no toleration is specified yet, return placement's toleration
+	if tolerations == nil {
+		return p.Tolerations
+	}
+
+	return append(p.Tolerations, tolerations...)
+}
+
 // Merge returns a Placement which results from merging the attributes of the
 // original Placement with the attributes of the supplied one. The supplied
 // Placement's attributes will override the original ones if defined.
@@ -107,7 +116,7 @@ func (p Placement) Merge(with Placement) Placement {
 		ret.PodAntiAffinity = with.PodAntiAffinity
 	}
 	if with.Tolerations != nil {
-		ret.Tolerations = with.Tolerations
+		ret.Tolerations = ret.mergeTolerations(with.Tolerations)
 	}
 	if with.TopologySpreadConstraints != nil {
 		ret.TopologySpreadConstraints = with.TopologySpreadConstraints

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -730,7 +730,7 @@ func (c *Cluster) applyAllPlacementIfNeeded(d *v1.PodSpec) {
 	// - For non-PVCs: `placement.all` and `placement.osd`
 	// - For PVCs: `placement.all` and inside the storageClassDeviceSet from the `placement` or `preparePlacement`
 
-	// The placement from these sources will be merged by default (if onlyApplyOSDPlacement is false) in case of NodeAffinity,
+	// The placement from these sources will be merged by default (if onlyApplyOSDPlacement is false) in case of NodeAffinity and toleration,
 	// in case of other placement rule like PodAffinity, PodAntiAffinity... it will override last placement with the current placement applied,
 	// See ApplyToPodSpec().
 


### PR DESCRIPTION
earlier, `ApplyToPodSpec()` was only taking one toleration and ignoring
tolerations from `placement.ALL()`.

this commit merge toleration for Mgr,Mon,Osd pod
example, for osd it will merge
spec.placement.all and
storageDeviceClassSets.Placement(in case of pvc) or
spec.placement.osd(in case of non-pvc's).

Signed-off-by: subhamkrai <srai@redhat.com>
(cherry picked from commit e1f232eeb7ac716e53ec27912ac0556062085a83)
Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
