### PR TITLE
helm: fix csiAddons enabled flag

### DIFF
--- a/build/rbac/get-helm-rbac.sh
+++ b/build/rbac/get-helm-rbac.sh
@@ -18,6 +18,7 @@ pushd "$SCRIPT_DIR" &>/dev/stderr
 options=(
   --namespace rook-ceph
   --set crds.enabled=false
+  --set csi.csiAddons.enabled=true
 )
 if [[ -z "${DO_NOT_INCLUDE_POD_SECURITY_POLICY_RESOURCES}" ]]; then
   options+=(--set pspEnable=true)

--- a/deploy/charts/rook-ceph/templates/role.yaml
+++ b/deploy/charts/rook-ceph/templates/role.yaml
@@ -61,7 +61,7 @@ rules:
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
 ---
-{{- if .Values.csi.csiAddons }}
+{{- if and .Values.csi.csiAddons .Values.csi.csiAddons.enabled }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -88,7 +88,7 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
-  {{- if .Values.csi.csiAddons }}
+  {{- if and .Values.csi.csiAddons .Values.csi.csiAddons.enabled }}
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
     verbs: ["create"]

--- a/deploy/charts/rook-ceph/templates/rolebinding.yaml
+++ b/deploy/charts/rook-ceph/templates/rolebinding.yaml
@@ -32,7 +32,7 @@ roleRef:
   name: cephfs-external-provisioner-cfg
   apiGroup: rbac.authorization.k8s.io
 ---
-{{- if .Values.csi.csiAddons }}
+{{- if and .Values.csi.csiAddons .Values.csi.csiAddons.enabled }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
**Description of your changes:**

We should use csiAddons.enabled to check whether csiAddons is used.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
