### PR TITLE
ceph: lift minimum supported version of ceph csi to v3.3.0

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -19,6 +19,10 @@ For documentation on consuming the storage:
 * RBD: See the [Block Storage](ceph-block.md) topic
 * CephFS: See the [Shared Filesystem](ceph-filesystem.md) topic
 
+## Supported Versions
+The supported Ceph CSI version is 3.3.0 or greater with Rook. Refer to ceph csi [releases](https://github.com/ceph/ceph-csi/releases)
+for more information.
+
 ## Static Provisioning
 
 Both drivers also support the creation of static PV and static PVC from existing RBD image/CephFS volume. Refer to [static PVC](https://github.com/ceph/ceph-csi/blob/devel/docs/static-pvc.md) for more information.

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -281,13 +281,6 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 	// critical pods in cluster but less priority than plugin pods
 	tp.ProvisionerPriorityClassName = k8sutil.GetValue(r.opConfig.Parameters, "CSI_PROVISIONER_PRIORITY_CLASSNAME", "")
 
-	// OMAP generator will be enabled by default
-	// If AllowUnsupported is set to false and if CSI version is less than
-	// <3.2.0 disable OMAP generator sidecar
-	if !v.SupportsOMAPController() {
-		tp.EnableOMAPGenerator = false
-	}
-
 	if strings.EqualFold(k8sutil.GetValue(r.opConfig.Parameters, "CSI_ENABLE_OMAP_GENERATOR", "false"), "true") {
 		tp.EnableOMAPGenerator = true
 	}

--- a/pkg/operator/ceph/csi/version.go
+++ b/pkg/operator/ceph/csi/version.go
@@ -25,22 +25,16 @@ import (
 )
 
 var (
-	//minimum supported version is 3.0.0
-	minimum = CephCSIVersion{3, 0, 0}
+	//minimum supported version is 3.3.0
+	minimum = CephCSIVersion{3, 3, 0}
 	//supportedCSIVersions are versions that rook supports
-	releasev310          = CephCSIVersion{3, 1, 0}
-	releasev320          = CephCSIVersion{3, 2, 0}
 	releasev330          = CephCSIVersion{3, 3, 0}
 	releasev340          = CephCSIVersion{3, 4, 0}
 	supportedCSIVersions = []CephCSIVersion{
 		minimum,
-		releasev310,
-		releasev320,
 		releasev330,
 		releasev340,
 	}
-	// omap generator is supported in v3.2.0+
-	omapSupportedVersions = releasev320
 	// for parsing the output of `cephcsi`
 	versionCSIPattern = regexp.MustCompile(`v(\d+)\.(\d+)\.(\d+)`)
 )
@@ -55,33 +49,6 @@ type CephCSIVersion struct {
 func (v *CephCSIVersion) String() string {
 	return fmt.Sprintf("v%d.%d.%d",
 		v.Major, v.Minor, v.Bugfix)
-}
-
-// SupportsOMAPController checks if the detected version supports OMAP generator
-func (v *CephCSIVersion) SupportsOMAPController() bool {
-
-	// if AllowUnsupported is set also a csi-image greater than the supported ones are allowed
-	if AllowUnsupported {
-		return true
-	}
-
-	if !v.isAtLeast(&minimum) {
-		return false
-	}
-
-	if v.Major > omapSupportedVersions.Major {
-		return true
-	}
-	if v.Major == omapSupportedVersions.Major {
-		if v.Minor > omapSupportedVersions.Minor {
-			return true
-		}
-		if v.Minor == omapSupportedVersions.Minor {
-			return v.Bugfix >= omapSupportedVersions.Bugfix
-		}
-	}
-
-	return false
 }
 
 // Supported checks if the detected version is part of the known supported CSI versions

--- a/pkg/operator/ceph/csi/version_test.go
+++ b/pkg/operator/ceph/csi/version_test.go
@@ -23,11 +23,7 @@ import (
 )
 
 var (
-	testMinVersion         = CephCSIVersion{2, 0, 0}
-	testReleaseV210        = CephCSIVersion{2, 1, 0}
-	testReleaseV300        = CephCSIVersion{3, 0, 0}
-	testReleaseV320        = CephCSIVersion{3, 2, 0}
-	testReleaseV321        = CephCSIVersion{3, 2, 1}
+	testMinVersion         = CephCSIVersion{3, 3, 0}
 	testReleaseV330        = CephCSIVersion{3, 3, 0}
 	testReleaseV340        = CephCSIVersion{3, 4, 0}
 	testVersionUnsupported = CephCSIVersion{4, 0, 0}
@@ -43,44 +39,8 @@ func TestIsAtLeast(t *testing.T) {
 	ret = testMinVersion.isAtLeast(&testMinVersion)
 	assert.Equal(t, true, ret)
 
-	// Test version which is greater (minor)
-	version = CephCSIVersion{2, 1, 0}
-	ret = testMinVersion.isAtLeast(&version)
-	assert.Equal(t, false, ret)
-
-	// Test version which is greater (bugfix)
-	version = CephCSIVersion{2, 2, 0}
-	ret = testMinVersion.isAtLeast(&version)
-	assert.Equal(t, false, ret)
-
-	// Test for v2.1.0
-	// Test version which is greater (bugfix)
-	version = CephCSIVersion{2, 0, 1}
-	ret = testReleaseV210.isAtLeast(&version)
-	assert.Equal(t, true, ret)
-
 	// Test version which is equal
-	ret = testReleaseV210.isAtLeast(&testReleaseV210)
-	assert.Equal(t, true, ret)
-
-	// Test version which is greater (minor)
-	version = CephCSIVersion{2, 1, 1}
-	ret = testReleaseV210.isAtLeast(&version)
-	assert.Equal(t, false, ret)
-
-	// Test version which is greater (bugfix)
-	version = CephCSIVersion{2, 2, 0}
-	ret = testReleaseV210.isAtLeast(&version)
-	assert.Equal(t, false, ret)
-
-	// Test for 3.0.0
-	// Test version which is equal
-	ret = testReleaseV300.isAtLeast(&testReleaseV300)
-	assert.Equal(t, true, ret)
-
-	// Test for 3.3.0
-	// Test version which is lesser
-	ret = testReleaseV330.isAtLeast(&testReleaseV300)
+	ret = testReleaseV330.isAtLeast(&testReleaseV330)
 	assert.Equal(t, true, ret)
 
 	// Test for 3.4.0
@@ -88,50 +48,23 @@ func TestIsAtLeast(t *testing.T) {
 	ret = testReleaseV340.isAtLeast(&testReleaseV330)
 	assert.Equal(t, true, ret)
 
-	// Test version which is greater (minor)
-	version = CephCSIVersion{3, 1, 1}
-	ret = testReleaseV300.isAtLeast(&version)
-	assert.Equal(t, false, ret)
-
-	// Test version which is greater (bugfix)
-	version = CephCSIVersion{3, 2, 0}
-	ret = testReleaseV300.isAtLeast(&version)
-	assert.Equal(t, false, ret)
 }
 
 func TestSupported(t *testing.T) {
 	AllowUnsupported = false
 	ret := testMinVersion.Supported()
-	assert.Equal(t, false, ret)
+	assert.Equal(t, true, ret)
 
 	ret = testVersionUnsupported.Supported()
 	assert.Equal(t, false, ret)
+
+	ret = testReleaseV330.Supported()
+	assert.Equal(t, true, ret)
 
 	ret = testReleaseV340.Supported()
 	assert.Equal(t, true, ret)
 }
 
-func TestSupportOMAPController(t *testing.T) {
-	AllowUnsupported = true
-	ret := testMinVersion.SupportsOMAPController()
-	assert.True(t, ret)
-
-	AllowUnsupported = false
-	ret = testMinVersion.SupportsOMAPController()
-	assert.False(t, ret)
-
-	ret = testReleaseV300.SupportsOMAPController()
-	assert.False(t, ret)
-
-	ret = testReleaseV320.SupportsOMAPController()
-	assert.True(t, ret)
-
-	ret = testReleaseV321.SupportsOMAPController()
-	assert.True(t, ret)
-
-	ret = testReleaseV330.SupportsOMAPController()
-	assert.True(t, ret)
-}
 func Test_extractCephCSIVersion(t *testing.T) {
 	expectedVersion := CephCSIVersion{3, 0, 0}
 	csiString := []byte(`Cephcsi Version: v3.0.0


### PR DESCRIPTION
With the release of Ceph CSI 3.4.0, Ceph CSI project came up
with a new support policy where we support only versions >= 3.3.0

The supported window of Ceph CSI versions is known as "N.(x-1)":
 (N (Latest major release) . (x (Latest minor release) - 1)).

For example, if Ceph CSI latest major version is 3.4.0 today,
support is provided for the versions above 3.3.0.
If users are running an unsupported Ceph CSI version, they will be
asked to upgrade when requesting support for the cluster.

This PR lift the minimum supported version of Ceph CSI to 3.3.0
in this repo.

Fix https://github.com/rook/rook/issues/8709

Ref #
https://github.com/ceph/ceph-csi/releases/tag/v3.4.0
https://github.com/ceph/ceph-csi/#known-to-work-co-platforms

NOTE:  Kept `minimum` and `releasev330` vars eventhough both points to the same version . Please let me know if I need to drop `releasev330`  and keep only `minimum` var.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
