### PR TITLE
cephfs-mirror: various fixes for random bootstrap peer import errors

### DIFF
--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -96,16 +96,18 @@ type CephToolCommand struct {
 	args            []string
 	timeout         time.Duration
 	JsonOutput      bool
+	combinedOutput  bool
 	RemoteExecution bool
 }
 
 func newCephToolCommand(tool string, context *clusterd.Context, clusterInfo *ClusterInfo, args []string) *CephToolCommand {
 	return &CephToolCommand{
-		context:     context,
-		tool:        tool,
-		clusterInfo: clusterInfo,
-		args:        args,
-		JsonOutput:  true,
+		context:        context,
+		tool:           tool,
+		clusterInfo:    clusterInfo,
+		args:           args,
+		JsonOutput:     true,
+		combinedOutput: false,
 	}
 }
 
@@ -173,7 +175,11 @@ func (c *CephToolCommand) run() ([]byte, error) {
 			output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)
 		}
 	} else if c.timeout == 0 {
-		output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
+		if c.combinedOutput {
+			output, err = c.context.Executor.ExecuteCommandWithCombinedOutput(command, args...)
+		} else {
+			output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
+		}
 	} else {
 		output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)
 	}

--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -173,6 +173,7 @@ func ImportFSMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluster
 	args := []string{"fs", "snapshot", "mirror", "peer_bootstrap", "import", fsName, strings.TrimSpace(token)}
 	cmd := NewCephCommand(context, clusterInfo, args)
 	cmd.JsonOutput = false
+	cmd.combinedOutput = true
 
 	// Run command
 	output, err := cmd.Run()

--- a/pkg/daemon/ceph/client/filesystem_mirror.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror.go
@@ -170,8 +170,9 @@ func ImportFSMirrorBootstrapPeer(context *clusterd.Context, clusterInfo *Cluster
 	logger.Infof("importing cephfs bootstrap peer token for filesystem %q", fsName)
 
 	// Build command
-	args := []string{"fs", "snapshot", "mirror", "peer_bootstrap", "import", fsName, token}
+	args := []string{"fs", "snapshot", "mirror", "peer_bootstrap", "import", fsName, strings.TrimSpace(token)}
 	cmd := NewCephCommand(context, clusterInfo, args)
+	cmd.JsonOutput = false
 
 	// Run command
 	output, err := cmd.Run()


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

cephfs-mirror: try to mitigate peer import error
Some users have reported issues while adding the token, this is not
always reproducible so perhaps it's a typo when importing the token and
adding trailing spaces.

core: add the ability to execute ceph commands with a combined output
Sometimes Ceph uses a different standard output to return errors or
merges standard error to standard out. So let's allow some commands to
return both in the output.

cephfs-mirror: use the combined output to possibly catch peer import error
By adding combined output to the executor we might be able to fetch more
error messages.

Signed-off-by: Sébastien Han <seb@redhat.com>

**Which issue is resolved by this Pull Request:**
Resolves #9151

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
