### PR TITLE
core: reduce init containers capabilities to their minimum

### DIFF
--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -9,6 +9,36 @@
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
+  name: rook-ceph-operator
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: true
+allowHostPID: false
+allowHostNetwork: false
+allowHostPorts: false
+allowHostIPC: false
+priority:
+allowedCapabilities: []
+readOnlyRootFilesystem: false
+requiredDropCapabilities: ["all"]
+defaultAddCapabilities: []
+runAsUser:
+  type: MustRunAs
+  uid: 2016
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+users:
+  # A user needs to be added for each rook service account.
+  # This assumes running in the default sample "rook-ceph" namespace.
+  # If other namespaces or service accounts are configured, they need to be updated here.
+  - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
+---
+# scc for the Rook and Ceph daemons
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
   name: rook-ceph
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
@@ -17,18 +47,20 @@ allowHostPID: false
 allowHostNetwork: false
 # set to true if running rook with the provider as host
 allowHostPorts: false
-priority:
-allowedCapabilities: ["MKNOD"]
 allowHostIPC: true
+priority:
 readOnlyRootFilesystem: false
 requiredDropCapabilities: []
 defaultAddCapabilities: []
+allowedCapabilities: ["MKNOD"]
 runAsUser:
-  type: RunAsAny
-seLinuxContext:
   type: MustRunAs
+  uid: 167
 fsGroup:
   type: MustRunAs
+  ranges:
+    - min: 167
+      max: 167
 supplementalGroups:
   type: RunAsAny
 volumes:
@@ -43,7 +75,6 @@ users:
   # A user needs to be added for each rook service account.
   # This assumes running in the default sample "rook-ceph" namespace.
   # If other namespaces or service accounts are configured, they need to be updated here.
-  - system:serviceaccount:rook-ceph:rook-ceph-system # serviceaccount:namespace:operator
   - system:serviceaccount:rook-ceph:default # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-mgr # serviceaccount:namespace:cluster
   - system:serviceaccount:rook-ceph:rook-ceph-osd # serviceaccount:namespace:cluster

--- a/pkg/apis/ceph.rook.io/v1/scc.go
+++ b/pkg/apis/ceph.rook.io/v1/scc.go
@@ -24,53 +24,101 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	CephUserID = int64(167)
+)
+
 // NewSecurityContextConstraints returns a new SecurityContextConstraints for Rook-Ceph to run on
 // OpenShift.
-func NewSecurityContextConstraints(name, namespace string) *secv1.SecurityContextConstraints {
-	return &secv1.SecurityContextConstraints{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "security.openshift.io/v1",
-			Kind:       "SecurityContextConstraints",
+func NewSecurityContextConstraints(namespace string) []*secv1.SecurityContextConstraints {
+	rookUserUID := int64(2016)
+	return []*secv1.SecurityContextConstraints{
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "security.openshift.io/v1",
+				Kind:       "SecurityContextConstraints",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rook-ceph-operator",
+				Namespace: namespace,
+			},
+
+			// AllowHostDirVolumePlugin allows pod to use the hostPath plugin for volumes to write log files
+			AllowHostDirVolumePlugin: true,
+			ReadOnlyRootFilesystem:   false,
+			AllowHostIPC:             false,
+			AllowHostNetwork:         false,
+			AllowHostPorts:           false,
+			RequiredDropCapabilities: []corev1.Capability{},
+			DefaultAddCapabilities:   []corev1.Capability{},
+			AllowedCapabilities:      []corev1.Capability{},
+			RunAsUser: secv1.RunAsUserStrategyOptions{
+				Type: secv1.RunAsUserStrategyMustRunAs,
+				UID:  &rookUserUID,
+			},
+			SELinuxContext: secv1.SELinuxContextStrategyOptions{
+				Type: secv1.SELinuxStrategyMustRunAs,
+			},
+			FSGroup: secv1.FSGroupStrategyOptions{
+				Type: secv1.FSGroupStrategyMustRunAs,
+			},
+			SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
+				Type: secv1.SupplementalGroupsStrategyRunAsAny,
+			},
+			Volumes: []secv1.FSType{},
+			Users: []string{
+				fmt.Sprintf("system:serviceaccount:%s:rook-ceph-system", namespace),
+			},
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		AllowPrivilegedContainer: true,
-		AllowHostDirVolumePlugin: true,
-		ReadOnlyRootFilesystem:   false,
-		AllowHostIPC:             true,
-		AllowHostNetwork:         false,
-		AllowHostPorts:           false,
-		AllowedCapabilities:      []corev1.Capability{"MKNOD"},
-		RequiredDropCapabilities: []corev1.Capability{},
-		DefaultAddCapabilities:   []corev1.Capability{},
-		RunAsUser: secv1.RunAsUserStrategyOptions{
-			Type: secv1.RunAsUserStrategyRunAsAny,
-		},
-		SELinuxContext: secv1.SELinuxContextStrategyOptions{
-			Type: secv1.SELinuxStrategyMustRunAs,
-		},
-		FSGroup: secv1.FSGroupStrategyOptions{
-			Type: secv1.FSGroupStrategyMustRunAs,
-		},
-		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
-			Type: secv1.SupplementalGroupsStrategyRunAsAny,
-		},
-		Volumes: []secv1.FSType{
-			secv1.FSTypeConfigMap,
-			secv1.FSTypeDownwardAPI,
-			secv1.FSTypeEmptyDir,
-			secv1.FSTypeHostPath,
-			secv1.FSTypePersistentVolumeClaim,
-			secv1.FSProjected,
-			secv1.FSTypeSecret,
-		},
-		Users: []string{
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-system", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:default", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-mgr", namespace),
-			fmt.Sprintf("system:serviceaccount:%s:rook-ceph-osd", namespace),
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "security.openshift.io/v1",
+				Kind:       "SecurityContextConstraints",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rook-ceph",
+				Namespace: namespace,
+			},
+			// AllowPrivilegedContainer is set to true so that the Rook-Ceph pods can run privileged
+			// It is useful when preparing disks to become OSDs.
+			AllowPrivilegedContainer: true,
+			// AllowHostDirVolumePlugin allows pod to use the hostPath plugin for volumes to write log files
+			AllowHostDirVolumePlugin: true,
+			ReadOnlyRootFilesystem:   false,
+			// AllowHostIPC is required when cluster-wide encryption is turned on
+			AllowHostIPC:             true,
+			AllowHostNetwork:         false,
+			AllowHostPorts:           false,
+			RequiredDropCapabilities: []corev1.Capability{},
+			DefaultAddCapabilities:   []corev1.Capability{},
+			AllowedCapabilities:      []corev1.Capability{"MKNOD"},
+			RunAsUser: secv1.RunAsUserStrategyOptions{
+				Type: secv1.RunAsUserStrategyMustRunAs,
+				UID:  &CephUserID,
+			},
+			SELinuxContext: secv1.SELinuxContextStrategyOptions{
+				Type: secv1.SELinuxStrategyMustRunAs,
+			},
+			FSGroup: secv1.FSGroupStrategyOptions{
+				Type: secv1.FSGroupStrategyMustRunAs,
+			},
+			SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
+				Type: secv1.SupplementalGroupsStrategyRunAsAny,
+			},
+			Volumes: []secv1.FSType{
+				secv1.FSTypeConfigMap,
+				secv1.FSTypeDownwardAPI,
+				secv1.FSTypeEmptyDir,
+				secv1.FSTypeHostPath,
+				secv1.FSTypePersistentVolumeClaim,
+				secv1.FSProjected,
+				secv1.FSTypeSecret,
+			},
+			Users: []string{
+				fmt.Sprintf("system:serviceaccount:%s:default", namespace),
+				fmt.Sprintf("system:serviceaccount:%s:rook-ceph-mgr", namespace),
+				fmt.Sprintf("system:serviceaccount:%s:rook-ceph-osd", namespace),
+			},
 		},
 	}
 }

--- a/pkg/apis/ceph.rook.io/v1/scc_test.go
+++ b/pkg/apis/ceph.rook.io/v1/scc_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestNewSecurityContextConstraints(t *testing.T) {
 	name := "rook-ceph"
-	scc := NewSecurityContextConstraints(name, name)
-	assert.True(t, scc.AllowPrivilegedContainer)
-	assert.Equal(t, name, scc.Name)
+	scc := NewSecurityContextConstraints(name)
+	assert.True(t, scc[1].AllowPrivilegedContainer)
+	assert.Equal(t, name, scc[1].Name)
 }

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -278,10 +278,10 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 	err := os.MkdirAll(cvLogDir, 0750)
 	if err != nil {
 		logger.Errorf("failed to create ceph-volume log directory %q, continue with default %q. %v", cvLogDir, cephLogDir, err)
-		baseArgs = []string{"-oL", cephVolumeCmd, cephVolumeMode, "prepare", "--bluestore"}
+		baseArgs = []string{"-oL", cephVolumeCmd, cephVolumeMode, "prepare", "--bluestore", "--no-tmpfs"}
 	} else {
 		// Always force Bluestore!
-		baseArgs = []string{"-oL", cephVolumeCmd, "--log-path", cvLogDir, cephVolumeMode, "prepare", "--bluestore"}
+		baseArgs = []string{"-oL", cephVolumeCmd, "--log-path", cvLogDir, cephVolumeMode, "prepare", "--bluestore", "--no-tmpfs"}
 	}
 
 	var metadataArg, walArg []string

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -239,14 +239,13 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 func (c *Cluster) makeCmdProxySidecarContainer(mgrConfig *mgrConfig) v1.Container {
 	_, adminKeyringVolMount := keyring.Volume().Admin(), keyring.VolumeMount().Admin()
 	container := v1.Container{
-		Name:            client.CommandProxyInitContainerName,
-		Command:         []string{"sleep"},
-		Args:            []string{"infinity"},
-		Image:           c.spec.CephVersion.Image,
-		VolumeMounts:    append(controller.DaemonVolumeMounts(mgrConfig.DataPathMap, mgrConfig.ResourceName), adminKeyringVolMount),
-		Env:             append(controller.DaemonEnvVars(c.spec.CephVersion.Image), v1.EnvVar{Name: "CEPH_ARGS", Value: fmt.Sprintf("-m $(ROOK_CEPH_MON_HOST) -k %s", keyring.VolumeMount().AdminKeyringFilePath())}),
-		Resources:       cephv1.GetMgrResources(c.spec.Resources),
-		SecurityContext: controller.PodSecurityContext(),
+		Name:         client.CommandProxyInitContainerName,
+		Command:      []string{"sleep"},
+		Args:         []string{"infinity"},
+		Image:        c.spec.CephVersion.Image,
+		VolumeMounts: append(controller.DaemonVolumeMounts(mgrConfig.DataPathMap, mgrConfig.ResourceName), adminKeyringVolMount),
+		Env:          append(controller.DaemonEnvVars(c.spec.CephVersion.Image), v1.EnvVar{Name: "CEPH_ARGS", Value: fmt.Sprintf("-m $(ROOK_CEPH_MON_HOST) -k %s", keyring.VolumeMount().AdminKeyringFilePath())}),
+		Resources:    cephv1.GetMgrResources(c.spec.Resources),
 	}
 
 	return container

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -197,6 +197,9 @@ func cephVolumeEnvVar() []v1.EnvVar {
 		// LVM will avoid interaction with udev.
 		// LVM will manage the relevant nodes in /dev directly.
 		{Name: "DM_DISABLE_UDEV", Value: "1"},
+		// CEPH_VOLUME_SKIP_NEEDS_ROOT indicates to ceph-volume to not look if the process is
+		// running as root and then fail otherwise
+		{Name: "CEPH_VOLUME_SKIP_NEEDS_ROOT", Value: "1"},
 	}
 }
 

--- a/pkg/operator/ceph/config/config.go
+++ b/pkg/operator/ceph/config/config.go
@@ -63,6 +63,9 @@ const (
 
 	// CephGroup is the Linux Ceph groupname
 	CephGroup = "ceph"
+
+	// EtcLogRotateCephDir defines Ceph logrotate directory.
+	EtcLogRotateCeph = "/etc/logrotate.d/ceph"
 )
 
 var (

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -485,7 +485,6 @@ func GenerateMinimalCephConfInitContainer(
 	containerImage string,
 	volumeMounts []v1.VolumeMount,
 	resources v1.ResourceRequirements,
-	securityContext *v1.SecurityContext,
 ) v1.Container {
 	cfgPath := client.DefaultConfigFilePath()
 	// Note that parameters like $(PARAM) will be replaced by Kubernetes with env var content before
@@ -506,14 +505,13 @@ chmod 444 ` + cfgPath + `
 cat ` + cfgPath + `
 `
 	return v1.Container{
-		Name:            "generate-minimal-ceph-conf",
-		Command:         []string{"/bin/bash", "-c", confScript},
-		Args:            []string{},
-		Image:           containerImage,
-		VolumeMounts:    volumeMounts,
-		Env:             config.StoredMonHostEnvVars(),
-		Resources:       resources,
-		SecurityContext: securityContext,
+		Name:         "generate-minimal-ceph-conf",
+		Command:      []string{"/bin/bash", "-c", confScript},
+		Args:         []string{},
+		Image:        containerImage,
+		VolumeMounts: volumeMounts,
+		Env:          config.StoredMonHostEnvVars(),
+		Resources:    resources,
 	}
 }
 

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -187,7 +187,6 @@ func (r *ReconcileCephNFS) connectionConfigInitContainer(nfs *cephv1.CephNFS, na
 			keyring.VolumeMount().Resource(instanceName(nfs, name)),
 		},
 		nfs.Spec.Server.Resources,
-		controller.PodSecurityContext(),
 	)
 }
 

--- a/pkg/operator/ceph/nfs/spec.go
+++ b/pkg/operator/ceph/nfs/spec.go
@@ -217,9 +217,10 @@ func (r *ReconcileCephNFS) daemonContainer(nfs *cephv1.CephNFS, cfg daemonConfig
 			nfsConfigMount,
 			dbusMount,
 		},
-		Env:             controller.DaemonEnvVars(r.cephClusterSpec.CephVersion.Image),
-		Resources:       nfs.Spec.Server.Resources,
-		SecurityContext: controller.PodSecurityContext(),
+		Env:       controller.DaemonEnvVars(r.cephClusterSpec.CephVersion.Image),
+		Resources: nfs.Spec.Server.Resources,
+		// TODO: can we remove this? And let the container run unprivileged?
+		SecurityContext: controller.ContainerSecurityContext(),
 	}
 }
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

core: add CHOWN capability to init container
Previously the chown init container when running on OpenShift was
running privileged. Now, we always add the minimal privileges needed
which is the CAP_CHOWN. Also, a small refactor has been done to
incorporate a common helper that adds CAPS to a given container through
security context.

core: remove unnecessary permissions to init containers
We don't need privileged containers for those init containers. The
`makeCmdProxySidecarContainer` just sleeps forever and proxyes CLI
commands to Ceph. And `GenerateMinimalCephConfInitContainer` simply
writes a Ceph config file in a volume. So these actions don't need to be
privileged.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
