### PR TITLE
Update ceph-object.md

### DIFF
--- a/Documentation/ceph-object.md
+++ b/Documentation/ceph-object.md
@@ -285,15 +285,15 @@ metadata:
 spec:
   ports:
   - name: rgw
-    port: 80
+    port: 8080
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: rook-ceph-rgw
     rook_cluster: rook-ceph
     rook_object_store: my-store
   sessionAffinity: None
-  type: NodePort
+  type: LoadBalancer
 ```
 
 Now create the external service.


### PR DESCRIPTION
For things to work "out of the box" port 8080 seems to be a better choice
than port 80(which does not seem to work).

However this requires the connection flag secure=False...

Also, in a bare metal cluster - I would suggest using type: LoadBalancer (in conjunction with metallb of course).

In python, using the minio client it looks like this:

```
mc = Minio(
    MINIO_HOST,
    access_key=MINIO_ACCESS_KEY,
    secret_key=MINIO_SECRET_KEY,
    secure=False
)
```