### PR TITLE
Truncate job name of the osd prepare job further to avoid pod generation failure on K8s 1.22

### DIFF
--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -72,7 +72,7 @@ func (c *ClusterController) startClusterCleanUp(context context.Context, cluster
 func (c *ClusterController) startCleanUpJobs(cluster *cephv1.CephCluster, cephHosts []string, monSecret, clusterFSID string) {
 	for _, hostName := range cephHosts {
 		logger.Infof("starting clean up job on node %q", hostName)
-		jobName := k8sutil.TruncateNodeName("cluster-cleanup-job-%s", hostName)
+		jobName := k8sutil.TruncateNodeNameForJob("cluster-cleanup-job-%s", hostName)
 		podSpec := c.cleanUpJobTemplateSpec(cluster, monSecret, clusterFSID)
 		podSpec.Spec.NodeSelector = map[string]string{v1.LabelHostname: hostName}
 		labels := controller.AppLabels(CleanupAppName, cluster.Namespace)

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -55,7 +55,7 @@ func (c *Cluster) makeJob(osdProps osdProperties, provisionConfig *provisionConf
 
 	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      k8sutil.TruncateNodeName(prepareAppNameFmt, osdProps.crushHostname),
+			Name:      k8sutil.TruncateNodeNameForJob(prepareAppNameFmt, osdProps.crushHostname),
 			Namespace: c.clusterInfo.Namespace,
 			Labels: map[string]string{
 				k8sutil.AppAttr:     prepareAppName,

--- a/pkg/operator/k8sutil/k8sutil.go
+++ b/pkg/operator/k8sutil/k8sutil.go
@@ -112,7 +112,7 @@ func TruncateNodeName(format, nodeName string) string {
 func truncateNodeName(format, nodeName string, maxLength int) string {
 	if len(nodeName)+len(fmt.Sprintf(format, "")) > maxLength {
 		hashed := Hash(nodeName)
-		logger.Infof("format and nodeName longer than %d chars, nodeName %s will be %s", validation.DNS1035LabelMaxLength, nodeName, hashed)
+		logger.Infof("format and nodeName longer than %d chars, nodeName %s will be %s", maxLength, nodeName, hashed)
 		nodeName = hashed
 	}
 	return fmt.Sprintf(format, nodeName)

--- a/pkg/operator/k8sutil/k8sutil_test.go
+++ b/pkg/operator/k8sutil/k8sutil_test.go
@@ -52,6 +52,28 @@ func TestTruncateNodeName(t *testing.T) {
 	}
 }
 
+func TestTruncateJobName(t *testing.T) {
+	// An entry's key is the result. The first value in the []string is the format and the second is the nodeName
+	tests := map[string][]string{
+		"rook-ceph-osd-prepare-k8s01": { // 27 chars
+			"rook-ceph-osd-prepare-%s", // 22 chars (without format)
+			"k8s01",                    // 5 chars
+		},
+		"rook-ceph-osd-prepare-k8s-worker-500.this.is.a.not.so": { // 53 chars
+			"rook-ceph-osd-prepare-%s",        // 22 chars (without format)
+			"k8s-worker-500.this.is.a.not.so", // 31 chars
+		},
+		// 54 chars, but ok that it is longer than 53 since it ends in an alphanumeric char
+		"rook-ceph-osd-prepare-4d2c3e33ccd2764180d42c20dce1d66a": {
+			"rook-ceph-osd-prepare-%s",         // 22 chars (without format)
+			"k8s-worker-ends-with-a-long-name", // 32 chars
+		},
+	}
+	for result, params := range tests {
+		assert.Equal(t, result, TruncateNodeNameForJob(params[0], params[1]))
+	}
+}
+
 func TestValidateLabelValue(t *testing.T) {
 	// The key is the result, and the value is the input.
 	tests := map[string]string{

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -920,7 +920,7 @@ func NewCephInstaller(t func() *testing.T, clientset *kubernetes.Clientset, sett
 		k8shelper:       k8shelp,
 		helmHelper:      utils.NewHelmHelper(testHelmPath()),
 		k8sVersion:      version.String(),
-		changeHostnames: k8shelp.VersionAtLeast("v1.18.0"),
+		changeHostnames: settings.ChangeHostName,
 		T:               t,
 	}
 	flag.Parse()

--- a/tests/framework/installer/ceph_settings.go
+++ b/tests/framework/installer/ceph_settings.go
@@ -45,6 +45,7 @@ type TestCephSettings struct {
 	SkipCleanupPolicy           bool
 	DirectMountToolbox          bool
 	EnableVolumeReplication     bool
+	ChangeHostName              bool
 	RookVersion                 string
 	CephVersion                 cephv1.CephVersionSpec
 }

--- a/tests/integration/ceph_helm_test.go
+++ b/tests/integration/ceph_helm_test.go
@@ -72,6 +72,7 @@ func (h *HelmSuite) SetupSuite() {
 		SkipOSDCreation:           false,
 		EnableAdmissionController: false,
 		EnableDiscovery:           true,
+		ChangeHostName:            true,
 		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.OctopusVersion,
 	}
@@ -91,7 +92,7 @@ func (h *HelmSuite) AfterTest(suiteName, testName string) {
 // Test to make sure all rook components are installed and Running
 func (h *HelmSuite) TestARookInstallViaHelm() {
 	checkIfRookClusterIsInstalled(h.Suite, h.k8shelper, h.settings.Namespace, h.settings.Namespace, 1)
- 	checkIfRookClusterHasHealthyIngress(h.Suite, h.k8shelper, h.settings.Namespace)
+	checkIfRookClusterHasHealthyIngress(h.Suite, h.k8shelper, h.settings.Namespace)
 }
 
 // Test BlockCreation on Rook that was installed via Helm

--- a/tests/integration/ceph_smoke_test.go
+++ b/tests/integration/ceph_smoke_test.go
@@ -94,6 +94,7 @@ func (s *SmokeSuite) SetupSuite() {
 		EnableAdmissionController: true,
 		UseCrashPruner:            true,
 		EnableVolumeReplication:   true,
+		ChangeHostName:            true,
 		RookVersion:               installer.LocalBuildTag,
 		CephVersion:               installer.ReturnCephVersion(),
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- In K8s 1.22 there is a bug in the job name generation that the job name is truncated an additional 10 characters. This can cause an issue in the generated pod name if it then ends in a non-alphanumeric character. In that case, we more aggressively generate a hashed job name.
- The generation of a long node name in the integration tests was being done based on the k8s version. In the past, older K8s versions did not support the changing name. Now it's more maintainable if we generate the long name depending on the test suite.
    
**Which issue is resolved by this Pull Request:**
Resolves #9294 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
