### PR TITLE
ci: fix mirror scenario by removing ownerref

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -817,15 +817,19 @@ jobs:
 
     - name: copy block mirror peer secret into the other cluster for replicapool
       run: |
-        kubectl -n rook-ceph get secret pool-peer-token-replicapool -o yaml |\
-        sed 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g; s/name: pool-peer-token-replicapool/name: pool-peer-token-replicapool-config/g' |\
-        kubectl create --namespace=rook-ceph-secondary -f -
+        kubectl -n rook-ceph get secret pool-peer-token-replicapool -o yaml > pool-peer-token-replicapool.yaml
+        yq delete --inplace pool-peer-token-replicapool.yaml metadata.ownerReferences
+        yq write --inplace pool-peer-token-replicapool.yaml metadata.namespace rook-ceph-secondary
+        yq write --inplace pool-peer-token-replicapool.yaml metadata.name pool-peer-token-replicapool-config
+        kubectl create --namespace=rook-ceph-secondary -f pool-peer-token-replicapool.yaml
 
     - name: copy block mirror peer secret into the other cluster for replicapool2 (using cluster global peer)
       run: |
-        kubectl -n rook-ceph get secret cluster-peer-token-my-cluster -o yaml |\
-        sed 's/namespace: rook-ceph/namespace: rook-ceph-secondary/g; s/name: cluster-peer-token-my-cluster/name: cluster-peer-token-my-cluster-config/g' |\
-        kubectl create --namespace=rook-ceph-secondary -f -
+        kubectl -n rook-ceph get secret cluster-peer-token-my-cluster -o yaml > cluster-peer-token-my-cluster.yaml
+        yq delete --inplace cluster-peer-token-my-cluster.yaml metadata.ownerReferences
+        yq write --inplace cluster-peer-token-my-cluster.yaml metadata.namespace rook-ceph-secondary
+        yq write --inplace cluster-peer-token-my-cluster.yaml metadata.name cluster-peer-token-my-cluster-config
+        kubectl create --namespace=rook-ceph-secondary -f cluster-peer-token-my-cluster.yaml
 
     - name: add block mirror peer secret to the other cluster for replicapool
       run: |


### PR DESCRIPTION
**Description of your changes:**

When we copy the peer token secret from a namespace to another we also
copy the ownerref, however the creation succeeds but the controller
removes the secret since the uid of the owner do not exist in that
namespace.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
