### PR TITLE
test: get more partition info setting up ci disk

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -57,7 +57,7 @@ jobs:
       run: tests/scripts/github-action-helper.sh deploy_cluster
 
     - name: wait for prepare pod
-      run: timeout 300 sh -c 'until kubectl -n rook-ceph logs -f $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'); do sleep 5; done'
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
 
     - name: wait for ceph to be ready
       run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready all 2
@@ -83,6 +83,11 @@ jobs:
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload canary test result
       uses: actions/upload-artifact@v2
@@ -148,21 +153,18 @@ jobs:
         tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/toolbox.yaml
 
     - name: wait for prepare pod
-      run: |
-        timeout 180 sh -c '[ $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'|wc -l) -eq 2 ]; do sleep 5; done'||true
-        for prepare in $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}'); do
-          kubectl -n rook-ceph logs -f $prepare
-          break
-        done
-        timeout 60 sh -c 'until kubectl -n rook-ceph logs $(kubectl -n rook-ceph get pod -l app=rook-ceph-osd,ceph_daemon_id=0 -o jsonpath='{.items[*].metadata.name}') --all-containers; do echo "waiting for osd container" && sleep 1; done'||true
-        kubectl -n rook-ceph describe job/$prepare||true
-        kubectl -n rook-ceph describe deploy/rook-ceph-osd-0||true
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
 
     - name: wait for ceph to be ready
       run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload  pvc test result
       uses: actions/upload-artifact@v2
@@ -230,6 +232,11 @@ jobs:
 
     - name: wait for ceph to be ready
       run: tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
+
+    - name: collect common
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload pvc-db test result
       uses: actions/upload-artifact@v2
@@ -302,6 +309,11 @@ jobs:
         tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
         kubectl -n rook-ceph get pods
 
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
+
     - name: Upload pvc-db-wal test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -371,6 +383,11 @@ jobs:
         tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
         kubectl -n rook-ceph get secrets
         sudo lsblk
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload encryption-pvc test result
       uses: actions/upload-artifact@v2
@@ -442,6 +459,11 @@ jobs:
         kubectl -n rook-ceph get pods
         kubectl -n rook-ceph get secrets
 
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
+
     - name: Upload encryption-pvc-db-wal test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -512,6 +534,11 @@ jobs:
         tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 1
         kubectl -n rook-ceph get pods
         kubectl -n rook-ceph get secrets
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload encryption-pvc-db test result
       uses: actions/upload-artifact@v2
@@ -601,6 +628,11 @@ jobs:
       run: |
         tests/scripts/deploy-validate-vault.sh validate_rgw
 
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
+
     - name: Upload encryption-pvc-kms-vault-token-auth test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -665,6 +697,11 @@ jobs:
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: Upload pvc test result
       uses: actions/upload-artifact@v2
@@ -871,6 +908,11 @@ jobs:
         # the check is not super ideal since 'mirroring_failed' is only displayed when there is a failure but not when it's working...
         timeout 60 sh -c 'while [ "$(kubectl exec -n rook-ceph deploy/rook-ceph-tools -t -- ceph fs snapshot mirror daemon status myfs|jq -r '.[0].filesystems[0]'|grep -c "mirroring_failed")" -eq 1 ]; do echo "waiting for filesystem to be mirrored" && sleep 1; done'
 
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
+
     - name: upload test result
       uses: actions/upload-artifact@v2
       if: always()
@@ -965,6 +1007,11 @@ jobs:
         not_committed_msg="there are no changes to commit for RGW configuration period for CephObjectStore"
         tests/scripts/github-action-helper.sh wait_for_operator_log_message "${not_committed_msg} ${ns_name_primary}" 120
         tests/scripts/github-action-helper.sh wait_for_operator_log_message "${not_committed_msg} ${ns_name_secondary}" 90
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
 
     - name: upload test result
       uses: actions/upload-artifact@v2

--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -76,6 +76,11 @@ jobs:
           minikube delete
           docker system prune -a
 
+      - name: collect common logs
+        if: always()
+        run: |
+          tests/scripts/collect-logs.sh
+
       - name: upload canary test result
         uses: actions/upload-artifact@v2
         if: always()
@@ -118,11 +123,19 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="pacific-devel" go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="smoke-ns"
+          export OPERATOR_NAMESPACE="smoke-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-smoke-suite-artifact
+          name: ceph-smoke-suite-pacific-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   smoke-suite-ceph-master:
@@ -160,11 +173,19 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=master go test -v -timeout 1800s -run TestCephSmokeSuite github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="smoke-ns"
+          export OPERATOR_NAMESPACE="smoke-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-smoke-suite-artifact
+          name: ceph-smoke-suite-master-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   object-suite-pacific-devel:
@@ -202,11 +223,19 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION="pacific-devel" go test -v -timeout 1800s -failfast -run TestCephObjectSuite github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="object-ns"
+          export OPERATOR_NAMESPACE="object-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-object-suite-artifact
+          name: ceph-object-suite-pacific-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   object-suite-master:
@@ -244,11 +273,19 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           SKIP_CLEANUP_POLICY=false CEPH_SUITE_VERSION=master go test -v -timeout 1800s -failfast -run TestCephObjectSuite github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="object-ns"
+          export OPERATOR_NAMESPACE="object-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-object-suite-artifact
+          name: ceph-object-suite-master-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   upgrade-from-pacific-stable-to-pacific-devel:
@@ -286,11 +323,19 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToPacificDevel github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="upgrade-ns"
+          export OPERATOR_NAMESPACE="upgrade-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-upgrade-suite-artifact
+          name: ceph-upgrade-suite-pacific-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   upgrade-from-octopus-stable-to-octopus-devel:
@@ -328,9 +373,17 @@ jobs:
           export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
           go test -v -timeout 1800s -failfast -run TestCephUpgradeSuite/TestUpgradeCephToOctopusDevel github.com/rook/rook/tests/integration
 
+      - name: collect common logs
+        if: always()
+        run: |
+          export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+          export CLUSTER_NAMESPACE="upgrade-ns"
+          export OPERATOR_NAMESPACE="upgrade-ns-system"
+          tests/scripts/collect-logs.sh
+
       - name: Artifact
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ceph-upgrade-suite-artifact
+          name: ceph-upgrade-suite-octopus-artifact
           path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -51,16 +51,25 @@ jobs:
 
     - name: TestCephHelmSuite
       run: |
-       tests/scripts/minikube.sh helm
-       tests/scripts/helm.sh up
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephHelmSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        tests/scripts/minikube.sh helm
+        tests/scripts/helm.sh up
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephHelmSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="helm-ns"
+        export OPERATOR_NAMESPACE="helm-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-helm-suite-artifact
+        name: ceph-helm-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -47,14 +47,23 @@ jobs:
 
     - name: TestCephMgrSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -failfast -run CephMgrSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        go test -v -timeout 1800s -failfast -run CephMgrSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="mgr-ns"
+        export OPERATOR_NAMESPACE="mgr-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-mgr-suite-artifact
+        name: ceph-mgr-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -48,15 +48,24 @@ jobs:
 
     - name: TestCephMultiClusterDeploySuite
       run: |
-       export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)1
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)1
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        go test -v -timeout 1800s -failfast -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export OPERATOR_NAMESPACE="multi-core-system"
+        CLUSTER_NAMESPACE="multi-core" tests/scripts/collect-logs.sh
+        CLUSTER_NAMESPACE="multi-external" tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-multi-cluster-deploy-suite-artifact
+        name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -48,14 +48,23 @@ jobs:
 
     - name: TestCephObjectSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="object-ns"
+        export OPERATOR_NAMESPACE="object-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-smoke-suite-artifact
+        name: ceph-object-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -49,14 +49,23 @@ jobs:
 
     - name: TestCephSmokeSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephSmokeSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephSmokeSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="smoke-ns"
+        export OPERATOR_NAMESPACE="smoke-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-smoke-suite-artifact
+        name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -48,14 +48,23 @@ jobs:
 
     - name: TestCephUpgradeSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -failfast -run CephUpgradeSuite/TestUpgradeRookToMaster github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        go test -v -timeout 1800s -failfast -run CephUpgradeSuite/TestUpgradeRookToMaster github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="upgrade-ns"
+        export OPERATOR_NAMESPACE="upgrade-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-upgrade-suite-artifact
+        name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
     - name: setup tmate session for debugging when event is PR

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -52,16 +52,25 @@ jobs:
 
     - name: TestCephHelmSuite
       run: |
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
         tests/scripts/minikube.sh helm
         tests/scripts/helm.sh up
         export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
         SKIP_TEST_CLEANUP=false SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephHelmSuite github.com/rook/rook/tests/integration
 
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="helm-ns"
+        export OPERATOR_NAMESPACE="helm-ns-system"
+        tests/scripts/collect-logs.sh
+
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-helm-suite-artifact
+        name: ceph-helm-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephMultiClusterDeploySuite:
@@ -100,15 +109,24 @@ jobs:
 
     - name: TestCephMultiClusterDeploySuite
       run: |
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
         export TEST_SCRATCH_DEVICE=$(sudo lsblk --paths|awk '/14G/ {print $1}'| head -1)1
         export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
         go test -v -timeout 1800s -run CephMultiClusterDeploySuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export OPERATOR_NAMESPACE="multi-core-system"
+        CLUSTER_NAMESPACE="multi-core" tests/scripts/collect-logs.sh
+        CLUSTER_NAMESPACE="multi-external" tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-multi-cluster-deploy-suite-artifact
+        name: ceph-multi-cluster-deploy-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephSmokeSuite:
@@ -147,14 +165,23 @@ jobs:
 
     - name: TestCephSmokeSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -run CephSmokeSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="smoke-ns"
+        export OPERATOR_NAMESPACE="smoke-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-smoke-suite-artifact
+        name: ceph-smoke-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephUpgradeSuite:
@@ -193,14 +220,23 @@ jobs:
 
     - name: TestCephUpgradeSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       go test -v -timeout 1800s -run CephUpgradeSuite/TestUpgradeRookToMaster github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        go test -v -timeout 1800s -run CephUpgradeSuite/TestUpgradeRookToMaster github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="upgrade-ns"
+        export OPERATOR_NAMESPACE="upgrade-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-upgrade-suite-artifact
+        name: ceph-upgrade-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/
 
   TestCephObjectSuite:
@@ -240,12 +276,21 @@ jobs:
 
     - name: TestCephObjectSuite
       run: |
-       export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
-       SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
+        tests/scripts/github-action-helper.sh collect_udev_logs_in_background
+        export DEVICE_FILTER=$(lsblk|awk '/14G/ {print $1}'| head -1)
+        SKIP_CLEANUP_POLICY=false go test -v -timeout 1800s -failfast -run CephObjectSuite github.com/rook/rook/tests/integration
+
+    - name: collect common logs
+      if: always()
+      run: |
+        export LOG_DIR="/home/runner/work/rook/rook/tests/integration/_output/tests/"
+        export CLUSTER_NAMESPACE="object-ns"
+        export OPERATOR_NAMESPACE="object-ns-system"
+        tests/scripts/collect-logs.sh
 
     - name: Artifact
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: ceph-smoke-suite-artifact
+        name: ceph-object-suite-artifact-${{ matrix.kubernetes-versions }}
         path: /home/runner/work/rook/rook/tests/integration/_output/tests/

--- a/tests/scripts/collect-logs.sh
+++ b/tests/scripts/collect-logs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -x
+
+# User parameters
+: "${CLUSTER_NAMESPACE:="rook-ceph"}"
+: "${OPERATOR_NAMESPACE:="$CLUSTER_NAMESPACE"}"
+: "${LOG_DIR:="test"}"
+
+LOG_DIR="${LOG_DIR%/}" # remove trailing slash if necessary
+mkdir -p "${LOG_DIR}"
+
+CEPH_CMD="kubectl -n ${CLUSTER_NAMESPACE} exec deploy/rook-ceph-tools -- ceph --connect-timeout 3"
+
+$CEPH_CMD -s > "${LOG_DIR}"/ceph-status.txt
+$CEPH_CMD osd dump > "${LOG_DIR}"/ceph-osd-dump.txt
+$CEPH_CMD report > "${LOG_DIR}"/ceph-report.txt
+
+kubectl -n "${OPERATOR_NAMESPACE}" logs deploy/rook-ceph-operator > "${LOG_DIR}"/operator-logs.txt
+kubectl -n "${OPERATOR_NAMESPACE}" get pods -o wide > "${LOG_DIR}"/operator-pods-list.txt
+kubectl -n "${CLUSTER_NAMESPACE}" get pods -o wide > "${LOG_DIR}"/cluster-pods-list.txt
+prepare_job="$(kubectl -n "${CLUSTER_NAMESPACE}" get job -l app=rook-ceph-osd-prepare --output name | awk 'FNR <= 1')" # outputs job/<name>
+kubectl -n "${CLUSTER_NAMESPACE}" describe "${prepare_job}" > "${LOG_DIR}"/osd-prepare-describe.txt
+kubectl -n "${CLUSTER_NAMESPACE}" logs "${prepare_job}" > "${LOG_DIR}"/osd-prepare-logs.txt
+kubectl -n "${CLUSTER_NAMESPACE}" describe deploy/rook-ceph-osd-0 > "${LOG_DIR}"/rook-ceph-osd-0-describe.txt
+kubectl -n "${CLUSTER_NAMESPACE}" describe deploy/rook-ceph-osd-1 > "${LOG_DIR}"/rook-ceph-osd-1-describe.txt
+kubectl -n "${CLUSTER_NAMESPACE}" logs deploy/rook-ceph-osd-0 --all-containers > "${LOG_DIR}"/rook-ceph-osd-0-logs.txt
+kubectl -n "${CLUSTER_NAMESPACE}" logs deploy/rook-ceph-osd-1 --all-containers > "${LOG_DIR}"/rook-ceph-osd-1-logs.txt
+kubectl get all -n "${OPERATOR_NAMESPACE}" -o wide > "${LOG_DIR}"/operator-wide.txt
+kubectl get all -n "${OPERATOR_NAMESPACE}" -o wide > "${LOG_DIR}"/operator-yaml.txt
+kubectl get all -n "${CLUSTER_NAMESPACE}" -o wide > "${LOG_DIR}"/cluster-wide.txt
+kubectl get all -n "${CLUSTER_NAMESPACE}" -o yaml > "${LOG_DIR}"/cluster-yaml.txt
+kubectl -n "${CLUSTER_NAMESPACE}" get cephcluster -o yaml > "${LOG_DIR}"/cephcluster.txt
+sudo lsblk | sudo tee -a "${LOG_DIR}"/lsblk.txt
+journalctl -o short-precise --dmesg > "${LOG_DIR}"/dmesg.txt
+journalctl > "${LOG_DIR}"/journalctl.txt

--- a/tests/scripts/validate_cluster.sh
+++ b/tests/scripts/validate_cluster.sh
@@ -40,7 +40,7 @@ function wait_for_daemon () {
     let timeout=timeout-1
   done
   echo "current status:"
-  eval "$EXEC_COMMAND -s"
+  $EXEC_COMMAND -s
 
   return 1
 }
@@ -96,25 +96,6 @@ function test_csi {
       sleep 5
     done
 EOF
-}
-
-function display_status {
-  $EXEC_COMMAND -s > test/ceph-status.txt
-  $EXEC_COMMAND osd dump > test/ceph-osd-dump.txt
-  $EXEC_COMMAND report > test/ceph-report.txt
-
-  kubectl -n rook-ceph logs deploy/rook-ceph-operator > test/operator-logs.txt
-  kubectl -n rook-ceph get pods -o wide > test/pods-list.txt
-  kubectl -n rook-ceph describe job/"$(kubectl -n rook-ceph get job -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}')" > test/osd-prepare-describe.txt
-  kubectl -n rook-ceph logs job/"$(kubectl -n rook-ceph get job -l app=rook-ceph-osd-prepare -o jsonpath='{.items[*].metadata.name}')" > test/osd-prepare-logs.txt
-  kubectl -n rook-ceph describe deploy/rook-ceph-osd-0 > test/rook-ceph-osd-0-describe.txt
-  kubectl -n rook-ceph describe deploy/rook-ceph-osd-1 > test/rook-ceph-osd-1-describe.txt
-  kubectl -n rook-ceph logs deploy/rook-ceph-osd-0 --all-containers > test/rook-ceph-osd-0-logs.txt
-  kubectl -n rook-ceph logs deploy/rook-ceph-osd-1 --all-containers > test/rook-ceph-osd-1-logs.txt
-  kubectl get all -n rook-ceph -o wide > test/cluster-wide.txt
-  kubectl get all -n rook-ceph -o yaml > test/cluster-yaml.txt
-  kubectl -n rook-ceph get cephcluster -o yaml > test/cephcluster.txt
-  sudo lsblk | sudo tee -a test/lsblk.txt
 }
 
 ########
@@ -173,7 +154,3 @@ $EXEC_COMMAND -s
 kubectl -n rook-ceph get pods
 kubectl -n rook-ceph logs "$(kubectl -n rook-ceph -l app=rook-ceph-operator get pods -o jsonpath='{.items[*].metadata.name}')"
 kubectl -n rook-ceph get cephcluster -o yaml
-
-set +eE
-display_status
-set -eE


### PR DESCRIPTION
Add some commands to get more partition info when setting up the GH
action runner's disk for use in integration tests. This will both aid in
debugging and may "jog" the system such that it will no longer need to
reload the partition info when running the OSD prepare job.

hopefully resolves #8975 but at least helps debug it more

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
