### PR TITLE
build: Run mv outside the OLM_CATALOG_DIR (backport #9319)

### DIFF
--- a/deploy/olm/generate-rook-csv.sh
+++ b/deploy/olm/generate-rook-csv.sh
@@ -118,8 +118,9 @@ function cleanup() {
 function generate_csv(){
     pushd "$OLM_CATALOG_DIR" &> /dev/null
     "${OP_SDK_CMD[@]}" "$VERSION"
-    mv "$CSV_BUNDLE_PATH/olm.clusterserviceversion.yaml" "$CSV_FILE_NAME"
     popd &> /dev/null
+
+    mv "$CSV_BUNDLE_PATH/olm.clusterserviceversion.yaml" "$CSV_FILE_NAME"
 
     # cleanup to get the expected state before merging the real data from assembles
     "${YQ_CMD_DELETE[@]}" "$CSV_FILE_NAME" 'spec.icon[*]'


### PR DESCRIPTION
The command needs to be run outside the OLM_CATALOG_DIR as it already
contains that directory in its paths.

Signed-off-by: Boris Ranto <branto@redhat.com>
(cherry picked from commit 4cb8bb3bec57a95f46f7a2936a63261bf1f23348)

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
