### PR TITLE
ceph: add affinity to csi version check job

### DIFF
--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -640,8 +640,11 @@ func (r *ReconcileCSI) validateCSIVersion(ownerInfo *k8sutil.OwnerInfo) (*CephCS
 	job := versionReporter.Job()
 	job.Spec.Template.Spec.ServiceAccountName = r.opConfig.ServiceAccount
 
-	// Apply csi provisioner toleration for csi version check job
+	// Apply csi provisioner toleration and affinity for csi version check job
 	job.Spec.Template.Spec.Tolerations = getToleration(r.opConfig.Parameters, provisionerTolerationsEnv, []corev1.Toleration{})
+	job.Spec.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: getNodeAffinity(r.opConfig.Parameters, provisionerNodeAffinityEnv, &corev1.NodeAffinity{}),
+	}
 	stdout, _, retcode, err := versionReporter.Run(timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to complete ceph CSI version job")


### PR DESCRIPTION
Fixes: #8323

Signed-off-by: Rakshith R <rar@redhat.com>

```
[rakshith@fedora rook]$ k get pod rook-ceph-csi-detect-version-4qdkw -oyaml 
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2021-10-13T09:04:38Z"
  generateName: rook-ceph-csi-detect-version-
  labels:
    app: rook-ceph-csi-detect-version
    controller-uid: c0d82ed3-2b57-48ad-b0ef-af91a7595151
    job-name: rook-ceph-csi-detect-version
    rook-version: v1.7.0-alpha.0.447.g7c863d53a
  name: rook-ceph-csi-detect-version-4qdkw
  namespace: rook-ceph
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: rook-ceph-csi-detect-version
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - ' linux'
     
 ```
            
**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
