### PR TITLE
core: run all the command with timeout where possible

### DIFF
--- a/cmd/rook/rook/rook.go
+++ b/cmd/rook/rook/rook.go
@@ -224,7 +224,7 @@ func TerminateFatal(reason error) {
 
 // GetOperatorBaseImageCephVersion returns the Ceph version of the operator image
 func GetOperatorBaseImageCephVersion(context *clusterd.Context) (string, error) {
-	output, err := context.Executor.ExecuteCommandWithOutput("ceph", "--version")
+	output, err := context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "ceph", "--version")
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to execute command to detect ceph version")
 	}

--- a/pkg/clusterd/disk_test.go
+++ b/pkg/clusterd/disk_test.go
@@ -17,6 +17,7 @@ package clusterd
 
 import (
 	"testing"
+	"time"
 
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ func TestDiscoverDevices(t *testing.T) {
 			logger.Infof("mock execute. %s", command)
 			return nil
 		},
-		MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, arg ...string) (string, error) {
 			logger.Infof("mock execute with output. %s", command)
 			return "", nil
 		},

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -170,15 +170,15 @@ func (c *CephToolCommand) run() ([]byte, error) {
 				err = errors.Errorf("%s. %s", err.Error(), stderr)
 			}
 		} else if c.timeout == 0 {
-			output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
+			output, err = c.context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, command, args...)
 		} else {
 			output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)
 		}
 	} else if c.timeout == 0 {
 		if c.combinedOutput {
-			output, err = c.context.Executor.ExecuteCommandWithCombinedOutput(command, args...)
+			output, err = c.context.Executor.ExecuteCommandWithCombinedOutput(exec.CephCommandsTimeout, command, args...)
 		} else {
-			output, err = c.context.Executor.ExecuteCommandWithOutput(command, args...)
+			output, err = c.context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, command, args...)
 		}
 	} else {
 		output, err = c.context.Executor.ExecuteCommandWithTimeout(c.timeout, command, args...)

--- a/pkg/daemon/ceph/client/command_test.go
+++ b/pkg/daemon/ceph/client/command_test.go
@@ -113,7 +113,7 @@ func TestNewRBDCommand(t *testing.T) {
 	t.Run("rbd command with no multus", func(t *testing.T) {
 		clusterInfo := AdminTestClusterInfo("rook")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			switch {
 			case command == "rbd" && args[0] == "create":
 				assert.Len(t, args, 8)

--- a/pkg/daemon/ceph/client/crash_test.go
+++ b/pkg/daemon/ceph/client/crash_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -39,7 +40,7 @@ var (
 func TestCephCrash(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 		if args[0] == "crash" && args[1] == "ls" {
 			return fakecrash, nil

--- a/pkg/daemon/ceph/client/crush.go
+++ b/pkg/daemon/ceph/client/crush.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -211,7 +212,7 @@ func GetOSDOnHost(context *clusterd.Context, clusterInfo *ClusterInfo, node stri
 func compileCRUSHMap(context *clusterd.Context, crushMapPath string) error {
 	mapFile := buildCompileCRUSHFileName(crushMapPath)
 	args := []string{"--compile", crushMapPath, "--outfn", mapFile}
-	output, err := context.Executor.ExecuteCommandWithOutput("crushtool", args...)
+	output, err := context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "crushtool", args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to compile crush map %q. %s", mapFile, output)
 	}
@@ -222,7 +223,7 @@ func compileCRUSHMap(context *clusterd.Context, crushMapPath string) error {
 func decompileCRUSHMap(context *clusterd.Context, crushMapPath string) error {
 	mapFile := buildDecompileCRUSHFileName(crushMapPath)
 	args := []string{"--decompile", crushMapPath, "--outfn", mapFile}
-	output, err := context.Executor.ExecuteCommandWithOutput("crushtool", args...)
+	output, err := context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "crushtool", args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to decompile crush map %q. %s", mapFile, output)
 	}

--- a/pkg/daemon/ceph/client/crush_rule_test.go
+++ b/pkg/daemon/ceph/client/crush_rule_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -61,7 +62,7 @@ func TestBuildCrushSteps(t *testing.T) {
 
 func TestCompileCRUSHMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if command == "crushtool" && args[0] == "--compile" && args[1] == "/tmp/063990228" && args[2] == "--outfn" && args[3] == "/tmp/063990228.compiled" {
 			return "3", nil
@@ -75,7 +76,7 @@ func TestCompileCRUSHMap(t *testing.T) {
 
 func TestDecompileCRUSHMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if command == "crushtool" && args[0] == "--decompile" && args[1] == "/tmp/063990228" && args[2] == "--outfn" && args[3] == "/tmp/063990228.decompiled" {
 			return "3", nil
@@ -89,7 +90,7 @@ func TestDecompileCRUSHMap(t *testing.T) {
 
 func TestInjectCRUSHMapMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "osd" && args[1] == "setcrushmap" && args[2] == "--in-file" && args[3] == "/tmp/063990228.compiled" {
 			return "3", nil
@@ -103,7 +104,7 @@ func TestInjectCRUSHMapMap(t *testing.T) {
 
 func TestSetCRUSHMapMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "osd" && args[1] == "crush" && args[2] == "set" && args[3] == "/tmp/063990228.compiled" {
 			return "3", nil

--- a/pkg/daemon/ceph/client/crush_test.go
+++ b/pkg/daemon/ceph/client/crush_test.go
@@ -18,6 +18,7 @@ package client
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -265,7 +266,7 @@ const testCrushMap = `{
 
 func TestGetCrushMap(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return testCrushMap, nil
@@ -283,7 +284,7 @@ func TestGetCrushMap(t *testing.T) {
 
 func TestGetOSDOnHost(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "ls" {
 			return "[\"osd.2\",\"osd.0\",\"osd.1\"]", nil

--- a/pkg/daemon/ceph/client/deviceclass_test.go
+++ b/pkg/daemon/ceph/client/deviceclass_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -27,7 +28,7 @@ import (
 
 func TestGetDeviceClassOSDs(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "class" && args[3] == "ls-osd" && args[4] == "ssd" {
 			// Mock executor for `ceph osd crush class ls-osd ssd`

--- a/pkg/daemon/ceph/client/erasure-code-profile_test.go
+++ b/pkg/daemon/ceph/client/erasure-code-profile_test.go
@@ -18,6 +18,7 @@ package client
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -52,7 +53,7 @@ func testCreateProfile(t *testing.T, failureDomain, crushRoot, deviceClass strin
 
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "erasure-code-profile" {
 			if args[2] == "get" {

--- a/pkg/daemon/ceph/client/filesystem_mirror_test.go
+++ b/pkg/daemon/ceph/client/filesystem_mirror_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -43,7 +44,7 @@ var (
 func TestEnableFilesystemSnapshotMirror(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -62,7 +63,7 @@ func TestEnableFilesystemSnapshotMirror(t *testing.T) {
 func TestDisableFilesystemSnapshotMirror(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -82,7 +83,7 @@ func TestImportFilesystemMirrorPeer(t *testing.T) {
 	fs := "myfs"
 	token := "my-token"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -103,7 +104,7 @@ func TestImportFilesystemMirrorPeer(t *testing.T) {
 func TestCreateFSMirrorBootstrapPeer(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
 			assert.Equal(t, "mirror", args[2])
@@ -126,7 +127,7 @@ func TestCreateFSMirrorBootstrapPeer(t *testing.T) {
 func TestRemoveFilesystemMirrorPeer(t *testing.T) {
 	peerUUID := "peer-uuid"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			assert.Equal(t, "snapshot", args[1])
@@ -147,7 +148,7 @@ func TestFSMirrorDaemonStatus(t *testing.T) {
 	fs := "myfs"
 	executor := &exectest.MockExecutor{}
 	t.Run("snapshot status command with fsName - test for Ceph v16.2.6 and earlier", func(t *testing.T) {
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "fs" {
 				assert.Equal(t, "snapshot", args[1])
 				assert.Equal(t, "mirror", args[2])
@@ -167,7 +168,7 @@ func TestFSMirrorDaemonStatus(t *testing.T) {
 		assert.Equal(t, "myfs", s[0].Filesystems[0].Name)
 	})
 	t.Run("snapshot status command without fsName - test for Ceph v16.2.7 and above", func(t *testing.T) {
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "fs" {
 				assert.Equal(t, "snapshot", args[1])
 				assert.Equal(t, "mirror", args[2])

--- a/pkg/daemon/ceph/client/filesystem_test.go
+++ b/pkg/daemon/ceph/client/filesystem_test.go
@@ -105,7 +105,7 @@ func TestFilesystemRemove(t *testing.T) {
 			DataPools:      []int{1},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -192,7 +192,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -240,7 +240,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -285,7 +285,7 @@ func TestFailAllStandbyReplayMDS(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -335,7 +335,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -360,7 +360,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test errors
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -407,7 +407,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 		},
 	}
 	// test get mds by id failed error
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -455,7 +455,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 			},
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "get" {
@@ -484,7 +484,7 @@ func TestGetMdsIdByRank(t *testing.T) {
 func TestGetMDSDump(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -507,7 +507,7 @@ func TestGetMDSDump(t *testing.T) {
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, mdsDump.Standbys, []MDSStandBy{{Name: "rook-ceph-filesystem-b", Rank: -1}})
 
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -524,7 +524,7 @@ func TestGetMDSDump(t *testing.T) {
 func TestWaitForNoStandbys(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -546,7 +546,7 @@ func TestWaitForNoStandbys(t *testing.T) {
 	err := WaitForNoStandbys(context, AdminTestClusterInfo("mycluster"), 6*time.Second)
 	assert.Error(t, err)
 
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {
@@ -560,7 +560,7 @@ func TestWaitForNoStandbys(t *testing.T) {
 	assert.Error(t, err)
 
 	firstCall := true
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "fs" {
 			if args[1] == "dump" {

--- a/pkg/daemon/ceph/client/image_test.go
+++ b/pkg/daemon/ceph/client/image_test.go
@@ -38,7 +38,7 @@ func TestCreateImage(t *testing.T) {
 
 	// mock an error during the create image call.  rbd tool returns error information to the output stream,
 	// separate from the error object, so verify that information also makes it back to us (because it is useful).
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
 			return "mocked detailed ceph error output stream", errors.New("some mocked error")
@@ -54,7 +54,7 @@ func TestCreateImage(t *testing.T) {
 	// (except for 0, that's OK)
 	createCalled := false
 	expectedSizeArg := ""
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "create":
 			createCalled = true
@@ -172,7 +172,7 @@ func TestListImageLogLevelInfo(t *testing.T) {
 	var err error
 	listCalled := false
 	emptyListResult := false
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
 			listCalled = true
@@ -237,7 +237,7 @@ func TestListImageLogLevelDebug(t *testing.T) {
 
 	listCalled := false
 	emptyListResult := false
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		switch {
 		case command == "rbd" && args[0] == "ls" && args[1] == "-l":
 			listCalled = true

--- a/pkg/daemon/ceph/client/mgr_test.go
+++ b/pkg/daemon/ceph/client/mgr_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -30,7 +31,7 @@ func TestEnableModuleRetries(t *testing.T) {
 	moduleEnableRetries := 0
 	moduleEnableWaitTime = 0
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "balancer" && args[1] == "on":
@@ -74,7 +75,7 @@ func TestEnableModuleRetries(t *testing.T) {
 
 func TestEnableModule(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mgr" && args[1] == "module" && args[2] == "enable":
@@ -107,7 +108,7 @@ func TestEnableModule(t *testing.T) {
 
 func TestEnableDisableBalancerModule(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "balancer" && args[1] == "on":
@@ -131,7 +132,7 @@ func TestEnableDisableBalancerModule(t *testing.T) {
 
 func TestSetBalancerMode(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "balancer" && args[1] == "mode" && args[2] == "upmap" {
 			return "", nil

--- a/pkg/daemon/ceph/client/mirror_test.go
+++ b/pkg/daemon/ceph/client/mirror_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -38,7 +39,7 @@ var (
 func TestCreateRBDMirrorBootstrapPeer(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "peer", args[2])
@@ -65,7 +66,7 @@ func TestEnablePoolMirroring(t *testing.T) {
 		},
 	}
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "enable", args[2])
@@ -84,7 +85,7 @@ func TestEnablePoolMirroring(t *testing.T) {
 func TestGetPoolMirroringStatus(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "status", args[2])
@@ -104,7 +105,7 @@ func TestGetPoolMirroringStatus(t *testing.T) {
 func TestImportRBDMirrorBootstrapPeer(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "peer", args[2])
@@ -121,7 +122,7 @@ func TestImportRBDMirrorBootstrapPeer(t *testing.T) {
 	err := ImportRBDMirrorBootstrapPeer(context, AdminTestClusterInfo("mycluster"), pool, "", []byte(bootstrapPeerToken))
 	assert.NoError(t, err)
 
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "peer", args[2])
@@ -143,7 +144,7 @@ func TestImportRBDMirrorBootstrapPeer(t *testing.T) {
 func TestGetPoolMirroringInfo(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "info", args[2])
@@ -167,7 +168,7 @@ func TestEnableSnapshotSchedule(t *testing.T) {
 	// Schedule with Interval
 	{
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %v %v", command, args)
 			if args[0] == "mirror" {
 				assert.Equal(t, "snapshot", args[1])
@@ -192,7 +193,7 @@ func TestEnableSnapshotSchedule(t *testing.T) {
 	{
 		startTime := "14:00:00-05:00"
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %v %v", command, args)
 			if args[0] == "mirror" {
 				assert.Equal(t, "snapshot", args[1])
@@ -218,7 +219,7 @@ func TestEnableSnapshotSchedule(t *testing.T) {
 func TestListSnapshotSchedules(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %v %v", command, args)
 		if args[0] == "mirror" {
 			assert.Equal(t, "snapshot", args[1])
@@ -240,7 +241,7 @@ func TestListSnapshotSchedules(t *testing.T) {
 func TestListSnapshotSchedulesRecursively(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %v %v", command, args)
 		if args[0] == "mirror" {
 			assert.Equal(t, "snapshot", args[1])
@@ -263,7 +264,7 @@ func TestListSnapshotSchedulesRecursively(t *testing.T) {
 func TestRemoveSnapshotSchedule(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %v %v", command, args)
 		if args[0] == "mirror" {
 			assert.Equal(t, "snapshot", args[1])
@@ -286,7 +287,7 @@ func TestRemoveSnapshotSchedules(t *testing.T) {
 	interval := "24h"
 	startTime := "14:00:00-05:00"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %v %v", command, args)
 		if args[0] == "mirror" {
 			switch args[3] {
@@ -317,7 +318,7 @@ func TestRemoveSnapshotSchedules(t *testing.T) {
 func TestDisableMirroring(t *testing.T) {
 	pool := "pool-test"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "disable", args[2])
@@ -336,7 +337,7 @@ func TestRemoveClusterPeer(t *testing.T) {
 	pool := "pool-test"
 	peerUUID := "39ae33fb-1dd6-4f9b-8ed7-0e4517068900"
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if args[0] == "mirror" {
 			assert.Equal(t, "pool", args[1])
 			assert.Equal(t, "peer", args[2])

--- a/pkg/daemon/ceph/client/mon_test.go
+++ b/pkg/daemon/ceph/client/mon_test.go
@@ -70,7 +70,7 @@ func TestCephArgs(t *testing.T) {
 
 func TestStretchElectionStrategy(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "mon" && args[1] == "set" && args[2] == "election_strategy" {
 			assert.Equal(t, "connectivity", args[3])
@@ -91,7 +91,7 @@ func TestStretchClusterMonTiebreaker(t *testing.T) {
 	setTiebreaker := false
 	enabledStretch := false
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mon" && args[1] == "enable_stretch_mode":
@@ -124,7 +124,7 @@ func TestStretchClusterMonTiebreaker(t *testing.T) {
 
 func TestMonDump(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "mon" && args[1] == "dump":

--- a/pkg/daemon/ceph/client/osd_test.go
+++ b/pkg/daemon/ceph/client/osd_test.go
@@ -19,6 +19,7 @@ package client
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -64,7 +65,7 @@ var (
 func TestHostTree(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyTreeResult := false
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "tree":
@@ -92,7 +93,7 @@ func TestHostTree(t *testing.T) {
 func TestOsdListNum(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	emptyOsdListNumResult := false
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "ls":
@@ -116,7 +117,7 @@ func TestOsdListNum(t *testing.T) {
 
 func TestOSDDeviceClasses(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "crush" && args[2] == "get-device-class" && len(args) > 3:
@@ -147,7 +148,7 @@ func TestOSDOkToStop(t *testing.T) {
 	seenArgs := []string{}
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		switch {
 		case args[0] == "osd" && args[1] == "ok-to-stop":

--- a/pkg/daemon/ceph/client/pool_test.go
+++ b/pkg/daemon/ceph/client/pool_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -58,7 +59,7 @@ func testCreateECPool(t *testing.T, overwrite bool, compressionMode string) {
 	}
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
@@ -110,7 +111,7 @@ func TestSetPoolApplication(t *testing.T) {
 	clusterInfo := AdminTestClusterInfo("mycluster")
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" && args[2] == "application" {
 			if args[3] == "get" {
@@ -167,7 +168,7 @@ func testCreateReplicaPool(t *testing.T, failureDomain, crushRoot, deviceClass, 
 	compressionModeCreated := false
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "create" {
@@ -249,7 +250,7 @@ func TestUpdateFailureDomain(t *testing.T) {
 	currentFailureDomain := "rack"
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "pool" {
 			if args[2] == "get" {
@@ -354,7 +355,7 @@ func TestGetPoolStatistics(t *testing.T) {
 	p.Trash.SnapCount = 0
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		a := "{\"images\":{\"count\":1,\"provisioned_bytes\":1024,\"snap_count\":1},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
 		logger.Infof("Command: %s %v", command, args)
 
@@ -384,7 +385,7 @@ func TestSetPoolReplicatedSizeProperty(t *testing.T) {
 	poolName := "mypool"
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 
 		if args[2] == "set" {
@@ -401,7 +402,7 @@ func TestSetPoolReplicatedSizeProperty(t *testing.T) {
 	assert.NoError(t, err)
 
 	// TEST POOL SIZE 1 AND RequireSafeReplicaSize True
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 
 		if args[2] == "set" {
@@ -427,7 +428,7 @@ func TestCreateStretchCrushRule(t *testing.T) {
 func testCreateStretchCrushRule(t *testing.T, alreadyExists bool) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "osd" {
 			if args[1] == "getcrushmap" {
@@ -493,7 +494,7 @@ func testCreatePoolWithReplicasPerFailureDomain(t *testing.T, failureDomain, cru
 	}
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		assert.Equal(t, command, "ceph")
 		assert.Equal(t, args[0], "osd")
@@ -557,7 +558,7 @@ func TestCreateHybridCrushRule(t *testing.T) {
 func testCreateHybridCrushRule(t *testing.T, alreadyExists bool) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "osd" {
 			if args[1] == "getcrushmap" {

--- a/pkg/daemon/ceph/client/status.go
+++ b/pkg/daemon/ceph/client/status.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -171,7 +172,7 @@ func StatusWithUser(context *clusterd.Context, clusterInfo *ClusterInfo) (CephSt
 	args := []string{"status", "--format", "json"}
 	command, args := FinalizeCephCommandArgs("ceph", clusterInfo, args, context.ConfigDir)
 
-	buf, err := context.Executor.ExecuteCommandWithOutput(command, args...)
+	buf, err := context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, command, args...)
 	if err != nil {
 		if buf != "" {
 			return CephStatus{}, errors.Wrapf(err, "failed to get status. %s", string(buf))

--- a/pkg/daemon/ceph/client/upgrade_test.go
+++ b/pkg/daemon/ceph/client/upgrade_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestGetCephMonVersionString(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		assert.Equal(t, "version", args[0])
 		return "", nil
 	}
@@ -43,7 +43,7 @@ func TestGetCephMonVersionString(t *testing.T) {
 
 func TestGetCephMonVersionsString(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		assert.Equal(t, "versions", args[0])
 		return "", nil
 	}
@@ -55,7 +55,7 @@ func TestGetCephMonVersionsString(t *testing.T) {
 
 func TestEnableReleaseOSDFunctionality(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		assert.Equal(t, "osd", args[0])
 		assert.Equal(t, "require-osd-release", args[1])
 		return "", nil
@@ -69,7 +69,7 @@ func TestEnableReleaseOSDFunctionality(t *testing.T) {
 func TestOkToStopDaemon(t *testing.T) {
 	// First test
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		switch {
 		case args[0] == "mon" && args[1] == "ok-to-stop" && args[2] == "a":
 			return "", nil
@@ -83,7 +83,7 @@ func TestOkToStopDaemon(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Second test
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		assert.Equal(t, "mgr", args[0])
 		assert.Equal(t, "ok-to-stop", args[1])
 		assert.Equal(t, "a", args[2])
@@ -96,7 +96,7 @@ func TestOkToStopDaemon(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Third test
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		assert.Equal(t, "dummy", args[0])
 		assert.Equal(t, "ok-to-stop", args[1])
 		assert.Equal(t, "a", args[2])
@@ -292,7 +292,7 @@ func TestOSDUpdateShouldCheckOkToStop(t *testing.T) {
 	treeOutput := ""
 	context := &clusterd.Context{
 		Executor: &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				t.Logf("command: %s %v", command, args)
 				if command != "ceph" || args[0] != "osd" {
 					panic("not a 'ceph osd' call")

--- a/pkg/daemon/ceph/osd/agent.go
+++ b/pkg/daemon/ceph/osd/agent.go
@@ -21,6 +21,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster/osd/config"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -56,7 +57,7 @@ func NewAgent(context *clusterd.Context, devices []DesiredDevice, metadataDevice
 }
 
 func getDeviceLVPath(context *clusterd.Context, deviceName string) string {
-	output, err := context.Executor.ExecuteCommandWithOutput("pvdisplay", "-C", "-o", "lvpath", "--noheadings", deviceName)
+	output, err := context.Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "pvdisplay", "-C", "-o", "lvpath", "--noheadings", deviceName)
 	if err != nil {
 		logger.Warningf("failed to retrieve logical volume path for %q. %v", deviceName, err)
 		return ""

--- a/pkg/daemon/ceph/osd/daemon_test.go
+++ b/pkg/daemon/ceph/osd/daemon_test.go
@@ -18,6 +18,7 @@ package osd
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -175,7 +176,7 @@ USEC_INITIALIZED=1128667
 func TestAvailableDevices(t *testing.T) {
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("OUTPUT for %s %v", command, args)
 
 			if command == "lsblk" {

--- a/pkg/daemon/ceph/osd/device_test.go
+++ b/pkg/daemon/ceph/osd/device_test.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
@@ -31,7 +32,7 @@ func TestOSDBootstrap(t *testing.T) {
 	configDir := t.TempDir()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
 	}

--- a/pkg/daemon/ceph/osd/encryption.go
+++ b/pkg/daemon/ceph/osd/encryption.go
@@ -28,6 +28,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/daemon/ceph/osd/kms"
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -41,7 +42,7 @@ var (
 
 func closeEncryptedDevice(context *clusterd.Context, dmName string) error {
 	args := []string{"--verbose", "luksClose", dmName}
-	cryptsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(cryptsetupBinary, args...)
+	cryptsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.NoCommandTimout, cryptsetupBinary, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to close encrypted device. %s", cryptsetupOut)
 	}
@@ -52,7 +53,7 @@ func closeEncryptedDevice(context *clusterd.Context, dmName string) error {
 
 func dmsetupVersion(context *clusterd.Context) error {
 	args := []string{"version"}
-	dmsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(dmsetupBinary, args...)
+	dmsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.CephCommandsTimeout, dmsetupBinary, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to find device mapper version. %s", dmsetupOut)
 	}
@@ -120,7 +121,7 @@ func setLUKSLabelAndSubsystem(context *clusterd.Context, clusterInfo *cephclient
 	logger.Infof("setting LUKS subsystem to %q and label to %q to disk %q", subsystem, label, disk)
 	// 48 characters limit for both label and subsystem
 	args := []string{"config", disk, "--subsystem", subsystem, "--label", label}
-	output, err := context.Executor.ExecuteCommandWithCombinedOutput(cryptsetupBinary, args...)
+	output, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.NoCommandTimout, cryptsetupBinary, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set subsystem %q and label %q to encrypted device %q. is your distro built with LUKS1 as a default?. %s", subsystem, label, disk, output)
 	}
@@ -131,7 +132,7 @@ func setLUKSLabelAndSubsystem(context *clusterd.Context, clusterInfo *cephclient
 
 func dumpLUKS(context *clusterd.Context, disk string) (string, error) {
 	args := []string{"luksDump", disk}
-	cryptsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(cryptsetupBinary, args...)
+	cryptsetupOut, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.NoCommandTimout, cryptsetupBinary, args...)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to dump LUKS header for disk %q. %s", disk, cryptsetupOut)
 	}

--- a/pkg/daemon/ceph/osd/encryption_test.go
+++ b/pkg/daemon/ceph/osd/encryption_test.go
@@ -18,6 +18,7 @@ package osd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -69,7 +70,7 @@ Digests:
 
 func TestCloseEncryptedDevice(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == "cryptsetup" && args[0] == "--verbose" && args[1] == "luksClose" {
 			return "success", nil
@@ -89,7 +90,7 @@ Library version:   1.02.154 (2018-12-07)
 Driver version:    4.40.0
 `
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == "dmsetup" && args[0] == "version" {
 			return dmsetupOutput, nil
@@ -105,7 +106,7 @@ Driver version:    4.40.0
 
 func TestIsCephEncryptedBlock(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == cryptsetupBinary && args[0] == "luksDump" {
 			return luksDump, nil

--- a/pkg/daemon/ceph/osd/nsenter.go
+++ b/pkg/daemon/ceph/osd/nsenter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/util/exec"
 )
 
 const (
@@ -62,7 +63,7 @@ func (ne *NSEnter) buildNsEnterCLI(binPath string) []string {
 
 func (ne *NSEnter) callNsEnter(binPath string) error {
 	args := ne.buildNsEnterCLI(binPath)
-	op, err := ne.context.Executor.ExecuteCommandWithCombinedOutput(nsenterCmd, args...)
+	op, err := ne.context.Executor.ExecuteCommandWithCombinedOutput(exec.CephCommandsTimeout, nsenterCmd, args...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to execute nsenter. output: %s", op)
 	}

--- a/pkg/daemon/ceph/osd/nsenter_test.go
+++ b/pkg/daemon/ceph/osd/nsenter_test.go
@@ -19,6 +19,7 @@ package osd
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -36,7 +37,7 @@ func TestBuildNsEnterCLI(t *testing.T) {
 
 func TestCheckIfBinaryExistsOnHost(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == "nsenter" && args[0] == "--mount=/rootfs/proc/1/ns/mnt" && args[1] == "--" && args[3] == "help" {
 			if args[2] == "/usr/sbin/lvm" || args[2] == "/sbin/lvm" {

--- a/pkg/daemon/ceph/osd/volume.go
+++ b/pkg/daemon/ceph/osd/volume.go
@@ -34,6 +34,7 @@ import (
 	oposd "github.com/rook/rook/pkg/operator/ceph/cluster/osd"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/util/display"
+	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
 )
 
@@ -337,7 +338,7 @@ func (a *OsdAgent) initializeBlockPVC(context *clusterd.Context, devices *Device
 			}
 
 			// execute ceph-volume with the device
-			op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, immediateExecuteArgs...)
+			op, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.NoCommandTimout, baseCommand, immediateExecuteArgs...)
 			if err != nil {
 				cvLogFilePath := path.Join(cvLogDir, "ceph-volume.log")
 
@@ -571,7 +572,7 @@ func (a *OsdAgent) initializeDevicesRawMode(context *clusterd.Context, devices *
 			immediateExecuteArgs = a.appendDeviceClassArg(device, immediateExecuteArgs)
 
 			// execute ceph-volume with the device
-			op, err := context.Executor.ExecuteCommandWithCombinedOutput(baseCommand, immediateExecuteArgs...)
+			op, err := context.Executor.ExecuteCommandWithCombinedOutput(exec.NoCommandTimout, baseCommand, immediateExecuteArgs...)
 			if err != nil {
 				cvLogFilePath := path.Join(cephLogDir, "ceph-volume.log")
 
@@ -758,7 +759,7 @@ func (a *OsdAgent) initializeDevicesLVMMode(context *clusterd.Context, devices *
 			"json",
 		}...)
 
-		cvOut, err := context.Executor.ExecuteCommandWithOutput(baseCommand, reportArgs...)
+		cvOut, err := context.Executor.ExecuteCommandWithOutput(exec.NoCommandTimout, baseCommand, reportArgs...)
 		if err != nil {
 			return errors.Wrapf(err, "failed ceph-volume json report: %s", cvOut) // fail return here as validation provided by ceph-volume
 		}
@@ -1152,7 +1153,7 @@ func callCephVolume(context *clusterd.Context, args ...string) (string, error) {
 
 	// Do not use combined output for "list" calls, otherwise we will get stderr is the output and this will break the json unmarshall
 	f := context.Executor.ExecuteCommandWithOutput
-	co, err := f(baseCommand, append(baseArgs, args...)...)
+	co, err := f(exec.NoCommandTimout, baseCommand, append(baseArgs, args...)...)
 	if err != nil {
 		// Print c-v log before exiting with failure
 		cvLog := readCVLogContent("/tmp/ceph-log/ceph-volume.log")

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -340,7 +341,7 @@ func TestConfigureCVDevices(t *testing.T) {
 	{
 		t.Log("Test case for creating new raw mode OSD on LV-backed PVC")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
 			if command == "lsblk" && args[0] == mountedDev {
 				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="lvm" PKNAME="" NAME="%s" KNAME="/dev/dm-1, a ...interface{})`, mapperDev), nil
@@ -368,7 +369,7 @@ func TestConfigureCVDevices(t *testing.T) {
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
-		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
 			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[6] == mapperDev {
 				return "", nil
@@ -404,7 +405,7 @@ func TestConfigureCVDevices(t *testing.T) {
 		// Test case for with no available lvm mode OSD and existing raw mode OSD on LV-backed PVC, it should return info of raw mode OSD
 		t.Log("Test case for with no available lvm mode OSD and existing raw mode OSD on LV-backed PVC, it should return info of raw mode OSD")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
 			if command == "lsblk" && args[0] == mountedDev {
 				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="lvm" PKNAME="" NAME="%s" KNAME="/dev/dm-1, a ...interface{})`, mapperDev), nil
@@ -429,7 +430,7 @@ func TestConfigureCVDevices(t *testing.T) {
 			}
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
-		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
 
@@ -459,7 +460,7 @@ func TestConfigureCVDevices(t *testing.T) {
 		// Test case for a lvm mode OSD on LV-backed PVC, it should return info of lvm mode OSD
 		t.Log("Test case for a lvm mode OSD on LV-backed PVC, it should return info of lvm mode OSD")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
 			if command == "lsblk" && args[0] == mountedDev {
 				return fmt.Sprintf(`SIZE="17179869184" ROTA="1" RO="0" TYPE="lvm" PKNAME="" NAME="%s" KNAME="/dev/dm-1"
@@ -529,7 +530,7 @@ func TestConfigureCVDevices(t *testing.T) {
 	{
 		t.Log("Test case for raw mode on partition")
 		executor := &exectest.MockExecutor{}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithOutput] %s %v", command, args)
 			// get lsblk for disks from cephVolumeRAWTestResult var
 			if command == "lsblk" && (args[0] == "/dev/vdb1") {
@@ -547,7 +548,7 @@ func TestConfigureCVDevices(t *testing.T) {
 			return "", errors.Errorf("unknown command %s %s", command, args)
 		}
 		deviceClassSet := false
-		executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("[MockExecuteCommandWithCombinedOutput] %s %v", command, args)
 			if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[7] == "--crush-device-class" {
 				assert.Equal(t, "myclass", args[8])
@@ -797,7 +798,7 @@ func TestInitializeBlock(t *testing.T) {
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
 
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("%s %v", command, args)
 
 			// Validate base common args
@@ -852,7 +853,7 @@ func TestInitializeBlock(t *testing.T) {
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
 
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("%s %v", command, args)
 
 			// Validate base common args
@@ -879,7 +880,7 @@ func TestInitializeBlock(t *testing.T) {
 
 func TestInitializeBlockPVC(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" {
 			return initializeBlockPVCTestResult, nil
@@ -906,7 +907,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 	assert.Equal(t, "", metadataBlockPath)
 	assert.Equal(t, "", walBlockPath)
 
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[7] == "--crush-device-class" {
 			assert.Equal(t, "foo", args[8])
@@ -950,7 +951,7 @@ func TestInitializeBlockPVC(t *testing.T) {
 
 func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[7] == "--block.db" {
 			return initializeBlockPVCTestResult, nil
@@ -979,7 +980,7 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 	assert.Equal(t, "/srv/set1-metadata-0-8c7kr", metadataBlockPath)
 	assert.Equal(t, "", walBlockPath)
 
-	executor.MockExecuteCommandWithCombinedOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithCombinedOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if args[1] == "ceph-volume" && args[2] == "raw" && args[3] == "prepare" && args[4] == "--bluestore" && args[7] == "--crush-device-class" && args[9] == "--block.db" {
 			return initializeBlockPVCTestResult, nil
@@ -1014,7 +1015,7 @@ func TestInitializeBlockPVCWithMetadata(t *testing.T) {
 
 func TestParseCephVolumeLVMResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		logger.Infof("%s %v", command, args)
@@ -1035,7 +1036,7 @@ func TestParseCephVolumeLVMResult(t *testing.T) {
 
 func TestParseCephVolumeRawResult(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 		if command == "stdbuf" {
 			if args[4] == "raw" && args[5] == "list" {
@@ -1064,7 +1065,7 @@ func TestParseCephVolumeRawResult(t *testing.T) {
 func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		if command == "stdbuf" {
@@ -1088,7 +1089,7 @@ func TestCephVolumeResultMultiClusterSingleOSD(t *testing.T) {
 func TestCephVolumeResultMultiClusterMultiOSD(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	// set up a mock function to return "rook owned" partitions on the device and it does not have a filesystem
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("%s %v", command, args)
 
 		if command == "stdbuf" {
@@ -1220,7 +1221,7 @@ func TestInitializeBlockWithMD(t *testing.T) {
 
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			// First command
 			if args[9] == "--osds-per-device" && args[10] == "1" && args[11] == "/dev/sda" && args[12] == "--db-devices" && args[13] == "/dev/sdd" && args[14] == "--report" {
 				return `[{"block_db": "/dev/sdd", "encryption": "None", "data": "/dev/sda", "data_size": "100.00 GB", "block_db_size": "100.00 GB"}]`, nil
@@ -1259,7 +1260,7 @@ func TestInitializeBlockWithMD(t *testing.T) {
 
 			return errors.Errorf("unknown command %s %s", command, args)
 		}
-		executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+		executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 			// First command
 			if args[9] == "--osds-per-device" && args[10] == "1" && args[11] == "/dev/sda" && args[12] == "--db-devices" && args[13] == "/dev/vg0/lv0" && args[14] == "--report" {
 				return `[{"block_db": "vg0/lv0", "encryption": "None", "data": "/dev/sda", "data_size": "100.00 GB", "block_db_size": "10.00 GB"}]`, nil

--- a/pkg/daemon/discover/discover.go
+++ b/pkg/daemon/discover/discover.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	pgkexec "github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/pkg/util/sys"
 
 	v1 "k8s.io/api/core/v1"
@@ -473,7 +474,7 @@ func probeDevices(context *clusterd.Context) ([]sys.LocalDisk, error) {
 // getCephVolumeInventory: Return a map of strings indexed by device with the
 // information about the device returned by the command <ceph-volume inventory>
 func getCephVolumeInventory(context *clusterd.Context) (*map[string]string, error) {
-	inventory, err := context.Executor.ExecuteCommandWithOutput("ceph-volume", "inventory", "--format", "json")
+	inventory, err := context.Executor.ExecuteCommandWithOutput(pgkexec.NoCommandTimout, "ceph-volume", "inventory", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute ceph-volume inventory. %+v", err)
 	}

--- a/pkg/daemon/discover/discover_test.go
+++ b/pkg/daemon/discover/discover_test.go
@@ -20,6 +20,7 @@ package discover
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/rook/rook/pkg/clusterd"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
@@ -71,7 +72,7 @@ Partition table holds up to 128 entries
 func TestProbeDevices(t *testing.T) {
 	// set up mock execute so we can verify the partitioning happens on sda
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("RUN Command %s  %v", command, args)
 		output := ""
 		if args[0] == "--all" {
@@ -340,7 +341,7 @@ func TestDeviceListsEqual(t *testing.T) {
 func TestGetCephVolumeInventory(t *testing.T) {
 	run := 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, arg ...string) (string, error) {
 			run++
 			logger.Infof("run %d command %s", run, command)
 			switch {

--- a/pkg/operator/ceph/client/controller_test.go
+++ b/pkg/operator/ceph/client/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -146,7 +147,7 @@ func TestCephClientController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -244,7 +245,7 @@ func TestCephClientController(t *testing.T) {
 	c.Client = cl
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/cluster/mgr/dashboard_test.go
+++ b/pkg/operator/ceph/cluster/mgr/dashboard_test.go
@@ -26,6 +26,7 @@ import (
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	cephver "github.com/rook/rook/pkg/operator/ceph/version"
 	"github.com/rook/rook/pkg/operator/test"
+	"github.com/rook/rook/pkg/util/exec"
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,7 +84,7 @@ func TestStartSecureDashboard(t *testing.T) {
 	moduleRetries := 0
 	exitCodeResponse := 0
 	clientset := test.New(t, 3)
-	mockFN := func(command string, args ...string) (string, error) {
+	mockFN := func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("command: %s %v", command, args)
 		exitCodeResponse = 0
 		if args[1] == "module" {
@@ -106,7 +107,7 @@ func TestStartSecureDashboard(t *testing.T) {
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: mockFN,
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, arg ...string) (string, error) {
-			return mockFN(command, arg...)
+			return mockFN(exec.NoCommandTimout, command, arg...)
 		},
 	}
 

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -50,7 +50,7 @@ func TestStartMgr(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Execute: %s %v", command, args)
 			if args[0] == "mgr" && args[1] == "stat" {
 				return `{"active_name": "a"}`, nil
@@ -244,7 +244,7 @@ func TestMgrSidecarReconcile(t *testing.T) {
 		},
 	}
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[1] == "dump" {
 				calledMgrDump = true
@@ -311,7 +311,7 @@ func TestConfigureModules(t *testing.T) {
 	configSettings := map[string]string{}
 	lastModuleConfigured := ""
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if command == "ceph" && len(args) > 3 {
 				if args[0] == "mgr" && args[1] == "module" {
@@ -443,7 +443,7 @@ func TestCluster_enableBalancerModule(t *testing.T) {
 	t.Run("on octopus we configure the balancer AND enable the upmap mode", func(t *testing.T) {
 		c.clusterInfo.CephVersion = cephver.Octopus
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if command == "ceph" {
 					if args[0] == "osd" && args[1] == "set-require-min-compat-client" {
@@ -467,7 +467,7 @@ func TestCluster_enableBalancerModule(t *testing.T) {
 	t.Run("on pacific we configure the balancer ONLY and don't set a mode", func(t *testing.T) {
 		c.clusterInfo.CephVersion = cephver.Pacific
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if command == "ceph" {
 					if args[0] == "osd" && args[1] == "set-require-min-compat-client" {

--- a/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
+++ b/pkg/operator/ceph/cluster/mgr/orchestrator_test.go
@@ -35,7 +35,7 @@ func TestOrchestratorModules(t *testing.T) {
 	rookBackendSet := false
 	backendErrorCount := 0
 	exec.CephCommandsTimeout = 15 * time.Second
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "mgr" && args[1] == "module" && args[2] == "enable" {
 			if args[3] == "rook" {

--- a/pkg/operator/ceph/cluster/mon/config.go
+++ b/pkg/operator/ceph/cluster/mon/config.go
@@ -309,7 +309,7 @@ func genSecret(executor exec.Executor, configDir, name string, args []string) (s
 		"-n", name,
 	}
 	args = append(base, args...)
-	_, err := executor.ExecuteCommandWithOutput("ceph-authtool", args...)
+	_, err := executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "ceph-authtool", args...)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to gen secret")
 	}

--- a/pkg/operator/ceph/cluster/mon/config_test.go
+++ b/pkg/operator/ceph/cluster/mon/config_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestCreateClusterSecrets(t *testing.T) {
 	defer os.RemoveAll(configDir)
 	adminSecret := "AQDkLIBd9vLGJxAAnXsIKPrwvUXAmY+D1g0X1Q==" //nolint:gosec // This is just a var name, not a real secret
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("COMMAND: %s %v", command, args)
 			if command == "ceph-authtool" && args[0] == "--create-keyring" {
 				filename := args[1]

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -47,7 +47,7 @@ func TestCheckHealth(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil
@@ -189,7 +189,7 @@ func TestEvictMonOnSameNode(t *testing.T) {
 	clientset := test.New(t, 1)
 	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
 			return "{\"key\":\"mysecurekey\"}", nil
 		},
@@ -285,7 +285,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 	updateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil
@@ -346,7 +346,7 @@ func TestAddRemoveMons(t *testing.T) {
 
 	monQuorumResponse := clienttest.MonInQuorumResponse()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return "{\"key\":\"mysecurekey\"}", nil

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -81,7 +81,7 @@ func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monRe
 	clientset := test.New(t, 3)
 	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
 				err := clienttest.CreateConfigDir(path.Join(configDir, namespace))
 				return "", errors.Wrap(err, "failed testing of start cluster without quorum response")
@@ -484,7 +484,7 @@ func TestConfigureArbiter(t *testing.T) {
 	currentArbiter := c.arbiterMon
 	setNewTiebreaker := false
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("%s %v", command, args)
 			if args[0] == "mon" {
 				if args[1] == "dump" {
@@ -711,7 +711,7 @@ func TestCheckIfArbiterReady(t *testing.T) {
 	crushZoneCount := 0
 	balanced := true
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			switch {
 			case args[0] == "osd" && args[1] == "crush" && args[2] == "dump":
 				crushBuckets := `

--- a/pkg/operator/ceph/cluster/osd/health_test.go
+++ b/pkg/operator/ceph/cluster/osd/health_test.go
@@ -43,7 +43,7 @@ func TestOSDHealthCheck(t *testing.T) {
 
 	var execCount = 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 			execCount++
 			if args[1] == "dump" {
@@ -140,11 +140,11 @@ func TestDeviceClasses(t *testing.T) {
 
 	var execCount = 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			return "{\"key\":\"mysecurekey\", \"osdid\":3.0}", nil
 		},
 	}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 		execCount++
 		if args[1] == "crush" && args[2] == "class" && args[3] == "ls" {

--- a/pkg/operator/ceph/cluster/osd/integration_test.go
+++ b/pkg/operator/ceph/cluster/osd/integration_test.go
@@ -528,7 +528,7 @@ func testOSDIntegration(t *testing.T) {
 
 func osdIntegrationTestExecutor(t *testing.T, clientset *fake.Clientset, namespace string) *exectest.MockExecutor {
 	return &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			t.Logf("command: %s %v", command, args)
 			if command != "ceph" {
 				return "", errors.Errorf("unexpected command %q with args %v", command, args)

--- a/pkg/operator/ceph/cluster/osd/osd_test.go
+++ b/pkg/operator/ceph/cluster/osd/osd_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -157,7 +158,7 @@ func TestAddRemoveNode(t *testing.T) {
 	clusterInfo.OwnerInfo = cephclient.NewMinimumOwnerInfo(t)
 	generateKey := "expected key"
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			return "{\"key\": \"" + generateKey + "\"}", nil
 		},
 	}
@@ -209,7 +210,7 @@ func TestAddRemoveNode(t *testing.T) {
 
 	// mock the ceph calls that will be called during remove node
 	context.Executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[0] == "status" {
 				return `{"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil

--- a/pkg/operator/ceph/cluster/osd/update_test.go
+++ b/pkg/operator/ceph/cluster/osd/update_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -144,7 +145,7 @@ func Test_updateExistingOSDs(t *testing.T) {
 		}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			t.Logf("command: %s %v", command, args)
 			if args[0] == "osd" {
 				if args[1] == "ok-to-stop" {

--- a/pkg/operator/ceph/cluster/rbd/controller_test.go
+++ b/pkg/operator/ceph/cluster/rbd/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -109,7 +110,7 @@ func TestCephRBDMirrorController(t *testing.T) {
 	s := scheme.Scheme
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/cluster/watcher_test.go
+++ b/pkg/operator/ceph/cluster/watcher_test.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -95,7 +96,7 @@ func TestOnK8sNode(t *testing.T) {
 	client := getFakeClient(objects...)
 
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		return "", errors.New("failed to get osd list on host")
 	}
 	clientCluster := newClientCluster(client, ns, &clusterd.Context{

--- a/pkg/operator/ceph/config/keyring/store_test.go
+++ b/pkg/operator/ceph/config/keyring/store_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rook/rook/pkg/clusterd"
@@ -37,7 +38,7 @@ func TestGenerateKey(t *testing.T) {
 	var generateKey = ""
 	var failGenerateKey = false
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if failGenerateKey {
 				return "", errors.New("test error")
 			}

--- a/pkg/operator/ceph/controller/mirror_peer_test.go
+++ b/pkg/operator/ceph/controller/mirror_peer_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -86,7 +87,7 @@ func TestGenerateStatusInfo(t *testing.T) {
 
 func TestExpandBootstrapPeerToken(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if reflect.DeepEqual(args[0:5], []string{"osd", "pool", "get", "pool", "all"}) {
 				return `{"pool_id":13}`, nil
 			}

--- a/pkg/operator/ceph/controller/spec_test.go
+++ b/pkg/operator/ceph/controller/spec_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
@@ -256,7 +257,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			ExternalMgrEndpoints: []v1.EndpointAddress{{IP: "192.168.0.1"}},
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "192.168.0.1:6801/2535462469"), nil
@@ -286,7 +287,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			ExternalMgrEndpoints: []v1.EndpointAddress{{IP: "192.168.0.1"}},
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "172.17.0.12:6801/2535462469"), nil
@@ -315,7 +316,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			ExternalMgrEndpoints: []v1.EndpointAddress{{IP: "192.168.0.1"}},
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "172.17.0.12:6801/2535462469"), nil
@@ -349,7 +350,7 @@ func TestConfigureExternalMetricsEndpoint(t *testing.T) {
 			ExternalMgrEndpoints: []v1.EndpointAddress{{IP: "192.168.0.1"}},
 		}
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[1] == "dump" {
 					return fmt.Sprintf(`{"active_addr":"%s"}`, "192.168.0.1:6801/2535462469"), nil

--- a/pkg/operator/ceph/csi/peermap/config_test.go
+++ b/pkg/operator/ceph/csi/peermap/config_test.go
@@ -238,7 +238,7 @@ var fakeMultiPeerCephBlockPool = cephv1.CephBlockPool{
 }
 
 var mockExecutor = &exectest.MockExecutor{
-	MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+	MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		// Fake pool details for "rook-ceph-primary" cluster
 		if args[0] == "osd" && args[1] == "pool" && args[2] == "get" && strings.HasSuffix(args[6], ns) {

--- a/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
+++ b/pkg/operator/ceph/disruption/clusterdisruption/osd_test.go
@@ -349,7 +349,7 @@ func TestReconcilePDBForOSD(t *testing.T) {
 			clusterInfo.Context = context.TODO()
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
 			executor := &exectest.MockExecutor{}
-			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "status" {
 					return tc.fakeCephStatus, nil
@@ -406,7 +406,7 @@ func TestPGHealthcheckTimeout(t *testing.T) {
 	clusterInfo.Context = context.TODO()
 	request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace}}
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[0] == "status" {
 			return unHealthyCephStatus, nil

--- a/pkg/operator/ceph/file/controller_test.go
+++ b/pkg/operator/ceph/file/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -178,7 +179,7 @@ func TestCephFilesystemController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -271,7 +272,7 @@ func TestCephFilesystemController(t *testing.T) {
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/clusterd"
@@ -142,7 +143,7 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 
 	if multiFS {
 		return &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if contains(args, "fs") && contains(args, "get") {
 					if firstGet {
 						firstGet = false
@@ -219,7 +220,7 @@ func fsExecutor(t *testing.T, fsName, configDir string, multiFS bool, createData
 	}
 
 	return &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if contains(args, "fs") && contains(args, "get") {
 				if firstGet {
 					firstGet = false
@@ -458,7 +459,7 @@ func TestUpgradeFilesystem(t *testing.T) {
 	}
 	createdFsResponse, _ := json.Marshal(mdsmap)
 	firstGet := false
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		if contains(args, "fs") && contains(args, "get") {
 			if firstGet {
 				firstGet = false
@@ -522,7 +523,7 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 	clientset := testop.New(t, 3)
 	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
 				err := clienttest.CreateConfigDir(path.Join(configDir, "ns"))
 				assert.Nil(t, err)

--- a/pkg/operator/ceph/file/mirror/controller_test.go
+++ b/pkg/operator/ceph/file/mirror/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -78,7 +79,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -217,7 +218,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 
 	t.Run("error - cluster is upgrading", func(t *testing.T) {
 		r.context.Executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}
@@ -239,7 +240,7 @@ func TestCephFilesystemMirrorController(t *testing.T) {
 
 	t.Run("success - running pacific", func(t *testing.T) {
 		r.context.Executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}

--- a/pkg/operator/ceph/file/subvolumegroup/controller_test.go
+++ b/pkg/operator/ceph/file/subvolumegroup/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -73,7 +74,7 @@ func TestCephClientController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -192,7 +193,7 @@ func TestCephClientController(t *testing.T) {
 		c.Client = cl
 
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "fs" && args[1] == "subvolumegroup" && args[2] == "create" {
 					return "", nil
 				}

--- a/pkg/operator/ceph/nfs/controller_test.go
+++ b/pkg/operator/ceph/nfs/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -65,7 +66,7 @@ func TestCephNFSController(t *testing.T) {
 
 	baseExecutor := func() *exectest.MockExecutor {
 		return &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(time time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("mock execute: %s %v", command, args)
 				if command == "ceph" && args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
@@ -79,7 +80,7 @@ func TestCephNFSController(t *testing.T) {
 		t.Helper()
 
 		return &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(time time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("mock execute: %s %v", command, args)
 				if command == "ceph" {
 					if args[0] == "status" {

--- a/pkg/operator/ceph/nfs/nfs_test.go
+++ b/pkg/operator/ceph/nfs/nfs_test.go
@@ -20,6 +20,7 @@ package nfs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -130,7 +131,7 @@ func TestReconcileCephNFS_upCephNFS(t *testing.T) {
 	clientset := k8sfake.NewSimpleClientset()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
 			if args[0] == "auth" {
 				if args[1] == "get-or-create-key" {

--- a/pkg/operator/ceph/object/controller_test.go
+++ b/pkg/operator/ceph/object/controller_test.go
@@ -323,7 +323,7 @@ func TestCephObjectStoreController(t *testing.T) {
 		}
 
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}
@@ -436,7 +436,7 @@ func TestCephObjectStoreController(t *testing.T) {
 
 		// Override executor with the new ceph status and more content
 		executor := &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}
@@ -628,7 +628,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -756,7 +756,7 @@ func TestCephObjectStoreControllerMultisite(t *testing.T) {
 
 func TestDiffVersions(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "versions" {
 				return `{
     "mon": {

--- a/pkg/operator/ceph/object/dependents_test.go
+++ b/pkg/operator/ceph/object/dependents_test.go
@@ -45,7 +45,7 @@ func TestCephObjectStoreDependents(t *testing.T) {
 	ns := "test-ceph-object-store-dependents"
 	var c *clusterd.Context
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if args[0] == "osd" {
 				if args[1] == "lspools" {
@@ -122,7 +122,7 @@ func TestCephObjectStoreDependents(t *testing.T) {
 
 	t.Run("no objectstore users and no buckets", func(t *testing.T) {
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "osd" {
 					if args[1] == "lspools" {
@@ -150,7 +150,7 @@ func TestCephObjectStoreDependents(t *testing.T) {
 
 	t.Run("one objectstore users but wrong store and no buckets", func(t *testing.T) {
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "osd" {
 					if args[1] == "lspools" {
@@ -180,7 +180,7 @@ func TestCephObjectStoreDependents(t *testing.T) {
 
 	t.Run("one objectstore users and no buckets", func(t *testing.T) {
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "osd" {
 					if args[1] == "lspools" {
@@ -211,7 +211,7 @@ func TestCephObjectStoreDependents(t *testing.T) {
 
 	t.Run("no objectstore users and buckets", func(t *testing.T) {
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("Command: %s %v", command, args)
 				if args[0] == "osd" {
 					if args[1] == "lspools" {

--- a/pkg/operator/ceph/object/objectstore_test.go
+++ b/pkg/operator/ceph/object/objectstore_test.go
@@ -72,7 +72,7 @@ const (
 )
 
 func TestReconcileRealm(t *testing.T) {
-	executorFunc := func(command string, args ...string) (string, error) {
+	executorFunc := func(timeout time.Duration, command string, args ...string) (string, error) {
 		idResponse := `{"id":"test-id"}`
 		logger.Infof("Execute: %s %v", command, args)
 		return idResponse, nil
@@ -181,7 +181,7 @@ func deleteStore(t *testing.T, name string, existingStores string, expectedDelet
 	executorFuncWithTimeout := func(timeout time.Duration, command string, args ...string) (string, error) {
 		return mockExecutorFuncOutput(command, args...)
 	}
-	executorFunc := func(command string, args ...string) (string, error) {
+	executorFunc := func(timeout time.Duration, command string, args ...string) (string, error) {
 		return mockExecutorFuncOutput(command, args...)
 	}
 
@@ -238,7 +238,7 @@ func TestGetObjectBucketProvisioner(t *testing.T) {
 func TestDashboard(t *testing.T) {
 	storeName := "myobject"
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			return "", nil
 		},
 		MockExecuteCommandWithTimeout: func(timeout time.Duration, command string, args ...string) (string, error) {
@@ -261,7 +261,7 @@ func TestDashboard(t *testing.T) {
 	err = enableRGWDashboard(objContext)
 	assert.Nil(t, err)
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "dashboard" && args[1] == "get-rgw-api-access-key" {
 				return access_key, nil
 			}
@@ -283,7 +283,7 @@ func TestDashboard(t *testing.T) {
 	err = enableRGWDashboard(objContext)
 	assert.Nil(t, err)
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "dashboard" && args[1] == "get-rgw-api-access-key" {
 				return access_key, nil
 			}

--- a/pkg/operator/ceph/object/realm/controller_test.go
+++ b/pkg/operator/ceph/object/realm/controller_test.go
@@ -135,7 +135,7 @@ func TestCephObjectRealmController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(r.scheme).WithRuntimeObjects(object...).Build()
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -228,7 +228,7 @@ func getObjectRealmAndReconcileObjectRealm(t *testing.T) (*ReconcileObjectRealm,
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -19,6 +19,7 @@ package object
 import (
 	"context"
 	"testing"
+	"time"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
@@ -41,7 +42,7 @@ func TestStartRGW(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 3)
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "auth" && args[1] == "get-or-create-key" {
 				return `{"key":"mysecurekey"}`, nil
 			}
@@ -79,7 +80,7 @@ func validateStart(ctx context.Context, t *testing.T, c *clusterConfig, clientse
 }
 
 func TestCreateObjectStore(t *testing.T) {
-	commandWithOutputFunc := func(command string, args ...string) (string, error) {
+	commandWithOutputFunc := func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if command == "ceph" {
 			if args[1] == "erasure-code-profile" {

--- a/pkg/operator/ceph/object/spec_test.go
+++ b/pkg/operator/ceph/object/spec_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -234,7 +235,7 @@ func TestSSLPodSpec(t *testing.T) {
 
 func TestValidateSpec(t *testing.T) {
 	executor := &exectest.MockExecutor{}
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return `{"types":[{"type_id": 0,"name": "osd"}, {"type_id": 1,"name": "host"}],"buckets":[{"id": -1,"name":"default"},{"id": -2,"name":"good"}, {"id": -3,"name":"host"}]}`, nil

--- a/pkg/operator/ceph/object/user/controller_test.go
+++ b/pkg/operator/ceph/object/user/controller_test.go
@@ -130,7 +130,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -218,7 +218,7 @@ func TestCephObjectStoreUserController(t *testing.T) {
 		cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}

--- a/pkg/operator/ceph/object/zone/controller_test.go
+++ b/pkg/operator/ceph/object/zone/controller_test.go
@@ -160,7 +160,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -263,7 +263,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -309,7 +309,7 @@ func TestCephObjectZoneController(t *testing.T) {
 	}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/object/zonegroup/controller_test.go
+++ b/pkg/operator/ceph/object/zonegroup/controller_test.go
@@ -153,7 +153,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -256,7 +256,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	cl = fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(object...).Build()
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -310,7 +310,7 @@ func TestCephObjectZoneGroupController(t *testing.T) {
 	}
 
 	executor = &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}

--- a/pkg/operator/ceph/pool/controller_test.go
+++ b/pkg/operator/ceph/pool/controller_test.go
@@ -50,7 +50,7 @@ func TestCreatePool(t *testing.T) {
 	enabledMetricsApp := false
 	clusterInfo := client.AdminTestClusterInfo("mycluster")
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			logger.Infof("Command: %s %v", command, args)
 			if command == "ceph" {
 				if args[1] == "erasure-code-profile" {
@@ -131,7 +131,7 @@ func TestDeletePool(t *testing.T) {
 	failOnDelete := false
 	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			emptyPool := "{\"images\":{\"count\":0,\"provisioned_bytes\":0,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
 			p := "{\"images\":{\"count\":1,\"provisioned_bytes\":1024,\"snap_count\":0},\"trash\":{\"count\":1,\"provisioned_bytes\":2048,\"snap_count\":0}}"
 			logger.Infof("Command: %s %v", command, args)
@@ -218,7 +218,7 @@ func TestCephBlockPoolController(t *testing.T) {
 	}
 
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 			if args[0] == "status" {
 				return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_ERR"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 			}
@@ -322,7 +322,7 @@ func TestCephBlockPoolController(t *testing.T) {
 		c.Client = cl
 
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "status" {
 					return `{"fsid":"c47cac40-9bee-4d52-823b-ccd803ba5bfe","health":{"checks":{},"status":"HEALTH_OK"},"pgmap":{"num_pgs":100,"pgs_by_state":[{"state_name":"active+clean","count":100}]}}`, nil
 				}
@@ -418,7 +418,7 @@ func TestCephBlockPoolController(t *testing.T) {
 
 	t.Run("success - mirroring set", func(t *testing.T) {
 		executor = &exectest.MockExecutor{
-			MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
+			MockExecuteCommandWithOutput: func(timeout time.Duration, command string, args ...string) (string, error) {
 				if args[0] == "mirror" && args[1] == "pool" && args[2] == "peer" && args[3] == "bootstrap" && args[4] == "create" {
 					return `eyJmc2lkIjoiYzZiMDg3ZjItNzgyOS00ZGJiLWJjZmMtNTNkYzM0ZTBiMzVkIiwiY2xpZW50X2lkIjoicmJkLW1pcnJvci1wZWVyIiwia2V5IjoiQVFBV1lsWmZVQ1Q2RGhBQVBtVnAwbGtubDA5YVZWS3lyRVV1NEE9PSIsIm1vbl9ob3N0IjoiW3YyOjE5Mi4xNjguMTExLjEwOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTA6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjEyOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTI6Njc4OV0sW3YyOjE5Mi4xNjguMTExLjExOjMzMDAsdjE6MTkyLjE2OC4xMTEuMTE6Njc4OV0ifQ==`, nil
 				}

--- a/pkg/operator/ceph/pool/validate_test.go
+++ b/pkg/operator/ceph/pool/validate_test.go
@@ -19,6 +19,7 @@ package pool
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -204,7 +205,7 @@ func TestValidateCrushProperties(t *testing.T) {
 	executor := &exectest.MockExecutor{}
 	context := &clusterd.Context{Executor: executor}
 	clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
-	executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+	executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 		logger.Infof("Command: %s %v", command, args)
 		if args[1] == "crush" && args[2] == "dump" {
 			return `{"types":[{"type_id": 0,"name": "osd"}],"buckets":[{"id": -1,"name":"default"},{"id": -2,"name":"good"}, {"id": -3,"name":"host"}]}`, nil
@@ -294,7 +295,7 @@ func TestValidateDeviceClasses(t *testing.T) {
 			clusterInfo := cephclient.AdminTestClusterInfo("mycluster")
 			executor := &exectest.MockExecutor{}
 			context := &clusterd.Context{Executor: executor}
-			executor.MockExecuteCommandWithOutput = func(command string, args ...string) (string, error) {
+			executor.MockExecuteCommandWithOutput = func(timeout time.Duration, command string, args ...string) (string, error) {
 				logger.Infof("ExecuteCommandWithOutputFile: %s %v", command, args)
 				if args[1] == "crush" && args[2] == "class" && args[3] == "ls-osd" && args[4] == "ssd" {
 					// Mock executor for `ceph osd crush class ls-osd ssd`

--- a/pkg/util/exec/test/mockexec.go
+++ b/pkg/util/exec/test/mockexec.go
@@ -30,8 +30,8 @@ type MockExecutor struct {
 	MockExecuteCommand                   func(command string, arg ...string) error
 	MockExecuteCommandWithEnv            func(env []string, command string, arg ...string) error
 	MockStartExecuteCommand              func(command string, arg ...string) (*exec.Cmd, error)
-	MockExecuteCommandWithOutput         func(command string, arg ...string) (string, error)
-	MockExecuteCommandWithCombinedOutput func(command string, arg ...string) (string, error)
+	MockExecuteCommandWithOutput         func(timeout time.Duration, command string, arg ...string) (string, error)
+	MockExecuteCommandWithCombinedOutput func(timeout time.Duration, command string, arg ...string) (string, error)
 	MockExecuteCommandWithTimeout        func(timeout time.Duration, command string, arg ...string) (string, error)
 }
 
@@ -54,9 +54,9 @@ func (e *MockExecutor) ExecuteCommandWithEnv(env []string, command string, arg .
 }
 
 // ExecuteCommandWithOutput mocks ExecuteCommandWithOutput
-func (e *MockExecutor) ExecuteCommandWithOutput(command string, arg ...string) (string, error) {
+func (e *MockExecutor) ExecuteCommandWithOutput(timeout time.Duration, command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithOutput != nil {
-		return e.MockExecuteCommandWithOutput(command, arg...)
+		return e.MockExecuteCommandWithOutput(timeout, command, arg...)
 	}
 
 	return "", nil
@@ -73,9 +73,9 @@ func (e *MockExecutor) ExecuteCommandWithTimeout(timeout time.Duration, command 
 }
 
 // ExecuteCommandWithCombinedOutput mocks ExecuteCommandWithCombinedOutput
-func (e *MockExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error) {
+func (e *MockExecutor) ExecuteCommandWithCombinedOutput(timeout time.Duration, command string, arg ...string) (string, error) {
 	if e.MockExecuteCommandWithCombinedOutput != nil {
-		return e.MockExecuteCommandWithCombinedOutput(command, arg...)
+		return e.MockExecuteCommandWithCombinedOutput(timeout, command, arg...)
 	}
 
 	return "", nil

--- a/pkg/util/exec/translate_exec.go
+++ b/pkg/util/exec/translate_exec.go
@@ -45,15 +45,15 @@ func (e *TranslateCommandExecutor) ExecuteCommandWithEnv(env []string, command s
 }
 
 // ExecuteCommandWithOutput starts a process and wait for its completion
-func (e *TranslateCommandExecutor) ExecuteCommandWithOutput(command string, arg ...string) (string, error) {
+func (e *TranslateCommandExecutor) ExecuteCommandWithOutput(timeout time.Duration, command string, arg ...string) (string, error) {
 	transCommand, transArgs := e.Translator(command, arg...)
-	return e.Executor.ExecuteCommandWithOutput(transCommand, transArgs...)
+	return e.Executor.ExecuteCommandWithOutput(timeout, transCommand, transArgs...)
 }
 
 // ExecuteCommandWithCombinedOutput starts a process and returns its stdout and stderr combined.
-func (e *TranslateCommandExecutor) ExecuteCommandWithCombinedOutput(command string, arg ...string) (string, error) {
+func (e *TranslateCommandExecutor) ExecuteCommandWithCombinedOutput(timeout time.Duration, command string, arg ...string) (string, error) {
 	transCommand, transArgs := e.Translator(command, arg...)
-	return e.Executor.ExecuteCommandWithCombinedOutput(transCommand, transArgs...)
+	return e.Executor.ExecuteCommandWithCombinedOutput(timeout, transCommand, transArgs...)
 }
 
 // ExecuteCommandWithTimeout starts a process and wait for its completion with timeout.

--- a/pkg/util/sys/device_test.go
+++ b/pkg/util/sys/device_test.go
@@ -18,6 +18,7 @@ package sys
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	exectest "github.com/rook/rook/pkg/util/exec/test"
 	"github.com/stretchr/testify/assert"
@@ -116,7 +117,7 @@ func TestParseFileSystem(t *testing.T) {
 func TestGetPartitions(t *testing.T) {
 	run := 0
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, arg ...string) (string, error) {
 			run++
 			logger.Infof("run %d command %s", run, command)
 			switch {
@@ -185,7 +186,7 @@ func TestParseUdevInfo(t *testing.T) {
 
 func TestListDevicesChildListDevicesChild(t *testing.T) {
 	executor := &exectest.MockExecutor{
-		MockExecuteCommandWithOutput: func(command string, arg ...string) (string, error) {
+		MockExecuteCommandWithOutput: func(timeout time.Duration, command string, arg ...string) (string, error) {
 			logger.Infof("command %s", command)
 			return lsblkChildOutput, nil
 		},

--- a/pkg/util/sys/kmod.go
+++ b/pkg/util/sys/kmod.go
@@ -42,7 +42,7 @@ func IsBuiltinKernelModule(name string, executor pkgexec.Executor) (bool, error)
 	}
 
 	kv = fmt.Sprintf("/lib/modules/%s/modules.builtin", kv)
-	out, err := executor.ExecuteCommandWithCombinedOutput("cat", kv)
+	out, err := executor.ExecuteCommandWithCombinedOutput(pkgexec.CephCommandsTimeout, "cat", kv)
 	if err != nil {
 		return false, fmt.Errorf("failed to cat %s: %+v", kv, err)
 	}
@@ -66,7 +66,7 @@ func LoadKernelModule(name string, options []string, executor pkgexec.Executor) 
 }
 
 func CheckKernelModuleParam(name, param string, executor pkgexec.Executor) (bool, error) {
-	out, err := executor.ExecuteCommandWithOutput("modinfo", "-F", "parm", name)
+	out, err := executor.ExecuteCommandWithOutput(pkgexec.CephCommandsTimeout, "modinfo", "-F", "parm", name)
 	if err != nil {
 		return false, fmt.Errorf("failed to check for %s module %s param: %+v", name, param, err)
 	}

--- a/tests/framework/installer/ceph_installer.go
+++ b/tests/framework/installer/ceph_installer.go
@@ -32,6 +32,7 @@ import (
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/ceph/cluster"
+	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/tests/framework/utils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -226,7 +227,7 @@ func (h *CephInstaller) CreateRookToolbox(manifests CephManifests) (err error) {
 func (h *CephInstaller) Execute(command string, parameters []string, namespace string) (error, string) {
 	clusterInfo := client.AdminTestClusterInfo(namespace)
 	cmd, args := client.FinalizeCephCommandArgs(command, clusterInfo, parameters, h.k8shelper.MakeContext().ConfigDir)
-	result, err := h.k8shelper.MakeContext().Executor.ExecuteCommandWithOutput(cmd, args...)
+	result, err := h.k8shelper.MakeContext().Executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, cmd, args...)
 	if err != nil {
 		logger.Warningf("Error executing command %q: <%v>", command, err)
 		return err, result

--- a/tests/framework/utils/helm_helper.go
+++ b/tests/framework/utils/helm_helper.go
@@ -43,7 +43,7 @@ func NewHelmHelper(helmPath string) *HelmHelper {
 
 // Execute is wrapper for executing helm commands
 func (h *HelmHelper) Execute(args ...string) (string, error) {
-	result, err := h.executor.ExecuteCommandWithOutput(h.HelmPath, args...)
+	result, err := h.executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, h.HelmPath, args...)
 	if err != nil {
 		logger.Errorf("Errors Encountered while executing helm command %v: %v", result, err)
 		return result, fmt.Errorf("Failed to run helm command on args %v : %v , err -> %v", args, result, err)

--- a/tests/framework/utils/snapshot.go
+++ b/tests/framework/utils/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rook/rook/pkg/util/exec"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,7 +43,7 @@ func (k8sh *K8sHelper) CheckSnapshotISReadyToUse(name, namespace string, retries
 	for i := 0; i < retries; i++ {
 		// sleep first and try to check snapshot is ready to cover the error cases.
 		time.Sleep(time.Duration(i) * time.Second)
-		ready, err := k8sh.executor.ExecuteCommandWithOutput("kubectl", "get", "volumesnapshot", name, "--namespace", namespace, "-o", "jsonpath={.status.readyToUse}")
+		ready, err := k8sh.executor.ExecuteCommandWithOutput(exec.CephCommandsTimeout, "kubectl", "get", "volumesnapshot", name, "--namespace", namespace, "-o", "jsonpath={.status.readyToUse}")
 		if err != nil {
 			return false, err
 		}

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rook/rook/pkg/daemon/ceph/client"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
 	"github.com/rook/rook/pkg/operator/k8sutil"
+	"github.com/rook/rook/pkg/util/exec"
 	"github.com/rook/rook/tests/framework/clients"
 	"github.com/rook/rook/tests/framework/installer"
 	"github.com/rook/rook/tests/framework/utils"
@@ -448,7 +449,7 @@ func waitForFilesystemActive(k8sh *utils.K8sHelper, clusterInfo *client.ClusterI
 	logger.Infof("waiting for filesystem %q to be active", filesystemName)
 	for i := 0; i < utils.RetryLoop; i++ {
 		// run the ceph fs status command
-		stat, err := k8sh.MakeContext().Executor.ExecuteCommandWithCombinedOutput(command, args...)
+		stat, err := k8sh.MakeContext().Executor.ExecuteCommandWithCombinedOutput(exec.CephCommandsTimeout, command, args...)
 		if err != nil {
 			logger.Warningf("failed to get filesystem %q status. %+v", filesystemName, err)
 		}


### PR DESCRIPTION
Adding timeout of 15sec for all the ceph commands where applicable.

Closes: #8940 
Signed-off-by: subhamkrai <srai@redhat.com>

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #8940 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
