### PR TITLE
helm: use operatorNamespace if exists for monitoring RBAC

### DIFF
--- a/deploy/charts/library/templates/_cluster-monitoring.tpl
+++ b/deploy/charts/library/templates/_cluster-monitoring.tpl
@@ -55,7 +55,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rook-ceph-system
-    namespace: {{ .Release.Namespace }} # namespace:cluster
+    namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:operator
 ---
 # Allow creation of monitoring resources in the mgr
 kind: RoleBinding


### PR DESCRIPTION
**Description of your changes:**

right now the RoleBinding for monitoring is created with the cluster namespace as the subject
This causes the operator to loop on reconcile due to it not having permissions to create `ServiceMonitor`s
in the other namespace

moving the subject to the operator namespace fixes this

**Which issue is resolved by this Pull Request:**
Resolves #9553

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
