### PR TITLE
ci: cleanup the cluster after error

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -95,6 +95,12 @@ To run specific tests inside a suite:
 go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration -testify.m TestARookClusterInstallation_SmokeTest
 ```
 
+By default, the test cluster is not cleaned after the integration test execution if it fails. If you want to force the cluster cleanup after test execution independently of the execution result, set the following env var:
+
+```console
+export FORCE_CLUSTER_CLEANUP=true
+```
+
 ### To run tests on OpenShift environment
 
 - Setup OpenShift environment and export KUBECONFIG before executing the tests.

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -626,8 +626,10 @@ func (h *CephInstaller) UninstallRookFromMultipleNS(manifests ...CephManifests) 
 
 	// If test failed do not teardown and leave the cluster in the state it is
 	if h.T().Failed() {
-		logger.Info("one of the tests failed, leaving the cluster in its bad shape for investigation")
-		return
+		if !h.settings.forceClusterCleanUp {
+			logger.Info("one of the tests failed, leaving the cluster in its bad shape for investigation")
+			return
+		}
 	}
 
 	logger.Infof("Uninstalling Rook")

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -43,6 +43,7 @@ type TestCephSettings struct {
 	IsExternal                  bool
 	SkipClusterCleanup          bool
 	SkipCleanupPolicy           bool
+	forceClusterCleanUp         bool
 	DirectMountToolbox          bool
 	EnableVolumeReplication     bool
 	RookVersion                 string
@@ -58,6 +59,12 @@ func (s *TestCephSettings) ApplyEnvVars() {
 	s.SkipCleanupPolicy = true
 	if os.Getenv("SKIP_CLEANUP_POLICY") == "false" {
 		s.SkipCleanupPolicy = false
+	}
+	s.forceClusterCleanUp = false
+	if os.Getenv("FORCE_CLUSTER_CLEANUP") == "true" {
+		s.forceClusterCleanUp = true
+		s.SkipCleanupPolicy = false
+		s.SkipClusterCleanup = false
 	}
 }
 


### PR DESCRIPTION
- Added information about the env. vars needed to force cluster cleanup.
- make possible to cleanup the cluster after test execution if it fails.

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
