### PR TITLE
docs: Correct VAULT_BACKEND_PATH

### DIFF
--- a/Documentation/ceph-kms.md
+++ b/Documentation/ceph-kms.md
@@ -142,11 +142,13 @@ security:
     connectionDetails:
         KMS_PROVIDER: vault
         VAULT_ADDR: https://vault.default.svc.cluster.local:8200
-        VAULT_BACKEND_PATH: rook/ver1
+        VAULT_BACKEND_PATH: rook
         VAULT_SECRET_ENGINE: kv
         VAULT_AUTH_METHOD: kubernetes
         VAULT_AUTH_KUBERNETES_ROLE: rook-ceph
 ```
+
+Note that the `VAULT_ADDR` value above assumes that Vault is accessible within the cluster itself on the default port (8200). If running elsewhere, please update the URL accordingly.
 
 ### General Vault configuration
 


### PR DESCRIPTION
Based on my testing with the guide above, the original value in the sample code here:

`VAULT_BACKEND_PATH: rook/ver1`

...did not work and resulted in a Vault path error when Rook attempted to provision the 
OSD filesystem.  When I simplified it to:

`VAULT_BACKEND_PATH: rook`

... then it worked. (Note I'm testing with Vault 1.9.1)

I also took the opportunity to add a comment/clarification about the `VAULT_ADDR` URL.

Signed-off-by: Shahak Nagiel snagiel@yahoo.com
