### PR TITLE
docs:  jaeger tracing deployment design doc

### DIFF
--- a/design/ceph/ceph-jaeger-tracing.md
+++ b/design/ceph/ceph-jaeger-tracing.md
@@ -1,0 +1,71 @@
+---
+title: deploy jaeger tracing components to ceph cluster
+target-version: release-1.8
+---
+
+# Tracing - Jaeger
+
+## Summary
+
+In order to make it possible to trace in Ceph, we would need the components of jaeger tracing to be deployed in the ceph cluster.
+
+the jaeger components consists of:
+1. elasticsearch - needs to be manually deployed.
+2. jaeger collector, agent and UI - are all managed by the jaeger Operator.
+
+[Jaeger operator documentation](https://www.jaegertracing.io/docs/1.28/operator/)
+
+### Goals
+
+to be able to see traces from the ceph cluster (rgw and osd) in the jaeger UI.
+
+## Proposal details
+
+When Ceph is deployed via Rook, we would like to add a parameter to the rook CR that will indicate to enable tracing and deploy the jaeger resources.
+
+<b> Ceph cluster yaml file:
+```yaml
+  apiVersion: ceph.rook.io/v1
+  kind: CephCluster
+  metadata:
+    name: rook-ceph
+    namespace: rook-ceph
+    [...]
+  spec:
+    [...]
+    tracing:
+      enabled: true
+    [...]
+
+```
+<b> default jaeger CR:
+```yaml
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger-production
+spec:
+  strategy: production
+  collector:
+    maxReplicas: 5
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  storage:
+    type: elasticsearch
+    options:
+      es:
+        server-urls: http://elasticsearch:9200
+```
+
+This feature won't install the Jaeger operator. it will be required to have ElasticSearch and Jaeger operator pre-installed,
+so we will document the process of installing the Jaeger operator, and how to enable tracing in rook CR.
+
+We also will need to add annotations to the rgw and osd deployments in order to auto-inject Jaeger Agent sidecar. 
+the annotation as described in Jaeger operator documentation:
+```yaml
+  annotations:
+    "sidecar.jaegertracing.io/inject": "true"
+```
+


### PR DESCRIPTION
Signed-off-by: Omri Zeneva <ozeneva@redhat.com>

This is a design doc for deploying Jaeger tracing components to ceph cluster using the [Jaeger operator](https://www.jaegertracing.io/docs/1.28/operator/)

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitsign docting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
