### PR TITLE
ci: add failfast go flag to stop tests sooner (optional)

### DIFF
--- a/.github/workflows/integration-test-flex-suite.yaml
+++ b/.github/workflows/integration-test-flex-suite.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: TestCephFlexSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephFlexSuite github.com/rook/rook/tests/integration
+       go test -v -timeout 1800s -failfast -run CephFlexSuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -54,7 +54,7 @@ jobs:
        tests/scripts/minikube.sh helm
        tests/scripts/helm.sh up
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephHelmSuite github.com/rook/rook/tests/integration
+       SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephHelmSuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -46,7 +46,7 @@ jobs:
     - name: TestCephMgrSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephMgrSuite github.com/rook/rook/tests/integration
+       go test -v -timeout 1800s -failfast -run CephMgrSuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
        export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)1
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
+       go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -46,10 +46,11 @@ jobs:
     - name: build rook
       run: tests/scripts/github-action-helper.sh build_rook
 
+       
     - name: TestCephSmokeSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
+       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephSmokeSuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: TestCephUpgradeSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephUpgradeSuite github.com/rook/rook/tests/integration
+       go test -v -timeout 1800s -failfast -run CephUpgradeSuite github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Description of your changes:**

With the -failfast flag the tests will not continue when one of them
fails. This allows us to log in the runner and observe the exact state
of any failure.

The flag can be activated via a label "ci-fail-fast" in the PR.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
