### PR TITLE
docs: fixed typo on rbd mirroring documentation

### DIFF
--- a/Documentation/rbd-mirroring.md
+++ b/Documentation/rbd-mirroring.md
@@ -181,7 +181,7 @@ to update the CephBlockPool CRD.
 ```bash
 [cluster-1]$ kubectl -n rook-ceph patch cephblockpool mirroredpool --type merge -p '{"spec":{"mirroring":{"peers": {"secretNames": ["rbd-primary-site-secret"]}}}}'
 ```
-## Create VolmeReplication CRDs
+## Create VolumeReplication CRDs
 
 Volume Replication Operator follows controller pattern and provides extended
 APIs for storage disaster recovery. The extended APIs are provided via Custom


### PR DESCRIPTION
Fixed typo from VolmeReplication  to VolumeReplication on the documentation page of RBD-mirroring.
Signed-off-by: Vivek Shinde vivek.j.shinde1@gmail.com

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
docs: Fixed typo from VolmeReplication  to VolumeReplication

**Which issue is resolved by this Pull Request:**
Resolves # 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
