### PR TITLE
ceph: fix probable cause of intermittent fails in the manager test

### DIFF
--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -177,8 +177,10 @@ func (s *CephMgrSuite) waitForOrchestrationModule() {
 
 			// Get status information
 			bytes := []byte(output)
+			logBytesInfo(bytes)
+
 			var status orchStatus
-			err := json.Unmarshal(bytes, &status)
+			err := json.Unmarshal(bytes[:len(output)], &status)
 			if err != nil {
 				logger.Error("Error getting ceph orch status")
 				continue
@@ -222,6 +224,14 @@ func (s *CephMgrSuite) TestStatus() {
 	assert.Equal(s.T(), status, "Backend: rook\nAvailable: Yes")
 }
 
+func logBytesInfo(bytesSlice []byte){
+	logger.Infof("---- bytes slice info ---")
+	logger.Infof("bytes: %v\n", bytesSlice)
+	logger.Infof("length: %d\n", len(bytesSlice))
+	logger.Infof("string: -->%s<--\n", string(bytesSlice))
+	logger.Infof("-------------------------")
+}
+
 func (s *CephMgrSuite) TestHostLs() {
 	logger.Info("Testing .... <ceph orch host ls>")
 
@@ -231,9 +241,10 @@ func (s *CephMgrSuite) TestHostLs() {
 	logger.Infof("output = %s", output)
 
 	hosts := []byte(output)
-	var hostsList []host
+	logBytesInfo(hosts)
 
-	err = json.Unmarshal(hosts, &hostsList)
+	var hostsList []host
+	err = json.Unmarshal(hosts[:len(output)], &hostsList)
 	if err != nil {
 		assert.Nil(s.T(), err)
 	}
@@ -265,9 +276,10 @@ func (s *CephMgrSuite) TestServiceLs() {
 	logger.Infof("output = %s", output)
 
 	services := []byte(output)
-	var servicesList []service
+	logBytesInfo(services)
 
-	err = json.Unmarshal(services, &servicesList)
+	var servicesList []service
+	err = json.Unmarshal(services[:len(output)], &servicesList)
 	assert.Nil(s.T(), err)
 
 	labelFilter := ""


### PR DESCRIPTION
Explicitly set the length of the string parameter in json.Unmarshal method

fixes: https://github.com/rook/rook/issues/8669

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

