### PR TITLE
docs: add OMAP quick fix warning to upgrade guide

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -416,6 +416,49 @@ updated we wait for things to settle (monitors to be in a quorum, PGs to be clea
 MDSes, etc.), then only when the condition is met we move to the next daemon. We repeat this process
 until all the daemons have been updated.
 
+### Disable `bluestore_fsck_quick_fix_on_mount`
+> **WARNING: There is a notice from Ceph for users upgrading to Ceph Pacific v16.2.6 or lower from
+> an earlier major version of Ceph. If you are upgrading to Ceph Pacific (v16), please upgrade to
+> v16.2.7 or higher if possible.**
+
+If you must upgrade to a version lower than v16.2.7, ensure that all instances of
+`bluestore_fsck_quick_fix_on_mount` in Rook-Ceph configs are removed.
+
+First, Ensure no references to `bluestore_fsck_quick_fix_on_mount` are present in the
+`rook-config-override` [ConfigMap](ceph-advanced-configuration.md#custom-cephconf-settings). Remove
+them if they exist.
+
+Finally, ensure no references to `bluestore_fsck_quick_fix_on_mount` are present in Ceph's internal
+configuration. Run all commands below from the [toolbox](ceph-toolbox.md).
+
+In the example below, two instances of `bluestore_fsck_quick_fix_on_mount` are present and are
+commented, and some output text has been removed for brevity.
+```sh
+ceph config-key dump
+```
+```
+{
+    "config/global/bluestore_fsck_quick_fix_on_mount": "false",       # <-- FALSE
+    "config/global/osd_scrub_auto_repair": "true",
+    "config/mgr.a/mgr/dashboard/server_port": "7000",
+    "config/mgr/mgr/balancer/active": "true",
+    "config/osd/bluestore_fsck_quick_fix_on_mount": "true",           # <-- TRUE
+}
+```
+
+Remove the configs for both with the commands below. Note how the `config/...` paths correspond to
+the output above.
+```sh
+ceph config-key rm config/global/bluestore_fsck_quick_fix_on_mount
+ceph config-key rm config/osd/bluestore_fsck_quick_fix_on_mount
+```
+
+It's best to run `ceph config-key dump` again to verify references to
+`bluestore_fsck_quick_fix_on_mount` are gone after this.
+
+See for more information, see here: https://github.com/rook/rook/issues/9185
+
+
 ### **Ceph images**
 
 Official Ceph container images can be found on [Quay](https://quay.io/repository/ceph/ceph?tab=tags).


### PR DESCRIPTION
Ceph has recently reported that it may be unsafe to upgrade clusters
from Nautilus/Octopus to Pacific v16.2.0 through v16.2.6. We are
tracking this in Rook issue https://github.com/rook/rook/issues/9185.
Add a warning to the upgrade doc about this.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
