### PR TITLE
docs: update scaledobject.yaml for applicable with keda v2.5

### DIFF
--- a/Documentation/ceph-monitoring.md
+++ b/Documentation/ceph-monitoring.md
@@ -213,11 +213,11 @@ spec:
 
 ### Horizontal Pod Scaling using Kubernetes Event-driven Autoscaling (KEDA)
 
-Using metrics exported from the Prometheus service, the horizontal pod scaling can use the custom metrics other than CPU and memory consumption. It can be done with help of Prometheus Scaler provided by the [KEDA](https://keda.sh/docs/2.4/scalers/prometheus/). See the [KEDA deployment guide](https://keda.sh/docs/2.4/deploy/) for details.
+Using metrics exported from the Prometheus service, the horizontal pod scaling can use the custom metrics other than CPU and memory consumption. It can be done with help of Prometheus Scaler provided by the [KEDA](https://keda.sh/docs/2.5/scalers/prometheus/). See the [KEDA deployment guide](https://keda.sh/docs/2.5/deploy/) for details.
 
 Following is an example to autoscale RGW:
 ```YAML
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
  name: rgw-scale
@@ -225,7 +225,7 @@ metadata:
 spec:
  scaleTargetRef:
    kind: Deployment
-   deploymentName: rook-ceph-rgw-my-store-a # deployment for the autoscaling
+   name: rook-ceph-rgw-my-store-a # deployment for the autoscaling
  minReplicaCount: 1
  maxReplicaCount: 5
  triggers:

--- a/deploy/examples/monitoring/keda-rgw.yaml
+++ b/deploy/examples/monitoring/keda-rgw.yaml
@@ -1,4 +1,4 @@
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: rgw-scale
@@ -6,14 +6,14 @@ metadata:
 spec:
   scaleTargetRef:
     kind: Deployment
-    deploymentName: rook-ceph-rgw-my-store-a
+    name: rook-ceph-rgw-my-store-a
   minReplicaCount: 1
   maxReplicaCount: 5
   triggers:
     - type: prometheus
       metadata:
-      serverAddress: http://rook-prometheus.rook-ceph.svc:9090
-      metricName: ceph_rgw_put_collector
-      query: |
-        sum(rate(ceph_rgw_put[2m]))
-      threshold: "90"
+        serverAddress: http://rook-prometheus.rook-ceph.svc:9090
+        metricName: ceph_rgw_put_collector
+        query: |
+          sum(rate(ceph_rgw_put[2m]))
+        threshold: "90"


### PR DESCRIPTION

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
Even though mention about keda 2.x version, the scaledObject.yaml or
rgw-keda.yaml referring to older keda CRs

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
