### PR TITLE
docs: Add node restart requirement for csi upgrade issue

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -62,6 +62,12 @@ git clone --single-branch --depth=1 --branch v1.7.4 https://github.com/rook/rook
 cd rook/cluster/examples/kubernetes/ceph
 ```
 
+**IMPORTANT** If you have RBD or CephFS volumes and are upgrading from Rook v1.6.0 - v1.6.4,
+there is an issue upgrading from those versions that causes the volumes to hang.
+Nodes will need to be restarted for the volumes to connect again. See
+[this issue](https://github.com/rook/rook/issues/8085#issuecomment-859234755) for more details.
+Future upgrades of Rook will not have this issue.
+
 If you have deployed the Rook Operator or the Ceph cluster into a different namespace than
 `rook-ceph`, see the [Update common resources and CRDs](#1-update-common-resources-and-crds)
 section for instructions on how to change the default namespaces in `common.yaml`.
@@ -130,6 +136,12 @@ In order to successfully upgrade a Rook cluster, the following prerequisites mus
   starting state.
 * All pods consuming Rook storage should be created, running, and in a steady state. No Rook
   persistent volumes should be in the act of being created or deleted.
+
+**IMPORTANT** If you have RBD or CephFS volumes and are upgrading from Rook v1.6.0 - v1.6.4,
+there is an issue upgrading from those versions that causes the volumes to hang.
+Nodes will need to be restarted for the volumes to connect again. See
+[this issue](https://github.com/rook/rook/issues/8085#issuecomment-859234755) for more details.
+Future upgrades of Rook will not have this issue.
 
 ## Health Verification
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The cephfs csi volume plugin if restarted when host networking is not enabled will cause the volumes to hang. In Rook v1.6.0 - v1.6.4 host networking was not enabled by default, causing all cephfs volumes to hang during upgrade from those releases. A note is added to the upgrade guide [as requested](https://github.com/rook/rook/issues/8085#issuecomment-933440203) to help make this issue more visible.

**Which issue is resolved by this Pull Request:**
Related to: #8085 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
