### PR TITLE
core: add context parameter to k8sutil pvc

### DIFF
--- a/pkg/operator/ceph/cluster/mon/mon.go
+++ b/pkg/operator/ceph/cluster/mon/mon.go
@@ -1161,7 +1161,7 @@ func (c *Cluster) updateMon(m *monConfig, d *apps.Deployment) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch pvc for mon %q", m.ResourceName)
 		}
-		k8sutil.ExpandPVCIfRequired(c.context.Client, desiredPvc, existingPvc)
+		k8sutil.ExpandPVCIfRequired(c.ClusterInfo.Context, c.context.Client, desiredPvc, existingPvc)
 	}
 
 	logger.Infof("deployment for mon %s already exists. updating if needed",

--- a/pkg/operator/ceph/cluster/osd/deviceSet.go
+++ b/pkg/operator/ceph/cluster/osd/deviceSet.go
@@ -209,7 +209,7 @@ func (c *Cluster) createDeviceSetPVC(existingPVCs map[string]*v1.PersistentVolum
 		logger.Infof("OSD PVC %q already exists", existingPVC.Name)
 
 		// Update the PVC in case the size changed
-		k8sutil.ExpandPVCIfRequired(c.context.Client, pvc, existingPVC)
+		k8sutil.ExpandPVCIfRequired(c.clusterInfo.Context, c.context.Client, pvc, existingPVC)
 		return existingPVC, nil
 	}
 

--- a/pkg/operator/k8sutil/pvc.go
+++ b/pkg/operator/k8sutil/pvc.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ExpandPVCIfRequired will expand the PVC if requested size is greater than the actual size of existing PVC
-func ExpandPVCIfRequired(client client.Client, desiredPVC *v1.PersistentVolumeClaim, currentPVC *v1.PersistentVolumeClaim) {
+func ExpandPVCIfRequired(ctx context.Context, client client.Client, desiredPVC *v1.PersistentVolumeClaim, currentPVC *v1.PersistentVolumeClaim) {
 	desiredSize, desiredOK := desiredPVC.Spec.Resources.Requests[v1.ResourceStorage]
 	currentSize, currentOK := currentPVC.Spec.Resources.Requests[v1.ResourceStorage]
 	if !desiredOK || !currentOK {
@@ -43,7 +43,7 @@ func ExpandPVCIfRequired(client client.Client, desiredPVC *v1.PersistentVolumeCl
 
 		// get StorageClass
 		storageClass := &storagev1.StorageClass{}
-		err := client.Get(context.TODO(), types.NamespacedName{Name: *(currentPVC.Spec.StorageClassName)}, storageClass)
+		err := client.Get(ctx, types.NamespacedName{Name: *(currentPVC.Spec.StorageClassName)}, storageClass)
 		if err != nil {
 			logger.Errorf("failed to get storageClass %q. %v", *(currentPVC.Spec.StorageClassName), err)
 			return
@@ -56,7 +56,7 @@ func ExpandPVCIfRequired(client client.Client, desiredPVC *v1.PersistentVolumeCl
 
 		currentPVC.Spec.Resources.Requests[v1.ResourceStorage] = desiredSize
 		logger.Infof("updating PVC %q size from %s to %s", currentPVC.Name, currentSize.String(), desiredSize.String())
-		if err = client.Update(context.TODO(), currentPVC); err != nil {
+		if err = client.Update(ctx, currentPVC); err != nil {
 			// log the error, but don't fail the reconcile
 			logger.Errorf("failed to update PVC size. %v", err)
 			return

--- a/pkg/operator/k8sutil/pvc_test.go
+++ b/pkg/operator/k8sutil/pvc_test.go
@@ -108,7 +108,7 @@ func TestExpandPVCIfRequired(t *testing.T) {
 
 		desiredPVC.Spec.Resources.Requests[v1.ResourceStorage] = apiresource.MustParse(tc.desiredPVCSize)
 
-		ExpandPVCIfRequired(cl, desiredPVC, existingPVC)
+		ExpandPVCIfRequired(context.TODO(), cl, desiredPVC, existingPVC)
 
 		// get existing PVC
 		err = cl.Get(context.TODO(), client.ObjectKey{Name: "test", Namespace: "rook-ceph"}, existingPVC)


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil pvc functions. By this, we
can handle cancellation during API call of pvc resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of #8700 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
