### PR TITLE
osd: cleanup cluster using the root UID

### DIFF
--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -123,10 +123,18 @@ func (c *ClusterController) cleanUpJobContainer(cluster *cephv1.CephCluster, mon
 		}...)
 	}
 
+	// Run a UID 0 since ceph-volume does not support running non-root
+	// See https://tracker.ceph.com/issues/53511
+	// Also, it's hard to catch the ceph version since the cluster is being deleted so not
+	// implementing a version check and simply always run this as root
+	rootUserID := int64(0)
+	securityContext := osd.PrivilegedContext()
+	securityContext.RunAsUser = &rootUserID
+
 	return v1.Container{
 		Name:            "host-cleanup",
 		Image:           c.rookImage,
-		SecurityContext: osd.PrivilegedContext(),
+		SecurityContext: securityContext,
 		VolumeMounts:    volumeMounts,
 		Env:             envVars,
 		Args:            []string{"ceph", "clean"},


### PR DESCRIPTION
**Description of your changes:**

We need to use the root UID to run the cleanup job since ceph-volume
does not support running as non-root in all the versions. We have this
ceph tracker to allow this https://tracker.ceph.com/issues/53511 but
it's not in all ceph's versions. Implementing a version check is tricky
since at this stage the cluster is being deleted and it's hard to catch
it.

Closes: https://github.com/rook/rook/issues/9375
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
