### PR TITLE
core: add context parameter to k8sutil pod

### DIFF
--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -60,8 +60,8 @@ func startOperator(cmd *cobra.Command, args []string) error {
 		rook.TerminateFatal(errors.Errorf("rook operator namespace is not provided. expose it via downward API in the rook operator manifest file using environment variable %q", k8sutil.PodNamespaceEnvVar))
 	}
 
-	rook.CheckOperatorResources(context.Clientset)
-	rookImage := rook.GetOperatorImage(context.Clientset, containerName)
+	rook.CheckOperatorResources(cmd.Context(), context.Clientset)
+	rookImage := rook.GetOperatorImage(cmd.Context(), context.Clientset, containerName)
 	rookBaseImageCephVersion, err := rook.GetOperatorBaseImageCephVersion(context)
 	if err != nil {
 		logger.Errorf("failed to get operator base image ceph version. %v", err)
@@ -69,7 +69,7 @@ func startOperator(cmd *cobra.Command, args []string) error {
 	opcontroller.OperatorCephBaseImageVersion = rookBaseImageCephVersion
 	logger.Infof("base ceph version inside the rook operator image is %q", opcontroller.OperatorCephBaseImageVersion)
 
-	serviceAccountName := rook.GetOperatorServiceAccount(context.Clientset)
+	serviceAccountName := rook.GetOperatorServiceAccount(cmd.Context(), context.Clientset)
 	op := operator.New(context, rookImage, serviceAccountName)
 	err = op.Run()
 	if err != nil {

--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rook
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -151,7 +152,7 @@ func NewContext() *clusterd.Context {
 	return context
 }
 
-func GetOperatorImage(clientset kubernetes.Interface, containerName string) string {
+func GetOperatorImage(ctx context.Context, clientset kubernetes.Interface, containerName string) string {
 
 	// If provided as a flag then use that value
 	if operatorImage != "" {
@@ -159,7 +160,7 @@ func GetOperatorImage(clientset kubernetes.Interface, containerName string) stri
 	}
 
 	// Getting the info of the operator pod
-	pod, err := k8sutil.GetRunningPod(clientset)
+	pod, err := k8sutil.GetRunningPod(ctx, clientset)
 	TerminateOnError(err, "failed to get pod")
 
 	// Get the actual operator container image name
@@ -169,7 +170,7 @@ func GetOperatorImage(clientset kubernetes.Interface, containerName string) stri
 	return containerImage
 }
 
-func GetOperatorServiceAccount(clientset kubernetes.Interface) string {
+func GetOperatorServiceAccount(ctx context.Context, clientset kubernetes.Interface) string {
 
 	// If provided as a flag then use that value
 	if serviceAccountName != "" {
@@ -177,15 +178,15 @@ func GetOperatorServiceAccount(clientset kubernetes.Interface) string {
 	}
 
 	// Getting the info of the operator pod
-	pod, err := k8sutil.GetRunningPod(clientset)
+	pod, err := k8sutil.GetRunningPod(ctx, clientset)
 	TerminateOnError(err, "failed to get pod")
 
 	return pod.Spec.ServiceAccountName
 }
 
-func CheckOperatorResources(clientset kubernetes.Interface) {
+func CheckOperatorResources(ctx context.Context, clientset kubernetes.Interface) {
 	// Getting the info of the operator pod
-	pod, err := k8sutil.GetRunningPod(clientset)
+	pod, err := k8sutil.GetRunningPod(ctx, clientset)
 	TerminateOnError(err, "failed to get pod")
 	resource := pod.Spec.Containers[0].Resources
 	// set env var if operator pod resources are set

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -367,7 +367,7 @@ func updateDeviceCM(clusterdContext *clusterd.Context) error {
 		}
 
 		// Get the discover daemon pod details to attach the owner reference to the config map
-		discoverPod, err := k8sutil.GetRunningPod(clusterdContext.Clientset)
+		discoverPod, err := k8sutil.GetRunningPod(ctx, clusterdContext.Clientset)
 		if err != nil {
 			logger.Warningf("failed to get discover pod to set ownerref. %+v", err)
 		} else {

--- a/pkg/operator/ceph/cluster/cephstatus_test.go
+++ b/pkg/operator/ceph/cluster/cephstatus_test.go
@@ -283,7 +283,7 @@ func TestForceDeleteStuckRookPodsOnNotReadyNodes(t *testing.T) {
 	}
 
 	// There should be no error
-	err = c.forceDeleteStuckRookPodsOnNotReadyNodes()
+	err = c.forceDeleteStuckRookPodsOnNotReadyNodes(ctx)
 	assert.NoError(t, err)
 
 	// The pod should still exist since its not deleted.
@@ -297,7 +297,7 @@ func TestForceDeleteStuckRookPodsOnNotReadyNodes(t *testing.T) {
 	assert.NoError(t, err)
 
 	// There should be no error as the pod is deleted
-	err = c.forceDeleteStuckRookPodsOnNotReadyNodes()
+	err = c.forceDeleteStuckRookPodsOnNotReadyNodes(ctx)
 	assert.NoError(t, err)
 
 	// The pod should be deleted since the pod is marked as deleted and the node is in NotReady state

--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -388,7 +388,7 @@ func (c *Cluster) readyToConfigureArbiter(checkOSDPods bool) (bool, error) {
 	if checkOSDPods {
 		// Wait for the OSD pods to be running
 		// can't use osd.AppName due to a circular dependency
-		allRunning, err := k8sutil.PodsWithLabelAreAllRunning(c.context.Clientset, c.Namespace, fmt.Sprintf("%s=rook-ceph-osd", k8sutil.AppAttr))
+		allRunning, err := k8sutil.PodsWithLabelAreAllRunning(c.ClusterInfo.Context, c.context.Clientset, c.Namespace, fmt.Sprintf("%s=rook-ceph-osd", k8sutil.AppAttr))
 		if err != nil {
 			return false, errors.Wrap(err, "failed to check whether all osds are running before enabling the arbiter")
 		}
@@ -1334,7 +1334,7 @@ func waitForQuorumWithMons(context *clusterd.Context, clusterInfo *cephclient.Cl
 		allPodsRunning := true
 		var runningMonNames []string
 		for _, m := range mons {
-			running, err := k8sutil.PodsRunningWithLabel(context.Clientset, clusterInfo.Namespace, fmt.Sprintf("app=%s,mon=%s", AppName, m))
+			running, err := k8sutil.PodsRunningWithLabel(clusterInfo.Context, context.Clientset, clusterInfo.Namespace, fmt.Sprintf("app=%s,mon=%s", AppName, m))
 			if err != nil {
 				logger.Infof("failed to query mon pod status, trying again. %v", err)
 				continue

--- a/pkg/operator/discover/discover.go
+++ b/pkg/operator/discover/discover.go
@@ -176,7 +176,7 @@ func (d *Discover) createDiscoverDaemonSet(ctx context.Context, namespace, disco
 		},
 	}
 	// Get the operator pod details to attach the owner reference to the discover daemon set
-	operatorPod, err := k8sutil.GetRunningPod(d.clientset)
+	operatorPod, err := k8sutil.GetRunningPod(ctx, d.clientset)
 	if err != nil {
 		logger.Errorf("failed to get operator pod. %+v", err)
 	} else {

--- a/pkg/operator/k8sutil/pod.go
+++ b/pkg/operator/k8sutil/pod.go
@@ -156,8 +156,7 @@ func AddUnreachableNodeToleration(podSpec *v1.PodSpec) {
 
 // GetRunningPod reads the name and namespace of a pod from the
 // environment, and returns the pod (if it exists).
-func GetRunningPod(clientset kubernetes.Interface) (*v1.Pod, error) {
-	ctx := context.TODO()
+func GetRunningPod(ctx context.Context, clientset kubernetes.Interface) (*v1.Pod, error) {
 	podName := os.Getenv(PodNameEnvVar)
 	if podName == "" {
 		return nil, fmt.Errorf("cannot detect the pod name. Please provide it using the downward API in the manifest file")
@@ -202,14 +201,14 @@ func GetMatchingContainer(containers []v1.Container, name string) (v1.Container,
 }
 
 // PodsRunningWithLabel returns the number of running pods with the given label
-func PodsRunningWithLabel(clientset kubernetes.Interface, namespace, label string) (int, error) {
-	running, _, err := podStatusWithLabel(clientset, namespace, label)
+func PodsRunningWithLabel(ctx context.Context, clientset kubernetes.Interface, namespace, label string) (int, error) {
+	running, _, err := podStatusWithLabel(ctx, clientset, namespace, label)
 	return running, err
 }
 
 // PodsWithLabelAreAllRunning returns whether all pods with the label are in running state
-func PodsWithLabelAreAllRunning(clientset kubernetes.Interface, namespace, label string) (bool, error) {
-	running, notRunning, err := podStatusWithLabel(clientset, namespace, label)
+func PodsWithLabelAreAllRunning(ctx context.Context, clientset kubernetes.Interface, namespace, label string) (bool, error) {
+	running, notRunning, err := podStatusWithLabel(ctx, clientset, namespace, label)
 	if err != nil {
 		return false, err
 	}
@@ -217,8 +216,7 @@ func PodsWithLabelAreAllRunning(clientset kubernetes.Interface, namespace, label
 	return running > 0 && notRunning == 0, err
 }
 
-func podStatusWithLabel(clientset kubernetes.Interface, namespace, label string) (int, int, error) {
-	ctx := context.TODO()
+func podStatusWithLabel(ctx context.Context, clientset kubernetes.Interface, namespace, label string) (int, int, error) {
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: label})
 	if err != nil {
 		return 0, 0, err
@@ -256,8 +254,7 @@ func GetPodPhaseMap(pods *v1.PodList) map[v1.PodPhase][]string {
 
 // GetJobLog gets the logs for the pod. If there is more than one pod with the label selector, the logs from
 // the first pod will be returned.
-func GetPodLog(clientset kubernetes.Interface, namespace string, labelSelector string) (string, error) {
-	ctx := context.TODO()
+func GetPodLog(ctx context.Context, clientset kubernetes.Interface, namespace string, labelSelector string) (string, error) {
 	opts := metav1.ListOptions{
 		LabelSelector: labelSelector,
 	}
@@ -347,8 +344,7 @@ func SetNodeAntiAffinityForPod(pod *v1.PodSpec, requiredDuringScheduling bool, t
 	}
 }
 
-func ForceDeletePodIfStuck(clusterdContext *clusterd.Context, pod v1.Pod) error {
-	ctx := context.TODO()
+func ForceDeletePodIfStuck(ctx context.Context, clusterdContext *clusterd.Context, pod v1.Pod) error {
 	logger.Debugf("checking if pod %q is stuck and should be force deleted", pod.Name)
 	if pod.DeletionTimestamp.IsZero() {
 		logger.Debugf("skipping pod %q restart since the pod is not deleted", pod.Name)
@@ -398,9 +394,9 @@ func removeDuplicateEnvVarsFromContainer(container *v1.Container) {
 	container.Env = vars
 }
 
-func IsPodScheduled(clientSet kubernetes.Interface, namespace, selector string) (bool, error) {
+func IsPodScheduled(ctx context.Context, clientSet kubernetes.Interface, namespace, selector string) (bool, error) {
 	listOpts := metav1.ListOptions{LabelSelector: selector}
-	podList, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), listOpts)
+	podList, err := clientSet.CoreV1().Pods(namespace).List(ctx, listOpts)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to list pods with label selector %q in namespace %q", selector, namespace)
 	}

--- a/pkg/operator/k8sutil/pod_test.go
+++ b/pkg/operator/k8sutil/pod_test.go
@@ -238,7 +238,7 @@ func TestIsMonScheduled(t *testing.T) {
 	}
 
 	// no pods running
-	isScheduled, err := IsPodScheduled(clientset, "ns", "a")
+	isScheduled, err := IsPodScheduled(ctx, clientset, "ns", "a")
 	assert.Error(t, err)
 	assert.False(t, isScheduled)
 
@@ -247,7 +247,7 @@ func TestIsMonScheduled(t *testing.T) {
 	// unscheduled pod
 	_, err = clientset.CoreV1().Pods("ns").Create(ctx, &pod, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	isScheduled, err = IsPodScheduled(clientset, "ns", selector)
+	isScheduled, err = IsPodScheduled(ctx, clientset, "ns", selector)
 	assert.NoError(t, err)
 	assert.False(t, isScheduled)
 
@@ -255,13 +255,13 @@ func TestIsMonScheduled(t *testing.T) {
 	pod.Spec.NodeName = "node0"
 	_, err = clientset.CoreV1().Pods("ns").Update(ctx, &pod, metav1.UpdateOptions{})
 	assert.NoError(t, err)
-	isScheduled, err = IsPodScheduled(clientset, "ns", selector)
+	isScheduled, err = IsPodScheduled(ctx, clientset, "ns", selector)
 	assert.NoError(t, err)
 	assert.True(t, isScheduled)
 
 	// no pods found
 	assert.NoError(t, err)
-	isScheduled, err = IsPodScheduled(clientset, "ns", "b")
+	isScheduled, err = IsPodScheduled(ctx, clientset, "ns", "b")
 	assert.Error(t, err)
 	assert.False(t, isScheduled)
 }

--- a/tests/integration/ceph_mgr_test.go
+++ b/tests/integration/ceph_mgr_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -311,7 +312,7 @@ func (s *CephMgrSuite) TestServiceLs() {
 		} else {
 			labelFilter = "app=rook-ceph-crashcollector"
 		}
-		k8sPods, err := k8sutil.PodsRunningWithLabel(s.k8sh.Clientset, s.namespace, labelFilter)
+		k8sPods, err := k8sutil.PodsRunningWithLabel(context.TODO(), s.k8sh.Clientset, s.namespace, labelFilter)
 		logger.Infof("Service: %+v", svc)
 		logger.Infof("k8s pods for svc %q using label <%q>: %d", svc.ServiceName, labelFilter, k8sPods)
 		assert.Nil(s.T(), err)


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil pod functions. By this, we
can handle cancellation during API call of pod resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of https://github.com/rook/rook/issues/8700

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
