### PR TITLE
bot: Enable backports to release-1.8

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -136,6 +136,44 @@ pull_request_rules:
       dismiss_reviews: {}
       delete_head_branch: {}
 
+  # release-1.8 branch
+  - name: automerge backport release-1.8
+    conditions:
+      - author=mergify[bot]
+      - base=release-1.8
+      - label!=do-not-merge
+      - 'status-success=DCO'
+      - 'check-success=canary'
+      - 'check-success=unittests'
+      - 'check-success=golangci-lint'
+      - 'check-success=codegen'
+      - 'check-success=lint'
+      - 'check-success=modcheck'
+      - 'check-success=pvc'
+      - 'check-success=pvc-db'
+      - 'check-success=pvc-db-wal'
+      - 'check-success=encryption-pvc'
+      - 'check-success=encryption-pvc-db'
+      - 'check-success=encryption-pvc-db-wal'
+      - 'check-success=encryption-pvc-kms-vault-token-auth'
+      - 'check-success=encryption-pvc-kms-vault-k8s-auth'
+      - 'check-success=lvm-pvc'
+      - 'check-success=multi-cluster-mirroring'
+      - 'check-success=rgw-multisite-testing'
+      - 'check-success=TestCephSmokeSuite (v1.16.15)'
+      - 'check-success=TestCephSmokeSuite (v1.22.2)'
+      - 'check-success=TestCephHelmSuite (v1.16.15)'
+      - 'check-success=TestCephHelmSuite (v1.22.2)'
+      - 'check-success=TestCephMultiClusterDeploySuite (v1.22.2)'
+      - 'check-success=TestCephUpgradeSuite (v1.16.15)'
+      - 'check-success=TestCephUpgradeSuite (v1.22.2)'
+    actions:
+      merge:
+        method: merge
+        strict: false
+      dismiss_reviews: {}
+      delete_head_branch: {}
+
   # release-1.6 branch
   - actions:
       backport:
@@ -153,3 +191,12 @@ pull_request_rules:
     conditions:
       - label=backport-release-1.7
     name: backport release-1.7
+
+  # release-1.8 branch
+  - actions:
+      backport:
+        branches:
+          - release-1.8
+    conditions:
+      - label=backport-release-1.8
+    name: backport release-1.8


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the creation of the release-1.8 branch we enable the mergify bot to open the backport PRs automatically based on the backport-release-1.8 label.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
