### PR TITLE
#8502: Make monitoring object labels overridable

### DIFF
--- a/pkg/apis/ceph.rook.io/v1/labels.go
+++ b/pkg/apis/ceph.rook.io/v1/labels.go
@@ -88,6 +88,16 @@ func (a Labels) ApplyToObjectMeta(t *metav1.ObjectMeta) {
 	}
 }
 
+// OverwriteApplyToObjectMeta adds labels to object meta, overwriting keys that are already defined.
+func (a Labels) OverwriteApplyToObjectMeta(t *metav1.ObjectMeta) {
+	if t.Labels == nil {
+		t.Labels = map[string]string{}
+	}
+	for k, v := range a {
+		t.Labels[k] = v
+	}
+}
+
 // Merge returns a Labels which results from merging the attributes of the
 // original Labels with the attributes of the supplied one. The supplied
 // Labels attributes will override the original ones if defined.

--- a/pkg/apis/ceph.rook.io/v1/labels_test.go
+++ b/pkg/apis/ceph.rook.io/v1/labels_test.go
@@ -153,6 +153,60 @@ func TestLabelsApply(t *testing.T) {
 	}
 }
 
+func TestLabelsOverwriteApply(t *testing.T) {
+	tcs := []struct {
+		name     string
+		target   *metav1.ObjectMeta
+		input    Labels
+		expected Labels
+	}{
+		{
+			name:   "it should be able to update meta with no label",
+			target: &metav1.ObjectMeta{},
+			input: Labels{
+				"foo": "bar",
+			},
+			expected: Labels{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "it should keep the original labels when new labels are set",
+			target: &metav1.ObjectMeta{
+				Labels: Labels{
+					"foo": "bar",
+				},
+			},
+			input: Labels{
+				"hello": "world",
+			},
+			expected: Labels{
+				"foo":   "bar",
+				"hello": "world",
+			},
+		},
+		{
+			name: "it should overwrite the existing keys",
+			target: &metav1.ObjectMeta{
+				Labels: Labels{
+					"foo": "bar",
+				},
+			},
+			input: Labels{
+				"foo": "baz",
+			},
+			expected: Labels{
+				"foo": "baz",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		tc.input.OverwriteApplyToObjectMeta(tc.target)
+		assert.Equal(t, map[string]string(tc.expected), tc.target.Labels)
+	}
+}
+
 func TestLabelsMerge(t *testing.T) {
 	testLabelsPart1 := Labels{
 		"foo":   "bar",

--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -465,7 +465,7 @@ func (c *Cluster) EnableServiceMonitor(activeDaemon string) error {
 	}
 	serviceMonitor.SetName(AppName)
 	serviceMonitor.SetNamespace(c.clusterInfo.Namespace)
-	cephv1.GetMonitoringLabels(c.spec.Labels).ApplyToObjectMeta(&serviceMonitor.ObjectMeta)
+	cephv1.GetMonitoringLabels(c.spec.Labels).OverwriteApplyToObjectMeta(&serviceMonitor.ObjectMeta)
 
 	if c.spec.External.Enable {
 		serviceMonitor.Spec.Endpoints[0].Port = controller.ServiceExternalMetricName
@@ -501,7 +501,7 @@ func (c *Cluster) DeployPrometheusRule(name, namespace string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to set owner reference to prometheus rule %q", prometheusRule.Name)
 	}
-	cephv1.GetMonitoringLabels(c.spec.Labels).ApplyToObjectMeta(&prometheusRule.ObjectMeta)
+	cephv1.GetMonitoringLabels(c.spec.Labels).OverwriteApplyToObjectMeta(&prometheusRule.ObjectMeta)
 	if _, err := k8sutil.CreateOrUpdatePrometheusRule(prometheusRule); err != nil {
 		return errors.Wrap(err, "prometheus rule could not be deployed")
 	}

--- a/pkg/operator/k8sutil/prometheus_test.go
+++ b/pkg/operator/k8sutil/prometheus_test.go
@@ -32,6 +32,7 @@ func TestGetServiceMonitor(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "rook-ceph-mgr", servicemonitor.GetName())
 	assert.Equal(t, "rook-ceph", servicemonitor.GetNamespace())
+	assert.NotNil(t, servicemonitor.GetLabels())
 	assert.NotNil(t, servicemonitor.Spec.NamespaceSelector.MatchNames)
 	assert.NotNil(t, servicemonitor.Spec.Endpoints)
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

The templates for the mgr-generated ServiceMonitor and PrometheusRule objects included the labels prometheus and team, making it impossible to override them as user.

This removes these labels from the templates and sets them in code, if not already set by the user.

**Which issue is resolved by this Pull Request:**
Resolves #8502

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
