### PR TITLE
helm: Add appVersion property to the charts

### DIFF
--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -50,8 +50,7 @@ To deploy from a local build from your development environment:
 
 ```console
 cd cluster/charts/rook-ceph
-kubectl create namespace rook-ceph
-helm install --namespace rook-ceph rook-ceph .
+helm install --create-namespace --namespace rook-ceph rook-ceph .
 ```
 
 ## Uninstalling the Chart

--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -42,7 +42,7 @@ $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz: $(HELM) $(HELM_OUTPUT_DIR) $(shell find 
 	@cp -aL $(HELM_CHARTS_DIR)/$(1) $(OUTPUT_DIR)
 	@$(SED_IN_PLACE) 's|VERSION|$(VERSION)|g' $(OUTPUT_DIR)/$(1)/values.yaml
 	@$(HELM) lint $(abspath $(OUTPUT_DIR)/$(1)) --set image.tag=$(VERSION)
-	@$(HELM) package --version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(OUTPUT_DIR)/$(1))
+	@$(HELM) package --version $(VERSION) --app-version $(VERSION) -d $(HELM_OUTPUT_DIR) $(abspath $(OUTPUT_DIR)/$(1))
 $(HELM_INDEX): $(HELM_OUTPUT_DIR)/$(1)-$(VERSION).tgz
 endef
 $(foreach p,$(HELM_CHARTS),$(eval $(call helm.chart,$(p))))

--- a/cluster/charts/rook-ceph-cluster/Chart.yaml
+++ b/cluster/charts/rook-ceph-cluster/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 description: Manages a single Ceph cluster namespace for Rook
 name: rook-ceph-cluster
 version: 0.0.1
+appVersion: 0.0.1
 icon: https://rook.io/images/rook-logo.svg
 sources:
   - https://github.com/rook/rook

--- a/cluster/charts/rook-ceph/Chart.yaml
+++ b/cluster/charts/rook-ceph/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 description: File, Block, and Object Storage Services for your Cloud-Native Environment
 name: rook-ceph
 version: 0.0.1
+appVersion: 0.0.1
 icon: https://rook.io/images/rook-logo.svg
 sources:
   - https://github.com/rook/rook


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The appVersion should be set to the version of the application. Since the helm charts are built by Rook in the same release version as Rook itself, the version and appVersion values will be the same.

**Which issue is resolved by this Pull Request:**
Resolves #3589 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
