### PR TITLE
helm: Update CI to the latest helm and fix the linter

### DIFF
--- a/deploy/charts/library/templates/_cluster-psp.tpl
+++ b/deploy/charts/library/templates/_cluster-psp.tpl
@@ -61,4 +61,4 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-cmd-reporter
     namespace: {{ .Release.Namespace }} # namespace:cluster
-{{- end -}}
+{{- end }}

--- a/deploy/charts/library/templates/_cluster-rolebinding.tpl
+++ b/deploy/charts/library/templates/_cluster-rolebinding.tpl
@@ -90,4 +90,4 @@ subjects:
   - kind: ServiceAccount
     name: rook-ceph-purge-osd
     namespace: {{ .Release.Namespace }} # namespace:cluster
-{{- end -}}
+{{- end }}

--- a/deploy/charts/library/templates/_recommended-labels.tpl
+++ b/deploy/charts/library/templates/_recommended-labels.tpl
@@ -6,4 +6,4 @@ app.kubernetes.io/part-of: rook-ceph-operator
 app.kubernetes.io/managed-by: helm
 app.kubernetes.io/created-by: helm
 helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-{{- end -}}
+{{- end }}

--- a/deploy/charts/library/templates/_suffix-cluster-namespace.tpl
+++ b/deploy/charts/library/templates/_suffix-cluster-namespace.tpl
@@ -14,5 +14,5 @@ If the cluster namespace is different from the operator namespace, we want to na
 {{- $clusterNamespace := .Release.Namespace -}}
 {{- if ne $clusterNamespace $operatorNamespace -}}
 {{ printf "-%s" $clusterNamespace }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
+++ b/deploy/charts/rook-ceph-cluster/templates/_helpers.tpl
@@ -3,14 +3,14 @@ Define the clusterName as defaulting to the release namespace
 */}}
 {{- define "clusterName" -}}
 {{ .Values.clusterName | default .Release.Namespace }}
-{{- end -}}
+{{- end }}
 
 {{/*
 Return the target Kubernetes version.
 */}}
 {{- define "capabilities.kubeVersion" -}}
 {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
-{{- end -}}
+{{- end }}
 
 {{/*
 Return the appropriate apiVersion for ingress.
@@ -22,5 +22,5 @@ Return the appropriate apiVersion for ingress.
 {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/rook-ceph-cluster/templates/rbac.yaml
+++ b/deploy/charts/rook-ceph-cluster/templates/rbac.yaml
@@ -14,7 +14,7 @@ clusterrolebindings
 {{- if .Values.pspEnable }}
 ---
 {{ include "library.cluster.psp.rolebindings" . }}
-{{- end -}}
+{{- end }}
 
 {{/*
 roles
@@ -38,4 +38,4 @@ rolebindings
 {{ include "library.cluster.monitoring.rolebindings" . }}
 {{- end }}
 
-{{- end -}}
+{{- end }}

--- a/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
+++ b/deploy/charts/rook-ceph/templates/cluster-rbac.yaml
@@ -18,7 +18,7 @@ clusterrolebindings
 {{- if .Values.pspEnable }}
 ---
 {{ include "library.cluster.psp.rolebindings" . }}
-{{- end -}}
+{{- end }}
 
 {{/*
 roles

--- a/deploy/charts/rook-ceph/templates/clusterrole.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrole.yaml
@@ -535,4 +535,4 @@ rules:
   - apiGroups: [""]
     resources: ["serviceaccounts"]
     verbs: ["get"]
-{{- end -}}
+{{- end }}

--- a/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/clusterrolebinding.yaml
@@ -99,4 +99,4 @@ roleRef:
   kind: ClusterRole
   name: rbd-external-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{- end }}

--- a/deploy/charts/rook-ceph/templates/psp.yaml
+++ b/deploy/charts/rook-ceph/templates/psp.yaml
@@ -168,4 +168,4 @@ subjects:
     name: rook-csi-rbd-provisioner-sa
     namespace: {{ .Release.Namespace }} # namespace:operator
 {{- end }}
-{{- end -}}
+{{- end }}

--- a/deploy/charts/rook-ceph/templates/rolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/rolebinding.yaml
@@ -47,7 +47,7 @@ roleRef:
   name: rbd-csi-nodeplugin
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- end -}}
+{{- end }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -61,4 +61,4 @@ roleRef:
   kind: Role
   name: rbd-external-provisioner-cfg
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{- end }}

--- a/tests/scripts/helm.sh
+++ b/tests/scripts/helm.sh
@@ -2,7 +2,7 @@
 
 temp="/tmp/rook-tests-scripts-helm"
 
-helm_version="${HELM_VERSION:-"v3.6.2"}"
+helm_version="${HELM_VERSION:-"v3.8.0"}"
 arch="${ARCH:-}"
 
 detectArch() {


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
- The CI was building with helm 3.6.2, now updating to the latest v3.8.0
- Recent versions of helm are failing the linter on the end tag if the tag is `{{- end -}}`. Instead, the correct end tag is `{{- end }}`.
    
**Which issue is resolved by this Pull Request:**
Resolves #9639 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
