### PR TITLE
build: add py3 script to build RBAC yaml from helm

### DIFF
--- a/build/rbac/extract-rbac.py
+++ b/build/rbac/extract-rbac.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import sys
+
+import ruamel.yaml
+
+def log(*values):
+    print(*values, file=sys.stderr, flush=True)
+
+rbac_kinds = [
+    "PodSecurityPolicy",
+    "ServiceAccount",
+    "ClusterRole",
+    "ClusterRoleBinding",
+    "Role",
+    "RoleBinding",
+]
+
+yaml=ruamel.yaml.YAML()
+# output lists in the form that is indented from the parent like below
+# parent:
+#   - list
+#   - items
+yaml.indent(sequence=4, offset=2)
+
+in_docs = yaml.load_all(sys.stdin.read())
+
+kept_docs = []
+
+num_parsed = 0
+num_kept = 0
+for doc in in_docs:
+    num_parsed += 1
+    kind = doc["kind"]
+    if kind not in rbac_kinds:
+        # we don't want non-RBAC resources
+        log("discarding doc with kind:", kind)
+        continue
+
+    log("keeping doc with kind:", kind)
+
+    # helm adds '# Source: <file>' comments to the top of each yaml doc. Strip these.
+    if doc.ca is not None and doc.ca.comment is not None:
+        comments = doc.ca.comment[1]
+        for comment in comments:
+            if comment.value.startswith("# Source: ") and comment.value.endswith(".yaml\n"):
+                log("dropping comment:", comment.value.strip())
+                comments.remove(comment)
+
+    kept_docs.append(doc)
+
+log("docs processed:", num_parsed)
+log("docs kept:", len(kept_docs))
+
+# log(kept_docs)
+yaml.dump_all(kept_docs, sys.stdout)


### PR DESCRIPTION
I have been testing this with:
helm template cluster/charts/rook-ceph/ --set crds.enabled=false | build/rbac/extract-rbac.py

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
