### PR TITLE
test: Upgrade test to update the toolbox spec

### DIFF
--- a/tests/integration/ceph_upgrade_test.go
+++ b/tests/integration/ceph_upgrade_test.go
@@ -116,7 +116,7 @@ func (s *UpgradeSuite) TestUpgradeRookToMaster() {
 	}()
 
 	//
-	// Upgrade Rook from v1.6 to master
+	// Upgrade Rook from v1.7 to master
 	//
 	logger.Infof("*** UPGRADING ROOK FROM %s to master ***", installer.Version1_7)
 	s.gatherLogs(s.settings.OperatorNamespace, "_before_master_upgrade")
@@ -128,7 +128,7 @@ func (s *UpgradeSuite) TestUpgradeRookToMaster() {
 	assert.NoError(s.T(), err)
 
 	logger.Infof("Done with automatic upgrade from %s to master", installer.Version1_7)
-	newFile := "post-upgrade-1_6-to-master-file"
+	newFile := "post-upgrade-1_7-to-master-file"
 	s.verifyFilesAfterUpgrade(filesystemName, newFile, message, rbdFilesToRead, cephfsFilesToRead)
 	rbdFilesToRead = append(rbdFilesToRead, newFile)
 	cephfsFilesToRead = append(cephfsFilesToRead, newFile)
@@ -421,6 +421,5 @@ func (s *UpgradeSuite) upgradeToMaster() {
 	require.NoError(s.T(),
 		s.k8sh.SetDeploymentVersion(s.settings.OperatorNamespace, operatorContainer, operatorContainer, installer.LocalBuildTag))
 
-	require.NoError(s.T(),
-		s.k8sh.SetDeploymentVersion(s.settings.Namespace, "rook-ceph-tools", "rook-ceph-tools", installer.LocalBuildTag))
+	require.NoError(s.T(), s.k8sh.ResourceOperation("apply", m.GetToolbox()))
 }


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The toolbox spec changed from 1.7 to 1.8 due to the removal of tini from the image. The upgrade test was failing on k8s 1.18 due to this issue.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
