### PR TITLE
core: create TRACE_INSECURE log level

### DIFF
--- a/cluster/charts/rook-ceph/values.yaml
+++ b/cluster/charts/rook-ceph/values.yaml
@@ -41,7 +41,7 @@ currentNamespaceOnly: false
 ## Annotations to be added to pod
 annotations: {}
 
-## LogLevel can be set to: TRACE, DEBUG, INFO, NOTICE, WARNING, ERROR or CRITICAL
+## The logging level for the operator: ERROR | WARNING | INFO | DEBUG
 logLevel: INFO
 
 ## If true, create & use RBAC resources

--- a/cluster/examples/kubernetes/ceph/operator-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/operator-openshift.yaml
@@ -100,7 +100,7 @@ metadata:
   # should be in the namespace of the operator
   namespace: rook-ceph # namespace:operator
 data:
-  # The logging level for the operator: INFO | DEBUG
+  # The logging level for the operator: ERROR | WARNING | INFO | DEBUG
   ROOK_LOG_LEVEL: "INFO"
 
   # Enable the CSI driver.

--- a/cluster/examples/kubernetes/ceph/operator.yaml
+++ b/cluster/examples/kubernetes/ceph/operator.yaml
@@ -22,7 +22,7 @@ metadata:
   # should be in the namespace of the operator
   namespace: rook-ceph # namespace:operator
 data:
-  # The logging level for the operator: INFO | DEBUG
+  # The logging level for the operator: ERROR | WARNING | INFO | DEBUG
   ROOK_LOG_LEVEL: "INFO"
 
   # Enable the CSI driver.

--- a/pkg/clusterd/context.go
+++ b/pkg/clusterd/context.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterd
 
 import (
-	"github.com/coreos/pkg/capnslog"
 	netclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/util/exec"
@@ -57,9 +56,6 @@ type Context struct {
 
 	// The root configuration directory used by services
 	ConfigDir string
-
-	// A value indicating the desired logging/tracing level
-	LogLevel capnslog.LogLevel
 
 	// The full path to a config file that can be used to override generated settings
 	ConfigFileOverride string

--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/coreos/pkg/capnslog"
 	"github.com/go-ini/ini"
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
@@ -49,18 +48,13 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 	}
 
 	// start with INFO level logging
-	context := &clusterd.Context{
-		LogLevel: capnslog.INFO,
-	}
+	context := &clusterd.Context{}
 
 	cephConfig, err := CreateDefaultCephConfig(context, clusterInfo)
 	if err != nil {
 		t.Fatalf("failed to create default ceph config. %+v", err)
 	}
 	verifyConfig(t, cephConfig, clusterInfo, 0)
-
-	// now use DEBUG level logging
-	context.LogLevel = capnslog.DEBUG
 
 	cephConfig, err = CreateDefaultCephConfig(context, clusterInfo)
 	if err != nil {

--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -72,7 +72,8 @@ func (c *debugHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Debugf("\n%s\n", string(dump))
+	// this can leak credentials for making requests
+	c.logger.Tracef("\n%s\n", string(dump))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -84,7 +85,8 @@ func (c *debugHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Debugf("\n%s\n", string(dump))
+	// this can leak any sensitive info like credentials in the response
+	c.logger.Tracef("\n%s\n", string(dump))
 
 	return resp, nil
 }

--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/coreos/pkg/capnslog"
+)
+
+const DefaultLogLevel = capnslog.INFO
+
+func SetGlobalLogLevel(userLogLevelSelection string, logger *capnslog.PackageLogger) {
+	// capnslog supports trace level logging, but in Rook we want to treat trace logging as insecure
+	// and block users from finding the value in most circumstances. If they request "TRACE" level
+	// logging, just output debug logs.
+	if userLogLevelSelection == "TRACE" {
+		userLogLevelSelection = "DEBUG"
+	}
+	// only if users give the super secret "TRACE_INSECURE" log level will they get real trace
+	// logging, which might leak credentials and other insecure nasties into their logs.
+	if userLogLevelSelection == "TRACE_INSECURE" {
+		userLogLevelSelection = "TRACE"
+	}
+
+	// parse given log level string then set up corresponding global logging level
+	logLevel, err := capnslog.ParseLevel(userLogLevelSelection)
+	if err != nil {
+		logger.Errorf("failed to parse log level %q. defaulting to %q. %v", userLogLevelSelection, DefaultLogLevel.String(), err)
+		logLevel = DefaultLogLevel
+	}
+
+	// If capnslog changes in the future to allow a more verbose level than TRACE and a user somehow
+	// enters it, then reject that log level, and revert to default. This can't be unit tested, but
+	// it'll probably never happen in the wild anyway, just here for safety.
+	if logLevel > capnslog.TRACE {
+		logger.Infof("not setting log level %q more verbose than TRACE. reverting to default %q", logLevel.String(), DefaultLogLevel.String())
+		logLevel = DefaultLogLevel
+	}
+
+	capnslog.SetGlobalLogLevel(logLevel)
+}

--- a/pkg/util/logging_test.go
+++ b/pkg/util/logging_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetGlobalLogLevel(t *testing.T) {
+	logger := capnslog.NewPackageLogger("github.com/rook/rook", "pkg/util/logging_test")
+
+	tests := []struct {
+		name                  string
+		userLogLevelSelection string
+		desiredLogLevel       capnslog.LogLevel
+	}{
+		{"INFO is supported", "INFO", capnslog.INFO},
+		{"DEBUG is supported", "DEBUG", capnslog.DEBUG},
+		{"WARNING is supported", "WARNING", capnslog.WARNING},
+		{"ERROR is supported", "ERROR", capnslog.ERROR},
+		{"TRACE will be turned into DEBUG", "TRACE", capnslog.DEBUG},
+		{"TRACE_INSECURE will be turned into TRACE", "TRACE_INSECURE", capnslog.TRACE},
+		{"an invalid input will be turned into INFO", "INVALID", capnslog.INFO},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetGlobalLogLevel(tt.userLogLevelSelection, logger)
+			t.Logf("asserting that log level %d can be shown", tt.desiredLogLevel)
+			assert.True(t, logger.LevelAt(tt.desiredLogLevel))
+			// logger.LevelAt will only tell whether the logger will output logs at the desired log
+			// level, but it won't actually tell what the log level is specifically. To make sure we
+			// won't output MORE logs, we should check for the next more verbose log level also.
+			nextMostVerboseLevel := tt.desiredLogLevel + 1
+			t.Logf("asserting that log level %d can NOT be shown", nextMostVerboseLevel)
+			assert.False(t, logger.LevelAt(nextMostVerboseLevel))
+		})
+	}
+}


### PR DESCRIPTION
Create a new log level for Rook that is hidden from users. This is the
most verbose log level, and it is the level developers would like to use
to get debug logs that are important for debugging but that could leak
senstivie information like credentials in production use.

If a user sets their debug level to "TRACE", they will merely get
"DEBUG" level logs. Only if they set "TRACE_INSECURE" will they get
trace logs, and those are likely to include insecure information. Rook
tries very hard not to leak sensitive information in logs even with
verbose "DEBUG" logs.

Resolves #8778

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
