### PR TITLE
docs: remove old commitlint component `ceph` from doc

### DIFF
--- a/Documentation/development-flow.md
+++ b/Documentation/development-flow.md
@@ -290,24 +290,7 @@ Closes: https://github.com/rook/rook/issues/<NUMBER>
 Signed-off-by: First Name Last Name <email address>
 ```
 
-The `component` **MUST** be one of the following:
-- bot
-- build
-- ceph
-- cephfs-mirror
-- ci
-- core
-- csi
-- docs
-- mds
-- mgr
-- mon
-- monitoring
-- osd
-- pool
-- rbd-mirror
-- rgw
-- test
+The `component` **MUST** be in the [list checked by the CI](https://github.com/rook/rook/blob/master/.commitlintrc.json).
 
 Note: sometimes you will feel like there is not so much to say, for instance if you are fixing a typo in a text.
 In that case, it is acceptable to shorten the commit message.


### PR DESCRIPTION
Removing `ceph` component from doc as component
`ceph` was removed from commitlint bot earlier.

Signed-off-by: subhamkrai <srai@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
