### PR TITLE
test: Create volume replication crds for yaml validation

### DIFF
--- a/tests/scripts/github-action-helper.sh
+++ b/tests/scripts/github-action-helper.sh
@@ -163,7 +163,16 @@ function build_rook_all() {
 
 function validate_yaml() {
   cd cluster/examples/kubernetes/ceph
+
+  # create the Rook CRDs and other resources
   kubectl create -f crds.yaml -f common.yaml
+
+  # create the volume replication CRDs
+  replication_version=v0.1.0
+  replication_url="https://raw.githubusercontent.com/csi-addons/volume-replication-operator/${replication_version}/config/crd/bases"
+  kubectl create -f "${replication_url}/replication.storage.openshift.io_volumereplications.yaml"
+  kubectl create -f "${replication_url}/replication.storage.openshift.io_volumereplicationclasses.yaml"
+
   # skipping folders and some yamls that are only for openshift.
   manifests="$(find . -maxdepth 1 -type f -name '*.yaml' -and -not -name '*openshift*' -and -not -name 'scc*')"
   with_f_arg="$(echo "$manifests" | awk '{printf " -f %s",$1}')" # don't add newline


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The yaml validation of the examples folder requires all the CRDs to be created in advance of the dry-run command. 

The issue this is fixing is that the canary integration test was failing with the following message in the yaml validation step:
```
unable to recognize "./volume-replication-class.yaml": no matches for kind "VolumeReplicationClass" in version "replication.storage.openshift.io/v1alpha1"
unable to recognize "./volume-replication.yaml": no matches for kind "VolumeReplication" in version "replication.storage.openshift.io/v1alpha1"
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
