### PR TITLE
osd: use multiple service account for vault role

### DIFF
--- a/Documentation/ceph-kms.md
+++ b/Documentation/ceph-kms.md
@@ -8,7 +8,7 @@ indent: true
 
 Rook has the ability to encrypt OSDs of clusters running on PVC via the flag (`encrypted: true`) in your `storageClassDeviceSets` [template](#pvc-based-cluster).
 By default, the Key Encryption Keys (also known as Data Encryption Keys) are stored in a Kubernetes Secret.
-However, if a Key Management System exists Rook is capable of using it. 
+However, if a Key Management System exists Rook is capable of using it.
 
 The `security` section contains settings related to encryption of the cluster.
 
@@ -91,8 +91,6 @@ ROOK_VAULT_SA=rook-vault-auth
 ROOK_SYSTEM_SA=rook-ceph-system
 ROOK_OSD_SA=rook-ceph-osd
 VAULT_POLICY_NAME=rook
-VAULT_ROOK_OP_ROLE_NAME=rook-op
-VAULT_ROOK_OSD_ROLE_NAME=rook-osd
 
 # create service account for vault to validate API token
 kubectl -n "$ROOK_NAMESPACE" create serviceaccount "$ROOK_VAULT_SA"
@@ -128,16 +126,9 @@ vault write auth/kubernetes/config \
 
 kill $proxy_pid
 
-# configure a role for rook operator
-vault write auth/kubernetes/role/"$VAULT_ROOK_OP_ROLE_NAME" \
-    bound_service_account_names="$ROOK_SYSTEM_SA" \
-    bound_service_account_namespaces="$ROOK_NAMESPACE" \
-    policies="$VAULT_POLICY_NAME" \
-    ttl=1440h
-
-# configure a role for rook osds
-vault write auth/kubernetes/role/"$VAULT_ROOK_OSD_ROLE_NAME" \
-    bound_service_account_names="$ROOK_OSD_SA" \
+# configure a role for rook
+vault write auth/kubernetes/role/"$ROOK_NAMESPACE" \
+    bound_service_account_names="$ROOK_SYSTEM_SA","$ROOK_OSD_SA" \
     bound_service_account_namespaces="$ROOK_NAMESPACE" \
     policies="$VAULT_POLICY_NAME" \
     ttl=1440h
@@ -154,8 +145,7 @@ security:
         VAULT_BACKEND_PATH: rook/ver1
         VAULT_SECRET_ENGINE: kv
         VAULT_AUTH_METHOD: kubernetes
-        VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE: rook-op
-        VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE: rook-osd
+        VAULT_AUTH_KUBERNETES_ROLE: rook-ceph
 ```
 
 ### General Vault configuration

--- a/cmd/rook/secret.go
+++ b/cmd/rook/secret.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/libopenstorage/secrets/vault"
 	"github.com/pkg/errors"
 	"github.com/rook/rook/cmd/rook/rook"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -77,14 +76,6 @@ func startSecret() *kms.Config {
 	err = kms.ValidateConnectionDetails(context, &cephCluster.Spec.Security, namespace)
 	if err != nil {
 		rook.TerminateFatal(errors.Wrap(err, "failed to validate kms connection details"))
-	}
-
-	// If Kubernetes authentication is enabled (through Service Accounts), use the role provided by
-	// the cluster spec
-	// Here we use VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE since this CLI is being called from an OSD
-	// init container, so the pod will use the "rook-ceph-osd" service account, different than the operator
-	if cephCluster.Spec.Security.KeyManagementService.IsK8sAuthEnabled() {
-		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails[vault.AuthKubernetesRole] = cephCluster.Spec.Security.KeyManagementService.ConnectionDetails[kms.RookOSDVaultAuthKubernetesRole]
 	}
 
 	return kms.NewConfig(context, &cephCluster.Spec, clusterInfo)

--- a/pkg/daemon/ceph/osd/kms/envs.go
+++ b/pkg/daemon/ceph/osd/kms/envs.go
@@ -73,18 +73,11 @@ func VaultConfigToEnvVar(spec cephv1.ClusterSpec) []v1.EnvVar {
 	}
 	for k, v := range spec.Security.KeyManagementService.ConnectionDetails {
 		// Skip TLS and token env var to avoid env being set multiple times
-		toSkip := append(cephv1.VaultTLSConnectionDetails, api.EnvVaultToken, vault.AuthKubernetesRole)
+		toSkip := append(cephv1.VaultTLSConnectionDetails, api.EnvVaultToken)
 		if sets.NewString(toSkip...).Has(k) {
 			continue
 		}
-		// We need to apply the osd role to VAULT_AUTH_KUBERNETES_ROLE
-		// This is only called from the Operator but will run inside the prepare job so it's ok to
-		// force the vault osd role
-		if k == RookOSDVaultAuthKubernetesRole {
-			envs = append(envs, v1.EnvVar{Name: vault.AuthKubernetesRole, Value: v})
-		} else {
-			envs = append(envs, v1.EnvVar{Name: k, Value: v})
-		}
+		envs = append(envs, v1.EnvVar{Name: k, Value: v})
 	}
 
 	// Add the VAULT_TOKEN

--- a/pkg/daemon/ceph/osd/kms/envs_test.go
+++ b/pkg/daemon/ceph/osd/kms/envs_test.go
@@ -104,14 +104,6 @@ func TestVaultConfigToEnvVar(t *testing.T) {
 			[]v1.EnvVar{{Name: "VAULT_BACKEND_PATH", Value: "foo/"}},
 		},
 		{
-			"test VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE",
-			args{spec: cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{ConnectionDetails: map[string]string{"VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE": "rook-osd"}}}}},
-			[]v1.EnvVar{
-				{Name: "VAULT_AUTH_KUBERNETES_ROLE", Value: "rook-osd"},
-				{Name: "VAULT_BACKEND_PATH", Value: "secret/"},
-			},
-		},
-		{
 			"test with tls config",
 			args{spec: cephv1.ClusterSpec{Security: cephv1.SecuritySpec{KeyManagementService: cephv1.KeyManagementServiceSpec{ConnectionDetails: map[string]string{"VAULT_CACERT": "my-secret-name"}}}}},
 			[]v1.EnvVar{

--- a/tests/manifests/test-kms-vault-spec-k8s-auth.yaml
+++ b/tests/manifests/test-kms-vault-spec-k8s-auth.yaml
@@ -11,5 +11,4 @@ spec:
         VAULT_CLIENT_CERT: "vault-client-cert"
         VAULT_CACERT: "vault-ca-cert"
         VAULT_AUTH_METHOD: kubernetes
-        VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE: rook-op
-        VAULT_AUTH_KUBERNETES_ROOK_OSD_ROLE: rook-osd
+        VAULT_AUTH_KUBERNETES_ROLE: "rook-ceph"

--- a/tests/scripts/deploy-validate-vault.sh
+++ b/tests/scripts/deploy-validate-vault.sh
@@ -29,8 +29,6 @@ ROOK_VAULT_SA=rook-vault-auth
 ROOK_SYSTEM_SA=rook-ceph-system
 ROOK_OSD_SA=rook-ceph-osd
 VAULT_POLICY_NAME=rook
-VAULT_ROOK_OP_ROLE_NAME=rook-op
-VAULT_ROOK_OSD_ROLE_NAME=rook-osd
 SECRET_NAME=vault-server-tls
 TMPDIR=$(mktemp -d)
 VAULT_SERVER=https://vault.default:8200
@@ -203,16 +201,9 @@ function set_up_vault_kubernetes_auth {
 
   kill $proxy_pid
 
-  # configure a role for rook operator
-  kubectl exec -ti vault-0 -- vault write auth/kubernetes/role/"$VAULT_ROOK_OP_ROLE_NAME" \
-    bound_service_account_names="$ROOK_SYSTEM_SA" \
-    bound_service_account_namespaces="$ROOK_NAMESPACE" \
-    policies="$VAULT_POLICY_NAME" \
-    ttl=1440h
-
-  # configure a role for rook osds
-  kubectl exec -ti vault-0 -- vault write auth/kubernetes/role/"$VAULT_ROOK_OSD_ROLE_NAME" \
-    bound_service_account_names="$ROOK_OSD_SA" \
+  # configure a role for rook
+  kubectl exec -ti vault-0 -- vault write auth/kubernetes/role/"$ROOK_NAMESPACE" \
+    bound_service_account_names="$ROOK_SYSTEM_SA","$ROOK_OSD_SA" \
     bound_service_account_namespaces="$ROOK_NAMESPACE" \
     policies="$VAULT_POLICY_NAME" \
     ttl=1440h


### PR DESCRIPTION
**Description of your changes:**

We can pass bound_service_account_names with a comma separated list of
service accounts. Let's do this instead of remapping new values.
Earlier, we thought a single service account could be added per Vault
role and we were using other variables like
`VAULT_AUTH_KUBERNETES_ROOK_OPERATOR_ROLE` that we were remapping to
`VAULT_AUTH_KUBERNETES_ROLE` internal for the API calls to Vault.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
