### PR TITLE
build: make crd/rbac generation order deterministic

### DIFF
--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -97,7 +97,19 @@ fi
 
 generating_main_crd
 
+# Linux doesn't guarantee file ordering, so we must sort the output to make sure it's deterministic.
+# In order to handle file paths with spaces in the yq command below, it's easiest to read the
+# file names into an array.
+# Set locale `LC_ALL=C` because different OSes have different sort behavior;
+# `C` sorting order is based on the byte values,
+# Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
+LC_ALL=C
+CRD_FILES=()
+while read -r line; do
+  CRD_FILES+=("$line")
+done < <(find "$OLM_CATALOG_DIR" -type f -name '*.yaml' | sort)
+
 echo "---" >> "$CEPH_CRDS_FILE_PATH" # yq doesn't output the first doc separator
-$YQ_BIN_PATH eval-all '.' "$OLM_CATALOG_DIR/"*.yaml >> "$CEPH_CRDS_FILE_PATH"
+$YQ_BIN_PATH eval-all '.' "${CRD_FILES[@]}" >> "$CEPH_CRDS_FILE_PATH"
 
 build_helm_resources


### PR DESCRIPTION
Linux doesn't guarantee file ordering, so when dealing with files in
order, we can use 'sort' to make sure the order is deterministic. For
yq's usage of files, we need to keep file names in an intermediate
variable, and this should be an array to support file paths with spaces.
'readarray' is not available on MacOS's built-in bash, so a longer
'while read' loop is needed for the array creation.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #9563 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
