### PR TITLE
osd: allow for injecting extra env. variables via ConfigMap

### DIFF
--- a/deploy/examples/osd-env-override.yaml
+++ b/deploy/examples/osd-env-override.yaml
@@ -1,0 +1,19 @@
+# ###############################################################################################################
+# The `rook-ceph-osd-env-override` ConfigMap is a development feature
+# that allows to inject arbitrary environment variables to OSD-related
+# containers created by the operator.
+# ###############################################################################################################
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rook-ceph-osd-env-override
+  namespace: rook-ceph
+data:
+  # Bypass the ASan's assertion that it is the very first loaded DSO.
+  # This is necessary for crimson-osd as it's currently built with
+  # the ASan sanitizer turned on which means the `libasan.so` must
+  # the be the very first loaded dynamic library. Unfortunately, this
+  # isn't fulfilled as the containers use `ld.preload`, so ASan was
+  # aborting the entire OSD.
+  ASAN_OPTIONS: verify_asan_link_order=0

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -32,6 +32,7 @@ const (
 	osdWalSizeEnvVarName      = "ROOK_OSD_WAL_SIZE"
 	osdsPerDeviceEnvVarName   = "ROOK_OSDS_PER_DEVICE"
 	osdDeviceClassEnvVarName  = "ROOK_OSD_DEVICE_CLASS"
+	osdConfigMapOverrideName  = "rook-ceph-osd-env-override"
 	// EncryptedDeviceEnvVarName is used in the pod spec to indicate whether the OSD is encrypted or not
 	EncryptedDeviceEnvVarName = "ROOK_ENCRYPTED_DEVICE"
 	PVCNameEnvVarName         = "ROOK_PVC_NAME"
@@ -211,6 +212,19 @@ func osdActivateEnvVar() []v1.EnvVar {
 	}
 
 	return append(cephVolumeEnvVar(), monEnvVars...)
+}
+
+func getEnvFromSources() []v1.EnvFromSource {
+	optionalConfigMapRef := true
+
+	return []v1.EnvFromSource{
+		{
+			ConfigMapRef: &v1.ConfigMapEnvSource{
+				LocalObjectReference: v1.LocalObjectReference{Name: osdConfigMapOverrideName},
+				Optional:             &optionalConfigMapRef,
+			},
+		},
+	}
 }
 
 func getTcmallocMaxTotalThreadCacheBytes(tcmallocMaxTotalThreadCacheBytes string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -302,6 +302,7 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 		Image:        c.spec.CephVersion.Image,
 		VolumeMounts: volumeMounts,
 		Env:          envVars,
+		EnvFrom:      getEnvFromSources(),
 		SecurityContext: &v1.SecurityContext{
 			Privileged:             &privileged,
 			RunAsUser:              &runAsUser,

--- a/pkg/operator/ceph/cluster/osd/spec.go
+++ b/pkg/operator/ceph/cluster/osd/spec.go
@@ -466,6 +466,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 				Image:           c.rookVersion,
 				VolumeMounts:    configVolumeMounts,
 				Env:             configEnvVars,
+				EnvFrom:         getEnvFromSources(),
 				SecurityContext: securityContext,
 			})
 	}
@@ -549,6 +550,7 @@ func (c *Cluster) makeDeployment(osdProps osdProperties, osd OSDInfo, provisionC
 					Image:           c.spec.CephVersion.Image,
 					VolumeMounts:    volumeMounts,
 					Env:             envVars,
+					EnvFrom:         getEnvFromSources(),
 					Resources:       osdProps.resources,
 					SecurityContext: securityContext,
 					StartupProbe:    controller.GenerateStartupProbeExecDaemon(opconfig.OsdType, osdID),
@@ -767,6 +769,7 @@ func (c *Cluster) getActivateOSDInitContainer(configDir, namespace, osdID string
 		VolumeMounts:    volMounts,
 		SecurityContext: controller.PrivilegedContext(true),
 		Env:             envVars,
+		EnvFrom:         getEnvFromSources(),
 		Resources:       osdProps.resources,
 	}
 


### PR DESCRIPTION
This is a reworked, implemented in a very different way version of the PR https://github.com/rook/rook/pull/9516.

<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
