### PR TITLE
test: remove unused minimal test versions

### DIFF
--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -18,8 +18,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	"testing"
@@ -35,17 +33,6 @@ import (
 
 const (
 	defaultNamespace = "default"
-	// UPDATE these versions when the integration test matrix changes
-	// These versions are for running a minimal test suite for more efficient tests across different versions of K8s
-	// instead of running all suites on all versions
-	// To run on multiple versions, add a comma separate list such as 1.16.0,1.17.0
-	flexDriverMinimalTestVersion      = "1.15.0"
-	cephMasterSuiteMinimalTestVersion = "1.16.0"
-	multiClusterMinimalTestVersion    = "1.16.0"
-	helmMinimalTestVersion            = "1.17.0"
-	upgradeMinimalTestVersion         = "1.18.0"
-	smokeSuiteMinimalTestVersion      = "1.19.0"
-	objectSuiteMinimalTestVersion     = "1.19.0"
 )
 
 var (
@@ -96,34 +83,10 @@ func HandlePanics(r interface{}, uninstaller func(), t func() *testing.T) {
 	}
 }
 
-func checkIfShouldRunForMinimalTestMatrix(t func() *testing.T, k8sh *utils.K8sHelper, version string) {
-	testArgs := os.Getenv("TEST_ARGUMENTS")
-	if !strings.Contains(testArgs, "min-test-matrix") {
-		logger.Infof("running all tests")
-		return
-	}
-	versions := strings.Split(version, ",")
-	logger.Infof("checking if tests are running on k8s %q", version)
-	matchedVersion := false
-	kubeVersion := ""
-	for _, v := range versions {
-		kubeVersion, matchedVersion = k8sh.VersionMinorMatches(v)
-		if matchedVersion {
-			break
-		}
-	}
-	if !matchedVersion {
-		logger.Infof("Skipping test suite since kube version %q does not match", kubeVersion)
-		t().Skip()
-	}
-	logger.Infof("Running test suite since kube version is %q", kubeVersion)
-}
-
 // StartTestCluster creates new instance of TestCephSettings struct
-func StartTestCluster(t func() *testing.T, settings *installer.TestCephSettings, minimalMatrixK8sVersion string) (*installer.CephInstaller, *utils.K8sHelper) {
+func StartTestCluster(t func() *testing.T, settings *installer.TestCephSettings) (*installer.CephInstaller, *utils.K8sHelper) {
 	k8shelper, err := utils.CreateK8sHelper(t)
 	require.NoError(t(), err)
-	checkIfShouldRunForMinimalTestMatrix(t, k8shelper, minimalMatrixK8sVersion)
 
 	// Turn on DEBUG logging
 	capnslog.SetGlobalLogLevel(capnslog.DEBUG)

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -99,7 +99,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 	}
 	s.settings.ApplyEnvVars()
 	s.clusterInfo = client.AdminClusterInfo(namespace)
-	s.installer, s.kh = StartTestCluster(s.T, s.settings, flexDriverMinimalTestVersion)
+	s.installer, s.kh = StartTestCluster(s.T, s.settings)
 	s.testClient = clients.CreateTestClient(s.kh, s.installer.Manifests)
 	s.bc = s.testClient.BlockClient
 }

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -77,7 +77,7 @@ func (h *HelmSuite) SetupSuite() {
 		CephVersion:               installer.OctopusVersion,
 	}
 	h.settings.ApplyEnvVars()
-	h.installer, h.k8shelper = StartTestCluster(h.T, h.settings, helmMinimalTestVersion)
+	h.installer, h.k8shelper = StartTestCluster(h.T, h.settings)
 	h.helper = clients.CreateTestClient(h.k8shelper, h.installer.Manifests)
 }
 

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -19,11 +19,12 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os/exec"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	"github.com/rook/rook/tests/framework/installer"
@@ -98,7 +99,7 @@ func (s *CephMgrSuite) SetupSuite() {
 		CephVersion:       installer.MasterVersion,
 	}
 	s.settings.ApplyEnvVars()
-	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, cephMasterSuiteMinimalTestVersion)
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
 	s.waitForOrchestrationModule()
 	s.prepareLocalStorageClass("local-storage")
 }

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -167,7 +167,7 @@ func (s *MultiClusterDeploySuite) setupMultiClusterCore() {
 	cmdOut := utils.ExecuteCommand(cmdArgs)
 	require.NoError(s.T(), cmdOut.Err)
 
-	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, multiClusterMinimalTestVersion)
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
 	s.testClient = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
 	s.coreToolbox = client.RunAllCephCommandsInToolboxPod
 }

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -79,7 +79,7 @@ func (s *ObjectSuite) SetupSuite() {
 		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()
-	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, objectSuiteMinimalTestVersion)
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
 	if s.k8sh.VersionAtLeast("v1.16.0") {
 		s.settings.EnableVolumeReplication = true
 	}

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -103,7 +103,7 @@ func (s *SmokeSuite) SetupSuite() {
 		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()
-	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, smokeSuiteMinimalTestVersion)
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
 	if s.k8sh.VersionAtLeast("v1.16.0") {
 		s.settings.EnableVolumeReplication = true
 	}

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -88,7 +88,7 @@ func (s *UpgradeSuite) SetupSuite() {
 		CephVersion:       installer.NautilusPartitionVersion,
 	}
 
-	s.installer, s.k8sh = StartTestCluster(s.T, s.settings, upgradeMinimalTestVersion)
+	s.installer, s.k8sh = StartTestCluster(s.T, s.settings)
 	s.helper = clients.CreateTestClient(s.k8sh, s.installer.Manifests)
 }
 


### PR DESCRIPTION
The `*SuiteMinimalTestVersion` vars in
`tests/integration/ceph_base_deploy_test.go` are no longer needed with
Jenkins no longer being used. Remove them.

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
