### PR TITLE
ceph: ability to set label to crash collector

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -517,6 +517,8 @@ You can set annotations / labels for Rook components for the list of key value p
 * `mon`: Set annotations / labels for mons
 * `osd`: Set annotations / labels for OSDs
 * `prepareosd`: Set annotations / labels for OSD Prepare Jobs
+* `monitoring`: Set annotations / labels for service monitor
+* `crashcollector`: Set annotations / labels for crash collectors
 When other keys are set, `all` will be merged together with the specific component.
 
 ### Placement Configuration Settings

--- a/cluster/examples/kubernetes/ceph/cluster.yaml
+++ b/cluster/examples/kubernetes/ceph/cluster.yaml
@@ -178,6 +178,7 @@ spec:
 # monitoring is a list of key-value pairs. It is injected into all the monitoring resources created by operator.
 # These labels can be passed as LabelSelector to Prometheus
 #    monitoring:
+#    crashcollector:
   resources:
 # The requests and limits set here, allow the mgr pod to use half of one CPU core and 1 gigabyte of memory
 #    mgr:

--- a/pkg/apis/ceph.rook.io/v1/keys.go
+++ b/pkg/apis/ceph.rook.io/v1/keys.go
@@ -17,13 +17,14 @@ limitations under the License.
 package v1
 
 const (
-	KeyAll                = "all"
-	KeyMds        KeyType = "mds"
-	KeyMon        KeyType = "mon"
-	KeyMonArbiter KeyType = "arbiter"
-	KeyMgr        KeyType = "mgr"
-	KeyOSDPrepare KeyType = "prepareosd"
-	KeyOSD        KeyType = "osd"
-	KeyCleanup    KeyType = "cleanup"
-	KeyMonitoring KeyType = "monitoring"
+	KeyAll                    = "all"
+	KeyMds            KeyType = "mds"
+	KeyMon            KeyType = "mon"
+	KeyMonArbiter     KeyType = "arbiter"
+	KeyMgr            KeyType = "mgr"
+	KeyOSDPrepare     KeyType = "prepareosd"
+	KeyOSD            KeyType = "osd"
+	KeyCleanup        KeyType = "cleanup"
+	KeyMonitoring     KeyType = "monitoring"
+	KeyCrashCollector KeyType = "crashcollector"
 )

--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -63,6 +63,11 @@ func GetMonitoringLabels(a LabelsSpec) Labels {
 	return mergeAllLabelsWithKey(a, KeyMonitoring)
 }
 
+// GetCrashCollectorLabels returns the Labels for the crash collector resources
+func GetCrashCollectorLabels(a LabelsSpec) Labels {
+	return mergeAllLabelsWithKey(a, KeyCrashCollector)
+}
+
 func mergeAllLabelsWithKey(a LabelsSpec, name KeyType) Labels {
 	all := a.All()
 	if all != nil {

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -95,6 +95,7 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 		}
 
 		deploy.ObjectMeta.Labels = deploymentLabels
+		cephv1.GetCrashCollectorLabels(cephCluster.Spec.Labels).ApplyToObjectMeta(&deploy.ObjectMeta)
 		k8sutil.AddRookVersionLabelToDeployment(deploy)
 		if cephVersion != nil {
 			controller.AddCephVersionLabelToDeployment(*cephVersion, deploy)


### PR DESCRIPTION
**Description of your changes:**

We can now set labels to the crash collector deployment by editing the
CephCluster CR with:

```yaml
spec:
  labels:
    crashcollector:
```

Closes: https://github.com/rook/rook/issues/9039
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/9039

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
