### PR TITLE
object: fix handling for notifications for OBC

### DIFF
--- a/pkg/operator/ceph/object/notification/controller.go
+++ b/pkg/operator/ceph/object/notification/controller.go
@@ -52,6 +52,7 @@ var logger = capnslog.NewPackageLogger("github.com/rook/rook", packageName)
 var waitForRequeueIfTopicNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 var waitForRequeueIfNotificationNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 var waitForRequeueIfObjectBucketNotReady = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
+var waitForRequeueIfNotificationNotDeleted = reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}
 
 // ReconcileNotifications reconciles a CephbucketNotification
 type ReconcileNotifications struct {

--- a/pkg/operator/ceph/object/notification/obc_label_controller_test.go
+++ b/pkg/operator/ceph/object/notification/obc_label_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rook/rook/pkg/operator/k8sutil"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,6 +42,69 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+func createOBResources(name string) (*bktv1alpha1.ObjectBucketClaim, *bktv1alpha1.ObjectBucket) {
+	return &bktv1alpha1.ObjectBucketClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "ObjectBucketClaim",
+			},
+			Spec: bktv1alpha1.ObjectBucketClaimSpec{
+				StorageClassName:   testSCName,
+				GenerateBucketName: name,
+			},
+			Status: bktv1alpha1.ObjectBucketClaimStatus{
+				Phase: bktv1alpha1.ObjectBucketClaimStatusPhasePending,
+			},
+		}, &bktv1alpha1.ObjectBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "ObjectBucket",
+			},
+			Spec: bktv1alpha1.ObjectBucketSpec{
+				StorageClassName: testSCName,
+				Connection: &bktv1alpha1.Connection{
+					Endpoint: &bktv1alpha1.Endpoint{
+						BucketHost: object.BuildDomainName(testStoreName, testNamespace),
+					},
+				},
+				ClaimRef: &corev1.ObjectReference{
+					Name: name},
+			},
+			Status: bktv1alpha1.ObjectBucketStatus{
+				Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
+			},
+		}
+}
+
+func createBucketNotification(name string) *cephv1.CephBucketNotification {
+	return &cephv1.CephBucketNotification{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "CephBucketNotification",
+		},
+		Spec: cephv1.BucketNotificationSpec{
+			Topic: testTopicName,
+		},
+	}
+}
+
+func setNotificationLabels(labelList []string) map[string]string {
+	var label = make(map[string]string)
+	for _, value := range labelList {
+		label[notificationLabelPrefix+value] = value
+	}
+	return label
+}
 
 func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 	mockSetup()
@@ -68,18 +132,7 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		},
 		Status: &cephv1.BucketTopicStatus{ARN: &testARN},
 	}
-	bucketNotification := &cephv1.CephBucketNotification{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testNotificationName,
-			Namespace: testNamespace,
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "CephBucketNotification",
-		},
-		Spec: cephv1.BucketNotificationSpec{
-			Topic: testTopicName,
-		},
-	}
+
 	cephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testNamespace,
@@ -92,45 +145,7 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 			},
 		},
 	}
-	obc := &bktv1alpha1.ObjectBucketClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testBucketName,
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				notificationLabelPrefix + testNotificationName: testNotificationName,
-			},
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "ObjectBucketClaim",
-		},
-		Spec: bktv1alpha1.ObjectBucketClaimSpec{
-			StorageClassName:   testSCName,
-			GenerateBucketName: testBucketName,
-		},
-		Status: bktv1alpha1.ObjectBucketClaimStatus{
-			Phase: bktv1alpha1.ObjectBucketClaimStatusPhasePending,
-		},
-	}
-	ob := &bktv1alpha1.ObjectBucket{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testBucketName,
-			Namespace: testNamespace,
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "ObjectBucket",
-		},
-		Spec: bktv1alpha1.ObjectBucketSpec{
-			StorageClassName: testSCName,
-			Connection: &bktv1alpha1.Connection{
-				Endpoint: &bktv1alpha1.Endpoint{
-					BucketHost: object.BuildDomainName(testStoreName, testNamespace),
-				},
-			},
-		},
-		Status: bktv1alpha1.ObjectBucketStatus{
-			Phase: bktv1alpha1.ObjectBucketStatusPhaseBound,
-		},
-	}
+
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      testBucketName,
@@ -173,10 +188,14 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		Type: k8sutil.RookType,
 	}
 
+	obc, ob := createOBResources(testBucketName)
+	obc.Labels = setNotificationLabels([]string{testNotificationName})
+
 	_, err := c.Clientset.CoreV1().Secrets(testNamespace).Create(ctx, secret, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	t.Run("provision OBC with notification label with no ob", func(t *testing.T) {
+		resetValues()
 		objects := []runtime.Object{
 			cephCluster,
 			obc,
@@ -189,10 +208,13 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.False(t, createWasInvoked)
+		assert.False(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 0, len(deletedNotifications))
 	})
 
 	t.Run("provision OBC with notification label with not ready ob", func(t *testing.T) {
+		resetValues()
 		objects := []runtime.Object{
 			cephCluster,
 			obc,
@@ -206,13 +228,16 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.False(t, createWasInvoked)
+		assert.False(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 0, len(deletedNotifications))
 	})
 
 	obc.Spec.ObjectBucketName = testBucketName
 	obc.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
 
 	t.Run("provision OBC with notification label with no notification", func(t *testing.T) {
+		resetValues()
 		objects := []runtime.Object{
 			cephCluster,
 			obc,
@@ -226,10 +251,14 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.False(t, createWasInvoked)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 0, len(deletedNotifications))
 	})
 
+	bucketNotification := createBucketNotification(testNotificationName)
 	t.Run("provision OBC with notification label and notification with no topic", func(t *testing.T) {
+		resetValues()
 		objects := []runtime.Object{
 			cephCluster,
 			obc,
@@ -244,10 +273,13 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.True(t, res.Requeue)
-		assert.False(t, createWasInvoked)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 0, len(deletedNotifications))
 	})
 
 	t.Run("provision OBC with notification label", func(t *testing.T) {
+		resetValues()
 		objects := []runtime.Object{
 			cephCluster,
 			obc,
@@ -263,6 +295,156 @@ func TestCephBucketNotificationOBCLabelController(t *testing.T) {
 		res, err := r.Reconcile(ctx, req)
 		assert.NoError(t, err)
 		assert.False(t, res.Requeue)
-		assert.True(t, createWasInvoked)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 1, len(createdNotifications))
+		assert.ElementsMatch(t, createdNotifications, []string{testNotificationName})
+		assert.Equal(t, 0, len(deletedNotifications))
+	})
+
+	t.Run("reconcile with already existing label for the obc", func(t *testing.T) {
+		resetValues()
+		noChangeOBC, noChangeOB := createOBResources(noChangeBucketName)
+		noChangeOBC.Labels = setNotificationLabels([]string{testNotificationName})
+		noChangeOBC.Spec.ObjectBucketName = noChangeBucketName
+		noChangeOBC.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		req.NamespacedName.Name = noChangeBucketName
+		objects := []runtime.Object{
+			cephCluster,
+			noChangeOBC,
+			noChangeOB,
+			bucketNotification,
+			bucketTopic,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 1, len(createdNotifications))
+		assert.ElementsMatch(t, createdNotifications, []string{testNotificationName})
+		assert.Equal(t, 0, len(deletedNotifications))
+	})
+
+	t.Run("delete notification from the obc", func(t *testing.T) {
+		resetValues()
+		deleteOBC, deleteOB := createOBResources(deleteBucketName)
+		deleteOBC.Spec.GenerateBucketName = deleteBucketName
+		deleteOBC.Spec.ObjectBucketName = deleteBucketName
+		deleteOBC.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		req.NamespacedName.Name = deleteBucketName
+		objects := []runtime.Object{
+			cephCluster,
+			deleteOBC,
+			deleteOB,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 1, len(deletedNotifications))
+		assert.ElementsMatch(t, deletedNotifications,
+			[]string{deleteBucketName + testNotificationName})
+	})
+
+	t.Run("provision OBC with multiple notification labels", func(t *testing.T) {
+		resetValues()
+		multipleCreateOBC, multipleCreateOB := createOBResources(multipleCreateBucketName)
+		multipleCreateOBC.Labels = setNotificationLabels([]string{testNotificationName + "-1", testNotificationName + "-2"})
+		multipleCreateOBC.Spec.ObjectBucketName = multipleCreateBucketName
+		multipleCreateOBC.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		bucketNotification1 := createBucketNotification(testNotificationName + "-1")
+		bucketNotification2 := createBucketNotification(testNotificationName + "-2")
+		req.NamespacedName.Name = multipleCreateBucketName
+
+		objects := []runtime.Object{
+			cephCluster,
+			multipleCreateOBC,
+			multipleCreateOB,
+			bucketNotification1,
+			bucketNotification2,
+			bucketTopic,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 2, len(createdNotifications))
+		assert.ElementsMatch(t, createdNotifications, []string{testNotificationName + "-1", testNotificationName + "-2"})
+		assert.Equal(t, 0, len(deletedNotifications))
+	})
+
+	t.Run("delete multiple notifications from the obc", func(t *testing.T) {
+		resetValues()
+		multipleDeleteOBC, multipleDeleteOB := createOBResources(multipleDeleteBucketName)
+		multipleDeleteOBC.Spec.GenerateBucketName = multipleDeleteBucketName
+		multipleDeleteOBC.Spec.ObjectBucketName = multipleDeleteBucketName
+		multipleDeleteOBC.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		req.NamespacedName.Name = multipleDeleteBucketName
+		objects := []runtime.Object{
+			cephCluster,
+			multipleDeleteOBC,
+			multipleDeleteOB,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 0, len(createdNotifications))
+		assert.Equal(t, 2, len(deletedNotifications))
+		assert.ElementsMatch(t, deletedNotifications,
+			[]string{multipleDeleteBucketName + testNotificationName + "-1", multipleDeleteBucketName + testNotificationName + "-2"})
+	})
+	t.Run("provision OBC with multiple delete and create of notifications", func(t *testing.T) {
+		resetValues()
+		multipleBothOBC, multipleBothOB := createOBResources(multipleBothBucketName)
+		multipleBothOBC.Labels = setNotificationLabels([]string{testNotificationName + "-1", testNotificationName + "-2"})
+		multipleBothOBC.Spec.ObjectBucketName = multipleBothBucketName
+		multipleBothOBC.Status.Phase = bktv1alpha1.ObjectBucketClaimStatusPhaseBound
+		bucketNotification1 := createBucketNotification(testNotificationName + "-1")
+		bucketNotification2 := createBucketNotification(testNotificationName + "-2")
+		req.NamespacedName.Name = multipleBothBucketName
+
+		objects := []runtime.Object{
+			cephCluster,
+			multipleBothOBC,
+			multipleBothOB,
+			bucketNotification1,
+			bucketNotification2,
+			bucketTopic,
+		}
+
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objects...).Build()
+
+		r := &ReconcileOBCLabels{client: cl, context: c, opManagerContext: ctx}
+
+		res, err := r.Reconcile(ctx, req)
+		assert.NoError(t, err)
+		assert.False(t, res.Requeue)
+		assert.True(t, getWasInvoked)
+		assert.Equal(t, 2, len(createdNotifications))
+		assert.ElementsMatch(t, createdNotifications, []string{testNotificationName + "-1", testNotificationName + "-2"})
+		assert.Equal(t, 2, len(deletedNotifications))
+		assert.ElementsMatch(t, deletedNotifications,
+			[]string{multipleDeleteBucketName + testNotificationName + "-1", multipleDeleteBucketName + testNotificationName + "-2"})
 	})
 }

--- a/pkg/operator/ceph/object/notification/s3ext.go
+++ b/pkg/operator/ceph/object/notification/s3ext.go
@@ -66,13 +66,16 @@ func (s *DeleteBucketNotificationRequestInput) Validate() error {
 
 const opDeleteBucketNotification = "DeleteBucketNotification"
 
-func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRequestInput) *request.Request {
+func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRequestInput, notificationId string) *request.Request {
 	op := &request.Operation{
 		Name:       opDeleteBucketNotification,
 		HTTPMethod: http.MethodDelete,
 		HTTPPath:   "/{Bucket}?notification",
 	}
 
+	if len(notificationId) > 0 {
+		op.HTTPPath = "/{Bucket}?notification=" + notificationId
+	}
 	if input == nil {
 		input = &DeleteBucketNotificationRequestInput{}
 	}
@@ -80,7 +83,7 @@ func DeleteBucketNotificationRequest(c *s3.S3, input *DeleteBucketNotificationRe
 	return c.NewRequest(op, input, nil)
 }
 
-func DeleteBucketNotification(c *s3.S3, input *DeleteBucketNotificationRequestInput) error {
-	req := DeleteBucketNotificationRequest(c, input)
+func DeleteBucketNotification(c *s3.S3, input *DeleteBucketNotificationRequestInput, notificationId string) error {
+	req := DeleteBucketNotificationRequest(c, input, notificationId)
 	return req.Send()
 }


### PR DESCRIPTION
Current approach is to delete all the existing notifcations from bucket
and re-add the notification from the labels.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
