### PR TITLE
rgw: do not create the rgw ops user on the secondary cluster

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -323,7 +323,19 @@ func GetAdminOPSUserCredentials(objContext *Context, spec *cephv1.ObjectStoreSpe
 		AdminOpsUser: true,
 	}
 	logger.Debugf("creating s3 user object %q for object store %q", userConfig.UserID, ns)
-	user, rgwerr, err := CreateUser(objContext, userConfig)
+
+	forceUserCreation := false
+	// If the cluster where we are running the rgw user create for the admin ops user is configured
+	// as a secondary cluster the gateway will error out with:
+	// 		Please run the command on master zone. Performing this operation on non-master zone leads to
+	// 		inconsistent metadata between zones
+	// It is safe to force it since the creation will return that the user already exists since it
+	// has been created by the primary cluster. In this case, we simply read the user details.
+	if spec.IsMultisite() {
+		forceUserCreation = true
+	}
+
+	user, rgwerr, err := CreateUser(objContext, userConfig, forceUserCreation)
 	if err != nil {
 		if rgwerr == ErrorCodeFileExists {
 			user, _, err = GetUser(objContext, userConfig.UserID)

--- a/pkg/operator/ceph/object/objectstore.go
+++ b/pkg/operator/ceph/object/objectstore.go
@@ -861,7 +861,10 @@ func enableRGWDashboard(context *Context) error {
 	}
 	// TODO:
 	// Use admin ops user instead!
-	u, errCode, err := CreateUser(context, user)
+	// It's safe to create the user with the force flag regardless if the cluster's dashboard is
+	// configured as a secondary rgw site. The creation will return the user already exists and we
+	// will just fetch it (it has been created by the primary cluster)
+	u, errCode, err := CreateUser(context, user, true)
 	if err != nil || errCode != 0 {
 		return errors.Wrapf(err, "failed to create user %q", DashboardUser)
 	}

--- a/pkg/operator/ceph/object/user.go
+++ b/pkg/operator/ceph/object/user.go
@@ -104,7 +104,7 @@ func GetUser(c *Context, id string) (*ObjectUser, int, error) {
 // CreateUser creates a new user with the information given.
 // The function is used **ONCE** only to provision so the RGW Admin Ops User
 // Subsequent interaction with the API will be done with the created user
-func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
+func CreateUser(c *Context, user ObjectUser, force bool) (*ObjectUser, int, error) {
 	logger.Debugf("creating s3 user %q", user.UserID)
 
 	if strings.TrimSpace(user.UserID) == "" {
@@ -132,6 +132,10 @@ func CreateUser(c *Context, user ObjectUser) (*ObjectUser, int, error) {
 
 	if user.AdminOpsUser {
 		args = append(args, "--caps", rgwAdminOpsUserCaps)
+	}
+
+	if force {
+		args = append(args, "--yes-i-really-mean-it")
 	}
 
 	result, err := runAdminCommand(c, true, args...)

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -250,10 +250,10 @@ function write_object_to_cluster1_read_from_cluster2() {
   BASE64_SECRET_KEY=$(kubectl -n rook-ceph get secrets realm-a-keys -o jsonpath="{.data.secret-key}")
   ACCESS_KEY=$(echo ${BASE64_ACCESS_KEY} | base64 --decode)
   SECRET_KEY=$(echo ${BASE64_SECRET_KEY} | base64 --decode)
-  s3cmd --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_1_IP_ADDR} mb s3://bkt
-  s3cmd --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_1_IP_ADDR} put ./1M.dat s3://bkt
+  s3cmd -v -d --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_1_IP_ADDR} mb s3://bkt
+  s3cmd -v -d --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_1_IP_ADDR} put ./1M.dat s3://bkt
   CLUSTER_2_IP_ADDR=$(kubectl -n rook-ceph-secondary get svc rook-ceph-rgw-zone-b-multisite-store -o jsonpath="{.spec.clusterIP}")
-  s3cmd --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_2_IP_ADDR} get s3://bkt/1M.dat 1M-get.dat --force
+  s3cmd -v -d --config=s3cfg --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY} --host=${CLUSTER_2_IP_ADDR} get s3://bkt/1M.dat 1M-get.dat --force
   diff 1M.dat 1M-get.dat
 }
 


### PR DESCRIPTION
**Description of your changes:**

If the cluster where the rgw is started is secondary and not primary,
trying to create the admin ops user will fail with:

```
Please run the command on master zone.
Performing this operation on non-master zone
leads to inconsistent metadata between zones
```

So we need to force the creation regardless, it is fine the creation will
return UserAlreadyExist and then we just read the current user.

Closes: https://github.com/rook/rook/issues/8671
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
