### PR TITLE
rgw: Add custom zone endpoint for object-store

### DIFF
--- a/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
+++ b/Documentation/CRDs/Object-Storage/ceph-object-store-crd.md
@@ -140,6 +140,7 @@ All the other settings from the gateway section will be ignored, except for `sec
 The [zone](../../Storage-Configuration/Object-Storage-RGW/ceph-object-multisite.md) settings allow the object store to join custom created [ceph-object-zone](ceph-object-multisite-crd.md).
 
 * `name`: the name of the ceph-object-zone the object store will be in.
+* `endpoint`: if this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint. You must also include the port in the definition. For example: "https://my-object-store.my-domain.net:443". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.
 
 ## Runtime settings
 

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -8764,6 +8764,9 @@ spec:
                   description: The multisite info
                   nullable: true
                   properties:
+                    endpoint:
+                      description: 'If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint. You must also include the port in the definition. For example: "https://my-object-store.my-domain.net:443". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.'
+                      type: string
                     name:
                       description: RGW Zone the Object Store is in
                       type: string

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -8756,6 +8756,9 @@ spec:
                   description: The multisite info
                   nullable: true
                   properties:
+                    endpoint:
+                      description: 'If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint. You must also include the port in the definition. For example: "https://my-object-store.my-domain.net:443". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.'
+                      type: string
                     name:
                       description: RGW Zone the Object Store is in
                       type: string

--- a/deploy/examples/object-multisite.yaml
+++ b/deploy/examples/object-multisite.yaml
@@ -49,3 +49,4 @@ spec:
     instances: 1
   zone:
     name: zone-a
+    #endpoint: http://zone-a.fqdn

--- a/design/ceph/object/store.md
+++ b/design/ceph/object/store.md
@@ -113,9 +113,13 @@ This section enables the object store to be part of a specified ceph-object-zone
 
 Specifying this section also ensures that the pool section in the ceph-object-zone is used for the object-store. If pools are specified for the object-store they are neither created nor deleted.
 
+Specifying an endpoint in this section means that the endpoint specified will be added to the zones endpoint list. If an endpoint is not specified the endpoint of the object-store the endpoint will be the Kubernetes clusterIP and the port.
+
 - `name`: name of the [ceph-object-zone](/design/ceph/object/ceph-object-zone.md) the object store is in. This name must be of a ceph-object-zone resource not just of a zone that has been already created.
+- `endpoint`:  if this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service endpoint created by Rook, you must set this to the externally reachable endpoint. You must also include the port in the definition. For example: "https://my-object-store.my-domain.net:443". In many cases, you should set this to the endpoint of the ingress resource that makes the CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.
 
 ```yaml
   zone:
     name: "name"
+    endpoint: http://zone.fqdn:8000
 ```

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -1423,6 +1423,13 @@ type GatewaySpec struct {
 type ZoneSpec struct {
 	// RGW Zone the Object Store is in
 	Name string `json:"name"`
+	// If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service
+	// endpoint created by Rook, you must set this to the externally reachable endpoint. You must also
+	// include the port in the definition. For example: "https://my-object-store.my-domain.net:443".
+	// In many cases, you should set this to the endpoint of the ingress resource that makes the
+	// CephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.
+	// +optional
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // ObjectStoreStatus represents the status of a Ceph Object Store resource

--- a/pkg/operator/ceph/object/controller.go
+++ b/pkg/operator/ceph/object/controller.go
@@ -380,7 +380,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 		// RECONCILE SERVICE
 		logger.Info("reconciling object store service")
-		_, err = cfg.reconcileService(cephObjectStore)
+		err = cfg.reconcileService(cephObjectStore)
 		if err != nil {
 			return r.setFailedStatus(k8sutil.ObservedGenerationNotAvailable, namespacedName, "failed to reconcile service", err)
 		}
@@ -420,7 +420,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 		// RECONCILE SERVICE
 		logger.Debug("reconciling object store service")
-		serviceIP, err := cfg.reconcileService(cephObjectStore)
+		err = cfg.reconcileService(cephObjectStore)
 		if err != nil {
 			return r.setFailedStatus(k8sutil.ObservedGenerationNotAvailable, namespacedName, "failed to reconcile service", err)
 		}
@@ -440,7 +440,7 @@ func (r *ReconcileCephObjectStore) reconcileCreateObjectStore(cephObjectStore *c
 
 		// Reconcile Multisite Creation
 		logger.Infof("setting multisite settings for object store %q", cephObjectStore.Name)
-		err = setMultisite(objContext, cephObjectStore, serviceIP)
+		err = setMultisite(objContext, cephObjectStore)
 		if err != nil && kerrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		} else if err != nil {

--- a/pkg/operator/ceph/object/spec.go
+++ b/pkg/operator/ceph/object/spec.go
@@ -505,22 +505,22 @@ func (c *clusterConfig) reconcileExternalEndpoint(cephObjectStore *cephv1.CephOb
 	return nil
 }
 
-func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore) (string, error) {
+func (c *clusterConfig) reconcileService(cephObjectStore *cephv1.CephObjectStore) error {
 	service := c.generateService(cephObjectStore)
 	// Set owner ref to the parent object
 	err := c.ownerInfo.SetControllerReference(service)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to set owner reference to ceph object store service %q", service.Name)
+		return errors.Wrapf(err, "failed to set owner reference to ceph object store service %q", service.Name)
 	}
 
 	svc, err := k8sutil.CreateOrUpdateService(c.clusterInfo.Context, c.context.Clientset, cephObjectStore.Namespace, service)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create or update object store %q service", cephObjectStore.Name)
+		return errors.Wrapf(err, "failed to create or update object store %q service", cephObjectStore.Name)
 	}
 
 	logger.Infof("ceph object store gateway service running at %s", svc.Spec.ClusterIP)
 
-	return svc.Spec.ClusterIP, nil
+	return nil
 }
 
 func (c *clusterConfig) vaultPrefixRGW() string {

--- a/pkg/operator/ceph/object/status.go
+++ b/pkg/operator/ceph/object/status.go
@@ -113,8 +113,9 @@ func updateStatusBucket(ctx context.Context, client client.Client, name types.Na
 
 func buildStatusInfo(cephObjectStore *cephv1.CephObjectStore) map[string]string {
 	m := make(map[string]string)
-
-	if cephObjectStore.Spec.Gateway.SecurePort != 0 && cephObjectStore.Spec.Gateway.Port != 0 {
+	if cephObjectStore.Spec.IsMultisite() && cephObjectStore.Spec.Zone.Endpoint != "" {
+		m["endpoint"] = cephObjectStore.Spec.Zone.Endpoint
+	} else if cephObjectStore.Spec.Gateway.SecurePort != 0 && cephObjectStore.Spec.Gateway.Port != 0 {
 		m["secureEndpoint"] = BuildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.SecurePort, true)
 		m["endpoint"] = BuildDNSEndpoint(BuildDomainName(cephObjectStore.Name, cephObjectStore.Namespace), cephObjectStore.Spec.Gateway.Port, false)
 	} else if cephObjectStore.Spec.Gateway.SecurePort != 0 {


### PR DESCRIPTION
If Ceph Zone and ZoneGroup endpoints lists are
modified manually after deployment they are modified
to include the original internal K8s clusterIPs if
the rook operator is restarted.

This commit allows for a custom endpoint to be
added for the Zone endpoints list. This custom
endpoint replaces the internal K8s clusterIPs
in the zone endpoints list so that the list
does not need to be modified manually anymore.

Signed-off-by: Ali Maredia <amaredia@redhat.com>
Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>

Co-Authored-By: Ali Maredia <amaredia@redhat.com>
Co-Authored-By: Jiffin Tony Thottan <thottanjiffin@gmail.com>

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/rook/rook/issues/6432

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
