### PR TITLE
ci: fix the test name for upgrade suite

### DIFF
--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -194,7 +194,7 @@ jobs:
     - name: TestCephUpgradeSuite
       run: |
        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephUpgradeSuite github.com/rook/rook/tests/integration
+       go test -v -timeout 1800s -run CephUpgradeSuite/TestUpgradeRookToMaster github.com/rook/rook/tests/integration
 
     - name: Artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Description of your changes:**

Since we were pointing at CephUpgradeSuite test only this was running
all the tests and thus some resources were created by other tests.
Let's just run the test we need.

Closes: https://github.com/rook/rook/issues/8843
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
