### PR TITLE
rgw: reduce RBAC for lib-bucket-provisioner

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrole.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrole.yaml
@@ -50,6 +50,8 @@ rules:
 ---
 # The cluster role for managing the Rook CRDs
 apiVersion: rbac.authorization.k8s.io/v1
+# Rook watches for its CRDs in all namespaces, so this should be a cluster-scoped role unless the
+# operator config `ROOK_CURRENT_NAMESPACE_ONLY=true`.
 kind: ClusterRole
 metadata:
   name: rook-ceph-global
@@ -66,6 +68,11 @@ rules:
   - nodes
   - nodes/proxy
   - services
+  # Rook watches secrets which it uses to configure access to external resources.
+  # e.g., external Ceph cluster; TLS certificates for the admission controller or object store
+  - secrets
+  # Rook watches for changes to the rook-operator-config configmap
+  - configmaps
   verbs:
   - get
   - list
@@ -222,6 +229,9 @@ rules:
   - list
   - watch
 ---
+# Used for provisioning ObjectBuckets (OBs) in response to ObjectBucketClaims (OBCs).
+# Note: Rook runs a copy of the lib-bucket-provisioner's OBC controller.
+# OBCs can be created in any Kubernetes namespace, so this must be a cluster-scoped role.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -230,27 +240,49 @@ metadata:
     operator: rook
     storage-backend: ceph
 rules:
-- apiGroups:
-  - ""
-  verbs:
-  - "*"
-  resources:
-  - secrets
-  - configmaps
-- apiGroups:
-    - storage.k8s.io
-  resources:
-    - storageclasses
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-  - "objectbucket.io"
-  verbs:
-  - "*"
-  resources:
-  - "*"
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs:
+      # OBC controller creates secrets and configmaps containing information for users about how to
+      # connect to object buckets. It deletes them when an OBC is deleted.
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs:
+      # OBC controller gets parameters from the OBC's storageclass
+      # Rook gets additional parameters from the OBC's storageclass
+      - get
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims"]
+    verbs:
+      # OBC controller needs to list/watch OBCs and get latest version of a reconciled OBC
+      - list
+      - watch
+      - get
+      # Ideally, update should not be needed, but the OBC controller updates the OBC with bucket
+      # information outside of the status subresource
+      - update
+      # OBC controller does not delete OBCs; users do this
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbuckets"]
+    verbs:
+      # OBC controller needs to list/watch OBs and get latest version of a reconciled OB
+      - list
+      - watch
+      - get
+      # OBC controller creates an OB when an OBC's bucket has been provisioned by Ceph, updates them
+      # when an OBC is updated, and deletes them when the OBC is de-provisioned.
+      - create
+      - update
+      - delete
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims/status", "objectbuckets/status"]
+    verbs:
+      # OBC controller updates OBC and OB statuses
+      - update
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -62,6 +62,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRoleBinding
+# Give Rook-Ceph Operator permissions to provision ObjectBuckets in response to ObjectBucketClaims.
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-object-bucket

--- a/cluster/examples/kubernetes/ceph/common.yaml
+++ b/cluster/examples/kubernetes/ceph/common.yaml
@@ -17,6 +17,7 @@ metadata:
   name: rook-ceph # namespace:cluster
 # OLM: BEGIN OBJECTBUCKET ROLEBINDING
 ---
+# Give Rook-Ceph Operator permissions to provision ObjectBuckets in response to ObjectBucketClaims.
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -128,6 +129,8 @@ rules:
 ---
 # The cluster role for managing the Rook CRDs
 apiVersion: rbac.authorization.k8s.io/v1
+# Rook watches for its CRDs in all namespaces, so this should be a cluster-scoped role unless the
+# operator config `ROOK_CURRENT_NAMESPACE_ONLY=true`.
 kind: ClusterRole
 metadata:
   name: rook-ceph-global
@@ -144,6 +147,11 @@ rules:
       - nodes
       - nodes/proxy
       - services
+      # Rook watches secrets which it uses to configure access to external resources.
+      # e.g., external Ceph cluster; TLS certificates for the admission controller or object store
+      - secrets
+      # Rook watches for changes to the rook-operator-config configmap
+      - configmaps
     verbs:
       - get
       - list
@@ -285,6 +293,9 @@ rules:
       - list
       - watch
 ---
+# Used for provisioning ObjectBuckets (OBs) in response to ObjectBucketClaims (OBCs).
+# Note: Rook runs a copy of the lib-bucket-provisioner's OBC controller.
+# OBCs can be created in any Kubernetes namespace, so this must be a cluster-scoped role.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -293,27 +304,49 @@ metadata:
     operator: rook
     storage-backend: ceph
 rules:
-  - apiGroups:
-      - ""
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
     verbs:
-      - "*"
-    resources:
-      - secrets
-      - configmaps
-  - apiGroups:
-      - storage.k8s.io
-    resources:
-      - storageclasses
-    verbs:
+      # OBC controller creates secrets and configmaps containing information for users about how to
+      # connect to object buckets. It deletes them when an OBC is deleted.
       - get
+      - create
+      - update
+      - delete
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs:
+      # OBC controller gets parameters from the OBC's storageclass
+      # Rook gets additional parameters from the OBC's storageclass
+      - get
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims"]
+    verbs:
+      # OBC controller needs to list/watch OBCs and get latest version of a reconciled OBC
       - list
       - watch
-  - apiGroups:
-      - "objectbucket.io"
+      - get
+      # Ideally, update should not be needed, but the OBC controller updates the OBC with bucket
+      # information outside of the status subresource
+      - update
+      # OBC controller does not delete OBCs; users do this
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbuckets"]
     verbs:
-      - "*"
-    resources:
-      - "*"
+      # OBC controller needs to list/watch OBs and get latest version of a reconciled OB
+      - list
+      - watch
+      - get
+      # OBC controller creates an OB when an OBC's bucket has been provisioned by Ceph, updates them
+      # when an OBC is updated, and deletes them when the OBC is de-provisioned.
+      - create
+      - update
+      - delete
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims/status", "objectbuckets/status"]
+    verbs:
+      # OBC controller updates OBC and OB statuses
+      - update
 # OLM: END OPERATOR ROLE
 # OLM: BEGIN SERVICE ACCOUNT SYSTEM
 ---


### PR DESCRIPTION
Reduce the RBAC scope for the lib-bucket-provisioner to the minimum
necessary for Rook to operate with lib-bucket-provisioner. Comment the
RBAC so that users can make informed decisions about whether or not they
can remove the permissions for their uses.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
