### PR TITLE
build: use intermediate tmp for offline image gen

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,10 @@ jobs:
       run: |
         GOPATH=$(go env GOPATH) make clean && make -j$nproc IMAGES='ceph' BUILD_CONTAINER_IMAGE=false build
 
+    - name: validate build
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: tests/scripts/validate_modified_files.sh build
+
     - name: run codegen
       working-directory: /Users/runner/go/src/github.com/rook/rook
       run: GOPATH=$(go env GOPATH) make codegen

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -124,15 +124,15 @@ csv: $(OPERATOR_SDK) $(YQ) ## Generate a CSV file for OLM.
 csv-clean: $(OPERATOR_SDK) $(YQ) ## Remove existing OLM files.
 	@rm -fr ../../cluster/olm/ceph/deploy/* ../../cluster/olm/ceph/templates/*
 
-# list-image creates list of images for offline installation
-list-image:
-	@echo "producing list of images for offline installation";\
-	# remove the file if already exists
-	rm -f $(MANIFESTS_DIR)/images.txt;\
+# reading from a file and outputting to the same file can have undefined results, so use this intermediate
+IMAGE_TMP="/tmp/rook-ceph-image-list"
+list-image: ## Create a list of images for offline installation
+	@echo "producing list of images for offline installation"
+	rm -f $(IMAGE_TMP)
 	awk '/image:/ {print $2}' $(MANIFESTS_DIR)/operator.yaml $(MANIFESTS_DIR)/cluster.yaml | \
-	cut -d: -f2- |\
-	tee $(MANIFESTS_DIR)/images.txt; \
+		cut -d: -f2- | tee $(IMAGE_TMP)
 	awk '/quay.io/ || /k8s.gcr.io/ {print $3}' ../../pkg/operator/ceph/csi/spec.go | \
-	cut -d= -f2- |\
-	tr -d '"' | tee -a $(MANIFESTS_DIR)/images.txt;\
-	cat $(MANIFESTS_DIR)/images.txt|sort -h|uniq|tee $(MANIFESTS_DIR)/images.txt
+		cut -d= -f2- | tr -d '"' | tee -a $(IMAGE_TMP)
+	rm -f $(MANIFESTS_DIR)/images.txt
+	cat $(IMAGE_TMP) | sort -h | uniq | tee $(MANIFESTS_DIR)/images.txt
+	rm -f $(IMAGE_TMP)


### PR DESCRIPTION
Reading from a file, processing the file in a pipe, and outputting the
piped content to the same file can have undefined results, often leading
to an empty file. Use an intermediate temp file for generating the
offline image list.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

I only observed the issue on MacOS, but it could effect linux as well if my understanding of the root cause is correct.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
