### PR TITLE
core: Remove old `rook-ceph-system-psp-users` ClusterRoleBinding 

### DIFF
--- a/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/cluster/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -153,23 +153,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rook-ceph-system-psp-users
-  labels:
-    operator: rook
-    storage-backend: ceph
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: rook-ceph-system-psp-user
-subjects:
-- kind: ServiceAccount
-  name: rook-ceph-system
-  namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: rook-csi-cephfs-provisioner-sa-psp
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Description of your changes:**
Remove old `rook-ceph-system-psp-users` ClusterRoleBinding. The ClusterRole it references no longer exists. It is replaced by `rook-ceph-system-psp`.

**Which issue is resolved by this Pull Request:**
Resolves #6448