### PR TITLE
core: eliminate unnecessary code

### DIFF
--- a/pkg/operator/ceph/cluster/mgr/mgr.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr.go
@@ -463,7 +463,7 @@ func (c *Cluster) configureMgrModules() error {
 func (c *Cluster) moduleMeetsMinVersion(name string) (*cephver.CephVersion, bool) {
 	minVersions := map[string]cephver.CephVersion{
 		// Put the modules here, example:
-		// pgautoscalerModuleName: {Major: 14},
+		// pgautoscalerModuleName: {Major: 15},
 	}
 	if ver, ok := minVersions[name]; ok {
 		// Check if the required min version is met

--- a/pkg/operator/ceph/cluster/mgr/mgr_test.go
+++ b/pkg/operator/ceph/cluster/mgr/mgr_test.go
@@ -360,7 +360,7 @@ func TestConfigureModules(t *testing.T) {
 	c.spec.Mgr.Modules = []cephv1.Module{
 		{Name: "pg_autoscaler", Enabled: true},
 	}
-	c.clusterInfo.CephVersion = cephver.CephVersion{Major: 14}
+	c.clusterInfo.CephVersion = cephver.CephVersion{Major: 15}
 	modulesEnabled = 0
 	assert.NoError(t, c.configureMgrModules())
 	assert.Equal(t, 1, modulesEnabled)

--- a/pkg/operator/ceph/version/version.go
+++ b/pkg/operator/ceph/version/version.go
@@ -48,14 +48,11 @@ var (
 	// Quincy Ceph version
 	Quincy = CephVersion{17, 0, 0, 0, ""}
 
-	// cephVolumeLVMDiskSortingCephVersion introduced a major regression in c-v and thus is not suitable for production
-	cephVolumeLVMDiskSortingCephVersion = CephVersion{Major: 14, Minor: 2, Extra: 13}
-
 	// supportedVersions are production-ready versions that rook supports
 	supportedVersions = []CephVersion{Octopus, Pacific}
 
 	// unsupportedVersions are possibly Ceph pin-point release that introduced breaking changes and not recommended
-	unsupportedVersions = []CephVersion{cephVolumeLVMDiskSortingCephVersion}
+	unsupportedVersions = []CephVersion{}
 
 	// for parsing the output of `ceph --version`
 	versionPattern = regexp.MustCompile(`ceph version (\d+)\.(\d+)\.(\d+)`)

--- a/pkg/operator/ceph/version/version_test.go
+++ b/pkg/operator/ceph/version/version_test.go
@@ -209,7 +209,6 @@ func TestCephVersion_Unsupported(t *testing.T) {
 		{"supported", fields{Major: 16, Minor: 2, Extra: 1, Build: 0}, false},
 		{"supported", fields{Major: 15, Minor: 2, Extra: 1, Build: 0}, false},
 		{"supported", fields{Major: 15, Minor: 2, Extra: 6, Build: 0}, false},
-		{"unsupported", fields{Major: 14, Minor: 2, Extra: 13, Build: 0}, true},
 		{"unsupported", fields{Major: 17, Minor: 2, Extra: 0, Build: 0}, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Description of your changes:**

We can eliminate the OSD creation code for Ceph < v15.2.0 because Nautilus(v14.2.z) is no longer supported. In other words, we can now expect that all newly-created OSDs on PVC are raw mode.

Please note that the existing lvm mode OSDs on PVCs still be supported after this change.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/development-flow.html#commit-structure).
- [x] **Skip Tests for Docs**: Add the flag for skipping the build if this is only a documentation change. See [here](https://github.com/rook/rook/blob/master/INSTALL.md#skip-ci) for the flag.
- [x] **Skip Unrelated Tests**: Add a flag to run tests for a specific storage provider. See [test options](https://github.com/rook/rook/blob/master/INSTALL.md#test-storage-provider).
- [x] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/development-flow.html#submitting-a-pull-request)
- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Integration tests have been added, if necessary.
- [x] Pending release notes updated with breaking and/or notable changes, if necessary.
- [x] Upgrade from previous release is tested and upgrade user guide is updated, if necessary.
- [x] Code generation (`make codegen`) has been run to update object specifications, if necessary.
