### PR TITLE
docs: add instructions to upgrade admission controller

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -340,6 +340,24 @@ When the operator is updated, it will proceed to update all of the Ceph daemons.
 kubectl -n $ROOK_OPERATOR_NAMESPACE set image deploy/rook-ceph-operator rook-ceph-operator=rook/ceph:v1.8.0
 ```
 
+#### Admission controller
+If you use the optional [Admission controller](admission-controller-usage.md), there are additional
+updates during this step. The admission controller has been integrated inside the operator
+instead of a separate deployment. This means that the webhook server certificates are now stored in
+the operator, and the operator manifest must be updated to use the one provided in
+`deploy/examples/operator.yaml`. If you are using Helm to manage the deployment, this is handled
+automatically.
+
+When updating the operator deployment with the latest example from Rook, there is risk of
+overwriting changes if you have customized the operator deployment or to the
+`rook-ceph-operator-config` ConfigMap. We suggest that you remove the ConfigMap from `operator.yaml`
+before moving on. Additionally, we encourage you to diff the current deployment and the latest one
+to be sure any changes you may have made don't get overwritten. Required changes include the
+`webhook-cert` volume/mount and `https-webhook` port, though there are some smaller changes as well.
+
+Once you are sure any custom modifications to your operator deployment won't be overwritten, apply
+the new `operator.yaml` with `kubectl apply -f deploy/examples/operator.yaml`.
+
 ### **4. Wait for the upgrade to complete**
 
 Watch now in amazement as the Ceph mons, mgrs, OSDs, rbd-mirrors, MDSes and RGWs are terminated and


### PR DESCRIPTION
In 1.8, the admission controller has merged with the operator and the
operator needs an emptyDir and a volume mount to store the webhook
certificates.

Co-authored-by: Blaine Gardner <blaine.gardner@redhat.com>
Co-authored-by: Sébastien Han <seb@redhat.com>

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
