### PR TITLE
osd: add CAP_MKNOD to PSP

### DIFF
--- a/build/rbac/rbac.yaml
+++ b/build/rbac/rbac.yaml
@@ -702,6 +702,7 @@ spec:
   allowedCapabilities:
     # required by CSI
     - SYS_ADMIN
+    - MKNOD
   fsGroup:
     rule: RunAsAny
   # runAsUser, supplementalGroups - Rook needs to run some pods as root

--- a/deploy/charts/rook-ceph/templates/psp.yaml
+++ b/deploy/charts/rook-ceph/templates/psp.yaml
@@ -21,6 +21,7 @@ spec:
   allowedCapabilities:
     # required by CSI
     - SYS_ADMIN
+    - MKNOD
   fsGroup:
     rule: RunAsAny
   # runAsUser, supplementalGroups - Rook needs to run some pods as root

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -718,6 +718,7 @@ spec:
   allowedCapabilities:
     # required by CSI
     - SYS_ADMIN
+    - MKNOD
   fsGroup:
     rule: RunAsAny
   # runAsUser, supplementalGroups - Rook needs to run some pods as root


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

This commit adds CAP_MKNOD to PodSecurityPolicy to allow OSD-prepare job
creating pods on PSP-enabled Kubernetes cluster.

Follow-up of https://github.com/rook/rook/pull/9158

Signed-off-by: Yuichiro Ueno <ueno@preferred.jp>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/9438

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
