### PR TITLE
core: add s5cmd binary to operator image

### DIFF
--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -225,12 +225,17 @@ export AWS_SECRET_ACCESS_KEY=7yGIZON7EhFORz0I40BFniML36D2rl8CQQ5kXU6l
 The access key and secret key can be retrieved as described in the section above on [client connections](#client-connections) or
 below in the section [creating a user](#create-a-user) if you are not creating the buckets with an `ObjectBucketClaim`.
 
-### Install s3cmd
+### Configure s5cmd
 
-To test the `CephObjectStore` we will install the `s3cmd` tool into the toolbox pod.
+To test the `CephObjectStore`, set the object store credentials in the toolbox pod for the `s5cmd` tool.
 
 ```console
-yum --assumeyes install s3cmd
+mkdir ~/.aws
+cat > ~/.aws/credentials << EOF
+[default]
+aws_access_key_id = ${AWS_ACCESS_KEY_ID}
+aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
+EOF
 ```
 
 ### PUT or GET an object
@@ -239,13 +244,13 @@ Upload a file to the newly created bucket
 
 ```console
 echo "Hello Rook" > /tmp/rookObj
-s3cmd put /tmp/rookObj --no-ssl --host=${AWS_HOST} --host-bucket=  s3://rookbucket
+s5cmd --endpoint-url http://$AWS_ENDPOINT cp /tmp/rookObj s3://rookbucket
 ```
 
 Download and verify the file from the bucket
 
 ```console
-s3cmd get s3://rookbucket/rookObj /tmp/rookObj-download --no-ssl --host=${AWS_HOST} --host-bucket=
+s5cmd --endpoint-url http://$AWS_ENDPOINT cp s3://rookbucket/rookObj /tmp/rookObj-download
 cat /tmp/rookObj-download
 ```
 

--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -22,3 +22,4 @@ v1.8...
 - Add support for [Kubernetes Authentication when using HashiCorp Vault Key Management Service](Documentation/ceph-kms.md##kubernetes-based-authentication).
 - Bucket notification supported via CRDs
 - The Rook Operator and the toolbox now run under the "rook" user and does not use "root" anymore.
+- The Operator image now includes the `s5cmd` binary to interact with S3 gateways.

--- a/images/ceph/Dockerfile
+++ b/images/ceph/Dockerfile
@@ -15,7 +15,17 @@
 # see Makefile for the BASEIMAGE definition
 FROM BASEIMAGE
 
-ARG ARCH
+# env vars for s5cmd
+ARG S5CMD_VERSION
+ARG S5CMD_ARCH
+
+# Install the s5cmd package to interact with s3 gateway
+RUN curl --fail -sSL -o /s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz && \
+    mkdir /s5cmd && \
+    tar xf /s5cmd.tar.gz -C /s5cmd && \
+    install /s5cmd/s5cmd /usr/local/bin/s5cmd && \
+    rm -rf /s5cmd.tar.gz /s5cmd
+
 COPY rook toolbox.sh set-ceph-debug-level /usr/local/bin/
 COPY ceph-monitoring /etc/ceph-monitoring
 COPY rook-external /etc/rook-external/

--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -39,10 +39,12 @@ TEMP := $(shell mktemp -d)
 ifeq ($(REAL_HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
+S5CMD_ARCH = Linux-64bit
 endif
 ifeq ($(REAL_HOST_PLATFORM),linux_arm64)
 OPERATOR_SDK_PLATFORM = aarch64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
+S5CMD_ARCH = Linux-arm64
 endif
 ifeq ($(REAL_HOST_PLATFORM),darwin_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-apple-darwin
@@ -53,6 +55,9 @@ $(info )
 $(info NOT INCLUDING OLM/CSV TEMPLATES!)
 $(info )
 endif
+
+# s5cmd's version
+S5CMD_VERSION = 1.4.0
 
 VOL_REPL_VERSION = v0.1.0
 VOL_REPL_URL = https://raw.githubusercontent.com/csi-addons/volume-replication-operator/$(VOL_REPL_VERSION)/config/crd/bases
@@ -87,8 +92,8 @@ endif
 	@cd $(TEMP) && $(SED_IN_PLACE) 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 	@if [ -z "$(BUILD_CONTAINER_IMAGE)" ]; then\
 		$(DOCKERCMD) build $(BUILD_ARGS) \
-		--build-arg ARCH=$(GOARCH) \
-		--build-arg TINI_VERSION=$(TINI_VERSION) \
+		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
+		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
 		-t $(CEPH_IMAGE) \
 		$(TEMP);\
 	fi

--- a/images/cross/Makefile
+++ b/images/cross/Makefile
@@ -25,6 +25,8 @@ do.build:
 	@$(DOCKERCMD) build $(BUILD_ARGS) \
 		--build-arg ARCH=$(GOARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
+		--build-arg S5CMD_VERSION=$(S5CMD_VERSION) \
+		--build-arg S5CMD_ARCH=$(S5CMD_ARCH) \
 		-t $(IMAGE) \
 		$(TEMP)
 	@rm -fr $(TEMP)


### PR DESCRIPTION
**Description of your changes:**

The toolbox can now interact with S3 gateways using the `s5cmd` tool.
The binary is only 12M so this does not add up too much to the operator
image size.

Closes: https://github.com/rook/rook/issues/4968
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/4968

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
