### PR TITLE
rgw: change the way to livenessProbe and introduce readinessProbe

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -7316,6 +7316,102 @@ spec:
                               type: integer
                           type: object
                       type: object
+                    readinessProbe:
+                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
+                      properties:
+                        disabled:
+                          description: Disabled determines whether probe is disable or not
+                          type: boolean
+                        probe:
+                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          properties:
+                            exec:
+                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
                   type: object
                 metadataPool:
                   description: The metadata pool settings

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -7311,6 +7311,102 @@ spec:
                               type: integer
                           type: object
                       type: object
+                    readinessProbe:
+                      description: ProbeSpec is a wrapper around Probe so it can be enabled or disabled for a Ceph daemon
+                      properties:
+                        disabled:
+                          description: Disabled determines whether probe is disable or not
+                          type: boolean
+                        probe:
+                          description: Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+                          properties:
+                            exec:
+                              description: One and only one of the following should be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
                   type: object
                 metadataPool:
                   description: The metadata pool settings

--- a/cluster/examples/kubernetes/ceph/object-ec.yaml
+++ b/cluster/examples/kubernetes/ceph/object-ec.yaml
@@ -87,6 +87,8 @@ spec:
     bucket:
       disabled: false
       interval: 60s
-    # Configure the pod liveness probe for the rgw daemon
+    # Configure the pod probes for the rgw daemon
     livenessProbe:
+      disabled: false
+    readinessProbe:
       disabled: false

--- a/cluster/examples/kubernetes/ceph/object-openshift.yaml
+++ b/cluster/examples/kubernetes/ceph/object-openshift.yaml
@@ -101,8 +101,10 @@ spec:
     bucket:
       disabled: false
       interval: 60s
-    # Configure the pod liveness probe for the rgw daemon
+    # Configure the pod probes for the rgw daemon
     livenessProbe:
+      disabled: false
+    readinessProbe:
       disabled: false
   # security oriented settings
   # security:

--- a/cluster/examples/kubernetes/ceph/object.yaml
+++ b/cluster/examples/kubernetes/ceph/object.yaml
@@ -107,8 +107,10 @@ spec:
     bucket:
       disabled: false
       interval: 60s
-    # Configure the pod liveness probe for the rgw daemon
+    # Configure the pod probes for the rgw daemon
     livenessProbe:
+      disabled: false
+    readinessProbe:
       disabled: false
   # security oriented settings
   # security:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1286,6 +1286,8 @@ type BucketHealthCheckSpec struct {
 	Bucket HealthCheckSpec `json:"bucket,omitempty"`
 	// +optional
 	LivenessProbe *ProbeSpec `json:"livenessProbe,omitempty"`
+	// +optional
+	ReadinessProbe *ProbeSpec `json:"readinessProbe,omitempty"`
 }
 
 // HealthCheckSpec represents the health check of an object store bucket

--- a/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ceph.rook.io/v1/zz_generated.deepcopy.go
@@ -68,6 +68,11 @@ func (in *BucketHealthCheckSpec) DeepCopyInto(out *BucketHealthCheckSpec) {
 		*out = new(ProbeSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ReadinessProbe != nil {
+		in, out := &in.ReadinessProbe, &out.ReadinessProbe
+		*out = new(ProbeSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operator/ceph/config/livenessprobe.go
+++ b/pkg/operator/ceph/config/livenessprobe.go
@@ -44,7 +44,7 @@ func ConfigureLivenessProbe(daemon rook.KeyType, container v1.Container, healthC
 			// If the spec value is not empty, let's apply it along with default when some fields are not specified
 			if probe != nil {
 				// Set the liveness probe on the container to overwrite the default probe created by Rook
-				container.LivenessProbe = GetLivenessProbeWithDefaults(probe, container.LivenessProbe)
+				container.LivenessProbe = GetProbeWithDefaults(probe, container.LivenessProbe)
 			}
 		}
 	}
@@ -52,7 +52,7 @@ func ConfigureLivenessProbe(daemon rook.KeyType, container v1.Container, healthC
 	return container
 }
 
-func GetLivenessProbeWithDefaults(desiredProbe, currentProbe *v1.Probe) *v1.Probe {
+func GetProbeWithDefaults(desiredProbe, currentProbe *v1.Probe) *v1.Probe {
 	newProbe := *desiredProbe
 
 	// Do not replace the handler with the previous one!

--- a/pkg/operator/ceph/config/livenessprobe_test.go
+++ b/pkg/operator/ceph/config/livenessprobe_test.go
@@ -75,7 +75,7 @@ func configLivenessProbeHelper(t *testing.T, keyType rook.KeyType) {
 	}
 }
 
-func TestGetLivenessProbeWithDefaults(t *testing.T) {
+func TestGetProbeWithDefaults(t *testing.T) {
 	t.Run("using default probe", func(t *testing.T) {
 		currentProb := &v1.Probe{
 			Handler: v1.Handler{
@@ -94,7 +94,7 @@ func TestGetLivenessProbeWithDefaults(t *testing.T) {
 		}
 		// in case of default probe
 		desiredProbe := &v1.Probe{}
-		desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, currentProb)
+		desiredProbe = GetProbeWithDefaults(desiredProbe, currentProb)
 		assert.Equal(t, desiredProbe, currentProb)
 	})
 
@@ -134,7 +134,7 @@ func TestGetLivenessProbeWithDefaults(t *testing.T) {
 			SuccessThreshold:    4,
 			TimeoutSeconds:      5,
 		}
-		desiredProbe = GetLivenessProbeWithDefaults(desiredProbe, currentProb)
+		desiredProbe = GetProbeWithDefaults(desiredProbe, currentProb)
 		assert.Equal(t, desiredProbe.Exec.Command, []string{"env", "-i", "sh", "-c", "ceph --admin-daemon /run/ceph/ceph-mon.c.asok mon_status"})
 		assert.Equal(t, desiredProbe.InitialDelaySeconds, int32(1))
 		assert.Equal(t, desiredProbe.FailureThreshold, int32(2))

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	livenessProbePath = "/swift/healthcheck"
+	readinessProbePath = "/swift/healthcheck"
 	// #nosec G101 since this is not leaking any hardcoded details
 	setupVaultTokenFile = `
 set -e
@@ -271,13 +271,16 @@ func (c *clusterConfig) makeDaemonContainer(rgwConfig *rgwConfig) v1.Container {
 		),
 		Env:             controller.DaemonEnvVars(c.clusterSpec.CephVersion.Image),
 		Resources:       c.store.Spec.Gateway.Resources,
-		LivenessProbe:   c.generateLiveProbe(),
+		LivenessProbe:   c.defaultLivenessProbe(),
+		ReadinessProbe:  c.defaultReadinessProbe(),
 		SecurityContext: controller.PodSecurityContext(),
 		WorkingDir:      cephconfig.VarLogCephDir,
 	}
 
 	// If the liveness probe is enabled
 	configureLivenessProbe(&container, c.store.Spec.HealthCheck)
+	// If the readiness probe is enabled
+	configureReadinessProbe(&container, c.store.Spec.HealthCheck)
 	if c.store.Spec.IsTLSEnabled() {
 		// Add a volume mount for the ssl certificate
 		mount := v1.VolumeMount{Name: certVolumeName, MountPath: certDir, ReadOnly: true}
@@ -321,7 +324,7 @@ func configureLivenessProbe(container *v1.Container, healthCheck cephv1.BucketHe
 			// If the spec value is empty, let's use a default
 			if probe != nil {
 				// Set the liveness probe on the container to overwrite the default probe created by Rook
-				container.LivenessProbe = cephconfig.GetLivenessProbeWithDefaults(probe, container.LivenessProbe)
+				container.LivenessProbe = cephconfig.GetProbeWithDefaults(probe, container.LivenessProbe)
 			}
 		} else {
 			container.LivenessProbe = nil
@@ -329,20 +332,47 @@ func configureLivenessProbe(container *v1.Container, healthCheck cephv1.BucketHe
 	}
 }
 
-func (c *clusterConfig) generateLiveProbe() *v1.Probe {
+// configureReadinessProbe returns the desired readiness probe for a given daemon
+func configureReadinessProbe(container *v1.Container, healthCheck cephv1.BucketHealthCheckSpec) {
+	if ok := healthCheck.ReadinessProbe; ok != nil {
+		if !healthCheck.ReadinessProbe.Disabled {
+			probe := healthCheck.ReadinessProbe.Probe
+			// If the spec value is empty, let's use a default
+			if probe != nil {
+				// Set the readiness probe on the container to overwrite the default probe created by Rook
+				container.ReadinessProbe = cephconfig.GetProbeWithDefaults(probe, container.ReadinessProbe)
+			}
+		} else {
+			container.ReadinessProbe = nil
+		}
+	}
+}
+
+func (c *clusterConfig) defaultLivenessProbe() *v1.Probe {
 	return &v1.Probe{
 		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Path:   livenessProbePath,
-				Port:   c.generateLiveProbePort(),
-				Scheme: c.generateLiveProbeScheme(),
+			TCPSocket: &v1.TCPSocketAction{
+				Port: c.generateProbePort(),
 			},
 		},
 		InitialDelaySeconds: 10,
 	}
 }
 
-func (c *clusterConfig) generateLiveProbeScheme() v1.URIScheme {
+func (c *clusterConfig) defaultReadinessProbe() *v1.Probe {
+	return &v1.Probe{
+		Handler: v1.Handler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   readinessProbePath,
+				Port:   c.generateProbePort(),
+				Scheme: c.generateReadinessProbeScheme(),
+			},
+		},
+		InitialDelaySeconds: 10,
+	}
+}
+
+func (c *clusterConfig) generateReadinessProbeScheme() v1.URIScheme {
 	// Default to HTTP
 	uriScheme := v1.URISchemeHTTP
 
@@ -355,7 +385,7 @@ func (c *clusterConfig) generateLiveProbeScheme() v1.URIScheme {
 	return uriScheme
 }
 
-func (c *clusterConfig) generateLiveProbePort() intstr.IntOrString {
+func (c *clusterConfig) generateProbePort() intstr.IntOrString {
 	// The port the liveness probe needs to probe
 	// Assume we run on SDN by default
 	port := intstr.FromInt(int(rgwPortInternalPort))
@@ -387,7 +417,7 @@ func (c *clusterConfig) generateService(cephObjectStore *cephv1.CephObjectStore)
 		svc.Spec.ClusterIP = v1.ClusterIPNone
 	}
 
-	destPort := c.generateLiveProbePort()
+	destPort := c.generateProbePort()
 
 	// When the cluster is external we must use the same one as the gateways are listening on
 	if cephObjectStore.Spec.IsExternal() {

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -36,6 +36,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestPodSpecs(t *testing.T) {
@@ -283,7 +284,7 @@ func TestValidateSpec(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestGenerateLiveProbe(t *testing.T) {
+func TestDefaultLivenessProbe(t *testing.T) {
 	store := simpleStore()
 	c := &clusterConfig{
 		store: store,
@@ -294,33 +295,93 @@ func TestGenerateLiveProbe(t *testing.T) {
 		},
 	}
 
+	desiredProbe := &v1.Probe{
+		Handler: v1.Handler{
+			TCPSocket: &v1.TCPSocketAction{
+				Port: intstr.FromInt(8080),
+			},
+		},
+		InitialDelaySeconds: 10,
+	}
 	// No SSL - HostNetwork is disabled - using internal port
-	p := c.generateLiveProbe()
-	assert.Equal(t, int32(8080), p.Handler.HTTPGet.Port.IntVal)
-	assert.Equal(t, v1.URISchemeHTTP, p.Handler.HTTPGet.Scheme)
+	p := c.defaultLivenessProbe()
+	assert.Equal(t, desiredProbe, p)
 
 	// No SSL - HostNetwork is enabled
 	c.store.Spec.Gateway.Port = 123
 	c.store.Spec.Gateway.SecurePort = 0
 	c.clusterSpec.Network.HostNetwork = true
-	p = c.generateLiveProbe()
-	assert.Equal(t, int32(123), p.Handler.HTTPGet.Port.IntVal)
+	p = c.defaultLivenessProbe()
+	desiredProbe.Handler.TCPSocket.Port = intstr.FromInt(123)
+	assert.Equal(t, desiredProbe, p)
 
 	// SSL - HostNetwork is enabled
 	c.store.Spec.Gateway.Port = 0
 	c.store.Spec.Gateway.SecurePort = 321
 	c.store.Spec.Gateway.SSLCertificateRef = "foo"
-	p = c.generateLiveProbe()
-	assert.Equal(t, int32(321), p.Handler.HTTPGet.Port.IntVal)
+	p = c.defaultLivenessProbe()
+	desiredProbe.Handler.TCPSocket.Port = intstr.FromInt(321)
+	assert.Equal(t, desiredProbe, p)
 
 	// Both Non-SSL and SSL are enabled
-	// liveprobe just on Non-SSL
+	// livenessProbe just on Non-SSL
 	c.store.Spec.Gateway.Port = 123
 	c.store.Spec.Gateway.SecurePort = 321
+	p = c.defaultLivenessProbe()
+	desiredProbe.Handler.TCPSocket.Port = intstr.FromInt(123)
+	assert.Equal(t, desiredProbe, p)
+}
+
+func TestDefaultReadinessProbe(t *testing.T) {
+	store := simpleStore()
+	c := &clusterConfig{
+		store: store,
+		clusterSpec: &cephv1.ClusterSpec{
+			Network: cephv1.NetworkSpec{
+				HostNetwork: false,
+			},
+		},
+	}
+
+	desiredProbe := &v1.Probe{
+		Handler: v1.Handler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   readinessProbePath,
+				Port:   intstr.FromInt(8080),
+				Scheme: v1.URISchemeHTTP,
+			},
+		},
+		InitialDelaySeconds: 10,
+	}
+	// No SSL - HostNetwork is disabled - using internal port
+	p := c.defaultReadinessProbe()
+	assert.Equal(t, desiredProbe, p)
+
+	// No SSL - HostNetwork is enabled
+	c.store.Spec.Gateway.Port = 123
+	c.store.Spec.Gateway.SecurePort = 0
+	c.clusterSpec.Network.HostNetwork = true
+	p = c.defaultReadinessProbe()
+	desiredProbe.Handler.HTTPGet.Port = intstr.FromInt(123)
+	assert.Equal(t, desiredProbe, p)
+
+	// SSL - HostNetwork is enabled
+	c.store.Spec.Gateway.Port = 0
+	c.store.Spec.Gateway.SecurePort = 321
 	c.store.Spec.Gateway.SSLCertificateRef = "foo"
-	p = c.generateLiveProbe()
-	assert.Equal(t, v1.URISchemeHTTP, p.Handler.HTTPGet.Scheme)
-	assert.Equal(t, int32(123), p.Handler.HTTPGet.Port.IntVal)
+	p = c.defaultReadinessProbe()
+	desiredProbe.Handler.HTTPGet.Port = intstr.FromInt(321)
+	desiredProbe.Handler.HTTPGet.Scheme = v1.URISchemeHTTPS
+	assert.Equal(t, desiredProbe, p)
+
+	// Both Non-SSL and SSL are enabled
+	// readinessProbe just on Non-SSL
+	c.store.Spec.Gateway.Port = 123
+	c.store.Spec.Gateway.SecurePort = 321
+	p = c.defaultReadinessProbe()
+	desiredProbe.Handler.HTTPGet.Port = intstr.FromInt(123)
+	desiredProbe.Handler.HTTPGet.Scheme = v1.URISchemeHTTP
+	assert.Equal(t, desiredProbe, p)
 }
 
 func TestCheckRGWKMS(t *testing.T) {

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -185,6 +185,7 @@ func createCephObjectStore(s suite.Suite, helper *clients.TestClient, k8sh *util
 		}
 		assert.True(s.T(), k8sh.CheckPodCountAndState("rook-ceph-rgw", namespace, 1, "Running"))
 		logger.Info("RGW pods are running")
+		assert.NoError(t, k8sh.WaitForLabeledDeploymentsToBeReady("app=rook-ceph-rgw", namespace))
 		logger.Infof("Object store %q created successfully", storeName)
 	})
 }


### PR DESCRIPTION
**Description of your changes:**

rgw doesn't respond `livenessProbe` if the number of connection reaches its limit (by default, 1000). Then rgw is out of service but still live. Hense the current `livenessProbe` logic is suitiable for `readinessProbe`. `tcpSocket` is enough for `livenessProbe`.

Remove rgw-multisite-test related code because this test doesn't exist in release-1.7 branch.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
