### PR TITLE
build: only produce binary for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ GO_PROJECT=github.com/rook/rook
 # inject the version number into the golang version package using the -X linker flag
 LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 
+# CGO_ENABLED value
+CGO_ENABLED_VALUE=0
+
 # ====================================================================================
 # Setup projects
 

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ endif
 
 # platforms
 PLATFORMS ?= $(ALL_PLATFORMS)
+# PLATFORMS_TO_BUILD_FOR controls for which platforms to build the rook binary for
+PLATFORMS_TO_BUILD_FOR ?= linux_amd64 linux_arm64
 SERVER_PLATFORMS := $(filter linux_%,$(PLATFORMS))
 CLIENT_PLATFORMS := $(filter-out linux_%,$(PLATFORMS))
 
@@ -117,7 +119,7 @@ build.common: build.version helm.build mod.check
 do.build.platform.%:
 	@$(MAKE) PLATFORM=$* go.build
 
-do.build.parallel: $(foreach p,$(PLATFORMS), do.build.platform.$(p))
+do.build.parallel: $(foreach p,$(PLATFORMS_TO_BUILD_FOR), do.build.platform.$(p))
 
 build: csv-clean build.common ## Only build for linux platform
 	@$(MAKE) go.build PLATFORM=linux_$(GOHOSTARCH)

--- a/build/makelib/common.mk
+++ b/build/makelib/common.mk
@@ -38,10 +38,6 @@ GOARCH := $(word 2, $(subst _, ,$(PLATFORM)))
 export GOOS GOARCH
 endif
 
-GOHOSTOS := $(shell go env GOHOSTOS)
-GOHOSTARCH := $(shell go env GOHOSTARCH)
-HOST_PLATFORM := $(GOHOSTOS)_$(GOHOSTARCH)
-
 ALL_PLATFORMS ?= darwin_amd64 windows_amd64 linux_amd64 linux_arm64
 
 ifeq ($(PLATFORM),linux_amd64)
@@ -58,11 +54,28 @@ CROSS_TRIPLE=x86_64-w64-mingw32
 endif
 export GOARM
 
+# force the build of a linux binary when running on MacOS
+GOHOSTOS=linux
+GOHOSTARCH := $(shell go env GOHOSTARCH)
+HOST_PLATFORM := $(GOHOSTOS)_$(GOHOSTARCH)
+
 ifneq ($(PLATFORM),$(HOST_PLATFORM))
+ifeq (,$(shell go env CC))
 CC := $(CROSS_TRIPLE)-gcc
-CXX := $(CROSS_TRIPLE)-g++
+else
+CC := $(shell go env CC)
+endif
+ifeq (,$(shell go env CXX))
+CXX := $(CROSS_TRIPLE)-gcc
+else
+CXX := $(shell go env CXX)
+endif
 export CC CXX
 endif
+
+# REAL_HOST_PLATFORM is used to determine the correct url to download the various binary tools from and it does not use
+# HOST_PLATFORM which is used to build the program.
+REAL_HOST_PLATFORM=$(shell go env GOHOSTOS)_$(GOHOSTARCH)
 
 # set the version number. you should not need to do this
 # for the majority of scenarios.

--- a/build/makelib/golang.mk
+++ b/build/makelib/golang.mk
@@ -152,8 +152,7 @@ go.lint: $(GOLINT)
 .PHONY: go.vet
 go.vet:
 	@echo === go vet
-	@echo CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GOHOST) vet $(GO_COMMON_FLAGS) $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES)
-	@CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GOHOST) vet $(GO_COMMON_FLAGS) $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES)
+	CGO_ENABLED=$(CGO_ENABLED_VALUE) $(GOHOST) vet $(GO_COMMON_FLAGS) $(GO_PACKAGES) $(GO_INTEGRATION_TEST_PACKAGES)
 
 .PHONY: go.fmt
 # ignore deepcopy generated files since the tool hardcoded the header with a "// +build" which in Golang 1.17 makes it fail gofmt since "////go:build" is preferred
@@ -189,7 +188,7 @@ $(GOLINT):
 $(GOFMT):
 	@echo === installing gofmt$(GOFMT_VERSION)
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@curl -sL https://dl.google.com/go/go$(GOFMT_VERSION).$(GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
+	@curl -sL https://dl.google.com/go/go$(GOFMT_VERSION).$(shell go env GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
 	@mv $(TOOLS_HOST_DIR)/tmp/go/bin/gofmt $(GOFMT)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 

--- a/build/makelib/helm.mk
+++ b/build/makelib/helm.mk
@@ -31,8 +31,8 @@ $(HELM_OUTPUT_DIR):
 $(HELM):
 	@echo === installing helm
 	@mkdir -p $(TOOLS_HOST_DIR)/tmp
-	@curl -sL https://get.helm.sh/helm-$(HELM_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
-	@mv $(TOOLS_HOST_DIR)/tmp/$(GOHOSTOS)-$(GOHOSTARCH)/helm $(HELM)
+	@curl -sL https://get.helm.sh/helm-$(HELM_VERSION)-$(shell go env GOHOSTOS)-$(GOHOSTARCH).tar.gz | tar -xz -C $(TOOLS_HOST_DIR)/tmp
+	@mv $(TOOLS_HOST_DIR)/tmp/$(shell go env GOHOSTOS)-$(GOHOSTARCH)/helm $(HELM)
 	@rm -fr $(TOOLS_HOST_DIR)/tmp
 
 define helm.chart

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -84,7 +84,7 @@ MANIFEST_TOOL := $(TOOLS_HOST_DIR)/manifest-tool-$(MANIFEST_TOOL_VERSION)
 $(MANIFEST_TOOL):
 	@echo === installing manifest-tool
 	mkdir -p $(TOOLS_HOST_DIR)
-	curl -sL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-$(GOHOSTOS)-$(GOHOSTARCH) > $@
+	curl -sL https://github.com/estesp/manifest-tool/releases/download/$(MANIFEST_TOOL_VERSION)/manifest-tool-$(shell go env GOHOSTOS)-$(GOHOSTARCH) > $@
 	chmod +x $@
 
 # ====================================================================================

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -36,15 +36,15 @@ TEMP := $(shell mktemp -d)
 # Note: as of version 1.3 of operator-sdk, the url format changed to:
 # ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 # (see: https://sdk.operatorframework.io/docs/installation/)
-ifeq ($(HOST_PLATFORM),linux_amd64)
+ifeq ($(REAL_HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
 endif
-ifeq ($(HOST_PLATFORM),linux_arm64)
+ifeq ($(REAL_HOST_PLATFORM),linux_arm64)
 OPERATOR_SDK_PLATFORM = aarch64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
 endif
-ifeq ($(HOST_PLATFORM),darwin_amd64)
+ifeq ($(REAL_HOST_PLATFORM),darwin_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
 INCLUDE_CSV_TEMPLATES = true
 endif
@@ -126,13 +126,13 @@ get-volume-replication-crds:
 	@cp $(CACHE_DIR)/crds/* $(CRD_TEMPLATE_DIR)
 
 $(YQ):
-	@echo === installing yq $(GOHOST)
+	@echo === installing yq $(REAL_HOST_PLATFORM)
 	@mkdir -p $(TOOLS_HOST_DIR)
-	@curl -JL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(HOST_PLATFORM) -o $(YQ)
+	@curl -JL https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(REAL_HOST_PLATFORM) -o $(YQ)
 	@chmod +x $(YQ)
 
 $(OPERATOR_SDK):
-	@echo === installing operator-sdk $(GOHOST)
+	@echo === installing operator-sdk $(REAL_HOST_PLATFORM)
 	@mkdir -p $(TOOLS_HOST_DIR)
 	@curl -JL -o $(TOOLS_HOST_DIR)/operator-sdk-$(OPERATOR_SDK_VERSION) \
 		https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-$(OPERATOR_SDK_PLATFORM)


### PR DESCRIPTION
**Description of your changes:**

We now build rook to build only for linux platforms and not darwin nor
windows anymore.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
