### PR TITLE
build: support build of rook on aarch64 (AWS/graviton)

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -33,8 +33,15 @@ MANIFESTS_DIR=../../cluster/examples/kubernetes/ceph
 
 TEMP := $(shell mktemp -d)
 
+# Note: as of version 1.3 of operator-sdk, the url format changed to:
+# ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+# (see: https://sdk.operatorframework.io/docs/installation/)
 ifeq ($(HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
+INCLUDE_CSV_TEMPLATES = true
+endif
+ifeq ($(HOST_PLATFORM),linux_arm64)
+OPERATOR_SDK_PLATFORM = aarch64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
 endif
 ifeq ($(HOST_PLATFORM),darwin_amd64)
@@ -116,6 +123,7 @@ $(OPERATOR_SDK):
 	@curl -JL -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) \
 		https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM)
 	@chmod +x $(OPERATOR_SDK)
+	@$(OPERATOR_SDK) version
 
 csv: $(OPERATOR_SDK) $(YQ) ## Generate a CSV file for OLM.
 	@echo Generating CSV manifests


### PR DESCRIPTION
Build rook in AWS/Graviton (ARM64) platform. Upon installation of
operator-sdk, make sure that the downloaded binary can actually be
executed on local machine by invoking 'operator-sdk version'.

issue: https://github.com/rook/rook/issues/8926

Signed-off-by: Shachar Sharon <ssharon@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
