### PR TITLE
osd: add privileged support (back) to blkdevmapper securityContext (work-around)

### DIFF
--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -777,12 +777,15 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 // To be able to perform this action, the CAP_MKNOD capability is required.
 // Provide a securityContext which requests the MKNOD capability for the container to function properly.
 func getBlockDevMapperContext() *v1.SecurityContext {
+	privileged := controller.HostPathRequiresPrivileged()
+
 	return &v1.SecurityContext{
 		Capabilities: &v1.Capabilities{
 			Add: []v1.Capability{
 				"MKNOD",
 			},
 		},
+		Privileged: &privileged,
 	}
 }
 

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -604,12 +604,13 @@ func (c *daemonConfig) buildAdminSocketCommand() string {
 	return command
 }
 
+func HostPathRequiresPrivileged() bool {
+	return os.Getenv("ROOK_HOSTPATH_REQUIRES_PRIVILEGED") == "true"
+}
+
 // PodSecurityContext detects if the pod needs privileges to run
 func PodSecurityContext() *v1.SecurityContext {
-	privileged := false
-	if os.Getenv("ROOK_HOSTPATH_REQUIRES_PRIVILEGED") == "true" {
-		privileged = true
-	}
+	privileged := HostPathRequiresPrivileged()
 
 	return &v1.SecurityContext{
 		Privileged: &privileged,


### PR DESCRIPTION
**Description of your changes:**
The blockdevmapper securityContext was changed to request a minimal set of required capabilities for its operation and drop running as privileged.  
While the base change works and is valid in terms of the container's copy operation, it turns out that OpenShift may require some additional configuration not currently covered by the limited securityContext and the capabilities granted.  

To not break those OpenShift deployments, make the blkdevmapper securityContext listen to the ROOK_HOSTPATH_REQUIRES_PRIVILEGED flag again to set privileged mode.  
This flag is true on OpenShift deployments and running as privileged works around the (missing) configuration problem for now.  
To properly drop privileged completely some additional investigation needs to be done on OpenShift deployments without relying on privileged execution.

This resolves the immediate problem of #9186  but just running everything privileged is not and should not be the proper solution long-term.  
According to @travisn in said issue, PR #9175 might be relevant here.

**Which issue is resolved by this Pull Request:**
Resolves #9186

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
