### PR TITLE
core: Allow downgrade of all daemons consistently

### DIFF
--- a/pkg/operator/ceph/cluster/version.go
+++ b/pkg/operator/ceph/cluster/version.go
@@ -109,7 +109,8 @@ func diffImageSpecAndClusterRunningVersion(imageSpecVersion cephver.CephVersion,
 			}
 
 			if cephver.IsInferior(imageSpecVersion, clusterRunningVersion) {
-				return true, errors.Errorf("image spec version %s is lower than the running cluster version %s, downgrading is not supported", imageSpecVersion.String(), clusterRunningVersion.String())
+				logger.Warningf("image spec version %s is lower than the running cluster version %s, downgrading is not supported", imageSpecVersion.String(), clusterRunningVersion.String())
+				return true, nil
 			}
 		}
 	}

--- a/pkg/operator/ceph/cluster/version_test.go
+++ b/pkg/operator/ceph/cluster/version_test.go
@@ -76,8 +76,9 @@ func TestDiffImageSpecAndClusterRunningVersion(t *testing.T) {
 	err = json.Unmarshal([]byte(fakeRunningVersions), &dummyRunningVersions3)
 	assert.NoError(t, err)
 
+	// Allow the downgrade
 	m, err = diffImageSpecAndClusterRunningVersion(fakeImageVersion, dummyRunningVersions3)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.True(t, m)
 
 	// 4 test - spec version is higher than running cluster --> we upgrade


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In the event a ceph image is specified that is lower than the current running version of the daemons, the downgrade is allowed, even if not technically supported. All of the core daemons (mon,mgr,osd) were being downgraded, but the daemons for other controllers (rgw,mds,rbdmirror) were not being downgraded, resulting in an inconsistent cluster. Now we log that the downgrade is not supported and all all of the daemons to be downgraded.

**Which issue is resolved by this Pull Request:**
Resolves #9097 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
