### PR TITLE
core: add context parameter to k8sutil kvstore

### DIFF
--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -243,7 +243,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 			Message:      err.Error(),
 			PvcBackedOSD: cfg.pvcBacked,
 		}
-		oposd.UpdateNodeOrPVCStatus(kv, cfg.nodeName, status)
+		oposd.UpdateNodeOrPVCStatus(clusterInfo.Context, kv, cfg.nodeName, status)
 
 		rook.TerminateFatal(err)
 	}

--- a/pkg/daemon/ceph/osd/daemon.go
+++ b/pkg/daemon/ceph/osd/daemon.go
@@ -174,7 +174,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// set the initial orchestration status
 	status := oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating}
-	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)
 
 	if err := client.WriteCephConfig(context, agent.clusterInfo); err != nil {
 		return errors.Wrap(err, "failed to generate ceph config")
@@ -215,7 +215,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// orchestration is about to start, update the status
 	status = oposd.OrchestrationStatus{Status: oposd.OrchestrationStatusOrchestrating, PvcBackedOSD: agent.pvcBacked}
-	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)
 
 	// start the desired OSDs on devices
 	logger.Infof("configuring osd devices: %+v", devices)
@@ -232,7 +232,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 	if len(deviceOSDs) == 0 {
 		logger.Warningf("skipping OSD configuration as no devices matched the storage settings for this node %q", agent.nodeName)
 		status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
-		oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
+		oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)
 		return nil
 	}
 
@@ -272,7 +272,7 @@ func Provision(context *clusterd.Context, agent *OsdAgent, crushLocation, topolo
 
 	// orchestration is completed, update the status
 	status = oposd.OrchestrationStatus{OSDs: deviceOSDs, Status: oposd.OrchestrationStatusCompleted, PvcBackedOSD: agent.pvcBacked}
-	oposd.UpdateNodeOrPVCStatus(agent.kv, agent.nodeName, status)
+	oposd.UpdateNodeOrPVCStatus(agent.clusterInfo.Context, agent.kv, agent.nodeName, status)
 
 	return nil
 }

--- a/pkg/operator/ceph/cluster/osd/status_test.go
+++ b/pkg/operator/ceph/cluster/osd/status_test.go
@@ -56,7 +56,7 @@ func TestOrchestrationStatus(t *testing.T) {
 
 	// update the status map with some status
 	status := OrchestrationStatus{Status: OrchestrationStatusOrchestrating, Message: "doing work"}
-	UpdateNodeOrPVCStatus(kv, nodeName, status)
+	UpdateNodeOrPVCStatus(ctx, kv, nodeName, status)
 
 	// retrieve the status and verify it
 	statusMap, err := c.context.Clientset.CoreV1().ConfigMaps(c.clusterInfo.Namespace).Get(ctx, cmName, metav1.GetOptions{})
@@ -94,7 +94,7 @@ func mockNodeOrchestrationCompletion(c *Cluster, nodeName string, statusMapWatch
 					},
 					Status: OrchestrationStatusCompleted,
 				}
-				UpdateNodeOrPVCStatus(c.kv, nodeName, *status)
+				UpdateNodeOrPVCStatus(ctx, c.kv, nodeName, *status)
 
 				// 2) call modify on the fake watcher so a watch event will get triggered
 				s, _ := json.Marshal(status)

--- a/pkg/operator/ceph/object/mime.go
+++ b/pkg/operator/ceph/object/mime.go
@@ -46,12 +46,12 @@ func mimeTypesMountPath() string {
 // store mime.types file in a config map
 func (c *clusterConfig) generateMimeTypes() error {
 	k := k8sutil.NewConfigMapKVStore(c.store.Namespace, c.context.Clientset, c.ownerInfo)
-	if _, err := k.GetValue(c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
+	if _, err := k.GetValue(c.clusterInfo.Context, c.mimeTypesConfigMapName(), mimeTypesFileName); err == nil || !kerrors.IsNotFound(err) {
 		logger.Infof("config map %q for object store %q already exists, not overwriting", c.mimeTypesConfigMapName(), c.store.Name)
 		return nil
 	}
 	// is not found
-	if err := k.SetValue(c.mimeTypesConfigMapName(), mimeTypesFileName, mimeTypes); err != nil {
+	if err := k.SetValue(c.clusterInfo.Context, c.mimeTypesConfigMapName(), mimeTypesFileName, mimeTypes); err != nil {
 		return errors.Wrapf(err, "failed to create config map for object store %q", c.store.Name)
 	}
 	return nil

--- a/pkg/operator/k8sutil/kvstore.go
+++ b/pkg/operator/k8sutil/kvstore.go
@@ -41,8 +41,7 @@ func NewConfigMapKVStore(namespace string, clientset kubernetes.Interface, owner
 	}
 }
 
-func (kv *ConfigMapKVStore) GetValue(storeName, key string) (string, error) {
-	ctx := context.TODO()
+func (kv *ConfigMapKVStore) GetValue(ctx context.Context, storeName, key string) (string, error) {
 	cm, err := kv.clientset.CoreV1().ConfigMaps(kv.namespace).Get(ctx, storeName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -56,12 +55,11 @@ func (kv *ConfigMapKVStore) GetValue(storeName, key string) (string, error) {
 	return val, nil
 }
 
-func (kv *ConfigMapKVStore) SetValue(storeName, key, value string) error {
-	return kv.SetValueWithLabels(storeName, key, value, nil)
+func (kv *ConfigMapKVStore) SetValue(ctx context.Context, storeName, key, value string) error {
+	return kv.SetValueWithLabels(ctx, storeName, key, value, nil)
 }
 
-func (kv *ConfigMapKVStore) SetValueWithLabels(storeName, key, value string, labels map[string]string) error {
-	ctx := context.TODO()
+func (kv *ConfigMapKVStore) SetValueWithLabels(ctx context.Context, storeName, key, value string, labels map[string]string) error {
 	cm, err := kv.clientset.CoreV1().ConfigMaps(kv.namespace).Get(ctx, storeName, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -99,8 +97,7 @@ func (kv *ConfigMapKVStore) SetValueWithLabels(storeName, key, value string, lab
 	return nil
 }
 
-func (kv *ConfigMapKVStore) GetStore(storeName string) (map[string]string, error) {
-	ctx := context.TODO()
+func (kv *ConfigMapKVStore) GetStore(ctx context.Context, storeName string) (map[string]string, error) {
 	cm, err := kv.clientset.CoreV1().ConfigMaps(kv.namespace).Get(ctx, storeName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -109,8 +106,7 @@ func (kv *ConfigMapKVStore) GetStore(storeName string) (map[string]string, error
 	return cm.Data, nil
 }
 
-func (kv *ConfigMapKVStore) ClearStore(storeName string) error {
-	ctx := context.TODO()
+func (kv *ConfigMapKVStore) ClearStore(ctx context.Context, storeName string) error {
 	err := kv.clientset.CoreV1().ConfigMaps(kv.namespace).Delete(ctx, storeName, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		// a real error, return it (we're OK with clearing a store that doesn't exist)


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil kvstore functions. By
this, we can handle cancellation during API call of kvstore resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of #8700 

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
