### PR TITLE
core: add `AllowHostDirVolumePlugin: true` to SCC and remove unused imports

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	_ "embed"
 	"fmt"
 
 	secv1 "github.com/openshift/api/security/v1"

--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -38,6 +38,7 @@ func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContex
 			Namespace: namespace,
 		},
 		AllowPrivilegedContainer: true,
+		AllowHostDirVolumePlugin: true,
 		ReadOnlyRootFilesystem:   false,
 		AllowHostIPC:             true,
 		AllowHostNetwork:         false,


### PR DESCRIPTION
Signed-off-by: Santosh Pillai <sapillai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- Adds `AllowHostDirVolumePlugin` to the `go` representation of the rook-ceph SCC for using the hostPath. Also making it consistent with the yaml representation. 
- Removes unused import.

From Openshift [Docs](https://docs.openshift.com/container-platform/4.9/authentication/managing-security-context-constraints.html):
``` 
For backwards compatibility, the usage of allowHostDirVolumePlugin overrides settings in the volumes field. For example, if allowHostDirVolumePlugin is set to false but allowed in the volumes field, then the hostPath value will be removed from volumes.
```

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
