### PR TITLE
ceph: fix blockOwnerDeletion error

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -288,6 +288,11 @@ rules:
     verbs:
       # OBC controller updates OBC and OB statuses
       - update
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims/finalizers", "objectbuckets/finalizers"]
+    verbs:
+      # OBC controller updates OBC and OB finalizers
+      - update
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -464,6 +464,11 @@ rules:
     verbs:
       # OBC controller updates OBC and OB statuses
       - update
+  - apiGroups: ["objectbucket.io"]
+    resources: ["objectbucketclaims/finalizers", "objectbuckets/finalizers"]
+    verbs:
+      # OBC controller updates OBC and OB finalizers
+      - update
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
See https://sdk.operatorframework.io/docs/faqs/ for further reference

Signed-off-by: Daniel Ruiz Capilla <crd1985@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
This PR adds a missing role to allow the object controller update the finalizers section in OBC and OB. Otherwise, an error like `secrets \"my-bucket\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on:` is thrown in the operator log.

This error raises when the plugin OwnerReferencesPermissionEnforcement  is enabled (OKD 4.8 in bare metal in my use case).

See <https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-> for further reference.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
