### PR TITLE
pool: fix possible segfault in remote executor

### DIFF
--- a/deploy/examples/cluster-on-pvc.yaml
+++ b/deploy/examples/cluster-on-pvc.yaml
@@ -12,6 +12,11 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph # namespace:cluster
 spec:
+  network:
+    provider: multus
+    selectors:
+      public: rook-ceph/public-net
+      cluster: rook-ceph/cluster-net
   dataDirHostPath: /var/lib/rook
   mon:
     # Set the number of mons to be started. Generally recommended to be 3.
@@ -100,7 +105,7 @@ spec:
           topologySpreadConstraints:
             - maxSkew: 1
               # IMPORTANT: If you don't have zone labels, change this to another key such as kubernetes.io/hostname
-              topologyKey: topology.kubernetes.io/zone
+              topologyKey: kubernetes.io/hostname
               whenUnsatisfiable: DoNotSchedule
               labelSelector:
                 matchExpressions:
@@ -120,8 +125,8 @@ spec:
           - metadata:
               name: data
               # if you are looking at giving your OSD a different CRUSH device class than the one detected by Ceph
-              # annotations:
-              #   crushDeviceClass: hybrid
+              annotations:
+                crushDeviceClass: hdd
             spec:
               resources:
                 requests:
@@ -169,12 +174,12 @@ spec:
   #   requests:
   #      cpu: "200m"
   #      memory: "200Mi"
-  disruptionManagement:
-    managePodBudgets: true
-    osdMaintenanceTimeout: 30
-    pgHealthCheckTimeout: 0
-    manageMachineDisruptionBudgets: false
-    machineDisruptionBudgetNamespace: openshift-machine-api
+  # disruptionManagement:
+  #   managePodBudgets: true
+  #   osdMaintenanceTimeout: 30
+  #   pgHealthCheckTimeout: 0
+  #   manageMachineDisruptionBudgets: false
+  #   machineDisruptionBudgetNamespace: openshift-machine-api
   # security oriented settings
   # security:
   # To enable the KMS configuration properly don't forget to uncomment the Secret at the end of the file

--- a/deploy/examples/cluster-test.yaml
+++ b/deploy/examples/cluster-test.yaml
@@ -26,6 +26,11 @@ metadata:
   name: my-cluster
   namespace: rook-ceph # namespace:cluster
 spec:
+  network:
+    provider: multus
+    selectors:
+      public: rook-ceph/public-net
+      cluster: rook-ceph/cluster-net
   dataDirHostPath: /var/lib/rook
   cephVersion:
     image: quay.io/ceph/ceph:v16.2.7
@@ -52,6 +57,7 @@ spec:
   disruptionManagement:
     managePodBudgets: true
 ---
+# FAILING ON MULTUS
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:

--- a/deploy/examples/operator-openshift.yaml
+++ b/deploy/examples/operator-openshift.yaml
@@ -117,11 +117,11 @@ data:
   # Set to true to enable host networking for CSI CephFS and RBD nodeplugins. This may be necessary
   # in some network configurations where the SDN does not provide access to an external cluster or
   # there is significant drop in read/write performance.
-  # CSI_ENABLE_HOST_NETWORK: "true"
+  CSI_ENABLE_HOST_NETWORK: "false"
 
   # Set logging level for csi containers.
   # Supported values from 0 to 5. 0 for general useful logs, 5 for trace level verbosity.
-  # CSI_LOG_LEVEL: "0"
+  CSI_LOG_LEVEL: "3"
 
   # Set replicas for csi provisioner deployment.
   CSI_PROVISIONER_REPLICAS: "2"

--- a/deploy/examples/operator.yaml
+++ b/deploy/examples/operator.yaml
@@ -35,11 +35,11 @@ data:
   # Set to true to enable host networking for CSI CephFS and RBD nodeplugins. This may be necessary
   # in some network configurations where the SDN does not provide access to an external cluster or
   # there is significant drop in read/write performance.
-  # CSI_ENABLE_HOST_NETWORK: "true"
+  CSI_ENABLE_HOST_NETWORK: "false"
 
   # Set logging level for csi containers.
   # Supported values from 0 to 5. 0 for general useful logs, 5 for trace level verbosity.
-  # CSI_LOG_LEVEL: "0"
+  CSI_LOG_LEVEL: "3"
 
   # Set replicas for csi provisioner deployment.
   CSI_PROVISIONER_REPLICAS: "2"

--- a/pkg/daemon/ceph/client/command.go
+++ b/pkg/daemon/ceph/client/command.go
@@ -166,7 +166,12 @@ func (c *CephToolCommand) run() ([]byte, error) {
 	if command == RBDTool {
 		if c.RemoteExecution {
 			output, stderr, err = c.context.RemoteExecutor.ExecCommandInContainerWithFullOutputWithTimeout(ProxyAppLabel, CommandProxyInitContainerName, c.clusterInfo.Namespace, append([]string{command}, args...)...)
-			if stderr != "" || err != nil {
+			// err != nil and stderr != "" are both valid errors and may occur independently. Apply
+			// the error message or stderr as needed, then join after to create the returned err.
+			if stderr != "" {
+				logger.Warningf("message reported on stderr from %q command %v: %s", RBDTool, args, stderr)
+			}
+			if err != nil {
 				err = errors.Errorf("%s. %s", err.Error(), stderr)
 			}
 		} else if c.timeout == 0 {


### PR DESCRIPTION
Original error check was:
if stderr != "" || err != nil {
	err = errors.Errorf("%s. %s", err.Error(), stderr)
}

Ceph uses stderr to output debug info, not just error messages. So
checking for stderr != "" as a condition for error is invalid. When
there is no error but there is stderr text, this code will segfault when
accessing err.Error().

Fix the check to be the usual Go error check as below:
if err != nil {...}

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>

Resolves #9623

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
