### PR TITLE
helm: Set correct ingress endpoint protocol

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -24,11 +24,19 @@ spec:
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
+                  {{- if .Values.cephClusterSpec.dashboard.ssl }}
+                  name: https-dashboard
+                  {{- else }}
                   name: http-dashboard
+                  {{- end }}
             pathType: Prefix
 {{- else }}
               serviceName: rook-ceph-mgr-dashboard
+              {{- if .Values.cephClusterSpec.dashboard.ssl }}
+              servicePort: https-dashboard
+              {{- else }}
               servicePort: http-dashboard
+              {{- end }}
 {{- end }}
   {{- if .Values.ingress.dashboard.tls }}
   tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -98,6 +98,8 @@ cephClusterSpec:
     # urlPrefix: /ceph-dashboard
     # serve the dashboard at the given port.
     # port: 8443
+    # serve the dashboard using SSL
+    ssl: true
 
   # Network configuration, see: https://github.com/rook/rook/blob/master/Documentation/ceph-cluster-crd.md#network-configuration-settings
   # network:


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
In the helm chart, the ingress for the dashbard was always referring to the http-dashboard port on the dashboard service. If ssl is enabled the https-dashboard port must be specified, or else the dashboard will not be available through the ingress.

The default is also changed from http to https when the dashboard is installed through the cluster helm chart.

**Which issue is resolved by this Pull Request:**
Resolves #9152 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
