### PR TITLE
core: add context parameter to k8sutil node

### DIFF
--- a/pkg/operator/ceph/cluster/cephstatus.go
+++ b/pkg/operator/ceph/cluster/cephstatus.go
@@ -286,7 +286,7 @@ func cephStatusOnError(errorMessage string) *cephclient.CephStatus {
 // forceDeleteStuckPodsOnNotReadyNodes lists all the nodes that are in NotReady state and
 // gets all the pods on the failed node and force delete the pods stuck in terminating state.
 func (c *cephStatusChecker) forceDeleteStuckRookPodsOnNotReadyNodes(ctx context.Context) error {
-	nodes, err := k8sutil.GetNotReadyKubernetesNodes(c.context.Clientset)
+	nodes, err := k8sutil.GetNotReadyKubernetesNodes(ctx, c.context.Clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to get NotReady nodes")
 	}

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -232,7 +232,7 @@ func (c *ClusterController) getCephHosts(namespace string) ([]string, error) {
 	logger.Infof("existing ceph daemons in the namespace %q. %s", namespace, b.String())
 
 	for nodeName := range nodeNameList {
-		podHostName, err := k8sutil.GetNodeHostName(c.context.Clientset, nodeName)
+		podHostName, err := k8sutil.GetNodeHostName(c.OpManagerCtx, c.context.Clientset, nodeName)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get hostname from node %q", nodeName)
 		}

--- a/pkg/operator/ceph/cluster/osd/create.go
+++ b/pkg/operator/ceph/cluster/osd/create.go
@@ -272,7 +272,7 @@ func (c *Cluster) startProvisioningOverNodes(config *provisionConfig, errs *prov
 		}
 
 		// Get the list of all nodes in the cluster. The placement settings will be applied below.
-		hostnameMap, err := k8sutil.GetNodeHostNames(c.context.Clientset)
+		hostnameMap, err := k8sutil.GetNodeHostNames(c.clusterInfo.Context, c.context.Clientset)
 		if err != nil {
 			errs.addError("failed to provision OSDs on nodes. failed to get node hostnames. %v", err)
 			return sets.NewString(), nil
@@ -287,7 +287,7 @@ func (c *Cluster) startProvisioningOverNodes(config *provisionConfig, errs *prov
 		logger.Debugf("storage nodes: %+v", c.spec.Storage.Nodes)
 	}
 	// generally speaking, this finds nodes which are capable of running new osds
-	validNodes := k8sutil.GetValidNodes(c.spec.Storage, c.context.Clientset, cephv1.GetOSDPlacement(c.spec.Placement))
+	validNodes := k8sutil.GetValidNodes(c.clusterInfo.Context, c.spec.Storage, c.context.Clientset, cephv1.GetOSDPlacement(c.spec.Placement))
 
 	logger.Infof("%d of the %d storage nodes are valid", len(validNodes), len(c.spec.Storage.Nodes))
 

--- a/pkg/operator/discover/discover_test.go
+++ b/pkg/operator/discover/discover_test.go
@@ -129,15 +129,15 @@ func TestGetAvailableDevices(t *testing.T) {
 		},
 	}
 
-	nodeDevices, err := ListDevices(context, ns, "" /* all nodes */)
+	nodeDevices, err := ListDevices(ctx, context, ns, "" /* all nodes */)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(nodeDevices))
 
-	devices, err := GetAvailableDevices(context, nodeName, ns, d, "^sd.", pvcBackedOSD)
+	devices, err := GetAvailableDevices(ctx, context, nodeName, ns, d, "^sd.", pvcBackedOSD)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(devices))
 	// devices should be in use now, 2nd try gets the same list
-	devices, err = GetAvailableDevices(context, nodeName, ns, d, "^sd.", pvcBackedOSD)
+	devices, err = GetAvailableDevices(ctx, context, nodeName, ns, d, "^sd.", pvcBackedOSD)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(devices))
 }

--- a/pkg/operator/k8sutil/node.go
+++ b/pkg/operator/k8sutil/node.go
@@ -62,8 +62,8 @@ func ValidNode(node v1.Node, placement cephv1.Placement) (bool, error) {
 
 // GetValidNodes returns all nodes that (1) are not cordoned, (2) meet Rook's placement terms, and
 // (3) are ready.
-func GetValidNodes(rookStorage cephv1.StorageScopeSpec, clientset kubernetes.Interface, placement cephv1.Placement) []cephv1.Node {
-	matchingK8sNodes, err := GetKubernetesNodesMatchingRookNodes(rookStorage.Nodes, clientset)
+func GetValidNodes(ctx context.Context, rookStorage cephv1.StorageScopeSpec, clientset kubernetes.Interface, placement cephv1.Placement) []cephv1.Node {
+	matchingK8sNodes, err := GetKubernetesNodesMatchingRookNodes(ctx, rookStorage.Nodes, clientset)
 	if err != nil {
 		// cannot list nodes, return empty nodes
 		logger.Errorf("failed to list nodes: %+v", err)
@@ -86,8 +86,7 @@ func GetValidNodes(rookStorage cephv1.StorageScopeSpec, clientset kubernetes.Int
 // GetNodeNameFromHostname returns the name of the node resource looked up by the hostname label
 // Typically these will be the same name, but sometimes they are not such as when nodes have a longer
 // dns name, but the hostname is short.
-func GetNodeNameFromHostname(clientset kubernetes.Interface, hostName string) (string, error) {
-	ctx := context.TODO()
+func GetNodeNameFromHostname(ctx context.Context, clientset kubernetes.Interface, hostName string) (string, error) {
 	options := metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.LabelHostname, hostName)}
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, options)
 	if err != nil {
@@ -101,8 +100,7 @@ func GetNodeNameFromHostname(clientset kubernetes.Interface, hostName string) (s
 }
 
 // GetNodeHostName returns the hostname label given the node name.
-func GetNodeHostName(clientset kubernetes.Interface, nodeName string) (string, error) {
-	ctx := context.TODO()
+func GetNodeHostName(ctx context.Context, clientset kubernetes.Interface, nodeName string) (string, error) {
 	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -121,8 +119,7 @@ func GetNodeHostNameLabel(node *v1.Node) (string, error) {
 // GetNodeHostNames returns the name of the node resource mapped to their hostname label.
 // Typically these will be the same name, but sometimes they are not such as when nodes have a longer
 // dns name, but the hostname is short.
-func GetNodeHostNames(clientset kubernetes.Interface) (map[string]string, error) {
-	ctx := context.TODO()
+func GetNodeHostNames(ctx context.Context, clientset kubernetes.Interface) (map[string]string, error) {
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -269,8 +266,7 @@ func normalizeHostname(kubernetesNode v1.Node) string {
 
 // GetKubernetesNodesMatchingRookNodes lists all the nodes in Kubernetes and returns all the
 // Kubernetes nodes that have a corresponding match in the list of Rook nodes.
-func GetKubernetesNodesMatchingRookNodes(rookNodes []cephv1.Node, clientset kubernetes.Interface) ([]v1.Node, error) {
-	ctx := context.TODO()
+func GetKubernetesNodesMatchingRookNodes(ctx context.Context, rookNodes []cephv1.Node, clientset kubernetes.Interface) ([]v1.Node, error) {
 	nodes := []v1.Node{}
 	k8sNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -287,8 +283,7 @@ func GetKubernetesNodesMatchingRookNodes(rookNodes []cephv1.Node, clientset kube
 }
 
 // GetNotReadyKubernetesNodes lists all the nodes that are in NotReady state
-func GetNotReadyKubernetesNodes(clientset kubernetes.Interface) ([]v1.Node, error) {
-	ctx := context.TODO()
+func GetNotReadyKubernetesNodes(ctx context.Context, clientset kubernetes.Interface) ([]v1.Node, error) {
 	nodes := []v1.Node{}
 	k8sNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/pkg/operator/k8sutil/node_test.go
+++ b/pkg/operator/k8sutil/node_test.go
@@ -70,7 +70,7 @@ func TestValidNode(t *testing.T) {
 	assert.Nil(t, nodeErr)
 	nodeErr = createNode(nodeB, v1.NodeNetworkUnavailable, clientset)
 	assert.Nil(t, nodeErr)
-	validNodes := GetValidNodes(storage, clientset, placement)
+	validNodes := GetValidNodes(context.TODO(), storage, clientset, placement)
 	assert.Equal(t, len(validNodes), 1)
 }
 
@@ -214,7 +214,7 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 	}
 
 	// no rook nodes specified
-	nodes, err := GetKubernetesNodesMatchingRookNodes(rookNodes, clientset)
+	nodes, err := GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Empty(t, nodes)
 
@@ -223,7 +223,7 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 		{Name: "node0"},
 		{Name: "node2"},
 		{Name: "node5"}}
-	nodes, err = GetKubernetesNodesMatchingRookNodes(rookNodes, clientset)
+	nodes, err = GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 2)
 	assert.Contains(t, nodes, getNode("node0"))
@@ -234,7 +234,7 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 		{Name: "node0"},
 		{Name: "node1"},
 		{Name: "node2"}}
-	nodes, err = GetKubernetesNodesMatchingRookNodes(rookNodes, clientset)
+	nodes, err = GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 3)
 	assert.Contains(t, nodes, getNode("node0"))
@@ -243,7 +243,7 @@ func TestGetRookNodesMatchingKubernetesNodes(t *testing.T) {
 
 	// no k8s nodes exist
 	clientset = optest.New(t, 0)
-	nodes, err = GetKubernetesNodesMatchingRookNodes(rookNodes, clientset)
+	nodes, err = GetKubernetesNodesMatchingRookNodes(ctx, rookNodes, clientset)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 0)
 }
@@ -379,13 +379,13 @@ func TestGetNotReadyKubernetesNodes(t *testing.T) {
 	clientset := optest.New(t, 0)
 
 	//when there is no node
-	nodes, err := GetNotReadyKubernetesNodes(clientset)
+	nodes, err := GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(nodes))
 
 	//when all the nodes are in ready state
 	clientset = optest.New(t, 2)
-	nodes, err = GetNotReadyKubernetesNodes(clientset)
+	nodes, err = GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(nodes))
 
@@ -404,7 +404,7 @@ func TestGetNotReadyKubernetesNodes(t *testing.T) {
 	}
 	_, err = clientset.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	nodes, err = GetNotReadyKubernetesNodes(clientset)
+	nodes, err = GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(nodes))
 
@@ -417,7 +417,7 @@ func TestGetNotReadyKubernetesNodes(t *testing.T) {
 		_, err := clientset.CoreV1().Nodes().Update(ctx, &updateNode, metav1.UpdateOptions{})
 		assert.NoError(t, err)
 	}
-	nodes, err = GetNotReadyKubernetesNodes(clientset)
+	nodes, err = GetNotReadyKubernetesNodes(ctx, clientset)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(nodes))
 }

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -279,7 +279,7 @@ func (s *CephMgrSuite) TestHostLs() {
 	sort.Strings(hostOutput)
 
 	// get the k8s nodes
-	nodes, err := k8sutil.GetNodeHostNames(s.k8sh.Clientset)
+	nodes, err := k8sutil.GetNodeHostNames(context.TODO(), s.k8sh.Clientset)
 	assert.Nil(s.T(), err)
 
 	k8sNodes := make([]string, 0, len(nodes))


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil node functions. By this,
we can handle cancellation during API call of node resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of https://github.com/rook/rook/issues/8700

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
