### PR TITLE
core: limit use of wildcards in cluster-scoped rbac

### DIFF
--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -83,10 +83,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  # Rook creates events for its custom resources
   - events
-  # PVs and PVCs are managed by the Rook provisioner
+  # Rook creates PVs and PVCs for OSDs managed by the Rook provisioner
   - persistentvolumes
   - persistentvolumeclaims
+  # Rook creates endpoints for mgr and object store access
   - endpoints
   verbs:
   - get
@@ -116,18 +118,71 @@ rules:
   - create
   - update
   - delete
-- apiGroups:
-  - ceph.rook.io
+# The Rook operator must be able to watch all ceph.rook.io resources to reconcile them.
+- apiGroups: ["ceph.rook.io"]
   resources:
-  - "*"
+  - cephclients
+  - cephclusters
+  - cephblockpools
+  - cephfilesystems
+  - cephnfses
+  - cephobjectstores
+  - cephobjectstoreusers
+  - cephobjectrealms
+  - cephobjectzonegroups
+  - cephobjectzones
+  - cephbuckettopics
+  - cephbucketnotifications
+  - cephrbdmirrors
+  - cephfilesystemmirrors
+  - cephfilesystemsubvolumegroups
   verbs:
-  - "*"
-- apiGroups:
-  - rook.io
+  - get
+  - list
+  - watch
+  # Ideally the update permission is not required, but Rook needs it to add finalizers to resources.
+  - update
+# Rook must have update access to status subresources for its custom resources.
+- apiGroups: ["ceph.rook.io"]
   resources:
-  - "*"
-  verbs:
-  - "*"
+  - cephclients/status
+  - cephclusters/status
+  - cephblockpools/status
+  - cephfilesystems/status
+  - cephnfses/status
+  - cephobjectstores/status
+  - cephobjectstoreusers/status
+  - cephobjectrealms/status
+  - cephobjectzonegroups/status
+  - cephobjectzones/status
+  - cephbuckettopics/status
+  - cephbucketnotifications/status
+  - cephrbdmirrors/status
+  - cephfilesystemmirrors/status
+  - cephfilesystemsubvolumegroups/status
+  verbs: ["update"]
+# The "*/finalizers" permission may need to be strictly given for K8s clusters where
+# OwnerReferencesPermissionEnforcement is enabled so that Rook can set blockOwnerDeletion on
+# resources owned by Rook CRs (e.g., a Secret owned by an OSD Deployment). See more:
+# https://kubernetes.io/docs/reference/access-authn-authz/_print/#ownerreferencespermissionenforcement
+- apiGroups: ["ceph.rook.io"]
+  resources:
+  - cephclients/finalizers
+  - cephclusters/finalizers
+  - cephblockpools/finalizers
+  - cephfilesystems/finalizers
+  - cephnfses/finalizers
+  - cephobjectstores/finalizers
+  - cephobjectstoreusers/finalizers
+  - cephobjectrealms/finalizers
+  - cephobjectzonegroups/finalizers
+  - cephobjectzones/finalizers
+  - cephbuckettopics/finalizers
+  - cephbucketnotifications/finalizers
+  - cephrbdmirrors/finalizers
+  - cephfilesystemmirrors/finalizers
+  - cephfilesystemsubvolumegroups/finalizers
+  verbs: ["update"]
 - apiGroups:
   - policy
   - apps
@@ -139,7 +194,13 @@ rules:
   - deployments
   - replicasets
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - deletecollection
 - apiGroups:
   - healthchecking.openshift.io
   resources:
@@ -289,9 +350,11 @@ rules:
       # OBC controller updates OBC and OB statuses
       - update
   - apiGroups: ["objectbucket.io"]
+    # This does not strictly allow the OBC/OB controllers to update finalizers. That is handled by
+    # the direct "update" permissions above. Instead, this allows Rook's controller to create
+    # resources which are owned by OBs/OBCs and where blockOwnerDeletion is set.
     resources: ["objectbucketclaims/finalizers", "objectbuckets/finalizers"]
     verbs:
-      # OBC controller updates OBC and OB finalizers
       - update
 ---
 kind: ClusterRole

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -259,10 +259,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      # Rook creates events for its custom resources
       - events
-      # PVs and PVCs are managed by the Rook provisioner
+      # Rook creates PVs and PVCs for OSDs managed by the Rook provisioner
       - persistentvolumes
       - persistentvolumeclaims
+      # Rook creates endpoints for mgr and object store access
       - endpoints
     verbs:
       - get
@@ -292,18 +294,71 @@ rules:
       - create
       - update
       - delete
-  - apiGroups:
-      - ceph.rook.io
+  # The Rook operator must be able to watch all ceph.rook.io resources to reconcile them.
+  - apiGroups: ["ceph.rook.io"]
     resources:
-      - "*"
+      - cephclients
+      - cephclusters
+      - cephblockpools
+      - cephfilesystems
+      - cephnfses
+      - cephobjectstores
+      - cephobjectstoreusers
+      - cephobjectrealms
+      - cephobjectzonegroups
+      - cephobjectzones
+      - cephbuckettopics
+      - cephbucketnotifications
+      - cephrbdmirrors
+      - cephfilesystemmirrors
+      - cephfilesystemsubvolumegroups
     verbs:
-      - "*"
-  - apiGroups:
-      - rook.io
+      - get
+      - list
+      - watch
+      # Ideally the update permission is not required, but Rook needs it to add finalizers to resources.
+      - update
+  # Rook must have update access to status subresources for its custom resources.
+  - apiGroups: ["ceph.rook.io"]
     resources:
-      - "*"
-    verbs:
-      - "*"
+      - cephclients/status
+      - cephclusters/status
+      - cephblockpools/status
+      - cephfilesystems/status
+      - cephnfses/status
+      - cephobjectstores/status
+      - cephobjectstoreusers/status
+      - cephobjectrealms/status
+      - cephobjectzonegroups/status
+      - cephobjectzones/status
+      - cephbuckettopics/status
+      - cephbucketnotifications/status
+      - cephrbdmirrors/status
+      - cephfilesystemmirrors/status
+      - cephfilesystemsubvolumegroups/status
+    verbs: ["update"]
+  # The "*/finalizers" permission may need to be strictly given for K8s clusters where
+  # OwnerReferencesPermissionEnforcement is enabled so that Rook can set blockOwnerDeletion on
+  # resources owned by Rook CRs (e.g., a Secret owned by an OSD Deployment). See more:
+  # https://kubernetes.io/docs/reference/access-authn-authz/_print/#ownerreferencespermissionenforcement
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephclients/finalizers
+      - cephclusters/finalizers
+      - cephblockpools/finalizers
+      - cephfilesystems/finalizers
+      - cephnfses/finalizers
+      - cephobjectstores/finalizers
+      - cephobjectstoreusers/finalizers
+      - cephobjectrealms/finalizers
+      - cephobjectzonegroups/finalizers
+      - cephobjectzones/finalizers
+      - cephbuckettopics/finalizers
+      - cephbucketnotifications/finalizers
+      - cephrbdmirrors/finalizers
+      - cephfilesystemmirrors/finalizers
+      - cephfilesystemsubvolumegroups/finalizers
+    verbs: ["update"]
   - apiGroups:
       - policy
       - apps
@@ -315,7 +370,13 @@ rules:
       - deployments
       - replicasets
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - deletecollection
   - apiGroups:
       - healthchecking.openshift.io
     resources:
@@ -465,9 +526,11 @@ rules:
       # OBC controller updates OBC and OB statuses
       - update
   - apiGroups: ["objectbucket.io"]
+    # This does not strictly allow the OBC/OB controllers to update finalizers. That is handled by
+    # the direct "update" permissions above. Instead, this allows Rook's controller to create
+    # resources which are owned by OBs/OBCs and where blockOwnerDeletion is set.
     resources: ["objectbucketclaims/finalizers", "objectbuckets/finalizers"]
     verbs:
-      # OBC controller updates OBC and OB finalizers
       - update
 ---
 kind: ClusterRole


### PR DESCRIPTION
Rook needs to be able to watch all `ceph.rook.io` resources to reconcile
them; however, it does not need blanket verb privileges. Reduce the
privileges as much as possible.

Ideally, Rook would only have update permissions to status and
finalizers of resources; however, finalizers are not a full-fledged
subresource at this time, and "update" permissions must be maintained
for `ceph.rook.io` resources.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

## Topic for discussion:
What should we do about the `rook-ceph-mgr` `Role` permissions (copied below)?
These are only needed if the user intends to use the rook mgr orchestrator module to control Rook. And I'm not sure if these permissions are fully up to date either (@jmolmo might have a fuller idea of that). Should we move these permissions to another file, or should we spend the time to pare them down?

```
# Aspects of ceph-mgr that operate within the cluster's namespace
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: rook-ceph-mgr
  namespace: {{ .Release.Namespace }} # namespace:cluster
rules:
  - apiGroups:
      - ""
    resources:
      - pods       <!-- I think this is b/c it can create jobs and so needs pod perms as well -->
      - services   <!-- is this for the service failover stuff @travisn ? is delete actually needed? -->
      - pods/log   <!-- only get perms should be needed for this I think -->
    verbs:
      - get
      - list
      - watch
      - create
      - update
      - delete
  - apiGroups:
      - batch
    resources:
      - jobs
    verbs:
      - get
      - list
      - watch
      - create
      - update
      - delete
  - apiGroups:
      - ceph.rook.io
    resources:
      - "*"
    verbs:
      - "*"     <!-- definitely need to pare this down, though it would still likely be all CRUD operations for the orchestrator -->
  - apiGroups:
      - apps
    resources:
      - deployments/scale
      - deployments     <!-- why does the mgr scale/patch deployments? -->
    verbs:
      - patch
      - delete
  - apiGroups:
      - ''
    resources:
      - persistentvolumeclaims
    verbs:
      - delete    <!-- why does the mgr delete PVCs!?!? -->
```

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

---

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
