### PR TITLE
core: add context to k8sutil replicaset and secret

### DIFF
--- a/pkg/operator/ceph/controller/mirror_peer.go
+++ b/pkg/operator/ceph/controller/mirror_peer.go
@@ -107,7 +107,7 @@ func CreateBootstrapPeerSecret(ctx *clusterd.Context, clusterInfo *cephclient.Cl
 
 	// Create Secret
 	logger.Debugf("store %s-mirror bootstrap token in a Kubernetes Secret %q in namespace %q", daemonType, s.Name, ns)
-	_, err = k8sutil.CreateOrUpdateSecret(ctx.Clientset, s)
+	_, err = k8sutil.CreateOrUpdateSecret(clusterInfo.Context, ctx.Clientset, s)
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return ImmediateRetryResult, errors.Wrapf(err, "failed to create %s-mirror bootstrap peer %q secret", daemonType, s.Name)
 	}

--- a/pkg/operator/k8sutil/replicaset.go
+++ b/pkg/operator/k8sutil/replicaset.go
@@ -24,8 +24,7 @@ import (
 )
 
 // DeleteReplicaSet makes a best effort at deleting a deployment and its pods, then waits for them to be deleted
-func DeleteReplicaSet(clientset kubernetes.Interface, namespace, name string) error {
-	ctx := context.TODO()
+func DeleteReplicaSet(ctx context.Context, clientset kubernetes.Interface, namespace, name string) error {
 	deleteAction := func(options *metav1.DeleteOptions) error {
 		return clientset.AppsV1().ReplicaSets(namespace).Delete(ctx, name, *options)
 	}

--- a/pkg/operator/k8sutil/secret.go
+++ b/pkg/operator/k8sutil/secret.go
@@ -27,8 +27,7 @@ import (
 )
 
 // CreateOrUpdateSecret creates a secret or updates the secret declaratively if it already exists.
-func CreateOrUpdateSecret(clientset kubernetes.Interface, secretDefinition *v1.Secret) (*v1.Secret, error) {
-	ctx := context.TODO()
+func CreateOrUpdateSecret(ctx context.Context, clientset kubernetes.Interface, secretDefinition *v1.Secret) (*v1.Secret, error) {
 	name := secretDefinition.Name
 	logger.Debugf("creating secret %s", name)
 


### PR DESCRIPTION
**Description of your changes:**

This commit adds context parameter to k8sutil replicaset and secret
functions. By this, we can handle cancellation during API call of
replicaset and secret resource.

Signed-off-by: Yuichiro Ueno <y1r.ueno@gmail.com>

**Which issue is resolved by this Pull Request:**
Part of #8700

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
