### PR TITLE
osd: add support for k8s with vault kms

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -600,11 +600,11 @@ jobs:
       run: |
         tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/operator.yaml
         cat tests/manifests/test-kms-vault.yaml >> tests/manifests/test-cluster-on-pvc-encrypted.yaml
-        yq merge --inplace --arrays append tests/manifests/test-cluster-on-pvc-encrypted.yaml tests/manifests/test-kms-vault-spec.yaml
+        yq merge --inplace --arrays append tests/manifests/test-cluster-on-pvc-encrypted.yaml tests/manifests/test-kms-vault-spec-token-auth.yaml
         yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].count" 2
         yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].volumeClaimTemplates[0].spec.resources.requests.storage" 6Gi
         kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
-        yq merge --inplace --arrays append tests/manifests/test-object.yaml tests/manifests/test-kms-vault-spec.yaml
+        yq merge --inplace --arrays append tests/manifests/test-object.yaml tests/manifests/test-kms-vault-spec-token-auth.yaml
         sed -i 's/ver1/ver2/g' tests/manifests/test-object.yaml
         kubectl create -f tests/manifests/test-object.yaml
         tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/toolbox.yaml
@@ -640,6 +640,90 @@ jobs:
         name: encryption-pvc-kms-vault-token-auth
         path: test
 
+    - name: setup tmate session for debugging when event is PR
+      if: failure() && github.event_name == 'pull_request'
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+
+  encryption-pvc-kms-vault-k8s-auth:
+    runs-on: ubuntu-18.04
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-ci')"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.4.2
+      with:
+        minikube version: 'v1.21.0'
+        kubernetes version: 'v1.19.2'
+        start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: print k8s cluster status
+      run: tests/scripts/github-action-helper.sh print_k8s_cluster_status
+
+    - name: install deps
+      run: tests/scripts/github-action-helper.sh install_deps
+
+    - name: use local disk and create partitions for osds
+      run: |
+        tests/scripts/github-action-helper.sh use_local_disk
+        tests/scripts/github-action-helper.sh create_partitions_for_osds
+
+    - name: build rook
+      run: tests/scripts/github-action-helper.sh build_rook
+
+    - name: create cluster prerequisites
+      run: |
+        tests/scripts/localPathPV.sh $(lsblk --paths|awk '/14G/ {print $1}'| head -1)
+        tests/scripts/github-action-helper.sh create_cluster_prerequisites
+
+    - name: deploy vault
+      run: KUBERNETES_AUTH=true tests/scripts/deploy-validate-vault.sh deploy
+
+    - name: deploy cluster
+      run: |
+        tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/operator.yaml
+        yq merge --inplace --arrays append tests/manifests/test-cluster-on-pvc-encrypted.yaml tests/manifests/test-kms-vault-spec-k8s-auth.yaml
+        yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].count" 2
+        yq write -i tests/manifests/test-cluster-on-pvc-encrypted.yaml "spec.storage.storageClassDeviceSets[0].volumeClaimTemplates[0].spec.resources.requests.storage" 6Gi
+        kubectl create -f tests/manifests/test-cluster-on-pvc-encrypted.yaml
+        tests/scripts/github-action-helper.sh deploy_manifest_with_local_build cluster/examples/kubernetes/ceph/toolbox.yaml
+
+    - name: wait for prepare pod
+      run: tests/scripts/github-action-helper.sh wait_for_prepare_pod
+
+    - name: wait for ceph to be ready
+      run: |
+        tests/scripts/github-action-helper.sh wait_for_ceph_to_be_ready osd 2
+        kubectl -n rook-ceph get pods
+        kubectl -n rook-ceph get secrets
+
+    - name: validate osd vault
+      run: |
+        tests/scripts/deploy-validate-vault.sh validate_osd
+        sudo lsblk
+
+    - name: collect common logs
+      if: always()
+      run: |
+        tests/scripts/collect-logs.sh
+
+    - name: Upload canary test result
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: canary
+        path: test
+        
     - name: setup tmate session for debugging when event is PR
       if: failure() && github.event_name == 'pull_request'
       uses: mxschmitt/action-tmate@v3

--- a/Documentation/ceph-kms.md
+++ b/Documentation/ceph-kms.md
@@ -1,0 +1,237 @@
+---
+title: Key Management System
+weight: 3650
+indent: true
+---
+
+# Key Management System
+
+Rook has the ability to encrypt OSDs of clusters running on PVC via the flag (`encrypted: true`) in your `storageClassDeviceSets` [template](#pvc-based-cluster).
+By default, the Key Encryption Keys (also known as Data Encryption Keys) are stored in a Kubernetes Secret.
+However, if a Key Management System exists Rook is capable of using it. 
+
+The `security` section contains settings related to encryption of the cluster.
+
+* `security`:
+  * `kms`: Key Management System settings
+    * `connectionDetails`: the list of parameters representing kms connection details
+    * `tokenSecretName`: the name of the Kubernetes Secret containing the kms authentication token
+
+Supported KMS providers:
+
+* [Vault](#vault)
+## Vault
+
+Rook supports storing OSD encryption keys in [HashiCorp Vault KMS](https://www.vaultproject.io/).
+
+### Authentication methods
+
+Rook support two authentication methods:
+
+* [token-based](#token-based-authentication): a token is provided by the user and is stored in a Kubernetes Secret. It's used to
+  authenticate the KMS by the Rook operator. This has several pitfalls such as:
+    * when the token expires it must be renewed, so the secret holding it must be updated
+    * no token automatic rotation
+* [Kubernetes Service Account](#kubernetes-based-authentication) uses [Vault Kubernetes native
+  authentication](https://www.vaultproject.io/docs/auth/kubernetes) mechanism and alleviate some of the limitations from the token authentication such as token automatic renewal. This method is
+  generally recommended over the token-based authentication.
+
+#### Token-based authentication
+
+When using the token-based authentication, a Kubernetes Secret must be created to hold the token.
+This is governed by the `tokenSecretName` parameter.
+
+Note: Rook supports **all** the Vault [environment variables](https://www.vaultproject.io/docs/commands#environment-variables).
+
+The Kubernetes Secret `rook-vault-token` should contain:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rook-vault-token
+  namespace: rook-ceph
+data:
+  token: <TOKEN> # base64 of a token to connect to Vault, for example: cy5GWXpsbzAyY2duVGVoRjhkWG5Bb3EyWjkK
+```
+
+You can create a token in Vault by running the following command:
+
+```console
+vault token create -policy=rook
+```
+
+Refer to the official vault document for more details on [how to create a
+token](https://www.vaultproject.io/docs/commands/token/create). For which policy to apply see the
+next section.
+
+In order for Rook to connect to Vault, you must configure the following in your `CephCluster` template:
+
+```yaml
+security:
+  kms:
+    # name of the k8s config map containing all the kms connection details
+    connectionDetails:
+      KMS_PROVIDER: vault
+      VAULT_ADDR: https://vault.default.svc.cluster.local:8200
+      VAULT_BACKEND_PATH: rook
+      VAULT_SECRET_ENGINE: kv
+      VAULT_AUTH_METHOD: token
+    # name of the k8s secret containing the kms authentication token
+    tokenSecretName: rook-vault-token
+```
+
+#### Kubernetes-based authentication
+
+In order to use the Kubernetes Service Account authentication method, the following must be run to properly configure Vault:
+
+```sh
+ROOK_NAMESPACE=rook-ceph
+ROOK_VAULT_SA=rook-vault-auth
+ROOK_SYSTEM_SA=rook-ceph-system
+ROOK_OSD_SA=rook-ceph-osd
+VAULT_POLICY_NAME=rook
+VAULT_ROOK_OP_ROLE_NAME=rook-op
+VAULT_ROOK_OSD_ROLE_NAME=rook-osd
+
+# create service account for vault to validate API token
+kubectl -n "$ROOK_NAMESPACE" create serviceaccount "$ROOK_VAULT_SA"
+
+# create the RBAC for this SA
+kubectl -n "$ROOK_NAMESPACE" create clusterrolebinding vault-tokenreview-binding --clusterrole=system:auth-delegator --serviceaccount="$ROOK_NAMESPACE":"$ROOK_VAULT_SA"
+
+# get the service account common.yaml created earlier
+VAULT_SA_SECRET_NAME=$(kubectl -n "$ROOK_NAMESPACE" get sa "$ROOK_VAULT_SA" -o jsonpath="{.secrets[*]['name']}")
+
+# Set SA_JWT_TOKEN value to the service account JWT used to access the TokenReview API
+SA_JWT_TOKEN=$(kubectl -n "$ROOK_NAMESPACE" get secret "$VAULT_SA_SECRET_NAME" -o jsonpath="{.data.token}" | base64 --decode)
+
+# Set SA_CA_CRT to the PEM encoded CA cert used to talk to Kubernetes API
+SA_CA_CRT=$(kubectl -n "$ROOK_NAMESPACE" get secret "$VAULT_SA_SECRET_NAME" -o jsonpath="{.data['ca\.crt']}" | base64 --decode)
+
+# get kubernetes endpoint
+K8S_HOST=$(kubectl config view --minify --flatten -o jsonpath="{.clusters[0].cluster.server}")
+
+# enable kubernetes auth
+vault auth enable kubernetes
+
+# To fetch the service account issuer
+kubectl proxy &
+proxy_pid=$!
+
+# configure the kubernetes auth
+vault write auth/kubernetes/config \
+    token_reviewer_jwt="$SA_JWT_TOKEN" \
+    kubernetes_host="$K8S_HOST" \
+    kubernetes_ca_cert="$SA_CA_CRT" \
+    issuer="$(curl --silent http://127.0.0.1:8001/.well-known/openid-configuration | jq -r .issuer)"
+
+kill $proxy_pid
+
+# configure a role for rook operator
+vault write auth/kubernetes/role/"$VAULT_ROOK_OP_ROLE_NAME" \
+    bound_service_account_names="$ROOK_SYSTEM_SA" \
+    bound_service_account_namespaces="$ROOK_NAMESPACE" \
+    policies="$VAULT_POLICY_NAME" \
+    ttl=1440h
+
+# configure a role for rook osds
+vault write auth/kubernetes/role/"$VAULT_ROOK_OSD_ROLE_NAME" \
+    bound_service_account_names="$ROOK_OSD_SA" \
+    bound_service_account_namespaces="$ROOK_NAMESPACE" \
+    policies="$VAULT_POLICY_NAME" \
+    ttl=1440h
+```
+
+Once done, your `CephCluster` CR should look like:
+
+```yaml
+security:
+  kms:
+    connectionDetails:
+        KMS_PROVIDER: vault
+        VAULT_ADDR: https://vault.default.svc.cluster.local:8200
+        VAULT_BACKEND_PATH: rook/ver1
+        VAULT_SECRET_ENGINE: kv
+        VAULT_AUTH_METHOD: kubernetes
+        VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE: rook-op
+        VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE: rook-osd
+```
+
+### General Vault configuration
+
+As part of the token, here is an example of a policy that can be used:
+
+```hcl
+path "rook/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "sys/mounts" {
+capabilities = ["read"]
+}
+```
+
+You can write the policy like so and then create a token:
+
+```console
+vault policy write rook /tmp/rook.hcl
+vault token create -policy=rook
+```
+>```
+>Key                  Value
+>---                  -----
+>token                s.FYzlo02cgnTehF8dXnAoq2Z9
+>token_accessor       oMo7sAXQKbYtxU4HtO8k3pko
+>token_duration       768h
+>token_renewable      true
+>token_policies       ["default" "rook"]
+>identity_policies    []
+>policies             ["default" "rook"]
+>```
+
+In the above example, Vault's secret backend path name is `rook`. It must be enabled with the following:
+
+```console
+vault secrets enable -path=rook kv
+```
+
+If a different path is used, the `VAULT_BACKEND_PATH` key in `connectionDetails` must be changed.
+
+### TLS configuration
+
+This is an advanced but recommended configuration for production deployments, in this case the `vault-connection-details` will look like:
+
+```yaml
+security:
+  kms:
+    # name of the k8s config map containing all the kms connection details
+    connectionDetails:
+      KMS_PROVIDER: vault
+      VAULT_ADDR: https://vault.default.svc.cluster.local:8200
+      VAULT_CACERT: <name of the k8s secret containing the PEM-encoded CA certificate>
+      VAULT_CLIENT_CERT: <name of the k8s secret containing the PEM-encoded client certificate>
+      VAULT_CLIENT_KEY: <name of the k8s secret containing the PEM-encoded private key>
+    # name of the k8s secret containing the kms authentication token
+    tokenSecretName: rook-vault-token
+```
+
+Each secret keys are expected to be:
+
+* VAULT_CACERT: `cert`
+* VAULT_CLIENT_CERT: `cert`
+* VAULT_CLIENT_KEY: `key`
+
+For instance `VAULT_CACERT` Secret named `vault-tls-ca-certificate` will look like:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-tls-ca-certificate
+  namespace: rook-ceph
+data:
+  cert: <PEM base64 encoded CA certificate>
+```
+
+Note: if you are using self-signed certificates (not known/approved by a proper CA) you must pass `VAULT_SKIP_VERIFY: true`.
+Communications will remain encrypted but the validity of the certificate will not be verified.

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -17,5 +17,6 @@ v1.8...
 
 - The Rook Operator does not use "tini" as an init process. Instead, it uses the "rook" and handles
   signals on its own.
-- Rook adds a finalizer `ceph.rook.io/disaster-protection` to resources critical to the Ceph cluster 
+- Rook adds a finalizer `ceph.rook.io/disaster-protection` to resources critical to the Ceph cluster
   (rook-ceph-mon secrets and configmap) so that the resources will not be accidentally deleted.
+- Add support for [Kubernetes Authentication when using HashiCorp Vault Key Management Service](Documentation/ceph-kms.md##kubernetes-based-authentication).

--- a/cmd/rook/secret.go
+++ b/cmd/rook/secret.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/libopenstorage/secrets/vault"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -76,6 +77,14 @@ func startSecret() *kms.Config {
 	err = kms.ValidateConnectionDetails(context, &cephCluster.Spec.Security, namespace)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrap(err, "failed to validate kms connection details"))
+	}
+
+	// If Kubernetes authentication is enabled (through Service Accounts), use the role provided by
+	// the cluster spec
+	// Here we use VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE since this CLI is being called from an OSD
+	// init container, so the pod will use the "rook-ceph-osd" service account, different than the operator
+	if cephCluster.Spec.Security.KeyManagementService.IsK8sAuthEnabled() {
+		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails[vault.AuthKubernetesRole] = cephCluster.Spec.Security.KeyManagementService.ConnectionDetails[kms.RookOSDVaultAuthKubernetesRole]
 	}
 
 	return kms.NewConfig(context, &cephCluster.Spec, clusterInfo)

--- a/pkg/apis/ceph.rook.io/v1/security.go
+++ b/pkg/apis/ceph.rook.io/v1/security.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/libopenstorage/secrets/vault"
 )
 
 var (
@@ -34,6 +35,11 @@ func (kms *KeyManagementServiceSpec) IsEnabled() bool {
 // IsTokenAuthEnabled return whether KMS token auth is enabled
 func (kms *KeyManagementServiceSpec) IsTokenAuthEnabled() bool {
 	return kms.TokenSecretName != ""
+}
+
+// IsK8sAuthEnabled return whether KMS Kubernetes auth is enabled
+func (kms *KeyManagementServiceSpec) IsK8sAuthEnabled() bool {
+	return getParam(kms.ConnectionDetails, vault.AuthMethod) == vault.AuthMethodKubernetes && kms.TokenSecretName == ""
 }
 
 // IsTLSEnabled return KMS TLS details are configured

--- a/pkg/apis/ceph.rook.io/v1/security_test.go
+++ b/pkg/apis/ceph.rook.io/v1/security_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "testing"
+
+func TestKeyManagementServiceSpec_IsK8sAuthEnabled(t *testing.T) {
+	type fields struct {
+		ConnectionDetails map[string]string
+		TokenSecretName   string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"k8s auth is disabled - everything is empty", fields{ConnectionDetails: map[string]string{}, TokenSecretName: ""}, false},
+		{"k8s auth is disabled - token is populated", fields{ConnectionDetails: map[string]string{}, TokenSecretName: "foo"}, false},
+		{"k8s auth is disabled since token is provided", fields{ConnectionDetails: map[string]string{"VAULT_AUTH_METHOD": "kubernetes"}, TokenSecretName: "rook-ceph-test-secret"}, false},
+		{"k8s auth is disabled since VAULT_AUTH_METHOD is unknown", fields{ConnectionDetails: map[string]string{"VAULT_AUTH_METHOD": "foo"}, TokenSecretName: ""}, false},
+		{"k8s auth is enabled", fields{ConnectionDetails: map[string]string{"VAULT_AUTH_METHOD": "kubernetes"}, TokenSecretName: ""}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kms := &KeyManagementServiceSpec{
+				ConnectionDetails: tt.fields.ConnectionDetails,
+				TokenSecretName:   tt.fields.TokenSecretName,
+			}
+			if got := kms.IsK8sAuthEnabled(); got != tt.want {
+				t.Errorf("KeyManagementServiceSpec.IsK8sAuthEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/daemon/ceph/client/upgrade.go
+++ b/pkg/daemon/ceph/client/upgrade.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rook/rook/pkg/clusterd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -189,7 +190,7 @@ func OkToContinue(context *clusterd.Context, clusterInfo *ClusterInfo, deploymen
 }
 
 func okToStopDaemon(context *clusterd.Context, clusterInfo *ClusterInfo, deployment, daemonType, daemonName string) error {
-	if !StringInSlice(daemonType, daemonNoCheck) {
+	if !sets.NewString(daemonNoCheck...).Has(daemonType) {
 		args := []string{daemonType, "ok-to-stop", daemonName}
 		buf, err := NewCephCommand(context, clusterInfo, args).Run()
 		if err != nil {
@@ -220,16 +221,6 @@ func okToContinueMDSDaemon(context *clusterd.Context, clusterInfo *ClusterInfo, 
 	}
 
 	return nil
-}
-
-// StringInSlice return whether an element is in a slice
-func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }
 
 // LeastUptodateDaemonVersion returns the ceph version of the least updated daemon type

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -72,11 +72,17 @@ func setKEKinEnv(context *clusterd.Context, clusterInfo *cephclient.ClusterInfo)
 			return errors.Wrapf(err, "failed to retrieve key encryption key from %q kms", kmsConfig.Provider)
 		}
 
+		if kek == "" {
+			return errors.New("key encryption key is empty")
+		}
+
 		// Set the KEK as an env variable for ceph-volume
 		err = os.Setenv(oposd.CephVolumeEncryptedKeyEnvVarName, kek)
 		if err != nil {
 			return errors.Wrap(err, "failed to set key encryption key env variable for ceph-volume")
 		}
+
+		logger.Debug("successfully set vault env variables")
 	}
 
 	return nil

--- a/pkg/daemon/ceph/osd/kms/vault.go
+++ b/pkg/daemon/ceph/osd/kms/vault.go
@@ -36,6 +36,13 @@ const (
 	EtcVaultDir = "/etc/vault"
 	// VaultSecretEngineKey is the type of secret engine used (kv, transit)
 	VaultSecretEngineKey = "VAULT_SECRET_ENGINE"
+	// RookOperatorVaultAuthKubernetesRole is the internal Rook mapping of the Vault role that maps
+	// operator's service account and namespace to the Vault policy that allows them to read the
+	// secrets
+	RookOperatorVaultAuthKubernetesRole = "VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE"
+	// RookOSDVaultAuthKubernetesRole is the internal Rook mapping of the Vault role that maps OSD's
+	// service account and namespace to the Vault policy that allows them to read the secrets
+	RookOSDVaultAuthKubernetesRole = "VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE"
 	// VaultKVSecretEngineKey is a kv secret engine type
 	VaultKVSecretEngineKey = "kv"
 	// VaultTransitSecretEngineKey is a transit secret engine type
@@ -43,7 +50,8 @@ const (
 )
 
 var (
-	vaultMandatoryConnectionDetails = []string{api.EnvVaultAddress}
+	vaultMandatoryConnectionDetails              = []string{api.EnvVaultAddress}
+	vaultK8sAuthMethodMandatoryConnectionDetails = []string{RookOperatorVaultAuthKubernetesRole, RookOSDVaultAuthKubernetesRole}
 )
 
 // Used for unit tests mocking too as well as production code
@@ -250,9 +258,28 @@ func (c *Config) IsVault() bool {
 
 func validateVaultConnectionDetails(clusterdContext *clusterd.Context, ns string, kmsConfig map[string]string) error {
 	ctx := context.TODO()
+	// If Kubernetes authentication is enabled, let's merge into mandatory details
+	isK8sAuthEnabled := GetParam(kmsConfig, vault.AuthMethod) == vault.AuthMethodKubernetes
+	if isK8sAuthEnabled {
+		vaultMandatoryConnectionDetails = append(vaultMandatoryConnectionDetails, vaultK8sAuthMethodMandatoryConnectionDetails...)
+	}
 	for _, option := range vaultMandatoryConnectionDetails {
 		if GetParam(kmsConfig, option) == "" {
 			return errors.Errorf("failed to find connection details %q", option)
+		}
+	}
+
+	// When validating the connection details, we need to give a value to VAULT_AUTH_KUBERNETES_ROLE
+	// with the role we are currently running on. If we run from the operator we must use
+	// VAULT_AUTH_KUBERNETES_ROLE to VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE
+	// The CLI does not use the env var so VAULT_AUTH_KUBERNETES_ROLE is incorrect since it's
+	// setting the operator role.
+	if isK8sAuthEnabled {
+		// If ROOK_CRUSHMAP_ROOT is empty we are most likely running from the operator
+		if os.Getenv("ROOK_CRUSHMAP_ROOT") == "" {
+			kmsConfig[vault.AuthKubernetesRole] = kmsConfig[RookOperatorVaultAuthKubernetesRole]
+		} else {
+			kmsConfig[vault.AuthKubernetesRole] = kmsConfig[RookOSDVaultAuthKubernetesRole]
 		}
 	}
 

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -278,7 +278,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		envVars = append(envVars, pvcNameEnvVar(osdProps.pvc.ClaimName))
 
 		if osdProps.encrypted {
-			// If a KMS is configured we populate
+			// If a KMS is configured we populate volume mounts and env variables
 			if c.spec.Security.KeyManagementService.IsEnabled() {
 				kmsProvider := kms.GetParam(c.spec.Security.KeyManagementService.ConnectionDetails, kms.Provider)
 				if kmsProvider == secrets.TypeVault {

--- a/tests/manifests/test-cluster-on-pvc-encrypted.yaml
+++ b/tests/manifests/test-cluster-on-pvc-encrypted.yaml
@@ -14,7 +14,7 @@ spec:
           requests:
             storage: 5Gi
   cephVersion:
-    image: quay.io/ceph/ceph:v15
+    image: quay.io/ceph/ceph:v16
   dashboard:
     enabled: false
   network:

--- a/tests/manifests/test-kms-vault-spec-k8s-auth.yaml
+++ b/tests/manifests/test-kms-vault-spec-k8s-auth.yaml
@@ -10,4 +10,6 @@ spec:
         VAULT_CLIENT_KEY: "vault-client-key"
         VAULT_CLIENT_CERT: "vault-client-cert"
         VAULT_CACERT: "vault-ca-cert"
-      tokenSecretName: rook-vault-token
+        VAULT_AUTH_METHOD: kubernetes
+        VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE: rook-op
+        VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE: rook-osd

--- a/tests/manifests/test-kms-vault-spec-token-auth.yaml
+++ b/tests/manifests/test-kms-vault-spec-token-auth.yaml
@@ -1,0 +1,14 @@
+spec:
+  security:
+    kms:
+      connectionDetails:
+        KMS_PROVIDER: vault
+        VAULT_ADDR: https://vault.default.svc.cluster.local:8200
+        VAULT_BACKEND_PATH: rook/ver1
+        VAULT_SECRET_ENGINE: kv
+        VAULT_SKIP_VERIFY: "true"
+        VAULT_CLIENT_KEY: "vault-client-key"
+        VAULT_CLIENT_CERT: "vault-client-cert"
+        VAULT_CACERT: "vault-ca-cert"
+        VAULT_AUTH_METHOD: token
+      tokenSecretName: rook-vault-token


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
  
Rook cluster-wide encryption can now use the native Kubernetes
authentication to interact with vault KMS instead of using the token
method.
    
Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
