### PR TITLE
update 1.3 upgrade notes to check CephCluster resource

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -181,6 +181,29 @@ kubectl -n $ROOK_SYSTEM_NAMESPACE get pods
 kubectl -n $ROOK_NAMESPACE get pods
 ```
 
+### Verify CephCluster Resource Health
+
+The upgrade health checks for Ceph and Rook may pass, but sanity checks will still prevent the upgrades from progressing if cluster components are not in good standing.
+For example, the MON health checks validate that the monitors are in quorum before allowing the upgrade, but also validate that there are an **odd number** of them in the config.
+
+To verify this, run the following command:
+
+```sh
+kubectl -n rook-ceph get cephclusters.ceph.rook.io 
+```
+
+In case the resource is not healthy (in this case the cluster has an even number MONs), or still `Progressing` you will see the following output:
+```console
+NAME        DATADIRHOSTPATH   MONCOUNT   AGE    PHASE   MESSAGE                        HEALTH
+rook-ceph   /var/lib/rook     4          492d   Progressing   failed to perform validation before cluster creation: mon count 4 cannot be even, must be odd to support a healthy quorum   HEALTH_WARN
+```
+
+For a healthy resource you should see the following:
+```console
+NAME        DATADIRHOSTPATH   MONCOUNT   AGE    PHASE   MESSAGE                        HEALTH
+rook-ceph   /var/lib/rook     3          556d   Ready   Cluster created successfully   HEALTH_OK
+```
+
 ### Status Output
 
 The Rook toolbox contains the Ceph tools that can give you status details of the cluster with the


### PR DESCRIPTION
**Description of your changes:**
docs: Add CephCluster health check to upgrade instructions

Adding notes and commands to check the CephCluster resource that silently prevents the cluster upgrade from progressing.

[skip ci]

Signed-off-by: Blaine Gardner b.blaine.gardner@gmail.com


**Which issue is resolved by this Pull Request:**
Resolves #7862

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
