### PR TITLE
mon: Set stretch tiebreaker reliably during failover

### DIFF
--- a/pkg/daemon/ceph/client/mon.go
+++ b/pkg/daemon/ceph/client/mon.go
@@ -64,6 +64,7 @@ type MonDump struct {
 	FSID             string         `json:"fsid"`
 	Mons             []MonDumpEntry `json:"mons"`
 	Quorum           []int          `json:"quorum"`
+	TiebreakerMon    string         `json:"tiebreaker_mon"`
 }
 
 type MonDumpEntry struct {
@@ -141,7 +142,7 @@ func SetMonStretchTiebreaker(context *clusterd.Context, clusterInfo *ClusterInfo
 		if code, ok := exec.ExitStatus(err); ok && code == int(syscall.EINVAL) {
 			// TODO: Get a more distinctive error from ceph so we don't have to compare the error message
 			if strings.Contains(string(buf), "stretch mode is already engaged") {
-				logger.Infof("stretch mode is already enabled")
+				logger.Info("stretch mode is already enabled")
 				return nil
 			}
 			return errors.Wrapf(err, "stretch mode failed to be enabled. %s", string(buf))

--- a/pkg/operator/ceph/cluster/cluster.go
+++ b/pkg/operator/ceph/cluster/cluster.go
@@ -138,8 +138,7 @@ func (c *cluster) reconcileCephDaemons(rookImage string, cephVersion cephver.Cep
 
 	// If a stretch cluster, enable the arbiter after the OSDs are created with the CRUSH map
 	if c.Spec.IsStretchCluster() {
-		failingOver := false
-		if err := c.mons.ConfigureArbiter(failingOver); err != nil {
+		if err := c.mons.ConfigureArbiter(); err != nil {
 			return errors.Wrap(err, "failed to configure stretch arbiter")
 		}
 	}

--- a/pkg/operator/ceph/cluster/mon/health.go
+++ b/pkg/operator/ceph/cluster/mon/health.go
@@ -453,9 +453,7 @@ func (c *Cluster) failoverMon(name string) error {
 
 	// remove the failed mon from a local list of the existing mons for finding a stretch zone
 	existingMons := c.clusterInfoToMonConfig(name)
-	// Cache the name of the current arbiter in case it is updated during the failover
-	// This allows a simple check for updating the arbiter later in this method
-	currentArbiter := c.arbiterMon
+
 	zone, err := c.findAvailableZoneIfStretched(existingMons)
 	if err != nil {
 		return errors.Wrap(err, "failed to find available stretch zone")
@@ -494,10 +492,9 @@ func (c *Cluster) failoverMon(name string) error {
 	}
 
 	// Assign to a zone if a stretch cluster
-	if c.spec.IsStretchCluster() && name == currentArbiter {
+	if c.spec.IsStretchCluster() {
 		// Update the arbiter mon for the stretch cluster if it changed
-		failingOver := true
-		if err := c.ConfigureArbiter(failingOver); err != nil {
+		if err := c.ConfigureArbiter(); err != nil {
 			return errors.Wrap(err, "failed to configure stretch arbiter")
 		}
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The failover of the arbiter mon in a stretch cluster was sometimes failing due to the new tiebreaker not being set in ceph. Rook would repeatedly try to remove the old tiebreaker mon and keep failing because the new tiebreaker had not been set. Now we make setting the tiebreaker idempotent in case the operator restarts in the middle of the operation or some other corner case causes the expected tiebreaker to be set. In that case, the next reconcile will also ensure the tiebreaker mon is set as expected.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
