### PR TITLE
helm: rook-ceph-cluster chart: Streamline pool definitions

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -1,26 +1,71 @@
-{{- $root := . -}}
 {{- range $blockpool := .Values.cephBlockPools -}}
+{{- if $blockpool.spec.metadataPool }}
+{{- if not $blockpool.spec.metadataPool.replicated }}
+{{- printf "metadataPool for BlockPool %s must be a replicated pool!" $blockpool.name | fail }}
+{{- end }}
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: {{ $blockpool.name }}-metadata
+spec:
+  {{- toYaml $blockpool.spec.metadataPool | nindent 2 }}
+{{- else }}
+{{- if $blockpool.spec.dataPool.erasureCoded }}
+{{- printf "BlockPool %s requires a replica metadataPool" $blockpool.name | fail }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
   name: {{ $blockpool.name }}
 spec:
-{{ toYaml $blockpool.spec | indent 2 }}
----
+  {{- toYaml $blockpool.spec.dataPool | nindent 2 }}
 {{- if default false $blockpool.storageClass.enabled }}
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $blockpool.storageClass.name }}
+  name: {{ default $blockpool.name $blockpool.storageClass.name }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: "{{ if default false $blockpool.storageClass.isDefault }}true{{ else }}false{{ end }}"
-provisioner: {{ $root.Values.operatorNamespace }}.rbd.csi.ceph.com
+    storageclass.kubernetes.io/is-default-class: "{{ printf "%v" (default false $blockpool.storageClass.isDefault) }}"
+provisioner: {{ $.Values.operatorNamespace }}.rbd.csi.ceph.com
 parameters:
+  {{- if $blockpool.metadataPool }}
+  pool: {{ $blockpool.name }}-metadata
+  dataPool: {{ $blockpool.name }}
+  {{- else }}
   pool: {{ $blockpool.name }}
-  clusterID: {{ $root.Release.Namespace }}
-{{ toYaml $blockpool.storageClass.parameters | indent 2 }}
+  {{- end }}
+  clusterID: {{ $.Release.Namespace }}
+  imageFormat: "2"
+  imageFeatures: layering
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
+  {{- toYaml $blockpool.storageClass.parameters | nindent 2 }}
 reclaimPolicy: {{ default "Delete" $blockpool.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $blockpool.storageClass.allowVolumeExpansion }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- if default false $blockpool.snapshotClass.enabled }}
+---
+{{- if $.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
+apiVersion: snapshot.storage.k8s.io/v1
+{{- else }}
+apiVersion: snapshot.storage.k8s.io/v1beta1
+{{- end }}
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ default $blockpool.name $blockpool.snapshotClass.name }}
+driver: {{ $.Values.operatorNamespace }}.rbd.csi.ceph.com
+parameters:
+  clusterID: {{ $.Values.operatorNamespace }}
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: {{ $.Values.operatorNamespace }}
+deletionPolicy: {{ default "Delete" $blockpool.snapshotClass.deletionPolicy }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -1,4 +1,3 @@
-{{- $root := . -}}
 {{- range $filesystem := .Values.cephFileSystems -}}
 ---
 apiVersion: ceph.rook.io/v1
@@ -6,22 +5,45 @@ kind: CephFilesystem
 metadata:
   name: {{ $filesystem.name }}
 spec:
-{{ toYaml $filesystem.spec | indent 2 }}
----
+  {{- toYaml $filesystem.spec | nindent 2 }}
 {{- if default false $filesystem.storageClass.enabled }}
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $filesystem.storageClass.name }}
+  name: {{ default $filesystem.name $filesystem.storageClass.name }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: "{{ if default false $filesystem.storageClass.isDefault }}true{{ else }}false{{ end }}"
-provisioner: {{ $root.Values.operatorNamespace }}.cephfs.csi.ceph.com
+    storageclass.kubernetes.io/is-default-class: "{{ printf "%v" (default false $filesystem.storageClass.isDefault) }}"
+provisioner: {{ $.Values.operatorNamespace }}.cephfs.csi.ceph.com
 parameters:
   fsName: {{ $filesystem.name }}
   pool: {{ $filesystem.name }}-data0
-  clusterID: {{ $root.Release.Namespace }}
-{{ toYaml $filesystem.storageClass.parameters | indent 2 }}
+  clusterID: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
+  {{- toYaml $filesystem.storageClass.parameters | nindent 2 }}
 reclaimPolicy: {{ default "Delete" $filesystem.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $filesystem.storageClass.allowVolumeExpansion }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- if default false $filesystem.snapshotClass.enabled }}
+---
+{{- if $.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
+apiVersion: snapshot.storage.k8s.io/v1
+{{- else }}
+apiVersion: snapshot.storage.k8s.io/v1beta1
+{{- end }}
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ default $filesystem.name $filesystem.snapshotClass.name }}
+driver: {{ $.Values.operatorNamespace }}.cephfs.csi.ceph.com
+parameters:
+  clusterID: {{ $.Values.operatorNamespace }}
+  csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/snapshotter-secret-namespace: {{ $.Values.operatorNamespace }}
+deletionPolicy: {{ default "Delete" $filesystem.snapshotClass.deletionPolicy }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/cephobjectstore.yaml
@@ -1,4 +1,3 @@
-{{- $root := . -}}
 {{- range $objectstore := .Values.cephObjectStores -}}
 ---
 apiVersion: ceph.rook.io/v1
@@ -6,18 +5,18 @@ kind: CephObjectStore
 metadata:
   name: {{ $objectstore.name }}
 spec:
-{{ toYaml $objectstore.spec | indent 2 }}
+  {{- toYaml $objectstore.spec | nindent 2 }}
 ---
 {{- if default false $objectstore.storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $objectstore.storageClass.name }}
-provisioner: {{ $root.Release.Namespace }}.ceph.rook.io/bucket
+  name: {{ default $objectstore.name $objectstore.storageClass.name }}
+provisioner: {{ $.Release.Namespace }}.ceph.rook.io/bucket
 reclaimPolicy: {{ default "Delete" $objectstore.storageClass.reclaimPolicy }}
 parameters:
   objectStoreName: {{ $objectstore.name }}
-  objectStoreNamespace: {{ $root.Release.Namespace }}
-{{ toYaml $objectstore.storageClass.parameters | indent 2 }}
-{{ end }}
-{{ end }}
+  objectStoreNamespace: {{ $.Release.Namespace }}
+  {{- toYaml $objectstore.storageClass.parameters | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -315,17 +315,19 @@ ingress:
 
 cephBlockPools:
   - name: ceph-blockpool
-    # see https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md#spec for available configuration
     spec:
-      failureDomain: host
-      replicated:
-        size: 3
+      # Optional metadata pool definition. Required when the dataPool is an erasure coded pool.
+      # see https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md#spec for available configuration
+      #metadataPool: {}
+      # see https://github.com/rook/rook/blob/master/Documentation/ceph-pool-crd.md#spec for available configuration
+      dataPool:
+        failureDomain: host
+        replicated:
+          size: 3
     storageClass:
       enabled: true
       name: ceph-block
       isDefault: true
-      reclaimPolicy: Delete
-      allowVolumeExpansion: true
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-block.md#provision-storage for available configuration
       parameters:
         # (optional) mapOptions is a comma-separated list of map options.
@@ -342,21 +344,11 @@ cephBlockPools:
         # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
         # unmapOptions: force
 
-        # RBD image format. Defaults to "2".
-        imageFormat: "2"
-        # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
-        imageFeatures: layering
-        # The secrets contain Ceph admin credentials.
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
-        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
         # Specify the filesystem type of the volume. If not specified, csi-provisioner
         # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
         # in hyperconverged settings where the volume is mounted on the same node as the osds.
         csi.storage.k8s.io/fstype: ext4
+    snapshotClass: {}
 
 cephFileSystems:
   - name: ceph-filesystem
@@ -374,23 +366,13 @@ cephFileSystems:
         activeStandby: true
     storageClass:
       enabled: true
-      isDefault: false
-      name: ceph-filesystem
-      reclaimPolicy: Delete
-      allowVolumeExpansion: true
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-filesystem.md#provision-storage for available configuration
       parameters:
-        # The secrets contain Ceph admin credentials.
-        csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-        csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
-        csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-        csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
-        csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-        csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
         # Specify the filesystem type of the volume. If not specified, csi-provisioner
         # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
         # in hyperconverged settings where the volume is mounted on the same node as the osds.
         csi.storage.k8s.io/fstype: ext4
+    snapshotClass: {}
 
 cephObjectStores:
   - name: ceph-objectstore
@@ -417,7 +399,6 @@ cephObjectStores:
     storageClass:
       enabled: true
       name: ceph-bucket
-      reclaimPolicy: Delete
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-object-bucket-claim.md#storageclass for available configuration
       parameters:
         # note: objectStoreNamespace and objectStoreName are configured by the chart


### PR DESCRIPTION
**Description of your changes:**
The current version of the Helm chart requires a lot of manual repetition work and does not simplify the pool definitions over just manually defining pools in a spec file.  
This change unifies the pool values.yaml layout and abstracts away additional flags/options that can be inferred from the how the operator deployment sets up its environment.

Aside from the BlockPool value changes, this initial set of changes tries to maintain backward compatibility with the values as previously defined. If this is not required, some more logic could just be inferred and not be made customizable (thus simplifying things more, e.g. only ever deriving names from the top-level `name:` field)

**Which issue is resolved by this Pull Request:**
Resolves #9179 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
