### PR TITLE
core: remove unused clientset

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -34,7 +34,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -159,9 +158,6 @@ func NewContext() *clusterd.Context {
 	// at runtime.
 	context.DynamicClientset, err = dynamic.NewForConfig(context.KubeConfig)
 	TerminateOnError(err, "failed to create dynamic clientset")
-
-	context.APIExtensionClientset, err = apiextensionsclient.NewForConfig(context.KubeConfig)
-	TerminateOnError(err, "failed to create k8s API extension clientset")
 
 	context.RookClientset, err = rookclient.NewForConfig(context.KubeConfig)
 	TerminateOnError(err, "failed to create rook clientset")

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	gopkg.in/ini.v1 v1.57.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.2
-	k8s.io/apiextensions-apiserver v0.21.1
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2
 	k8s.io/cloud-provider v0.21.1

--- a/pkg/clusterd/context.go
+++ b/pkg/clusterd/context.go
@@ -22,7 +22,6 @@ import (
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -42,9 +41,6 @@ type Context struct {
 
 	// Represents the Client provided by the controller-runtime package to interact with Kubernetes objects
 	Client client.Client
-
-	// APIExtensionClientset is a connection to the API Extension kubernetes API
-	APIExtensionClientset apiextensionsclient.Interface
 
 	// RookClientset is a typed connection to the rook API
 	RookClientset rookclient.Interface


### PR DESCRIPTION
**Description of your changes:**

Removing ancient clientset which was not used anywhere any more.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
