### PR TITLE
bot: Mergify deprected the strict merge option

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -46,7 +46,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 
@@ -64,7 +63,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 
@@ -98,7 +96,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 
@@ -132,7 +129,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 
@@ -170,7 +166,6 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-        strict: false
       dismiss_reviews: {}
       delete_head_branch: {}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The strict merge option was not being used and anyway has been depcrecated by the mergify bot.

This is currently resulting in the following CI failure:
```
Summary Failing after 3s — The Mergify configuration is invalid
```

The details of the failure show:

The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.com/strict-mode-deprecation/

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
