### PR TITLE
ceph: stop using tini

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -14,3 +14,6 @@ v1.8...
   to update to a newer version before updating to Rook v1.8.
 
 ## Features
+
+- The Rook Operator does not use "tini" as an init process. Instead, it uses the "rook" and handles
+  signals on its own.

--- a/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/deployment.yaml
@@ -24,9 +24,10 @@ spec:
       containers:
         - name: rook-ceph-tools
           image: {{ .Values.toolbox.image }}
-          command: ["/tini"]
-          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          command: ["/bin/bash"]
+          args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
+          tty: true
           env:
             - name: ROOK_CEPH_USERNAME
               valueFrom:

--- a/cluster/examples/kubernetes/ceph/toolbox.yaml
+++ b/cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -19,9 +19,10 @@ spec:
       containers:
         - name: rook-ceph-tools
           image: rook/ceph:master
-          command: ["/tini"]
-          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          command: ["/bin/bash"]
+          args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
+          tty: true
           env:
             - name: ROOK_CEPH_USERNAME
               valueFrom:

--- a/cmd/rook/util/copybins.go
+++ b/cmd/rook/util/copybins.go
@@ -24,19 +24,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CopyBinsCmd defines a top-level utility command which copies rook and tini binaries from the Rook
+// CopyBinsCmd defines a top-level utility command which copies rook binary from the Rook
 // container image to a directory.
 var CopyBinsCmd = &cobra.Command{
 	Use:   "copy-binaries",
-	Short: "Copy 'rook' and 'tini' binaries from a container to a given directory.",
-	Long: `Copy 'rook' and 'tini' binaries from a container to a given directory.
+	Short: "Copy 'rook' binary from a container to a given directory.",
+	Long: `Copy 'rook' binary from a container to a given directory.
 As an example, 'cmd-reporter run' may often need to be run from a container
 other than the container containing the 'rook' binary. Use this command to copy
-the 'rook' and required 'tini' binaries from the container containing the 'rook'
+the 'rook' binary from the container containing the 'rook'
 binary to a Kubernetes EmptyDir volume mounted at the given directory in a pod's
 init container. From the pod's main container, mount the volume which now
-contains the 'rook' and 'tini' binaries, and call 'rook cmd-reporter run' from
-'tini' in order to run the desired command from a non-Rook container.`,
+contains the 'rook' binary, and call 'rook cmd-reporter run' from
+'rook' in order to run the desired command from a non-Rook container.`,
 	Args: cobra.NoArgs,
 	RunE: runCopyBins,
 }
@@ -44,7 +44,7 @@ contains the 'rook' and 'tini' binaries, and call 'rook cmd-reporter run' from
 func init() {
 	// copy-binaries
 	CopyBinsCmd.Flags().StringVar(&copyToDir, "copy-to-dir", "",
-		"The directory into which 'tini' and 'rook' binaries will be copied.")
+		"The directory into which 'rook' binary will be copied.")
 	if err := CopyBinsCmd.MarkFlagRequired("copy-to-dir"); err != nil {
 		panic(err)
 	}
@@ -52,7 +52,7 @@ func init() {
 
 func runCopyBins(cCmd *cobra.Command, cArgs []string) error {
 	if err := util.CopyBinaries(copyToDir); err != nil {
-		rook.TerminateFatal(fmt.Errorf("could not copy binaries to %s. %+v", copyToDir, err))
+		rook.TerminateFatal(fmt.Errorf("could not copy binary to %s. %+v", copyToDir, err))
 	}
 	return nil
 }

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -16,15 +16,9 @@
 FROM BASEIMAGE
 
 ARG ARCH
-ARG TINI_VERSION
-
-# Run tini as PID 1 and avoid signal handling issues
-RUN curl --fail -sSL -o /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} && \
-    chmod +x /tini
-
 COPY rook toolbox.sh set-ceph-debug-level /usr/local/bin/
 COPY ceph-monitoring /etc/ceph-monitoring
 COPY rook-external /etc/rook-external/
 COPY ceph-csv-templates /etc/ceph-csv-templates
-ENTRYPOINT ["/tini", "--", "/usr/local/bin/rook"]
+ENTRYPOINT ["/usr/local/bin/rook"]
 CMD [""]

--- a/pkg/daemon/util/cmdreporter_test.go
+++ b/pkg/daemon/util/cmdreporter_test.go
@@ -74,6 +74,7 @@ func TestCommandMarshallingUnmarshalling(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	ctx := context.TODO()
 	client := fake.NewSimpleClientset
 	type fields struct {
 		clientset     kubernetes.Interface
@@ -101,6 +102,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r, err := NewCmdReporter(
+				ctx,
 				tt.fields.clientset,
 				tt.fields.cmd,
 				tt.fields.args,
@@ -145,7 +147,7 @@ func TestRunner_Run(t *testing.T) {
 		defer func() { os.Unsetenv("GO_HELPER_PROCESS_PRINT_COMMAND") }()
 
 		k8s := newClient()
-		r, err := NewCmdReporter(k8s, cmd, args, "command-configmap", "command-namespace")
+		r, err := NewCmdReporter(ctx, k8s, cmd, args, "command-configmap", "command-namespace")
 		assert.NoError(t, err)
 		assert.NoError(t, r.Run())
 
@@ -168,7 +170,7 @@ func TestRunner_Run(t *testing.T) {
 		defer func() { os.Unsetenv("GO_HELPER_PROCESS_RETCODE") }()
 
 		k8s := newClient()
-		r, err := NewCmdReporter(k8s, []string{"standin-cmd"}, []string{"--some", "arg"}, "outputs-configmap", "outputs-namespace")
+		r, err := NewCmdReporter(ctx, k8s, []string{"standin-cmd"}, []string{"--some", "arg"}, "outputs-configmap", "outputs-namespace")
 		assert.NoError(t, err)
 		assert.NoError(t, r.Run())
 
@@ -195,7 +197,7 @@ func TestRunner_Run(t *testing.T) {
 	}
 	_, err := k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(ctx, cm, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	r, err := NewCmdReporter(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	r, err := NewCmdReporter(ctx, k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
 	assert.NoError(t, err)
 	assert.Error(t, r.Run())
 	cm, err = k8s.CoreV1().ConfigMaps("preexisting-namespace").Get(ctx, "preexisting-configmap", metav1.GetOptions{})
@@ -218,7 +220,7 @@ func TestRunner_Run(t *testing.T) {
 	}
 	_, err = k8s.CoreV1().ConfigMaps("preexisting-namespace").Create(ctx, cm, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	r, err = NewCmdReporter(k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
+	r, err = NewCmdReporter(ctx, k8s, []string{"some-command"}, []string{"some", "args"}, "preexisting-configmap", "preexisting-namespace")
 	assert.NoError(t, err)
 	assert.NoError(t, r.Run())
 	verifyConfigMap(k8s, "", "", "0", "preexisting-configmap", "preexisting-namespace")

--- a/pkg/daemon/util/copybins.go
+++ b/pkg/daemon/util/copybins.go
@@ -26,14 +26,10 @@ import (
 
 // override these for unit testing
 var defaultRookDir = "/usr/local/bin"
-var defaultTiniDir = "/"
 
-// CopyBinaries copies the "tini" and "rook" binaries to a shared volume at the target path.
+// CopyBinaries copies the "rook" binary to a shared volume at the target path.
 func CopyBinaries(target string) error {
-	if err := copyBinary(defaultRookDir, target, "rook"); err != nil {
-		return err
-	}
-	return copyBinary(defaultTiniDir, target, "tini")
+	return copyBinary(defaultRookDir, target, "rook")
 }
 
 // #nosec G307 Calling defer to close the file without checking the error return is not a risk for a simple file open and close

--- a/pkg/daemon/util/copybins_test.go
+++ b/pkg/daemon/util/copybins_test.go
@@ -25,8 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCopyBinaries(t *testing.T) {
-
+func TestCopyBinary(t *testing.T) {
 	createTestBinary := func(binPath string) {
 		f, err := os.Create(binPath)
 		assert.NoError(t, err)
@@ -76,79 +75,34 @@ func TestCopyBinaries(t *testing.T) {
 	oDefaultRookDir := defaultRookDir
 	defaultRookDir = path.Join(testRootDir, "/usr/local/bin")
 	defer func() { defaultRookDir = oDefaultRookDir }()
-	// set default tini dir for unit tests
-	oDefaultTiniDir := defaultTiniDir
-	defaultTiniDir = path.Join(testRootDir, "/")
-	defer func() { defaultTiniDir = oDefaultTiniDir }()
 
-	// expect failure if rook binary is available in path but not tini
+	// expect success if binary is available in path
 	// testRootDir/
 	//   bin/
 	//     rook
 	//   copy-to-dir/
 	createTestBinary(path.Join(envPath, "rook"))
-
-	err = CopyBinaries(copyToDir)
-	assert.Error(t, err)
-	if err == nil {
-		panic(err)
-	}
-
-	err = os.Remove(path.Join(envPath, "rook"))
-	assert.NoError(t, err)
-
-	// expect failure if tini binary is available in path but not rook
-	// testRootDir/
-	//   bin/
-	//     tini
-	//   copy-to-dir/
-	createTestBinary(path.Join(envPath, "tini"))
-
-	err = CopyBinaries(copyToDir)
-	assert.Error(t, err)
-	if err == nil {
-		panic(err)
-	}
-
-	err = os.Remove(path.Join(envPath, "tini"))
-	assert.NoError(t, err)
-
-	// expect success if both binaries are available in path
-	// testRootDir/
-	//   bin/
-	//     rook
-	//     tini
-	//   copy-to-dir/
-	createTestBinary(path.Join(envPath, "rook"))
-	createTestBinary(path.Join(envPath, "tini"))
 	cleanDir(copyToDir)
 
 	err = CopyBinaries(copyToDir)
 	assert.NoError(t, err)
 	r := fileText(path.Join(copyToDir, "rook"))
 	assert.Contains(t, r, path.Join(testRootDir, "bin/rook"))
-	r = fileText(path.Join(copyToDir, "tini"))
-	assert.Contains(t, r, path.Join(testRootDir, "bin/tini"))
 
-	// expect success if both binaries are available in default locations AND in path
-	// additionally expect that the binaries will be taken from the default location in this case
+	// expect success if the binary is available in default locations AND in path
+	// additionally expect that the binary will be taken from the default location in this case
 	// testRootDir/
-	//   tini
 	//   usr/local/bin/
 	//     rook
 	//   bin/
 	//     rook
-	//     tini
 	//   copy-to-dir/
 	mkdir(defaultRookDir)
 	createTestBinary(path.Join(defaultRookDir, "rook"))
-	createTestBinary(path.Join(defaultTiniDir, "tini"))
 	cleanDir(copyToDir)
 
 	err = CopyBinaries(copyToDir)
 	assert.NoError(t, err)
 	r = fileText(path.Join(copyToDir, "rook"))
 	assert.Contains(t, r, path.Join(testRootDir, "usr/local/bin/rook"))
-	r = fileText(path.Join(copyToDir, "tini"))
-	assert.Contains(t, r, path.Join(testRootDir, "tini"))
 }

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -608,8 +608,8 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 	// to modify the storage by instead running an innocuous command.
 	d.Spec.Template.Spec.InitContainers = []v1.Container{}
 	d.Spec.Template.Spec.Containers[0].Image = c.rookVersion
-	d.Spec.Template.Spec.Containers[0].Command = []string{"/tini"}
-	d.Spec.Template.Spec.Containers[0].Args = []string{"--", "sleep", "3600"}
+	d.Spec.Template.Spec.Containers[0].Command = []string{"sleep"} // sleep responds to signals so we don't need to wrap it
+	d.Spec.Template.Spec.Containers[0].Args = []string{"3600"}
 	// remove the liveness probe on the canary pod
 	d.Spec.Template.Spec.Containers[0].LivenessProbe = nil
 

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -552,7 +552,7 @@ func osdIntegrationTestExecutor(t *testing.T, clientset *fake.Clientset, namespa
 					// ceph osd ls returns an array of osd IDs like [0,1,2]
 					// build this based on the number of deployments since they should be equal
 					// for this test
-					l, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{})
+					l, err := clientset.AppsV1().Deployments(namespace).List(contextStandard.TODO(), metav1.ListOptions{})
 					if err != nil {
 						panic(fmt.Sprintf("failed to build 'ceph osd ls' output. %v", err))
 					}
@@ -620,7 +620,7 @@ func newDummyStorageClassDeviceSet(
 
 func waitForNumConfigMaps(clientset kubernetes.Interface, namespace string, count int) []corev1.ConfigMap {
 	for {
-		cms, err := clientset.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{})
+		cms, err := clientset.CoreV1().ConfigMaps(namespace).List(contextStandard.TODO(), metav1.ListOptions{})
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -299,8 +299,8 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 	readOnlyRootFilesystem := false
 
 	osdProvisionContainer := v1.Container{
-		Command:      []string{path.Join(rookBinariesMountPath, "tini")},
-		Args:         []string{"--", path.Join(rookBinariesMountPath, "rook"), "ceph", "osd", "provision"},
+		Command:      []string{path.Join(rookBinariesMountPath, "rook")},
+		Args:         []string{"ceph", "osd", "provision"},
 		Name:         "provision",
 		Image:        c.spec.CephVersion.Image,
 		VolumeMounts: volumeMounts,

--- a/pkg/operator/ceph/cluster/osd/spec_test.go
+++ b/pkg/operator/ceph/cluster/osd/spec_test.go
@@ -60,12 +60,10 @@ func TestPodContainer(t *testing.T) {
 	logger.Infof("container: %+v", container)
 	assert.Equal(t, "copy-binaries", container.Args[0])
 	container = c.Spec.Containers[0]
-	assert.Equal(t, "/rook/tini", container.Command[0])
-	assert.Equal(t, "--", container.Args[0])
-	assert.Equal(t, "/rook/rook", container.Args[1])
-	assert.Equal(t, "ceph", container.Args[2])
-	assert.Equal(t, "osd", container.Args[3])
-	assert.Equal(t, "provision", container.Args[4])
+	assert.Equal(t, "/rook/rook", container.Command[0])
+	assert.Equal(t, "ceph", container.Args[0])
+	assert.Equal(t, "osd", container.Args[1])
+	assert.Equal(t, "provision", container.Args[2])
 
 	for _, c := range c.Spec.Containers {
 		vars := operatortest.FindDuplicateEnvVars(c)

--- a/pkg/operator/ceph/operator.go
+++ b/pkg/operator/ceph/operator.go
@@ -41,9 +41,9 @@ var (
 	// ImmediateRetryResult Return this for a immediate retry of the reconciliation loop with the same request object.
 	ImmediateRetryResult = reconcile.Result{Requeue: true}
 
-	// Signals to watch for to terminate the operator gracefully
+	// ShutdownSignals signals to watch for to terminate the operator gracefully
 	// Using os.Interrupt is more portable across platforms instead of os.SIGINT
-	shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	ShutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 
 	// Placeholder for the CRD manager life cycle, first we have the context to manage cancellation
 	// of the manager.
@@ -85,7 +85,7 @@ func New(context *clusterd.Context, rookImage, serviceAccount string) *Operator 
 func (o *Operator) Run() error {
 	// Initialize signal handler and context for the operator process life cycle
 	// This context is used to handle the graceful termination of the operator
-	operatorContext, operatorStop := signal.NotifyContext(context.Background(), shutdownSignals...)
+	operatorContext, operatorStop := signal.NotifyContext(context.Background(), ShutdownSignals...)
 	defer operatorStop()
 
 	// Start the CRD manager

--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -42,10 +42,10 @@ const (
 	CmdReporterContainerName = "cmd-reporter"
 
 	// CopyBinariesInitContainerName defines the name of the CmdReporter init container which copies
-	// the 'rook' and 'tini' binaries.
+	// the 'rook' binary.
 	CopyBinariesInitContainerName = "init-copy-binaries"
 
-	// CopyBinariesMountDir defines the dir into which the 'rook' and 'tini' binaries will be copied
+	// CopyBinariesMountDir defines the dir into which the 'rook' binary will be copied
 	// in the CmdReporter job pod's containers.
 	CopyBinariesMountDir = "/rook/copied-binaries"
 )
@@ -85,7 +85,7 @@ type cmdReporterCfg struct {
 // job will be identified with the job name specified. Everything will be created in the job
 // namespace and will be owned by the owner reference given.
 //
-// The Rook image defines the Rook image from which the 'rook' and 'tini' binaries will be taken in
+// The Rook image defines the Rook image from which the 'rook' binary will be taken in
 // order to run the cmd and args in the run image. If the run image is the same as the Rook image,
 // then the command will run without the binaries being copied from the same Rook image.
 func New(
@@ -351,11 +351,9 @@ func (cr *cmdReporterCfg) container() (*v1.Container, error) {
 		return nil, fmt.Errorf("failed to convert user cmd %+v and args %+v into an argument for '--command'. %+v", cr.cmd, cr.args, err)
 	}
 
-	cmd := []string{
-		path.Join(CopyBinariesMountDir, "tini"), "--", path.Join(CopyBinariesMountDir, "rook"),
-	}
+	cmd := []string{path.Join(CopyBinariesMountDir, "rook")}
 	if !cr.needToCopyBinaries() {
-		// tini -- rook is already the cmd entrypoint if we don't need to copy binaries
+		// rook is already the cmd entrypoint if we don't need to copy binaries
 		cmd = nil
 	}
 

--- a/pkg/operator/k8sutil/volume.go
+++ b/pkg/operator/k8sutil/volume.go
@@ -81,7 +81,7 @@ func NodeConfigURI() (string, error) {
 }
 
 func BinariesMountInfo() (v1.EnvVar, v1.Volume, v1.VolumeMount) {
-	// To get rook inside the container, the config init container needs to copy "tini" and "rook" binaries into a volume.
+	// To get rook inside the container, the config init container needs to copy "rook" binary into a volume.
 	// Set the config flag so rook will copy the binaries.
 	// Create the volume and mount that will be shared between the init container and the daemon container
 	volumeName := "rookbinaries"


### PR DESCRIPTION
**Description of your changes:**

We don't need to use tini.
We don't have anything in the rook operator that would
either create zombie processes (no threads) or use
exec (to fork). The Go binary has a really good
signal handling mechanism.

Closes: https://github.com/rook/rook/issues/8794
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
