### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/daemon/ceph/client/config_test.go
+++ b/pkg/daemon/ceph/client/config_test.go
@@ -18,8 +18,6 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -66,11 +64,7 @@ func TestCreateDefaultCephConfig(t *testing.T) {
 func TestGenerateConfigFile(t *testing.T) {
 	ctx := context.TODO()
 	// set up a temporary config directory that will be cleaned up after test
-	configDir, err := ioutil.TempDir("", "TestGenerateConfigFile")
-	if err != nil {
-		t.Fatalf("failed to create temp config dir: %+v", err)
-	}
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 
 	// create mocked cluster context and info
 	clientset := test.New(t, 3)
@@ -90,7 +84,7 @@ func TestGenerateConfigFile(t *testing.T) {
 		},
 		Data: data,
 	}
-	_, err = clientset.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
 	clusterInfo := &ClusterInfo{

--- a/pkg/daemon/ceph/osd/device_test.go
+++ b/pkg/daemon/ceph/osd/device_test.go
@@ -17,7 +17,6 @@ package osd
 
 import (
 	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -29,8 +28,7 @@ import (
 )
 
 func TestOSDBootstrap(t *testing.T) {
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
@@ -39,7 +37,6 @@ func TestOSDBootstrap(t *testing.T) {
 	}
 
 	context := &clusterd.Context{Executor: executor, ConfigDir: configDir}
-	defer os.RemoveAll(context.ConfigDir)
 	err := createOSDBootstrapKeyring(context, client.AdminTestClusterInfo("mycluster"), configDir)
 	assert.Nil(t, err)
 

--- a/pkg/daemon/ceph/osd/volume_test.go
+++ b/pkg/daemon/ceph/osd/volume_test.go
@@ -324,12 +324,8 @@ func TestConfigureCVDevices(t *testing.T) {
 	}()
 
 	originalCephConfigDir := cephConfigDir
-	cephConfigDir, err = ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	cephConfigDir = t.TempDir()
 	defer func() {
-		os.RemoveAll(cephConfigDir)
 		cephConfigDir = originalCephConfigDir
 	}()
 

--- a/pkg/daemon/util/copybins_test.go
+++ b/pkg/daemon/util/copybins_test.go
@@ -58,15 +58,13 @@ func TestCopyBinary(t *testing.T) {
 	// testRootDir/
 	//   bin/
 	//   copy-to-dir/
-	testRootDir, err := ioutil.TempDir("", "rook-cmd-reporter-copy-binaries-test")
-	assert.NoError(t, err)
-	defer os.RemoveAll(testRootDir)
+	testRootDir := t.TempDir()
 	// create a test PATH="testRootDir/bin"
 	envPath := path.Join(testRootDir, "bin")
 	mkdir(envPath)
 	oPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oPath)
-	err = os.Setenv("PATH", envPath)
+	err := os.Setenv("PATH", envPath)
 	assert.NoError(t, err)
 	// create initial copy-to-dir
 	copyToDir := path.Join(testRootDir, "copy-to-dir")

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -19,7 +19,6 @@ package mgr
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -65,7 +64,7 @@ func TestStartMgr(t *testing.T) {
 	}
 
 	clientset := testop.New(t, 3)
-	configDir, _ := ioutil.TempDir("", "")
+	configDir := t.TempDir()
 	scheme := scheme.Scheme
 	err := policyv1.AddToScheme(scheme)
 	assert.NoError(t, err)
@@ -73,7 +72,6 @@ func TestStartMgr(t *testing.T) {
 	assert.NoError(t, err)
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 
-	defer os.RemoveAll(configDir)
 	ctx := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,
@@ -257,8 +255,7 @@ func TestMgrSidecarReconcile(t *testing.T) {
 		},
 	}
 	clientset := testop.New(t, 3)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	ctx := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,

--- a/pkg/operator/ceph/cluster/mon/health_test.go
+++ b/pkg/operator/ceph/cluster/mon/health_test.go
@@ -19,7 +19,6 @@ package mon
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -57,8 +56,7 @@ func TestCheckHealth(t *testing.T) {
 		},
 	}
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	context := &clusterd.Context{
 		Clientset: clientset,
 		ConfigDir: configDir,
@@ -78,7 +76,6 @@ func TestCheckHealth(t *testing.T) {
 	c.spec.Mon.Count = 3
 	logger.Infof("initial mons: %v", c.ClusterInfo.Monitors)
 	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
 
 	c.mapping.Schedule["f"] = &MonScheduleInfo{
 		Name:    "node0",
@@ -190,8 +187,7 @@ func TestSkipMonFailover(t *testing.T) {
 func TestEvictMonOnSameNode(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			logger.Infof("executing command: %s %+v", command, args)
@@ -298,8 +294,7 @@ func TestCheckHealthNotFound(t *testing.T) {
 		},
 	}
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	context := &clusterd.Context{
 		Clientset: clientset,
 		ConfigDir: configDir,
@@ -309,7 +304,6 @@ func TestCheckHealthNotFound(t *testing.T) {
 	c := New(context, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 2, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
 	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
 
 	c.mapping.Schedule["a"] = &MonScheduleInfo{
 		Name: "node0",
@@ -361,8 +355,7 @@ func TestAddRemoveMons(t *testing.T) {
 		},
 	}
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	context := &clusterd.Context{
 		Clientset: clientset,
 		ConfigDir: configDir,
@@ -373,7 +366,6 @@ func TestAddRemoveMons(t *testing.T) {
 	setCommonMonProperties(c, 0, cephv1.MonSpec{Count: 5, AllowMultiplePerNode: true}, "myversion")
 	c.maxMonID = 0 // "a" is max mon id
 	c.waitForStart = false
-	defer os.RemoveAll(c.context.ConfigDir)
 
 	// checking the health will increase the mons as desired all in one go
 	err := c.checkHealth(ctx)

--- a/pkg/operator/ceph/cluster/mon/mon_test.go
+++ b/pkg/operator/ceph/cluster/mon/mon_test.go
@@ -19,7 +19,6 @@ package mon
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -80,8 +79,7 @@ func newTestStartCluster(t *testing.T, namespace string) (*clusterd.Context, err
 
 func newTestStartClusterWithQuorumResponse(t *testing.T, namespace string, monResponse func() (string, error)) (*clusterd.Context, error) {
 	clientset := test.New(t, 3)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
@@ -298,8 +296,7 @@ func TestPersistMons(t *testing.T) {
 func TestSaveMonEndpoints(t *testing.T) {
 	ctx := context.TODO()
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	setCommonMonProperties(c, 1, cephv1.MonSpec{Count: 3, AllowMultiplePerNode: true}, "myversion")
@@ -346,8 +343,7 @@ func TestSaveMonEndpoints(t *testing.T) {
 
 func TestMaxMonID(t *testing.T) {
 	clientset := test.New(t, 1)
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	ownerInfo := cephclient.NewMinimumOwnerInfoWithOwnerRef()
 	c := New(&clusterd.Context{Clientset: clientset, ConfigDir: configDir}, "ns", cephv1.ClusterSpec{}, ownerInfo)
 	c.ClusterInfo = clienttest.CreateTestClusterInfo(1)

--- a/pkg/operator/ceph/file/filesystem_test.go
+++ b/pkg/operator/ceph/file/filesystem_test.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -319,12 +317,11 @@ func TestCreateFilesystem(t *testing.T) {
 	ctx := context.TODO()
 	var deploymentsUpdated *[]*apps.Deployment
 	mds.UpdateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
-	configDir, _ := ioutil.TempDir("", "")
+	configDir := t.TempDir()
 	fsName := "myfs"
 	addDataPoolCount := 0
 	createDataPoolCount := 0
 	executor := fsExecutor(t, fsName, configDir, false, &createDataPoolCount, &addDataPoolCount)
-	defer os.RemoveAll(configDir)
 	clientset := testop.New(t, 1)
 	context := &clusterd.Context{
 		Executor:  executor,
@@ -398,13 +395,12 @@ func TestUpgradeFilesystem(t *testing.T) {
 	ctx := context.TODO()
 	var deploymentsUpdated *[]*apps.Deployment
 	mds.UpdateDeploymentAndWait, deploymentsUpdated = testopk8s.UpdateDeploymentAndWaitStub()
-	configDir, _ := ioutil.TempDir("", "")
+	configDir := t.TempDir()
 
 	fsName := "myfs"
 	addDataPoolCount := 0
 	createDataPoolCount := 0
 	executor := fsExecutor(t, fsName, configDir, false, &createDataPoolCount, &addDataPoolCount)
-	defer os.RemoveAll(configDir)
 	clientset := testop.New(t, 1)
 	context := &clusterd.Context{
 		Executor:  executor,
@@ -518,7 +514,7 @@ func TestUpgradeFilesystem(t *testing.T) {
 func TestCreateNopoolFilesystem(t *testing.T) {
 	ctx := context.TODO()
 	clientset := testop.New(t, 3)
-	configDir, _ := ioutil.TempDir("", "")
+	configDir := t.TempDir()
 	executor := &exectest.MockExecutor{
 		MockExecuteCommandWithOutput: func(command string, args ...string) (string, error) {
 			if strings.Contains(command, "ceph-authtool") {
@@ -530,7 +526,6 @@ func TestCreateNopoolFilesystem(t *testing.T) {
 			return "", errors.New("unknown command error")
 		},
 	}
-	defer os.RemoveAll(configDir)
 	context := &clusterd.Context{
 		Executor:  executor,
 		ConfigDir: configDir,

--- a/pkg/operator/ceph/object/rgw_test.go
+++ b/pkg/operator/ceph/object/rgw_test.go
@@ -18,8 +18,6 @@ package object
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
@@ -51,8 +49,7 @@ func TestStartRGW(t *testing.T) {
 		},
 	}
 
-	configDir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	info := clienttest.CreateTestClusterInfo(1)
 	context := &clusterd.Context{Clientset: clientset, Executor: executor, ConfigDir: configDir}
 	store := simpleStore()

--- a/tests/integration/ceph_base_object_test.go
+++ b/tests/integration/ceph_base_object_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -255,9 +254,7 @@ func generateRgwTlsCertSecret(t *testing.T, helper *clients.TestClient, k8sh *ut
 	ctx := context.TODO()
 	root, err := utils.FindRookRoot()
 	require.NoError(t, err, "failed to get rook root")
-	tlscertdir, err := ioutil.TempDir(root, "tlscertdir")
-	require.NoError(t, err, "failed to create directory for TLS certs")
-	defer os.RemoveAll(tlscertdir)
+	tlscertdir := t.TempDir()
 	cmdArgs := utils.CommandArgs{Command: filepath.Join(root, "tests/scripts/generate-tls-config.sh"),
 		CmdArgs: []string{tlscertdir, rgwServiceName, namespace}}
 	cmdOut := utils.ExecuteCommand(cmdArgs)


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
We can write less code by using the `T.TempDir` function from the `testing` package to create temporary test directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

**Which issue is resolved by this Pull Request:**
N/A

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
