### PR TITLE
rgw: fix startup probe

### DIFF
--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -420,18 +420,10 @@ func (c *clusterConfig) defaultReadinessProbe() *v1.Probe {
 }
 
 func (c *clusterConfig) defaultStartupProbe() *v1.Probe {
-	return &v1.Probe{
-		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Path:   readinessProbePath,
-				Port:   c.generateProbePort(),
-				Scheme: c.generateReadinessProbeScheme(),
-			},
-		},
-		InitialDelaySeconds: 10,
-		PeriodSeconds:       10,
-		FailureThreshold:    18,
-	}
+	probe := c.defaultLivenessProbe()
+	probe.PeriodSeconds = 10
+	probe.FailureThreshold = 18
+	return probe
 }
 
 func (c *clusterConfig) generateReadinessProbeScheme() v1.URIScheme {


### PR DESCRIPTION
**Description of your changes:**

It's better to set the same handler to startupProbe as livenessProbe. Otherwise, we might hit the following problem.

https://github.com/rook/rook/issues/6304

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
