### PR TITLE
core: reconcile operator configuration with env var

### DIFF
--- a/pkg/operator/ceph/controller/predicate.go
+++ b/pkg/operator/ceph/controller/predicate.go
@@ -745,6 +745,8 @@ func DuplicateCephClusters(ctx context.Context, c client.Client, object client.O
 		return true
 	}
 
+	logger.Debugf("found %d ceph clusters in namespace %q", len(cephClusterList.Items), object.GetNamespace())
+
 	// This check is needed when the operator is down and a cluster was created
 	if len(cephClusterList.Items) > 1 {
 		// Since multiple predicate are using this function we don't want all of them to log the

--- a/pkg/operator/ceph/csi/predicate.go
+++ b/pkg/operator/ceph/csi/predicate.go
@@ -25,14 +25,16 @@ import (
 	"github.com/rook/rook/pkg/operator/ceph/controller"
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // predicateController is the predicate function to trigger reconcile on operator configuration cm change
-func predicateController(ctx context.Context, c client.Client) predicate.Funcs {
+func predicateController(ctx context.Context, c client.Client, opNamespace string) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			// if the operator configuration file is created we want to reconcile
@@ -48,12 +50,24 @@ func predicateController(ctx context.Context, c client.Client) predicate.Funcs {
 				if controller.DuplicateCephClusters(ctx, c, e.Object, false) {
 					return false
 				}
+
+				// We still have users that don't use the ConfigMap to configure the
+				// operator/csi and still rely on environment variables from the operator pod's
+				// spec. So we still want to reconcile the controller if the ConfigMap cannot be found.
+				err := c.Get(ctx, types.NamespacedName{Name: opcontroller.OperatorSettingConfigMapName, Namespace: opNamespace}, &v1.ConfigMap{})
+				if err != nil && kerrors.IsNotFound(err) {
+					logger.Debugf("could not find operator configuration ConfigMap, will reconcile the csi controller")
+					return true
+				}
+
 				// This allows us to avoid a double reconcile of the CSI controller if this is not
 				// the first generation of the CephCluster. So only return true if this is the very
 				// first instance of the CephCluster
 				// Corner case is when the cluster is created but the operator is down AND the cm
 				// does not exist... However, these days the operator config map is part of the
 				// operator.yaml so it's probably acceptable?
+				// This does not account for the case where the cephcluster is already deployed and
+				// the upgrade the operator or restart it. However, the CM check above should catch that
 				return cephCluster.Generation == 1
 			}
 
@@ -76,6 +90,11 @@ func predicateController(ctx context.Context, c client.Client) predicate.Funcs {
 		},
 
 		DeleteFunc: func(e event.DeleteEvent) bool {
+			// if the operator configuration file is deleted we want to reconcile to apply the
+			// configuration based on environment variables present in the operator's pod spec
+			if cm, ok := e.Object.(*v1.ConfigMap); ok {
+				return cm.Name == opcontroller.OperatorSettingConfigMapName
+			}
 			return false
 		},
 

--- a/pkg/operator/ceph/csi/predicate_test.go
+++ b/pkg/operator/ceph/csi/predicate_test.go
@@ -17,9 +17,18 @@ limitations under the License.
 package csi
 
 import (
+	"context"
 	"testing"
 
+	"github.com/coreos/pkg/capnslog"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/rook/rook/pkg/client/clientset/versioned/scheme"
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 func Test_findCSIChange(t *testing.T) {
@@ -121,5 +130,121 @@ func Test_findCSIChange(t *testing.T) {
   }`
 		b := findCSIChange(str)
 		assert.True(t, b)
+	})
+}
+
+func Test_predicateController(t *testing.T) {
+	capnslog.SetGlobalLogLevel(capnslog.DEBUG)
+	var (
+		client    client.WithWatch
+		namespace v1.Namespace
+		p         predicate.Funcs
+		c         event.CreateEvent
+		d         event.DeleteEvent
+		u         event.UpdateEvent
+		cm        v1.ConfigMap
+		cm2       v1.ConfigMap
+		cluster   cephv1.CephCluster
+		cluster2  cephv1.CephCluster
+	)
+
+	s := scheme.Scheme
+	s.AddKnownTypes(cephv1.SchemeGroupVersion, &v1.ConfigMap{}, &v1.ConfigMapList{}, &cephv1.CephCluster{}, &cephv1.CephClusterList{})
+	client = fake.NewClientBuilder().WithScheme(s).Build()
+
+	t.Run("create event is not the one we are looking for", func(t *testing.T) {
+		c = event.CreateEvent{Object: &namespace}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Create(c))
+	})
+
+	t.Run("create event is a CM but not the operator config", func(t *testing.T) {
+		c = event.CreateEvent{Object: &cm}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Create(c))
+	})
+
+	t.Run("delete event is a CM and it's not the operator config", func(t *testing.T) {
+		d = event.DeleteEvent{Object: &cm}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Delete(d))
+	})
+
+	t.Run("create event is a CM and it's the operator config", func(t *testing.T) {
+		cm.Name = "rook-ceph-operator-config"
+		c = event.CreateEvent{Object: &cm}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.True(t, p.Create(c))
+	})
+
+	t.Run("delete event is a CM and it's the operator config", func(t *testing.T) {
+		d = event.DeleteEvent{Object: &cm}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.True(t, p.Delete(d))
+	})
+
+	t.Run("update event is a CM and it's the operator config but nothing changed", func(t *testing.T) {
+		u = event.UpdateEvent{ObjectOld: &cm, ObjectNew: &cm}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Update(u))
+	})
+
+	t.Run("update event is a CM and the content changed but with incorrect setting", func(t *testing.T) {
+		cm.Data = map[string]string{"foo": "bar"}
+		cm2.Name = "rook-ceph-operator-config"
+		cm2.Data = map[string]string{"foo": "ooo"}
+		u = event.UpdateEvent{ObjectOld: &cm, ObjectNew: &cm2}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Update(u))
+	})
+
+	t.Run("update event is a CM and the content changed with correct setting", func(t *testing.T) {
+		cm.Data = map[string]string{"foo": "bar"}
+		cm2.Name = "rook-ceph-operator-config"
+		cm2.Data = map[string]string{"CSI_PROVISIONER_REPLICAS": "2"}
+		u = event.UpdateEvent{ObjectOld: &cm, ObjectNew: &cm2}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.True(t, p.Update(u))
+	})
+
+	t.Run("create event is a CephCluster and it's the first instance and a cm is present", func(t *testing.T) {
+		cm.Namespace = "rook-ceph"
+		err := client.Create(context.TODO(), &cm)
+		assert.NoError(t, err)
+		cluster.Generation = 1
+		c = event.CreateEvent{Object: &cluster}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.True(t, p.Create(c))
+	})
+
+	t.Run("create event is a CephCluster and it's not the first instance", func(t *testing.T) {
+		cluster.Generation = 2
+		c = event.CreateEvent{Object: &cluster}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Create(c))
+	})
+
+	t.Run("create event is a CephCluster and it's not the first instance but no cm so we reconcile", func(t *testing.T) {
+		err := client.Delete(context.TODO(), &cm)
+		assert.NoError(t, err)
+		cluster.Generation = 2
+		c = event.CreateEvent{Object: &cluster}
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.True(t, p.Create(c))
+	})
+
+	t.Run("create event is a CephCluster and a cluster already exists - not reconciling", func(t *testing.T) {
+		cluster.Name = "ceph1"
+		cluster2.Name = "ceph2"
+		cluster.Namespace = "rook-ceph"
+		cluster2.Namespace = "rook-ceph"
+		err := client.Create(context.TODO(), &cluster)
+		assert.NoError(t, err)
+		err = client.Create(context.TODO(), &cluster2)
+		assert.NoError(t, err)
+		c = event.CreateEvent{Object: &cluster2}
+		assert.Equal(t, "rook-ceph", c.Object.GetNamespace())
+		p = predicateController(context.TODO(), client, "rook-ceph")
+		assert.False(t, p.Create(c))
 	})
 }


### PR DESCRIPTION
**Description of your changes:**

Previously, we were ignoring configuration changes coming from the
operator's pod env variables. We were assuming most users were using the
operator configmap "rook-ceph-operator-config" but most Helm users
don't. Now we will reconcile if a cephcluster is found during a CREATE
event (can be an operator restart or a cephcluster creation) AND no
"rook-ceph-operator-config" is found which means the operator's pod env
var are used.
Also, unit tests have been added (long due) for the predicate!

Closes: #9602, #9487, #9579
Signed-off-by: Sébastien Han <seb@redhat.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->


**Which issue is resolved by this Pull Request:**
Resolves #9602, #9487, #9579

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
