### PR TITLE
build: updating tini init command in direct mount toolbox

### DIFF
--- a/deploy/examples/direct-mount.yaml
+++ b/deploy/examples/direct-mount.yaml
@@ -19,9 +19,10 @@ spec:
       containers:
         - name: rook-direct-mount
           image: rook/ceph:master
-          command: ["/tini"]
-          args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+          command: ["/bin/bash"]
+          args: ["-m", "-c", "/usr/local/bin/toolbox.sh"]
           imagePullPolicy: IfNotPresent
+          tty: true
           env:
             - name: ROOK_CEPH_USERNAME
               valueFrom:

--- a/deploy/examples/direct-mount.yaml
+++ b/deploy/examples/direct-mount.yaml
@@ -36,6 +36,7 @@ spec:
                   key: ceph-secret
           securityContext:
             privileged: true
+            runAsUser: 0
           volumeMounts:
             - mountPath: /dev
               name: dev


### PR DESCRIPTION
the tini have been removed but was still present at direct mount
used the bin/bash shell in place of tini

Closes: https://github.com/rook/rook/issues/9382
Signed-off-by: parth-gr <paarora@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
