### PR TITLE
rook-ceph-cluster chart: the ingress template needs to point to servi…

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -24,11 +24,11 @@ spec:
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
-                  name: http-dashboard
+                  name: https-dashboard
             pathType: Prefix
 {{- else }}
               serviceName: rook-ceph-mgr-dashboard
-              servicePort: http-dashboard
+              servicePort: https-dashboard
 {{- end }}
   {{- if .Values.ingress.dashboard.tls }}
   tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}


### PR DESCRIPTION
…ce httpS-dashboard

Signed-off-by: cyril.cros <cyril.cros@polytechnique.edu>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Points the ingress template to the right service port of `rook-ceph-mgr-dashboard`, `https-dashboard` vs `http-dashboard`

**Which issue is resolved by this Pull Request:**
Resolves #9152

**Checklist:**

- [X ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
