### PR TITLE
docs: Reset the pending release notes for 1.9

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -1,29 +1,6 @@
-# Major Themes
-
-v1.8...
-
-## K8s Version Support
-
-## Upgrade Guides
+# v1.9 Pending Release Notes
 
 ## Breaking Changes
 
-- Flex driver is fully deprecated. If you are still using flex volumes, before upgrading to v1.8
-  you will need to convert them to csi volumes. See the flex conversion tool.
-- Min supported version of K8s is now 1.16. If running on an older version of K8s it is recommended
-  to update to a newer version before updating to Rook v1.8.
-- Directory structure of the YAML examples has changed. Files are now in `deploy/examples` and subdirectories.
-
-### Ceph
 
 ## Features
-
-- The Rook Operator does not use "tini" as an init process. Instead, it uses the "rook" and handles
-  signals on its own.
-- Rook adds a finalizer `ceph.rook.io/disaster-protection` to resources critical to the Ceph cluster
-  (rook-ceph-mon secrets and configmap) so that the resources will not be accidentally deleted.
-- Add support for [Kubernetes Authentication when using HashiCorp Vault Key Management Service](Documentation/ceph-kms.md##kubernetes-based-authentication).
-- Bucket notification supported via CRDs
-- The failure domain of a pool can be changed on the CephBlockPool instead of requiring toolbox commands
-- The Rook Operator and the toolbox now run under the "rook" user and does not use "root" anymore.
-- The Operator image now includes the `s5cmd` binary to interact with S3 gateways.


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the v1.8 release pending, we can reset the pending release notes for v1.9.

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
