### PR TITLE
Revert "ci: trigger push build action after tag creation"

### DIFF
--- a/.github/workflows/push-build.yaml
+++ b/.github/workflows/push-build.yaml
@@ -4,9 +4,8 @@ on:
     branches:
       - master
       - release-*
-  workflow_run:
-    workflows: ["Tag"]
-    types: [completed]
+    tags:
+      - v*
 
 defaults:
   run:
@@ -16,12 +15,7 @@ defaults:
 jobs:
   push-image-to-container-registry:
     runs-on: ubuntu-18.04
-    # github.repository == 'rook/rook': for running the test only in 'rook/rook' repo
-    # github.event_name == 'push': This is for any push to master or release branches
-    # github.event.workflow_run.conclusion == 'success': For the tagged workflow completion
-    if: |
-      github.repository == 'rook/rook' &&
-      (github.event_name == 'push' || github.event.workflow_run.conclusion == 'success')
+    if: github.repository == 'rook/rook'
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This reverts commit c53304c3b4f762488d8129cecc65282eaa612acc.

After experimenting with this release, we have found that the
`workflow_run` action source doesn't work for branches. The
documentation was updated with this PR and has more detail.
https://github.com/github/docs/pull/531

For now, we will revert back to using on.push.tags = ["v*"]

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
