### PR TITLE
rgw: handle the non-existence of the bucket correctly when removing bucket

### DIFF
--- a/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
+++ b/pkg/operator/ceph/object/bucket/rgw-handlers_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/ceph/go-ceph/rgw/admin"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned/fake"
+	"github.com/rook/rook/pkg/clusterd"
+	"github.com/rook/rook/pkg/daemon/ceph/client"
+	cephobject "github.com/rook/rook/pkg/operator/ceph/object"
+	"github.com/rook/rook/pkg/operator/test"
+	"github.com/stretchr/testify/assert"
+)
+
+type statusError struct {
+	Code      string `json:"Code,omitempty"`
+	RequestID string `json:"RequestId,omitempty"`
+	HostID    string `json:"HostId,omitempty"`
+}
+
+func TestDeleteOBCResource(t *testing.T) {
+	clusterInfo := client.AdminTestClusterInfo("ns")
+	p := NewProvisioner(&clusterd.Context{RookClientset: rookclient.NewSimpleClientset(), Clientset: test.New(t, 1)}, clusterInfo)
+	mockClient := func(errCodeRemoveBucket string, errCodeGetBucketInfo string) *cephobject.MockClient {
+		return &cephobject.MockClient{
+			MockDo: func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "rook-ceph-rgw-my-store.mycluster.svc/admin/bucket" {
+					if req.Method == http.MethodDelete {
+						status, _ := json.Marshal(statusError{errCodeRemoveBucket, "requestid", "hostid"})
+						return &http.Response{
+							StatusCode: 404,
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte(status))),
+						}, nil
+					}
+					if req.Method == http.MethodGet {
+						status, _ := json.Marshal(statusError{errCodeGetBucketInfo, "requestid", "hostid"})
+						return &http.Response{
+							StatusCode: 404,
+							Body:       ioutil.NopCloser(bytes.NewReader([]byte(status))),
+						}, nil
+					}
+				}
+				return nil, fmt.Errorf("unexpected request: %q. method %q. path %q", req.URL.RawQuery, req.Method, req.URL.Path)
+			},
+		}
+	}
+
+	t.Run("remove bucket returns NoSuchBucket", func(t *testing.T) {
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchBucket", ""))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		err = p.deleteOBCResource("bucket")
+		assert.NoError(t, err)
+	})
+
+	t.Run("remove bucket returns NoSuchKey and get bucket info returns NoSuchBucket", func(t *testing.T) {
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchBucket"))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		err = p.deleteOBCResource("bucket")
+		assert.NoError(t, err)
+	})
+
+	t.Run("remove bucket returns NoSuchKey and get bucket info returns an error other than NoSuchBucket", func(t *testing.T) {
+		adminClient, err := admin.New("rook-ceph-rgw-my-store.mycluster.svc", "53S6B9S809NUP19IJ2K3", "1bXPegzsGClvoGAiJdHQD1uOW2sQBLAZM9j9VtXR", mockClient("NoSuchKey", "NoSuchKey"))
+		assert.NoError(t, err)
+		p.adminOpsClient = adminClient
+		err = p.deleteOBCResource("bucket")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
**Description of your changes:**

ceph might return NoSuchKey than NoSuchBucket when the target bucket does not exist.
then we can use GetBucketInfo() to judge the existence of the bucket.

see: https://github.com/ceph/ceph/pull/44413

**Which issue is resolved by this Pull Request:**
Resolves #9494

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
