### PR TITLE
build: updated locale for rbac generation

### DIFF
--- a/build/rbac/keep-rbac-yaml.sh
+++ b/build/rbac/keep-rbac-yaml.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -eEuo pipefail
+# setting locate `LC_ALL=C` because different OS do files sorting differently, 
+# so setting a common behaviour, `C` sorting order is based on the byte values,
+# Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
+LC_ALL=C
 
 # READS FROM STDIN
 # WRITES TO STDOUT


### PR DESCRIPTION
Currently there was an issue related to sorting
files in Rbac generation in different platforms
Updated the locale to LC_ALL=C so rbac generation
can done correctly

Closes: https://github.com/rook/rook/issues/9331
Co-authored-by: Blaine Gardner blaine.gardner@redhat.com
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
