### PR TITLE
helm: addition of mountOptions into storage class configuration

### DIFF
--- a/Documentation/helm-ceph-cluster.md
+++ b/Documentation/helm-ceph-cluster.md
@@ -88,6 +88,7 @@ The `cephBlockPools` array in the values file will define a list of CephBlockPoo
 | `storageClass.parameters`           | See [Block Storage](ceph-block.md) documentation or the helm values.yaml for suitable values                                                                                                                            | see values.yaml  |
 | `storageClass.reclaimPolicy`        | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class.                                                             | `Delete`         |
 | `storageClass.allowVolumeExpansion` | Whether [volume expansion](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion) is allowed by default.                                                                                  | `true`           |
+| `storageClass.mountOptions`         | Specifies the mount options for storageClass                                                                                                                                                                            | `[]`             |
 
 ### Ceph File Systems
 
@@ -101,6 +102,7 @@ The `cephFileSystems` array in the values file will define a list of CephFileSys
 | `storageClass.name`          | The name of the storage class                                                                                                                               | `ceph-filesystem` |
 | `storageClass.parameters`    | See [Shared Filesystem](ceph-filesystem.md) documentation or the helm values.yaml for suitable values                                                       | see values.yaml   |
 | `storageClass.reclaimPolicy` | The default [Reclaim Policy](https://kubernetes.io/docs/concepts/storage/storage-classes/#reclaim-policy) to apply to PVCs created with this storage class. | `Delete`          |
+| `storageClass.mountOptions`  | Specifies the mount options for storageClass                                                                                                                | `[]`              |
 
 ### Ceph Object Stores
 

--- a/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephblockpool.yaml
@@ -22,5 +22,11 @@ parameters:
 {{ toYaml $blockpool.storageClass.parameters | indent 2 }}
 reclaimPolicy: {{ default "Delete" $blockpool.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $blockpool.storageClass.allowVolumeExpansion }}
+{{- if $blockpool.storageClass.mountOptions }}
+mountOptions:
+  {{- range $blockpool.storageClass.mountOptions }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/cephfilesystem.yaml
@@ -23,5 +23,11 @@ parameters:
 {{ toYaml $filesystem.storageClass.parameters | indent 2 }}
 reclaimPolicy: {{ default "Delete" $filesystem.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ default "true" $filesystem.storageClass.allowVolumeExpansion }}
+{{- if $filesystem.storageClass.mountOptions }}
+mountOptions:
+  {{- range $filesystem.storageClass.mountOptions }}
+  - {{ . }}
+  {{- end }}
+{{- end }}
 {{ end }}
 {{ end }}

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -329,6 +329,7 @@ cephBlockPools:
       isDefault: true
       reclaimPolicy: Delete
       allowVolumeExpansion: true
+      mountOptions: []
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-block.md#provision-storage for available configuration
       parameters:
         # (optional) mapOptions is a comma-separated list of map options.
@@ -381,6 +382,7 @@ cephFileSystems:
       name: ceph-filesystem
       reclaimPolicy: Delete
       allowVolumeExpansion: true
+      mountOptions: []
       # see https://github.com/rook/rook/blob/master/Documentation/ceph-filesystem.md#provision-storage for available configuration
       parameters:
         # The secrets contain Ceph admin credentials.


### PR DESCRIPTION
It should be possible to configure the storage classs mount options, this follows
the helm code used by the ceph-csi project for their ceph-csi-rbd and ceph-csi-cephfs
helm charts.

Signed-off-by: Tom Hellier <me@tomhellier.com>

**Description of your changes:**
Adds the ability to use the storageClass mount options provided by the csi storage class

**Which issue is resolved by this Pull Request:**
Resolves #9286 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
