### PR TITLE
core: support priority class for crashcollector

### DIFF
--- a/Documentation/ceph-cluster-crd.md
+++ b/Documentation/ceph-cluster-crd.md
@@ -601,10 +601,11 @@ Priority class names can be specified so that the Rook components will have thos
 
 You can set priority class names for Rook components for the list of key value pairs:
 
-* `all`: Set priority class names for MGRs, Mons, OSDs.
+* `all`: Set priority class names for MGRs, Mons, OSDs, and crashcollectors.
 * `mgr`: Set priority class names for MGRs.
 * `mon`: Set priority class names for Mons.
 * `osd`: Set priority class names for OSDs.
+* `crashcollector`: Set priority class names for crashcollectors.
 
 The specific component keys will act as overrides to `all`.
 

--- a/deploy/charts/rook-ceph-cluster/values.yaml
+++ b/deploy/charts/rook-ceph-cluster/values.yaml
@@ -238,6 +238,7 @@ cephClusterSpec:
   #   mon: rook-ceph-mon-priority-class
   #   osd: rook-ceph-osd-priority-class
   #   mgr: rook-ceph-mgr-priority-class
+  #   crashcollector: rook-ceph-crashcollector-priority-class
 
   storage: # cluster level storage configuration and selection
     useAllNodes: true

--- a/deploy/examples/cluster.yaml
+++ b/deploy/examples/cluster.yaml
@@ -207,6 +207,7 @@ spec:
 #    mon: rook-ceph-mon-priority-class
 #    osd: rook-ceph-osd-priority-class
 #    mgr: rook-ceph-mgr-priority-class
+#    crashcollector: rook-ceph-crashcollector-priority-class
   storage: # cluster level storage configuration and selection
     useAllNodes: true
     useAllDevices: true

--- a/pkg/apis/ceph.rook.io/v1/priorityclasses.go
+++ b/pkg/apis/ceph.rook.io/v1/priorityclasses.go
@@ -55,3 +55,11 @@ func GetCleanupPriorityClassName(p PriorityClassNamesSpec) string {
 	}
 	return p[KeyCleanup]
 }
+
+// GetCrashCollectorPriorityClassName returns the priority class name for the crashcollector
+func GetCrashCollectorPriorityClassName(p PriorityClassNamesSpec) string {
+	if _, ok := p[KeyCrashCollector]; !ok {
+		return p.All()
+	}
+	return p[KeyCrashCollector]
+}

--- a/pkg/apis/ceph.rook.io/v1/priorityclasses_test.go
+++ b/pkg/apis/ceph.rook.io/v1/priorityclasses_test.go
@@ -30,6 +30,7 @@ all: all-class
 mgr: mgr-class
 mon: mon-class
 osd: osd-class
+crashcollector: crashcollector-class
 `)
 
 	// convert the raw spec yaml into JSON
@@ -43,10 +44,11 @@ osd: osd-class
 
 	// the unmarshalled priority class names spec should equal the expected spec below
 	expected := PriorityClassNamesSpec{
-		"all": "all-class",
-		"mgr": "mgr-class",
-		"mon": "mon-class",
-		"osd": "osd-class",
+		"all":            "all-class",
+		"mgr":            "mgr-class",
+		"mon":            "mon-class",
+		"osd":            "osd-class",
+		"crashcollector": "crashcollector-class",
 	}
 	assert.Equal(t, expected, priorityClassNames)
 }

--- a/pkg/operator/ceph/cluster/crash/crash.go
+++ b/pkg/operator/ceph/cluster/crash/crash.go
@@ -113,10 +113,11 @@ func (r *ReconcileNode) createOrUpdateCephCrash(node corev1.Node, tolerations []
 				Containers: []corev1.Container{
 					getCrashDaemonContainer(cephCluster, *cephVersion),
 				},
-				Tolerations:   tolerations,
-				RestartPolicy: corev1.RestartPolicyAlways,
-				HostNetwork:   cephCluster.Spec.Network.IsHost(),
-				Volumes:       volumes,
+				Tolerations:       tolerations,
+				RestartPolicy:     corev1.RestartPolicyAlways,
+				HostNetwork:       cephCluster.Spec.Network.IsHost(),
+				Volumes:           volumes,
+				PriorityClassName: cephv1.GetCrashCollectorPriorityClassName(cephCluster.Spec.PriorityClassNames),
 			},
 		}
 


### PR DESCRIPTION
**Description of your changes:**

Support priorityClass to crashcollectos as mons, mgrs, and osds.

https://rook.io/docs/rook/v1.8/ceph-cluster-crd.html#priority-class-names-configuration-settings

The main use case is applying the high priority to crashcollectors to preempt normal pods under heavy load. Without this feature, we might lose crash information.

Closes: https://github.com/rook/rook/issues/9500

Signed-off-by: Satoru Takeuchi <satoru.takeuchi@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #9500

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
