### PR TITLE
osd: allow for injecting extra environment variables.

### DIFF
--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	kms "github.com/rook/rook/pkg/daemon/ceph/osd/kms"
@@ -232,4 +233,21 @@ func getTcmallocMaxTotalThreadCacheBytesFromFile() string {
 	}
 
 	return iniCephEnvConfigFile.Section("").Key(tcmallocMaxTotalThreadCacheBytesEnv).String()
+}
+
+func parseExtraEnvVars(vars string) []v1.EnvVar {
+	extraVars := strings.Split(vars, ";")
+	var envVars []v1.EnvVar
+	for _, extraVar := range extraVars {
+		endNameIndex := strings.Index(extraVar, "=")
+		if endNameIndex < 0 {
+			logger.Infof("Invalid extra var: %s", extraVar)
+			continue
+		}
+		name := extraVar[:endNameIndex]
+		val := extraVar[endNameIndex+1:]
+		envVars = append(envVars, v1.EnvVar{Name: name, Value: val})
+	}
+	logger.Infof("additional osd env args: %v", envVars)
+	return envVars
 }

--- a/pkg/operator/ceph/cluster/osd/envs_test.go
+++ b/pkg/operator/ceph/cluster/osd/envs_test.go
@@ -92,3 +92,10 @@ func TestGetTcmallocMaxTotalThreadCacheBytes(t *testing.T) {
 	v = getTcmallocMaxTotalThreadCacheBytes("")
 	assert.Equal(t, "134217728", v.Value)
 }
+
+func TestParseExtraEnv(t *testing.T) {
+	vars := parseExtraEnvVars("foo=bar=0")
+	assert.Equal(t, 1, len(vars))
+	assert.Equal(t, "foo", vars[0].Name)
+	assert.Equal(t, "bar=0", vars[0].Value)
+}

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package osd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -229,6 +230,11 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 
 	if osdProps.metadataDevice != "" {
 		envVars = append(envVars, metadataDeviceEnvVar(osdProps.metadataDevice))
+	}
+	if extraEnvVarsValue, err := k8sutil.GetOperatorSetting(context.TODO(), c.context.Clientset, controller.OperatorSettingConfigMapName, "OSD_EXTRA_ENV_VARS", ""); err != nil {
+		logger.Warningf("failed to get extra env vars for osd prepare. %v", err)
+	} else if extraEnvVarsValue != "" {
+		envVars = append(envVars, parseExtraEnvVars(extraEnvVarsValue)...)
 	}
 
 	volumeMounts := append(controller.CephVolumeMounts(provisionConfig.DataPathMap, true), []v1.VolumeMount{


### PR DESCRIPTION
This patch is both stripped down (no support for extra argvs) and extended (envs at both prepare and main stages) version
of the Travis Nielsen's patch (https://github.com/rook/rook/pull/8763) to accommodate crimson-osd in Rook. Also, the naming convention isn't crimson-specific anymore as the mechanism could be useful with the classical OSD as well (e.g. tuning TCMalloc or even the dynamic linker).

The need for the patch comes from the fact that, although crimson finally exposes the same CLI interface as the classical
OSD, the broadly used development builds have ASan built in. As ASan, by default, complains if it isn't the very first loaded
DSO, we need to set the `ASAN_OPTIONS` environment variable to `verify_asan_link_order=0` to mitigate the early aborts.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
