### PR TITLE
ceph: support ephemeral volumes with Ceph CSI RBD and CephFS driver

### DIFF
--- a/Documentation/ceph-csi-drivers.md
+++ b/Documentation/ceph-csi-drivers.md
@@ -3,7 +3,7 @@ title: Ceph CSI
 weight: 3200
 indent: true
 ---
-
+{% include_relative branch.liquid %}
 # Ceph CSI Drivers
 
 There are two CSI drivers integrated with Rook that will enable different scenarios:
@@ -92,3 +92,39 @@ kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replicatio
 2. Enable the volume replication controller:
    - For Helm deployments see the [csi.volumeReplication.enabled setting](helm-operator.md#configuration).
    - For non-Helm deployments set `CSI_ENABLE_VOLUME_REPLICATION: "true"` in operator.yaml
+
+## Ephemeral volume support
+
+The generic ephemeral volume feature adds support for specifying PVCs in the
+`volumes` field to indicate a user would like to create a Volume as part of the pod spec.
+This feature requires the GenericEphemeralVolume feature gate to be enabled.
+
+For example:
+
+```yaml
+kind: Pod
+apiVersion: v1
+...
+  volumes:
+    - name: mypvc
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            storageClassName: "rook-ceph-block"
+            resources:
+              requests:
+                storage: 1Gi
+```
+
+A volume claim template is defined inside the pod spec which refers to a volume
+provisioned and used by the pod with its lifecycle. The volumes are provisioned
+when pod get spawned and destroyed at time of pod delete.
+
+Refer to [ephemeral-doc]( https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes )
+for more info. Also, See the example manifests for an [RBD ephemeral volume]
+(https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/rbd/pod-ephemeral.yaml)
+and a [CephFS ephemeral volume](https://github.com/rook/rook/tree/{{ branchName }}/cluster/examples/kubernetes/ceph/csi/cephfs/pod-ephemeral.yaml).
+
+### Prerequisites
+Kubernetes version 1.21 or greater is required.

--- a/cluster/examples/kubernetes/ceph/csi/cephfs/pod-ephemeral.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/cephfs/pod-ephemeral.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-cephfs-demo-ephemeral-pod
+spec:
+  containers:
+    - name: web-server
+      image: docker.io/library/nginx:latest
+      volumeMounts:
+        - mountPath: "/myspace"
+          name: mypvc
+  volumes:
+    - name: mypvc
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteMany"]
+            storageClassName: "rook-cephfs"
+            resources:
+              requests:
+                storage: 1Gi

--- a/cluster/examples/kubernetes/ceph/csi/rbd/pod-ephemeral.yaml
+++ b/cluster/examples/kubernetes/ceph/csi/rbd/pod-ephemeral.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-rbd-demo-ephemeral-pod
+spec:
+  containers:
+    - name: web-server
+      image: docker.io/library/nginx:latest
+      volumeMounts:
+        - mountPath: "/myspace"
+          name: mypvc
+  volumes:
+    - name: mypvc
+      ephemeral:
+        volumeClaimTemplate:
+          spec:
+            accessModes: ["ReadWriteOnce"]
+            storageClassName: "rook-ceph-block"
+            resources:
+              requests:
+                storage: 1Gi


### PR DESCRIPTION
This commit make required changes for ceph csi drivers to work with
ephemeral volume support. With ephemeral volume support a user can
specify ephemeral volumes in its pod spec and tie the lifecycle
of the PVC with the POD.

An example POD spec looks like this:

```
kind: Pod
apiVersion: v1
metadata:
  name: my-app
   spec:
  containers:
    - name: csi-rbd-demo-pod
      image: busybox
      volumeMounts:
        - mountPath: "/scratch"
          name: mypvc
      command: [ "sleep", "1000000" ]
  volumes:
    - name: mypvc
      ephemeral:
        volumeClaimTemplate:
          spec:
            accessModes: [ "ReadWriteOnce" ]
            storageClassName: "csi-rbd-sc"
            resources:
              requests:
                storage: 1Gi
```

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
