### PR TITLE
ceph: add workaround for Parallel RBD PVC Creation hangs on new pools

### DIFF
--- a/Documentation/ceph-csi-troubleshooting.md
+++ b/Documentation/ceph-csi-troubleshooting.md
@@ -441,3 +441,13 @@ $ rbd ls --id=csi-rbd-node -m=10.111.136.166:6789 --key=AQDpIQhg+v83EhAAgLboWIbl
 ```
 
 Where `-m` is one of the mon endpoints and the `--key` is the key used by the CSI driver for accessing the Ceph cluster.
+
+## Parallel RBD PVC creation hangs for new BlockPool
+
+This issue is specifically present in CephCSI `v3.4.x`, used by rook `>=v1.7.1` and occurs when multiple parallel PVCs creation requests are issued on a newly created uninitialized blockpool. Follow the steps below to workaround the issue:
+* Execute `rbd pool init <pool_name>` command from [toolbox](./ceph-toolbox.md) or ceph-csi pods(similar to [this](#rbd-commands)).
+* Restart the csi-rbdplugin-provisioner-xxx pods.
+
+    `kubectl -n rook-ceph delete pods -l app=csi-rbdplugin-provisioner`
+
+After following the above steps, multiple parallel PVC creation will work as expected.


### PR DESCRIPTION
This commit adds workaround for Parallel RBD PVC Creation hangs on
new pools in ceph-csi-troubleshooting.md.
Refer: #8696

Signed-off-by: Rakshith R <rar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
