### PR TITLE
csi: skip validation when installing snapshotter

### DIFF
--- a/tests/framework/utils/snapshot.go
+++ b/tests/framework/utils/snapshot.go
@@ -112,20 +112,33 @@ func (k8sh *K8sHelper) DeleteSnapshotController() error {
 
 // snapshotCRD can be used for creating or deleting the snapshot CRD's
 func (k8sh *K8sHelper) snapshotCRD(action string) error {
+	// setting validate=false to skip CRD validation during create operation to
+	// support lower Kubernetes versions.
+	args := func(crdpath string) []string {
+		a := []string{
+			action,
+			"-f",
+			crdpath,
+		}
+		if action == "create" {
+			a = append(a, "--validate=false")
+		}
+		return a
+	}
 	snapshotClassCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, snapshotClassCRDPath)
-	_, err := k8sh.Kubectl(action, "-f", snapshotClassCRD)
+	_, err := k8sh.Kubectl(args(snapshotClassCRD)...)
 	if err != nil {
 		return err
 	}
 
 	snapshotContentsCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeSnapshotContentsCRDPath)
-	_, err = k8sh.Kubectl(action, "-f", snapshotContentsCRD)
+	_, err = k8sh.Kubectl(args(snapshotContentsCRD)...)
 	if err != nil {
 		return err
 	}
 
 	snapshotCRD := fmt.Sprintf("%s/%s/%s", repoURL, snapshotterVersion, volumeSnapshotCRDPath)
-	_, err = k8sh.Kubectl(action, "-f", snapshotCRD)
+	_, err = k8sh.Kubectl(args(snapshotCRD)...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

In kubernetes 1.18 we are seeing CRD validation errors when installing with kubectl, adding `validate=false` to skip the validation and to make tests works with kubernetes 1.18

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #9670

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
