### PR TITLE
security: update auth permissions for external cluster

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -76,12 +76,19 @@ jobs:
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
     
+    - name: test external script with restricted_auth_permission flag and without having cephfs_filesystem flag
+      run: |
+        toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+        # create `radosNamespace1` rados-namespace for `replicapool` rbd data-pool
+        kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace1
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --rbd-data-pool-name replicapool --rados-namespace radosNamespace1 --cluster-name rookStorage --restricted-auth-permission true
+
     - name: test external script with restricted_auth_permission flag
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
-        # create `rados` rados-namespace for `replicapool` rbd data-pool
+        # create `radosNamespace` rados-namespace for `replicapool` rbd data-pool
         kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace
-        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py  --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -75,6 +75,13 @@ jobs:
       run: |
         toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
         timeout 60 sh -c "until kubectl -n rook-ceph exec $toolbox -- ceph fs subvolumegroup ls myfs|jq .[0].name|grep -q "group-a"; do sleep 1 && echo 'waiting for the subvolumegroup to be created'; done"
+    
+    - name: test external script with restricted_auth_permission flag
+      run: |
+        toolbox=$(kubectl get pod -l app=rook-ceph-tools -n rook-ceph -o jsonpath='{.items[*].metadata.name}')
+        # create `rados` rados-namespace for `replicapool` rbd data-pool
+        kubectl -n rook-ceph exec $toolbox -- rbd namespace create replicapool/radosNamespace
+        kubectl -n rook-ceph exec $toolbox -- python3 /etc/ceph/create-external-cluster-resources.py  --cephfs-filesystem-name myfs --rbd-data-pool-name replicapool --rados-namespace radosNamespace --cluster-name rookStorage --restricted-auth-permission true
 
     - name: check-ownerreferences
       run: tests/scripts/github-action-helper.sh check_ownerreferences

--- a/deploy/examples/create-external-cluster-resources.py
+++ b/deploy/examples/create-external-cluster-resources.py
@@ -97,6 +97,7 @@ class DummyRados(object):
         self.cmd_output_map['''{"caps": ["mon", "profile rbd", "mgr", "allow rw", "osd", "profile rbd"], "entity": "client.csi-rbd-provisioner", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-rbd-provisioner","key":"AQBNgrNe1geyKxAA8ekViRdE+hss5OweYBkwNg==","caps":{"mgr":"allow rw","mon":"profile rbd","osd":"profile rbd"}}]'''
         self.cmd_output_map['''{"caps": ["mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs *=*", "mds", "allow rw"], "entity": "client.csi-cephfs-node", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-node","key":"AQBOgrNeENunKxAAPCmgE7R6G8DcXnaJ1F32qg==","caps":{"mds":"allow rw","mgr":"allow rw","mon":"allow r","osd":"allow rw tag cephfs *=*"}}]'''
         self.cmd_output_map['''{"caps": ["mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner","key":"AQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r","osd":"allow rw tag cephfs metadata=*"}}]'''
+        self.cmd_output_map['''{"caps": ["mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=*"], "entity": "client.csi-cephfs-provisioner-openshift-storage", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner-openshift-storage","key":"BQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r","osd":"allow rw tag cephfs metadata=*"}}]'''
         self.cmd_output_map['''{"caps": ["mon", "allow r", "mgr", "allow rw", "osd", "allow rw tag cephfs metadata=myfs"], "entity": "client.csi-cephfs-provisioner-openshift-storage-myfs", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.csi-cephfs-provisioner-openshift-storage-myfs","key":"CQBOgrNeAFgcGBAAvGqKOAD0D3xxmVY0R912dg==","caps":{"mgr":"allow rw","mon":"allow r","osd":"allow rw tag cephfs metadata=myfs"}}]'''
         self.cmd_output_map['''{"caps": ["mon", "allow r, allow command quorum_status, allow command version", "mgr", "allow command config", "osd", "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"], "entity": "client.healthchecker", "format": "json", "prefix": "auth get-or-create"}'''] = '''[{"entity":"client.healthchecker","key":"AQDFkbNeft5bFRAATndLNUSEKruozxiZi3lrdA==","caps":{"mon": "allow r, allow command quorum_status, allow command version", "mgr": "allow command config", "osd": "allow rwx pool=default.rgw.meta, allow r pool=.rgw.root, allow rw pool=default.rgw.control, allow rx pool=default.rgw.log, allow x pool=default.rgw.buckets.index"}}]'''
         self.cmd_output_map['''{"format": "json", "prefix": "mgr services"}'''] = '''{"dashboard": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:7000/", "prometheus": "http://rook-ceph-mgr-a-57cf9f84bc-f4jnl:9283/"}'''
@@ -172,7 +173,7 @@ class RadosJSON:
         common_group.add_argument("--rgw-pool-prefix", default="",
                                   help="RGW Pool prefix")
         common_group.add_argument("--restricted-auth-permission", default=False,
-                                  help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster and pool namespaces. Mandatory flags that need to be set are --cephfs-filesystem-name, --rbd-data-pool-name, --rados-namespace and --cluster-name. Note: Restricting the users per pool, per cluster and per pool namespace will require to create new users and new secrets for that users.")
+                                  help="Restricted cephCSIKeyrings auth permissions to specific pools, cluster and pool namespaces. Mandatory flags that need to be set are --rbd-data-pool-name, --rados-namespace and --cluster-name. Note: Restricting the users per pool, per cluster and per pool namespace will require to create new users and new secrets for that users.")
 
         output_group = argP.add_argument_group('output')
         output_group.add_argument("--format", "-t", choices=["json", "bash"],
@@ -516,16 +517,24 @@ class RadosJSON:
         cmd_json = {}
         if self._arg_parser.restricted_auth_permission:
             cluster_name = self._arg_parser.cluster_name
-            cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
-            if cephfs_filesystem == "" or cluster_name == "":
+            if cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--cephfs-filesystem-name' and '--cluster-name' flags")
-            entity = "client.csi-cephfs-provisioner-{}-{}".format(cluster_name,cephfs_filesystem)
-            cmd_json = {"prefix": "auth get-or-create",
-                        "entity": entity,
-                        "caps": ["mon", "allow r", "mgr", "allow rw",
-                                 "osd", "allow rw tag cephfs metadata={}".format(cephfs_filesystem)],
-                        "format": "json"}
+                    "cluster_name not found, please set the '--cluster-name' flag")
+            cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
+            if cephfs_filesystem == "":
+                entity = "client.csi-cephfs-provisioner-{}".format(cluster_name)
+                cmd_json = {"prefix": "auth get-or-create",
+                            "entity": entity,
+                            "caps": ["mon", "allow r", "mgr", "allow rw",
+                                    "osd", "allow rw tag cephfs metadata=*"],
+                            "format": "json"}
+            else:
+                entity = "client.csi-cephfs-provisioner-{}-{}".format(cluster_name,cephfs_filesystem)
+                cmd_json = {"prefix": "auth get-or-create",
+                            "entity": entity,
+                            "caps": ["mon", "allow r", "mgr", "allow rw",
+                                    "osd", "allow rw tag cephfs metadata={}".format(cephfs_filesystem)],
+                            "format": "json"}
         else:
             cmd_json = {"prefix": "auth get-or-create",
                         "entity": entity,
@@ -547,19 +556,29 @@ class RadosJSON:
         cmd_json = {}
         if self._arg_parser.restricted_auth_permission:
             cluster_name = self._arg_parser.cluster_name
-            cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
-            if cephfs_filesystem == "" or cluster_name == "":
+            if cluster_name == "":
                 raise ExecutionFailureException(
-                    "mandatory flags not found, please set the '--cephfs-filesystem-name' and '--cluster-name' flags")
-            entity = "client.csi-cephfs-node-{}-{}".format(cluster_name,cephfs_filesystem)
-            cmd_json = {"prefix": "auth get-or-create",
-                        "entity": entity,
-                        "caps": ["mon", "allow r",
-                                 "mgr", "allow rw",
-                                 "osd", "allow rw tag cephfs data={}".format(
-                                     cephfs_filesystem),
-                                 "mds", "allow rw"],
-                        "format": "json"}
+                    "cluster_name not found, please set the '--cluster-name' flag")
+            cephfs_filesystem = self._arg_parser.cephfs_filesystem_name
+            if cephfs_filesystem == "":
+                entity = "client.csi-cephfs-node-{}".format(cluster_name)
+                cmd_json = {"prefix": "auth get-or-create",
+                            "entity": entity,
+                            "caps": ["mon", "allow r",
+                                    "mgr", "allow rw",
+                                    "osd", "allow rw tag cephfs *=*",
+                                    "mds", "allow rw"],
+                            "format": "json"}
+            else:
+                entity = "client.csi-cephfs-node-{}-{}".format(cluster_name,cephfs_filesystem)
+                cmd_json = {"prefix": "auth get-or-create",
+                            "entity": entity,
+                            "caps": ["mon", "allow r",
+                                    "mgr", "allow rw",
+                                    "osd", "allow rw tag cephfs data={}".format(
+                                        cephfs_filesystem),
+                                    "mds", "allow rw"],
+                            "format": "json"}
         else:
             cmd_json = {"prefix": "auth get-or-create",
                         "entity": entity,
@@ -953,7 +972,7 @@ class RadosJSON:
                     },
                 })
             # if 'CSI_CEPHFS_PROVISIONER_SECRET' exists, then only add 'rook-csi-cephfs-provisioner' Secret
-            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']:
+            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] and cephfs_filesystem != "":
                 json_out.append({
                     "name": "rook-csi-cephfs-provisioner-{}-{}".format(cluster_name,cephfs_filesystem),
                     "kind": "Secret",
@@ -962,8 +981,17 @@ class RadosJSON:
                         "adminKey": self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']
                     },
                 })
+            if self.out_map['CSI_CEPHFS_PROVISIONER_SECRET'] and cephfs_filesystem == "":
+                json_out.append({
+                    "name": "rook-csi-cephfs-provisioner-{}".format(cluster_name),
+                    "kind": "Secret",
+                    "data": {
+                        "adminID": 'csi-cephfs-provisioner-{}'.format(cluster_name),
+                        "adminKey": self.out_map['CSI_CEPHFS_PROVISIONER_SECRET']
+                    },
+                })    
             # if 'CSI_CEPHFS_NODE_SECRET' exists, then only add 'rook-csi-cephfs-node' Secret
-            if self.out_map['CSI_CEPHFS_NODE_SECRET']:
+            if self.out_map['CSI_CEPHFS_NODE_SECRET'] and cephfs_filesystem != "":
                 json_out.append({
                     "name": "rook-csi-cephfs-node-{}-{}".format(cluster_name,cephfs_filesystem),
                     "kind": "Secret",
@@ -972,6 +1000,15 @@ class RadosJSON:
                         "adminKey": self.out_map['CSI_CEPHFS_NODE_SECRET']
                     }
                 })
+            if self.out_map['CSI_CEPHFS_NODE_SECRET'] and cephfs_filesystem == "":
+                json_out.append({
+                    "name": "rook-csi-cephfs-node-{}".format(cluster_name),
+                    "kind": "Secret",
+                    "data": {
+                        "adminID": 'csi-cephfs-node-{}'.format(cluster_name),
+                        "adminKey": self.out_map['CSI_CEPHFS_NODE_SECRET']
+                    }
+                })    
         else:
             json_out.append({
                 "name": "rook-csi-rbd-node",
@@ -1194,8 +1231,10 @@ class TestRadosJSON(unittest.TestCase):
         csiKeyring = self.rjObj.create_cephCSIKeyring_cephFSProvisioner()
         print("cephCSIKeyring without restricting it to a metadata pool. {}".format(csiKeyring))
         self.rjObj._arg_parser.restricted_auth_permission = True
-        self.rjObj._arg_parser.cephfs_filesystem_name = "myfs"
         self.rjObj._arg_parser.cluster_name = "openshift-storage"
+        csiKeyring = self.rjObj.create_cephCSIKeyring_cephFSProvisioner()
+        print("cephCSIKeyring for a specific cluster. {}".format(csiKeyring))
+        self.rjObj._arg_parser.cephfs_filesystem_name = "myfs"
         csiKeyring = self.rjObj.create_cephCSIKeyring_cephFSProvisioner()
         print("cephCSIKeyring for a specific metadata pool and cluster. {}".format(csiKeyring))
 


### PR DESCRIPTION
Added a clusterName, poolName , filesystemName, radosNamespace
as a suffix on ceph auth principals for external cluster so
every csi authentication would be unique if
restricted_auth_permission flag is specified.

Closes: https://github.com/rook/rook/issues/9192
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
