### PR TITLE
rgw: use trace logs for RGW admin HTTP info

### DIFF
--- a/pkg/operator/ceph/object/admin.go
+++ b/pkg/operator/ceph/object/admin.go
@@ -72,7 +72,8 @@ func (c *debugHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Debugf("\n%s\n", string(dump))
+	// this can leak credentials for making requests
+	c.logger.Tracef("\n%s\n", string(dump))
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -84,7 +85,8 @@ func (c *debugHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.logger.Debugf("\n%s\n", string(dump))
+	// this can leak any sensitive info like credentials in the response
+	c.logger.Tracef("\n%s\n", string(dump))
 
 	return resp, nil
 }


### PR DESCRIPTION
Debug logs for the RGW Admin Ops debugHTTPClient can leak credentials
used to access the Admin Ops API as well as credentials that may be
returned for any buckets/users. Use trace logs instead, which users are
unlikely to enable in production to mitigate the risk.

This is a partial backport of #8808. Including `TRACE_LOGGING` proved challenging given how much the controller code changed between 1.7 and master, but changing the leaky debug logs to trace is simple.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
