### PR TITLE
core: remove unnecessary option

### DIFF
--- a/cmd/rook/ceph/operator.go
+++ b/cmd/rook/ceph/operator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ceph
 
 import (
+	"flag"
 	"os"
 
 	"github.com/pkg/errors"
@@ -43,7 +44,10 @@ func init() {
 	operatorCmd.Flags().BoolVar(&operator.EnableMachineDisruptionBudget, "enable-machine-disruption-budget", false, "enable fencing controllers")
 
 	flags.SetFlagsFromEnv(operatorCmd.Flags(), rook.RookEnvVarPrefix)
-	flags.SetLoggingFlags(operatorCmd.Flags())
+	operatorCmd.Flags().AddGoFlagSet(flag.CommandLine)
+	if err := operatorCmd.Flags().Parse(nil); err != nil {
+		panic(err)
+	}
 	operatorCmd.RunE = startOperator
 }
 

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -16,7 +16,6 @@ limitations under the License.
 package flags
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -53,20 +52,6 @@ func createRequiredFlagError(name string, flags []string) error {
 	}
 
 	return fmt.Errorf("%s are required for %s", strings.Join(flags, ","), name)
-}
-
-func SetLoggingFlags(flags *pflag.FlagSet) {
-	//Add commandline flags to the flagset. We will always write to stderr
-	//and not to a file by default
-	flags.AddGoFlagSet(flag.CommandLine)
-	if err := flags.Set("logtostderr", "true"); err != nil {
-		// TODO: fix me
-		// 2021-09-02 09:41:29.645366 I | op-flags: failed to set flag "logtostderr". no such flag -logtostderr
-		logger.Infof("failed to set flag %q. %v", "logtostderr", err)
-	}
-	if err := flags.Parse(nil); err != nil {
-		panic(err)
-	}
 }
 
 func SetFlagsFromEnv(flags *pflag.FlagSet, prefix string) {


### PR DESCRIPTION
**Description of your changes:**

rook command doesn't interpret `logtostderr` option. It's OK to just remove this option because `capnslog` outputs all logs to stdout by default. It's better to keep `AddGoFlagSet()` call because some libraries might define their own flags with Go's `flag` package.

**Checklist:**

- [o] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [o] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [o] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [o] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [o] Documentation has been updated, if necessary.
- [o] Unit tests have been added, if necessary.
- [o] Integration tests have been added, if necessary.
- [o] Pending release notes updated with breaking and/or notable changes, if necessary.
- [o] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [o] Code generation (`make codegen`) has been run to update object specifications, if necessary.
