### PR TITLE
bot: Add more ceph commit prefixes

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -7,12 +7,21 @@
       2,
       "always",
       [
-        "build",
         "bot",
+        "build",
         "ceph",
+        "cephfs-mirror",
         "ci",
         "core",
+        "csi",
         "docs",
+        "mds",
+        "mgr",
+        "mon",
+        "osd",
+        "pool",
+        "rbd-mirror",
+        "rgw",
         "test"
       ]
     ],

--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -298,9 +298,19 @@ The `component` **MUST** be one of the following:
 - bot
 - build
 - ceph
+- cephfs-mirror
 - ci
 - core
+- csi
 - docs
+- mds
+- mgr
+- mon
+- monitoring
+- osd
+- pool
+- rbd-mirror
+- rgw
 - test
 
 Note: sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the storage providers moved to their own repo, we add more possible prefixes for commits to the ceph operator, including the ceph daemons and csi driver.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
