### PR TITLE
build: Default to amd64 arch for the the s5cmd tool

### DIFF
--- a/images/ceph/Makefile
+++ b/images/ceph/Makefile
@@ -36,10 +36,10 @@ TEMP := $(shell mktemp -d)
 # Note: as of version 1.3 of operator-sdk, the url format changed to:
 # ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
 # (see: https://sdk.operatorframework.io/docs/installation/)
+S5CMD_ARCH = Linux-64bit
 ifeq ($(REAL_HOST_PLATFORM),linux_amd64)
 OPERATOR_SDK_PLATFORM = x86_64-linux-gnu
 INCLUDE_CSV_TEMPLATES = true
-S5CMD_ARCH = Linux-64bit
 endif
 ifeq ($(REAL_HOST_PLATFORM),linux_arm64)
 OPERATOR_SDK_PLATFORM = aarch64-linux-gnu


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
On mac, the docker build was failing due to an unspecified S5CMD_ARCH. Now we default to build amd64 always and override it if the arch is arm64. 

Though not sure why the official mac build was running and my local build hit this issue...

```
 === Generated CSV templates can be found at /var/folders/fw/dvkm8bzd60n8j0j40y55ngvw0000gn/T/tmp.Ux4igYyI/cluster/olm/ceph/templates
if [ -z "" ]; then\
		docker build -q \
		--build-arg S5CMD_VERSION=1.4.0 \
		--build-arg S5CMD_ARCH= \
		-t build-a63aad4e/ceph-amd64 \
		/var/folders/fw/dvkm8bzd60n8j0j40y55ngvw0000gn/T/tmp.Ux4igYyI;\
	fi
Sending build context to Docker daemon  50.67MB
Step 1/12 : FROM quay.io/ceph/ceph-amd64:v16.2.6-20210918
 ---> fd4c47aacbc9
Step 2/12 : ARG S5CMD_VERSION
 ---> Using cache
 ---> a35e2fd1136a
Step 3/12 : ARG S5CMD_ARCH
 ---> Using cache
 ---> 7b7d06d5c4c4
Step 4/12 : RUN curl --fail -sSL -o /tmp/s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz &&     mkdir /tmp/s5cmd &&     tar xf /tmp/s5cmd.tar.gz -C /tmp/s5cmd &&     install /tmp/s5cmd/s5cmd /usr/local/bin/s5cmd &&     rm -rf /tmp/s5cmd.tar.gz /tmp/s5cmd
 ---> Running in 378853b6e3c8
curl: (22) The requested URL returned error: 404 
The command '/bin/sh -c curl --fail -sSL -o /tmp/s5cmd.tar.gz https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_${S5CMD_ARCH}.tar.gz &&     mkdir /tmp/s5cmd &&     tar xf /tmp/s5cmd.tar.gz -C /tmp/s5cmd &&     install /tmp/s5cmd/s5cmd /usr/local/bin/s5cmd &&     rm -rf /tmp/s5cmd.tar.gz /tmp/s5cmd' returned a non-zero code: 22
make[2]: *** [do.build] Error 22
make[1]: *** [ceph.linux_amd64] Error 2
make: *** [build] Error 2
```

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
