### PR TITLE
build: set LC_ALL on the make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Linux doesn't guarantee file ordering, so sort the files to make sure order is deterministic.
+# And in order to handle file paths with spaces, it's easiest to read the file names into an array.
+# Set locale `LC_ALL=C` because different OSes have different sort behavior;
+# `C` sorting order is based on the byte values,
+# Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
+LC_ALL=C
+export LC_ALL
+
 include build/makelib/common.mk
 include build/makelib/helm.mk
 

--- a/build/crds/build-crds.sh
+++ b/build/crds/build-crds.sh
@@ -97,13 +97,6 @@ fi
 
 generating_main_crd
 
-# Linux doesn't guarantee file ordering, so we must sort the output to make sure it's deterministic.
-# In order to handle file paths with spaces in the yq command below, it's easiest to read the
-# file names into an array.
-# Set locale `LC_ALL=C` because different OSes have different sort behavior;
-# `C` sorting order is based on the byte values,
-# Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
-LC_ALL=C
 CRD_FILES=()
 while read -r line; do
   CRD_FILES+=("$line")

--- a/build/rbac/keep-rbac-yaml.sh
+++ b/build/rbac/keep-rbac-yaml.sh
@@ -35,12 +35,6 @@ sed '/^# Source: /d' | # helm adds '# Source: <file>' comments atop of each yaml
 $YQ eval --split-exp '.kind + " " + .metadata.name + " "' - # split into files by <kind> <name> .yaml
 # outputting the filenames with spaces after kind and name keeps the same sorting from before
 
-# Linux doesn't guarantee file ordering, so sort the files to make sure order is deterministic.
-# And in order to handle file paths with spaces, it's easiest to read the file names into an array.
-# Set locale `LC_ALL=C` because different OSes have different sort behavior;
-# `C` sorting order is based on the byte values,
-# Reference: https://blog.zhimingwang.org/macos-lc_collate-hunt
-LC_ALL=C
 RBAC_FILES=()
 while read -r line; do
   RBAC_FILES+=("$line")


### PR DESCRIPTION
**Description of your changes:**

Simply applying `LC_ALL=C` will work for the current shell only. For all
the shells and sub-shell to use it, we must set it globally.
Making it the first thing in the Make entrypoint now so the CRD and RBAC
sorting works on all the platforms.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
