### PR TITLE
build: update command to generate image list

### DIFF
--- a/cluster/examples/kubernetes/ceph/images.txt
+++ b/cluster/examples/kubernetes/ceph/images.txt
@@ -1,9 +1,9 @@
- rook/ceph:master
- quay.io/ceph/ceph:v16.2.6
- quay.io/cephcsi/cephcsi:v3.4.0
+ k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
  k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
  k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
- k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
- k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
  k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+ k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.0
+ quay.io/ceph/ceph:v16.2.6
+ quay.io/cephcsi/cephcsi:v3.4.0
  quay.io/csiaddons/volumereplication-operator:v0.1.0
+ rook/ceph:master

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -131,7 +131,8 @@ list-image:
 	rm -f $(MANIFESTS_DIR)/images.txt;\
 	awk '/image:/ {print $2}' $(MANIFESTS_DIR)/operator.yaml $(MANIFESTS_DIR)/cluster.yaml | \
 	cut -d: -f2- |\
-	tee -a $(MANIFESTS_DIR)/images.txt && \
+	tee $(MANIFESTS_DIR)/images.txt; \
 	awk '/quay.io/ || /k8s.gcr.io/ {print $3}' ../../pkg/operator/ceph/csi/spec.go | \
 	cut -d= -f2- |\
-	tr -d '"' | tee -a $(MANIFESTS_DIR)/images.txt
+	tr -d '"' | tee -a $(MANIFESTS_DIR)/images.txt;\
+	cat $(MANIFESTS_DIR)/images.txt|sort -h|uniq|tee $(MANIFESTS_DIR)/images.txt


### PR DESCRIPTION
While build.all we have race condition where
images.txt file was update with duplicate entries.
So, removing `-a` from 1st tee and also add `uniq` command
to confirm no duplicate entry is in the file.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
