### PR TITLE
helm: Allow further configurability of the ingress version

### DIFF
--- a/.github/workflows/integration-test-setup/action.yaml
+++ b/.github/workflows/integration-test-setup/action.yaml
@@ -19,9 +19,9 @@ runs:
       - name: setup minikube
         uses: manusa/actions-setup-minikube@v2.4.2
         with:
-          minikube version: "v1.23.2"
+          minikube version: "v1.24.0"
           kubernetes version: ${{ inputs.kubernetes-version }}
-          start args: --memory 6g --cpus=2
+          start args: --memory 6g --cpus=2 --addons ingress
           github token: ${{ inputs.github-token }}
 
       - name: print k8s cluster status

--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -16,9 +16,9 @@ runs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.23.2'
+        minikube version: 'v1.24.0'
         kubernetes version: 'v1.22.2'
-        start args: --memory 6g --cpus=2
+        start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 
     - name: install deps

--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -57,6 +57,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | Parameter              | Description                                                          | Default     |
 | ---------------------- | -------------------------------------------------------------------- | ----------- |
 | `operatorNamespace`    | Namespace of the Rook Operator                                       | `rook-ceph` |
+| `kubeVersion`          | Optional override of the target kubernetes version                   | ``          |
 | `configOverride`       | Cluster ceph.conf override                                           | <empty>     |
 | `toolbox.enabled`      | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
 | `toolbox.tolerations`  | Toolbox tolerations                                                  | `[]`        |

--- a/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -4,3 +4,23 @@ Define the clusterName as defaulting to the release namespace
 {{- define "clusterName" -}}
 {{ .Values.clusterName | default .Release.Namespace }}
 {{- end -}}
+
+{{/*
+Return the target Kubernetes version.
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.ingress.dashboard.host }}
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
+apiVersion: {{ include "capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "clusterName" . }}-dashboard
@@ -20,7 +14,14 @@ spec:
         paths:
           - path: {{ .Values.ingress.dashboard.host.path | default "/" }}
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if (semverCompare "<1.18-0" (include "capabilities.kubeVersion" .)) }}
+              serviceName: rook-ceph-mgr-dashboard
+              {{- if .Values.cephClusterSpec.dashboard.ssl }}
+              servicePort: https-dashboard
+              {{- else }}
+              servicePort: http-dashboard
+              {{- end }}
+{{- else }}
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
@@ -30,13 +31,6 @@ spec:
                   name: http-dashboard
                   {{- end }}
             pathType: Prefix
-{{- else }}
-              serviceName: rook-ceph-mgr-dashboard
-              {{- if .Values.cephClusterSpec.dashboard.ssl }}
-              servicePort: https-dashboard
-              {{- else }}
-              servicePort: http-dashboard
-              {{- end }}
 {{- end }}
   {{- if .Values.ingress.dashboard.tls }}
   tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -8,6 +8,9 @@ operatorNamespace: rook-ceph
 # The metadata.name of the CephCluster CR. The default name is the same as the namespace.
 # clusterName: rook-ceph
 
+# Ability to override the kubernetes version used in rendering the helm chart
+# kubeVersion: 1.21
+
 # Ability to override ceph.conf
 # configOverride: |
 #   [global]

--- a/tests/integration/ceph_base_deploy_test.go
+++ b/tests/integration/ceph_base_deploy_test.go
@@ -74,6 +74,12 @@ func checkIfRookClusterIsHealthy(s suite.Suite, testClient *clients.TestClient, 
 	require.Nil(s.T(), err)
 }
 
+func checkIfRookClusterHasHealthyIngress(s suite.Suite, k8sh *utils.K8sHelper, clusterNamespace string) {
+	logger.Infof("Testing ingress %s health", clusterNamespace)
+	_, err := k8sh.GetResourceStatus("Ingress", clusterNamespace + "-dashboard", clusterNamespace)
+	assert.NoError(s.T(), err)
+}
+
 func HandlePanics(r interface{}, uninstaller func(), t func() *testing.T) {
 	if r != nil {
 		logger.Infof("unexpected panic occurred during test %s, --> %v", t().Name(), r)

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -91,6 +91,7 @@ func (h *HelmSuite) AfterTest(suiteName, testName string) {
 // Test to make sure all rook components are installed and Running
 func (h *HelmSuite) TestARookInstallViaHelm() {
 	checkIfRookClusterIsInstalled(h.Suite, h.k8shelper, h.settings.Namespace, h.settings.Namespace, 1)
+ 	checkIfRookClusterHasHealthyIngress(h.Suite, h.k8shelper, h.settings.Namespace)
 }
 
 // Test BlockCreation on Rook that was installed via Helm


### PR DESCRIPTION
The ingress api version changed when it went to v1, and this has caused a lot of problems on how this is handled across the helm ecosystem.
This PR uses the standard introduced by bitnami to deal with overriding the ingress version.

**Description of your changes:**
As discussed in the issue, the helm chart cannot deploy to clusters older than 1.18.

**Which issue is resolved by this Pull Request:**
Resolves #9174

**Checklist:**

- [X] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [X] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [X] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [X] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [X] Documentation has been updated, if necessary.
- [X] Unit tests have been added, if necessary.
- [X] Integration tests have been added, if necessary.
- [X] Pending release notes updated with breaking and/or notable changes, if necessary.
- [X] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [X] Code generation (`make codegen`) has been run to update object specifications, if necessary.
