### PR TITLE
osd: Merge all osd resources including custom

### DIFF
--- a/pkg/operator/k8sutil/resources.go
+++ b/pkg/operator/k8sutil/resources.go
@@ -148,37 +148,16 @@ func (info *OwnerInfo) GetUID() types.UID {
 }
 
 func MergeResourceRequirements(first, second v1.ResourceRequirements) v1.ResourceRequirements {
-	// if the first has a value not set check if second has and set it in first
-	if _, ok := first.Limits[v1.ResourceCPU]; !ok {
-		if _, ok = second.Limits[v1.ResourceCPU]; ok {
-			if first.Limits == nil {
-				first.Limits = v1.ResourceList{}
-			}
-			first.Limits[v1.ResourceCPU] = second.Limits[v1.ResourceCPU]
+	// if the first has no limits set, apply the second limits if any are specified
+	if len(first.Limits) == 0 {
+		if len(second.Limits) > 0 {
+			first.Limits = second.Limits
 		}
 	}
-	if _, ok := first.Limits[v1.ResourceMemory]; !ok {
-		if _, ok = second.Limits[v1.ResourceMemory]; ok {
-			if first.Limits == nil {
-				first.Limits = v1.ResourceList{}
-			}
-			first.Limits[v1.ResourceMemory] = second.Limits[v1.ResourceMemory]
-		}
-	}
-	if _, ok := first.Requests[v1.ResourceCPU]; !ok {
-		if _, ok = second.Requests[v1.ResourceCPU]; ok {
-			if first.Requests == nil {
-				first.Requests = v1.ResourceList{}
-			}
-			first.Requests[v1.ResourceCPU] = second.Requests[v1.ResourceCPU]
-		}
-	}
-	if _, ok := first.Requests[v1.ResourceMemory]; !ok {
-		if _, ok = second.Requests[v1.ResourceMemory]; ok {
-			if first.Requests == nil {
-				first.Requests = v1.ResourceList{}
-			}
-			first.Requests[v1.ResourceMemory] = second.Requests[v1.ResourceMemory]
+	// if the first has no requests set, apply the second requests if any are specified
+	if len(first.Requests) == 0 {
+		if len(second.Requests) > 0 {
+			first.Requests = second.Requests
 		}
 	}
 	return first

--- a/pkg/operator/k8sutil/resources_test.go
+++ b/pkg/operator/k8sutil/resources_test.go
@@ -37,17 +37,18 @@ func TestMergeResourceRequirements(t *testing.T) {
 	first = v1.ResourceRequirements{}
 	second = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			v1.ResourceCPU: *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceCPU:     *resource.NewQuantity(100.0, resource.BinarySI),
+			v1.ResourceStorage: *resource.NewQuantity(50.0, resource.BinarySI),
 		},
 		Requests: v1.ResourceList{
-			v1.ResourceMemory: *resource.NewQuantity(1337.0, resource.BinarySI),
+			v1.ResourceName("foo"): *resource.NewQuantity(23.0, resource.BinarySI),
 		},
 	}
 	result = MergeResourceRequirements(first, second)
-	assert.Equal(t, 1, len(result.Limits))
+	assert.Equal(t, 2, len(result.Limits))
 	assert.Equal(t, 1, len(result.Requests))
 	assert.Equal(t, "100", result.Limits.Cpu().String())
-	assert.Equal(t, "1337", result.Requests.Memory().String())
+	assert.Equal(t, "50", result.Limits.Storage().String())
 
 	first = v1.ResourceRequirements{
 		Limits: v1.ResourceList{


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**
The merging of OSD resource limits and requests assumed that only the cpu and memory resources needed to be merged. It is also possible to set custom resource properties such as intel.com/sriov_net_in: '1' for use with multus, so the merging needs to be more general.

**Which issue is resolved by this Pull Request:**
Resolves #9653 

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
