### PR TITLE
mgr: Update services when active mgr changes

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -196,7 +196,10 @@ If this value is empty, each pod will get an ephemeral directory to store their 
 * `mon`: contains mon related options [mon settings](#mon-settings)
 For more details on the mons and when to choose a number other than `3`, see the [mon health doc](ceph-mon-health.md).
 * `mgr`: manager top level section
-  * `count`: set number of ceph managers between `1` to `2`. The default value is 1. This is only needed if plural ceph managers are needed.
+  * `count`: set number of ceph managers between `1` to `2`. The default value is 1. This is only needed if two ceph managers are needed.
+    If there are two managers, it is important for all mgr services point to the active mgr and not the passive mgr. Therefore, Rook will
+    automatically update all services (in the cluster namespace) that have a label `app=rook-ceph-mgr` with a selector pointing to the
+    active mgr. This commonly applies to services for the dashboard or the prometheus metrics collector.
   * `modules`: is the list of Ceph manager modules to enable
 * `crashCollector`: The settings for crash collector daemon(s).
   * `disable`: is set to `true`, the crash collector will not run on any node where a Ceph daemon runs

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/ceph/controller"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	testopk8s "github.com/rook/rook/pkg/operator/k8sutil/test"
 	testop "github.com/rook/rook/pkg/operator/test"
@@ -37,6 +38,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -94,7 +96,7 @@ func TestStartMgr(t *testing.T) {
 
 	// start a basic service
 	err = c.Start()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	validateStart(t, c)
 	assert.ElementsMatch(t, []string{}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
@@ -102,7 +104,7 @@ func TestStartMgr(t *testing.T) {
 	c.spec.Dashboard.URLPrefix = "/test"
 	c.spec.Dashboard.Port = 12345
 	err = c.Start()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	validateStart(t, c)
 	assert.ElementsMatch(t, []string{"rook-ceph-mgr-a"}, testopk8s.DeploymentNamesUpdated(deploymentsUpdated))
 	testopk8s.ClearDeploymentsUpdated(deploymentsUpdated)
@@ -112,19 +114,19 @@ func TestStartMgr(t *testing.T) {
 	c.spec.Dashboard.Enabled = false
 	// delete the previous mgr since the mocked test won't update the existing one
 	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-a", metav1.DeleteOptions{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = c.Start()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	validateStart(t, c)
 
 	c.spec.Mgr.Count = 1
 	c.spec.Dashboard.Enabled = false
 	// clean the previous deployments
 	err = c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Delete(context.TODO(), "rook-ceph-mgr-a", metav1.DeleteOptions{})
-	assert.Nil(t, err)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+	assert.NoError(t, err)
 	err = c.Start()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	validateStart(t, c)
 }
 
@@ -134,7 +136,7 @@ func validateStart(t *testing.T, c *Cluster) {
 		logger.Infof("Looking for cephmgr replica %d", i)
 		daemonName := mgrNames[i]
 		d, err := c.context.Clientset.AppsV1().Deployments(c.clusterInfo.Namespace).Get(context.TODO(), fmt.Sprintf("rook-ceph-mgr-%s", daemonName), metav1.GetOptions{})
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, map[string]string{"my": "annotation"}, d.Spec.Template.Annotations)
 		assert.Contains(t, d.Spec.Template.Labels, "my-label-key")
 		assert.Equal(t, "my-priority-class", d.Spec.Template.Spec.PriorityClassName)
@@ -159,7 +161,7 @@ func validateStart(t *testing.T, c *Cluster) {
 
 func validateServices(t *testing.T, c *Cluster) {
 	_, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr", metav1.GetOptions{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	ds, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Get(context.TODO(), "rook-ceph-mgr-dashboard", metav1.GetOptions{})
 	if c.spec.Dashboard.Enabled {
@@ -174,6 +176,62 @@ func validateServices(t *testing.T, c *Cluster) {
 	} else {
 		assert.True(t, kerrors.IsNotFound(err))
 	}
+}
+
+func TestUpdateServiceSelectors(t *testing.T) {
+	clientset := testop.New(t, 3)
+	ctx := &clusterd.Context{Clientset: clientset}
+	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
+	spec := cephv1.ClusterSpec{
+		Dashboard: cephv1.DashboardSpec{
+			Enabled: true,
+			Port:    7000,
+		},
+	}
+	c := &Cluster{spec: spec, context: ctx, clusterInfo: clusterInfo}
+
+	t.Run("initial active daemon", func(t *testing.T) {
+		activeDaemon := "a"
+		err := c.reconcileServices(activeDaemon)
+		assert.NoError(t, err)
+		validateServiceActiveDaemon(t, c, activeDaemon, 2, 0)
+	})
+
+	t.Run("update active daemon", func(t *testing.T) {
+		activeDaemon := "b"
+		err := c.updateServiceSelectors(activeDaemon)
+		assert.NoError(t, err)
+		validateServiceActiveDaemon(t, c, activeDaemon, 2, 0)
+	})
+
+	t.Run("skip non-mgr services", func(t *testing.T) {
+		svc := corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "mysvc"}}
+		_, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).Create(clusterInfo.Context, &svc, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		activeDaemon := "c"
+		err = c.updateServiceSelectors(activeDaemon)
+		assert.NoError(t, err)
+		validateServiceActiveDaemon(t, c, activeDaemon, 2, 1)
+	})
+}
+
+func validateServiceActiveDaemon(t *testing.T, c *Cluster, activeDaemon string, expectedUpdated, expectedSkipped int) {
+	services, err := c.context.Clientset.CoreV1().Services(c.clusterInfo.Namespace).List(c.clusterInfo.Context, metav1.ListOptions{})
+	assert.NoError(t, err)
+	skipped := 0
+	updated := 0
+	for _, service := range services.Items {
+		if service.Labels["app"] == "rook-ceph-mgr" {
+			updated++
+			assert.Equal(t, activeDaemon, service.Spec.Selector[controller.DaemonIDLabel])
+		} else {
+			skipped++
+			assert.Equal(t, "", service.Spec.Selector[controller.DaemonIDLabel])
+		}
+	}
+	assert.Equal(t, expectedUpdated, updated)
+	assert.Equal(t, expectedSkipped, skipped)
 }
 
 func TestMgrSidecarReconcile(t *testing.T) {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
When the active mgr changes, there may be user-created services that also need to have their selector updated to point to the new active mgr. Now the operator will update any service in the rook operator namespace that has the label app=rook-ceph-mgr to point to the active mgr.

**Which issue is resolved by this Pull Request:**
Resolves #7988 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
