### PR TITLE
build: Run csv target during build.all

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
       working-directory: /Users/runner/go/src/github.com/rook/rook
       run: tests/scripts/validate_modified_files.sh crd
 
+    - name: run csv-ceph
+      working-directory: /Users/runner/go/src/github.com/rook/rook
+      run: make csv-clean && GOPATH=$(go env GOPATH) make csv-ceph CSV_VERSION=9999.9999.9999 CSV_PLATFORM=ocp ROOK_OP_VERSION='{{.RookOperatorImage}}'
+
     - name: run gen-rbac
       working-directory: /Users/runner/go/src/github.com/rook/rook
       run: GOPATH=$(go env GOPATH) make gen-rbac
@@ -92,6 +96,9 @@ jobs:
     - name: build.all rook with go ${{ matrix.go-version }}
       run: |
         tests/scripts/github-action-helper.sh build_rook_all
+
+    - name: run csv-ceph
+      run: make csv-clean && GOPATH=$(go env GOPATH) make csv-ceph CSV_VERSION=9999.9999.9999 CSV_PLATFORM=ocp ROOK_OP_VERSION='{{.RookOperatorImage}}'
 
     - name: setup tmate session for debugging
       if: failure()


### PR DESCRIPTION
This is related to #9319; it seemed to me that csv generation wasn't being fully tested.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
