### PR TITLE
mgr: run the watch side car config on /etc/ceph

### DIFF
--- a/cmd/rook/ceph/mgr.go
+++ b/cmd/rook/ceph/mgr.go
@@ -66,6 +66,7 @@ func init() {
 // Start the mgr daemon sidecar
 func runMgrSidecar(cmd *cobra.Command, args []string) error {
 	rook.SetLogLevel()
+	clusterInfo.Context = cmd.Context()
 
 	context := createContext()
 	clusterInfo.Monitors = mon.ParseMonEndpoints(cfg.monEndpoints)

--- a/pkg/operator/ceph/cluster/cleanup.go
+++ b/pkg/operator/ceph/cluster/cleanup.go
@@ -127,9 +127,7 @@ func (c *ClusterController) cleanUpJobContainer(cluster *cephv1.CephCluster, mon
 	// See https://tracker.ceph.com/issues/53511
 	// Also, it's hard to catch the ceph version since the cluster is being deleted so not
 	// implementing a version check and simply always run this as root
-	rootUserID := int64(0)
-	securityContext := osd.PrivilegedContext()
-	securityContext.RunAsUser = &rootUserID
+	securityContext := controller.PrivilegedContext(true)
 
 	return v1.Container{
 		Name:            "host-cleanup",

--- a/pkg/operator/ceph/cluster/mgr/spec.go
+++ b/pkg/operator/ceph/cluster/mgr/spec.go
@@ -228,11 +228,12 @@ func (c *Cluster) makeMgrSidecarContainer(mgrConfig *mgrConfig) v1.Container {
 	}
 
 	return v1.Container{
-		Args:      []string{"ceph", "mgr", "watch-active"},
-		Name:      "watch-active",
-		Image:     c.rookVersion,
-		Env:       envVars,
-		Resources: cephv1.GetMgrSidecarResources(c.spec.Resources),
+		Args:            []string{"ceph", "mgr", "watch-active"},
+		Name:            "watch-active",
+		Image:           c.rookVersion,
+		Env:             envVars,
+		Resources:       cephv1.GetMgrSidecarResources(c.spec.Resources),
+		SecurityContext: controller.PrivilegedContext(true),
 	}
 }
 

--- a/pkg/operator/ceph/cluster/osd/config.go
+++ b/pkg/operator/ceph/cluster/osd/config.go
@@ -25,21 +25,11 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/mgr"
 	opconfig "github.com/rook/rook/pkg/operator/ceph/config"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
 	dmCryptKeySize = 128
 )
-
-// PrivilegedContext returns a privileged Pod security context
-func PrivilegedContext() *v1.SecurityContext {
-	privileged := true
-
-	return &v1.SecurityContext{
-		Privileged: &privileged,
-	}
-}
 
 func osdOnSDNFlag(network cephv1.NetworkSpec) []string {
 	var args []string

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -765,7 +765,7 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 		Name:            "activate",
 		Image:           c.spec.CephVersion.Image,
 		VolumeMounts:    volMounts,
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Env:             envVars,
 		Resources:       osdProps.resources,
 	}
@@ -857,7 +857,7 @@ func (c *Cluster) generateEncryptionOpenBlockContainer(resources v1.ResourceRequ
 			fmt.Sprintf(openEncryptedBlock, c.clusterInfo.FSID, pvcName, encryptionKeyPath(), encryptionBlockDestinationCopy(mountPath, blockType), encryptionDMName(pvcName, cryptBlockType), encryptionDMPath(pvcName, cryptBlockType)),
 		},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, volumeMountPVCName), getDeviceMapperMount()},
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       resources,
 	}
 }
@@ -1111,7 +1111,7 @@ func (c *Cluster) getActivatePVCInitContainer(osdProps osdProperties, osdID stri
 			},
 		},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(osdDataPath, osdProps.pvc.ClaimName)},
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
 	}
 
@@ -1139,7 +1139,7 @@ func (c *Cluster) getExpandPVCInitContainer(osdProps osdProperties, osdID string
 		},
 		Args:            []string{"bluefs-bdev-expand", "--path", osdDataPath},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(osdDataPath, osdProps.pvc.ClaimName)},
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
 	}
 }
@@ -1166,7 +1166,7 @@ func (c *Cluster) getExpandEncryptedPVCInitContainer(mountPath string, osdProps 
 		},
 		Args:            []string{"--verbose", "resize", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    volMount,
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
 	}
 }
@@ -1196,7 +1196,7 @@ func (c *Cluster) getEncryptedStatusPVCInitContainer(mountPath string, osdProps 
 		},
 		Args:            []string{"--verbose", "status", encryptionDMName(osdProps.pvc.ClaimName, DmcryptBlockType)},
 		VolumeMounts:    []v1.VolumeMount{getPvcOSDBridgeMountActivate(mountPath, osdProps.pvc.ClaimName)},
-		SecurityContext: PrivilegedContext(),
+		SecurityContext: controller.PrivilegedContext(true),
 		Resources:       osdProps.resources,
 	}
 }

--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -620,6 +620,22 @@ func PodSecurityContext() *v1.SecurityContext {
 	}
 }
 
+// PrivilegedContext returns a privileged Pod security context
+func PrivilegedContext(runAsRoot bool) *v1.SecurityContext {
+	privileged := true
+	rootUser := int64(0)
+
+	sec := &v1.SecurityContext{
+		Privileged: &privileged,
+	}
+
+	if runAsRoot {
+		sec.RunAsUser = &rootUser
+	}
+
+	return sec
+}
+
 // LogCollectorContainer runs a cron job to rotate logs
 func LogCollectorContainer(daemonID, ns string, c cephv1.ClusterSpec) *v1.Container {
 	return &v1.Container{


### PR DESCRIPTION
**Description of your changes:**

We don't need to use /var/lib/rook for the ceph config and keyring, so
let's use /etc/ceph which has the right permissions too. Also, we need
to run with the ceph user since the rook image defaults to the "rook"
user.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #9385

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
