### PR TITLE
nfs: make rados.namespace optional

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -6008,13 +6008,11 @@ spec:
                   nullable: true
                   properties:
                     namespace:
-                      description: Namespace is the RADOS namespace where NFS client recovery data is stored.
+                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored. This setting is required for Ceph v15 and ignored for Ceph v16. As of Ceph Pacific v16+, this is internally set to the name of the CephNFS.
                       type: string
                     pool:
-                      description: Pool used to represent the Ganesha's pool name in version older than 16.2.7 As of Ceph Pacific 16.2.7, NFS Ganesha's pool name is hardcoded to ".nfs", so this setting will be ignored.
+                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons. This setting is required for Ceph v15 and ignored for Ceph v16. As of Ceph Pacific 16.2.7+, this is internally hardcoded to ".nfs".
                       type: string
-                  required:
-                    - namespace
                   type: object
                 server:
                   description: Server is the Ganesha Server specification

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -6004,13 +6004,11 @@ spec:
                   nullable: true
                   properties:
                     namespace:
-                      description: Namespace is the RADOS namespace where NFS client recovery data is stored.
+                      description: The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored. This setting is required for Ceph v15 and ignored for Ceph v16. As of Ceph Pacific v16+, this is internally set to the name of the CephNFS.
                       type: string
                     pool:
-                      description: Pool used to represent the Ganesha's pool name in version older than 16.2.7 As of Ceph Pacific 16.2.7, NFS Ganesha's pool name is hardcoded to ".nfs", so this setting will be ignored.
+                      description: The Ceph pool used store the shared configuration for NFS-Ganesha daemons. This setting is required for Ceph v15 and ignored for Ceph v16. As of Ceph Pacific 16.2.7+, this is internally hardcoded to ".nfs".
                       type: string
-                  required:
-                    - namespace
                   type: object
                 server:
                   description: Server is the Ganesha Server specification

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1812,14 +1812,17 @@ type NFSGaneshaSpec struct {
 
 // GaneshaRADOSSpec represents the specification of a Ganesha RADOS object
 type GaneshaRADOSSpec struct {
-	// Pool used to represent the Ganesha's pool name in version older than 16.2.7
-	// As of Ceph Pacific 16.2.7, NFS Ganesha's pool name is hardcoded to ".nfs", so this
-	// setting will be ignored.
+	// The Ceph pool used store the shared configuration for NFS-Ganesha daemons.
+	// This setting is required for Ceph v15 and ignored for Ceph v16.
+	// As of Ceph Pacific 16.2.7+, this is internally hardcoded to ".nfs".
 	// +optional
 	Pool string `json:"pool,omitempty"`
 
-	// Namespace is the RADOS namespace where NFS client recovery data is stored.
-	Namespace string `json:"namespace"`
+	// The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha config is stored.
+	// This setting is required for Ceph v15 and ignored for Ceph v16.
+	// As of Ceph Pacific v16+, this is internally set to the name of the CephNFS.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // GaneshaServerSpec represents the specification of a Ganesha Server


### PR DESCRIPTION
Fix the CephNFS spec.rados API specifiation to be clear that spec.rados
is optional for all Ceph v16 versions, including that
spec.rados.namespace is optional.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
