### PR TITLE
docs: Fix the links from docs to github examples in master branch

### DIFF
--- a/Documentation/branch.liquid
+++ b/Documentation/branch.liquid
@@ -1,6 +1,6 @@
 {% assign url = page.url | split: '/' %}
 {% assign currentVersion = url[3] %}
-{% if currentVersion != 'master' %}
+{% if currentVersion != 'latest' %}
 {% assign branchName = currentVersion | replace: 'v', '' | prepend: 'release-' %}
 {% else %}
 {% assign branchName = currentVersion %}


### PR DESCRIPTION

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the recent rename of master docs to the latest docs, the links from the docs back to github need to be generated with the latest url instead of master.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
