### PR TITLE
core: add missing error type check to exec

### DIFF
--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -17,9 +17,16 @@ limitations under the License.
 package exec
 
 import (
-	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 	"testing"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kexec "k8s.io/utils/exec"
 )
 
 func Test_assertErrorType(t *testing.T) {
@@ -42,4 +49,92 @@ func Test_assertErrorType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtractExitCode(t *testing.T) {
+	mockExecExitError := func(retcode int) *exec.ExitError {
+		// we can't create an exec.ExitError directly, but we can get one by running a command that fails
+		// use go's type assertion to be sure we are returning exactly *exec.ExitError
+		cmd := mockExecCommandReturns("stdout", "stderr", retcode)
+		err := cmd.Run()
+
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("failed to create an *exec.ExitError. instead %T", err)
+		}
+		return ee
+	}
+
+	expectError := true
+	noError := false
+
+	tests := []struct {
+		name     string
+		inputErr error
+		want     int
+		wantErr  bool
+	}{
+		{"*exec.ExitError",
+			mockExecExitError(3),
+			3, noError},
+		/* {"exec.ExitError", // non-pointer case is impossible (won't compile) */
+		{"*kexec.CodeExitError (pointer)",
+			&kexec.CodeExitError{Err: errors.New("some error"), Code: 4},
+			4, noError},
+		{"kexec.CodeExitError (non-pointer)",
+			kexec.CodeExitError{Err: errors.New("some error"), Code: 5},
+			5, noError},
+		{"*kerrors.StatusError",
+			&kerrors.StatusError{ErrStatus: metav1.Status{Code: 6}},
+			6, noError},
+		/* {"kerrors.StatusError", // non-pointer case is impossible (won't compile) */
+		{"unknown error type with error code extractable from error message",
+			errors.New("command terminated with exit code 7"),
+			7, noError},
+		{"unknown error type with no extractable error code",
+			errors.New("command with no extractable error code even with an int here: 8"),
+			-1, expectError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractExitCode(tt.inputErr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractExitCode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ExtractExitCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Mock an exec command where we really only care about the return values
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func mockExecCommandReturns(stdout, stderr string, retcode int) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=TestExecHelperProcess") //nolint:gosec //Rook controls the input to the exec arguments
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_HELPER_PROCESS=1",
+		fmt.Sprintf("GO_HELPER_PROCESS_STDOUT=%s", stdout),
+		fmt.Sprintf("GO_HELPER_PROCESS_STDERR=%s", stderr),
+		fmt.Sprintf("GO_HELPER_PROCESS_RETCODE=%d", retcode),
+	)
+	return cmd
+}
+
+// TestHelperProcess isn't a real test. It's used as a helper process.
+// Inspired by: https://github.com/golang/go/blob/master/src/os/exec/exec_test.go
+func TestExecHelperProcess(*testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	// test should set these in its environment to control the output of the test commands
+	fmt.Fprint(os.Stdout, os.Getenv("GO_HELPER_PROCESS_STDOUT"))
+	fmt.Fprint(os.Stderr, os.Getenv("GO_HELPER_PROCESS_STDERR"))
+	rc, err := strconv.Atoi(os.Getenv("GO_HELPER_PROCESS_RETCODE"))
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(rc)
 }


### PR DESCRIPTION
In ExtractExitCode, there is one error type that can be valid as a
pointer or not-as-a-pointer. Add a case to the type check for the
non-pointer condition.

Resolves #8280

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
