### PR TITLE
rgw: read tls secret hint for insecure tls

### DIFF
--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -91,7 +91,18 @@ When the `zone` section is set pools with the object stores name will not be cre
 The gateway settings correspond to the RGW daemon settings.
 
 * `type`: `S3` is supported
-* `sslCertificateRef`: If specified, this is the name of the Kubernetes secret(`opaque` or `tls` type) that contains the TLS certificate to be used for secure connections to the object store. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in PEM form."
+* `sslCertificateRef`: If specified, this is the name of the Kubernetes secret(`opaque` or `tls`
+  type) that contains the TLS certificate to be used for secure connections to the object store.
+  If it is an opaque Kubernetes Secret, Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be
+  in the format expected by the [RGW
+  service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb):
+  "The server key, server certificate, and any other CA or intermediate certificates be supplied in
+  one file. Each of these items must be in PEM form." They are scenarios where the certificate DNS is set for a particular domain
+  that does not include the local Kubernetes DNS, namely the object store DNS service endpoint. If
+  adding the service DNS name to the certificate is not empty another key can be specified in the
+  secret's data: `insecureSkipVerify: true` to skip the certificate verification. It is not
+  recommended to enable this option since TLS is susceptible to machine-in-the-middle attacks unless
+  custom verification is used.
 * `port`: The port on which the Object service will be reachable. If host networking is enabled, the RGW daemons will also listen on that port. If running on SDN, the RGW daemon listening port will be 8080 internally.
 * `securePort`: The secure port on which RGW pods will be listening. A TLS certificate must be specified either via `sslCerticateRef` or `service.annotations`
 * `instances`: The number of pods that will be started to load balance this object store.

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -79,7 +79,15 @@ If there is a `zone` section in object-store configuration, then the pool sectio
 
 The gateway settings correspond to the RGW service.
 - `type`: Can be `s3`. In the future support for `swift` can be added.
-- `sslCertificateRef`: If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. The secret must be in the same namespace as the Rook cluster. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form." If the certificate is not specified, SSL will not be configured.
+- `sslCertificateRef`: If specified, this is the name of the Kubernetes secret that contains the SSL
+  certificate to be used for secure connections to the object store. The secret must be in the same
+  namespace as the Rook cluster. If it is an opaque Kubernetes Secret, Rook will look in the secret
+  provided at the `cert` key name. The value of the `cert` key must be in the format expected by the
+  [RGW
+  service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb):
+  "The server key, server certificate, and any other CA or intermediate certificates be supplied in
+  one file. Each of these items must be in pem form." If the certificate is not specified, SSL will
+  not be configured.
 - `caBundleRef`: If specified, this is the name of the Kubernetes secret (type `opaque`) that contains ca-bundle to use. The secret must be in the same namespace as the Rook cluster. Rook will look in the secret provided at the `cabundle` key name.
 - `port`: The service port where the RGW service will be listening (http)
 - `securePort`: The service port where the RGW service will be listening (https)

--- a/design/common/object-bucket.md
+++ b/design/common/object-bucket.md
@@ -97,7 +97,19 @@ The pools are the backing data store for the object store and are created with s
 
 The gateway settings correspond to the RGW service.
 - `type`: Can be `s3`. In the future support for `swift` can be added.
-- `sslCertificateRef`: If specified, this is the name of the Kubernetes secret that contains the SSL certificate to be used for secure connections to the object store. The secret must be in the same namespace as the Rook cluster. Rook will look in the secret provided at the `cert` key name. The value of the `cert` key must be in the format expected by the [RGW service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb): "The server key, server certificate, and any other CA or intermediate certificates be supplied in one file. Each of these items must be in pem form." If the certificate is not specified, SSL will not be configured.
+- `sslCertificateRef`: If specified, this is the name of the Kubernetes secret that contains the SSL
+  certificate to be used for secure connections to the object store. The secret must be in the same
+  namespace as the Rook cluster. If it is an opaque Kubernetes Secret, Rook will look in the secret provided at the `cert` key name. The
+  value of the `cert` key must be in the format expected by the [RGW
+  service](https://docs.ceph.com/docs/master/install/ceph-deploy/install-ceph-gateway/#using-ssl-with-civetweb):
+  "The server key, server certificate, and any other CA or intermediate certificates be supplied in
+  one file. Each of these items must be in pem form." If the certificate is not specified, SSL will
+  not be configured. They are scenarios where the certificate DNS is set for a particular domain
+  that does not include the local Kubernetes DNS, namely the object store DNS service endpoint. If
+  adding the service DNS name to the certificate is not empty another key can be specified in the
+  secret's data: `insecureSkipVerify: true` to skip the certificate verification. It is not
+  recommended to enable this option since TLS is susceptible to machine-in-the-middle attacks unless
+  custom verification is used.
 - `port`: The service port where the RGW service will be listening (http)
 - `securePort`: The service port where the RGW service will be listening (https)
 - `instances`: The number of RGW pods that will be started for this object store (ignored if allNodes=true)

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -55,6 +55,7 @@ type Provisioner struct {
 	endpoint             string
 	additionalConfigData map[string]string
 	tlsCert              []byte
+	insecureTLS          bool
 	adminOpsClient       *admin.API
 }
 
@@ -606,7 +607,7 @@ func (p *Provisioner) setTlsCaCert() error {
 	}
 	p.tlsCert = make([]byte, 0)
 	if objStore.Spec.Gateway.SecurePort == p.storePort {
-		p.tlsCert, err = cephObject.GetTlsCaCert(p.objectContext, &objStore.Spec)
+		p.tlsCert, p.insecureTLS, err = cephObject.GetTlsCaCert(p.objectContext, &objStore.Spec)
 		if err != nil {
 			return err
 		}
@@ -621,8 +622,7 @@ func (p *Provisioner) setAdminOpsAPIClient() error {
 		Timeout: cephObject.HttpTimeOut,
 	}
 	if p.tlsCert != nil {
-		insecure := false
-		httpClient.Transport = cephObject.BuildTransportTLS(p.tlsCert, insecure)
+		httpClient.Transport = cephObject.BuildTransportTLS(p.tlsCert, p.insecureTLS)
 	}
 
 	// Fetch the ceph object store


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

If the admin wants to use insecure TLS to validate connections to rgw
internally, the TLS secret can have another entry "insecureSkipVerify"
and set it to "true".

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #8993

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
