### PR TITLE
helm: Use a more explicit value for ingress (backport #9280)

### DIFF
--- a/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
+++ b/cluster/charts/rook-ceph-cluster/templates/ingress.yaml
@@ -14,14 +14,7 @@ spec:
         paths:
           - path: {{ .Values.ingress.dashboard.host.path | default "/" }}
             backend:
-{{- if (semverCompare "<1.18-0" (include "capabilities.kubeVersion" .)) }}
-              serviceName: rook-ceph-mgr-dashboard
-              {{- if .Values.cephClusterSpec.dashboard.ssl }}
-              servicePort: https-dashboard
-              {{- else }}
-              servicePort: http-dashboard
-              {{- end }}
-{{- else }}
+{{- if (eq "networking.k8s.io/v1" (include "capabilities.ingress.apiVersion" .)) }}
               service:
                 name: rook-ceph-mgr-dashboard
                 port:
@@ -31,6 +24,13 @@ spec:
                   name: http-dashboard
                   {{- end }}
             pathType: Prefix
+{{- else }}
+              serviceName: rook-ceph-mgr-dashboard
+              {{- if .Values.cephClusterSpec.dashboard.ssl }}
+              servicePort: https-dashboard
+              {{- else }}
+              servicePort: http-dashboard
+              {{- end }}
 {{- end }}
   {{- if .Values.ingress.dashboard.tls }}
   tls: {{- toYaml .Values.ingress.dashboard.tls | nindent 4 }}


### PR DESCRIPTION
This is a manual backport as there are merge conflicts, so mergify cannot do it for us.