### PR TITLE
helm: add optional monitoring RBAC to operator chart

### DIFF
--- a/Documentation/ceph-upgrade.md
+++ b/Documentation/ceph-upgrade.md
@@ -319,6 +319,12 @@ step to upgrade the Prometheus RBAC resources as well.
 kubectl apply -f deploy/examples/monitoring/rbac.yaml
 ```
 
+If you use the `rook-ceph` operator Helm chart, you should also add `monitoring.enabled` to
+your Helm values with two caveats:
+- this is unnecessary if you deploy monitoring RBAC from `deploy/examples/monitoring/rbac.yaml`
+- this is unnecessary if you use `rook-ceph-cluster` charts exclusively outside of the `rook-ceph`
+  operator namespace.
+
 ### **2. Update Ceph CSI versions**
 
 > Automatically updated if you are upgrading via the helm chart

--- a/Documentation/helm-operator.md
+++ b/Documentation/helm-operator.md
@@ -148,6 +148,7 @@ The following tables lists the configurable parameters of the rook-operator char
 | `admissionController.tolerations`   | Array of tolerations in YAML format which will be added to admission controller deployment.                                 | <none>                                                    |
 | `admissionController.nodeAffinity`  | The node labels for affinity of the admission controller deployment (***)                                                   | <none>                                                    |
 | `allowMultipleFilesystems`          | **(experimental in  Octopus (v15))** Allows multiple filesystems to be deployed to a Ceph cluster.                          | `false`                                                   |
+| `monitoring.enabled`                | Create necessary RBAC rules for Rook to integrate with Prometheus monitoring in the operator namespace. Requires Prometheus to be pre-installed. | `false` |
 
 &ast; &ast; &ast; `nodeAffinity` and `*NodeAffinity` options should have the format `"role=storage,rook; storage=ceph"` or `storage=;role=rook-example` or `storage=;` (_checks only for presence of key_)
 

--- a/deploy/charts/library/templates/_cluster-monitoring.tpl
+++ b/deploy/charts/library/templates/_cluster-monitoring.tpl
@@ -4,7 +4,6 @@ These should be scoped to the namespace where the CephCluster is located.
 */}}
 
 {{- define "library.cluster.monitoring.roles" -}}
-# ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
+++ b/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
@@ -26,8 +26,18 @@ roles
 ---
 {{ include "library.cluster.roles" . }}
 
+{{- if .Values.monitoring.enabled }}
+---
+{{ include "library.cluster.monitoring.roles" . }}
+{{- end }}
+
 {{/*
 rolebindings
 */}}
 ---
 {{ include "library.cluster.rolebindings" . }}
+
+{{- if .Values.monitoring.enabled }}
+---
+{{ include "library.cluster.monitoring.rolebindings" . }}
+{{- end }}

--- a/deploy/charts/rook-ceph/values.yaml
+++ b/deploy/charts/rook-ceph/values.yaml
@@ -353,3 +353,8 @@ admissionController:
   #      operator: Exists
   #      effect: NoSchedule
   # nodeAffinity: key1=value1,value2; key2=value3
+
+monitoring:
+  # requires Prometheus to be pre-installed
+  # enabling will also create RBAC rules to allow Operator to create ServiceMonitors
+  enabled: false


### PR DESCRIPTION
An older version of the Helm chart always installed RBAC permissions for
enabling monitoring. In an effort to reduce the privileges Rook uses by
default, they were removed. We need to still include the monitoring RBAC
optionally since the change could break some users.

Co-authored-by: Mathieu Parent <mathieu.parent@insee.fr>
Co-authored-by: Blaine Gardner <blaine.gardner@redhat.com>

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #9398 (with the caveat that values `monitoring.enabled` should be set to `true`)

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
