### PR TITLE
docs: Explain about region in storage class for OBC

### DIFF
--- a/Documentation/ceph-object-bucket-claim.md
+++ b/Documentation/ceph-object-bucket-claim.md
@@ -105,13 +105,14 @@ provisioner: rook-ceph.ceph.rook.io/bucket [2]
 parameters: [3]
   objectStoreName: my-store
   objectStoreNamespace: rook-ceph
-  region: us-west-1
-  bucketName: ceph-bucket [4]
-reclaimPolicy: Delete [5]
+  region: us-west-1 [4]
+  bucketName: ceph-bucket [5]
+reclaimPolicy: Delete [6]
 ```
 1. `label`(optional) here associates this `StorageClass` to a specific provisioner.
 1. `provisioner` responsible for handling `OBCs` referencing this `StorageClass`.
 1. **all** `parameter` required.
+1. `region` defines the region in which the bucket should be created. For Rook, this is CephObjectZoneGroup (if applicable) of the related CephObjectStore; So if you need to define region other than `us-east-1` create `CephObjectZoneGroup` accordingly. Please refer to [Ceph's documentation](https://docs.ceph.com/en/latest/radosgw/multisite/#zone-groups) for more details. 
 1. `bucketName` is required for access to existing buckets but is omitted when provisioning new buckets.
 Unlike greenfield provisioning, the brownfield bucket name appears in the `StorageClass`, not the `OBC`.
 1. rook-ceph provisioner decides how to treat the `reclaimPolicy` when an `OBC` is deleted for the bucket. See explanation as [specified in Kubernetes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain)


### PR DESCRIPTION


<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The default value for region in RGW is us-east-1, if users want to use
other regions then they need to create zone/zonegroup accordingly before
defining it in storage class.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #9486

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
