### PR TITLE
pool: Allow more data chunks in an ec pool

### DIFF
--- a/cluster/charts/rook-ceph/templates/resources.yaml
+++ b/cluster/charts/rook-ceph/templates/resources.yaml
@@ -60,13 +60,11 @@ spec:
                       description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                      maximum: 9
+                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                      maximum: 9
+                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                       minimum: 0
                       type: integer
                   required:
@@ -4842,13 +4840,11 @@ spec:
                             description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                            maximum: 9
+                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                            maximum: 9
+                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                             minimum: 0
                             type: integer
                         required:
@@ -5009,13 +5005,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -6051,13 +6045,11 @@ spec:
                               description: The algorithm for erasure coding
                               type: string
                             codingChunks:
-                              description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                              maximum: 9
+                              description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                               minimum: 0
                               type: integer
                             dataChunks:
-                              description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                              maximum: 9
+                              description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                               minimum: 0
                               type: integer
                           required:
@@ -6934,13 +6926,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -7968,13 +7958,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -8463,13 +8451,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -8628,13 +8614,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:

--- a/cluster/examples/kubernetes/ceph/crds.yaml
+++ b/cluster/examples/kubernetes/ceph/crds.yaml
@@ -63,13 +63,11 @@ spec:
                       description: The algorithm for erasure coding
                       type: string
                     codingChunks:
-                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                      maximum: 9
+                      description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                       minimum: 0
                       type: integer
                     dataChunks:
-                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                      maximum: 9
+                      description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                       minimum: 0
                       type: integer
                   required:
@@ -4839,13 +4837,11 @@ spec:
                             description: The algorithm for erasure coding
                             type: string
                           codingChunks:
-                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                            maximum: 9
+                            description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                             minimum: 0
                             type: integer
                           dataChunks:
-                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                            maximum: 9
+                            description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                             minimum: 0
                             type: integer
                         required:
@@ -5006,13 +5002,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -6047,13 +6041,11 @@ spec:
                               description: The algorithm for erasure coding
                               type: string
                             codingChunks:
-                              description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                              maximum: 9
+                              description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                               minimum: 0
                               type: integer
                             dataChunks:
-                              description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                              maximum: 9
+                              description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                               minimum: 0
                               type: integer
                           required:
@@ -6928,13 +6920,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -7962,13 +7952,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -8454,13 +8442,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:
@@ -8619,13 +8605,11 @@ spec:
                           description: The algorithm for erasure coding
                           type: string
                         codingChunks:
-                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type). This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
                           minimum: 0
                           type: integer
                         dataChunks:
-                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
-                          maximum: 9
+                          description: Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type). The number of chunks required to recover an object when any single OSD is lost is the same as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
                           minimum: 0
                           type: integer
                       required:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -916,14 +916,15 @@ type QuotaSpec struct {
 
 // ErasureCodedSpec represents the spec for erasure code in a pool
 type ErasureCodedSpec struct {
-	// Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
+	// Number of coding chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
+	// This is the number of OSDs that can be lost simultaneously before data cannot be recovered.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=9
 	CodingChunks uint `json:"codingChunks"`
 
-	// Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type)
+	// Number of data chunks per object in an erasure coded storage pool (required for erasure-coded pool type).
+	// The number of chunks required to recover an object when any single OSD is lost is the same
+	// as dataChunks so be aware that the larger the number of data chunks, the higher the cost of recovery.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=9
 	DataChunks uint `json:"dataChunks"`
 
 	// The algorithm for erasure coding


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The schema has a limit of nine data and nine coding chunks in an EC pool. More data chunks may be desired, even if not typically recommended due to the higher recovery cost. To allow for the higher chunks sizes if desired, we increase the limit.

**Which issue is resolved by this Pull Request:**
Resolves #9106

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
