### PR TITLE
build: backport gen_release_notes.sh script

### DIFF
--- a/tests/scripts/gen_release_notes.sh
+++ b/tests/scripts/gen_release_notes.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+
+function help() {
+  print="
+  To run this command,
+  1. verify you are selecting right branch from GitHub UI dropdown menu
+  2. enter the tag you want to create
+  "
+  echo "$print"
+  exit 1
+}
+
+if [ -z "${GITHUB_USER}" ] || [ -z "${GITHUB_TOKEN}" ]; then
+  echo "requires both GITHUB_USER and GITHUB_TOKEN to be set as env variable"
+  help
+fi
+
+pr_list=$(git log --pretty="%s" --merges --left-only "${FROM_BRANCH}"..."${TO_TAG}" | grep pull | awk '/Merge pull request/ {print $4}' | cut -c 2-)
+
+# for releases notes
+function release_notes() {
+  for pr in $pr_list; do
+  # get PR title
+  backport_pr=$(curl -s -u "${GITHUB_USER}":"${GITHUB_TOKEN}" "https://api.github.com/repos/rook/rook/pulls/${pr}" | jq '.title')
+  # with upstream/release-1.6 v1.6.8, it was giving extra PR numbers, so removing after PR for changing tag is merged.
+  if [[ "$backport_pr" =~ ./*"build: Update build version to $TO_TAG"* ]]; then
+    break
+  fi
+  # check if it is manual backport PR or not, for mergify backport PR it will contain "(backport"
+  if [[ "$backport_pr" =~ .*"(backport".* ]]; then
+    # find the PR number after the #
+    original_pr=$(echo "$backport_pr" | sed -n -e 's/^.*#//p' | grep -E0o '[0-9]' | tr -d '\n')
+  else
+    # in manual backport PR, we'll directly fetch the owner and title from the PR number
+    original_pr=$pr
+  fi
+  # get the PR title and PR owner in required format
+  title_with_user=$(curl -s -u "${GITHUB_USER}":"${GITHUB_TOKEN}" "https://api.github.com/repos/rook/rook/pulls/${original_pr}" |  jq '.title+ " (#, @"+.user.login+")"')
+  # add PR number after "#"
+  result=$(echo "$title_with_user" | sed "s/(#/(#$original_pr/" |tail -c +2)
+  # remove last `"`
+  result=${result%\"}
+  echo "$result"
+  done
+}
+
+release_notes


### PR DESCRIPTION
Backport the tests/scripts/gen_release_notes.sh script to release-1.7
that is needed by the create-tag workflow.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
