### PR TITLE
ceph: bucket notifications refactoring work

### DIFF
--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"syscall"
 
@@ -374,9 +375,8 @@ func WatchControllerPredicate() predicate.Funcs {
 					logger.Debugf("object %q matched on update but %q label is set, doing nothing", objNew.Name, DoNotReconcileLabelName)
 					return false
 				}
-				diff := cmp.Diff(objOld.Labels, objNew.Labels, resourceQtyComparer)
-				if diff != "" {
-					logger.Infof("CR labels has changed for %q. diff=%s", objNew.Name, diff)
+				if !reflect.DeepEqual(objOld.Labels, objNew.Labels) {
+					logger.Infof("CR labels has changed for %q", objNew.Name)
 					return true
 				} else if objOld.Spec.ObjectBucketName != objNew.Spec.ObjectBucketName {
 					logger.Infof("CR %q bucket name changed from %q to %q", objNew.Name, objOld.Spec.ObjectBucketName, objNew.Spec.ObjectBucketName)

--- a/pkg/operator/ceph/object/bucket/provisioner.go
+++ b/pkg/operator/ceph/object/bucket/provisioner.go
@@ -428,7 +428,7 @@ func (p *Provisioner) composeObjectBucket() *bktv1alpha1.ObjectBucket {
 			},
 		},
 		AdditionalState: map[string]string{
-			cephUser: p.cephUserName,
+			CephUser: p.cephUserName,
 		},
 	}
 
@@ -685,7 +685,7 @@ func (p Provisioner) updateAdditionalSettings(ob *bktv1alpha1.ObjectBucket) erro
 			return errors.Wrapf(err, "failed to parse maxSize quota for user %q", p.cephUserName)
 		}
 	}
-	objectUser, err := p.adminOpsClient.GetUser(p.clusterInfo.Context, admin.User{ID: ob.Spec.Connection.AdditionalState[cephUser]})
+	objectUser, err := p.adminOpsClient.GetUser(p.clusterInfo.Context, admin.User{ID: ob.Spec.Connection.AdditionalState[CephUser]})
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch user %q", p.cephUserName)
 	}

--- a/pkg/operator/ceph/object/bucket/util.go
+++ b/pkg/operator/ceph/object/bucket/util.go
@@ -35,7 +35,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", "op-bucket-prov")
 
 const (
 	genUserLen           = 8
-	cephUser             = "cephUser"
+	CephUser             = "cephUser"
 	objectStoreName      = "objectStoreName"
 	objectStoreNamespace = "objectStoreNamespace"
 	objectStoreEndpoint  = "endpoint"
@@ -72,7 +72,7 @@ func isStaticBucket(sc *storagev1.StorageClass) (string, bool) {
 }
 
 func getCephUser(ob *bktv1alpha1.ObjectBucket) string {
-	return ob.Spec.AdditionalState[cephUser]
+	return ob.Spec.AdditionalState[CephUser]
 }
 
 func (p *Provisioner) getObjectStore() (*cephv1.CephObjectStore, error) {

--- a/pkg/operator/ceph/object/notification/controller_test.go
+++ b/pkg/operator/ceph/object/notification/controller_test.go
@@ -1,0 +1,515 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package notification to manage a rook bucket notifications.
+package notification
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/operator/test"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	testTopicName        = "topic-a"
+	testNotificationName = "notification-a"
+	testNamespace        = "rook-ceph"
+	testStoreName        = "test-store"
+	testARN              = "arn:aws:sns:" + testStoreName + "::" + testTopicName
+	testBucketName       = "my-bucket"
+	testSCName           = "my-storage-class"
+)
+
+var createWasInvoked bool
+
+func mockCleanup() {
+	createWasInvoked = false
+	createNotificationFunc = createNotification
+	deleteAllNotificationsFunc = deleteAllNotifications
+}
+
+func mockSetup() {
+	createWasInvoked = false
+	createNotificationFunc = func(p provisioner, bucket *bktv1alpha1.ObjectBucket, topicARN string, notification *cephv1.CephBucketNotification) error {
+		createWasInvoked = true
+		return nil
+	}
+	deleteAllNotificationsFunc = func(p provisioner, bucket *bktv1alpha1.ObjectBucket) error {
+		return nil
+	}
+}
+
+func TestCephBucketNotificationController(t *testing.T) {
+	mockSetup()
+	defer mockCleanup()
+	ctx := context.TODO()
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	bucketTopic := &cephv1.CephBucketTopic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTopicName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketTopic",
+		},
+		Spec: cephv1.BucketTopicSpec{
+			ObjectStoreName:      testStoreName,
+			ObjectStoreNamespace: testNamespace,
+			Endpoint: cephv1.TopicEndpointSpec{
+				HTTP: &cephv1.HTTPEndpointSpec{
+					URI: "http://localhost",
+				},
+			},
+		},
+		Status: &cephv1.BucketTopicStatus{ARN: nil},
+	}
+	bucketNotification := &cephv1.CephBucketNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNotificationName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketNotification",
+		},
+		Spec: cephv1.BucketNotificationSpec{
+			Topic: testTopicName,
+		},
+	}
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNamespace,
+			Namespace: testNamespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: k8sutil.EmptyStatus,
+			CephStatus: &cephv1.CephStatus{
+				Health: "",
+			},
+		},
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testNotificationName,
+			Namespace: testNamespace,
+		},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(
+		cephv1.SchemeGroupVersion,
+		&cephv1.CephBucketNotification{},
+		&cephv1.CephBucketNotificationList{},
+		&cephv1.CephBucketTopic{},
+		&cephv1.CephBucketTopicList{},
+		&cephv1.CephCluster{},
+		&cephv1.CephClusterList{},
+		&bktv1alpha1.ObjectBucketClaim{},
+		&bktv1alpha1.ObjectBucketClaimList{},
+	)
+
+	c := &clusterd.Context{
+		Executor:      &exectest.MockExecutor{},
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     test.New(t, 3),
+	}
+
+	secrets := map[string][]byte{
+		"fsid":         []byte("name"),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: testNamespace,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+
+	_, err := c.Clientset.CoreV1().Secrets(testNamespace).Create(ctx, secret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	t.Run("create notification configuration without a topic", func(t *testing.T) {
+		// Objects to track in the fake client.
+		objects := []runtime.Object{
+			bucketNotification,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		// provisioning requeued because the topic is not configured
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("create notification and topic configuration when there is no cluster", func(t *testing.T) {
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		// provisioning requeued because the cluster does not exist
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("create notification and topic configuration cluster is not ready", func(t *testing.T) {
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+			cephCluster,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		// provisioning requeued because the cluster is not ready
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("create notification and topic configuration when topic is not yet provisioned", func(t *testing.T) {
+		cephCluster.Status.Phase = k8sutil.ReadyStatus
+		cephCluster.Status.CephStatus.Health = "HEALTH_OK"
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+			cephCluster,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		// provisioning requeued because the topic is not provisioned on the RGW
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("create notification and topic configuration", func(t *testing.T) {
+		cephCluster.Status.Phase = k8sutil.ReadyStatus
+		cephCluster.Status.CephStatus.Health = "HEALTH_OK"
+		bucketTopic.Status.ARN = &testARN
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+			cephCluster,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+}
+
+func TestCephBucketNotificationControllerWithOBC(t *testing.T) {
+	mockSetup()
+	defer mockCleanup()
+	ctx := context.TODO()
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	bucketTopic := &cephv1.CephBucketTopic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTopicName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketTopic",
+		},
+		Spec: cephv1.BucketTopicSpec{
+			ObjectStoreName:      testStoreName,
+			ObjectStoreNamespace: testNamespace,
+			Endpoint: cephv1.TopicEndpointSpec{
+				HTTP: &cephv1.HTTPEndpointSpec{
+					URI: "http://localhost",
+				},
+			},
+		},
+		Status: &cephv1.BucketTopicStatus{ARN: &testARN},
+	}
+	bucketNotification := &cephv1.CephBucketNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNotificationName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketNotification",
+		},
+		Spec: cephv1.BucketNotificationSpec{
+			Topic: testTopicName,
+		},
+	}
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNamespace,
+			Namespace: testNamespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: k8sutil.ReadyStatus,
+			CephStatus: &cephv1.CephStatus{
+				Health: "HEALTH_OK",
+			},
+		},
+	}
+	obc := &bktv1alpha1.ObjectBucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBucketName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				notificationLabelPrefix + testNotificationName: testNotificationName,
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectBucketClaim",
+		},
+		Spec: bktv1alpha1.ObjectBucketClaimSpec{
+			StorageClassName:   testSCName,
+			GenerateBucketName: testBucketName,
+		},
+		Status: bktv1alpha1.ObjectBucketClaimStatus{
+			Phase: bktv1alpha1.ObjectBucketClaimStatusPhasePending,
+		},
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testNotificationName,
+			Namespace: testNamespace,
+		},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(
+		cephv1.SchemeGroupVersion,
+		&cephv1.CephBucketNotification{},
+		&cephv1.CephBucketNotificationList{},
+		&cephv1.CephBucketTopic{},
+		&cephv1.CephBucketTopicList{},
+		&cephv1.CephCluster{},
+		&cephv1.CephClusterList{},
+		&bktv1alpha1.ObjectBucketClaim{},
+		&bktv1alpha1.ObjectBucketClaimList{},
+		&bktv1alpha1.ObjectBucket{},
+		&bktv1alpha1.ObjectBucketList{},
+	)
+
+	c := &clusterd.Context{
+		Executor:      &exectest.MockExecutor{},
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     test.New(t, 3),
+	}
+
+	secrets := map[string][]byte{
+		"fsid":         []byte("name"),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: testNamespace,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+
+	_, err := c.Clientset.CoreV1().Secrets(testNamespace).Create(ctx, secret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	t.Run("provision notification when OBC exists but no OB", func(t *testing.T) {
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+			cephCluster,
+			obc,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("provision notification when OB exists", func(t *testing.T) {
+		ob := &bktv1alpha1.ObjectBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testBucketName,
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "ObjectBucket",
+			},
+			Spec: bktv1alpha1.ObjectBucketSpec{
+				StorageClassName: testSCName,
+				Connection: &bktv1alpha1.Connection{
+					Endpoint: &bktv1alpha1.Endpoint{
+						BucketHost: object.BuildDomainName(testStoreName, testNamespace),
+					},
+				},
+			},
+			Status: bktv1alpha1.ObjectBucketStatus{
+				Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
+			},
+		}
+		obc.Spec.ObjectBucketName = testBucketName
+		obc.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		objects := []runtime.Object{
+			bucketNotification,
+			bucketTopic,
+			cephCluster,
+			obc,
+			ob,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileNotifications{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		// notification configuration is set
+		err = r.client.Get(ctx, types.NamespacedName{Name: testNotificationName, Namespace: testNamespace}, bucketNotification)
+		assert.NoError(t, err, bucketNotification)
+		assert.True(t, createWasInvoked)
+	})
+}
+
+func TestGetCephObjectStoreName(t *testing.T) {
+	ob := bktv1alpha1.ObjectBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBucketName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectBucket",
+		},
+		Spec: bktv1alpha1.ObjectBucketSpec{
+			StorageClassName: testSCName,
+			Connection: &bktv1alpha1.Connection{
+				Endpoint: &bktv1alpha1.Endpoint{
+					BucketHost: "",
+				},
+			},
+		},
+		Status: bktv1alpha1.ObjectBucketStatus{
+			Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
+		},
+	}
+
+	t.Run("empty bucket host", func(t *testing.T) {
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.Error(t, err)
+		assert.Empty(t, objectStore.Name)
+	})
+	t.Run("malformed suffix", func(t *testing.T) {
+		ob.Spec.Connection.Endpoint.BucketHost = "rook-ceph-rgw-" + testStoreName + ".."
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.Error(t, err)
+		assert.Empty(t, objectStore.Name)
+	})
+	t.Run("malformed prefix", func(t *testing.T) {
+		ob.Spec.Connection.Endpoint.BucketHost = "rook-rgw-" + testStoreName + "." + testNamespace + ".svc"
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.Error(t, err)
+		assert.Empty(t, objectStore.Name)
+	})
+	t.Run("empty store name", func(t *testing.T) {
+		ob.Spec.Connection.Endpoint.BucketHost = "rook-ceph-rgw-" + "." + testNamespace + ".svc"
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.Error(t, err)
+		assert.Empty(t, objectStore.Name)
+	})
+	t.Run("store name contains rgw", func(t *testing.T) {
+		testStoreNameWithRGW := "my-rgw-store"
+		ob.Spec.Connection.Endpoint.BucketHost = "rook-ceph-rgw-" + testStoreNameWithRGW + "." + testNamespace + ".svc"
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.NoError(t, err)
+		assert.Equal(t, testStoreNameWithRGW, objectStore.Name)
+		assert.Equal(t, testNamespace, objectStore.Namespace)
+	})
+	t.Run("valid store name", func(t *testing.T) {
+		ob.Spec.Connection.Endpoint.BucketHost = "rook-ceph-rgw-" + testStoreName + "." + testNamespace + ".svc"
+		objectStore, err := getCephObjectStoreName(ob)
+		assert.NoError(t, err)
+		assert.Equal(t, testStoreName, objectStore.Name)
+		assert.Equal(t, testNamespace, objectStore.Namespace)
+	})
+}

--- a/pkg/operator/ceph/object/notification/obc_label_controller_test.go
+++ b/pkg/operator/ceph/object/notification/obc_label_controller_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package notification to manage a rook bucket notifications.
+package notification
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/coreos/pkg/capnslog"
+	bktv1alpha1 "github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/operator/test"
+
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestCephBucketNotificationOBCLabelController(t *testing.T) {
+	mockSetup()
+	defer mockCleanup()
+	ctx := context.TODO()
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	bucketTopic := &cephv1.CephBucketTopic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTopicName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketTopic",
+		},
+		Spec: cephv1.BucketTopicSpec{
+			ObjectStoreName:      testStoreName,
+			ObjectStoreNamespace: testNamespace,
+			Endpoint: cephv1.TopicEndpointSpec{
+				HTTP: &cephv1.HTTPEndpointSpec{
+					URI: "http://localhost",
+				},
+			},
+		},
+		Status: &cephv1.BucketTopicStatus{ARN: &testARN},
+	}
+	bucketNotification := &cephv1.CephBucketNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNotificationName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketNotification",
+		},
+		Spec: cephv1.BucketNotificationSpec{
+			Topic: testTopicName,
+		},
+	}
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNamespace,
+			Namespace: testNamespace,
+		},
+		Status: cephv1.ClusterStatus{
+			Phase: k8sutil.ReadyStatus,
+			CephStatus: &cephv1.CephStatus{
+				Health: "HEALTH_OK",
+			},
+		},
+	}
+	obc := &bktv1alpha1.ObjectBucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBucketName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				notificationLabelPrefix + testNotificationName: testNotificationName,
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectBucketClaim",
+		},
+		Spec: bktv1alpha1.ObjectBucketClaimSpec{
+			StorageClassName:   testSCName,
+			GenerateBucketName: testBucketName,
+		},
+		Status: bktv1alpha1.ObjectBucketClaimStatus{
+			Phase: bktv1alpha1.ObjectBucketClaimStatusPhasePending,
+		},
+	}
+	ob := &bktv1alpha1.ObjectBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testBucketName,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ObjectBucket",
+		},
+		Spec: bktv1alpha1.ObjectBucketSpec{
+			StorageClassName: testSCName,
+			Connection: &bktv1alpha1.Connection{
+				Endpoint: &bktv1alpha1.Endpoint{
+					BucketHost: object.BuildDomainName(testStoreName, testNamespace),
+				},
+			},
+		},
+		Status: bktv1alpha1.ObjectBucketStatus{
+			Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
+		},
+	}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      testBucketName,
+			Namespace: testNamespace,
+		},
+	}
+
+	s := scheme.Scheme
+	s.AddKnownTypes(
+		cephv1.SchemeGroupVersion,
+		&cephv1.CephBucketNotification{},
+		&cephv1.CephBucketNotificationList{},
+		&cephv1.CephBucketTopic{},
+		&cephv1.CephBucketTopicList{},
+		&cephv1.CephCluster{},
+		&cephv1.CephClusterList{},
+		&bktv1alpha1.ObjectBucketClaim{},
+		&bktv1alpha1.ObjectBucketClaimList{},
+		&bktv1alpha1.ObjectBucket{},
+		&bktv1alpha1.ObjectBucketList{},
+	)
+
+	c := &clusterd.Context{
+		Executor:      &exectest.MockExecutor{},
+		RookClientset: rookclient.NewSimpleClientset(),
+		Clientset:     test.New(t, 3),
+	}
+
+	secrets := map[string][]byte{
+		"fsid":         []byte("name"),
+		"mon-secret":   []byte("monsecret"),
+		"admin-secret": []byte("adminsecret"),
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rook-ceph-mon",
+			Namespace: testNamespace,
+		},
+		Data: secrets,
+		Type: k8sutil.RookType,
+	}
+
+	_, err := c.Clientset.CoreV1().Secrets(testNamespace).Create(ctx, secret, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	t.Run("provision OBC with notification label with no ob", func(t *testing.T) {
+		objects := []runtime.Object{
+			cephCluster,
+			obc,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("provision OBC with notification label with not ready ob", func(t *testing.T) {
+		objects := []runtime.Object{
+			cephCluster,
+			obc,
+			ob,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.False(t, createWasInvoked)
+	})
+
+	obc.Spec.ObjectBucketName = testBucketName
+	obc.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+
+	t.Run("provision OBC with notification label with no notification", func(t *testing.T) {
+		objects := []runtime.Object{
+			cephCluster,
+			obc,
+			ob,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("provision OBC with notification label and notification with no topic", func(t *testing.T) {
+		objects := []runtime.Object{
+			cephCluster,
+			obc,
+			ob,
+			bucketNotification,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+		assert.False(t, createWasInvoked)
+	})
+
+	t.Run("provision OBC with notification label", func(t *testing.T) {
+		objects := []runtime.Object{
+			cephCluster,
+			obc,
+			ob,
+			bucketNotification,
+			bucketTopic,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, createWasInvoked)
+	})
+}

--- a/pkg/operator/ceph/object/notification/s3ext.go
+++ b/pkg/operator/ceph/object/notification/s3ext.go
@@ -66,7 +66,7 @@ func (s *DeleteBucketNotificationRequestInput) Validate() error {
 
 const opDeleteBucketNotification = "DeleteBucketNotification"
 
-func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRequestInput) (req *request.Request) {
+func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRequestInput) *request.Request {
 	op := &request.Operation{
 		Name:       opDeleteBucketNotification,
 		HTTPMethod: http.MethodDelete,
@@ -77,8 +77,7 @@ func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRe
 		input = &DeleteBucketNotificationRequestInput{}
 	}
 
-	req = c.NewRequest(op, input, nil)
-	return
+	return c.NewRequest(op, input, nil)
 }
 
 func DeleteBucketNotification(c *s3.S3, input *DeleteBucketNotificationRequestInput) error {

--- a/pkg/operator/ceph/object/topic/controller.go
+++ b/pkg/operator/ceph/object/topic/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package topic to manage a rook bucket notification topic.
+// Package topic to manage a rook bucket topics.
 package topic
 
 import (
@@ -190,26 +190,30 @@ func (r *ReconcileBucketTopic) reconcile(request reconcile.Request) (reconcile.R
 }
 
 func (r *ReconcileBucketTopic) createCephBucketTopic(topic *cephv1.CephBucketTopic) (topicARN *string, err error) {
-	provisioner := Provisioner{
-		Client:           r.client,
-		Context:          r.context,
-		ClusterInfo:      r.clusterInfo,
-		ClusterSpec:      r.clusterSpec,
-		opManagerContext: r.opManagerContext,
-	}
-	topicARN, err = provisioner.Create(topic)
+	topicARN, err = createTopicFunc(
+		provisioner{
+			client:           r.client,
+			context:          r.context,
+			clusterInfo:      r.clusterInfo,
+			clusterSpec:      r.clusterSpec,
+			opManagerContext: r.opManagerContext,
+		},
+		topic,
+	)
 	return
 }
 
 func (r *ReconcileBucketTopic) deleteCephBucketTopic(topic *cephv1.CephBucketTopic) error {
-	provisioner := Provisioner{
-		Client:           r.client,
-		Context:          r.context,
-		ClusterInfo:      r.clusterInfo,
-		ClusterSpec:      r.clusterSpec,
-		opManagerContext: r.opManagerContext,
-	}
-	return provisioner.Delete(topic)
+	return deleteTopicFunc(
+		provisioner{
+			client:           r.client,
+			context:          r.context,
+			clusterInfo:      r.clusterInfo,
+			clusterSpec:      r.clusterSpec,
+			opManagerContext: r.opManagerContext,
+		},
+		topic,
+	)
 }
 
 func (r *ReconcileBucketTopic) setFailedStatus(name types.NamespacedName, errMessage string, err error) (reconcile.Result, error) {

--- a/pkg/operator/ceph/object/topic/controller_test.go
+++ b/pkg/operator/ceph/object/topic/controller_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2021 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topic to manage a rook bucket topics.
+package topic
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/coreos/pkg/capnslog"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/operator/test"
+
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	exectest "github.com/rook/rook/pkg/util/exec/test"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	name           = "topic-a"
+	namespace      = "rook-ceph"
+	store          = "test-store"
+	userCreateJSON = `{
+		"user_id": "rgw-admin-ops-user",
+		"display_name": "RGW Admin Ops User",
+		"email": "",
+		"suspended": 0,
+		"max_buckets": 0,
+		"subusers": [],
+		"keys": [
+			{
+				"user": "rgw-admin-ops-user",
+				"access_key": "EOE7FYCNOBZJ5VFV909G",
+				"secret_key": "qmIqpWm8HxCzmynCrD6U6vKWi4hnDBndOnmxXNsV"
+			}
+		]
+	}`
+)
+
+func TestCephBucketTopicController(t *testing.T) {
+	ctx := context.TODO()
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	os.Setenv("ROOK_LOG_LEVEL", "DEBUG")
+
+	bucketTopic := &cephv1.CephBucketTopic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketTopic",
+		},
+		Spec: cephv1.BucketTopicSpec{
+			ObjectStoreName:      store,
+			ObjectStoreNamespace: namespace,
+			Endpoint: cephv1.TopicEndpointSpec{
+				HTTP: &cephv1.HTTPEndpointSpec{
+					URI: "http://localhost",
+				},
+			},
+		},
+	}
+	clusterInfo := cephclient.AdminClusterInfo(namespace, "rook")
+	clusterSpec := cephv1.ClusterSpec{}
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	t.Run("do nothing since there is no CephCluster", func(t *testing.T) {
+		// Objects to track in the fake client.
+		objects := []runtime.Object{
+			bucketTopic,
+		}
+
+		c := &clusterd.Context{
+			Executor:      &exectest.MockExecutor{},
+			RookClientset: rookclient.NewSimpleClientset(),
+			Clientset:     test.New(t, 3),
+		}
+
+		s := scheme.Scheme
+		s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephBucketTopic{}, &cephv1.CephBucketTopicList{})
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileBucketTopic{client: cl, context: c, clusterInfo: clusterInfo, clusterSpec: &clusterSpec, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+	})
+
+	t.Run("CephCluster is not ready", func(t *testing.T) {
+		// Objects to track in the fake client.
+		objects := []runtime.Object{
+			bucketTopic,
+			&cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespace,
+					Namespace: namespace,
+				},
+				Status: cephv1.ClusterStatus{
+					Phase: "",
+					CephStatus: &cephv1.CephStatus{
+						Health: "",
+					},
+				},
+			},
+		}
+
+		c := &clusterd.Context{
+			Executor:      &exectest.MockExecutor{},
+			RookClientset: rookclient.NewSimpleClientset(),
+			Clientset:     test.New(t, 3),
+		}
+
+		s := scheme.Scheme
+		s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephBucketTopic{}, &cephv1.CephBucketTopicList{}, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileBucketTopic{client: cl, context: c, clusterInfo: clusterInfo, clusterSpec: &clusterSpec, opManagerContext: ctx}
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.True(t, res.Requeue)
+	})
+
+	t.Run("creating a topic", func(t *testing.T) {
+		// Objects to track in the fake client.
+		objects := []runtime.Object{
+			bucketTopic,
+			&cephv1.CephCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespace,
+					Namespace: namespace,
+				},
+				Status: cephv1.ClusterStatus{
+					Phase: k8sutil.ReadyStatus,
+					CephStatus: &cephv1.CephStatus{
+						Health: "HEALTH_OK",
+					},
+				},
+			},
+		}
+
+		executor := &exectest.MockExecutor{
+			MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
+				if args[0] == "user" && args[1] == "create" {
+					return userCreateJSON, nil
+				}
+				return "", nil
+			},
+		}
+
+		c := &clusterd.Context{
+			Executor:      executor,
+			RookClientset: rookclient.NewSimpleClientset(),
+			Clientset:     test.New(t, 3),
+		}
+
+		secrets := map[string][]byte{
+			"fsid":         []byte("name"),
+			"mon-secret":   []byte("monsecret"),
+			"admin-secret": []byte("adminsecret"),
+		}
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rook-ceph-mon",
+				Namespace: namespace,
+			},
+			Data: secrets,
+			Type: k8sutil.RookType,
+		}
+		_, err := c.Clientset.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		s := scheme.Scheme
+		s.AddKnownTypes(cephv1.SchemeGroupVersion, &cephv1.CephBucketTopic{}, &cephv1.CephBucketTopicList{}, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		cephObjectStore := &cephv1.CephObjectStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      store,
+				Namespace: namespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "CephObjectStore"},
+			Spec: cephv1.ObjectStoreSpec{
+				Gateway: cephv1.GatewaySpec{
+					Port: int32(80),
+				},
+			},
+		}
+
+		_, err = c.RookClientset.CephV1().CephObjectStores(namespace).Create(ctx, cephObjectStore, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		r := &ReconcileBucketTopic{client: cl, context: c, clusterInfo: clusterInfo, clusterSpec: &clusterSpec, opManagerContext: ctx}
+
+		err = r.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, bucketTopic)
+		assert.NoError(t, err, bucketTopic)
+
+		// mock the provisioner
+		expectedARN := "arn:aws:sns:" + store + "::" + bucketTopic.Name
+		createTopicFunc = func(p provisioner, topic *cephv1.CephBucketTopic) (*string, error) {
+			return &expectedARN, nil
+		}
+		defer func() { createTopicFunc = createTopic }()
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		err = r.client.Get(ctx, req.NamespacedName, bucketTopic)
+		assert.NoError(t, err)
+		assert.NotNil(t, bucketTopic.Status.ARN)
+		assert.Equal(t, *bucketTopic.Status.ARN, expectedARN)
+	})
+}


### PR DESCRIPTION
This PR is addressing followup work from: https://github.com/rook/rook/pull/8426

- [x] code reuse in the bucket notification controller and OBC label controller
- [x] use the regular S3 agent for notification provisioning (topic will still need the special SNS client)
- [x] move the OBC label predicate to `WatchPredicateForNonCRDObject`
- [x] go through all of the controllers' reconciliation error conditions and decide which should return error with nil `ReportReconcileResult` (immediate retry) and which should define a delayed retry by returning error with `ReportReconcileResult`
- [x] add unit tests for the notification controller
- [x] unit tests for the obc label controller
- [x] add unit tests for the topic controller

Following tasks will be broken off to their own PRs:
- add OBC list in notification status
- fetch the list of notifications from the RGW and do the diff with the labels instead of deleting all notifications on any label change
- More integration tests: https://github.com/rook/rook/pull/9169