### PR TITLE
test: Run all integration tests against the local build

### DIFF
--- a/tests/framework/installer/ceph_helm_installer.go
+++ b/tests/framework/installer/ceph_helm_installer.go
@@ -77,7 +77,7 @@ func (h *CephInstaller) CreateRookCephClusterViaHelm(values map[string]interface
 	values["configOverride"] = clusterCustomSettings
 	values["toolbox"] = map[string]interface{}{
 		"enabled": true,
-		"image":   "rook/ceph:master",
+		"image":   "rook/ceph:" + LocalBuildTag,
 	}
 	values["cephClusterSpec"] = clusterCRD["spec"]
 

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -448,7 +448,7 @@ func (h *CephInstaller) installRookOperator() (bool, error) {
 		startDiscovery = true
 		err := h.CreateRookOperatorViaHelm(map[string]interface{}{
 			"enableDiscoveryDaemon": true,
-			"image":                 map[string]interface{}{"tag": "master"},
+			"image":                 map[string]interface{}{"tag": LocalBuildTag},
 		})
 		if err != nil {
 			return false, errors.Wrap(err, "failed to configure helm")
@@ -479,7 +479,7 @@ func (h *CephInstaller) installRookOperator() (bool, error) {
 }
 
 func (h *CephInstaller) InstallRook() (bool, error) {
-	if h.settings.RookVersion != VersionMaster {
+	if h.settings.RookVersion != LocalBuildTag {
 		// make sure we have the images from a previous release locally so the test doesn't hit a timeout
 		assert.NoError(h.T(), h.k8shelper.GetDockerImage("rook/ceph:"+h.settings.RookVersion))
 	}
@@ -499,7 +499,7 @@ func (h *CephInstaller) InstallRook() (bool, error) {
 
 	if h.settings.UseHelm {
 		err = h.CreateRookCephClusterViaHelm(map[string]interface{}{
-			"image": "rook/ceph:master",
+			"image": "rook/ceph:" + LocalBuildTag,
 		})
 		if err != nil {
 			return false, errors.Wrap(err, "failed to install ceph cluster using Helm")
@@ -901,7 +901,7 @@ spec:
           restartPolicy: Never
           containers:
               - name: rook-cleaner
-                image: rook/ceph:` + VersionMaster + `
+                image: rook/ceph:` + LocalBuildTag + `
                 securityContext:
                     privileged: true
                 volumeMounts:
@@ -931,7 +931,7 @@ spec:
           restartPolicy: Never
           containers:
               - name: rook-cleaner
-                image: rook/ceph:` + VersionMaster + `
+                image: rook/ceph:` + LocalBuildTag + `
                 securityContext:
                     privileged: true
                 volumeMounts:

--- a/tests/framework/installer/ceph_manifests.go
+++ b/tests/framework/installer/ceph_manifests.go
@@ -56,7 +56,7 @@ type CephManifestsMaster struct {
 // NewCephManifests gets the manifest type depending on the Rook version desired
 func NewCephManifests(settings *TestCephSettings) CephManifests {
 	switch settings.RookVersion {
-	case VersionMaster:
+	case LocalBuildTag:
 		return &CephManifestsMaster{settings}
 	case Version1_6:
 		return &CephManifestsV1_6{settings}

--- a/tests/framework/installer/installer.go
+++ b/tests/framework/installer/installer.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	// VersionMaster tag for the latest manifests
-	VersionMaster = "master"
+	// LocalBuildTag tag for the latest manifests
+	LocalBuildTag = "local-build"
 
 	// test suite names
 	CassandraTestSuite = "cassandra"

--- a/tests/framework/installer/settings.go
+++ b/tests/framework/installer/settings.go
@@ -21,11 +21,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/tests/framework/utils"
 )
+
+var imageMatch = regexp.MustCompile(`image: rook\/ceph:[a-z0-9.-]+`)
 
 func readManifest(provider, filename string) string {
 	rootDir, err := utils.FindRookRoot()
@@ -38,7 +41,7 @@ func readManifest(provider, filename string) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "failed to read manifest at %s", manifest))
 	}
-	return string(contents)
+	return imageMatch.ReplaceAllString(string(contents), "image: rook/ceph:"+LocalBuildTag)
 }
 
 func readManifestFromGithub(rookVersion, provider, filename string) string {

--- a/tests/integration/ceph_flex_test.go
+++ b/tests/integration/ceph_flex_test.go
@@ -94,7 +94,7 @@ func (s *CephFlexDriverSuite) SetupSuite() {
 		SkipOSDCreation:    false,
 		UseCSI:             false,
 		DirectMountToolbox: true,
-		RookVersion:        installer.VersionMaster,
+		RookVersion:        installer.LocalBuildTag,
 		CephVersion:        installer.OctopusVersion,
 	}
 	s.settings.ApplyEnvVars()

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -73,7 +73,7 @@ func (h *HelmSuite) SetupSuite() {
 		SkipOSDCreation:           false,
 		EnableAdmissionController: false,
 		EnableDiscovery:           true,
-		RookVersion:               installer.VersionMaster,
+		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.OctopusVersion,
 	}
 	h.settings.ApplyEnvVars()

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -95,7 +95,7 @@ func (s *CephMgrSuite) SetupSuite() {
 		UseCSI:            true,
 		SkipOSDCreation:   true,
 		EnableDiscovery:   true,
-		RookVersion:       installer.VersionMaster,
+		RookVersion:       installer.LocalBuildTag,
 		CephVersion:       installer.MasterVersion,
 	}
 	s.settings.ApplyEnvVars()
@@ -224,7 +224,7 @@ func (s *CephMgrSuite) TestStatus() {
 	assert.Equal(s.T(), status, "Backend: rook\nAvailable: Yes")
 }
 
-func logBytesInfo(bytesSlice []byte){
+func logBytesInfo(bytesSlice []byte) {
 	logger.Infof("---- bytes slice info ---")
 	logger.Infof("bytes: %v\n", bytesSlice)
 	logger.Infof("length: %d\n", len(bytesSlice))

--- a/tests/integration/ceph_multi_cluster_test.go
+++ b/tests/integration/ceph_multi_cluster_test.go
@@ -87,7 +87,7 @@ func (s *MultiClusterDeploySuite) SetupSuite() {
 		UseCSI:                    true,
 		MultipleMgrs:              true,
 		EnableAdmissionController: true,
-		RookVersion:               installer.VersionMaster,
+		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.NautilusVersion,
 	}
 	s.settings.ApplyEnvVars()

--- a/tests/integration/ceph_object_test.go
+++ b/tests/integration/ceph_object_test.go
@@ -75,7 +75,7 @@ func (s *ObjectSuite) SetupSuite() {
 		UseCSI:                    true,
 		EnableAdmissionController: true,
 		UseCrashPruner:            true,
-		RookVersion:               installer.VersionMaster,
+		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -99,7 +99,7 @@ func (s *SmokeSuite) SetupSuite() {
 		UseCSI:                    true,
 		EnableAdmissionController: true,
 		UseCrashPruner:            true,
-		RookVersion:               installer.VersionMaster,
+		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.PacificVersion,
 	}
 	s.settings.ApplyEnvVars()

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -183,7 +183,7 @@ func (s *UpgradeSuite) TestUpgradeToMaster() {
 	s.gatherLogs(s.settings.OperatorNamespace, "_before_master_upgrade")
 	s.upgradeToMaster()
 
-	s.verifyOperatorImage(installer.VersionMaster)
+	s.verifyOperatorImage(installer.LocalBuildTag)
 	s.verifyRookUpgrade(numOSDs)
 	err = s.installer.WaitForToolbox(s.namespace)
 	assert.NoError(s.T(), err)
@@ -359,15 +359,15 @@ func (s *UpgradeSuite) verifyFilesAfterUpgrade(fsName, newFileToWrite, messageFo
 // verify the upgrade but merely starts the upgrade process.
 func (s *UpgradeSuite) upgradeToMaster() {
 	// Apply the CRDs for the latest master
-	s.settings.RookVersion = installer.VersionMaster
+	s.settings.RookVersion = installer.LocalBuildTag
 	m := installer.NewCephManifests(s.settings)
 	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetCRDs(s.k8sh)))
 
 	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetCommon()))
 
 	require.NoError(s.T(),
-		s.k8sh.SetDeploymentVersion(s.settings.OperatorNamespace, operatorContainer, operatorContainer, installer.VersionMaster))
+		s.k8sh.SetDeploymentVersion(s.settings.OperatorNamespace, operatorContainer, operatorContainer, installer.LocalBuildTag))
 
 	require.NoError(s.T(),
-		s.k8sh.SetDeploymentVersion(s.settings.Namespace, "rook-ceph-tools", "rook-ceph-tools", installer.VersionMaster))
+		s.k8sh.SetDeploymentVersion(s.settings.Namespace, "rook-ceph-tools", "rook-ceph-tools", installer.LocalBuildTag))
 }

--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -121,7 +121,7 @@ function build_rook() {
   tests/scripts/validate_modified_files.sh build
   docker images
   if [[ "$build_type" == "build" ]]; then
-    docker tag "$(docker images | awk '/build-/ {print $1}')" rook/ceph:master
+    docker tag "$(docker images | awk '/build-/ {print $1}')" rook/ceph:local-build
   fi
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/master/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The integration tests must always be run against the local build of rook, and an image should never be pulled from dockerhub. To prevent pulling a release or master tag, the local build will use a tag specific to the build and not ever published elsewhere.

This was first merged to release-1.7 with #8780 so it could be tested where we were seeing the issue with tests not matching the build. Now we cherry-pick to master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/master/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/master/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
