### PR TITLE
ci: run tmate session only on PR

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -91,8 +91,8 @@ jobs:
         name: canary
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -171,8 +171,8 @@ jobs:
         name:  pvc
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -238,8 +238,8 @@ jobs:
         name: pvc-db
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -309,8 +309,8 @@ jobs:
         name: pvc-db-wal
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -379,8 +379,8 @@ jobs:
         name: encryption-pvc
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -449,8 +449,8 @@ jobs:
         name: encryption-pvc-db-wal
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -520,8 +520,8 @@ jobs:
         name: encryption-pvc-db
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -608,8 +608,8 @@ jobs:
         name: encryption-pvc-kms-vault-token-auth
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -673,8 +673,8 @@ jobs:
         name: lvm-pvc
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -878,8 +878,8 @@ jobs:
         name: multi-cluster-mirroring
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60
 
@@ -960,7 +960,7 @@ jobs:
         name: rgw-multisite-testing
         path: test
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -63,7 +63,7 @@ jobs:
         name: ceph-helm-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -55,7 +55,7 @@ jobs:
         name: ceph-mgr-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -59,7 +59,7 @@ jobs:
         name: ceph-multi-cluster-deploy-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -58,7 +58,7 @@ jobs:
         name: ceph-smoke-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -59,7 +59,7 @@ jobs:
         name: ceph-smoke-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -58,7 +58,7 @@ jobs:
         name: ceph-upgrade-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3
       timeout-minutes: 60

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -64,11 +64,6 @@ jobs:
         name: ceph-helm-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-
   TestCephMultiClusterDeploySuite:
     runs-on: ubuntu-18.04
     strategy:
@@ -116,11 +111,6 @@ jobs:
         name: ceph-multi-cluster-deploy-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-
   TestCephSmokeSuite:
     runs-on: ubuntu-18.04
     strategy:
@@ -166,11 +156,6 @@ jobs:
       with:
         name: ceph-smoke-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
-
-    - name: setup tmate session for debugging
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
 
   TestCephUpgradeSuite:
     runs-on: ubuntu-18.04
@@ -218,11 +203,6 @@ jobs:
         name: ceph-upgrade-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
-    - name: setup tmate session for debugging
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-
   TestCephObjectSuite:
     if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     runs-on: ubuntu-18.04
@@ -269,8 +249,3 @@ jobs:
       with:
         name: ceph-smoke-suite-artifact
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
-
-    - name: setup tmate session for debugging
-      if: failure()
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 60


### PR DESCRIPTION
run tmate only for `pull_request` event and
remove for other events. As during release
when tests fail it takes extra 30 min to fail the
test or someone manually has to end the test
which is painfully especially during release time.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
