### PR TITLE
build: fix the default target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ include build/makelib/helm.mk
 
 .PHONY: all
 all: build
+.DEFAULT_GOAL := all
 
 # ====================================================================================
 # Build Options


### PR DESCRIPTION
**Description of your changes:**

The current default target of Makefile is "_output/charts".

```
$ make -d
...
Successfully remade target file '/home/sat/go/src/github.com/rook/rook/_output/charts'.
```

It's because Makefile first includes "build/makelib/helm.mk", this file defines
some targets, and the first entry is regarded as the default target.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
