### PR TITLE
multus: do not build all the args to remote exec cmd

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -126,10 +126,27 @@ func NewRBDCommand(context *clusterd.Context, clusterInfo *ClusterInfo, args []s
 }
 
 func (c *CephToolCommand) run() ([]byte, error) {
-	command, args := FinalizeCephCommandArgs(c.tool, c.clusterInfo, c.args, c.context.ConfigDir)
+	// Return if the context has been canceled
 	if c.clusterInfo.Context.Err() != nil {
 		return nil, c.clusterInfo.Context.Err()
 	}
+
+	// Initialize the command and args
+	command := c.tool
+	args := c.args
+
+	// If this is a remote execution, we don't want to build the full set of args. For instance all
+	// these args are not needed since those paths don't exist inside the cmd-proxy container:
+	//      --cluster=openshift-storage
+	//		--conf=/var/lib/rook/openshift-storage/openshift-storage.config
+	//		--name=client.admin
+	//		--keyring=/var/lib/rook/openshift-storage/client.admin.keyring
+	//
+	// The cmd-proxy container will take care of the rest with the help of the env CEPH_ARGS
+	if !c.RemoteExecution {
+		command, args = FinalizeCephCommandArgs(c.tool, c.clusterInfo, c.args, c.context.ConfigDir)
+	}
+
 	if c.JsonOutput {
 		args = append(args, "--format", "json")
 	} else {
@@ -147,7 +164,7 @@ func (c *CephToolCommand) run() ([]byte, error) {
 	if command == RBDTool {
 		if c.RemoteExecution {
 			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
-			output = fmt.Sprintf("%s.%s", output, stderr)
+			output = fmt.Sprintf("%s. %s", output, stderr)
 		} else if c.timeout == 0 {
 			output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
 		} else {

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -116,6 +116,7 @@ func TestNewRBDCommand(t *testing.T) {
 		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
 			switch {
 			case command == "rbd" && args[0] == "create":
+				assert.Len(t, args, 8)
 				return "success", nil
 			}
 			return "", errors.Errorf("unexpected ceph command %q", args)
@@ -137,6 +138,7 @@ func TestNewRBDCommand(t *testing.T) {
 		assert.True(t, cmd.RemoteExecution)
 		_, err := cmd.Run()
 		assert.Error(t, err)
+		assert.Len(t, cmd.args, 4)
 		// This is not the best but it shows we go through the right codepath
 		assert.EqualError(t, err, "no pods found with selector \"rook-ceph-mgr\"")
 	})


### PR DESCRIPTION
**Description of your changes:**

When proxying commands to the cmd-proxy container we don't need to build
the command line with the same flags as the operator. The cmd-proxy
container does not use any ceph config file and just relies on the
CEPH_ARGS environment variable in the container. So passing the same
args as the operator causes to fail since we don't have a ceph config
file in `/var/lib/rook/openshift-storage/openshift-storage.config` thus
the remote exec fails with:

```
global_init: unable to open config file from search list ...
```

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
