### PR TITLE
docs: add doc note for caBundleRef for cephobjectstore

### DIFF
--- a/Documentation/ceph-object-store-crd.md
+++ b/Documentation/ceph-object-store-crd.md
@@ -37,6 +37,7 @@ spec:
   preservePoolsOnDelete: true
   gateway:
     # sslCertificateRef:
+    # caBundleRef:
     port: 80
     # securePort: 443
     instances: 1
@@ -103,6 +104,9 @@ The gateway settings correspond to the RGW daemon settings.
   secret's data: `insecureSkipVerify: true` to skip the certificate verification. It is not
   recommended to enable this option since TLS is susceptible to machine-in-the-middle attacks unless
   custom verification is used.
+* `caBundleRef`: If specified, this is the name of the Kubernetes secret (type `opaque`) that
+  contains additional custom ca-bundle to use. The secret must be in the same namespace as the Rook
+  cluster. Rook will look in the secret provided at the `cabundle` key name.
 * `port`: The port on which the Object service will be reachable. If host networking is enabled, the RGW daemons will also listen on that port. If running on SDN, the RGW daemon listening port will be 8080 internally.
 * `securePort`: The secure port on which RGW pods will be listening. A TLS certificate must be specified either via `sslCerticateRef` or `service.annotations`
 * `instances`: The number of pods that will be started to load balance this object store.


### PR DESCRIPTION
Add missed doc note for caBundleRef added as fix for issue
https://github.com/rook/rook/issues/8490

Related-Issue: https://github.com/rook/rook/issues/8490
Signed-off-by: Denis Egorenko <degorenko@mirantis.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
