### PR TITLE
helm: allow further configurability of ingress version (manual backport)

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -57,6 +57,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | Parameter              | Description                                                          | Default     |
 | ---------------------- | -------------------------------------------------------------------- | ----------- |
 | `operatorNamespace`    | Namespace of the Rook Operator                                       | `rook-ceph` |
+| `kubeVersion`          | Optional override of the target kubernetes version                   | ``          |
 | `configOverride`       | Cluster ceph.conf override                                           | <empty>     |
 | `toolbox.enabled`      | Enable Ceph debugging pod deployment. See [toolbox](ceph-toolbox.md) | `false`     |
 | `toolbox.tolerations`  | Toolbox tolerations                                                  | `[]`        |

--- a/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/cluster/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -31,3 +31,23 @@ Define the clusterName as defaulting to the release namespace
 {{- define "clusterName" -}}
 {{ .Values.clusterName | default .Release.Namespace }}
 {{- end -}}
+
+{{/*
+Return the target Kubernetes version.
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "capabilities.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (include "capabilities.kubeVersion" .) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.ingress.dashboard.host }}
 ---
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end -}}
+apiVersion: {{ include "capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "clusterName" . }}-dashboard
@@ -20,7 +14,14 @@ spec:
         paths:
           - path: {{ .Values.ingress.dashboard.host.path | default "/" }}
             backend:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- if (semverCompare "<1.18-0" (include "capabilities.kubeVersion" .)) }}
+              serviceName: rook-ceph-mgr-dashboard
+              {{- if .Values.cephClusterSpec.dashboard.ssl }}
+              servicePort: https-dashboard
+              {{- else }}
+              servicePort: http-dashboard
+              {{- end }}
+{{- else }}
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
@@ -30,13 +31,6 @@ spec:
                   name: http-dashboard
                   {{- end }}
             pathType: Prefix
-{{- else }}
-              serviceName: rook-ceph-mgr-dashboard
-              {{- if .Values.cephClusterSpec.dashboard.ssl }}
-              servicePort: https-dashboard
-              {{- else }}
-              servicePort: http-dashboard
-              {{- end }}
 {{- end }}
   {{- if .Values.ingress.dashboard.tls }}
   tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}

--- a/cluster/charts/rook-ceph-cluster/values.yaml
+++ b/cluster/charts/rook-ceph-cluster/values.yaml
@@ -8,6 +8,9 @@ operatorNamespace: rook-ceph
 # The metadata.name of the CephCluster CR. The default name is the same as the namespace.
 # clusterName: rook-ceph
 
+# Ability to override the kubernetes version used in rendering the helm chart
+# kubeVersion: 1.21
+
 # Ability to override ceph.conf
 # configOverride: |
 #   [global]


### PR DESCRIPTION
The ingress api version changed when it went to v1, and this has caused some upheaval
throughout the kubernetes ecosystem. This commit uses a common method of deciding which
ingress api to use, and allows the optional override of the kubernetes version
presented to helm using the helm build-in capabilities.
also add an ingress into the helm integration tests so any regressions to how ingresses
are handled in the future are caught easier.

Closes rook#9174

Signed-off-by: Tom Hellier <me@tomhellier.com>
(cherry picked from commit ba4460247710124d00d8768614f7dd2dcd8c8758)

**Which issue is resolved by this Pull Request:**
Resolves #9232 
