### PR TITLE
core: add context parameter to k8sutil configMap

### DIFF
--- a/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
+++ b/pkg/operator/k8sutil/cmdreporter/cmdreporter.go
@@ -155,7 +155,7 @@ func (cr *CmdReporter) Run(ctx context.Context, timeout time.Duration) (stdout, 
 	delOpts.Wait = true
 	delOpts.ErrorOnTimeout = true
 	// configmap's name will be the same as the app
-	err := k8sutil.DeleteConfigMap(cr.clientset, jobName, namespace, delOpts)
+	err := k8sutil.DeleteConfigMap(ctx, cr.clientset, jobName, namespace, delOpts)
 	if err != nil {
 		return "", "", -1, fmt.Errorf("%s. failed to delete existing results ConfigMap %s. %+v", errMsg, jobName, err)
 	}
@@ -180,7 +180,7 @@ func (cr *CmdReporter) Run(ctx context.Context, timeout time.Duration) (stdout, 
 
 	// just to be explicit: delete idempotently, and don't wait for delete to complete
 	delOpts = &k8sutil.DeleteOptions{MustDelete: false, WaitOptions: k8sutil.WaitOptions{Wait: false}}
-	if err := k8sutil.DeleteConfigMap(cr.clientset, jobName, namespace, delOpts); err != nil {
+	if err := k8sutil.DeleteConfigMap(ctx, cr.clientset, jobName, namespace, delOpts); err != nil {
 		logger.Errorf("continuing after failing to delete ConfigMap %s for job %s; user may need to delete it manually. %+v",
 			jobName, jobName, err)
 	}

--- a/pkg/operator/k8sutil/configmap.go
+++ b/pkg/operator/k8sutil/configmap.go
@@ -28,8 +28,7 @@ import (
 )
 
 // DeleteConfigMap deletes a ConfigMap.
-func DeleteConfigMap(clientset kubernetes.Interface, cmName, namespace string, opts *DeleteOptions) error {
-	ctx := context.TODO()
+func DeleteConfigMap(ctx context.Context, clientset kubernetes.Interface, cmName, namespace string, opts *DeleteOptions) error {
 	k8sOpts := BaseKubernetesDeleteOptions()
 	delete := func() error { return clientset.CoreV1().ConfigMaps(namespace).Delete(ctx, cmName, *k8sOpts) }
 	verify := func() error {

--- a/pkg/operator/k8sutil/configmap_test.go
+++ b/pkg/operator/k8sutil/configmap_test.go
@@ -51,7 +51,7 @@ func TestDeleteConfigMap(t *testing.T) {
 	opts := &DeleteOptions{}
 	opts.Wait = true
 	opts.ErrorOnTimeout = true
-	err = DeleteConfigMap(k8s, "test-configmap", "test-namespace", opts)
+	err = DeleteConfigMap(ctx, k8s, "test-configmap", "test-namespace", opts)
 	assert.NoError(t, err)
 
 	_, err = k8s.CoreV1().ConfigMaps("test-namespace").Get(ctx, "test-configmap", metav1.GetOptions{})


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil configMap functions. By
this, we can handle cancellation during API call of configMap resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of #8700

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
