### PR TITLE
docs: stop pasting toolbox yaml in doc

### DIFF
--- a/Documentation/ceph-toolbox.md
+++ b/Documentation/ceph-toolbox.md
@@ -20,69 +20,10 @@ The toolbox can be run in two modes:
 The rook toolbox can run as a deployment in a Kubernetes cluster where you can connect and
 run arbitrary Ceph commands.
 
-Save the tools spec as `toolbox.yaml`:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: rook-ceph-tools
-  namespace: rook-ceph
-  labels:
-    app: rook-ceph-tools
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: rook-ceph-tools
-  template:
-    metadata:
-      labels:
-        app: rook-ceph-tools
-    spec:
-      dnsPolicy: ClusterFirstWithHostNet
-      containers:
-      - name: rook-ceph-tools
-        image: rook/ceph:master
-        command: ["/tini"]
-        args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
-        imagePullPolicy: IfNotPresent
-        env:
-          - name: ROOK_CEPH_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: rook-ceph-mon
-                key: ceph-username
-          - name: ROOK_CEPH_SECRET
-            valueFrom:
-              secretKeyRef:
-                name: rook-ceph-mon
-                key: ceph-secret
-        volumeMounts:
-          - mountPath: /etc/ceph
-            name: ceph-config
-          - name: mon-endpoint-volume
-            mountPath: /etc/rook
-      volumes:
-        - name: mon-endpoint-volume
-          configMap:
-            name: rook-ceph-mon-endpoints
-            items:
-            - key: data
-              path: mon-endpoints
-        - name: ceph-config
-          emptyDir: {}
-      tolerations:
-        - key: "node.kubernetes.io/unreachable"
-          operator: "Exists"
-          effect: "NoExecute"
-          tolerationSeconds: 5
-```
-
 Launch the rook-ceph-tools pod:
 
 ```console
-kubectl create -f toolbox.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/toolbox.yaml
 ```
 
 Wait for the toolbox pod to download its container and get to the `running` state:
@@ -119,72 +60,10 @@ logs, you can run a script as a Kubernetes Job. The toolbox job will run a scrip
 in the job spec. The script has the full flexibility of a bash script.
 
 In this example, the `ceph status` command is executed when the job is created.
-
-```yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: rook-ceph-toolbox-job
-  namespace: rook-ceph
-  labels:
-    app: ceph-toolbox-job
-spec:
-  template:
-    spec:
-      initContainers:
-      - name: config-init
-        image: rook/ceph:master
-        command: ["/usr/local/bin/toolbox.sh"]
-        args: ["--skip-watch"]
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: ROOK_CEPH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: rook-ceph-mon
-              key: ceph-username
-        - name: ROOK_CEPH_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: rook-ceph-mon
-              key: ceph-secret
-        volumeMounts:
-        - mountPath: /etc/ceph
-          name: ceph-config
-        - name: mon-endpoint-volume
-          mountPath: /etc/rook
-      containers:
-      - name: script
-        image: rook/ceph:master
-        volumeMounts:
-        - mountPath: /etc/ceph
-          name: ceph-config
-          readOnly: true
-        command:
-        - "bash"
-        - "-c"
-        - |
-          # Modify this script to run any ceph, rbd, radosgw-admin, or other commands that could
-          # be run in the toolbox pod. The output of the commands can be seen by getting the pod log.
-          #
-          # example: print the ceph status
-          ceph status
-      volumes:
-      - name: mon-endpoint-volume
-        configMap:
-          name: rook-ceph-mon-endpoints
-          items:
-          - key: data
-            path: mon-endpoints
-      - name: ceph-config
-        emptyDir: {}
-      restartPolicy: Never
-```
-
 Create the toolbox job:
 
 ```console
-kubectl create -f toolbox-job.yaml
+kubectl create -f cluster/examples/kubernetes/ceph/toolbox-job.yaml
 ```
 
 After the job completes, see the results of the script:


### PR DESCRIPTION
**Description of your changes:**

We should only rely on the content of the repo and not copy YAML
examples into the documentation as it forces us to keep all versions in
sync all the time. The examples directory is the only source of truth.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
