### PR TITLE
ci: wait longer for pod label to be deleted

### DIFF
--- a/tests/framework/utils/env.go
+++ b/tests/framework/utils/env.go
@@ -29,7 +29,7 @@ func TestEnvName() string {
 
 // TestRetryNumber  get the max retry. Example, for OpenShift it's 40.
 func TestRetryNumber() int {
-	count := GetEnvVarWithDefault("RETRY_MAX", "30")
+	count := GetEnvVarWithDefault("RETRY_MAX", "45")
 	number, err := strconv.Atoi(count)
 	if err != nil {
 		panic(fmt.Errorf("Error when converting to numeric value %v", err))


### PR DESCRIPTION
I've seen cases were the CI needs a few more seconds to delete and
object store. When logging in the runner, the object store is gone and
the timing matches too with the runner's logs (comparing with the
operator's logs).

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
