### PR TITLE
csi: fix snapshot tests

### DIFF
--- a/tests/framework/utils/snapshot.go
+++ b/tests/framework/utils/snapshot.go
@@ -40,6 +40,8 @@ const (
 // CheckSnapshotISReadyToUse checks snapshot is ready to use
 func (k8sh *K8sHelper) CheckSnapshotISReadyToUse(name, namespace string, retries int) (bool, error) {
 	for i := 0; i < retries; i++ {
+		// sleep first and try to check snapshot is ready to cover the error cases.
+		time.Sleep(time.Duration(i) * time.Second)
 		ready, err := k8sh.executor.ExecuteCommandWithOutput("kubectl", "get", "volumesnapshot", name, "--namespace", namespace, "-o", "jsonpath={.status.readyToUse}")
 		if err != nil {
 			return false, err
@@ -52,7 +54,6 @@ func (k8sh *K8sHelper) CheckSnapshotISReadyToUse(name, namespace string, retries
 		if val {
 			return true, nil
 		}
-		time.Sleep(RetryInterval * time.Second)
 	}
 	return false, fmt.Errorf("giving up waiting for %q snapshot in namespace %q", name, namespace)
 }

--- a/tests/integration/ceph_base_file_test.go
+++ b/tests/integration/ceph_base_file_test.go
@@ -118,7 +118,17 @@ func fileSystemCSISnapshotTest(helper *clients.TestClient, k8sh *utils.K8sHelper
 	logger.Infof("install snapshot controller")
 	err = k8sh.CreateSnapshotController()
 	require.NoError(s.T(), err)
+	// cleanup the CRD and controller in defer to make sure the CRD and
+	// controller are removed as block test also install CRD and controller.
+	defer func() {
+		logger.Infof("delete snapshot-controller")
+		err = k8sh.DeleteSnapshotController()
+		require.NoError(s.T(), err)
 
+		logger.Infof("delete snapshot CRD")
+		err = k8sh.DeleteSnapshotCRD()
+		require.NoError(s.T(), err)
+	}()
 	logger.Infof("check snapshot controller is running")
 	err = k8sh.WaitForSnapshotController(15)
 	require.NoError(s.T(), err)
@@ -221,14 +231,6 @@ func fileSystemCSISnapshotTest(helper *clients.TestClient, k8sh *utils.K8sHelper
 	err = helper.FSClient.DeleteSnapshotClass(snapshotClassName, snapshotDeletePolicy, namespace)
 	require.NoError(s.T(), err)
 	logger.Infof("delete snapshot-controller")
-
-	err = k8sh.DeleteSnapshotController()
-	require.NoError(s.T(), err)
-	logger.Infof("delete snapshot CRD")
-
-	// remove snapshotcontroller and delete snapshot CRD
-	err = k8sh.DeleteSnapshotCRD()
-	require.NoError(s.T(), err)
 }
 
 // Smoke Test for File System Storage - Test check the following operations on Filesystem Storage in order


### PR DESCRIPTION
<!-- Please take a look at our [Contributing](https://rook.io/docs/rook/latest/development-flow.html)
documentation before submitting a Pull Request!
Thank you for contributing to Rook! -->

**Description of your changes:**

Currently, we sleep only if the snapshot is not ready and try again, this covers only the happy path. the checks might fail to get the snapshot object or the `.status.readyToUse` might not be set yet. First sleep and then try to check snapshot is ready or not, if we do this we cover all the cases when checking the snapshot ready status. Changed sleep internal to do incremental sleep to give more time for tests.

cleanup the CRD and controller in defer to make sure the CRD and controller are removed as filesystem/block test also install CRD and controller separately.

**Which issue is resolved by this Pull Request:**
Resolves #

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [ ] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [ ] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
- [ ] Pending release notes updated with breaking and/or notable changes, if necessary.
- [ ] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [ ] Code generation (`make codegen`) has been run to update object specifications, if necessary.
