### PR TITLE
build: Add K8s 1.23 to the CI tests

### DIFF
--- a/.github/workflows/daily-nightly-jobs.yml
+++ b/.github/workflows/daily-nightly-jobs.yml
@@ -101,7 +101,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -135,7 +135,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephSmokeSuite
         run: |
@@ -169,7 +169,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -203,7 +203,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephObjectSuite
         run: |
@@ -237,7 +237,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephUpgradeSuite
         run: |
@@ -271,7 +271,7 @@ jobs:
         uses: ./.github/workflows/integration-test-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          kubernetes-version: "1.22.2"
+          kubernetes-version: "1.23.0"
 
       - name: TestCephUpgradeSuite
         run: |

--- a/.github/workflows/integration-test-helm-suite.yaml
+++ b/.github/workflows/integration-test-helm-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.22.2']
+        kubernetes-versions : ['v1.16.15', 'v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-mgr-suite.yaml
+++ b/.github/workflows/integration-test-mgr-suite.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.22.2']
+        kubernetes-versions : ['v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-multi-cluster-suite.yaml
+++ b/.github/workflows/integration-test-multi-cluster-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.22.2']
+        kubernetes-versions : ['v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-object-suite.yaml
+++ b/.github/workflows/integration-test-object-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.22.2']
+        kubernetes-versions : ['v1.16.15', 'v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-smoke-suite.yaml
+++ b/.github/workflows/integration-test-smoke-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.22.2']
+        kubernetes-versions : ['v1.16.15', 'v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-test-upgrade-suite.yaml
+++ b/.github/workflows/integration-test-upgrade-suite.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.22.2']
+        kubernetes-versions : ['v1.16.15', 'v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/integration-tests-on-release.yaml
+++ b/.github/workflows/integration-tests-on-release.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.22.2']
+        kubernetes-versions : ['v1.16.15','v1.18.20','v1.21.7','v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.22.2']
+        kubernetes-versions : ['v1.16.15','v1.18.20','v1.21.7','v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.22.2']
+        kubernetes-versions : ['v1.16.15','v1.18.20','v1.21.7','v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -138,7 +138,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15','v1.18.15','v1.20.5','v1.22.2']
+        kubernetes-versions : ['v1.16.15','v1.18.20','v1.21.7','v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-versions : ['v1.16.15', 'v1.22.2']
+        kubernetes-versions : ['v1.16.15', 'v1.23.0']
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/setup-cluster-resources/action.yaml
+++ b/.github/workflows/setup-cluster-resources/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
         minikube version: 'v1.24.0'
-        kubernetes version: 'v1.22.2'
+        kubernetes version: 'v1.23.0'
         start args: --memory 6g --cpus=2 --addons ingress
         github token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
With the release of k8s 1.23 we update the CI to run PRs against K8s 1.16 and K8s 1.23, the oldest and latest releases that are supported. The master branch will run against the latest v1.16, 1.18, 1.21, and 1.23.

**Which issue is resolved by this Pull Request:**
Resolves #9374 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
