### PR TITLE
ceph: initialize rbd block pool after creation

### DIFF
--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -356,6 +356,14 @@ func createPool(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo, 
 		return errors.Wrapf(err, "failed to create pool %q", p.Name)
 	}
 
+	logger.Infof("initializing pool %q", p.Name)
+	args := []string{"pool", "init", p.Name}
+	output, err := cephclient.NewRBDCommand(context, clusterInfo, args).Run()
+	if err != nil {
+		return errors.Wrapf(err, "failed to initialize pool %q. %s", p.Name, string(output))
+	}
+	logger.Infof("successfully initialized pool %q", p.Name)
+
 	return nil
 }
 

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -51,6 +51,9 @@ func TestCreatePool(t *testing.T) {
 			if command == "ceph" && args[1] == "erasure-code-profile" {
 				return `{"k":"2","m":"1","plugin":"jerasure","technique":"reed_sol_van"}`, nil
 			}
+			if command == "rbd" {
+				assert.Equal(t, []string{"pool", "init", "mypool"}, args[0:3])
+			}
 			return "", nil
 		},
 	}


### PR DESCRIPTION
This is done in order to prevent deadlock when parallel
PVC create requests are issued on a new uninitialized
rbd block pool due to https://tracker.ceph.com/issues/52537.

Fixes: #8696

Signed-off-by: Rakshith R <rar@redhat.com>

### verified by testing it locally
```
[rakshith@fedora ceph-csi]$ ./scripts/rook.sh create-block-pool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   525  100   525    0     0   1299      0 --:--:-- --:--:-- --:--:--  1299
cephblockpool.ceph.rook.io/new-pool created
Checking RBD (new-pool) stats... 0s
RBD (new-pool) is successfully created...
[rakshith@fedora ceph-csi]$ k apply -f rbd/storageclass-test.yaml 
storageclass.storage.k8s.io/rook-ceph-block-1 created
[rakshith@fedora ceph-csi]$ k apply -f rbd/pvc.yaml 
persistentvolumeclaim/rbd-1 created
persistentvolumeclaim/rbd-2 created
persistentvolumeclaim/rbd-3 created
persistentvolumeclaim/rbd-4 created
[rakshith@fedora ceph-csi]$ k get pvc
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
rbd-1   Bound    pvc-81fbaf0e-aba8-4f18-8e4b-aeb18fb17527   1Gi        RWO            rook-ceph-block-1   34s
rbd-2   Bound    pvc-7e599340-1b14-42f7-9517-bb9733ded3f2   1Gi        RWO            rook-ceph-block-1   33s
rbd-3   Bound    pvc-ebb4d196-ee25-4369-b908-c91908324c9f   1Gi        RWO            rook-ceph-block-1   33s
rbd-4   Bound    pvc-e513679e-4c37-4236-84f0-ce0d044f87fe   1Gi        RWO            rook-ceph-block-1   33s
```

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
