### PR TITLE
core: add context parameter to k8sutil deployment

### DIFF
--- a/pkg/daemon/ceph/osd/remove.go
+++ b/pkg/daemon/ceph/osd/remove.go
@@ -87,7 +87,7 @@ func removeOSD(clusterdContext *clusterd.Context, clusterInfo *client.ClusterInf
 		logger.Errorf("failed to fetch the deployment %q. %v", deploymentName, err)
 	} else {
 		logger.Infof("removing the OSD deployment %q", deploymentName)
-		if err := k8sutil.DeleteDeployment(clusterdContext.Clientset, clusterInfo.Namespace, deploymentName); err != nil {
+		if err := k8sutil.DeleteDeployment(clusterInfo.Context, clusterdContext.Clientset, clusterInfo.Namespace, deploymentName); err != nil {
 			if err != nil {
 				// Continue purging the OSD even if the deployment fails to be deleted
 				logger.Errorf("failed to delete deployment for OSD %d. %v", osdID, err)

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -170,7 +170,7 @@ func (c *Cluster) Start() error {
 	// If the mgr is newly created, wait for it to start before continuing with the service and
 	// module configuration
 	for _, d := range deploymentsToWaitFor {
-		if err := waitForDeploymentToStart(c.context, d); err != nil {
+		if err := waitForDeploymentToStart(c.clusterInfo.Context, c.context, d); err != nil {
 			return errors.Wrapf(err, "failed to wait for mgr %q to start", d.Name)
 		}
 	}

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -57,7 +57,7 @@ func TestStartMgr(t *testing.T) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}
-	waitForDeploymentToStart = func(clusterdContext *clusterd.Context, deployment *apps.Deployment) error {
+	waitForDeploymentToStart = func(ctx context.Context, clusterdContext *clusterd.Context, deployment *apps.Deployment) error {
 		logger.Infof("simulated mgr deployment starting")
 		return nil
 	}

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -673,7 +673,7 @@ func scheduleMonitor(c *Cluster, mon *monConfig) (*apps.Deployment, error) {
 			logger.Infof("created canary deployment %s", d.Name)
 			break
 		} else if kerrors.IsAlreadyExists(err) {
-			if err := k8sutil.DeleteDeployment(c.context.Clientset, c.Namespace, d.Name); err != nil {
+			if err := k8sutil.DeleteDeployment(c.ClusterInfo.Context, c.context.Clientset, c.Namespace, d.Name); err != nil {
 				return nil, errors.Wrapf(err, "failed to delete canary deployment %s", d.Name)
 			}
 			logger.Infof("deleted existing canary deployment %s", d.Name)
@@ -782,7 +782,7 @@ func (c *Cluster) initMonIPs(mons []*monConfig) error {
 // Delete mon canary deployments (and associated PVCs) using deployment labels
 // to select this kind of temporary deployments
 func (c *Cluster) removeCanaryDeployments() {
-	canaryDeployments, err := k8sutil.GetDeployments(c.context.Clientset, c.Namespace, "app=rook-ceph-mon,mon_canary=true")
+	canaryDeployments, err := k8sutil.GetDeployments(c.ClusterInfo.Context, c.context.Clientset, c.Namespace, "app=rook-ceph-mon,mon_canary=true")
 	if err != nil {
 		logger.Warningf("failed to get the list of monitor canary deployments. %v", err)
 		return

--- a/pkg/operator/ceph/cluster/mon/spec.go
+++ b/pkg/operator/ceph/cluster/mon/spec.go
@@ -380,6 +380,6 @@ func UpdateCephDeploymentAndWait(context *clusterd.Context, clusterInfo *client.
 		return nil
 	}
 
-	err := k8sutil.UpdateDeploymentAndWait(context, deployment, clusterInfo.Namespace, callback)
+	err := k8sutil.UpdateDeploymentAndWait(clusterInfo.Context, context, deployment, clusterInfo.Namespace, callback)
 	return err
 }

--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -383,7 +383,7 @@ func createDaemonOnPVC(c *Cluster, osd OSDInfo, pvcName string, config *provisio
 	message := fmt.Sprintf("Processing OSD %d on PVC %q", osd.ID, pvcName)
 	updateConditionFunc(c.clusterInfo.Context, c.context, c.clusterInfo.NamespacedName(), cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, message)
 
-	_, err = k8sutil.CreateDeployment(c.context.Clientset, d)
+	_, err = k8sutil.CreateDeployment(c.clusterInfo.Context, c.context.Clientset, d)
 	return errors.Wrapf(err, "failed to create deployment for OSD %d on PVC %q", osd.ID, pvcName)
 }
 
@@ -396,6 +396,6 @@ func createDaemonOnNode(c *Cluster, osd OSDInfo, nodeName string, config *provis
 	message := fmt.Sprintf("Processing OSD %d on node %q", osd.ID, nodeName)
 	updateConditionFunc(c.clusterInfo.Context, c.context, c.clusterInfo.NamespacedName(), cephv1.ConditionProgressing, v1.ConditionTrue, cephv1.ClusterProgressingReason, message)
 
-	_, err = k8sutil.CreateDeployment(c.context.Clientset, d)
+	_, err = k8sutil.CreateDeployment(c.clusterInfo.Context, c.context.Clientset, d)
 	return errors.Wrapf(err, "failed to create deployment for OSD %d on node %q", osd.ID, nodeName)
 }

--- a/pkg/operator/ceph/cluster/osd/health.go
+++ b/pkg/operator/ceph/cluster/osd/health.go
@@ -156,7 +156,7 @@ func (m *OSDHealthMonitor) checkOSDDump() error {
 
 func (m *OSDHealthMonitor) removeOSDDeploymentIfSafeToDestroy(outOSDid int) error {
 	label := fmt.Sprintf("ceph-osd-id=%d", outOSDid)
-	dp, err := k8sutil.GetDeployments(m.context.Clientset, m.clusterInfo.Namespace, label)
+	dp, err := k8sutil.GetDeployments(m.clusterInfo.Context, m.context.Clientset, m.clusterInfo.Namespace, label)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			return nil
@@ -175,7 +175,7 @@ func (m *OSDHealthMonitor) removeOSDDeploymentIfSafeToDestroy(outOSDid int) erro
 			currentTime := time.Now().UTC()
 			if podDeletionTimeStamp.Before(currentTime) {
 				logger.Infof("osd.%d is 'safe-to-destroy'. removing the osd deployment.", outOSDid)
-				if err := k8sutil.DeleteDeployment(m.context.Clientset, dp.Items[0].Namespace, dp.Items[0].Name); err != nil {
+				if err := k8sutil.DeleteDeployment(m.clusterInfo.Context, m.context.Clientset, dp.Items[0].Namespace, dp.Items[0].Name); err != nil {
 					return errors.Wrapf(err, "failed to delete osd deployment %s", dp.Items[0].Name)
 				}
 			}

--- a/pkg/operator/ceph/cluster/osd/update.go
+++ b/pkg/operator/ceph/cluster/osd/update.go
@@ -178,7 +178,7 @@ func (c *updateConfig) updateExistingOSDs(errs *provisionErrors) {
 	// when waiting on deployments to be updated, only list OSDs we intend to update specifically by ID
 	listFunc := c.cluster.getFuncToListDeploymentsWithIDs(listIDs)
 
-	failures := updateMultipleDeploymentsAndWaitFunc(c.cluster.context.Clientset, updatedDeployments, listFunc)
+	failures := updateMultipleDeploymentsAndWaitFunc(c.cluster.clusterInfo.Context, c.cluster.context.Clientset, updatedDeployments, listFunc)
 	for _, f := range failures {
 		errs.addError("%v", errors.Wrapf(f.Error, "failed to update OSD deployment %q", f.ResourceName))
 	}

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -132,6 +132,7 @@ func Test_updateExistingOSDs(t *testing.T) {
 
 	updateMultipleDeploymentsAndWaitFunc =
 		func(
+			ctx context.Context,
 			clientset kubernetes.Interface,
 			deployments []*appsv1.Deployment,
 			listFunc func() (*appsv1.DeploymentList, error),

--- a/pkg/operator/ceph/csi/controller.go
+++ b/pkg/operator/ceph/csi/controller.go
@@ -160,7 +160,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to get server version")
 	}
 
-	ownerRef, err := k8sutil.GetDeploymentOwnerReference(r.context.Clientset, os.Getenv(k8sutil.PodNameEnvVar), r.opConfig.OperatorNamespace)
+	ownerRef, err := k8sutil.GetDeploymentOwnerReference(r.opManagerContext, r.context.Clientset, os.Getenv(k8sutil.PodNameEnvVar), r.opConfig.OperatorNamespace)
 	if err != nil {
 		logger.Warningf("could not find deployment owner reference to assign to csi drivers. %v", err)
 	}
@@ -177,7 +177,7 @@ func (r *ReconcileCSI) reconcile(request reconcile.Request) (reconcile.Result, e
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed creating csi config map")
 	}
 
-	err = peermap.CreateOrUpdateConfig(r.context, &peermap.PeerIDMappings{})
+	err = peermap.CreateOrUpdateConfig(r.opManagerContext, r.context, &peermap.PeerIDMappings{})
 	if err != nil {
 		return opcontroller.ImmediateRetryResult, errors.Wrap(err, "failed to create pool ID mapping config map")
 	}

--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -389,7 +389,7 @@ func TestCreateOrUpdateConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create empty ID mapping configMap
-	err = CreateOrUpdateConfig(fakeContext, &PeerIDMappings{})
+	err = CreateOrUpdateConfig(context.TODO(), fakeContext, &PeerIDMappings{})
 	assert.NoError(t, err)
 	validateConfig(t, fakeContext, PeerIDMappings{})
 
@@ -405,7 +405,7 @@ func TestCreateOrUpdateConfig(t *testing.T) {
 		},
 	}
 
-	err = CreateOrUpdateConfig(fakeContext, actualMappings)
+	err = CreateOrUpdateConfig(context.TODO(), fakeContext, actualMappings)
 	assert.NoError(t, err)
 	//validateConfig(t, fakeContext, actualMappings)
 
@@ -420,7 +420,7 @@ func TestCreateOrUpdateConfig(t *testing.T) {
 		},
 	})
 
-	err = CreateOrUpdateConfig(fakeContext, &mappings)
+	err = CreateOrUpdateConfig(context.TODO(), fakeContext, &mappings)
 	assert.NoError(t, err)
 	validateConfig(t, fakeContext, mappings)
 }

--- a/pkg/operator/ceph/csi/spec.go
+++ b/pkg/operator/ceph/csi/spec.go
@@ -439,7 +439,7 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 		if err != nil {
 			return errors.Wrapf(err, "failed to apply network config to rbd plugin provisioner deployment %q", rbdProvisionerDeployment.Name)
 		}
-		_, err = k8sutil.CreateOrUpdateDeployment(r.context.Clientset, rbdProvisionerDeployment)
+		_, err = k8sutil.CreateOrUpdateDeployment(r.opManagerContext, r.context.Clientset, rbdProvisionerDeployment)
 		if err != nil {
 			return errors.Wrapf(err, "failed to start rbd provisioner deployment %q", rbdProvisionerDeployment.Name)
 		}
@@ -508,7 +508,7 @@ func (r *ReconcileCSI) startDrivers(ver *version.Info, ownerInfo *k8sutil.OwnerI
 		if err != nil {
 			return errors.Wrapf(err, "failed to apply network config to cephfs plugin provisioner deployment %q", cephfsProvisionerDeployment.Name)
 		}
-		_, err = k8sutil.CreateOrUpdateDeployment(r.context.Clientset, cephfsProvisionerDeployment)
+		_, err = k8sutil.CreateOrUpdateDeployment(r.opManagerContext, r.context.Clientset, cephfsProvisionerDeployment)
 		if err != nil {
 			return errors.Wrapf(err, "failed to start cephfs provisioner deployment %q", cephfsProvisionerDeployment.Name)
 		}
@@ -576,7 +576,7 @@ func (r *ReconcileCSI) deleteCSIDriverResources(ver *version.Info, daemonset, de
 		succeeded = false
 	}
 
-	err = k8sutil.DeleteDeployment(r.context.Clientset, r.opConfig.OperatorNamespace, deployment)
+	err = k8sutil.DeleteDeployment(r.opManagerContext, r.context.Clientset, r.opConfig.OperatorNamespace, deployment)
 	if err != nil {
 		logger.Errorf("failed to delete the %q. %v", deployment, err)
 		succeeded = false

--- a/pkg/operator/ceph/file/mds/mds.go
+++ b/pkg/operator/ceph/file/mds/mds.go
@@ -298,7 +298,7 @@ func (c *Cluster) upgradeMDS() error {
 
 func (c *Cluster) scaleDownDeployments(replicas int32, activeCount int32, desiredDeployments map[string]bool, delete bool) error {
 	// Remove extraneous mds deployments if they exist
-	deps, err := getMdsDeployments(c.context, c.fs.Namespace, c.fs.Name)
+	deps, err := getMdsDeployments(c.clusterInfo.Context, c.context, c.fs.Namespace, c.fs.Name)
 	if err != nil {
 		return errors.Wrapf(err,
 			fmt.Sprintf("cannot verify the removal of extraneous mds deployments for filesystem %s. ", c.fs.Name)+
@@ -331,13 +331,13 @@ func (c *Cluster) scaleDownDeployments(replicas int32, activeCount int32, desire
 			localdeployment := d
 			if !delete {
 				// stop mds daemon only by scaling deployment replicas to 0
-				if err := scaleMdsDeployment(c.context, c.fs.Namespace, &localdeployment, 0); err != nil {
+				if err := scaleMdsDeployment(c.clusterInfo.Context, c.context, c.fs.Namespace, &localdeployment, 0); err != nil {
 					errCount++
 					logger.Errorf("failed to scale mds deployment %q. %v", localdeployment.GetName(), err)
 				}
 				continue
 			}
-			if err := deleteMdsDeployment(c.context, c.fs.Namespace, &localdeployment); err != nil {
+			if err := deleteMdsDeployment(c.clusterInfo.Context, c.context, c.fs.Namespace, &localdeployment); err != nil {
 				errCount++
 				logger.Errorf("failed to delete mds deployment. %v", err)
 			}

--- a/pkg/operator/ceph/file/mds/spec.go
+++ b/pkg/operator/ceph/file/mds/spec.go
@@ -160,17 +160,16 @@ func (c *Cluster) podLabels(mdsConfig *mdsConfig, includeNewLabels bool) map[str
 	return labels
 }
 
-func getMdsDeployments(context *clusterd.Context, namespace, fsName string) (*apps.DeploymentList, error) {
+func getMdsDeployments(ctx context.Context, context *clusterd.Context, namespace, fsName string) (*apps.DeploymentList, error) {
 	fsLabelSelector := fmt.Sprintf("rook_file_system=%s", fsName)
-	deps, err := k8sutil.GetDeployments(context.Clientset, namespace, fsLabelSelector)
+	deps, err := k8sutil.GetDeployments(ctx, context.Clientset, namespace, fsLabelSelector)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get deployments for filesystem %s (matching label selector %q)", fsName, fsLabelSelector)
 	}
 	return deps, nil
 }
 
-func deleteMdsDeployment(clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment) error {
-	ctx := context.TODO()
+func deleteMdsDeployment(ctx context.Context, clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment) error {
 	// Delete the mds deployment
 	logger.Infof("deleting mds deployment %s", deployment.Name)
 	var gracePeriod int64
@@ -182,8 +181,7 @@ func deleteMdsDeployment(clusterdContext *clusterd.Context, namespace string, de
 	return nil
 }
 
-func scaleMdsDeployment(clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment, replicas int32) error {
-	ctx := context.TODO()
+func scaleMdsDeployment(ctx context.Context, clusterdContext *clusterd.Context, namespace string, deployment *apps.Deployment, replicas int32) error {
 	// scale mds deployment
 	logger.Infof("scaling mds deployment %q to %d replicas", deployment.Name, replicas)
 	d, err := clusterdContext.Clientset.AppsV1().Deployments(namespace).Get(ctx, deployment.GetName(), metav1.GetOptions{})

--- a/pkg/operator/ceph/object/rgw.go
+++ b/pkg/operator/ceph/object/rgw.go
@@ -174,7 +174,7 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 	}
 
 	// scale down scenario
-	deps, err := k8sutil.GetDeployments(c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
+	deps, err := k8sutil.GetDeployments(c.clusterInfo.Context, c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
 	if err != nil {
 		logger.Warningf("could not get deployments for object store %q (matching label selector %q). %v", c.store.Name, c.storeLabelSelector(), err)
 	}
@@ -186,7 +186,7 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 		for i := 0; i < diffCount; {
 			depIDToRemove := currentRgwInstances - 1
 			depNameToRemove := fmt.Sprintf("%s-%s-%s", AppName, c.store.Name, k8sutil.IndexToName(depIDToRemove))
-			if err := k8sutil.DeleteDeployment(c.context.Clientset, c.store.Namespace, depNameToRemove); err != nil {
+			if err := k8sutil.DeleteDeployment(c.clusterInfo.Context, c.context.Clientset, c.store.Namespace, depNameToRemove); err != nil {
 				logger.Warningf("error during deletion of deployment %q resource. %v", depNameToRemove, err)
 			}
 			currentRgwInstances = currentRgwInstances - 1
@@ -205,7 +205,7 @@ func (c *clusterConfig) startRGWPods(realmName, zoneGroupName, zoneName string) 
 			}
 		}
 		// verify scale down was successful
-		deps, err = k8sutil.GetDeployments(c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
+		deps, err = k8sutil.GetDeployments(c.clusterInfo.Context, c.context.Clientset, c.store.Namespace, c.storeLabelSelector())
 		if err != nil {
 			logger.Warningf("could not get deployments for object store %q (matching label selector %q). %v", c.store.Name, c.storeLabelSelector(), err)
 		}

--- a/pkg/operator/ceph/pool/controller.go
+++ b/pkg/operator/ceph/pool/controller.go
@@ -299,7 +299,7 @@ func (r *ReconcileCephBlockPool) reconcile(request reconcile.Request) (reconcile
 		}
 
 		// ReconcilePoolIDMap updates the `rook-ceph-csi-mapping-config` with local and peer cluster pool ID map
-		err = peermap.ReconcilePoolIDMap(r.context, r.clusterInfo, cephBlockPool)
+		err = peermap.ReconcilePoolIDMap(r.opManagerContext, r.context, r.clusterInfo, cephBlockPool)
 		if err != nil {
 			return reconcileResponse, errors.Wrapf(err, "failed to update pool ID mapping config for the pool %q", cephBlockPool.Name)
 		}

--- a/pkg/operator/k8sutil/deployment_test.go
+++ b/pkg/operator/k8sutil/deployment_test.go
@@ -146,7 +146,7 @@ func TestUpdateMultipleDeploymentsAndWait(t *testing.T) {
 			timesCalled++
 			return l, nil
 		}
-		failures = UpdateMultipleDeploymentsAndWait(clientset, deployments, listFunc)
+		failures = UpdateMultipleDeploymentsAndWait(context.TODO(), clientset, deployments, listFunc)
 		assert.Len(t, failures, 3)
 		assert.ElementsMatch(t,
 			[]string{failures[0].ResourceName, failures[1].ResourceName, failures[2].ResourceName},
@@ -191,7 +191,7 @@ func TestUpdateMultipleDeployments(t *testing.T) {
 	t.Run("no deployments to be updated", func(t *testing.T) {
 		clientset = fake.NewSimpleClientset()
 		deployments = []*appsv1.Deployment{}
-		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(clientset, deployments)
+		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(context.TODO(), clientset, deployments)
 		assert.Len(t, deploymentsUpdated, 0)
 		assert.Len(t, failures, 0)
 	})
@@ -206,7 +206,7 @@ func TestUpdateMultipleDeployments(t *testing.T) {
 			modifiedDeployment("d2", nil),
 			modifiedDeployment("d3", nil),
 		}
-		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(clientset, deployments)
+		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(context.TODO(), clientset, deployments)
 		assert.Len(t, deploymentsUpdated, 3)
 		assert.Len(t, failures, 0)
 		assert.Contains(t, deploymentsUpdated, "d1")
@@ -226,7 +226,7 @@ func TestUpdateMultipleDeployments(t *testing.T) {
 			// d2 from before should also not be updated
 			d3, // should be updated
 		}
-		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(clientset, deployments)
+		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(context.TODO(), clientset, deployments)
 		assert.Len(t, deploymentsUpdated, 1)
 		assert.Len(t, failures, 0)
 		assert.Contains(t, deploymentsUpdated, "d3")
@@ -243,7 +243,7 @@ func TestUpdateMultipleDeployments(t *testing.T) {
 			modifiedDeployment("d3", newInt32(30)),
 			modifiedDeployment("d4", newInt32(30)),
 		}
-		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(clientset, deployments)
+		deploymentsUpdated, failures, pds = UpdateMultipleDeployments(context.TODO(), clientset, deployments)
 		assert.Len(t, deploymentsUpdated, 2)
 		assert.Len(t, failures, 2)
 		assert.Contains(t, deploymentsUpdated, "d1")

--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -272,7 +273,7 @@ func (s *UpgradeSuite) deployClusterforUpgrade(objectStoreName, objectUserID, me
 	cephfsFilesToRead := []string{}
 
 	// Get some info about the currently deployed OSDs to determine later if they are all updated
-	osdDepList, err := k8sutil.GetDeployments(s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
+	osdDepList, err := k8sutil.GetDeployments(context.TODO(), s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
 	require.NoError(s.T(), err)
 	osdDeps := osdDepList.Items
 	numOSDs := len(osdDeps) // there should be this many upgraded OSDs
@@ -291,7 +292,7 @@ func (s *UpgradeSuite) gatherLogs(systemNamespace, testSuffix string) {
 }
 
 func (s *UpgradeSuite) upgradeCephVersion(newCephImage string, numOSDs int) {
-	osdDepList, err := k8sutil.GetDeployments(s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
+	osdDepList, err := k8sutil.GetDeployments(context.TODO(), s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
 	require.NoError(s.T(), err)
 	oldCephVersion := osdDepList.Items[0].Labels["ceph-version"] // upgraded OSDs should not have this version label
 
@@ -306,24 +307,24 @@ func (s *UpgradeSuite) verifyOperatorImage(expectedImage string) {
 	systemNamespace := installer.SystemNamespace(s.namespace)
 
 	// verify that the operator spec is updated
-	version, err := k8sutil.GetDeploymentImage(s.k8sh.Clientset, systemNamespace, operatorContainer, operatorContainer)
+	version, err := k8sutil.GetDeploymentImage(context.TODO(), s.k8sh.Clientset, systemNamespace, operatorContainer, operatorContainer)
 	assert.NoError(s.T(), err)
 	assert.Equal(s.T(), "rook/ceph:"+expectedImage, version)
 }
 
 func (s *UpgradeSuite) verifyRookUpgrade(numOSDs int) {
 	// Get some info about the currently deployed mons to determine later if they are all updated
-	monDepList, err := k8sutil.GetDeployments(s.k8sh.Clientset, s.namespace, "app=rook-ceph-mon")
+	monDepList, err := k8sutil.GetDeployments(context.TODO(), s.k8sh.Clientset, s.namespace, "app=rook-ceph-mon")
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), s.settings.Mons, len(monDepList.Items), monDepList.Items)
 
 	// Get some info about the currently deployed mgr to determine later if it is updated
-	mgrDepList, err := k8sutil.GetDeployments(s.k8sh.Clientset, s.namespace, "app=rook-ceph-mgr")
+	mgrDepList, err := k8sutil.GetDeployments(context.TODO(), s.k8sh.Clientset, s.namespace, "app=rook-ceph-mgr")
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), 1, len(mgrDepList.Items))
 
 	// Get some info about the currently deployed OSDs to determine later if they are all updated
-	osdDepList, err := k8sutil.GetDeployments(s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
+	osdDepList, err := k8sutil.GetDeployments(context.TODO(), s.k8sh.Clientset, s.namespace, "app=rook-ceph-osd")
 	require.NoError(s.T(), err)
 	require.NotZero(s.T(), len(osdDepList.Items))
 	require.Equal(s.T(), numOSDs, len(osdDepList.Items), osdDepList.Items)


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil deployment functions. By
this, we can handle cancellation during API call of deployment resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>



**Which issue is resolved by this Pull Request:**
Part of https://github.com/rook/rook/issues/8700

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
