### PR TITLE
docs: Recommend primary affinity over hybrid pools

### DIFF
--- a/Documentation/ceph-pool-crd.md
+++ b/Documentation/ceph-pool-crd.md
@@ -35,6 +35,10 @@ spec:
 Hybrid storage is a combination of two different storage tiers. For example, SSD and HDD.
 This helps to improve the read performance of cluster by placing, say, 1st copy of data on the higher performance tier (SSD or NVME) and remaining replicated copies on lower cost tier (HDDs).
 
+**WARNING** Hybrid storage pools are likely to suffer from lower availability if a node goes down. The data across the two
+tiers may actually end up on the same node, instead of being spread across unique nodes (or failure domains) as expected.
+Instead of using hybrid pools, consider configuring [primary affinity](https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity) from the toolbox.
+
 ```yaml
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Hybrid pools suffer from lower availability when a node goes down, so we recommend primary affinity instead of hybrid pools.

**Which issue is resolved by this Pull Request:**
Resolves #9298 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
