### PR TITLE
build: fix offline image build race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ build.version:
 build.common: build.version helm.build mod.check
 	@$(MAKE) go.init
 	@$(MAKE) go.validate
+	@$(MAKE) -C images/ceph list-image
 
 do.build.platform.%:
 	@$(MAKE) PLATFORM=$* go.build

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -69,7 +69,6 @@ do.build:
 	@mkdir -p $(TEMP)/rook-external/test-data
 	@cp $(MANIFESTS_DIR)/create-external-cluster-resources.* $(TEMP)/rook-external/
 	@cp $(MANIFESTS_DIR)/test-data/ceph-status-out $(TEMP)/rook-external/test-data/
-	@$(MAKE) list-image
 
 ifeq ($(INCLUDE_CSV_TEMPLATES),true)
 	@$(MAKE) CSV_TEMPLATE_DIR=$(TEMP) generate-csv-templates


### PR DESCRIPTION
When generating the offline image list, the threaded crossbuild can
try to generate the image list from muliple jobs at once, resulting in
undefined behavior (usually an empty file) for the output file. To fix
this, we can generate this file in the `build.common` step which is not
run in parallel.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
