### PR TITLE
build: fix cross build run script

### DIFF
--- a/images/cross/run.sh
+++ b/images/cross/run.sh
@@ -33,4 +33,4 @@ export HOME=/home/${BUILDER_USER}
 echo "127.0.0.1 $(cat /etc/hostname)" >> /etc/hosts
 [[ -S /var/run/docker.sock ]] && chmod 666 /var/run/docker.sock
 chown -R "$BUILDER_UID":"$BUILDER_GID" "$HOME"
-exec chpst -u :"$BUILDER_UID":"$BUILDER_GID" "${ARGS[0]}"
+exec chpst -u :"$BUILDER_UID":"$BUILDER_GID" "${ARGS[@]}"


### PR DESCRIPTION
Fixes issues with the `build/run` tooling, notably for publishing images
where `build/run make <args>` would only result in `make` being called
without args.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
