### PR TITLE
csi: restrict csiaddons to use only 1 port

### DIFF
--- a/build/rbac/rbac.yaml
+++ b/build/rbac/rbac.yaml
@@ -758,8 +758,8 @@ spec:
     - min: 9283
       max: 9283
     # port for CSIAddons
-    - min: 9061
-      max: 9079
+    - min: 9070
+      max: 9070
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/rook-ceph/templates/psp.yaml
+++ b/deploy/charts/rook-ceph/templates/psp.yaml
@@ -77,8 +77,8 @@ spec:
     - min: 9283
       max: 9283
     # port for CSIAddons
-    - min: 9061
-      max: 9079
+    - min: 9070
+      max: 9070
 {{- if .Values.rbacEnable }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/examples/common.yaml
+++ b/deploy/examples/common.yaml
@@ -842,8 +842,8 @@ spec:
     - min: 9283
       max: 9283
     # port for CSIAddons
-    - min: 9061
-      max: 9079
+    - min: 9070
+      max: 9070
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This commit restrict csiaddons to open only 1 port
as per the requirement which is required for security.

Fixes: #9604

Signed-off-by: yati1998 <ypadia@redhat.com>
